### PR TITLE
Improve TS plugin options

### DIFF
--- a/packages/next/src/server/typescript/rules/config.ts
+++ b/packages/next/src/server/typescript/rules/config.ts
@@ -126,7 +126,7 @@ const API_DOCS: Record<
     options: {
       '"nodejs"': 'Prefer the Node.js runtime.',
       '"edge"': 'Prefer the Edge runtime.',
-      '"experimental-edge"': 'Prefer the experimental Edge runtime.',
+      '"experimental-edge"': `@deprecated\n\nThis option is no longer experimental. Use \`edge\` instead.`,
     },
     link: 'https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#runtime',
   },


### PR DESCRIPTION
The `experimental-edge` config is no longer needed:

![CleanShot-2024-02-23-xxccX9gb@2x](https://github.com/vercel/next.js/assets/3676859/8a75143d-630e-4eae-a323-a78fd11e83ce)

This PR:

![CleanShot-2024-02-23-EmCglptd@2x](https://github.com/vercel/next.js/assets/3676859/0cacd221-1c4a-4b30-afde-19eb9b4883de)


Closes NEXT-2580