### PR TITLE
fix router crash on revalidate + popstate

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -183,6 +183,7 @@ export function createEmptyCacheNode(): CacheNode {
     rsc: null,
     prefetchRsc: null,
     parallelRoutes: new Map(),
+    lazyDataResolved: false,
   }
 }
 
@@ -578,7 +579,6 @@ function Router({
         return
       }
 
-      // @ts-ignore useTransition exists
       // TODO-APP: Ideally the back button should not use startTransition as it should apply the updates synchronously
       // Without startTransition works if the cache is there for this path
       startTransition(() => {

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.test.tsx
@@ -182,6 +182,7 @@ describe('navigateReducer', () => {
         "buildId": "development",
         "cache": {
           "lazyData": null,
+          "lazyDataResolved": false,
           "parallelRoutes": Map {
             "children" => Map {
               "linking" => {
@@ -402,6 +403,7 @@ describe('navigateReducer', () => {
         "buildId": "development",
         "cache": {
           "lazyData": null,
+          "lazyDataResolved": false,
           "parallelRoutes": Map {
             "children" => Map {
               "linking" => {
@@ -1142,6 +1144,7 @@ describe('navigateReducer', () => {
         "buildId": "development",
         "cache": {
           "lazyData": null,
+          "lazyDataResolved": false,
           "parallelRoutes": Map {
             "children" => Map {
               "linking" => {
@@ -1406,6 +1409,7 @@ describe('navigateReducer', () => {
         "buildId": "development",
         "cache": {
           "lazyData": null,
+          "lazyDataResolved": false,
           "parallelRoutes": Map {
             "children" => Map {
               "parallel-tab-bar" => {
@@ -1824,6 +1828,7 @@ describe('navigateReducer', () => {
         "buildId": "development",
         "cache": {
           "lazyData": null,
+          "lazyDataResolved": false,
           "parallelRoutes": Map {
             "children" => Map {
               "linking" => {

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.test.tsx
@@ -165,6 +165,7 @@ describe('serverPatchReducer', () => {
         "buildId": "development",
         "cache": {
           "lazyData": null,
+          "lazyDataResolved": false,
           "parallelRoutes": Map {
             "children" => Map {
               "linking" => {
@@ -378,6 +379,7 @@ describe('serverPatchReducer', () => {
         "buildId": "development",
         "cache": {
           "lazyData": null,
+          "lazyDataResolved": false,
           "parallelRoutes": Map {
             "children" => Map {
               "linking" => {

--- a/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
@@ -18,6 +18,11 @@ export type CacheNode = ReadyCacheNode | LazyCacheNode
 
 export type LazyCacheNode = {
   /**
+   * Whether the lazy cache node data promise has been resolved.
+   * This value is only true after we've called `use` on the promise (and applied the data to the tree).
+   */
+  lazyDataResolved?: boolean
+  /**
    * When rsc is null, this is a lazily-initialized cache node.
    *
    * If the app attempts to render it, it triggers a lazy data fetch,
@@ -59,6 +64,11 @@ export type LazyCacheNode = {
 }
 
 export type ReadyCacheNode = {
+  /**
+   * Whether the lazy cache node data promise has been resolved.
+   * This value is only true after we've called `use` on the promise (and applied the data to the tree).
+   */
+  lazyDataResolved?: boolean
   /**
    * When rsc is not null, it represents the RSC data for the
    * corresponding segment.

--- a/packages/next/src/shared/lib/router/action-queue.ts
+++ b/packages/next/src/shared/lib/router/action-queue.ts
@@ -140,8 +140,8 @@ function dispatchAction(
   const newAction: ActionQueueNode = {
     payload,
     next: null,
-    resolve: resolvers!.resolve,
-    reject: resolvers!.reject,
+    resolve: resolvers.resolve,
+    reject: resolvers.reject,
   }
 
   // Check if the queue is empty

--- a/test/e2e/app-dir/navigation/app/popstate-revalidate/foo/action.ts
+++ b/test/e2e/app-dir/navigation/app/popstate-revalidate/foo/action.ts
@@ -1,0 +1,8 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+
+export async function action() {
+  revalidatePath('/', 'layout')
+  return true
+}

--- a/test/e2e/app-dir/navigation/app/popstate-revalidate/foo/page.tsx
+++ b/test/e2e/app-dir/navigation/app/popstate-revalidate/foo/page.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useFormState } from 'react-dom'
+import { action } from './action'
+
+export default function Page() {
+  const [submitted, formAction] = useFormState(action, false)
+  if (submitted) {
+    return <div>Form Submitted.</div>
+  }
+
+  return (
+    <div>
+      <h1>Form</h1>
+      <form action={formAction}>
+        <button id="submit-button">Push this button to submit the form</button>
+      </form>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/navigation/app/popstate-revalidate/page.tsx
+++ b/test/e2e/app-dir/navigation/app/popstate-revalidate/page.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+
+export default async function Home() {
+  await new Promise((resolve) => setTimeout(resolve, 1500))
+
+  return (
+    <div>
+      <h1>Home</h1>
+      <Link href="/popstate-revalidate/foo">To /foo</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -862,5 +862,28 @@ createNextDescribe(
         })
       })
     })
+
+    describe('browser back to a revalidated page', () => {
+      it('should load the page', async () => {
+        const browser = await next.browser('/popstate-revalidate')
+        expect(await browser.elementByCss('h1').text()).toBe('Home')
+        await browser.elementByCss("[href='/popstate-revalidate/foo']").click()
+        await browser.waitForElementByCss('#submit-button')
+        expect(await browser.elementByCss('h1').text()).toBe('Form')
+        await browser.elementById('submit-button').click()
+
+        await retry(async () => {
+          expect(await browser.elementByCss('body').text()).toContain(
+            'Form Submitted.'
+          )
+        })
+
+        await browser.back()
+
+        await retry(async () => {
+          expect(await browser.elementByCss('h1').text()).toBe('Home')
+        })
+      })
+    })
   }
 )


### PR DESCRIPTION
### What
When the popstate action is fired (as is the case in a browser back button), if the page you're going back to has missing cache node data, the router will crash.

### Why
Almost all router actions will suspend at the app-router level with the exception of `ACTION_RESTORE`. This was to address an issue where suspending in the router would add enough delay for browser scroll restoration behavior not to work. 

As a result, when going back to the page with missing data, app-router wouldn't suspend but layout-router would suspend on the missing data while triggering a lazy fetch. We trigger a server-patch with the applied lazy data, but when React replays the render, it will replay the branch without the cache node data applied. This results in the router getting caught in a loop of suspending, applying the cache node, replaying the branch without the cache node, and eventually crashing due to an error thrown by React to prevent re-suspending indefinitely.

### How
This adds a property to the cache node to signal if the lazy data has been resolved. If it has been, we won't call the server patch action again. 

Fixes #61336
Closes NEXT-2438
