### PR TITLE
Update @types/react and @types/react-dom versions in create-next-app setup script

### DIFF
--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -201,7 +201,7 @@ export const installTemplate = async ({
       typescript: "^5",
       "@types/node": "^20",
       "@types/react": "^18.2.57",
-      "@types/react-dom": "^18",
+      "@types/react-dom": "^18.2.19",
     };
   }
 

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -200,7 +200,7 @@ export const installTemplate = async ({
       ...packageJson.devDependencies,
       typescript: "^5",
       "@types/node": "^20",
-      "@types/react": "^18",
+      "@types/react": "^18.2.57",
       "@types/react-dom": "^18",
     };
   }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
This PR updates the versions of `@types/react` and `@types/react-dom` used in the create-next-app setup script from the generic `^18` to the specific latest versions, `^18.2.57` and `^18.2.19` respectively. This approach sometimes results in having the version numbers resolve to the base version (18.0.0), ignoring all other updates, and making TypeScript throw errors when importing features added after the base version.

Example:
Importing `cache` from react throws the error below because of this issue

```bash
Module '"react"' has no exported member 'cache'.
```
<img width="1173" alt="Screenshot 2024-02-21 at 17 54 14" src="https://github.com/vercel/next.js/assets/74430629/f7cb76cd-3776-4114-9c79-d7f5a0fc63f2">

Example project showing the error
https://github.com/Eprince-hub/cache-import-error-repro

The above example is a new next.js project created with `create-next-app` by running the script below
`pnpm create next-app@latest . --app --no-eslint --no-src-dir --import-alias @/\* --no-tailwind` and choosing the option for the project to be created in TypeScript. I installed another dependency with a dependency "@types/react": "^18.0.0", and the error happens when I import  `cache` from react `import { cache } from 'react';`, "(maybe it's also possible to reproduce without the extra dependency installation)"

Changes Made:
- Updated `@types/react` version from `^18` to `^18.2.57`
- Updated `@types/react-dom` version from `^18` to `^18.2.19`





