### PR TITLE
fix flakey navigation test

### DIFF
--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -1,6 +1,6 @@
 import { createNextDescribe } from 'e2e-utils'
 import { retry, waitFor } from 'next-test-utils'
-import type { Request } from 'playwright'
+import type { Response } from 'playwright'
 
 createNextDescribe(
   'app dir - navigation',
@@ -15,7 +15,7 @@ createNextDescribe(
           `""`
         )
 
-        browser.elementById('set-query').click()
+        await browser.elementById('set-query').click()
 
         await retry(() =>
           expect(browser.elementById('query').text()).resolves.toEqual(
@@ -34,20 +34,21 @@ createNextDescribe(
           headers: Record<string, string>
         }> = []
 
-        const browser = await next.browser('/search-params?name=名')
-        async function requestHandler(req: Request) {
-          const res = await req.response()
-          if (!res) return
+        const browser = await next.browser('/search-params?name=名', {
+          beforePageLoad(page) {
+            page.on('response', async (res: Response) => {
+              requests.push({
+                pathname: new URL(res.url()).pathname,
+                ok: res.ok(),
+                headers: res.headers(),
+              })
+            })
+          },
+        })
 
-          requests.push({
-            pathname: new URL(req.url()).pathname,
-            ok: res.ok(),
-            headers: res.headers(),
-          })
-        }
-        browser.on('request', requestHandler)
         expect(await browser.elementById('name').text()).toBe('名')
         await browser.elementById('link').click()
+        await browser.waitForElementByCss('#set-query')
 
         await retry(() =>
           expect(requests).toContainEqual({
@@ -58,9 +59,6 @@ createNextDescribe(
             }),
           })
         )
-
-        browser.off('request', requestHandler)
-        await browser.close()
       })
 
       it('should not reset shallow url updates on prefetch', async () => {
@@ -610,7 +608,7 @@ createNextDescribe(
         // it doesn't repeatedly initiate the mpa navigation request
         it('should not continously initiate a mpa navigation to the same URL when router state changes', async () => {
           let requestCount = 0
-          const browser = await next.browser('/mpa-nav-test', {
+          await next.browser('/mpa-nav-test', {
             beforePageLoad(page) {
               page.on('request', (request) => {
                 const url = new URL(request.url())
@@ -621,8 +619,6 @@ createNextDescribe(
               })
             },
           })
-
-          await browser.waitForElementByCss('#link-to-slow-page')
 
           // wait a few seconds since prefetches are triggered in 1s intervals in the page component
           await waitFor(5000)


### PR DESCRIPTION
This test pretty consistently fails locally and in CI with the following error in the request handler:

> Target page, context or browser has been closed

[x-ref](https://github.com/vercel/next.js/actions/runs/8069442877/job/22047444250#step:27:798)
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2626