### PR TITLE
fix: directory flag prompt

### DIFF
--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -343,7 +343,9 @@ async function run(): Promise<void> {
 
     if (
       !process.argv.includes('--src-dir') &&
-      !process.argv.includes('--no-src-dir')
+      !process.argv.includes('--no-src-dir') &&
+      !process.argv.includes('--app') &&
+      !process.argv.includes('--no-app')
     ) {
       if (ciInfo.isCI) {
         program.srcDir = getPrefOrDefault('srcDir')
@@ -363,7 +365,12 @@ async function run(): Promise<void> {
       }
     }
 
-    if (!process.argv.includes('--app') && !process.argv.includes('--no-app')) {
+    if (
+      !process.argv.includes('--app') &&
+      !process.argv.includes('--no-app') &&
+      !process.argv.includes('--src-dir') &&
+      !process.argv.includes('--no-src-dir')
+    ) {
       if (ciInfo.isCI) {
         program.app = getPrefOrDefault('app')
       } else {

--- a/test/integration/create-next-app/templates-app.test.ts
+++ b/test/integration/create-next-app/templates-app.test.ts
@@ -194,4 +194,32 @@ describe('create-next-app --app', () => {
       )
     })
   })
+
+  it('should get no prompt with --app and without --src-dir or --no-src-dir flag', async () => {
+    await useTempDir(async (cwd) => {
+      const projectName = 'app-dir-test'
+      const childProcess = createNextApp(
+        [
+          projectName,
+          '--ts',
+          '--tailwind',
+          '--eslint',
+          '--app',
+          '--import-alias=@/*',
+        ],
+        {
+          cwd,
+        },
+        testVersion
+      )
+
+      const exitCode = await spawnExitPromise(childProcess)
+      expect(exitCode).toBe(0)
+      await startsWithoutError(
+        path.join(cwd, projectName),
+        ['default', 'turbo'],
+        true
+      )
+    })
+  })
 })

--- a/test/integration/create-next-app/templates-pages.test.ts
+++ b/test/integration/create-next-app/templates-pages.test.ts
@@ -392,4 +392,32 @@ describe('create-next-app templates', () => {
       })
     })
   })
+
+  it('should get no prompt with --src-dir and without --app or --no-app flag', async () => {
+    await useTempDir(async (cwd) => {
+      const projectName = 'src-dir-test'
+      const childProcess = createNextApp(
+        [
+          projectName,
+          '--ts',
+          '--tailwind',
+          '--eslint',
+          '--src-dir',
+          '--import-alias=@/*',
+        ],
+        {
+          cwd,
+        },
+        testVersion
+      )
+
+      const exitCode = await spawnExitPromise(childProcess)
+      expect(exitCode).toBe(0)
+      await startsWithoutError(
+        path.join(cwd, projectName),
+        ['default', 'turbo'],
+        true
+      )
+    })
+  })
 })


### PR DESCRIPTION
Fix non-interactive `create-next-app` with `--src-dir` or `--app` flag still prompts question 

Fixes #62494 
