### PR TITLE
refactor(jscodeshift): naming variables explicitly

### DIFF
--- a/packages/next-codemod/transforms/add-missing-react-import.ts
+++ b/packages/next-codemod/transforms/add-missing-react-import.ts
@@ -6,22 +6,22 @@ import type {
   Options,
 } from 'jscodeshift'
 
-function addReactImport(j: JSCodeshift, root: Collection) {
+function addReactImport(jscodeshift: JSCodeshift, root: Collection) {
   // We create an import specifier, this is the value of an import, eg:
   // import React from 'react'
   // The specifier would be `React`
-  const ReactDefaultSpecifier = j.importDefaultSpecifier(j.identifier('React'))
+  const ReactDefaultSpecifier = jscodeshift.importDefaultSpecifier(jscodeshift.identifier('React'))
 
   // Check if this file is already importing `react`
   // so that we can attach `React` to the existing import instead of creating a new `import` node
-  const originalReactImport = root.find(j.ImportDeclaration, {
+  const originalReactImport = root.find(jscodeshift.ImportDeclaration, {
     source: {
       value: 'react',
     },
   })
   if (originalReactImport.length > 0) {
     // Check if `React` is already imported. In that case we don't have to do anything
-    if (originalReactImport.find(j.ImportDefaultSpecifier).length > 0) {
+    if (originalReactImport.find(jscodeshift.ImportDefaultSpecifier).length > 0) {
       return
     }
 
@@ -34,13 +34,13 @@ function addReactImport(j: JSCodeshift, root: Collection) {
 
   // Create import node
   // import React from 'react'
-  const ReactImport = j.importDeclaration(
+  const ReactImport = jscodeshift.importDeclaration(
     [ReactDefaultSpecifier],
-    j.stringLiteral('react')
+    jscodeshift.stringLiteral('react')
   )
 
   // Find the Program, this is the top level AST node
-  const Program = root.find(j.Program)
+  const Program = root.find(jscodeshift.Program)
   // Attach the import at the top of the body
   Program.forEach((node) => {
     node.value.body.unshift(ReactImport)
@@ -52,12 +52,12 @@ export default function transformer(
   api: API,
   options: Options
 ) {
-  const j = api.jscodeshift.withParser('tsx')
-  const root = j(file.source)
+  const tsxcodeshift = api.jscodeshift.withParser('tsx')
+  const root = tsxcodeshift(file.source)
 
   const hasReactImport = (r) => {
     return (
-      r.find(j.ImportDefaultSpecifier, {
+      r.find(tsxcodeshift.ImportDefaultSpecifier, {
         local: {
           type: 'Identifier',
           name: 'React',
@@ -68,7 +68,7 @@ export default function transformer(
 
   const hasReactVariableUsage = (r) => {
     return (
-      r.find(j.MemberExpression, {
+      r.find(tsxcodeshift.MemberExpression, {
         object: {
           type: 'Identifier',
           name: 'React',
@@ -82,7 +82,7 @@ export default function transformer(
   }
 
   if (hasReactVariableUsage(root)) {
-    addReactImport(j, root)
+    addReactImport(tsxcodeshift, root)
   }
 
   return root.toSource(options)


### PR DESCRIPTION
### What?
I thought the jscodeshift variable name was non-explicit.

### How?
The variable name from 'j' was changed to 'jscodeshift' and 'tsxcodeshift'.
