### PR TITLE
Use consistent /_not-found entrypoint for dev and build

### DIFF
--- a/packages/next-swc/crates/next-core/src/app_structure.rs
+++ b/packages/next-swc/crates/next-core/src/app_structure.rs
@@ -1076,10 +1076,6 @@ async fn directory_tree_to_entrypoints_internal_untraced(
         };
 
         {
-            let app_page = app_page.clone_push_str("not-found")?;
-            add_app_page(app_dir, &mut result, app_page, not_found_tree).await?;
-        }
-        {
             let app_page = app_page.clone_push_str("_not-found")?;
             add_app_page(app_dir, &mut result, app_page, not_found_tree).await?;
         }

--- a/packages/next-swc/crates/next-core/src/app_structure.rs
+++ b/packages/next-swc/crates/next-core/src/app_structure.rs
@@ -1075,7 +1075,10 @@ async fn directory_tree_to_entrypoints_internal_untraced(
             }.cell()
         };
 
-        // /_not-found is a special entrypoint that is used to render the 404 case.
+        {
+            let app_page = app_page.clone_push_str("not-found")?;
+            add_app_page(app_dir, &mut result, app_page, not_found_tree).await?;
+        }
         {
             let app_page = app_page.clone_push_str("_not-found")?;
             add_app_page(app_dir, &mut result, app_page, not_found_tree).await?;

--- a/packages/next-swc/crates/next-core/src/app_structure.rs
+++ b/packages/next-swc/crates/next-core/src/app_structure.rs
@@ -1075,10 +1075,7 @@ async fn directory_tree_to_entrypoints_internal_untraced(
             }.cell()
         };
 
