### PR TITLE
feat(error-overlay): hide `<unknown>`/`stringify` methods in `<anonymous>` file from stack

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
@@ -2,79 +2,64 @@ import * as React from 'react'
 import { CodeFrame } from '../../components/CodeFrame'
 import type { ReadyRuntimeError } from '../../helpers/getErrorByType'
 import { noop as css } from '../../helpers/noop-template'
-import type { OriginalStackFrame } from '../../helpers/stack-frame'
 import { groupStackFramesByFramework } from '../../helpers/group-stack-frames-by-framework'
 import { GroupedStackFrames } from './GroupedStackFrames'
 import { ComponentStackFrameRow } from './ComponentStackFrameRow'
 
 export type RuntimeErrorProps = { error: ReadyRuntimeError }
 
-const RuntimeError: React.FC<RuntimeErrorProps> = function RuntimeError({
-  error,
-}) {
-  const firstFirstPartyFrameIndex = React.useMemo<number>(() => {
-    return error.frames.findIndex(
-      (entry) =>
-        entry.expanded &&
-        Boolean(entry.originalCodeFrame) &&
-        Boolean(entry.originalStackFrame)
-    )
-  }, [error.frames])
-  const firstFrame = React.useMemo<OriginalStackFrame | null>(() => {
-    return error.frames[firstFirstPartyFrameIndex] ?? null
-  }, [error.frames, firstFirstPartyFrameIndex])
+export function RuntimeError({ error }: RuntimeErrorProps) {
+  const { firstFrame, allLeadingFrames, allCallStackFrames } =
+    React.useMemo(() => {
+      const filteredFrames = error.frames.filter(
+        (f) => f.sourceStackFrame.file !== '<anonymous>'
+      )
 
-  const allLeadingFrames = React.useMemo<OriginalStackFrame[]>(
-    () =>
-      firstFirstPartyFrameIndex < 0
-        ? []
-        : error.frames.slice(0, firstFirstPartyFrameIndex),
-    [error.frames, firstFirstPartyFrameIndex]
-  )
+      const firstFirstPartyFrameIndex = filteredFrames.findIndex(
+        (entry) =>
+          entry.expanded &&
+          Boolean(entry.originalCodeFrame) &&
+          Boolean(entry.originalStackFrame)
+      )
+
+      return {
+        firstFrame: filteredFrames[firstFirstPartyFrameIndex] ?? null,
+        allLeadingFrames:
+          firstFirstPartyFrameIndex < 0
+            ? []
+            : filteredFrames.slice(0, firstFirstPartyFrameIndex),
+        allCallStackFrames: filteredFrames.slice(firstFirstPartyFrameIndex + 1),
+      }
+    }, [error.frames])
 
   const [all, setAll] = React.useState(firstFrame == null)
-  const toggleAll = React.useCallback(() => {
-    setAll((v) => !v)
-  }, [])
 
-  const leadingFrames = React.useMemo(
-    () => allLeadingFrames.filter((f) => f.expanded || all),
-    [all, allLeadingFrames]
-  )
-  const allCallStackFrames = React.useMemo<OriginalStackFrame[]>(
-    () => error.frames.slice(firstFirstPartyFrameIndex + 1),
-    [error.frames, firstFirstPartyFrameIndex]
-  )
-  const visibleCallStackFrames = React.useMemo<OriginalStackFrame[]>(
-    () => allCallStackFrames.filter((f) => f.expanded || all),
-    [all, allCallStackFrames]
-  )
-
-  const canShowMore = React.useMemo<boolean>(() => {
-    return (
-      allCallStackFrames.length !== visibleCallStackFrames.length ||
-      (all && firstFrame != null)
+  const {
+    canShowMore,
+    stackFramesGroupedByFramework,
+    leadingFramesGroupedByFramework,
+  } = React.useMemo(() => {
+    const leadingFrames = allLeadingFrames.filter((f) => f.expanded || all)
+    const visibleCallStackFrames = allCallStackFrames.filter(
+      (f) => f.expanded || all
     )
-  }, [
-    all,
-    allCallStackFrames.length,
-    firstFrame,
-    visibleCallStackFrames.length,
-  ])
 
-  const stackFramesGroupedByFramework = React.useMemo(
-    () => groupStackFramesByFramework(allCallStackFrames),
-    [allCallStackFrames]
-  )
+    return {
+      canShowMore:
+        allCallStackFrames.length !== visibleCallStackFrames.length ||
+        (all && firstFrame != null),
 
-  const leadingFramesGroupedByFramework = React.useMemo(
-    () => groupStackFramesByFramework(leadingFrames),
-    [leadingFrames]
-  )
+      stackFramesGroupedByFramework:
+        groupStackFramesByFramework(allCallStackFrames),
+
+      leadingFramesGroupedByFramework:
+        groupStackFramesByFramework(leadingFrames),
+    }
+  }, [all, allCallStackFrames, allLeadingFrames, firstFrame])
 
   return (
     <React.Fragment>
-      {firstFrame ? (
+      {firstFrame && (
         <React.Fragment>
           <h2>Source</h2>
           <GroupedStackFrames
@@ -86,7 +71,7 @@ const RuntimeError: React.FC<RuntimeErrorProps> = function RuntimeError({
             codeFrame={firstFrame.originalCodeFrame!}
           />
         </React.Fragment>
-      ) : undefined}
+      )}
 
       {error.componentStackFrames ? (
         <>
@@ -115,7 +100,7 @@ const RuntimeError: React.FC<RuntimeErrorProps> = function RuntimeError({
             tabIndex={10}
             data-nextjs-data-runtime-error-collapsed-action
             type="button"
-            onClick={toggleAll}
+            onClick={() => setAll(!all)}
           >
             {all ? 'Hide' : 'Show'} collapsed frames
           </button>
@@ -212,5 +197,3 @@ export const styles = css`
     margin-bottom: var(--size-gap-double);
   }
 `
-
-export { RuntimeError }

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
@@ -63,7 +63,7 @@ export function RuntimeError({ error }: RuntimeErrorProps) {
 
   return (
     <React.Fragment>
-      {firstFrame && (
+      {firstFrame ? (
         <React.Fragment>
           <h2>Source</h2>
           <GroupedStackFrames
@@ -75,7 +75,7 @@ export function RuntimeError({ error }: RuntimeErrorProps) {
             codeFrame={firstFrame.originalCodeFrame!}
           />
         </React.Fragment>
-      )}
+      ) : undefined}
 
       {error.componentStackFrames ? (
         <>

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
@@ -12,7 +12,11 @@ export function RuntimeError({ error }: RuntimeErrorProps) {
   const { firstFrame, allLeadingFrames, allCallStackFrames } =
     React.useMemo(() => {
       const filteredFrames = error.frames.filter(
-        (f) => f.sourceStackFrame.file !== '<anonymous>'
+        (f) =>
+          !(
+            f.sourceStackFrame.file === '<anonymous>' &&
+            ['stringify', '<unknown>'].includes(f.sourceStackFrame.methodName)
+          )
       )
 
       const firstFirstPartyFrameIndex = filteredFrames.findIndex(
@@ -36,8 +40,8 @@ export function RuntimeError({ error }: RuntimeErrorProps) {
 
   const {
     canShowMore,
-    stackFramesGroupedByFramework,
     leadingFramesGroupedByFramework,
+    stackFramesGroupedByFramework,
   } = React.useMemo(() => {
     const leadingFrames = allLeadingFrames.filter((f) => f.expanded || all)
     const visibleCallStackFrames = allCallStackFrames.filter(

--- a/packages/next/src/client/components/react-dev-overlay/server/shared.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/shared.ts
@@ -17,7 +17,7 @@ const reactVendoredRe =
 const reactNodeModulesRe = /node_modules[\\/](react|react-dom|scheduler)[\\/]/
 
 const nextRe =
-  /([\\/]next[\\/](dist|src)[\\/]|[\\/].next[\\/]static[\\/]chunks[\\/]webpack\.js$)/
+  /([\\/]next[\\/]|[\\/].next[\\/]static[\\/]chunks[\\/]webpack\.js$)/
 
 /** Given a potential file path, it parses which package the file belongs to. */
 export function findSourcePackage(

--- a/packages/next/src/client/components/react-dev-overlay/server/shared.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/shared.ts
@@ -17,7 +17,7 @@ const reactVendoredRe =
 const reactNodeModulesRe = /node_modules[\\/](react|react-dom|scheduler)[\\/]/
 
 const nextRe =
-  /([\\/]next[\\/]|[\\/].next[\\/]static[\\/]chunks[\\/]webpack\.js$)/
+  /(node_modules[\\/]next[\\/]|[\\/].next[\\/]static[\\/]chunks[\\/]webpack\.js$)/
 
 /** Given a potential file path, it parses which package the file belongs to. */
 export function findSourcePackage(


### PR DESCRIPTION
### What?

Clean up the error overlay:

<details>
<summary><b>Before:</b></summary>
<img src="https://github.com/vercel/next.js/assets/18369201/22c3ab2c-8445-4c25-8554-a5ab51100af4"/>
</details>

<details>
<summary><b>After:</b></summary>
<img src="https://github.com/vercel/next.js/assets/18369201/403c30fc-8b27-4529-838c-47d9cbe52381"/></details>


I also simplified the current code as it was likely using `useMemo` a bit eagerly.

### Why?

This is an unactionable line by the user, no value in showing it in the overlay.

### How?

Filter out the frame before rendering it in the overlay.

This answers [this question](https://github.com/vercel/next.js/pull/62206#issuecomment-1956636486) too, since the module grouping is local. Now that `<anonymous>` is filtered out, the two Next.js groups are now merged into one, further cleaning up the stack.

Closes NEXT-2505