### PR TITLE
Turbopack: remove node_modules error filter

### DIFF
--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -142,9 +142,6 @@ export function processIssues(
     const formatted = formatIssue(issue)
     newIssues.set(issueKey, issue)
 
-    // We show errors in node_modules to the console, but don't throw for them
-    if (/(^|\/)node_modules(\/|$)/.test(issue.filePath)) continue
-
     relevantIssues.add(formatted)
   }
 


### PR DESCRIPTION
### What?

This isn't needed

### Why?

### How?


Closes PACK-2604