### PR TITLE
Revert "Ensure webpack build worker defaults on"

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1495,8 +1495,12 @@ export default async function build(
       let buildTraceContext: undefined | BuildTraceContext
       let buildTracesPromise: Promise<any> | undefined = undefined
 
-      // webpack build worker is always enabled unless manually disabled
-      const useBuildWorker = config.experimental.webpackBuildWorker !== false
+      // If there's has a custom webpack config and disable the build worker.
+      // Otherwise respect the option if it's set.
+      const useBuildWorker =
+        config.experimental.webpackBuildWorker ||
+        (config.experimental.webpackBuildWorker === undefined &&
+          !config.webpack)
       const runServerAndEdgeInParallel =
         config.experimental.parallelServerCompiles
       const collectServerBuildTracesInParallel =

--- a/test/e2e/streaming-ssr/index.test.ts
+++ b/test/e2e/streaming-ssr/index.test.ts
@@ -170,11 +170,7 @@ if (isNextProd) {
 
     it('should pass correct nextRuntime values', async () => {
       const content = await next.readFile('runtimes.txt')
-      expect([...new Set(content.split('\n'))].sort()).toEqual([
-        'client',
-        'edge',
-        'nodejs',
-      ])
+      expect(content.split('\n').sort()).toEqual(['client', 'edge', 'nodejs'])
     })
 
     it('should generate html response by streaming correctly', async () => {


### PR DESCRIPTION
Reverts vercel/next.js#62214

Enabling build worker by default breaks some mdx rendering pages with `next build`
x-ref: https://vercel.slack.com/archives/C04DUD7EB1B/p1708543258307169