### PR TITLE
Update data cache max size error

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -562,15 +562,18 @@ export class IncrementalCache implements IncrementalCacheType {
 
     if (this.dev && !ctx.fetchCache) return
     // FetchCache has upper limit of 2MB per-entry currently
+    const itemSize = JSON.stringify(data).length
     if (
       ctx.fetchCache &&
       // we don't show this error/warning when a custom cache handler is being used
       // as it might not have this limit
       !this.hasCustomCacheHandler &&
-      JSON.stringify(data).length > 2 * 1024 * 1024
+      itemSize > 2 * 1024 * 1024
     ) {
       if (this.dev) {
-        throw new Error(`fetch for over 2MB of data can not be cached`)
+        throw new Error(
+          `Failed to set Next.js data cache, items over 2MB can not be cached (${itemSize} bytes)`
+        )
       }
       return
     }

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -3091,7 +3091,7 @@ createNextDescribe(
                 .length
             ).toBe(2)
             expect(next.cliOutput.substring(cliOutputStart)).toContain(
-              'Error: fetch for over 2MB of data can not be cached'
+              'Error: Failed to set Next.js data cache, items over 2MB can not be cached'
             )
             return 'success'
           }, 'success')
@@ -3122,7 +3122,7 @@ createNextDescribe(
           }, 'success')
 
           expect(next.cliOutput.substring(cliOutputStart)).not.toContain(
-            'Error: fetch for over 2MB of data can not be cached'
+            'Error: Failed to set Next.js data cache, items over 2MB can not be cached'
           )
         })
       }


### PR DESCRIPTION
Makes the error message more specific to Next.js and provides specific size that exceeded the limit. 

x-ref: [slack thread](https://vercel.slack.com/archives/C05U6TZ2DCP/p1708543103375799)

Closes NEXT-2559