### PR TITLE
Correctly pass prependData and additionalData to sass-loader for Turbopack

### DIFF
--- a/packages/next-swc/crates/next-core/src/sass.rs
+++ b/packages/next-swc/crates/next-core/src/sass.rs
@@ -26,6 +26,8 @@ pub async fn maybe_add_sass_loader(
         ("*.scss", ".css"),
         ("*.sass", ".css"),
     ] {
+        // additionalData is a loader option but Next.js has it under `sassOptions` in
+        // `next.config.js`
         let additional_data = sass_options
             .get("prependData")
             .or(sass_options.get("additionalData"));

--- a/packages/next-swc/crates/next-core/src/sass.rs
+++ b/packages/next-swc/crates/next-core/src/sass.rs
@@ -26,6 +26,9 @@ pub async fn maybe_add_sass_loader(
         ("*.scss", ".css"),
         ("*.sass", ".css"),
     ] {
+        let additional_data = sass_options
+            .get("prependData")
+            .or(sass_options.get("additionalData"));
         let rule = rules.get_mut(pattern);
         let loader = WebpackLoaderItem {
             loader: "next/dist/compiled/sass-loader".to_string(),
@@ -33,6 +36,7 @@ pub async fn maybe_add_sass_loader(
                 //https://github.com/vercel/turbo/blob/d527eb54be384a4658243304cecd547d09c05c6b/crates/turbopack-node/src/transforms/webpack.rs#L191
                 "sourceMap": false,
                 "sassOptions": sass_options,
+                "additionalData": additional_data
             })
             .as_object()
             .unwrap()


### PR DESCRIPTION
## What?

Ensures that `prependData` and `additionalData` are passed as loader options instead of as part of `sassOptions`, mirrors webpack behavior.

Covers two cases that currently fail in #62321.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2571