### PR TITLE
chore(examples): fix `with-cypress` build

### DIFF
--- a/examples/with-cypress/components/about-component.cy.tsx
+++ b/examples/with-cypress/components/about-component.cy.tsx
@@ -1,4 +1,4 @@
-import AboutComponent from "./components/about-component";
+import AboutComponent from "./about-component";
 /* eslint-disable */
 // Disable ESLint to prevent failing linting inside the Next.js repo.
 // If you're using ESLint on your project, we recommend installing the ESLint Cypress plugin instead:

--- a/examples/with-cypress/tsconfig.json
+++ b/examples/with-cypress/tsconfig.json
@@ -22,5 +22,5 @@
     "strictNullChecks": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/*.cy.*"]
 }


### PR DESCRIPTION
### What?

Fix the `with-cypress` example build errors.

### Why?

`next build` is broken.

### How?

exclude tests from compilation, fix import

Fixes #50124

Closes NEXT-2629