### PR TITLE
docs: fix typo

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/08-analytics.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/08-analytics.mdx
@@ -204,14 +204,16 @@ useReportWebVitals((metric) => {
 > etc.)
 
 > ```js
-> useReportWebVitals(metric => {
+> useReportWebVitals((metric) => {
 >   // Use `window.gtag` if you initialized Google Analytics as this example:
 >   // https://github.com/vercel/next.js/blob/canary/examples/with-google-analytics/pages/_app.js
 >   window.gtag('event', metric.name, {
->     value: Math.round(metric.name === 'CLS' ? metric.value * 1000 : metric.value), // values must be integers
+>     value: Math.round(
+>       metric.name === 'CLS' ? metric.value * 1000 : metric.value
+>     ), // values must be integers
 >     event_label: metric.id, // id unique to current page load
 >     non_interaction: true, // avoids affecting bounce rate.
->   });
+>   })
 > })
 > ```
 >

--- a/docs/02-app/01-building-your-application/06-optimizing/08-analytics.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/08-analytics.mdx
@@ -212,7 +212,7 @@ useReportWebVitals((metric) => {
 >     event_label: metric.id, // id unique to current page load
 >     non_interaction: true, // avoids affecting bounce rate.
 >   });
-> }
+> })
 > ```
 >
 > Read more about [sending results to Google Analytics](https://github.com/GoogleChrome/web-vitals#send-the-results-to-google-analytics).


### PR DESCRIPTION
### What?
I found a small typo in the docs.(analytics.mdx)
Missing ")" in the end of function.

### How?
Add ")" in the end.