### PR TITLE
Turbopack: resolve endpoints to avoid extra nesting in tracing

### DIFF
--- a/packages/next-swc/crates/next-api/src/app.rs
+++ b/packages/next-swc/crates/next-api/src/app.rs
@@ -381,7 +381,7 @@ impl AppProject {
 }
 
 #[turbo_tasks::function]
-pub async fn app_entry_point_to_route(
+pub fn app_entry_point_to_route(
     app_project: Vc<AppProject>,
     entrypoint: AppEntrypoint,
 ) -> Vc<Route> {

--- a/packages/next-swc/crates/next-api/src/pages.rs
+++ b/packages/next-swc/crates/next-api/src/pages.rs
@@ -182,6 +182,10 @@ impl PagesProject {
             add_dir_to_routes(&mut routes, *pages, make_page_route).await?;
         }
 
+        for route in routes.values_mut() {
+            route.resolve().await?;
+        }
+
         Ok(Vc::cell(routes))
     }
 

--- a/packages/next-swc/crates/next-api/src/route.rs
+++ b/packages/next-swc/crates/next-api/src/route.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{debug::ValueDebugFormat, trace::TraceRawVcs, Completion, Vc};
@@ -9,6 +10,19 @@ pub struct AppPageRoute {
     pub original_name: String,
     pub html_endpoint: Vc<Box<dyn Endpoint>>,
     pub rsc_endpoint: Vc<Box<dyn Endpoint>>,
+}
+
+impl AppPageRoute {
+    async fn resolve(&mut self) -> Result<()> {
+        let Self {
+            html_endpoint,
+            rsc_endpoint,
+            ..
+        } = self;
+        *html_endpoint = html_endpoint.resolve().await?;
+        *rsc_endpoint = rsc_endpoint.resolve().await?;
+        Ok(())
+    }
 }
 
 #[turbo_tasks::value(shared)]
@@ -27,6 +41,33 @@ pub enum Route {
         endpoint: Vc<Box<dyn Endpoint>>,
     },
     Conflict,
+}
+
+impl Route {
+    pub async fn resolve(&mut self) -> Result<()> {
+        match self {
+            Route::Page {
+                html_endpoint,
+                data_endpoint,
+            } => {
+                *html_endpoint = html_endpoint.resolve().await?;
+                *data_endpoint = data_endpoint.resolve().await?;
+            }
+            Route::PageApi { endpoint } => {
+                *endpoint = endpoint.resolve().await?;
+            }
+            Route::AppPage(routes) => {
+                for route in routes {
+                    route.resolve().await?;
+                }
+            }
+            Route::AppRoute { endpoint, .. } => {
+                *endpoint = endpoint.resolve().await?;
+            }
+            Route::Conflict => {}
+        }
+        Ok(())
+    }
 }
 
 #[turbo_tasks::value_trait]


### PR DESCRIPTION
### Why?

Allows to correctly aggregate different endpoints in tracing

Closes PACK-2559