### PR TITLE
Simplify node/edge server chunking some

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -969,6 +969,14 @@ export default async function getBaseWebpackConfig(
           return false
         }
 
+        if (isNodeServer || isEdgeServer) {
+          return {
+            filename: `${isEdgeServer ? 'edge-chunks/' : ''}[name].js`,
+            chunks: 'all',
+            minChunks: 2,
+          }
+        }
+
         const frameworkCacheGroup = {
           chunks: 'all' as const,
           name: 'framework',
@@ -985,21 +993,6 @@ export default async function getBaseWebpackConfig(
           priority: 40,
           // Don't let webpack eliminate this chunk (prevents this chunk from
           // becoming a part of the commons chunk)
-          enforce: true,
-        }
-
-        const nextRuntimeCacheGroup = {
-          chunks: 'all' as const,
-          name: 'next-runtime',
-          test(module: any) {
-            const resource = module.nameForCondition?.()
-            return resource
-              ? nextFrameworkPaths.some((pkgPath) =>
-                  resource.startsWith(pkgPath)
-                )
-              : false
-          },
-          priority: 30,
           enforce: true,
         }
 
@@ -1043,19 +1036,6 @@ export default async function getBaseWebpackConfig(
           priority: 30,
           minChunks: 1,
           reuseExistingChunk: true,
-        }
-
-        if (isNodeServer || isEdgeServer) {
-          return {
-            filename: `${isEdgeServer ? 'edge-chunks/' : ''}[name].js`,
-            cacheGroups: {
-              nextRuntime: nextRuntimeCacheGroup,
-              framework: frameworkCacheGroup,
-              lib: libCacheGroup,
-            },
-            chunks: 'all',
-            minChunks: 2,
-          }
         }
 
         // client chunking


### PR DESCRIPTION
This continues https://github.com/vercel/next.js/pull/62336 and ensures we chunk fully but removes the cache groups as that introduces some un-necessary duplication. With this configuration we ensure we split chunks of all types which fixes the OOM/cache size issue and also avoids overall chunk size increase. 

Closes NEXT-2577