### PR TITLE
fix(next-core): properly normalize app route for _

### DIFF
--- a/packages/next-swc/crates/next-core/src/app_structure.rs
+++ b/packages/next-swc/crates/next-core/src/app_structure.rs
@@ -381,7 +381,7 @@ async fn get_directory_tree_internal(
                 // appDir ignores paths starting with an underscore
                 if !basename.starts_with('_') {
                     let result = get_directory_tree(dir, page_extensions);
-                    subdirectories.insert(get_underscore_normalized_path(basename), result);
+                    subdirectories.insert(basename.to_string(), result);
                 }
             }
             // TODO(WEB-952) handle symlinks in app dir
@@ -1143,11 +1143,6 @@ async fn directory_tree_to_entrypoints_internal_untraced(
         }
     }
     Ok(Vc::cell(result))
-}
-
-/// If path contains %5F, replace it with _. [reference](https://github.com/vercel/next.js/blob/c390c1662bc79e12cf7c037dcb382ef5ead6e492/packages/next/src/build/entries.ts#L119)
-fn get_underscore_normalized_path(path: &str) -> String {
-    path.replace("%5F", "_")
 }
 
 /// Returns the global metadata for an app directory.

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -4667,9 +4667,10 @@
   "test/e2e/app-dir/underscore-ignore-app-paths/underscore-ignore-app-paths.test.ts": {
     "passed": [
       "underscore-ignore-app-paths should not serve app path with underscore",
-      "underscore-ignore-app-paths should serve pages path with underscore"
+      "underscore-ignore-app-paths should serve pages path with underscore",
+      "underscore-ignore-app-paths should serve app path with %5F"
     ],
-    "failed": ["underscore-ignore-app-paths should serve app path with %5F"],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -2220,11 +2220,10 @@
   "test/e2e/app-dir/_allow-underscored-root-directory/_allow-underscored-root-directory.test.ts": {
     "passed": [
       "_allow-underscored-root-directory should not serve app path with underscore",
-      "_allow-underscored-root-directory should pages path with a underscore at the root"
-    ],
-    "failed": [
+      "_allow-underscored-root-directory should pages path with a underscore at the root",
       "_allow-underscored-root-directory should serve app path with %5F"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
### What

This PR amends turbopack's behavior to handle some cases of normalized path (`%5F` starting path), mainly fixes entry lookup works against original path without normalization, also bends the output path of client reference manifest matchs to what next.js expects. 

Closes PACK-2553