### PR TITLE
update turbopack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "serde",
  "smallvec",
@@ -3421,7 +3421,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "serde",
@@ -7408,7 +7408,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7440,7 +7440,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7452,7 +7452,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7467,7 +7467,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7481,7 +7481,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7498,7 +7498,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7529,7 +7529,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "base16",
  "hex",
@@ -7541,7 +7541,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7555,7 +7555,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7565,7 +7565,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "mimalloc",
 ]
@@ -7573,7 +7573,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7598,7 +7598,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7630,7 +7630,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7671,7 +7671,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7696,7 +7696,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7714,7 +7714,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7745,7 +7745,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7773,7 +7773,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7798,7 +7798,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7835,7 +7835,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7871,7 +7871,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "serde",
  "serde_json",
@@ -7882,7 +7882,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7907,7 +7907,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7924,7 +7924,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7940,7 +7940,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7960,7 +7960,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "serde",
@@ -7975,7 +7975,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7990,7 +7990,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8025,7 +8025,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "serde",
@@ -8041,7 +8041,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8052,7 +8052,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8068,7 +8068,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.3#234a7e599628195685955f20c7b2f49e0689a3ab"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240220.5#b369462951ce5046594d901405a659e2f29b0b71"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.90.10", features = [
 testing = { version = "0.35.18" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240220.3" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240220.5" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240220.3" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240220.5" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240220.3" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240220.5" }
 
 # General Deps
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -192,7 +192,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.4",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240220.3",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240220.5",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1074,8 +1074,8 @@ importers:
         specifier: 0.26.4
         version: 0.26.4
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240220.3
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240220.3'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240220.5
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240220.5'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -25626,8 +25626,8 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240220.3':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240220.3}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240220.5':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240220.5}
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
* https://github.com/vercel/turbo/pull/7430 <!-- Tobias Koppers - disable manifest chunks by default  -->
* https://github.com/vercel/turbo/pull/7431 <!-- Donny/강동윤 - fix(turbopack): Fix `pure` lint for CSS Modules in lightningcss mode  -->