### PR TITLE
chore(cli): add clarifying comment

### DIFF
--- a/packages/next/src/cli/next-lint.ts
+++ b/packages/next/src/cli/next-lint.ts
@@ -189,6 +189,8 @@ const nextLint: CliCommand = async (args) => {
       } else if (lintResults && !lintOutput) {
         printAndExit(green('✔ No ESLint warnings or errors'), 0)
       } else {
+        // this makes sure we exit 1 after the error from line 116
+        // in packages/next/src/lib/eslint/runLintCheck
         process.exit(1)
       }
     })


### PR DESCRIPTION
## Changes

- Add clarifying comment around why we're `process.exit(1)` at the end of `runLintCheck`
- Related → https://github.com/vercel/next.js/pull/62378
- Fixes → https://github.com/vercel/next.js/issues/31605

Closes NEXT-2576