### PR TITLE
fix(build-output): show stack during CSR bailout warning

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1179,8 +1179,8 @@ async function renderToHTMLOrFlightImpl(
         // a suspense boundary.
         const shouldBailoutToCSR = isBailoutToCSRError(err)
         if (shouldBailoutToCSR) {
+          const stack = getStackWithoutErrorMessage(err)
           if (renderOpts.experimental.missingSuspenseWithCSRBailout) {
-            const stack = getStackWithoutErrorMessage(err)
             error(
               `${err.reason} should be wrapped in a suspense boundary at page "${pagePath}". Read more: https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout\n${stack}`
             )
@@ -1189,7 +1189,7 @@ async function renderToHTMLOrFlightImpl(
           }
 
           warn(
-            `Entire page "${pagePath}" deopted into client-side rendering due to "${err.reason}". Read more: https://nextjs.org/docs/messages/deopted-into-client-rendering`
+            `Entire page "${pagePath}" deopted into client-side rendering due to "${err.reason}". Read more: https://nextjs.org/docs/messages/deopted-into-client-rendering\n${stack}`
           )
         }
 

--- a/test/e2e/app-dir/missing-suspense-with-csr-bailout/missing-suspense-with-csr-bailout.test.ts
+++ b/test/e2e/app-dir/missing-suspense-with-csr-bailout/missing-suspense-with-csr-bailout.test.ts
@@ -39,6 +39,26 @@ createNextDescribe(
         await next.renameFile('app/layout.js', 'app/layout-suspense.js')
         await next.renameFile('app/layout-no-suspense.js', 'app/layout.js')
       })
+
+      it('should pass build if missingSuspenseWithCSRBailout os set to false', async () => {
+        let _content
+        await next.patchFile('next.config.js', (content) => {
+          _content = content
+          return content.replace(
+            '{}',
+            '{ experimental: { missingSuspenseWithCSRBailout: false } }'
+          )
+        })
+
+        const result = await next.build()
+        expect(result.exitCode).toBe(0)
+        expect(result.cliOutput).toMatch(
+          '⚠ Entire page "/" deopted into client-side rendering due to "useSearchParams()". Read more: https://nextjs.org/docs/messages/deopted-into-client-rendering'
+        )
+        expect(result.cliOutput).toMatch(/app\/page\.js:\d+:\d+/)
+
+        await next.patchFile('next.config.js', _content)
+      })
     })
 
     describe('next/dynamic', () => {


### PR DESCRIPTION
### What?

We should treat the warning for CSR bailout the same as the hard-error, and show the stack trace for either case.

### Why?

It might be useful to track down the source of this warning.

### How?

We have the stack info already, but we only showed it during the error logging. We should show it for warnings too.

This is similar to #61200

Closes NEXT-2624