### PR TITLE
better reference for what is serializable by React

### DIFF
--- a/docs/02-app/01-building-your-application/03-rendering/03-composition-patterns.mdx
+++ b/docs/02-app/01-building-your-application/03-rendering/03-composition-patterns.mdx
@@ -402,7 +402,7 @@ export default function Layout({ children }) {
 
 ### Passing props from Server to Client Components (Serialization)
 
-If you fetch data in a Server Component, you may want to pass data down as props to Client Components. Props passed from the Server to Client Components need to be [serializable](https://developer.mozilla.org/docs/Glossary/Serialization) by React.
+If you fetch data in a Server Component, you may want to pass data down as props to Client Components. Props passed from the Server to Client Components need to be [serializable](https://react.dev/reference/react/use-server#serializable-parameters-and-return-values) by React.
 
 If your Client Components depend on data that is not serializable, you can [fetch data on the client with a third party library](/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating#fetching-data-on-the-client-with-third-party-libraries) or on the server via a [Route Handler](/docs/app/building-your-application/routing/route-handlers).
 


### PR DESCRIPTION
The current link just takes you to the definition of serialization on MDN.  I'm proposing this should link to the React docs and what they are able to serialize because it is way more than JSON.
