### PR TITLE
Turbopack: limit build concurrency, show progress bar

### DIFF
--- a/packages/next/src/build/progress.ts
+++ b/packages/next/src/build/progress.ts
@@ -68,22 +68,19 @@ export const createProgress = (total: number, label: string) => {
     }
 
     const isFinished = curProgress === total
-    // Use \r to reset current line with spinner.
-    // If it's 100% progressed, then we don't need to break a new line to avoid logging from routes while building.
-    const newText = `\r ${
-      isFinished ? Log.prefixes.event : Log.prefixes.info
-    } ${label} (${curProgress}/${total}) ${
-      isFinished ? '' : process.stdout.isTTY ? '\n' : '\r'
-    }`
-    if (progressSpinner) {
-      progressSpinner.text = newText
+    if (progressSpinner && !isFinished) {
+      progressSpinner.setText(`${label} (${curProgress}/${total})`)
     } else {
-      console.log(newText)
-    }
-
-    if (isFinished && progressSpinner) {
-      progressSpinner.stop()
-      console.log(newText)
+      if (progressSpinner) {
+        progressSpinner.stop()
+      }
+      console.log(
+        ` ${
+          isFinished ? Log.prefixes.event : Log.prefixes.info
+        } ${label} (${curProgress}/${total}) ${
+          isFinished ? '' : process.stdout.isTTY ? '\n' : '\r'
+        }`
+      )
     }
   }
 }

--- a/packages/next/src/build/progress.ts
+++ b/packages/next/src/build/progress.ts
@@ -1,0 +1,89 @@
+import * as Log from '../build/output/log'
+import createSpinner from './spinner'
+
+function divideSegments(number: number, segments: number): number[] {
+  const result = []
+  while (number > 0 && segments > 0) {
+    const dividedNumber =
+      number < segments ? number : Math.floor(number / segments)
+
+    number -= dividedNumber
+    segments--
+    result.push(dividedNumber)
+  }
+  return result
+}
+
+export const createProgress = (total: number, label: string) => {
+  const segments = divideSegments(total, 4)
+
+  if (total === 0) {
+    throw new Error('invariant: progress total can not be zero')
+  }
+  let currentSegmentTotal = segments.shift()
+  let currentSegmentCount = 0
+  let lastProgressOutput = Date.now()
+  let curProgress = 0
+  let progressSpinner = createSpinner(`${label} (${curProgress}/${total})`, {
+    spinner: {
+      frames: [
+        '[    ]',
+        '[=   ]',
+        '[==  ]',
+        '[=== ]',
+        '[ ===]',
+        '[  ==]',
+        '[   =]',
+        '[    ]',
+        '[   =]',
+        '[  ==]',
+        '[ ===]',
+        '[====]',
+        '[=== ]',
+        '[==  ]',
+        '[=   ]',
+      ],
+      interval: 200,
+    },
+  })
+
+  return () => {
+    curProgress++
+
+    // Make sure we only log once
+    // - per fully generated segment, or
+    // - per minute
+    // when not showing the spinner
+    if (!progressSpinner) {
+      currentSegmentCount++
+
+      if (currentSegmentCount === currentSegmentTotal) {
+        currentSegmentTotal = segments.shift()
+        currentSegmentCount = 0
+      } else if (lastProgressOutput + 60000 > Date.now()) {
+        return
+      }
+
+      lastProgressOutput = Date.now()
+    }
+
+    const isFinished = curProgress === total
+    // Use \r to reset current line with spinner.
+    // If it's 100% progressed, then we don't need to break a new line to avoid logging from routes while building.
+    const newText = `\r ${
+      isFinished ? Log.prefixes.event : Log.prefixes.info
+    } ${label} (${curProgress}/${total}) ${
+      isFinished ? '' : process.stdout.isTTY ? '\n' : '\r'
+    }`
+    if (progressSpinner) {
+      progressSpinner.text = newText
+    } else {
+      console.log(newText)
+    }
+
+    if (isFinished && progressSpinner) {
+      progressSpinner.stop()
+      console.log(newText)
+    }
+  }
+}

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -18,7 +18,6 @@ import { dirname, join, resolve, sep } from 'path'
 import { formatAmpMessages } from '../build/output/index'
 import type { AmpPageStatus } from '../build/output/index'
 import * as Log from '../build/output/log'
-import createSpinner from '../build/spinner'
 import { RSC_SUFFIX, SSG_FALLBACK_EXPORT_ERROR } from '../lib/constants'
 import { recursiveCopy } from '../lib/recursive-copy'
 import {
@@ -56,93 +55,7 @@ import { needsExperimentalReact } from '../lib/needs-experimental-react'
 import { formatManifest } from '../build/manifests/formatter/format-manifest'
 import { validateRevalidate } from '../server/lib/patch-fetch'
 import { TurborepoAccessTraceResult } from '../build/turborepo-access-trace'
-
-function divideSegments(number: number, segments: number): number[] {
-  const result = []
-  while (number > 0 && segments > 0) {
-    const dividedNumber =
-      number < segments ? number : Math.floor(number / segments)
-
-    number -= dividedNumber
-    segments--
-    result.push(dividedNumber)
-  }
-  return result
-}
-
-const createProgress = (total: number, label: string) => {
-  const segments = divideSegments(total, 4)
-
-  if (total === 0) {
-    throw new Error('invariant: progress total can not be zero')
-  }
-  let currentSegmentTotal = segments.shift()
-  let currentSegmentCount = 0
-  let lastProgressOutput = Date.now()
-  let curProgress = 0
-  let progressSpinner = createSpinner(`${label} (${curProgress}/${total})`, {
-    spinner: {
-      frames: [
-        '[    ]',
-        '[=   ]',
-        '[==  ]',
-        '[=== ]',
-        '[ ===]',
-        '[  ==]',
-        '[   =]',
-        '[    ]',
-        '[   =]',
-        '[  ==]',
-        '[ ===]',
-        '[====]',
-        '[=== ]',
-        '[==  ]',
-        '[=   ]',
-      ],
-      interval: 200,
-    },
-  })
-
-  return () => {
-    curProgress++
-
-    // Make sure we only log once
-    // - per fully generated segment, or
-    // - per minute
-    // when not showing the spinner
-    if (!progressSpinner) {
-      currentSegmentCount++
-
-      if (currentSegmentCount === currentSegmentTotal) {
-        currentSegmentTotal = segments.shift()
-        currentSegmentCount = 0
-      } else if (lastProgressOutput + 60000 > Date.now()) {
-        return
-      }
-
-      lastProgressOutput = Date.now()
-    }
-
-    const isFinished = curProgress === total
-    // Use \r to reset current line with spinner.
-    // If it's 100% progressed, then we don't need to break a new line to avoid logging from routes while building.
-    const newText = `\r ${
-      isFinished ? Log.prefixes.event : Log.prefixes.info
-    } ${label} (${curProgress}/${total}) ${
-      isFinished ? '' : process.stdout.isTTY ? '\n' : '\r'
-    }`
-    if (progressSpinner) {
-      progressSpinner.text = newText
-    } else {
-      console.log(newText)
-    }
-
-    if (isFinished && progressSpinner) {
-      progressSpinner.stop()
-      console.log(newText)
-    }
-  }
-}
+import { createProgress } from '../build/progress'
 
 export class ExportError extends Error {
   code = 'NEXT_EXPORT_ERROR'


### PR DESCRIPTION
### What?

Run 10 concurrent Turbopack compilation jobs instead of all of them
show a progress spinner

### Why?

* In future this allows to reclaim memory for finished jobs
* It looks nicer in tracing


Closes PACK-2561