### PR TITLE
Fix test flake

### DIFF
--- a/test/e2e/app-dir/interception-route-prefetch-cache/app/Modal.tsx
+++ b/test/e2e/app-dir/interception-route-prefetch-cache/app/Modal.tsx
@@ -1,27 +1,15 @@
-'use client'
-
-import { useRouter } from 'next/navigation'
-
 interface ModalProps {
   title: string
   context: string
 }
 
 export function Modal({ title, context }: ModalProps) {
-  const router = useRouter()
-
   return (
     <div>
       <div className="modal">
         <h1>{title}</h1>
         <h2>{context}</h2>
       </div>
-      <div
-        className="modal-overlay"
-        onClick={() => {
-          router.back()
-        }}
-      />
     </div>
   )
 }


### PR DESCRIPTION
This onClick isn't actually being used by the test and seems to be causing a flake unrelated to the test assertions. This removes the unused code for now so we can still keep the relevant part of the test in-tact. (Specifically, this test is asserting that we're using the correct prefetch cache entry for interception routes that originate from different trees but resolve to the same URL)

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2568