### PR TITLE
fix(docs): fix onClick function example

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/05-error-handling.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/05-error-handling.mdx
@@ -44,10 +44,8 @@ export default function Error({
     <div>
       <h2>Something went wrong!</h2>
       <button
-        onClick={
-          // Attempt to recover by trying to re-render the segment
-          () => reset()
-        }
+        // Attempt to recover by trying to re-render the segment
+        onClick={reset}
       >
         Try again
       </button>

--- a/docs/02-app/01-building-your-application/01-routing/05-error-handling.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/05-error-handling.mdx
@@ -69,10 +69,8 @@ export default function Error({ error, reset }) {
     <div>
       <h2>Something went wrong!</h2>
       <button
-        onClick={
-          // Attempt to recover by trying to re-render the segment
-          () => reset()
-        }
+        // Attempt to recover by trying to re-render the segment
+        onClick={reset}
       >
         Try again
       </button>
@@ -115,7 +113,7 @@ export default function Error({
   return (
     <div>
       <h2>Something went wrong!</h2>
-      <button onClick={() => reset()}>Try again</button>
+      <button onClick={reset}>Try again</button>
     </div>
   )
 }
@@ -128,7 +126,7 @@ export default function Error({ error, reset }) {
   return (
     <div>
       <h2>Something went wrong!</h2>
-      <button onClick={() => reset()}>Try again</button>
+      <button onClick={reset}>Try again</button>
     </div>
   )
 }
@@ -187,7 +185,7 @@ export default function GlobalError({
     <html>
       <body>
         <h2>Something went wrong!</h2>
-        <button onClick={() => reset()}>Try again</button>
+        <button onClick={reset}>Try again</button>
       </body>
     </html>
   )
@@ -202,7 +200,7 @@ export default function GlobalError({ error, reset }) {
     <html>
       <body>
         <h2>Something went wrong!</h2>
-        <button onClick={() => reset()}>Try again</button>
+        <button onClick={reset}>Try again</button>
       </body>
     </html>
   )

--- a/docs/02-app/02-api-reference/02-file-conventions/error.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/error.mdx
@@ -32,10 +32,8 @@ export default function Error({
     <div>
       <h2>Something went wrong!</h2>
       <button
-        onClick={
-          // Attempt to recover by trying to re-render the segment
-          () => reset()
-        }
+        // Attempt to recover by trying to re-render the segment
+        onClick={reset}
       >
         Try again
       </button>
@@ -59,10 +57,8 @@ export default function Error({ error, reset }) {
     <div>
       <h2>Something went wrong!</h2>
       <button
-        onClick={
-          // Attempt to recover by trying to re-render the segment
-          () => reset()
-        }
+        // Attempt to recover by trying to re-render the segment
+        onClick={reset}
       >
         Try again
       </button>
@@ -120,7 +116,7 @@ export default function GlobalError({
     <html>
       <body>
         <h2>Something went wrong!</h2>
-        <button onClick={() => reset()}>Try again</button>
+        <button onClick={reset}>Try again</button>
       </body>
     </html>
   )
@@ -135,7 +131,7 @@ export default function GlobalError({ error, reset }) {
     <html>
       <body>
         <h2>Something went wrong!</h2>
-        <button onClick={() => reset()}>Try again</button>
+        <button onClick={reset}>Try again</button>
       </body>
     </html>
   )

--- a/test/e2e/app-dir/app-css/app/error/client-component/error.js
+++ b/test/e2e/app-dir/app-css/app/error/client-component/error.js
@@ -6,7 +6,7 @@ export default function ErrorBoundary({ error, reset }) {
   return (
     <>
       <p id="error-boundary-message">An error occurred: {error.message}</p>
-      <button id="reset" onClick={() => reset()} className={styles.button}>
+      <button id="reset" onClick={reset} className={styles.button}>
         Try again
       </button>
     </>

--- a/test/e2e/app-dir/errors/app/client-component/error.js
+++ b/test/e2e/app-dir/errors/app/client-component/error.js
@@ -6,7 +6,7 @@ export default function ErrorBoundary({ error, reset }) {
   return (
     <>
       <p id="error-boundary-message">An error occurred: {error.message}</p>
-      <button id="reset" onClick={() => reset()} className={styles.button}>
+      <button id="reset" onClick={reset} className={styles.button}>
         Try again
       </button>
     </>

--- a/test/e2e/app-dir/errors/app/server-component/error.js
+++ b/test/e2e/app-dir/errors/app/server-component/error.js
@@ -5,7 +5,7 @@ export default function ErrorBoundary({ error, reset }) {
     <>
       <p id="error-boundary-message">{error.message}</p>
       <p id="error-boundary-digest">{error.digest}</p>
-      <button id="reset" onClick={() => reset()}>
+      <button id="reset" onClick={reset}>
         Try again
       </button>
     </>


### PR DESCRIPTION
### What?
I found an example where the return from onClick wraps a function of type () => void back into a function of type () => void.

### How?
I assigned the function directly to onClick.