### PR TITLE
Migrate locale redirect handling to router-server

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -50,7 +50,6 @@ import {
   PAGES_MANIFEST,
   STATIC_STATUS_PAGES,
 } from '../shared/lib/constants'
-import { RedirectStatusCode } from '../client/components/redirect-status-code'
 import { isDynamicRoute } from '../shared/lib/router/utils'
 import { checkIsOnDemandRevalidate } from './api-utils'
 import { setConfig } from '../shared/lib/runtime-config.external'

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1167,36 +1167,6 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         }
       }
 
-      if (
-        // Edge runtime always has minimal mode enabled.
-        process.env.NEXT_RUNTIME !== 'edge' &&
-        !this.minimalMode &&
-        defaultLocale
-      ) {
-        const { getLocaleRedirect } =
-          require('../shared/lib/i18n/get-locale-redirect') as typeof import('../shared/lib/i18n/get-locale-redirect')
-        const redirect = getLocaleRedirect({
-          defaultLocale,
-          domainLocale,
-          headers: req.headers,
-          nextConfig: this.nextConfig,
-          pathLocale: pathnameInfo.locale,
-          urlParsed: {
-            ...url,
-            pathname: pathnameInfo.locale
-              ? `/${pathnameInfo.locale}${url.pathname}`
-              : url.pathname,
-          },
-        })
-
-        if (redirect) {
-          return res
-            .redirect(redirect, RedirectStatusCode.TemporaryRedirect)
-            .body(redirect)
-            .send()
-        }
-      }
-
       addRequestMeta(req, 'isLocaleDomain', Boolean(domainLocale))
 
       if (pathnameInfo.locale) {

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -146,12 +146,22 @@ export async function initialize(opts: {
     require('./render-server') as typeof import('./render-server')
 
   const requestHandlerImpl: WorkerRequestHandler = async (req, res) => {
-    if (config.i18n && config.i18n?.localeDetection !== false) {
+    if (
+      !opts.minimalMode &&
+      config.i18n &&
+      config.i18n?.localeDetection !== false
+    ) {
       const urlParts = (req.url || '').split('?', 1)
-      const urlNoQuery = urlParts[0] || ''
+      let urlNoQuery = urlParts[0] || ''
       const pathnameInfo = getNextPathnameInfo(urlNoQuery, {
         nextConfig: config,
       })
+
+      if (pathnameInfo.basePath) {
+        req.url = removePathPrefix(req.url!, config.basePath)
+        urlNoQuery = removePathPrefix(urlNoQuery, config.basePath)
+      }
+
       const domainLocale = detectDomainLocale(
         config.i18n.domains,
         getHostname({ hostname: urlNoQuery }, req.headers)

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -149,18 +149,18 @@ export async function initialize(opts: {
     if (
       !opts.minimalMode &&
       config.i18n &&
-      config.i18n?.localeDetection !== false
+      config.i18n.localeDetection !== false
     ) {
       const urlParts = (req.url || '').split('?', 1)
       let urlNoQuery = urlParts[0] || ''
+
+      if (config.basePath) {
+        urlNoQuery = removePathPrefix(urlNoQuery, config.basePath)
+      }
+
       const pathnameInfo = getNextPathnameInfo(urlNoQuery, {
         nextConfig: config,
       })
-
-      if (pathnameInfo.basePath) {
-        req.url = removePathPrefix(req.url!, config.basePath)
-        urlNoQuery = removePathPrefix(urlNoQuery, config.basePath)
-      }
 
       const domainLocale = detectDomainLocale(
         config.i18n.domains,

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -27,6 +27,7 @@ import setupCompression from 'next/dist/compiled/compression'
 import { NoFallbackError } from '../base-server'
 import { signalFromNodeResponse } from '../web/spec-extension/adapters/next-request'
 import { isPostpone } from './router-utils/is-postpone'
+import { parseUrl as parseUrlUtil } from '../../shared/lib/router/utils/parse-url'
 
 import {
   PHASE_PRODUCTION_SERVER,
@@ -161,6 +162,9 @@ export async function initialize(opts: {
 
       const { getLocaleRedirect } =
         require('../../shared/lib/i18n/get-locale-redirect') as typeof import('../../shared/lib/i18n/get-locale-redirect')
+
+      const parsedUrl = parseUrlUtil((req.url || '')?.replace(/^\/+/, '/'))
+
       const redirect = getLocaleRedirect({
         defaultLocale,
         domainLocale,
@@ -168,7 +172,7 @@ export async function initialize(opts: {
         nextConfig: config,
         pathLocale: pathnameInfo.locale,
         urlParsed: {
-          ...url,
+          ...parsedUrl,
           pathname: pathnameInfo.locale
             ? `/${pathnameInfo.locale}${urlNoQuery}`
             : urlNoQuery,

--- a/packages/next/src/shared/lib/i18n/get-locale-redirect.ts
+++ b/packages/next/src/shared/lib/i18n/get-locale-redirect.ts
@@ -5,7 +5,6 @@ import { denormalizePagePath } from '../page-path/denormalize-page-path'
 import { detectDomainLocale } from './detect-domain-locale'
 import { formatUrl } from '../router/utils/format-url'
 import { getCookieParser } from '../../../server/api-utils/get-cookie-parser'
-import { removePathPrefix } from '../router/utils/remove-path-prefix'
 
 interface Options {
   defaultLocale: string
@@ -106,21 +105,7 @@ export function getLocaleRedirect({
       }
     }
 
-    let invokePath =
-      typeof headers?.['x-invoke-path'] === 'string'
-        ? headers['x-invoke-path']
-        : undefined
-    if (nextConfig.basePath && invokePath) {
-      invokePath = removePathPrefix(invokePath, nextConfig.basePath)
-    }
-
-    // Avoid infinite redirects when the detected user locale is same as a non-default domain locale
-    const isDetectedLocaleSameAsInvokePath = invokePath === `/${detectedLocale}`
-
-    if (
-      !isDetectedLocaleSameAsInvokePath &&
-      detectedLocale.toLowerCase() !== defaultLocale.toLowerCase()
-    ) {
+    if (detectedLocale.toLowerCase() !== defaultLocale.toLowerCase()) {
       return formatUrl({
         ...urlParsed,
         pathname: `${nextConfig.basePath || ''}/${detectedLocale}${

--- a/test/e2e/i18n-preferred-locale-detection/app/middleware.js
+++ b/test/e2e/i18n-preferred-locale-detection/app/middleware.js
@@ -1,0 +1,4 @@
+export async function middleware() {
+  const noop = () => {}
+  noop()
+}

--- a/test/e2e/i18n-preferred-locale-detection/app/next.config.js
+++ b/test/e2e/i18n-preferred-locale-detection/app/next.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  i18n: {
+    locales: ['en', 'id'],
+    defaultLocale: 'en',
+  },
+  experimental: {
+    clientRouterFilter: true,
+    clientRouterFilterRedirects: true,
+  },
+}

--- a/test/e2e/i18n-preferred-locale-detection/app/pages/index.js
+++ b/test/e2e/i18n-preferred-locale-detection/app/pages/index.js
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+
+export const getServerSideProps = async ({ locale }) => {
+  return {
+    props: {
+      locale,
+    },
+  }
+}
+
+export default function Home({ locale }) {
+  return (
+    <div>
+      <div id="index">Index</div>
+      <div id="current-locale">{locale}</div>
+      <Link href="/new" id="to-new">
+        To new
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/i18n-preferred-locale-detection/app/pages/new.js
+++ b/test/e2e/i18n-preferred-locale-detection/app/pages/new.js
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+
+export const getServerSideProps = async ({ locale }) => {
+  return {
+    props: {
+      locale,
+    },
+  }
+}
+
+export default function New({ locale }) {
+  return (
+    <div>
+      <div id="new">New</div>
+      <div id="current-locale">{locale}</div>
+      <Link href="/" id="to-index">
+        To index (No Locale Specified)
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/i18n-preferred-locale-detection/i18n-preferred-locale-detection.test.ts
+++ b/test/e2e/i18n-preferred-locale-detection/i18n-preferred-locale-detection.test.ts
@@ -1,0 +1,62 @@
+import { join } from 'path'
+import { FileRef, nextTestSetup } from 'e2e-utils'
+
+describe('i18-preferred-locale-redirect', () => {
+  const { next } = nextTestSetup({
+    files: new FileRef(join(__dirname, './app/')),
+  })
+
+  it('should request a path prefixed with my preferred detected locale when accessing index', async () => {
+    const browser = await next.browser('/new', {
+      locale: 'id',
+    })
+
+    let requestedPreferredLocalePathCount = 0
+    browser.on('request', (request: any) => {
+      if (new URL(request.url(), 'http://n').pathname === '/id') {
+        requestedPreferredLocalePathCount++
+      }
+    })
+
+    const goToIndex = async () => {
+      await browser.get(next.url)
+    }
+
+    await expect(goToIndex()).resolves.not.toThrow(/ERR_TOO_MANY_REDIRECTS/)
+
+    await browser.waitForElementByCss('#index')
+
+    expect(await browser.elementByCss('#index').text()).toBe('Index')
+    expect(await browser.elementByCss('#current-locale').text()).toBe('id')
+
+    expect(requestedPreferredLocalePathCount).toBe(1)
+  })
+
+  it('should not request a path prefixed with my preferred detected locale when clicking link to index from a non-locale-prefixed path', async () => {
+    const browser = await next.browser('/new', {
+      locale: 'id',
+    })
+
+    await browser
+      .waitForElementByCss('#to-index')
+      .click()
+      .waitForElementByCss('#index')
+
+    expect(await browser.elementByCss('#index').text()).toBe('Index')
+    expect(await browser.elementByCss('#current-locale').text()).toBe('en')
+  })
+
+  it('should request a path prefixed with my preferred detected locale when clicking link to index from a locale-prefixed path', async () => {
+    const browser = await next.browser('/id/new', {
+      locale: 'id',
+    })
+
+    await browser
+      .waitForElementByCss('#to-index')
+      .click()
+      .waitForElementByCss('#index')
+
+    expect(await browser.elementByCss('#index').text()).toBe('Index')
+    expect(await browser.elementByCss('#current-locale').text()).toBe('id')
+  })
+})

--- a/test/e2e/i18n-preferred-locale-detection/i18n-preferred-locale-detection.test.ts
+++ b/test/e2e/i18n-preferred-locale-detection/i18n-preferred-locale-detection.test.ts
@@ -1,3 +1,4 @@
+import type { Request } from 'playwright'
 import { join } from 'path'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 
@@ -12,7 +13,7 @@ describe('i18-preferred-locale-redirect', () => {
     })
 
     let requestedPreferredLocalePathCount = 0
-    browser.on('request', (request: any) => {
+    browser.on('request', (request: Request) => {
       if (new URL(request.url(), 'http://n').pathname === '/id') {
         requestedPreferredLocalePathCount++
       }


### PR DESCRIPTION
This moves the locale redirect handling out of `base-server` as it shouldn't be handled here and should be at the routing level. This avoids the duplicate handling with middleware that causes the incorrect detection/infinite looping. Test case from separate PR was carried over to prevent regression.

Fixes: https://github.com/vercel/next.js/issues/55648
Closes: https://github.com/vercel/next.js/pull/62435
Closes: NEXT-2627
Closes: NEXT-2628