### PR TITLE
Add experimental flag for early exit on prerender error

### DIFF
--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -622,6 +622,14 @@ export async function exportAppImpl(
         })
       })
 
+      if (nextConfig.experimental.prerenderEarlyExit) {
+        if (result && 'error' in result) {
+          throw new Error(
+            `Export encountered an error on ${path}, exiting due to prerenderEarlyExit: true being set`
+          )
+        }
+      }
+
       if (progress) progress()
 
       return { result, path }

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -292,6 +292,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         parallelServerBuildTraces: z.boolean().optional(),
         ppr: z.boolean().optional(),
         taint: z.boolean().optional(),
+        prerenderEarlyExit: z.boolean().optional(),
         proxyTimeout: z.number().gte(0).optional(),
         serverComponentsExternalPackages: z.array(z.string()).optional(),
         scrollRestoration: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -167,6 +167,7 @@ export interface NextJsWebpackConfig {
 }
 
 export interface ExperimentalConfig {
+  prerenderEarlyExit?: boolean
   linkNoTouchStart?: boolean
   caseSensitiveRoutes?: boolean
   useDeploymentId?: boolean
@@ -837,6 +838,7 @@ export const defaultConfig: NextConfig = {
   output: !!process.env.NEXT_PRIVATE_STANDALONE ? 'standalone' : undefined,
   modularizeImports: undefined,
   experimental: {
+    prerenderEarlyExit: false,
     serverMinification: true,
     serverSourceMaps: false,
     linkNoTouchStart: false,


### PR DESCRIPTION
This adds an experimental flag to allow exiting during prerendering when the first path errors instead of waiting until all prerendering is finished to then fail the build. 

x-ref: [slack thread](https://vercel.slack.com/archives/C0676QZBWKS/p1708559793380989)
Closes: NEXT-2561

Closes NEXT-2563