### PR TITLE
Fix redirect under suspense boundary with basePath

### DIFF
--- a/packages/next/src/client/components/redirect-boundary.tsx
+++ b/packages/next/src/client/components/redirect-boundary.tsx
@@ -60,7 +60,6 @@ export class RedirectErrorBoundary extends React.Component<
 
   render() {
     const { redirect, redirectType } = this.state
-    const basePath = this.props.router
     if (redirect !== null && redirectType !== null) {
       return (
         <HandleRedirect

--- a/packages/next/src/client/components/redirect-boundary.tsx
+++ b/packages/next/src/client/components/redirect-boundary.tsx
@@ -60,6 +60,7 @@ export class RedirectErrorBoundary extends React.Component<
 
   render() {
     const { redirect, redirectType } = this.state
+    const basePath = this.props.router
     if (redirect !== null && redirectType !== null) {
       return (
         <HandleRedirect

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -952,6 +952,7 @@ async function renderToHTMLOrFlightImpl(
         polyfills,
         renderServerInsertedHTML,
         serverCapturedErrors: allCapturedErrors,
+        basePath: renderOpts.basePath,
       })
 
       const renderer = createStaticRenderer({
@@ -1281,6 +1282,7 @@ async function renderToHTMLOrFlightImpl(
                 polyfills,
                 renderServerInsertedHTML,
                 serverCapturedErrors: [],
+                basePath: renderOpts.basePath,
               }),
               serverInsertedHTMLToHead: true,
               validateRootLayout,

--- a/packages/next/src/server/app-render/make-get-server-inserted-html.tsx
+++ b/packages/next/src/server/app-render/make-get-server-inserted-html.tsx
@@ -8,15 +8,18 @@ import {
 import { renderToReadableStream } from 'react-dom/server.edge'
 import { streamToString } from '../stream-utils/node-web-streams-helper'
 import { RedirectStatusCode } from '../../client/components/redirect-status-code'
+import { addPathPrefix } from '../../shared/lib/router/utils/add-path-prefix'
 
 export function makeGetServerInsertedHTML({
   polyfills,
   renderServerInsertedHTML,
   serverCapturedErrors,
+  basePath,
 }: {
   polyfills: JSX.IntrinsicElements['script'][]
   renderServerInsertedHTML: () => React.ReactNode
   serverCapturedErrors: Error[]
+  basePath: string
 }) {
   let flushedErrorMetaTagsUntilIndex = 0
   let hasUnflushedPolyfills = polyfills.length !== 0
@@ -37,7 +40,10 @@ export function makeGetServerInsertedHTML({
           ) : null
         )
       } else if (isRedirectError(error)) {
-        const redirectUrl = getURLFromRedirectError(error)
+        const redirectUrl = addPathPrefix(
+          getURLFromRedirectError(error),
+          basePath
+        )
         const statusCode = getRedirectStatusCodeFromError(error)
         const isPermanent =
           statusCode === RedirectStatusCode.PermanentRedirect ? true : false

--- a/test/e2e/app-dir/app-basepath/app/dynamic/[id]/loading.js
+++ b/test/e2e/app-dir/app-basepath/app/dynamic/[id]/loading.js
@@ -1,0 +1,4 @@
+// Have loading.js to trigger suspense boundary for /dynamic/[id] page
+export default function Loading() {
+  return <div>loading</div>
+}

--- a/test/e2e/app-dir/app-basepath/app/dynamic/[id]/page.js
+++ b/test/e2e/app-dir/app-basepath/app/dynamic/[id]/page.js
@@ -1,0 +1,11 @@
+import { redirect } from 'next/navigation'
+
+export default async function Page({ params: { id } }) {
+  if (id === 'source') redirect('/dynamic/dest')
+
+  return (
+    <div>
+      <p>{`id:${id}`}</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-basepath/index.test.ts
+++ b/test/e2e/app-dir/app-basepath/index.test.ts
@@ -1,5 +1,5 @@
 import { createNextDescribe } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 createNextDescribe(
   'app dir - basepath',
@@ -42,10 +42,9 @@ createNextDescribe(
 
     it('should prefix redirect() with basePath', async () => {
       const browser = await next.browser('/base/redirect')
-      await check(async () => {
+      await retry(async () => {
         expect(await browser.url()).toBe(`${next.url}/base/another`)
-        return 'success'
-      }, 'success')
+      })
     })
 
     it('should render usePathname without the basePath', async () => {
@@ -55,6 +54,14 @@ createNextDescribe(
         expect($('#pathname').data('pathname')).toBe(pathname)
       })
       await Promise.all(validatorPromises)
+    })
+
+    it('should handle redirect in dynamic in suspense boundary routes with basePath', async () => {
+      const browser = await next.browser('/base/dynamic/source')
+      await retry(async () => {
+        expect(await browser.url()).toBe(`${next.url}/base/dynamic/dest`)
+        expect(await browser.elementByCss('p').text()).toBe(`id:dest`)
+      })
     })
   }
 )


### PR DESCRIPTION
### What

Fixes `redirect()` call under suspense boundary, redirect url should include the `basePath` in the url.

### Why

`redirect()` under suspense boundaries will go through server html insertion, which is being used every time by suspense boundary resolved, new errors will triggered from SSR streaming. It was missing before.

Fixes NEXT-2615
Fixes #62407