### PR TITLE
Pass whole prefetch entry rather than status property

### DIFF
--- a/packages/next/src/client/components/router-reducer/apply-flight-data.ts
+++ b/packages/next/src/client/components/router-reducer/apply-flight-data.ts
@@ -2,12 +2,13 @@ import type { CacheNode } from '../../../shared/lib/app-router-context.shared-ru
 import type { FlightDataPath } from '../../../server/app-render/types'
 import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-head'
 import { fillCacheWithNewSubTreeData } from './fill-cache-with-new-subtree-data'
+import type { PrefetchCacheEntry } from './router-reducer-types'
 
 export function applyFlightData(
   existingCache: CacheNode,
   cache: CacheNode,
   flightDataPath: FlightDataPath,
-  hasReusablePrefetch: boolean = false
+  prefetchEntry?: PrefetchCacheEntry
 ): boolean {
   // The one before last item is the router state tree patch
   const [treePatch, cacheNodeSeedData, head] = flightDataPath.slice(-3)
@@ -32,7 +33,7 @@ export function applyFlightData(
       treePatch,
       cacheNodeSeedData,
       head,
-      hasReusablePrefetch
+      prefetchEntry
     )
   } else {
     // Copy rsc for the root node of the cache.
@@ -47,7 +48,7 @@ export function applyFlightData(
       cache,
       existingCache,
       flightDataPath,
-      hasReusablePrefetch
+      prefetchEntry
     )
   }
 

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
@@ -78,7 +78,7 @@ describe('fillCacheWithNewSubtreeData', () => {
     // Mirrors the way router-reducer values are passed in.
     const flightDataPath = flightData[0]
 
-    fillCacheWithNewSubTreeData(cache, existingCache, flightDataPath, false)
+    fillCacheWithNewSubTreeData(cache, existingCache, flightDataPath)
 
     const expectedCache: CacheNode = {
       lazyData: null,

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
@@ -6,6 +6,7 @@ import type {
 import { invalidateCacheByRouterState } from './invalidate-cache-by-router-state'
 import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-head'
 import { createRouterCacheKey } from './create-router-cache-key'
+import type { PrefetchCacheEntry } from './router-reducer-types'
 
 /**
  * Fill cache with rsc based on flightDataPath
@@ -14,7 +15,7 @@ export function fillCacheWithNewSubTreeData(
   newCache: CacheNode,
   existingCache: CacheNode,
   flightDataPath: FlightDataPath,
-  hasReusablePrefetch?: boolean
+  prefetchEntry?: PrefetchCacheEntry
 ): void {
   const isLastEntry = flightDataPath.length <= 5
   const [parallelRouteKey, segment] = flightDataPath
@@ -71,7 +72,7 @@ export function fillCacheWithNewSubTreeData(
         flightDataPath[2],
         seedData,
         flightDataPath[4],
-        hasReusablePrefetch
+        prefetchEntry
       )
 
       childSegmentMap.set(cacheKey, childCacheNode)
@@ -99,6 +100,6 @@ export function fillCacheWithNewSubTreeData(
     childCacheNode,
     existingChildCacheNode,
     flightDataPath.slice(2),
-    hasReusablePrefetch
+    prefetchEntry
   )
 }

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
@@ -4,6 +4,10 @@ import type {
   CacheNodeSeedData,
 } from '../../../server/app-render/types'
 import { createRouterCacheKey } from './create-router-cache-key'
+import {
+  PrefetchCacheEntryStatus,
+  type PrefetchCacheEntry,
+} from './router-reducer-types'
 
 export function fillLazyItemsTillLeafWithHead(
   newCache: CacheNode,
@@ -11,7 +15,7 @@ export function fillLazyItemsTillLeafWithHead(
   routerState: FlightRouterState,
   cacheNodeSeedData: CacheNodeSeedData | null,
   head: React.ReactNode,
-  hasReusablePrefetch?: boolean
+  prefetchEntry?: PrefetchCacheEntry
 ): void {
   const isLastSegment = Object.keys(routerState[1]).length === 0
   if (isLastSegment) {
@@ -42,6 +46,10 @@ export function fillLazyItemsTillLeafWithHead(
       const existingParallelRoutesCacheNode =
         existingCache.parallelRoutes.get(key)
       if (existingParallelRoutesCacheNode) {
+        const hasReusablePrefetch =
+          prefetchEntry?.kind === 'auto' &&
+          prefetchEntry.status === PrefetchCacheEntryStatus.reusable
+
         let parallelRouteCacheNode = new Map(existingParallelRoutesCacheNode)
         const existingCacheNode = parallelRouteCacheNode.get(cacheKey)
         let newCacheNode: CacheNode
@@ -91,7 +99,7 @@ export function fillLazyItemsTillLeafWithHead(
           parallelRouteState,
           parallelSeedData ? parallelSeedData : null,
           head,
-          hasReusablePrefetch
+          prefetchEntry
         )
 
         newCache.parallelRoutes.set(key, parallelRouteCacheNode)
@@ -133,7 +141,7 @@ export function fillLazyItemsTillLeafWithHead(
       parallelRouteState,
       parallelSeedData,
       head,
-      hasReusablePrefetch
+      prefetchEntry
     )
   }
 }

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
@@ -84,7 +84,7 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
     cache.rsc = existingCache.rsc
     cache.prefetchRsc = existingCache.prefetchRsc
     // Create a copy of the existing cache with the rsc applied.
-    fillCacheWithNewSubTreeData(cache, existingCache, flightDataPath, false)
+    fillCacheWithNewSubTreeData(cache, existingCache, flightDataPath)
 
     // Invalidate the cache below the flight segment path. This should remove the 'about' node.
     invalidateCacheBelowFlightSegmentPath(

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -15,7 +15,6 @@ import type {
   ReadonlyReducerState,
   ReducerState,
 } from '../router-reducer-types'
-import { PrefetchCacheEntryStatus } from '../router-reducer-types'
 import { handleMutable } from '../handle-mutable'
 import { applyFlightData } from '../apply-flight-data'
 import { prefetchQueue } from './prefetch-reducer'
@@ -104,11 +103,7 @@ function navigateReducer_noPPR(
     buildId: state.buildId,
     prefetchCache: state.prefetchCache,
   })
-  const {
-    treeAtTimeOfPrefetch,
-    data,
-    status: prefetchEntryCacheStatus,
-  } = prefetchValues
+  const { treeAtTimeOfPrefetch, data } = prefetchValues
 
   prefetchQueue.bump(data)
 
@@ -168,8 +163,7 @@ function navigateReducer_noPPR(
             currentCache,
             cache,
             flightDataPath,
-            prefetchValues.kind === 'auto' &&
-              prefetchEntryCacheStatus === PrefetchCacheEntryStatus.reusable
+            prefetchValues
           )
 
           const hardNavigate = shouldHardNavigate(
@@ -252,11 +246,7 @@ function navigateReducer_PPR(
     buildId: state.buildId,
     prefetchCache: state.prefetchCache,
   })
-  const {
-    treeAtTimeOfPrefetch,
-    data,
-    status: prefetchEntryCacheStatus,
-  } = prefetchValues
+  const { treeAtTimeOfPrefetch, data } = prefetchValues
 
   prefetchQueue.bump(data)
 
@@ -393,8 +383,7 @@ function navigateReducer_PPR(
               currentCache,
               cache,
               flightDataPath,
-              prefetchValues.kind === 'auto' &&
-                prefetchEntryCacheStatus === PrefetchCacheEntryStatus.reusable
+              prefetchValues
             )
 
             const hardNavigate = shouldHardNavigate(


### PR DESCRIPTION
No change in behavior -- this PR updates `applyFlightData` and its recursive functions to receive the prefetch entry rather than a boolean. We only use the actual prefetch entry in `fillLazyItemsTillLeafWithHead` but I found kept getting confused about what this argument was needed for when it was provided so far away from the part where we read the boolean. 

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2556