### PR TITLE
fix(create-next-app): exclude .next in tsconfig for vscode lint

### DIFF
--- a/packages/create-next-app/templates/app-tw/ts/tsconfig.json
+++ b/packages/create-next-app/templates/app-tw/ts/tsconfig.json
@@ -22,5 +22,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", ".next"]
 }

--- a/packages/create-next-app/templates/app/ts/tsconfig.json
+++ b/packages/create-next-app/templates/app/ts/tsconfig.json
@@ -22,5 +22,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", ".next"]
 }


### PR DESCRIPTION
### What?
Extending the tsconfig.json `exclude` field to cover the `.next/` folder in the create-next-app templates for app dir. 

### Why?
Without it, linting on Visual Studio Code is considerably slower when combined with format on save lint/format setting in the editor.

### How?
Narrow the scope of files covered by the wildcard patterns in the `include` field in tsconfig.json.