-        {
-            let app_page = app_page.clone_push_str("not-found")?;
-            add_app_page(app_dir, &mut result, app_page, not_found_tree).await?;
-        }
+        // /_not-found is a special entrypoint that is used to render the 404 case.
         {
             let app_page = app_page.clone_push_str("_not-found")?;
             add_app_page(app_dir, &mut result, app_page, not_found_tree).await?;

--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -243,7 +243,9 @@ export function createPagesMapping({
       let pageKey = getPageFromPath(pagePath, pageExtensions)
       if (isAppRoute) {
         pageKey = pageKey.replace(/%5F/g, '_')
-        pageKey = pageKey.replace(/^\/not-found$/g, '/_not-found')
+        if (pageKey === '/not-found') {
+          pageKey = pageKey.replace('/not-found', '/_not-found')
+        }
       }
 
       const normalizedPath = normalizePathSep(

--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -243,9 +243,7 @@ export function createPagesMapping({
       let pageKey = getPageFromPath(pagePath, pageExtensions)
       if (isAppRoute) {
         pageKey = pageKey.replace(/%5F/g, '_')
-        if (pageKey === '/not-found') {
-          pageKey = pageKey.replace('/not-found', '/_not-found')
-        }
+        pageKey = pageKey.replace(/^\/not-found$/g, '/_not-found')
       }
 
       const normalizedPath = normalizePathSep(

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -445,7 +445,7 @@ export class ClientReferenceManifestPlugin {
       // dev: app/not-found
       // prod: app/_not-found
       if (/^app\/_?not-found(\.[^.]+)?$/.test(entryName)) {
-        manifestEntryFiles.push(this.dev ? 'app/not-found' : 'app/_not-found')
+        manifestEntryFiles.push('app/_not-found')
       }
 
       const groupName = entryNameToGroupName(entryName)
@@ -488,16 +488,6 @@ export class ClientReferenceManifestPlugin {
           pagePath.slice('app'.length)
         )}]=${json}`
       ) as unknown as webpack.sources.RawSource
-
-      if (pagePath === 'app/not-found') {
-        // Create a separate special manifest for the root not-found page.
-        assets['server/app/_not-found_' + CLIENT_REFERENCE_MANIFEST + '.js'] =
-          new sources.RawSource(
-            `globalThis.__RSC_MANIFEST=(globalThis.__RSC_MANIFEST||{});globalThis.__RSC_MANIFEST[${JSON.stringify(
-              '/_not-found'
-            )}]=${json}`
-          ) as unknown as webpack.sources.RawSource
-      }
     }
 
     pluginState.ASYNC_CLIENT_MODULES = []

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -441,11 +441,9 @@ export class ClientReferenceManifestPlugin {
         manifestEntryFiles.push(entryName.replace(/\/page(\.[^/]+)?$/, '/page'))
       }
 
-      // Special case for the root not-found page.
-      // dev: app/not-found
-      // prod: app/_not-found
-      if (/^app\/_?not-found(\.[^.]+)?$/.test(entryName)) {
-        manifestEntryFiles.push(this.dev ? 'app/not-found' : 'app/_not-found')
+      // Special case for the root not-found page: app/_not-found
+      if (/^app\/_not-found(\.[^.]+)?$/.test(entryName)) {
+        manifestEntryFiles.push('app/_not-found')
       }
 
       const groupName = entryNameToGroupName(entryName)
@@ -488,16 +486,6 @@ export class ClientReferenceManifestPlugin {
           pagePath.slice('app'.length)
         )}]=${json}`
       ) as unknown as webpack.sources.RawSource
-
-      if (pagePath === 'app/not-found') {
-        // Create a separate special manifest for the root not-found page.
-        assets['server/app/_not-found_' + CLIENT_REFERENCE_MANIFEST + '.js'] =
-          new sources.RawSource(
-            `globalThis.__RSC_MANIFEST=(globalThis.__RSC_MANIFEST||{});globalThis.__RSC_MANIFEST[${JSON.stringify(
-              '/_not-found'
-            )}]=${json}`
-          ) as unknown as webpack.sources.RawSource
-      }
     }
 
     pluginState.ASYNC_CLIENT_MODULES = []

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -441,9 +441,11 @@ export class ClientReferenceManifestPlugin {
         manifestEntryFiles.push(entryName.replace(/\/page(\.[^/]+)?$/, '/page'))
       }
 
-      // Special case for the root not-found page: app/_not-found
-      if (/^app\/_not-found(\.[^.]+)?$/.test(entryName)) {
-        manifestEntryFiles.push('app/_not-found')
+      // Special case for the root not-found page.
+      // dev: app/not-found
+      // prod: app/_not-found
+      if (/^app\/_?not-found(\.[^.]+)?$/.test(entryName)) {
+        manifestEntryFiles.push(this.dev ? 'app/not-found' : 'app/_not-found')
       }
 
       const groupName = entryNameToGroupName(entryName)
@@ -486,6 +488,16 @@ export class ClientReferenceManifestPlugin {
           pagePath.slice('app'.length)
         )}]=${json}`
       ) as unknown as webpack.sources.RawSource
+
+      if (pagePath === 'app/not-found') {
+        // Create a separate special manifest for the root not-found page.
+        assets['server/app/_not-found_' + CLIENT_REFERENCE_MANIFEST + '.js'] =
+          new sources.RawSource(
+            `globalThis.__RSC_MANIFEST=(globalThis.__RSC_MANIFEST||{});globalThis.__RSC_MANIFEST[${JSON.stringify(
+              '/_not-found'
+            )}]=${json}`
+          ) as unknown as webpack.sources.RawSource
+      }
     }
 
     pluginState.ASYNC_CLIENT_MODULES = []

--- a/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -242,6 +242,7 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
           // include the client reference manifest
           const clientManifestsForPage =
             entrypoint.name.endsWith('/page') ||
+            entrypoint.name === 'app/not-found' ||
             entrypoint.name === 'app/_not-found'
               ? nodePath.join(
                   outputPath,

--- a/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -242,7 +242,6 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
           // include the client reference manifest
           const clientManifestsForPage =
             entrypoint.name.endsWith('/page') ||
-            entrypoint.name === 'app/not-found' ||
             entrypoint.name === 'app/_not-found'
               ? nodePath.join(
                   outputPath,

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -3265,7 +3265,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         if (this.enabledDirectories.app) {
           // Use the not-found entry in app directory
           result = await this.findPageComponents({
-            page: this.renderOpts.dev ? '/not-found' : '/_not-found',
+            page: '/_not-found',
             query,
             params: {},
             isAppPath: true,

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -3265,7 +3265,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         if (this.enabledDirectories.app) {
           // Use the not-found entry in app directory
           result = await this.findPageComponents({
-            page: '/_not-found',
+            page: this.renderOpts.dev ? '/not-found' : '/_not-found',
             query,
             params: {},
             isAppPath: true,

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -467,11 +467,11 @@ export async function findPagePathData(
     }
   }
 
-  if (page === '/not-found' && appDir) {
+  if (page === '/_not-found' && appDir) {
     return {
       filename: require.resolve('next/dist/client/components/not-found-error'),
-      bundlePath: 'app/not-found',
-      page: '/not-found',
+      bundlePath: 'app/_not-found',
+      page: '/_not-found',
     }
   }
 

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -467,11 +467,11 @@ export async function findPagePathData(
     }
   }
 
-  if (page === '/_not-found' && appDir) {
+  if (page === '/not-found' && appDir) {
     return {
       filename: require.resolve('next/dist/client/components/not-found-error'),
-      bundlePath: 'app/_not-found',
-      page: '/_not-found',
+      bundlePath: 'app/not-found',
+      page: '/not-found',
     }
   }
 

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -482,9 +482,14 @@ export async function initialize(opts: {
       res.statusCode = 404
 
       if (appNotFound) {
-        return await invokeRender(parsedUrl, '/_not-found', handleIndex, {
-          'x-invoke-status': '404',
-        })
+        return await invokeRender(
+          parsedUrl,
+          opts.dev ? '/not-found' : '/_not-found',
+          handleIndex,
+          {
+            'x-invoke-status': '404',
+          }
+        )
       }
 
       await invokeRender(parsedUrl, '/404', handleIndex, {

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -482,14 +482,9 @@ export async function initialize(opts: {
       res.statusCode = 404
 
       if (appNotFound) {
-        return await invokeRender(
-          parsedUrl,
-          opts.dev ? '/not-found' : '/_not-found',
-          handleIndex,
-          {
-            'x-invoke-status': '404',
-          }
-        )
+        return await invokeRender(parsedUrl, '/_not-found', handleIndex, {
+          'x-invoke-status': '404',
+        })
       }
 
       await invokeRender(parsedUrl, '/404', handleIndex, {

--- a/packages/next/src/server/load-components.ts
+++ b/packages/next/src/server/load-components.ts
@@ -139,7 +139,8 @@ async function loadComponentsImpl<N = any>({
 
   // Make sure to avoid loading the manifest for Route Handlers
   const hasClientManifest =
-    isAppPath && (page.endsWith('/page') || page === '/_not-found')
+    isAppPath &&
+    (page.endsWith('/page') || page === '/not-found' || page === '/_not-found')
 
   // Load the manifest files first
   const [

--- a/packages/next/src/server/load-components.ts
+++ b/packages/next/src/server/load-components.ts
@@ -139,8 +139,7 @@ async function loadComponentsImpl<N = any>({
 
   // Make sure to avoid loading the manifest for Route Handlers
   const hasClientManifest =
-    isAppPath &&
-    (page.endsWith('/page') || page === '/not-found' || page === '/_not-found')
+    isAppPath && (page.endsWith('/page') || page === '/_not-found')
 
   // Load the manifest files first
   const [

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1306,7 +1306,9 @@ export default class NextNodeServer extends BaseServer {
     const is404 = res.statusCode === 404
 
     if (is404 && this.enabledDirectories.app) {
-      const notFoundPathname = '/_not-found'
+      const notFoundPathname = this.renderOpts.dev
+        ? '/not-found'
+        : '/_not-found'
 
       if (this.renderOpts.dev) {
         await this.ensurePage({

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1306,9 +1306,7 @@ export default class NextNodeServer extends BaseServer {
     const is404 = res.statusCode === 404
 
     if (is404 && this.enabledDirectories.app) {
-      const notFoundPathname = this.renderOpts.dev
-        ? '/not-found'
-        : '/_not-found'
+      const notFoundPathname = '/_not-found'
 
       if (this.renderOpts.dev) {
         await this.ensurePage({

--- a/packages/next/src/server/web-server.ts
+++ b/packages/next/src/server/web-server.ts
@@ -242,7 +242,7 @@ export default class NextWebServer extends BaseServer<WebServerOptions> {
 
     // For edge runtime if the pathname hit as /_not-found entrypoint,
     // override the pathname to /404 for rendering
-    if (pathname === (renderOpts.dev ? '/not-found' : '/_not-found')) {
+    if (pathname === '/_not-found') {
       pathname = '/404'
     }
     return renderToHTML(

--- a/packages/next/src/server/web-server.ts
+++ b/packages/next/src/server/web-server.ts
@@ -242,7 +242,7 @@ export default class NextWebServer extends BaseServer<WebServerOptions> {
 
     // For edge runtime if the pathname hit as /_not-found entrypoint,
     // override the pathname to /404 for rendering
-    if (pathname === '/_not-found') {
+    if (pathname === (renderOpts.dev ? '/not-found' : '/_not-found')) {
       pathname = '/404'
     }
     return renderToHTML(

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -239,7 +239,6 @@ describe('next.rs api', () => {
       '/app',
       '/app-edge',
       '/app-nodejs',
-      '/not-found',
       '/page-edge',
       '/page-nodejs',
       '/route-edge',

--- a/test/e2e/app-dir/not-found-default/index.test.ts
+++ b/test/e2e/app-dir/not-found-default/index.test.ts
@@ -31,12 +31,6 @@ createNextDescribe(
       expect(await browser.elementByCss('html').getAttribute('class')).toBe(
         'root-layout-html'
       )
-
-      if (isNextDev) {
-        const cliOutput = next.cliOutput
-        expect(cliOutput).toContain('/not-found')
-        expect(cliOutput).not.toContain('/_error')
-      }
     })
 
     it('should error on server notFound from root layout on server-side', async () => {

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -845,10 +845,10 @@ describe('Prerender', () => {
     })
 
     it('should handle fallback only page correctly HTML', async () => {
-      const browser = await webdriver(next.url, '/fallback-only/first%2Fpost')
+      const $ = await next.render$('fallback-only/first%2Fpost')
+      expect($('p').text()).toContain('hi fallback')
 
-      const text = await browser.elementByCss('p').text()
-      expect(text).toContain('hi fallback')
+      const browser = await webdriver(next.url, '/fallback-only/first%2Fpost')
 
       // wait for fallback data to load
       await check(() => browser.elementByCss('p').text(), /Post/)


### PR DESCRIPTION
## What?

#62528 caused `test/e2e/app-dir/not-found/conflict-route` to fail compilation in Turbopack, this compiler error was previously already reported by Turbopack but Next.js didn't show it, which #62528 resolved.

This PR changes the handling for the not-found handling to be consistent between development and build, which ensures that the "special" page no longer conflicts with `app/not-found/page.js`.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2617