### PR TITLE
Update Turbopack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "serde",
  "smallvec",
@@ -3147,15 +3147,16 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.68.5"
+version = "0.68.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b554d4032a7bc4d1546b2962ec3f80efd28a78734e72e3466096b075be1fa8b"
+checksum = "ca835b60f32cd43b7bcd21ba77563bee0c08f336700463e03eb086d15e46608a"
 dependencies = [
  "convert_case 0.5.0",
  "handlebars",
  "once_cell",
  "regex",
  "serde",
+ "swc_atoms",
  "swc_cached",
  "swc_common",
  "swc_ecma_ast",
@@ -3421,7 +3422,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "serde",
@@ -7409,7 +7410,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7441,7 +7442,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7453,7 +7454,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7468,7 +7469,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7482,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7499,7 +7500,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7531,7 +7532,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "base16",
  "hex",
@@ -7543,7 +7544,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7557,7 +7558,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7567,7 +7568,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "mimalloc",
 ]
@@ -7575,7 +7576,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7600,7 +7601,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7632,7 +7633,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7673,7 +7674,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7698,7 +7699,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7716,7 +7717,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7747,7 +7748,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7775,7 +7776,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7800,7 +7801,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7837,7 +7838,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7873,7 +7874,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "serde",
  "serde_json",
@@ -7884,7 +7885,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7909,7 +7910,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7926,7 +7927,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7942,7 +7943,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7962,7 +7963,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "serde",
@@ -7977,7 +7978,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7992,7 +7993,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8027,7 +8028,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "serde",
@@ -8043,7 +8044,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8054,7 +8055,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8070,7 +8071,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240227.2#8381f7ceae559a27b6e9a5c4de6fcb5c1d814edc"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "serde",
  "smallvec",
@@ -3422,7 +3422,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "serde",
@@ -7410,7 +7410,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7442,7 +7442,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7454,7 +7454,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7469,7 +7469,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7483,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7500,7 +7500,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7532,7 +7532,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "base16",
  "hex",
@@ -7544,7 +7544,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7558,7 +7558,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7568,7 +7568,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "mimalloc",
 ]
@@ -7576,7 +7576,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7601,7 +7601,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7633,7 +7633,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7674,7 +7674,7 @@ dependencies = [
 [[package]]
 name = "turbopack-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7699,7 +7699,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7717,7 +7717,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7748,7 +7748,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7776,7 +7776,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7801,7 +7801,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7838,7 +7838,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7874,7 +7874,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "serde",
  "serde_json",
@@ -7885,7 +7885,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7910,7 +7910,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7927,7 +7927,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7943,7 +7943,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7963,7 +7963,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "serde",
@@ -7978,7 +7978,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7993,7 +7993,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8028,7 +8028,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "serde",
@@ -8044,7 +8044,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8055,7 +8055,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8071,7 +8071,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.1#87e479a54ebb08fde8bc4410c0909c48797283fd"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240228.3#0c4d8b2723edf17e1f2ccd258f59652465fd3978"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.90.12", features = [
 testing = { version = "0.35.19" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240227.2" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240228.1" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240227.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240228.1" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240227.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240228.1" }
 
 # General Deps
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.90.12", features = [
 testing = { version = "0.35.19" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240228.1" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240228.3" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240228.1" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240228.3" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240228.1" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240228.3" }
 
 # General Deps
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -192,7 +192,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.4",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240228.1",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240228.3",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -192,7 +192,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.4",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240227.2",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240228.1",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1074,8 +1074,8 @@ importers:
         specifier: 0.26.4
         version: 0.26.4
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240227.2
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240227.2'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240228.1
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240228.1'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -25602,8 +25602,8 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240227.2':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240227.2}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240228.1':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240228.1}
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1074,8 +1074,8 @@ importers:
         specifier: 0.26.4
         version: 0.26.4
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240228.1
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240228.1'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240228.3
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240228.3'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -25602,8 +25602,8 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240228.1':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240228.1}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240228.3':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240228.3}
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
### What?

* https://github.com/vercel/turbo/pull/7520 <!-- Leah - fix(turbopack): restore `require.resolve` functionality  -->
* https://github.com/vercel/turbo/pull/7504 <!-- Donny/강동윤 - fix(turbopack): Enable CSS parsing option for legacy nesting syntax  -->
* https://github.com/vercel/turbo/pull/7528 <!-- Tobias Koppers - add test case for ?:  -->
* https://github.com/vercel/turbo/pull/7518 <!-- Donny/강동윤 - Update `swc_core` to `v0.90.12`  -->
* https://github.com/vercel/turbo/pull/7535 <!-- Donny/강동윤 - fix(turbopack): Fix ordering of `IssueStage`s  -->
* https://github.com/vercel/turbo/pull/7406 <!-- Leah - fix(turbopack-core): don't resolve exports field in folders  -->
* https://github.com/vercel/turbo/pull/7537 <!-- Donny/강동윤 - feat(turbopack): Add `JsValue::TypeOf`  -->
* https://github.com/vercel/turbo/pull/7527 <!-- Tobias Koppers - implement handling for alias field resolving in more cases  -->
* https://github.com/vercel/turbo/pull/7539 <!-- Tobias Koppers - add external require back to edge runtime  -->

### Why?

To keep in sync

### How?

