### PR TITLE
fix(next-core): do not error for externalpkg's asset import request

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_server/resolve.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/resolve.rs
@@ -155,6 +155,7 @@ impl ResolvePlugin for ExternalCjsModulesResolvePlugin {
         enum FileType {
             CommonJs,
             EcmaScriptModule,
+            Assets,
             UnsupportedExtension,
             InvalidPackageJson,
         }
@@ -191,6 +192,10 @@ impl ResolvePlugin for ExternalCjsModulesResolvePlugin {
                 }
 
                 return Ok(FileType::CommonJs);
+            }
+
+            if (matches!(ext, Some("css")) || matches!(ext, Some("scss"))) {
+                return Ok(FileType::Assets);
             }
 
             Ok(FileType::UnsupportedExtension)
@@ -361,6 +366,7 @@ impl ResolvePlugin for ExternalCjsModulesResolvePlugin {
                      would result in an error in Node.js.",
                 )
             }
+            (FileType::Assets, _) => Ok(ResolveResultOption::none()),
         }
     }
 }


### PR DESCRIPTION
### What

This maybe a stopgap, however if pkg is specified as serverexternal and it contains imports to non-ecma assets (css, notably) Turbopack emits hard error. those asset can't be marked as external anyway since node.js can't import it directly but have to be processed by transformer, so PR ignores those module request even pkg itself is marked as external.

Closes PACK-2592