### PR TITLE
Add compiler error for conflicting App Router and Pages Router in Turbopack

### DIFF
--- a/packages/next-swc/crates/next-api/src/project.rs
+++ b/packages/next-swc/crates/next-api/src/project.rs
@@ -40,7 +40,7 @@ use turbopack_binding::{
             context::AssetContext,
             diagnostics::DiagnosticExt,
             file_source::FileSource,
-            issue::{Issue, IssueExt, IssueSeverity, OptionStyledString, StyledString},
+            issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
             output::{OutputAsset, OutputAssets},
             resolve::{find_context_file, FindContextFileResult},
             source::Source,
@@ -359,8 +359,8 @@ struct ConflictIssue {
 #[turbo_tasks::value_impl]
 impl Issue for ConflictIssue {
     #[turbo_tasks::function]
-    fn category(&self) -> Vc<String> {
-        Vc::cell("next app".to_string())
+    fn stage(&self) -> Vc<IssueStage> {
+        IssueStage::AppStructure.cell()
     }
 
     #[turbo_tasks::function]

--- a/packages/next-swc/crates/next-api/src/project.rs
+++ b/packages/next-swc/crates/next-api/src/project.rs
@@ -40,6 +40,7 @@ use turbopack_binding::{
             context::AssetContext,
             diagnostics::DiagnosticExt,
             file_source::FileSource,
+            issue::{Issue, IssueExt, IssueSeverity, OptionStyledString, StyledString},
             output::{OutputAsset, OutputAssets},
             resolve::{find_context_file, FindContextFileResult},
             source::Source,
@@ -347,6 +348,42 @@ impl ProjectDefineEnv {
     }
 }
 
+#[turbo_tasks::value(shared)]
+struct ConflictIssue {
+    path: Vc<FileSystemPath>,
+    title: Vc<StyledString>,
+    description: Vc<StyledString>,
+    severity: Vc<IssueSeverity>,
+}
+
+#[turbo_tasks::value_impl]
+impl Issue for ConflictIssue {
+    #[turbo_tasks::function]
+    fn category(&self) -> Vc<String> {
+        Vc::cell("next app".to_string())
+    }
+
+    #[turbo_tasks::function]
+    fn severity(&self) -> Vc<IssueSeverity> {
+        self.severity
+    }
+
+    #[turbo_tasks::function]
+    fn file_path(&self) -> Vc<FileSystemPath> {
+        self.path
+    }
+
+    #[turbo_tasks::function]
+    fn title(&self) -> Vc<StyledString> {
+        self.title
+    }
+
+    #[turbo_tasks::function]
+    fn description(&self) -> Vc<OptionStyledString> {
+        Vc::cell(Some(self.description))
+    }
+}
+
 #[turbo_tasks::value_impl]
 impl Project {
     #[turbo_tasks::function]
@@ -639,6 +676,24 @@ impl Project {
         for (pathname, page_route) in pages_project.routes().await?.iter() {
             match routes.entry(pathname.clone()) {
                 Entry::Occupied(mut entry) => {
+                    ConflictIssue {
+                        path: self.project_path(),
+                        title: StyledString::Text(
+                            format!("App Router and Pages Router both match path: {}", pathname)
+                                .to_string(),
+                        )
+                        .cell(),
+                        description: StyledString::Text(
+                            "Next.js does not support having both App Router and Pages Router \
+                             routes matching the same path. Please remove one of the conflicting \
+                             routes."
+                                .to_string(),
+                        )
+                        .cell(),
+                        severity: IssueSeverity::Error.cell(),
+                    }
+                    .cell()
+                    .emit();
                     *entry.get_mut() = Route::Conflict;
                 }
                 Entry::Vacant(entry) => {

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1338,8 +1338,6 @@ export default async function build(
           throw new Error("next build doesn't support turbopack yet")
         }
 
-        // TODO: Without NODE_ENV=development React will error that the RSC payload was rendered using development React while renderToHTML is called on the production React.
-        // This is caused by Turbopack not having the production build option yet.
         const startTime = process.hrtime()
         const bindings = await loadBindings(config?.experimental?.useWasmBinary)
         const dev = false

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1017,18 +1017,21 @@ export default async function build(
         app: appPaths.length > 0 ? appPaths : undefined,
       }
 
-      const numConflictingAppPaths = conflictingAppPagePaths.length
-      if (mappedAppPages && numConflictingAppPaths > 0) {
-        Log.error(
-          `Conflicting app and page file${
-            numConflictingAppPaths === 1 ? ' was' : 's were'
-          } found, please remove the conflicting files to continue:`
-        )
-        for (const [pagePath, appPath] of conflictingAppPagePaths) {
-          Log.error(`  "${pagePath}" - "${appPath}"`)
+      // Turbopack already handles conflicting app and page routes.
+      if (!IS_TURBOPACK_BUILD) {
+        const numConflictingAppPaths = conflictingAppPagePaths.length
+        if (mappedAppPages && numConflictingAppPaths > 0) {
+          Log.error(
+            `Conflicting app and page file${
+              numConflictingAppPaths === 1 ? ' was' : 's were'
+            } found, please remove the conflicting files to continue:`
+          )
+          for (const [pagePath, appPath] of conflictingAppPagePaths) {
+            Log.error(`  "${pagePath}" - "${appPath}"`)
+          }
+          await telemetry.flush()
+          process.exit(1)
         }
-        await telemetry.flush()
-        process.exit(1)
       }
 
       const conflictingPublicFiles: string[] = []

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1354,7 +1354,6 @@ export default async function build(
             allowedRevalidateHeaderKeys: undefined,
             clientRouterFilters: undefined,
             config,
-            // When passing `false` you get `react.jsxDEV is not a function`
             dev,
             distDir,
             fetchCacheKeyPrefix: undefined,

--- a/test/e2e/conflicting-app-page-error/index.test.ts
+++ b/test/e2e/conflicting-app-page-error/index.test.ts
@@ -1,8 +1,8 @@
 import {
   getRedboxHeader,
   hasRedbox,
-  check,
   getRedboxSource,
+  retry,
 } from 'next-test-utils'
 import { createNextDescribe } from 'e2e-utils'
 
@@ -17,15 +17,24 @@ createNextDescribe(
     if (isNextStart) {
       it('should print error for conflicting app/page', async () => {
         const { cliOutput } = await next.build()
-        expect(cliOutput).toMatch(
-          /Conflicting app and page files? (were|was) found/
-        )
+        if (process.env.TURBOPACK) {
+          expect(cliOutput).toContain(
+            'App Router and Pages Router both match path: /'
+          )
+          expect(cliOutput).toContain(
+            'App Router and Pages Router both match path: /another'
+          )
+        } else {
+          expect(cliOutput).toMatch(
+            /Conflicting app and page files? (were|was) found/
+          )
 
-        for (const [pagePath, appPath] of [
-          ['pages/index.js', 'app/page.js'],
-          ['pages/another.js', 'app/another/page.js'],
-        ]) {
-          expect(cliOutput).toContain(`"${pagePath}" - "${appPath}"`)
+          for (const [pagePath, appPath] of [
+            ['pages/index.js', 'app/page.js'],
+            ['pages/another.js', 'app/another/page.js'],
+          ]) {
+            expect(cliOutput).toContain(`"${pagePath}" - "${appPath}"`)
+          }
         }
 
         expect(cliOutput).not.toContain('/non-conflict-pages')
@@ -34,19 +43,21 @@ createNextDescribe(
     }
 
     async function containConflictsError(browser, conflicts) {
-      await check(async () => {
+      await retry(async () => {
         expect(await hasRedbox(browser)).toBe(true)
         const redboxSource = await getRedboxSource(browser)
-        expect(redboxSource).toMatch(
-          /Conflicting app and page files? (were|was) found, please remove the conflicting files to continue:/
-        )
-
-        for (const pair of conflicts) {
-          expect(redboxSource).toContain(`"${pair[0]}" - "${pair[1]}"`)
+        if (process.env.TURBOPACK) {
+          expect(redboxSource).toContain(
+            'App Router and Pages Router both match path:'
+          )
         }
 
-        return 'success'
-      }, /success/)
+        if (!process.env.TURBOPACK) {
+          for (const pair of conflicts) {
+            expect(redboxSource).toContain(`"${pair[0]}" - "${pair[1]}"`)
+          }
+        }
+      })
     }
 
     if (isNextDev) {


### PR DESCRIPTION
## What?

Working on fixing `test/e2e/conflicting-app-page-error`, this adds a compiler error for the case where App Router routes conflict with Pages Router routes. It's not 1:1 the same error as in webpack because in the webpack version we hijacked the App Router resolving logic to assume there's a certain set of paths, where Turbopack has the full route to route tree resolving implementation which doesn't assume there's a single page that can be resolved.

The tests are updated to reflect this change.


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2592