### PR TITLE
Fix performance spans

### DIFF
--- a/packages/next/src/server/client-component-renderer-logger.ts
+++ b/packages/next/src/server/client-component-renderer-logger.ts
@@ -1,0 +1,53 @@
+// Combined load times for loading client components
+let clientComponentLoadStart = 0
+let clientComponentLoadTimes = 0
+let clientComponentLoadCount = 0
+
+export function wrapClientComponentLoader(ComponentMod: any) {
+  if (typeof performance === 'undefined') {
+    return ComponentMod.__next_app__
+  }
+
+  return {
+    require: (...args: any[]) => {
+      if (clientComponentLoadStart === 0) {
+        clientComponentLoadStart = performance.now()
+      }
+
+      const startTime = performance.now()
+      try {
+        clientComponentLoadCount += 1
+        return ComponentMod.__next_app__.require(...args)
+      } finally {
+        clientComponentLoadTimes += performance.now() - startTime
+      }
+    },
+    loadChunk: (...args: any[]) => {
+      const startTime = performance.now()
+      try {
+        clientComponentLoadCount += 1
+        return ComponentMod.__next_app__.loadChunk(...args)
+      } finally {
+        clientComponentLoadTimes += performance.now() - startTime
+      }
+    },
+  }
+}
+
+export function getClientComponentLoaderMetrics(
+  options: { reset?: boolean } = {}
+) {
+  const metrics = {
+    clientComponentLoadStart,
+    clientComponentLoadTimes,
+    clientComponentLoadCount,
+  }
+
+  if (options.reset) {
+    clientComponentLoadStart = 0
+    clientComponentLoadTimes = 0
+    clientComponentLoadCount = 0
+  }
+
+  return metrics
+}

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -232,16 +232,6 @@ class NextTracerImpl implements NextTracer {
 
     const spanName = options.spanName ?? type
 
-    if (process.env.NEXT_OTEL_LOG_PREFIX && LogSpanAllowList.includes(type)) {
-      performance.measure(
-        `${process.env.NEXT_OTEL_LOG_PREFIX}:next-${spanName.replace(
-          /[A-Z]/g,
-          (match: string) => '-' + match.toLowerCase()
-        )}`,
-        {}
-      )
-    }
-
     if (
       (!NextVanillaSpanAllowlist.includes(type) &&
         process.env.NEXT_OTEL_VERBOSE !== '1') ||
@@ -276,16 +266,15 @@ class NextTracerImpl implements NextTracer {
         spanName,
         options,
         (span: Span) => {
-          const startTime = Date.now()
+          const startTime = performance?.now()
 
           const onCleanup = () => {
             rootSpanAttributesStore.delete(spanId)
             if (
-              typeof performance !== 'undefined' &&
+              startTime &&
               process.env.NEXT_OTEL_PERFORMANCE_PREFIX &&
               LogSpanAllowList.includes(type || ('' as any))
             ) {
-              const { timeOrigin } = performance
               performance.measure(
                 `${process.env.NEXT_OTEL_PERFORMANCE_PREFIX}:next-${(
                   type.split('.').pop() || ''
@@ -294,8 +283,8 @@ class NextTracerImpl implements NextTracer {
                   (match: string) => '-' + match.toLowerCase()
                 )}`,
                 {
-                  start: startTime - timeOrigin,
-                  end: Date.now() - timeOrigin,
+                  start: startTime,
+                  end: performance.now(),
                 }
               )
             }

--- a/packages/next/src/server/pipe-readable.ts
+++ b/packages/next/src/server/pipe-readable.ts
@@ -7,6 +7,7 @@ import {
 import { DetachedPromise } from '../lib/detached-promise'
 import { getTracer } from './lib/trace/tracer'
 import { NextNodeServerSpan } from './lib/trace/constants'
+import { getClientComponentLoaderMetrics } from './client-component-renderer-logger'
 
 export function isAbortError(e: any): e is Error & { name: 'AbortError' } {
   return e?.name === 'AbortError' || e?.name === ResponseAbortedName
@@ -48,6 +49,23 @@ function createWriterFromResponse(
       // started writing chunks.
       if (!started) {
         started = true
+
+        if (
+          typeof performance !== 'undefined' &&
+          process.env.NEXT_OTEL_PERFORMANCE_PREFIX
+        ) {
+          const metrics = getClientComponentLoaderMetrics()
+          performance.measure(
+            `${process.env.NEXT_OTEL_PERFORMANCE_PREFIX}:next-client-component-loading`,
+            {
+              start: metrics.clientComponentLoadStart,
+              end:
+                metrics.clientComponentLoadStart +
+                metrics.clientComponentLoadTimes,
+            }
+          )
+        }
+
         res.flushHeaders()
         getTracer().trace(
           NextNodeServerSpan.startResponse,


### PR DESCRIPTION
- Remove a not-needed `performance.measure()` call.
- Fixes reporting client component loading span to happen on headers flush.
- Simplifies measures by using `performance.now()`


Closes NEXT-2546