### PR TITLE
OTEL: Add top span for middleware

### DIFF
--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -106,6 +106,10 @@ enum ResolveMetadataSpan {
   generateViewport = 'ResolveMetadata.generateViewport',
 }
 
+enum MiddlewareSpan {
+  execute = 'Middleware.execute',
+}
+
 type SpanTypes =
   | `${BaseServerSpan}`
   | `${LoadComponentsSpan}`
@@ -118,9 +122,11 @@ type SpanTypes =
   | `${NodeSpan}`
   | `${AppRouteRouteHandlersSpan}`
   | `${ResolveMetadataSpan}`
+  | `${MiddlewareSpan}`
 
 // This list is used to filter out spans that are not relevant to the user
 export const NextVanillaSpanAllowlist = [
+  MiddlewareSpan.execute,
   BaseServerSpan.handleRequest,
   RenderSpan.getServerSideProps,
   RenderSpan.getStaticProps,
@@ -158,6 +164,7 @@ export {
   NodeSpan,
   AppRouteRouteHandlersSpan,
   ResolveMetadataSpan,
+  MiddlewareSpan,
 }
 
 export type { SpanTypes }

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -18,6 +18,7 @@ import { RequestAsyncStorageWrapper } from '../async-storage/request-async-stora
 import { requestAsyncStorage } from '../../client/components/request-async-storage.external'
 import { getTracer } from '../lib/trace/tracer'
 import type { TextMapGetter } from 'next/dist/compiled/@opentelemetry/api'
+import { MiddlewareSpan } from '../lib/trace/constants'
 
 class NextRequestHint extends NextRequest {
   sourcePage: string
@@ -213,23 +214,34 @@ export async function adapter(
     const isMiddleware =
       params.page === '/middleware' || params.page === '/src/middleware'
     if (isMiddleware) {
-      return RequestAsyncStorageWrapper.wrap(
-        requestAsyncStorage,
+      return getTracer().trace(
+        MiddlewareSpan.execute,
         {
-          req: request,
-          renderOpts: {
-            onUpdateCookies: (cookies) => {
-              cookiesFromResponse = cookies
-            },
-            // @ts-expect-error: TODO: investigate why previewProps isn't on RenderOpts
-            previewProps: prerenderManifest?.preview || {
-              previewModeId: 'development-id',
-              previewModeEncryptionKey: '',
-              previewModeSigningKey: '',
-            },
+          spanName: 'middleware',
+          attributes: {
+            'http.target': request.nextUrl.pathname,
+            'http.method': request.method,
           },
         },
-        () => params.handler(request, event)
+        () =>
+          RequestAsyncStorageWrapper.wrap(
+            requestAsyncStorage,
+            {
+              req: request,
+              renderOpts: {
+                onUpdateCookies: (cookies) => {
+                  cookiesFromResponse = cookies
+                },
+                // @ts-expect-error: TODO: investigate why previewProps isn't on RenderOpts
+                previewProps: prerenderManifest?.preview || {
+                  previewModeId: 'development-id',
+                  previewModeEncryptionKey: '',
+                  previewModeSigningKey: '',
+                },
+              },
+            },
+            () => params.handler(request, event)
+          )
       )
     }
     return params.handler(request, event)

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -217,7 +217,7 @@ export async function adapter(
       return getTracer().trace(
         MiddlewareSpan.execute,
         {
-          spanName: 'middleware',
+          spanName: `middleware ${request.method} ${request.nextUrl.pathname}`,
           attributes: {
             'http.target': request.nextUrl.pathname,
             'http.method': request.method,

--- a/test/e2e/opentelemetry/app/behind-middleware/layout.tsx
+++ b/test/e2e/opentelemetry/app/behind-middleware/layout.tsx
@@ -1,0 +1,15 @@
+export default async function Layout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}
+
+export async function generateMetadata() {
+  return {}
+}

--- a/test/e2e/opentelemetry/app/behind-middleware/page.tsx
+++ b/test/e2e/opentelemetry/app/behind-middleware/page.tsx
@@ -1,0 +1,10 @@
+// We want to trace this fetch in runtime
+export const dynamic = 'force-dynamic'
+
+export async function generateMetadata() {
+  return {}
+}
+
+export default async function Page() {
+  return <pre>Behind middleware</pre>
+}

--- a/test/e2e/opentelemetry/collector.ts
+++ b/test/e2e/opentelemetry/collector.ts
@@ -32,7 +32,13 @@ export async function connectCollector({
     })
 
     const newSpans = JSON.parse(body.toString('utf-8')) as SavedSpan[]
-    spans.push(...newSpans)
+    const filteredSpans = newSpans.filter((span) => {
+      if (span.attributes?.['next.bubble'] === true) {
+        return false
+      }
+      return true
+    })
+    spans.push(...filteredSpans)
     res.statusCode = 202
     res.end()
   })

--- a/test/e2e/opentelemetry/middleware.ts
+++ b/test/e2e/opentelemetry/middleware.ts
@@ -1,0 +1,15 @@
+import type { NextRequest, NextFetchEvent } from 'next/server'
+import { NextResponse } from 'next/server'
+
+export const config: {
+  matcher: string[]
+} = {
+  matcher: ['/behind-middleware', '/behind-middleware/:path*'],
+}
+
+export async function middleware(
+  request: NextRequest,
+  event?: NextFetchEvent
+): Promise<Response> {
+  return NextResponse.next()
+}

--- a/test/e2e/opentelemetry/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/opentelemetry.test.ts
@@ -445,11 +445,11 @@ createNextDescribe(
                 runtime: 'edge',
                 traceId: env.span.traceId,
                 parentId: env.span.rootParentId,
-                name: 'middleware',
+                name: 'middleware GET /behind-middleware',
                 attributes: {
                   'http.method': 'GET',
                   'http.target': '/behind-middleware',
-                  'next.span_name': 'middleware',
+                  'next.span_name': 'middleware GET /behind-middleware',
                   'next.span_type': 'Middleware.execute',
                 },
                 status: { code: 0 },

--- a/test/e2e/opentelemetry/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/opentelemetry.test.ts
@@ -436,6 +436,43 @@ createNextDescribe(
               },
             ])
           })
+
+          it('should trace middleware', async () => {
+            await next.fetch('/behind-middleware', env.fetchInit)
+
+            await expectTrace(getCollector(), [
+              {
+                runtime: 'edge',
+                traceId: env.span.traceId,
+                parentId: env.span.rootParentId,
+                name: 'middleware',
+                attributes: {
+                  'http.method': 'GET',
+                  'http.target': '/behind-middleware',
+                  'next.span_name': 'middleware',
+                  'next.span_type': 'Middleware.execute',
+                },
+                status: { code: 0 },
+                spans: [],
+              },
+
+              {
+                runtime: 'nodejs',
+                traceId: env.span.traceId,
+                parentId: env.span.rootParentId,
+                name: 'GET /behind-middleware',
+                attributes: {
+                  'http.method': 'GET',
+                  'http.route': '/behind-middleware',
+                  'http.status_code': 200,
+                  'http.target': '/behind-middleware',
+                  'next.route': '/behind-middleware',
+                  'next.span_name': 'GET /behind-middleware',
+                  'next.span_type': 'BaseServer.handleRequest',
+                },
+              },
+            ])
+          })
         })
 
         describe('pages', () => {


### PR DESCRIPTION
Without this, any spans added by the middleware implementation would be orphaned and create extra traces.