### PR TITLE
feat(docs): update 14-internationalization.mdx

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/14-internationalization.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/14-internationalization.mdx
@@ -33,6 +33,7 @@ match(languages, locales, defaultLocale) // -> 'en-US'
 Routing can be internationalized by either the sub-path (`/fr/products`) or domain (`my-site.fr/products`). With this information, you can now redirect the user based on the locale inside [Middleware](/docs/app/building-your-application/routing/middleware).
 
 ```js filename="middleware.js"
+import { NextResponse } from "next/server";
 
 let locales = ['en-US', 'nl-NL', 'nl']
 
@@ -53,7 +54,7 @@ export function middleware(request) {
   request.nextUrl.pathname = `/${locale}${pathname}`
   // e.g. incoming request is /products
   // The new URL is now /en-US/products
-  return Response.redirect(request.nextUrl)
+  return NextResponse.redirect(request.nextUrl)
 }
 
 export const config = {


### PR DESCRIPTION
### Improving Documentation

follow the [example](https://github.com/vercel/next.js/blob/canary/examples/app-dir-i18n-routing/middleware.ts#L53), it is better to use NextResponse instead of Response.
