### PR TITLE
fix stream compatible

### DIFF
--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js
@@ -2060,7 +2060,13 @@ function createFromReadableStream(stream, options) {
 function createFromFetch(promiseForResponse, options) {
   var response = createResponseFromOptions(options);
   promiseForResponse.then(function (r) {
-    startReadingFromStream(response, r.body);
+        if (r.body) {
+            startReadingFromStream(response, r.body);
+          } else {
+           r.blob().then(function (blob) {
+               startReadingFromStream(response, blob.stream());
+            })
+          }
   }, function (e) {
     reportGlobalError(response, e);
   });


### PR DESCRIPTION
What?
Enhances streaming compatibility in Next.js by handling cases where fetch responses lack a direct body stream.

Why?
To ensure data can be streamed efficiently, even when the fetch API does not provide a body stream, improving the framework's robustness and functionality.

How?
Implements a workaround by converting the response to a blob and then using blob.stream() for streaming the data.

Fixes #56641 