### PR TITLE
fix(next-lint): fix next lint not throwing exit 1 on error

### DIFF
--- a/packages/next/src/cli/next-lint.ts
+++ b/packages/next/src/cli/next-lint.ts
@@ -188,6 +188,8 @@ const nextLint: CliCommand = async (args) => {
         printAndExit(lintOutput, 0)
       } else if (lintResults && !lintOutput) {
         printAndExit(green('✔ No ESLint warnings or errors'), 0)
+      } else {
+        process.exit(1)
       }
     })
     .catch((err) => {


### PR DESCRIPTION
## Changes

The error on https://github.com/vercel/next.js/blob/3e92d8a41d5ed4970e252b6e34f11b100dacd167/packages/next/src/lib/eslint/runLintCheck.ts#L117 runs to the `try` in here → https://github.com/vercel/next.js/blob/3e92d8a41d5ed4970e252b6e34f11b100dacd167/packages/next/src/cli/next-lint.ts#L191 instead of throwing in the `catch`, so we add a last `else` statement to `process.exit(1)`.

Closes NEXT-2567