### PR TITLE
refactor(docs): change quotation marks

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/10-parallel-routes.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/10-parallel-routes.mdx
@@ -154,7 +154,7 @@ export default function Layout({
   admin: React.ReactNode
 }) {
   const role = checkUserRole()
-  return <>{role === 'admin' ? admin : user}</>
+  return <>{role === "admin" ? admin : user}</>
 }
 ```
 
@@ -163,7 +163,7 @@ import { checkUserRole } from '@/lib/auth'
 
 export default function Layout({ user, admin }) {
   const role = checkUserRole()
-  return <>{role === 'admin' ? admin : user}</>
+  return <>{role === "admin" ? admin : user}</>
 }
 ```
 


### PR DESCRIPTION
### What?
In other documents, double quotes are used for strings that do not contain a router, but here, single quotes are used.
### How?
Converted the string to double quotes.