### PR TITLE
Server Action tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -5,6 +5,7 @@ on:
     branches: ['canary', 'next-14-1']
   pull_request:
     types: [opened, synchronize]
+    branches: ['canary', 'next-14-1']
 
 env:
   NAPI_CLI_VERSION: 2.14.7

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -829,10 +829,10 @@ async fn insert_next_shared_aliases(
     );
 
     import_map.insert_exact_alias(
-        "private-next-rsc-action-proxy",
+        "private-next-rsc-server-reference",
         request_to_import_mapping(
             project_path,
-            "next/dist/build/webpack/loaders/next-flight-loader/action-proxy",
+            "next/dist/build/webpack/loaders/next-flight-loader/server-reference",
         ),
     );
     import_map.insert_exact_alias(

--- a/packages/next-swc/crates/next-core/src/next_server/resolve.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/resolve.rs
@@ -86,7 +86,7 @@ impl ResolvePlugin for ExternalCjsModulesResolvePlugin {
         }
 
         // from https://github.com/vercel/next.js/blob/8d1c619ad650f5d147207f267441caf12acd91d1/packages/next/src/build/handle-externals.ts#L188
-        let never_external_regex = lazy_regex::regex!("^(?:private-next-pages\\/|next\\/(?:dist\\/pages\\/|(?:app|document|link|image|legacy\\/image|constants|dynamic|script|navigation|headers|router)$)|string-hash|private-next-rsc-action-validate|private-next-rsc-action-client-wrapper|private-next-rsc-action-proxy$)");
+        let never_external_regex = lazy_regex::regex!("^(?:private-next-pages\\/|next\\/(?:dist\\/pages\\/|(?:app|document|link|image|legacy\\/image|constants|dynamic|script|navigation|headers|router)$)|string-hash|private-next-rsc-action-validate|private-next-rsc-action-client-wrapper|private-next-rsc-server-reference$)");
 
         if never_external_regex.is_match(&request_value.request().unwrap_or_default()) {
             return Ok(ResolveResultOption::none());

--- a/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -132,7 +132,7 @@ impl<C: Comments> ServerActions<C> {
                     self.config.enabled,
                 );
 
-                if is_action_fn && !self.config.is_react_server_layer {
+                if is_action_fn && !self.config.is_react_server_layer && !self.in_action_file {
                     HANDLER.with(|handler| {
                         handler
                             .struct_span_err(
@@ -459,7 +459,8 @@ impl<C: Comments> VisitMut for ServerActions<C> {
             });
         }
 
-        if !self.in_action_file {
+        if !(self.in_action_file && self.in_export_decl) {
+            // It's an action function. If it doesn't have a name, give it one.
             match f.ident.as_mut() {
                 None => {
                     let action_name = gen_ident(&mut self.action_cnt);
@@ -541,7 +542,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
             });
         }
 
-        if !self.in_action_file {
+        if !(self.in_action_file && self.in_export_decl) {
             // Collect all the identifiers defined inside the closure and used
             // in the action function. With deduplication.
             retain_names_from_declared_idents(&mut child_names, &current_declared_idents);
@@ -1022,6 +1023,8 @@ impl<C: Comments> VisitMut for ServerActions<C> {
 
         if self.has_action {
             let mut actions = self.export_actions.clone();
+
+            // All exported values are considered as actions if the file is an action file.
             if self.in_action_file {
                 actions.extend(self.exported_idents.iter().map(|e| e.1.clone()));
             };

--- a/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -47,23 +47,24 @@ pub fn server_actions<C: Comments>(
         in_default_export_decl: false,
         has_action: false,
 
-        ident_cnt: 0,
-        in_module: true,
+        action_cnt: 0,
+        in_module_level: true,
         in_action_fn: false,
-        in_action_closure: false,
-        closure_idents: Default::default(),
-        action_closure_idents: Default::default(),
+        should_track_names: false,
+
+        names: Default::default(),
+        declared_idents: Default::default(),
+
         exported_idents: Default::default(),
-        inlined_action_closure_idents: Default::default(),
 
         // This flag allows us to rewrite `function foo() {}` to `const foo = createProxy(...)`.
         rewrite_fn_decl_to_proxy_decl: None,
         rewrite_default_fn_expr_to_proxy_expr: None,
+        rewrite_expr_to_proxy_expr: None,
 
         annotations: Default::default(),
         extra_items: Default::default(),
         export_actions: Default::default(),
-        replaced_action_proxies: Default::default(),
     })
 }
 
@@ -88,21 +89,21 @@ struct ServerActions<C: Comments> {
     in_default_export_decl: bool,
     has_action: bool,
 
-    ident_cnt: u32,
-    in_module: bool,
+    action_cnt: u32,
+    in_module_level: bool,
     in_action_fn: bool,
-    in_action_closure: bool,
-    closure_idents: Vec<Id>,
-    action_closure_idents: Vec<Name>,
-    inlined_action_closure_idents: Vec<(Id, Id)>,
+    should_track_names: bool,
+
+    names: Vec<Name>,
+    declared_idents: Vec<Id>,
 
     // This flag allows us to rewrite `function foo() {}` to `const foo = createProxy(...)`.
     rewrite_fn_decl_to_proxy_decl: Option<VarDecl>,
     rewrite_default_fn_expr_to_proxy_expr: Option<Box<Expr>>,
+    rewrite_expr_to_proxy_expr: Option<Box<Expr>>,
 
     // (ident, export name)
     exported_idents: Vec<(Id, String)>,
-    replaced_action_proxies: Vec<(Ident, Box<Expr>)>,
 
     annotations: Vec<Stmt>,
     extra_items: Vec<ModuleItem>,
@@ -149,38 +150,16 @@ impl<C: Comments> ServerActions<C> {
 
     fn maybe_hoist_and_create_proxy(
         &mut self,
-        ident: &Ident,
+        ids_from_closure: Vec<Name>,
         function: Option<&mut Box<Function>>,
         arrow: Option<&mut ArrowExpr>,
-    ) -> (Option<Box<Expr>>, Option<Box<Expr>>) {
-        let action_name: JsWord = gen_ident(&mut self.ident_cnt);
+    ) -> Option<Box<Expr>> {
+        let action_name: JsWord = gen_ident(&mut self.action_cnt);
         let action_ident = private_ident!(action_name.clone());
-
-        if !self.in_action_file {
-            self.inlined_action_closure_idents
-                .push((ident.to_id(), action_ident.to_id()));
-        }
-
         let export_name: JsWord = action_name;
 
         self.has_action = true;
         self.export_actions.push(export_name.to_string());
-
-        // Hoist the function to the top level and export it. To hoist it, we need to
-        // first Collect all the identifiers defined in the closure and used
-        // in the action function. Dedup the identifiers.
-        let mut added_ids = Vec::new();
-        let mut ids_from_closure = self.action_closure_idents.clone();
-        ids_from_closure.retain(|id| {
-            if added_ids.contains(id) {
-                false
-            } else if self.closure_idents.contains(&id.0) {
-                added_ids.push(id.clone());
-                true
-            } else {
-                false
-            }
-        });
 
         if let Some(a) = arrow {
             let register_action_expr = annotate_ident_as_action(
@@ -198,9 +177,6 @@ impl<C: Comments> ServerActions<C> {
                 block.visit_mut_with(&mut ClosureReplacer {
                     used_ids: &ids_from_closure,
                 });
-
-                self.replaced_action_proxies
-                    .push((ident.clone(), Box::new(register_action_expr.clone())));
             }
 
             // export const $ACTION_myAction = async () => {}
@@ -309,10 +285,7 @@ impl<C: Comments> ServerActions<C> {
                     .into(),
                 })));
 
-            return (
-                Some(Box::new(Expr::Ident(ident.clone()))),
-                Some(Box::new(register_action_expr)),
-            );
+            return Some(Box::new(register_action_expr.clone()));
         } else if let Some(f) = function {
             let register_action_expr = annotate_ident_as_action(
                 action_ident.clone(),
@@ -328,9 +301,6 @@ impl<C: Comments> ServerActions<C> {
             f.body.visit_mut_with(&mut ClosureReplacer {
                 used_ids: &ids_from_closure,
             });
-
-            self.replaced_action_proxies
-                .push((ident.clone(), Box::new(register_action_expr.clone())));
 
             // export async function $ACTION_myAction () {}
             let mut new_params: Vec<Param> = vec![];
@@ -411,13 +381,10 @@ impl<C: Comments> ServerActions<C> {
                     .into(),
                 })));
 
-            return (
-                Some(Box::new(Expr::Ident(ident.clone()))),
-                Some(Box::new(register_action_expr)),
-            );
+            return Some(Box::new(register_action_expr));
         }
 
-        (None, None)
+        None
     }
 }
 
@@ -451,29 +418,34 @@ impl<C: Comments> VisitMut for ServerActions<C> {
     }
 
     fn visit_mut_fn_expr(&mut self, f: &mut FnExpr) {
-        let is_action_fn = self.get_action_info(f.function.body.as_mut(), false);
+        let is_action_fn = self.get_action_info(f.function.body.as_mut(), true);
 
+        let current_declared_idents = self.declared_idents.clone();
+        let current_names = self.names.clone();
+        self.names = vec![];
+
+        // Visit children
         {
-            // Visit children
             let old_in_action_fn = self.in_action_fn;
-            let old_in_module = self.in_module;
-            let old_in_action_closure = self.in_action_closure;
+            let old_in_module = self.in_module_level;
+            let old_should_track_names = self.should_track_names;
             let old_in_export_decl = self.in_export_decl;
             let old_in_default_export_decl = self.in_default_export_decl;
-            let old_closure_idents = self.closure_idents.clone();
             self.in_action_fn = is_action_fn;
-            self.in_module = false;
-            self.in_action_closure = true;
+            self.in_module_level = false;
+            self.should_track_names = true;
             self.in_export_decl = false;
             self.in_default_export_decl = false;
             f.visit_mut_children_with(self);
             self.in_action_fn = old_in_action_fn;
-            self.in_module = old_in_module;
-            self.in_action_closure = old_in_action_closure;
+            self.in_module_level = old_in_module;
+            self.should_track_names = old_should_track_names;
             self.in_export_decl = old_in_export_decl;
             self.in_default_export_decl = old_in_default_export_decl;
-            self.closure_idents = old_closure_idents;
         }
+
+        let mut child_names = self.names.clone();
+        self.names.extend(current_names);
 
         if !is_action_fn {
             return;
@@ -487,25 +459,32 @@ impl<C: Comments> VisitMut for ServerActions<C> {
             });
         }
 
-        if !self.in_action_file && self.in_default_export_decl {
-            // This function expression is also the default export:
-            // `export default async function() {}`
-            // In this case, we need to collect the action and hoist, because this specific
-            // case (default export) isn't handled by `visit_mut_expr`.
-            let ident = match f.ident.as_mut() {
+        if !self.in_action_file {
+            match f.ident.as_mut() {
                 None => {
-                    let action_name = gen_ident(&mut self.ident_cnt);
+                    let action_name = gen_ident(&mut self.action_cnt);
                     let ident = Ident::new(action_name, DUMMY_SP);
                     f.ident.insert(ident)
                 }
                 Some(i) => i,
             };
 
-            let (_, register_action_expr) =
-                self.maybe_hoist_and_create_proxy(ident, Some(&mut f.function), None);
+            // Collect all the identifiers defined inside the closure and used
+            // in the action function. With deduplication.
+            retain_names_from_declared_idents(&mut child_names, &current_declared_idents);
 
-            // Replace the original function expr with a action proxy expr.
-            self.rewrite_default_fn_expr_to_proxy_expr = register_action_expr;
+            let maybe_new_expr =
+                self.maybe_hoist_and_create_proxy(child_names, Some(&mut f.function), None);
+
+            if self.in_default_export_decl {
+                // This function expression is also the default export:
+                // `export default async function() {}`
+                // This specific case (default export) isn't handled by `visit_mut_expr`.
+                // Replace the original function expr with a action proxy expr.
+                self.rewrite_default_fn_expr_to_proxy_expr = maybe_new_expr;
+            } else {
+                self.rewrite_expr_to_proxy_expr = maybe_new_expr;
+            }
         }
     }
 
@@ -523,27 +502,32 @@ impl<C: Comments> VisitMut for ServerActions<C> {
     fn visit_mut_fn_decl(&mut self, f: &mut FnDecl) {
         let is_action_fn = self.get_action_info(f.function.body.as_mut(), true);
 
+        let current_declared_idents = self.declared_idents.clone();
+        let current_names = self.names.clone();
+        self.names = vec![];
+
         {
             // Visit children
             let old_in_action_fn = self.in_action_fn;
-            let old_in_module = self.in_module;
-            let old_in_action_closure = self.in_action_closure;
+            let old_in_module = self.in_module_level;
+            let old_should_track_names = self.should_track_names;
             let old_in_export_decl = self.in_export_decl;
             let old_in_default_export_decl = self.in_default_export_decl;
-            let old_closure_idents = self.closure_idents.clone();
             self.in_action_fn = is_action_fn;
-            self.in_module = false;
-            self.in_action_closure = true;
+            self.in_module_level = false;
+            self.should_track_names = true;
             self.in_export_decl = false;
             self.in_default_export_decl = false;
             f.visit_mut_children_with(self);
             self.in_action_fn = old_in_action_fn;
-            self.in_module = old_in_module;
-            self.in_action_closure = old_in_action_closure;
+            self.in_module_level = old_in_module;
+            self.should_track_names = old_should_track_names;
             self.in_export_decl = old_in_export_decl;
             self.in_default_export_decl = old_in_default_export_decl;
-            self.closure_idents = old_closure_idents;
         }
+
+        let mut child_names = self.names.clone();
+        self.names.extend(current_names);
 
         if !is_action_fn {
             return;
@@ -555,9 +539,15 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                     .struct_span_err(f.ident.span, "Server actions must be async functions")
                     .emit();
             });
-        } else if !self.in_action_file {
-            let (_, register_action_expr) =
-                self.maybe_hoist_and_create_proxy(&f.ident, Some(&mut f.function), None);
+        }
+
+        if !self.in_action_file {
+            // Collect all the identifiers defined inside the closure and used
+            // in the action function. With deduplication.
+            retain_names_from_declared_idents(&mut child_names, &current_declared_idents);
+
+            let maybe_new_expr =
+                self.maybe_hoist_and_create_proxy(child_names, Some(&mut f.function), None);
 
             // Replace the original function declaration with a action proxy declaration
             // expr.
@@ -568,7 +558,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                 decls: vec![VarDeclarator {
                     span: DUMMY_SP,
                     name: Pat::Ident(f.ident.clone().into()),
-                    init: register_action_expr,
+                    init: maybe_new_expr,
                     definite: false,
                 }],
             });
@@ -584,37 +574,40 @@ impl<C: Comments> VisitMut for ServerActions<C> {
             } else {
                 None
             },
-            false,
+            true,
         );
+
+        let current_declared_idents = self.declared_idents.clone();
+        let current_names = self.names.clone();
+        self.names = vec![];
 
         {
             // Visit children
             let old_in_action_fn = self.in_action_fn;
-            let old_in_module = self.in_module;
-            let old_in_action_closure = self.in_action_closure;
+            let old_in_module = self.in_module_level;
+            let old_should_track_names = self.should_track_names;
             let old_in_export_decl = self.in_export_decl;
             let old_in_default_export_decl = self.in_default_export_decl;
-            let old_closure_idents = self.closure_idents.clone();
             self.in_action_fn = is_action_fn;
-            self.in_module = false;
-            self.in_action_closure = true;
+            self.in_module_level = false;
+            self.should_track_names = true;
             self.in_export_decl = false;
             self.in_default_export_decl = false;
             {
-                if !self.in_action_fn && !self.in_action_file {
-                    for n in &mut a.params {
-                        collect_pat_idents(n, &mut self.closure_idents);
-                    }
+                for n in &mut a.params {
+                    collect_pat_idents(n, &mut self.declared_idents);
                 }
             }
             a.visit_mut_children_with(self);
             self.in_action_fn = old_in_action_fn;
-            self.in_module = old_in_module;
-            self.in_action_closure = old_in_action_closure;
+            self.in_module_level = old_in_module;
+            self.should_track_names = old_should_track_names;
             self.in_export_decl = old_in_export_decl;
             self.in_default_export_decl = old_in_default_export_decl;
-            self.closure_idents = old_closure_idents;
         }
+
+        let mut child_names = self.names.clone();
+        self.names.extend(current_names);
 
         if !is_action_fn {
             return;
@@ -627,6 +620,13 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                     .emit();
             });
         }
+
+        // Collect all the identifiers defined inside the closure and used
+        // in the action function. With deduplication.
+        retain_names_from_declared_idents(&mut child_names, &current_declared_idents);
+
+        let maybe_new_expr = self.maybe_hoist_and_create_proxy(child_names, None, Some(a));
+        self.rewrite_expr_to_proxy_expr = maybe_new_expr;
     }
 
     fn visit_mut_module(&mut self, m: &mut Module) {
@@ -637,31 +637,32 @@ impl<C: Comments> VisitMut for ServerActions<C> {
     fn visit_mut_stmt(&mut self, n: &mut Stmt) {
         n.visit_mut_children_with(self);
 
-        if self.in_module {
+        if self.in_module_level {
             return;
         }
 
-        let ids = collect_idents_in_stmt(n);
-        if !self.in_action_fn && !self.in_action_file {
-            self.closure_idents.extend(ids);
-        }
+        // If it's a closure (not in the module level), we need to collect
+        // identifiers defined in the closure.
+        self.declared_idents.extend(collect_decl_idents_in_stmt(n));
     }
 
     fn visit_mut_param(&mut self, n: &mut Param) {
         n.visit_mut_children_with(self);
 
-        if !self.in_action_fn && !self.in_action_file {
-            collect_pat_idents(&n.pat, &mut self.closure_idents);
+        if self.in_module_level {
+            return;
         }
+
+        collect_pat_idents(&n.pat, &mut self.declared_idents);
     }
 
     fn visit_mut_prop_or_spread(&mut self, n: &mut PropOrSpread) {
-        if self.in_action_fn && self.in_action_closure {
+        if !self.in_module_level && self.should_track_names {
             if let PropOrSpread::Prop(box Prop::Shorthand(i)) = n {
-                self.in_action_closure = false;
-                self.action_closure_idents.push(Name::from(&*i));
+                self.names.push(Name::from(&*i));
+                self.should_track_names = false;
                 n.visit_mut_children_with(self);
-                self.in_action_closure = true;
+                self.should_track_names = true;
                 return;
             }
         }
@@ -670,73 +671,21 @@ impl<C: Comments> VisitMut for ServerActions<C> {
     }
 
     fn visit_mut_expr(&mut self, n: &mut Expr) {
-        if self.in_action_fn && self.in_action_closure {
+        if !self.in_module_level && self.should_track_names {
             if let Ok(name) = Name::try_from(&*n) {
-                self.in_action_closure = false;
-                self.action_closure_idents.push(name);
+                self.names.push(name);
+                self.should_track_names = false;
                 n.visit_mut_children_with(self);
-                self.in_action_closure = true;
+                self.should_track_names = true;
                 return;
             }
         }
 
+        self.rewrite_expr_to_proxy_expr = None;
         n.visit_mut_children_with(self);
-
-        if self.in_action_file {
-            return;
-        }
-
-        match n {
-            Expr::Arrow(a) => {
-                let is_action_fn = self.get_action_info(
-                    if let BlockStmtOrExpr::BlockStmt(block) = &mut *a.body {
-                        Some(block)
-                    } else {
-                        None
-                    },
-                    true,
-                );
-
-                if !is_action_fn {
-                    return;
-                }
-
-                // We need to give a name to the arrow function
-                // action and hoist it to the top.
-                let action_name = gen_ident(&mut self.ident_cnt);
-                let ident = private_ident!(action_name);
-
-                let (maybe_new_expr, _) = self.maybe_hoist_and_create_proxy(&ident, None, Some(a));
-
-                *n = if let Some(new_expr) = maybe_new_expr {
-                    *new_expr
-                } else {
-                    Expr::Arrow(a.clone())
-                };
-            }
-            Expr::Fn(f) => {
-                let is_action_fn = self.get_action_info(f.function.body.as_mut(), true);
-
-                if !is_action_fn {
-                    return;
-                }
-                let ident = match f.ident.as_mut() {
-                    None => {
-                        let action_name = gen_ident(&mut self.ident_cnt);
-                        let ident = Ident::new(action_name, DUMMY_SP);
-                        f.ident.insert(ident)
-                    }
-                    Some(i) => i,
-                };
-
-                let (maybe_new_expr, _) =
-                    self.maybe_hoist_and_create_proxy(ident, Some(&mut f.function), None);
-
-                if let Some(new_expr) = maybe_new_expr {
-                    *n = *new_expr;
-                }
-            }
-            _ => {}
+        if let Some(expr) = &self.rewrite_expr_to_proxy_expr {
+            *n = (**expr).clone();
+            self.rewrite_expr_to_proxy_expr = None;
         }
     }
 
@@ -833,7 +782,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                             } else {
                                 // export default function() {}
                                 let new_ident =
-                                    Ident::new(gen_ident(&mut self.ident_cnt), DUMMY_SP);
+                                    Ident::new(gen_ident(&mut self.action_cnt), DUMMY_SP);
                                 f.ident = Some(new_ident.clone());
                                 self.exported_idents
                                     .push((new_ident.to_id(), "default".into()));
@@ -852,7 +801,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                                 } else {
                                     // export default async () => {}
                                     let new_ident =
-                                        Ident::new(gen_ident(&mut self.ident_cnt), DUMMY_SP);
+                                        Ident::new(gen_ident(&mut self.action_cnt), DUMMY_SP);
 
                                     self.exported_idents
                                         .push((new_ident.to_id(), "default".into()));
@@ -871,7 +820,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                             Expr::Call(call) => {
                                 // export default fn()
                                 let new_ident =
-                                    Ident::new(gen_ident(&mut self.ident_cnt), DUMMY_SP);
+                                    Ident::new(gen_ident(&mut self.action_cnt), DUMMY_SP);
 
                                 self.exported_idents
                                     .push((new_ident.to_id(), "default".into()));
@@ -1150,10 +1099,6 @@ impl<C: Comments> VisitMut for ServerActions<C> {
 
         *stmts = new;
 
-        stmts.visit_mut_with(&mut ClosureActionReplacer {
-            replaced_action_proxies: &self.replaced_action_proxies,
-        });
-
         self.annotations = old_annotations;
     }
 
@@ -1174,6 +1119,22 @@ impl<C: Comments> VisitMut for ServerActions<C> {
     }
 
     noop_visit_mut_type!();
+}
+
+fn retain_names_from_declared_idents(child_names: &mut Vec<Name>, current_declared_idents: &[Id]) {
+    // Collect all the identifiers defined inside the closure and used
+    // in the action function. With deduplication.
+    let mut added_names = Vec::new();
+    child_names.retain(|name| {
+        if added_names.contains(name) {
+            false
+        } else if current_declared_idents.contains(&name.0) {
+            added_names.push(name.clone());
+            true
+        } else {
+            false
+        }
+    });
 }
 
 fn gen_ident(cnt: &mut u32) -> JsWord {
@@ -1574,7 +1535,7 @@ fn collect_idents_in_var_decls(decls: &[VarDeclarator]) -> Vec<Id> {
     ids
 }
 
-fn collect_idents_in_stmt(stmt: &Stmt) -> Vec<Id> {
+fn collect_decl_idents_in_stmt(stmt: &Stmt) -> Vec<Id> {
     let mut ids = Vec::new();
 
     if let Stmt::Decl(Decl::Var(var)) = &stmt {
@@ -1582,45 +1543,6 @@ fn collect_idents_in_stmt(stmt: &Stmt) -> Vec<Id> {
     }
 
     ids
-}
-
-pub(crate) struct ClosureActionReplacer<'a> {
-    replaced_action_proxies: &'a Vec<(Ident, Box<Expr>)>,
-}
-
-impl ClosureActionReplacer<'_> {
-    fn index(&self, i: &Ident) -> Option<usize> {
-        self.replaced_action_proxies
-            .iter()
-            .position(|(ident, _)| ident.sym == i.sym && ident.span.ctxt == i.span.ctxt)
-    }
-}
-
-impl VisitMut for ClosureActionReplacer<'_> {
-    fn visit_mut_expr(&mut self, e: &mut Expr) {
-        e.visit_mut_children_with(self);
-
-        if let Expr::Ident(i) = e {
-            if let Some(index) = self.index(i) {
-                *e = *self.replaced_action_proxies[index].1.clone();
-            }
-        }
-    }
-
-    fn visit_mut_prop_or_spread(&mut self, n: &mut PropOrSpread) {
-        n.visit_mut_children_with(self);
-
-        if let PropOrSpread::Prop(box Prop::Shorthand(i)) = n {
-            if let Some(index) = self.index(i) {
-                *n = PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
-                    key: PropName::Ident(i.clone()),
-                    value: Box::new(*self.replaced_action_proxies[index].1.clone()),
-                })));
-            }
-        }
-    }
-
-    noop_visit_mut_type!();
 }
 
 pub(crate) struct ClosureReplacer<'a> {

--- a/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -1021,11 +1021,11 @@ impl<C: Comments> VisitMut for ServerActions<C> {
         }
 
         if self.has_action {
-            let actions = if self.in_action_file {
-                self.exported_idents.iter().map(|e| e.1.clone()).collect()
-            } else {
-                self.export_actions.clone()
+            let mut actions = self.export_actions.clone();
+            if self.in_action_file {
+                actions.extend(self.exported_idents.iter().map(|e| e.1.clone()));
             };
+
             let actions = actions
                 .into_iter()
                 .map(|name| (generate_action_id(&self.file_name, &name), name))

--- a/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -1045,19 +1045,19 @@ impl<C: Comments> VisitMut for ServerActions<C> {
 
             if self.config.is_react_server_layer {
                 // Inlined actions are only allowed on the server layer.
-                // import { createActionProxy } from 'private-next-rsc-action-proxy'
-                // createActionProxy("action_id")
+                // import { registerServerReference } from 'private-next-rsc-server-reference'
+                // registerServerReference("action_id")
                 new.push(ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
                     span: DUMMY_SP,
                     specifiers: vec![ImportSpecifier::Named(ImportNamedSpecifier {
                         span: DUMMY_SP,
-                        local: quote_ident!("createActionProxy"),
+                        local: quote_ident!("registerServerReference"),
                         imported: None,
                         is_type_only: false,
                     })],
                     src: Box::new(Str {
                         span: DUMMY_SP,
-                        value: "private-next-rsc-action-proxy".into(),
+                        value: "private-next-rsc-server-reference".into(),
                         raw: None,
                     }),
                     type_only: false,
@@ -1214,13 +1214,13 @@ fn annotate_ident_as_action(
     file_name: &str,
     export_name: String,
 ) -> Expr {
-    // Add the proxy wrapper call `createActionProxy($$id, $$bound, myAction,
+    // Add the proxy wrapper call `registerServerReference($$id, $$bound, myAction,
     // maybe_orig_action)`.
     let action_id = generate_action_id(file_name, &export_name);
 
     let proxy_expr = Expr::Call(CallExpr {
         span: DUMMY_SP,
-        callee: quote_ident!("createActionProxy").as_callee(),
+        callee: quote_ident!("registerServerReference").as_callee(),
         args: vec![
             // $$id
             ExprOrSpread {

--- a/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/client-graph/1/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/client-graph/1/output.js
@@ -1,5 +1,5 @@
 /* __next_internal_client_entry_do_not_use__ default auto */ /* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ export async function $$ACTION_0() {}
 export default function App() {
-    var fn = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
+    var fn = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
     return <div>App</div>;
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/1/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/1/output.js
@@ -1,8 +1,8 @@
-/* __next_internal_action_entry_do_not_use__ {"ab21efdafbe611287bc25c0462b1e0510d13e48b":"foo"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"ab21efdafbe611287bc25c0462b1e0510d13e48b":"foo"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export function foo() {}
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     foo
 ]);
-createActionProxy("ab21efdafbe611287bc25c0462b1e0510d13e48b", foo);
+registerServerReference("ab21efdafbe611287bc25c0462b1e0510d13e48b", foo);

--- a/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/2/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/2/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"ac840dcaf5e8197cb02b7f3a43c119b7a770b272":"bar"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"ac840dcaf5e8197cb02b7f3a43c119b7a770b272":"bar"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 'use strict';
 export function bar() {}
@@ -6,4 +6,4 @@ import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     bar
 ]);
-createActionProxy("ac840dcaf5e8197cb02b7f3a43c119b7a770b272", bar);
+registerServerReference("ac840dcaf5e8197cb02b7f3a43c119b7a770b272", bar);

--- a/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/3/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/3/output.js
@@ -1,8 +1,8 @@
-/* __next_internal_action_entry_do_not_use__ {"b78c261f135a7a852508c2920bd7228020ff4bd7":"x"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"b78c261f135a7a852508c2920bd7228020ff4bd7":"x"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export const x = 1;
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     x
 ]);
-createActionProxy("b78c261f135a7a852508c2920bd7228020ff4bd7", x);
+registerServerReference("b78c261f135a7a852508c2920bd7228020ff4bd7", x);

--- a/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/4/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/4/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export default class Component {
     render() {

--- a/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/5/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/5/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export * from 'foo';
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";

--- a/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/6/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/6/output.js
@@ -1,6 +1,6 @@
-/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-export default createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
+export default registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
 export async function $$ACTION_0() {}
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([]);

--- a/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/6/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/6/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export default createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
 export async function $$ACTION_0() {}

--- a/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/6/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/6/output.js
@@ -1,5 +1,6 @@
 /* __next_internal_action_entry_do_not_use__ {} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-export default (()=>{});
+export default createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
+export async function $$ACTION_0() {}
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([]);

--- a/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/7/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/7/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-const foo = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
+const foo = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
 export async function $$ACTION_0() {}

--- a/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/7/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/7/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-const foo = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1);
-export async function $$ACTION_1() {}
+const foo = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
+export async function $$ACTION_0() {}

--- a/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/8/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/8/output.js
@@ -1,6 +1,6 @@
-/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-const foo = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
+const foo = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
 export async function $$ACTION_0() {
     'use strict';
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/8/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/errors/server-actions/server-graph/8/output.js
@@ -1,7 +1,7 @@
-/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-const foo = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1);
-export async function $$ACTION_1() {
+const foo = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
+export async function $$ACTION_0() {
     'use strict';
 }
 const bar = async ()=>{

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/client/5/input.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/client/5/input.js
@@ -1,0 +1,26 @@
+'use server'
+
+let a, f
+
+export async function action0(b, c, ...g) {
+  return async function action1(d) {
+    'use server'
+    let f
+    console.log(...window, { window })
+    console.log(a, b, action2)
+
+    async function action2(e) {
+      'use server'
+      console.log(a, c, d, e, f, g)
+    }
+
+    return [
+      action2,
+      async function action3(e) {
+        'use server'
+        action2(e)
+        console.log(a, c, d, e)
+      },
+    ]
+  }
+}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/client/5/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/client/5/output.js
@@ -1,0 +1,2 @@
+/* __next_internal_action_entry_do_not_use__ {"0090eaf4e1f08a2d94f6be401e54a2ded399b87c":"action0","188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ export var action0 = createServerReference("0090eaf4e1f08a2d94f6be401e54a2ded399b87c");
+import { createServerReference } from "private-next-rsc-action-client-wrapper";

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/1/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/1/output.js
@@ -1,8 +1,8 @@
-/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import deleteFromDb from 'db';
 export function Item({ id1, id2 }) {
-    var deleteItem = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
+    var deleteItem = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         id1,
         id2
     ]));
@@ -18,7 +18,7 @@ export default function Home() {
         name: 'John',
         test: 'test'
     };
-    const action = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
+    const action = registerServerReference("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
         info.name,
         info.test
     ]));

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/1/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/1/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import deleteFromDb from 'db';
 export function Item({ id1, id2 }) {
@@ -6,10 +6,7 @@ export function Item({ id1, id2 }) {
         id1,
         id2
     ]));
-    return <Button action={createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
-        id1,
-        id2
-    ]))}>Delete</Button>;
+    return <Button action={deleteItem}>Delete</Button>;
 }
 export async function $$ACTION_0($$ACTION_CLOSURE_BOUND) {
     var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);
@@ -21,14 +18,14 @@ export default function Home() {
         name: 'John',
         test: 'test'
     };
-    const action = createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2).bind(null, encryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", [
+    const action = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
         info.name,
         info.test
     ]));
     return null;
 }
-export async function $$ACTION_2($$ACTION_CLOSURE_BOUND) {
-    var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_CLOSURE_BOUND);
+export async function $$ACTION_1($$ACTION_CLOSURE_BOUND) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
     console.log($$ACTION_ARG_0);
     console.log($$ACTION_ARG_1);
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/10/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/10/output.js
@@ -1,8 +1,8 @@
-/* __next_internal_action_entry_do_not_use__ {"c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export default async function foo() {}
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     foo
 ]);
-createActionProxy("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", foo);
+registerServerReference("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", foo);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/11/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/11/output.js
@@ -1,8 +1,8 @@
-/* __next_internal_action_entry_do_not_use__ {"c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export default async function $$ACTION_0() {}
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     $$ACTION_0
 ]);
-createActionProxy("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", $$ACTION_0);
+registerServerReference("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", $$ACTION_0);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/12/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/12/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 async function foo() {}
 export default foo;
@@ -6,4 +6,4 @@ import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     foo
 ]);
-createActionProxy("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", foo);
+registerServerReference("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", foo);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/13/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/13/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"ac840dcaf5e8197cb02b7f3a43c119b7a770b272":"bar","c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"ac840dcaf5e8197cb02b7f3a43c119b7a770b272":"bar","c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 const foo = async function() {};
 export default foo;
@@ -9,5 +9,5 @@ ensureServerEntryExports([
     foo,
     bar
 ]);
-createActionProxy("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", foo);
-createActionProxy("ac840dcaf5e8197cb02b7f3a43c119b7a770b272", bar);
+registerServerReference("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", foo);
+registerServerReference("ac840dcaf5e8197cb02b7f3a43c119b7a770b272", bar);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/14/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/14/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"ab21efdafbe611287bc25c0462b1e0510d13e48b":"foo"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"ab21efdafbe611287bc25c0462b1e0510d13e48b":"foo"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export async function foo() {
     async function bar() {}
@@ -7,4 +7,4 @@ import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     foo
 ]);
-createActionProxy("ab21efdafbe611287bc25c0462b1e0510d13e48b", foo);
+registerServerReference("ab21efdafbe611287bc25c0462b1e0510d13e48b", foo);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/15/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/15/output.js
@@ -1,6 +1,6 @@
-/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-export default $$ACTION_0 = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1);
+export default $$ACTION_0 = registerServerReference("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1);
 var $$ACTION_0;
 export async function $$ACTION_1(a, b) {
     console.log(a, b);
@@ -9,4 +9,4 @@ import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     $$ACTION_0
 ]);
-createActionProxy("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", $$ACTION_0);
+registerServerReference("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", $$ACTION_0);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/15/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/15/output.js
@@ -1,9 +1,10 @@
 /* __next_internal_action_entry_do_not_use__ {"c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-export default $$ACTION_0 = async (a, b)=>{
-    console.log(a, b);
-};
+export default $$ACTION_0 = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1);
 var $$ACTION_0;
+export async function $$ACTION_1(a, b) {
+    console.log(a, b);
+}
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     $$ACTION_0

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/15/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/15/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export default $$ACTION_0 = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1);
 var $$ACTION_0;

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/16/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/16/output.js
@@ -1,10 +1,10 @@
-/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import deleteFromDb from 'db';
 const v1 = 'v1';
 export function Item({ id1, id2 }) {
     const v2 = id2;
-    const deleteItem = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
+    const deleteItem = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         id1,
         v2
     ]));
@@ -17,7 +17,7 @@ export async function $$ACTION_0($$ACTION_CLOSURE_BOUND) {
     await deleteFromDb($$ACTION_ARG_1);
 }
 const f = (x)=>{
-    var g = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
+    var g = registerServerReference("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
         x
     ]));
 };
@@ -26,7 +26,7 @@ export async function $$ACTION_1($$ACTION_CLOSURE_BOUND, y, ...z) {
     return $$ACTION_ARG_0 + y + z[0];
 }
 const g = (x)=>{
-    f = createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2).bind(null, encryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", [
+    f = registerServerReference("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2).bind(null, encryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", [
         x
     ]));
 };

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/16/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/16/output.js
@@ -1,36 +1,36 @@
-/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2","9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c":"$$ACTION_4"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import deleteFromDb from 'db';
 const v1 = 'v1';
 export function Item({ id1, id2 }) {
     const v2 = id2;
-    const deleteItem = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
+    const deleteItem = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         id1,
         v2
     ]));
     return <Button action={deleteItem}>Delete</Button>;
 }
-export async function $$ACTION_1($$ACTION_CLOSURE_BOUND) {
-    var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
+export async function $$ACTION_0($$ACTION_CLOSURE_BOUND) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);
     await deleteFromDb($$ACTION_ARG_0);
     await deleteFromDb(v1);
     await deleteFromDb($$ACTION_ARG_1);
 }
 const f = (x)=>{
-    var g = createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2).bind(null, encryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", [
+    var g = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
+        x
+    ]));
+};
+export async function $$ACTION_1($$ACTION_CLOSURE_BOUND, y, ...z) {
+    var [$$ACTION_ARG_0] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
+    return $$ACTION_ARG_0 + y + z[0];
+}
+const g = (x)=>{
+    f = createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2).bind(null, encryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", [
         x
     ]));
 };
 export async function $$ACTION_2($$ACTION_CLOSURE_BOUND, y, ...z) {
     var [$$ACTION_ARG_0] = await decryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_CLOSURE_BOUND);
-    return $$ACTION_ARG_0 + y + z[0];
-}
-const g = (x)=>{
-    f = createActionProxy("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_4).bind(null, encryptActionBoundArgs("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", [
-        x
-    ]));
-};
-export async function $$ACTION_4($$ACTION_CLOSURE_BOUND, y, ...z) {
-    var [$$ACTION_ARG_0] = await decryptActionBoundArgs("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_CLOSURE_BOUND);
     return $$ACTION_ARG_0 + y + z[0];
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/17/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/17/output.js
@@ -1,6 +1,6 @@
-/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","ab21efdafbe611287bc25c0462b1e0510d13e48b":"foo","ac840dcaf5e8197cb02b7f3a43c119b7a770b272":"bar"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","ab21efdafbe611287bc25c0462b1e0510d13e48b":"foo","ac840dcaf5e8197cb02b7f3a43c119b7a770b272":"bar"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-export const foo = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
+export const foo = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
 export async function $$ACTION_0() {}
 const bar = async ()=>{};
 export { bar };
@@ -9,5 +9,5 @@ ensureServerEntryExports([
     foo,
     bar
 ]);
-createActionProxy("ab21efdafbe611287bc25c0462b1e0510d13e48b", foo);
-createActionProxy("ac840dcaf5e8197cb02b7f3a43c119b7a770b272", bar);
+registerServerReference("ab21efdafbe611287bc25c0462b1e0510d13e48b", foo);
+registerServerReference("ac840dcaf5e8197cb02b7f3a43c119b7a770b272", bar);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/17/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/17/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"ab21efdafbe611287bc25c0462b1e0510d13e48b":"foo","ac840dcaf5e8197cb02b7f3a43c119b7a770b272":"bar"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","ab21efdafbe611287bc25c0462b1e0510d13e48b":"foo","ac840dcaf5e8197cb02b7f3a43c119b7a770b272":"bar"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export const foo = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
 export async function $$ACTION_0() {}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/17/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/17/output.js
@@ -1,6 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"ab21efdafbe611287bc25c0462b1e0510d13e48b":"foo","ac840dcaf5e8197cb02b7f3a43c119b7a770b272":"bar"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-export const foo = async ()=>{};
+export const foo = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
+export async function $$ACTION_0() {}
 const bar = async ()=>{};
 export { bar };
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/18/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/18/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import deleteFromDb from 'db';
 const v1 = 'v1';
@@ -6,7 +6,7 @@ export function Item({ id1, id2 }) {
     const v2 = id2;
     return <>
 
-      <Button action={createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
+      <Button action={registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         id1,
         v2
     ]))}>
@@ -15,7 +15,7 @@ export function Item({ id1, id2 }) {
 
       </Button>
 
-      <Button action={createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2).bind(null, encryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", [
+      <Button action={registerServerReference("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2).bind(null, encryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", [
         id1,
         v2
     ]))}>

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/18/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/18/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","56a859f462d35a297c46a1bbd1e6a9058c104ab8":"$$ACTION_3"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import deleteFromDb from 'db';
 const v1 = 'v1';
@@ -6,7 +6,7 @@ export function Item({ id1, id2 }) {
     const v2 = id2;
     return <>
 
-      <Button action={createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
+      <Button action={createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         id1,
         v2
     ]))}>
@@ -15,7 +15,7 @@ export function Item({ id1, id2 }) {
 
       </Button>
 
-      <Button action={createActionProxy("56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_3).bind(null, encryptActionBoundArgs("56a859f462d35a297c46a1bbd1e6a9058c104ab8", [
+      <Button action={createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2).bind(null, encryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", [
         id1,
         v2
     ]))}>
@@ -26,14 +26,14 @@ export function Item({ id1, id2 }) {
 
     </>;
 }
-export async function $$ACTION_1($$ACTION_CLOSURE_BOUND) {
-    var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
+export async function $$ACTION_0($$ACTION_CLOSURE_BOUND) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);
     await deleteFromDb($$ACTION_ARG_0);
     await deleteFromDb(v1);
     await deleteFromDb($$ACTION_ARG_1);
 }
-export async function $$ACTION_3($$ACTION_CLOSURE_BOUND) {
-    var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_CLOSURE_BOUND);
+export async function $$ACTION_2($$ACTION_CLOSURE_BOUND) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_CLOSURE_BOUND);
     await deleteFromDb($$ACTION_ARG_0);
     await deleteFromDb(v1);
     await deleteFromDb($$ACTION_ARG_1);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/19/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/19/output.js
@@ -1,9 +1,9 @@
-/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export function Item({ value }) {
     return <>
 
-      <Button action={createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
+      <Button action={registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         value
     ]))}>
 

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/19/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/19/output.js
@@ -1,9 +1,9 @@
-/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export function Item({ value }) {
     return <>
 
-      <Button action={createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
+      <Button action={createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         value
     ]))}>
 
@@ -13,7 +13,7 @@ export function Item({ value }) {
 
     </>;
 }
-export async function $$ACTION_1($$ACTION_CLOSURE_BOUND, value2) {
-    var [$$ACTION_ARG_0] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
+export async function $$ACTION_0($$ACTION_CLOSURE_BOUND, value2) {
+    var [$$ACTION_ARG_0] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);
     return $$ACTION_ARG_0 * value2;
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/2/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/2/output.js
@@ -1,11 +1,11 @@
-/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-var myAction = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
+var myAction = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
 export async function $$ACTION_0(a, b, c) {
     console.log('a');
 }
 export default function Page() {
     return <Button action={myAction}>Delete</Button>;
 }
-export const action = withValidate(createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1));
+export const action = withValidate(registerServerReference("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1));
 export async function $$ACTION_1() {}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/2/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/2/output.js
@@ -1,11 +1,11 @@
-/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 var myAction = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
 export async function $$ACTION_0(a, b, c) {
     console.log('a');
 }
 export default function Page() {
-    return <Button action={createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0)}>Delete</Button>;
+    return <Button action={myAction}>Delete</Button>;
 }
-export const action = withValidate(createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2));
-export async function $$ACTION_2() {}
+export const action = withValidate(createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1));
+export async function $$ACTION_1() {}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/20/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/20/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 const [foo] = [
     null
@@ -8,4 +8,4 @@ import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     foo
 ]);
-createActionProxy("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", foo);
+registerServerReference("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", foo);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/21/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/21/output.js
@@ -1,10 +1,10 @@
-/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","56a859f462d35a297c46a1bbd1e6a9058c104ab8":"$$ACTION_3","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","56a859f462d35a297c46a1bbd1e6a9058c104ab8":"$$ACTION_3","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { validator, another } from 'auth';
 const x = 1;
 export default function Page() {
     const y = 1;
-    return <Foo action={validator(createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
+    return <Foo action={validator(registerServerReference("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
         y
     ])))}/>;
 }
@@ -12,7 +12,7 @@ export async function $$ACTION_1($$ACTION_CLOSURE_BOUND, z) {
     var [$$ACTION_ARG_0] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
     return x + $$ACTION_ARG_0 + z;
 }
-validator(createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2));
+validator(registerServerReference("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2));
 export async function $$ACTION_2() {}
-another(validator(createActionProxy("56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_3)));
+another(validator(registerServerReference("56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_3)));
 export async function $$ACTION_3() {}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/21/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/21/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"1383664d1dc2d9cfe33b88df3fa0eaffef8b99bc":"$$ACTION_5","188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","56a859f462d35a297c46a1bbd1e6a9058c104ab8":"$$ACTION_3"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","56a859f462d35a297c46a1bbd1e6a9058c104ab8":"$$ACTION_3","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { validator, another } from 'auth';
 const x = 1;
@@ -12,7 +12,7 @@ export async function $$ACTION_1($$ACTION_CLOSURE_BOUND, z) {
     var [$$ACTION_ARG_0] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
     return x + $$ACTION_ARG_0 + z;
 }
-validator(createActionProxy("56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_3));
+validator(createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2));
+export async function $$ACTION_2() {}
+another(validator(createActionProxy("56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_3)));
 export async function $$ACTION_3() {}
-another(validator(createActionProxy("1383664d1dc2d9cfe33b88df3fa0eaffef8b99bc", $$ACTION_5)));
-export async function $$ACTION_5() {}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/22/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/22/output.js
@@ -1,9 +1,9 @@
-/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2","c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default","f14702b5a021dd117f7ec7a3c838f397c2046d3b":"action"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2","c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default","f14702b5a021dd117f7ec7a3c838f397c2046d3b":"action"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { validator } from 'auth';
-export const action = validator(createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0));
+export const action = validator(registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0));
 export async function $$ACTION_0() {}
-export default $$ACTION_1 = validator(createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2));
+export default $$ACTION_1 = validator(registerServerReference("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2));
 var $$ACTION_1;
 export async function $$ACTION_2() {}
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
@@ -11,5 +11,5 @@ ensureServerEntryExports([
     action,
     $$ACTION_1
 ]);
-createActionProxy("f14702b5a021dd117f7ec7a3c838f397c2046d3b", action);
-createActionProxy("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", $$ACTION_1);
+registerServerReference("f14702b5a021dd117f7ec7a3c838f397c2046d3b", action);
+registerServerReference("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", $$ACTION_1);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/22/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/22/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default","f14702b5a021dd117f7ec7a3c838f397c2046d3b":"action"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2","c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default","f14702b5a021dd117f7ec7a3c838f397c2046d3b":"action"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { validator } from 'auth';
 export const action = validator(createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0));

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/22/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/22/output.js
@@ -1,13 +1,15 @@
 /* __next_internal_action_entry_do_not_use__ {"c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default","f14702b5a021dd117f7ec7a3c838f397c2046d3b":"action"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { validator } from 'auth';
-export const action = validator(async ()=>{});
-export default $$ACTION_0 = validator(async ()=>{});
-var $$ACTION_0;
+export const action = validator(createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0));
+export async function $$ACTION_0() {}
+export default $$ACTION_1 = validator(createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2));
+var $$ACTION_1;
+export async function $$ACTION_2() {}
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     action,
-    $$ACTION_0
+    $$ACTION_1
 ]);
 createActionProxy("f14702b5a021dd117f7ec7a3c838f397c2046d3b", action);
-createActionProxy("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", $$ACTION_0);
+createActionProxy("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", $$ACTION_1);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/23/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/23/output.js
@@ -1,11 +1,11 @@
-/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export default function Page({ foo, x, y }) {
-    var action = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
+    var action = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         x
     ]));
     action.bind(null, foo[0], foo[1], foo.x, foo[y]);
-    const action2 = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
+    const action2 = registerServerReference("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
         x
     ]));
     action2.bind(null, foo[0], foo[1], foo.x, foo[y]);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/23/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/23/output.js
@@ -1,13 +1,11 @@
-/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export default function Page({ foo, x, y }) {
     var action = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         x
     ]));
-    createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
-        x
-    ])).bind(null, foo[0], foo[1], foo.x, foo[y]);
-    const action2 = createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2).bind(null, encryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", [
+    action.bind(null, foo[0], foo[1], foo.x, foo[y]);
+    const action2 = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
         x
     ]));
     action2.bind(null, foo[0], foo[1], foo.x, foo[y]);
@@ -16,7 +14,7 @@ export async function $$ACTION_0($$ACTION_CLOSURE_BOUND, a, b, c, d) {
     var [$$ACTION_ARG_0] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);
     console.log(a, b, $$ACTION_ARG_0, c, d);
 }
-export async function $$ACTION_2($$ACTION_CLOSURE_BOUND, a, b, c, d) {
-    var [$$ACTION_ARG_0] = await decryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_CLOSURE_BOUND);
+export async function $$ACTION_1($$ACTION_CLOSURE_BOUND, a, b, c, d) {
+    var [$$ACTION_ARG_0] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
     console.log(a, b, $$ACTION_ARG_0, c, d);
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/24/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/24/output.js
@@ -1,7 +1,7 @@
-/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export default function Page({ foo, x, y }) {
-    var action = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
+    var action = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         foo
     ]));
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/25/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/25/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import deleteFromDb from 'db';
 export function Item({ id1, id2 }) {
@@ -7,7 +7,7 @@ export function Item({ id1, id2 }) {
         id1++;
         return <Button action={deleteItem}>Delete</Button>;
     })();
-    var deleteItem = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
+    var deleteItem = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         id1,
         id2
     ]));
@@ -26,7 +26,7 @@ export function Item2({ id1, id2 }) {
     id1++;
     temp.push(<Button action={deleteItem}>Delete</Button>);
     return temp;
-    var deleteItem = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
+    var deleteItem = registerServerReference("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
         id1,
         id2
     ]));

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/25/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/25/output.js
@@ -5,10 +5,7 @@ export function Item({ id1, id2 }) {
     id1++;
     return (()=>{
         id1++;
-        return <Button action={createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
-            id1,
-            id2
-        ]))}>Delete</Button>;
+        return <Button action={deleteItem}>Delete</Button>;
     })();
     var deleteItem = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         id1,
@@ -25,15 +22,9 @@ export async function $$ACTION_0($$ACTION_CLOSURE_BOUND) {
 export function Item2({ id1, id2 }) {
     id1++;
     const temp = [];
-    temp.push(<Button action={createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
-        id1,
-        id2
-    ]))}>Delete</Button>);
+    temp.push(<Button action={deleteItem}>Delete</Button>);
     id1++;
-    temp.push(<Button action={createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
-        id1,
-        id2
-    ]))}>Delete</Button>);
+    temp.push(<Button action={deleteItem}>Delete</Button>);
     return temp;
     var deleteItem = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
         id1,

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/26/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/26/output.js
@@ -1,7 +1,7 @@
-/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 const noop = (action)=>action;
-export const log = noop(createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0));
+export const log = noop(registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0));
 export async function $$ACTION_0(data) {
     console.log(data);
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/26/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/26/output.js
@@ -1,7 +1,7 @@
-/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 const noop = (action)=>action;
-export const log = noop(createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1));
-export async function $$ACTION_1(data) {
+export const log = noop(createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0));
+export async function $$ACTION_0(data) {
     console.log(data);
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/27/input.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/27/input.js
@@ -1,5 +1,5 @@
 // Rules here:
-// 1. Each exported function should still be exported, but as a reference `createActionProxy(...)`.
+// 1. Each exported function should still be exported, but as a reference `registerServerReference(...)`.
 // 2. Actual action functions should be renamed to `$$ACTION_...` and got exported.
 
 async function foo() {

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/27/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/27/output.js
@@ -1,26 +1,26 @@
 // Rules here:
-// 1. Each exported function should still be exported, but as a reference `createActionProxy(...)`.
+// 1. Each exported function should still be exported, but as a reference `registerServerReference(...)`.
 // 2. Actual action functions should be renamed to `$$ACTION_...` and got exported.
-/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","56a859f462d35a297c46a1bbd1e6a9058c104ab8":"$$ACTION_3","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2","9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c":"$$ACTION_4"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","56a859f462d35a297c46a1bbd1e6a9058c104ab8":"$$ACTION_3","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2","9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c":"$$ACTION_4"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-var foo = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
+var foo = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
 export async function $$ACTION_0() {
     console.log(1);
 }
 export { foo };
-export var bar = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1);
+export var bar = registerServerReference("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1);
 export async function $$ACTION_1() {
     console.log(2);
 }
-export default createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2);
+export default registerServerReference("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2);
 export async function $$ACTION_2() {
     console.log(3);
 }
-export const qux = createActionProxy("56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_3);
+export const qux = registerServerReference("56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_3);
 export async function $$ACTION_3() {
     console.log(4);
 }
-export const quux = createActionProxy("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_4);
+export const quux = registerServerReference("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_4);
 export async function $$ACTION_4() {
     console.log(5);
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/27/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/27/output.js
@@ -1,7 +1,7 @@
 // Rules here:
 // 1. Each exported function should still be exported, but as a reference `createActionProxy(...)`.
 // 2. Actual action functions should be renamed to `$$ACTION_...` and got exported.
-/* __next_internal_action_entry_do_not_use__ {"1383664d1dc2d9cfe33b88df3fa0eaffef8b99bc":"$$ACTION_5","188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2","9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c":"$$ACTION_4"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","56a859f462d35a297c46a1bbd1e6a9058c104ab8":"$$ACTION_3","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2","9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c":"$$ACTION_4"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 var foo = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
 export async function $$ACTION_0() {
@@ -14,14 +14,13 @@ export async function $$ACTION_1() {
 }
 export default createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2);
 export async function $$ACTION_2() {
-    'use server';
     console.log(3);
 }
-export const qux = createActionProxy("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_4);
-export async function $$ACTION_4() {
+export const qux = createActionProxy("56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_3);
+export async function $$ACTION_3() {
     console.log(4);
 }
-export const quux = createActionProxy("1383664d1dc2d9cfe33b88df3fa0eaffef8b99bc", $$ACTION_5);
-export async function $$ACTION_5() {
+export const quux = createActionProxy("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_4);
+export async function $$ACTION_4() {
     console.log(5);
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/28/input.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/28/input.js
@@ -1,0 +1,24 @@
+let a, f
+
+function Comp(b, c, ...g) {
+  return async function action1(d) {
+    'use server'
+    let f
+    console.log(...window, { window })
+    console.log(a, b, action2)
+
+    async function action2(e) {
+      'use server'
+      console.log(a, c, d, e, f, g)
+    }
+
+    return [
+      action2,
+      async function action3(e) {
+        'use server'
+        action2(e)
+        console.log(a, c, d, e)
+      },
+    ]
+  }
+}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/28/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/28/output.js
@@ -1,0 +1,41 @@
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+let a, f;
+function Comp(b, c, ...g) {
+    return createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2).bind(null, encryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", [
+        c,
+        g,
+        b
+    ]));
+}
+export async function $$ACTION_0($$ACTION_CLOSURE_BOUND, e) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2, $$ACTION_ARG_3] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);
+    console.log(a, $$ACTION_ARG_0, $$ACTION_ARG_1, e, $$ACTION_ARG_2, $$ACTION_ARG_3);
+}
+export async function $$ACTION_1($$ACTION_CLOSURE_BOUND, e) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
+    $$ACTION_ARG_0(e);
+    console.log(a, $$ACTION_ARG_1, $$ACTION_ARG_2, e);
+}
+export async function $$ACTION_2($$ACTION_CLOSURE_BOUND, d) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2] = await decryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_CLOSURE_BOUND);
+    let f;
+    console.log(...window, {
+        window
+    });
+    console.log(a, $$ACTION_ARG_2, action2);
+    var action2 = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
+        $$ACTION_ARG_0,
+        d,
+        f,
+        $$ACTION_ARG_1
+    ]));
+    return [
+        action2,
+        createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
+            action2,
+            $$ACTION_ARG_0,
+            d
+        ]))
+    ];
+}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/28/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/28/output.js
@@ -1,8 +1,8 @@
-/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 let a, f;
 function Comp(b, c, ...g) {
-    return createActionProxy("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2).bind(null, encryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", [
+    return registerServerReference("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2).bind(null, encryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", [
         c,
         g,
         b
@@ -24,7 +24,7 @@ export async function $$ACTION_2($$ACTION_CLOSURE_BOUND, d) {
         window
     });
     console.log(a, $$ACTION_ARG_2, action2);
-    var action2 = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
+    var action2 = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         $$ACTION_ARG_0,
         d,
         f,
@@ -32,7 +32,7 @@ export async function $$ACTION_2($$ACTION_CLOSURE_BOUND, d) {
     ]));
     return [
         action2,
-        createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
+        registerServerReference("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
             action2,
             $$ACTION_ARG_0,
             d

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/29/input.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/29/input.js
@@ -1,0 +1,8 @@
+'use server'
+
+export const dec = async (value) => {
+  return value - 1
+}
+
+// Test case for https://github.com/vercel/next.js/issues/54655
+export default dec

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/29/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/29/output.js
@@ -1,6 +1,6 @@
-/* __next_internal_action_entry_do_not_use__ {"28baf972d345b86b747ad0df73d75a0088a42214":"dec","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"28baf972d345b86b747ad0df73d75a0088a42214":"dec","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-export const dec = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
+export const dec = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
 export async function $$ACTION_0(value) {
     return value - 1;
 }
@@ -11,5 +11,5 @@ ensureServerEntryExports([
     dec,
     dec
 ]);
-createActionProxy("28baf972d345b86b747ad0df73d75a0088a42214", dec);
-createActionProxy("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", dec);
+registerServerReference("28baf972d345b86b747ad0df73d75a0088a42214", dec);
+registerServerReference("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", dec);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/29/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/29/output.js
@@ -1,0 +1,15 @@
+/* __next_internal_action_entry_do_not_use__ {"28baf972d345b86b747ad0df73d75a0088a42214":"dec","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+export const dec = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
+export async function $$ACTION_0(value) {
+    return value - 1;
+}
+// Test case for https://github.com/vercel/next.js/issues/54655
+export default dec;
+import { ensureServerEntryExports } from "private-next-rsc-action-validate";
+ensureServerEntryExports([
+    dec,
+    dec
+]);
+createActionProxy("28baf972d345b86b747ad0df73d75a0088a42214", dec);
+createActionProxy("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", dec);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/3/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/3/output.js
@@ -1,5 +1,5 @@
 // app/send.ts
-/* __next_internal_action_entry_do_not_use__ {"e10665baac148856374b2789aceb970f66fec33e":"myAction"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"e10665baac148856374b2789aceb970f66fec33e":"myAction"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export async function myAction(a, b, c) {
     console.log('a');
@@ -8,4 +8,4 @@ import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     myAction
 ]);
-createActionProxy("e10665baac148856374b2789aceb970f66fec33e", myAction);
+registerServerReference("e10665baac148856374b2789aceb970f66fec33e", myAction);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/30/input.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/30/input.js
@@ -1,0 +1,26 @@
+'use server'
+
+let a, f
+
+export async function action0(b, c, ...g) {
+  return async function action1(d) {
+    'use server'
+    let f
+    console.log(...window, { window })
+    console.log(a, b, action2)
+
+    async function action2(e) {
+      'use server'
+      console.log(a, c, d, e, f, g)
+    }
+
+    return [
+      action2,
+      async function action3(e) {
+        'use server'
+        action2(e)
+        console.log(a, c, d, e)
+      },
+    ]
+  }
+}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/30/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/30/output.js
@@ -1,0 +1,46 @@
+/* __next_internal_action_entry_do_not_use__ {"0090eaf4e1f08a2d94f6be401e54a2ded399b87c":"action0","188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9878bfa39811ca7650992850a8751f9591b6a557":"$$ACTION_2"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+let a, f;
+export async function action0(b, c, ...g) {
+    return registerServerReference("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_2).bind(null, encryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", [
+        c,
+        g,
+        b
+    ]));
+}
+export async function $$ACTION_0($$ACTION_CLOSURE_BOUND, e) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2, $$ACTION_ARG_3] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);
+    console.log(a, $$ACTION_ARG_0, $$ACTION_ARG_1, e, $$ACTION_ARG_2, $$ACTION_ARG_3);
+}
+export async function $$ACTION_1($$ACTION_CLOSURE_BOUND, e) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
+    $$ACTION_ARG_0(e);
+    console.log(a, $$ACTION_ARG_1, $$ACTION_ARG_2, e);
+}
+export async function $$ACTION_2($$ACTION_CLOSURE_BOUND, d) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2] = await decryptActionBoundArgs("9878bfa39811ca7650992850a8751f9591b6a557", $$ACTION_CLOSURE_BOUND);
+    let f;
+    console.log(...window, {
+        window
+    });
+    console.log(a, $$ACTION_ARG_2, action2);
+    var action2 = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
+        $$ACTION_ARG_0,
+        d,
+        f,
+        $$ACTION_ARG_1
+    ]));
+    return [
+        action2,
+        registerServerReference("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
+            action2,
+            $$ACTION_ARG_0,
+            d
+        ]))
+    ];
+}
+import { ensureServerEntryExports } from "private-next-rsc-action-validate";
+ensureServerEntryExports([
+    action0
+]);
+registerServerReference("0090eaf4e1f08a2d94f6be401e54a2ded399b87c", action0);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/4/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/4/output.js
@@ -1,18 +1,19 @@
-/* __next_internal_action_entry_do_not_use__ {"1ab723c80dcca470e0410b4b2a2fc2bf21f41476":"c","6e7bc104e4d6e7fda190c4a51be969cfd0be6d6d":"a","d1f7eb64271d7c601dfef7d4d7053de1c2ca4338":"b"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"1ab723c80dcca470e0410b4b2a2fc2bf21f41476":"c","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","6e7bc104e4d6e7fda190c4a51be969cfd0be6d6d":"a","d1f7eb64271d7c601dfef7d4d7053de1c2ca4338":"b"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export async function a() {}
 export async function b() {}
 export async function c() {}
 function d() {}
 function Foo() {
-    async function e() {}
+    var e = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
 }
+export async function $$ACTION_0() {}
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     a,
     b,
     c
 ]);
-createActionProxy("6e7bc104e4d6e7fda190c4a51be969cfd0be6d6d", a);
-createActionProxy("d1f7eb64271d7c601dfef7d4d7053de1c2ca4338", b);
-createActionProxy("1ab723c80dcca470e0410b4b2a2fc2bf21f41476", c);
+registerServerReference("6e7bc104e4d6e7fda190c4a51be969cfd0be6d6d", a);
+registerServerReference("d1f7eb64271d7c601dfef7d4d7053de1c2ca4338", b);
+registerServerReference("1ab723c80dcca470e0410b4b2a2fc2bf21f41476", c);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/4/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/4/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"1ab723c80dcca470e0410b4b2a2fc2bf21f41476":"c","6e7bc104e4d6e7fda190c4a51be969cfd0be6d6d":"a","d1f7eb64271d7c601dfef7d4d7053de1c2ca4338":"b"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+/* __next_internal_action_entry_do_not_use__ {"1ab723c80dcca470e0410b4b2a2fc2bf21f41476":"c","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","6e7bc104e4d6e7fda190c4a51be969cfd0be6d6d":"a","d1f7eb64271d7c601dfef7d4d7053de1c2ca4338":"b"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export async function a() {}
 export async function b() {}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/4/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/4/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"1ab723c80dcca470e0410b4b2a2fc2bf21f41476":"c","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","6e7bc104e4d6e7fda190c4a51be969cfd0be6d6d":"a","d1f7eb64271d7c601dfef7d4d7053de1c2ca4338":"b"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+/* __next_internal_action_entry_do_not_use__ {"1ab723c80dcca470e0410b4b2a2fc2bf21f41476":"c","6e7bc104e4d6e7fda190c4a51be969cfd0be6d6d":"a","d1f7eb64271d7c601dfef7d4d7053de1c2ca4338":"b"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export async function a() {}
 export async function b() {}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/5/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/5/output.js
@@ -1,10 +1,10 @@
-/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import deleteFromDb from 'db';
 const v1 = 'v1';
 export function Item({ id1, id2, id3, id4 }) {
     const v2 = id2;
-    var deleteItem = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
+    var deleteItem = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         id1,
         v2,
         id3,

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/5/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/5/output.js
@@ -10,12 +10,7 @@ export function Item({ id1, id2, id3, id4 }) {
         id3,
         id4.x
     ]));
-    return <Button action={createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
-        id1,
-        v2,
-        id3,
-        id4.x
-    ]))}>Delete</Button>;
+    return <Button action={deleteItem}>Delete</Button>;
 }
 export async function $$ACTION_0($$ACTION_CLOSURE_BOUND) {
     var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2, $$ACTION_ARG_3] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/6/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/6/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import f, { f1, f2 } from 'foo';
 const f3 = 1;
@@ -19,7 +19,7 @@ export function y(p, [p1, { p2 }], ...p3) {
     if (true) {
         const f8 = 1;
     }
-    var action = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
+    var action = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         f2,
         f11,
         p,

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/6/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/6/output.js
@@ -27,14 +27,7 @@ export function y(p, [p1, { p2 }], ...p3) {
         p2,
         p3
     ]));
-    return <Button action={createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
-        f2,
-        f11,
-        p,
-        p1,
-        p2,
-        p3
-    ]))}>Delete</Button>;
+    return <Button action={action}>Delete</Button>;
 }
 export async function $$ACTION_0($$ACTION_CLOSURE_BOUND) {
     var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2, $$ACTION_ARG_3, $$ACTION_ARG_4, $$ACTION_ARG_5] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/7/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/7/output.js
@@ -1,8 +1,8 @@
-/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","56a859f462d35a297c46a1bbd1e6a9058c104ab8":"$$ACTION_3","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c":"$$ACTION_4"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","56a859f462d35a297c46a1bbd1e6a9058c104ab8":"$$ACTION_3","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c":"$$ACTION_4"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import deleteFromDb from 'db';
 export function Item1(product, foo, bar) {
-    const a = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
+    const a = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
         product.id,
         product?.foo,
         product.bar.baz,
@@ -17,7 +17,7 @@ export async function $$ACTION_0($$ACTION_CLOSURE_BOUND) {
     await deleteFromDb($$ACTION_ARG_3.id, $$ACTION_ARG_3?.foo, $$ACTION_ARG_3.bar.baz, $$ACTION_ARG_3[$$ACTION_ARG_4, $$ACTION_ARG_5]);
 }
 export function Item2(product, foo, bar) {
-    var deleteItem2 = createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
+    var deleteItem2 = registerServerReference("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
         product.id,
         product?.foo,
         product.bar.baz,
@@ -32,7 +32,7 @@ export async function $$ACTION_1($$ACTION_CLOSURE_BOUND) {
     await deleteFromDb($$ACTION_ARG_3.id, $$ACTION_ARG_3?.foo, $$ACTION_ARG_3.bar.baz, $$ACTION_ARG_3[$$ACTION_ARG_4, $$ACTION_ARG_5]);
 }
 export function Item3(product, foo, bar) {
-    const deleteItem3 = createActionProxy("56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_3).bind(null, encryptActionBoundArgs("56a859f462d35a297c46a1bbd1e6a9058c104ab8", [
+    const deleteItem3 = registerServerReference("56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_3).bind(null, encryptActionBoundArgs("56a859f462d35a297c46a1bbd1e6a9058c104ab8", [
         product.id,
         product?.foo,
         product.bar.baz,
@@ -47,7 +47,7 @@ export async function $$ACTION_3($$ACTION_CLOSURE_BOUND) {
     await deleteFromDb($$ACTION_ARG_3.id, $$ACTION_ARG_3?.foo, $$ACTION_ARG_3.bar.baz, $$ACTION_ARG_3[$$ACTION_ARG_4, $$ACTION_ARG_5]);
 }
 export function Item4(product, foo, bar) {
-    const deleteItem4 = createActionProxy("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_4).bind(null, encryptActionBoundArgs("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", [
+    const deleteItem4 = registerServerReference("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_4).bind(null, encryptActionBoundArgs("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", [
         product.id,
         product?.foo,
         product.bar.baz,

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/7/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/7/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"1383664d1dc2d9cfe33b88df3fa0eaffef8b99bc":"$$ACTION_5","188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","56a859f462d35a297c46a1bbd1e6a9058c104ab8":"$$ACTION_3","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"188d5d945750dc32e2c842b93c75a65763d4a922":"$$ACTION_1","56a859f462d35a297c46a1bbd1e6a9058c104ab8":"$$ACTION_3","6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0","9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c":"$$ACTION_4"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import deleteFromDb from 'db';
 export function Item1(product, foo, bar) {
@@ -25,14 +25,7 @@ export function Item2(product, foo, bar) {
         foo,
         bar
     ]));
-    return <Button action={createActionProxy("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
-        product.id,
-        product?.foo,
-        product.bar.baz,
-        product,
-        foo,
-        bar
-    ]))}>Delete</Button>;
+    return <Button action={deleteItem2}>Delete</Button>;
 }
 export async function $$ACTION_1($$ACTION_CLOSURE_BOUND) {
     var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2, $$ACTION_ARG_3, $$ACTION_ARG_4, $$ACTION_ARG_5] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
@@ -54,7 +47,7 @@ export async function $$ACTION_3($$ACTION_CLOSURE_BOUND) {
     await deleteFromDb($$ACTION_ARG_3.id, $$ACTION_ARG_3?.foo, $$ACTION_ARG_3.bar.baz, $$ACTION_ARG_3[$$ACTION_ARG_4, $$ACTION_ARG_5]);
 }
 export function Item4(product, foo, bar) {
-    const deleteItem4 = createActionProxy("1383664d1dc2d9cfe33b88df3fa0eaffef8b99bc", $$ACTION_5).bind(null, encryptActionBoundArgs("1383664d1dc2d9cfe33b88df3fa0eaffef8b99bc", [
+    const deleteItem4 = createActionProxy("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_4).bind(null, encryptActionBoundArgs("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", [
         product.id,
         product?.foo,
         product.bar.baz,
@@ -64,7 +57,7 @@ export function Item4(product, foo, bar) {
     ]));
     return <Button action={deleteItem4}>Delete</Button>;
 }
-export async function $$ACTION_5($$ACTION_CLOSURE_BOUND) {
-    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2, $$ACTION_ARG_3, $$ACTION_ARG_4, $$ACTION_ARG_5] = await decryptActionBoundArgs("1383664d1dc2d9cfe33b88df3fa0eaffef8b99bc", $$ACTION_CLOSURE_BOUND);
+export async function $$ACTION_4($$ACTION_CLOSURE_BOUND) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2, $$ACTION_ARG_3, $$ACTION_ARG_4, $$ACTION_ARG_5] = await decryptActionBoundArgs("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_CLOSURE_BOUND);
     await deleteFromDb($$ACTION_ARG_3.id, $$ACTION_ARG_3?.foo, $$ACTION_ARG_3.bar.baz, $$ACTION_ARG_3[$$ACTION_ARG_4, $$ACTION_ARG_5]);
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/8/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/8/output.js
@@ -1,6 +1,6 @@
-/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-var myAction = createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
+var myAction = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0);
 export async function $$ACTION_0(a, b, c) {
     // comment
     'use strict';

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/8/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/8/output.js
@@ -7,5 +7,5 @@ export async function $$ACTION_0(a, b, c) {
     console.log('a');
 }
 export default function Page() {
-    return <Button action={createActionProxy("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0)}>Delete</Button>;
+    return <Button action={myAction}>Delete</Button>;
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/9/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/9/output.js
@@ -1,5 +1,5 @@
 // app/send.ts
-/* __next_internal_action_entry_do_not_use__ {"050e3854b72b19e3c7e3966a67535543a90bf7e0":"baz","ab21efdafbe611287bc25c0462b1e0510d13e48b":"foo","c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { createActionProxy } from "private-next-rsc-action-proxy";
+/* __next_internal_action_entry_do_not_use__ {"050e3854b72b19e3c7e3966a67535543a90bf7e0":"baz","ab21efdafbe611287bc25c0462b1e0510d13e48b":"foo","c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 async function foo() {}
 export { foo };
@@ -13,6 +13,6 @@ ensureServerEntryExports([
     bar,
     qux
 ]);
-createActionProxy("ab21efdafbe611287bc25c0462b1e0510d13e48b", foo);
-createActionProxy("050e3854b72b19e3c7e3966a67535543a90bf7e0", bar);
-createActionProxy("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", qux);
+registerServerReference("ab21efdafbe611287bc25c0462b1e0510d13e48b", foo);
+registerServerReference("050e3854b72b19e3c7e3966a67535543a90bf7e0", bar);
+registerServerReference("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", qux);

--- a/packages/next/src/build/create-compiler-aliases.ts
+++ b/packages/next/src/build/create-compiler-aliases.ts
@@ -148,7 +148,7 @@ export function createWebpackAliases({
       'next/dist/build/webpack/loaders/next-flight-loader/action-client-wrapper',
 
     [RSC_ACTION_PROXY_ALIAS]:
-      'next/dist/build/webpack/loaders/next-flight-loader/action-proxy',
+      'next/dist/build/webpack/loaders/next-flight-loader/server-reference',
 
     [RSC_ACTION_ENCRYPTION_ALIAS]:
       'next/dist/server/app-render/action-encryption',

--- a/packages/next/src/build/handle-externals.ts
+++ b/packages/next/src/build/handle-externals.ts
@@ -197,7 +197,7 @@ export function makeExternalHandler({
       }
 
       const notExternalModules =
-        /^(?:private-next-pages\/|next\/(?:dist\/pages\/|(?:app|document|link|image|legacy\/image|constants|dynamic|script|navigation|headers|router)$)|string-hash|private-next-rsc-action-validate|private-next-rsc-action-client-wrapper|private-next-rsc-action-proxy$)/
+        /^(?:private-next-pages\/|next\/(?:dist\/pages\/|(?:app|document|link|image|legacy\/image|constants|dynamic|script|navigation|headers|router)$)|string-hash|private-next-rsc-action-validate|private-next-rsc-action-client-wrapper|private-next-rsc-server-reference$)/
       if (notExternalModules.test(request)) {
         return
       }

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -11,6 +11,8 @@ import type { BuildManifest } from '../../server/get-page-files'
 import type { RequestData } from '../../server/web/types'
 import type { NextConfigComplete } from '../../server/config-shared'
 import { PAGE_TYPES } from '../../lib/page-types'
+import { setReferenceManifestsSingleton } from '../../server/app-render/action-encryption-utils'
+import { createServerModuleMap } from '../../server/app-render/action-utils'
 
 declare const incrementalCacheHandler: any
 // OPTIONAL_IMPORT:incrementalCacheHandler
@@ -43,6 +45,17 @@ const subresourceIntegrityManifest = sriEnabled
   ? maybeJSONParse(self.__SUBRESOURCE_INTEGRITY_MANIFEST)
   : undefined
 const nextFontManifest = maybeJSONParse(self.__NEXT_FONT_MANIFEST)
+
+if (rscManifest && rscServerManifest) {
+  setReferenceManifestsSingleton({
+    clientReferenceManifest: rscManifest,
+    serverActionsManifest: rscServerManifest,
+    serverModuleMap: createServerModuleMap({
+      serverActionsManifest: rscServerManifest,
+      pageName: 'VAR_PAGE',
+    }),
+  })
+}
 
 const render = getRender({
   pagesType: PAGE_TYPES.APP,

--- a/packages/next/src/build/webpack/loaders/next-flight-loader/action-proxy.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/action-proxy.ts
@@ -1,6 +1,17 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { registerServerReference } from 'react-server-dom-webpack/server.edge'
 
+const SERVER_REFERENCE_TAG = Symbol.for('react.server.reference')
+
+function isServerReference(reference: any) {
+  return reference && reference.$$typeof === SERVER_REFERENCE_TAG
+}
+
 export function createActionProxy(id: string, action: any) {
+  // Avoid registering the same action twice
+  if (isServerReference(action)) {
+    return action
+  }
+
   return registerServerReference(action, id, null)
 }

--- a/packages/next/src/build/webpack/loaders/next-flight-loader/server-reference.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/server-reference.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { registerServerReference } from 'react-server-dom-webpack/server.edge'
+import { registerServerReference as flightRegisterServerReference } from 'react-server-dom-webpack/server.edge'
 
 const SERVER_REFERENCE_TAG = Symbol.for('react.server.reference')
 
@@ -7,11 +7,11 @@ function isServerReference(reference: any) {
   return reference && reference.$$typeof === SERVER_REFERENCE_TAG
 }
 
-export function createActionProxy(id: string, action: any) {
+export function registerServerReference(id: string, action: any) {
   // Avoid registering the same action twice
   if (isServerReference(action)) {
     return action
   }
 
-  return registerServerReference(action, id, null)
+  return flightRegisterServerReference(action, id, null)
 }

--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -40,7 +40,7 @@ export const ROOT_DIR_ALIAS = 'private-next-root-dir'
 export const APP_DIR_ALIAS = 'private-next-app-dir'
 export const RSC_MOD_REF_PROXY_ALIAS = 'private-next-rsc-mod-ref-proxy'
 export const RSC_ACTION_VALIDATE_ALIAS = 'private-next-rsc-action-validate'
-export const RSC_ACTION_PROXY_ALIAS = 'private-next-rsc-action-proxy'
+export const RSC_ACTION_PROXY_ALIAS = 'private-next-rsc-server-reference'
 export const RSC_ACTION_ENCRYPTION_ALIAS = 'private-next-rsc-action-encryption'
 export const RSC_ACTION_CLIENT_WRAPPER_ALIAS =
   'private-next-rsc-action-client-wrapper'

--- a/packages/next/src/server/app-render/action-utils.ts
+++ b/packages/next/src/server/app-render/action-utils.ts
@@ -1,0 +1,28 @@
+import type { ActionManifest } from '../../build/webpack/plugins/flight-client-entry-plugin'
+
+// This function creates a Flight-acceptable server module map proxy from our
+// Server Reference Manifest similar to our client module map.
+// This is because our manifest contains a lot of internal Next.js data that
+// are relevant to the runtime, workers, etc. that React doesn't need to know.
+export function createServerModuleMap({
+  serverActionsManifest,
+  pageName,
+}: {
+  serverActionsManifest: ActionManifest
+  pageName: string
+}) {
+  return new Proxy(
+    {},
+    {
+      get: (_, id: string) => {
+        return {
+          id: serverActionsManifest[
+            process.env.NEXT_RUNTIME === 'edge' ? 'edge' : 'node'
+          ][id].workers['app' + pageName],
+          name: id,
+          chunks: [],
+        }
+      },
+    }
+  )
+}

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -80,6 +80,7 @@ import { DetachedPromise } from '../../lib/detached-promise'
 import { isDynamicServerError } from '../../client/components/hooks-server-context'
 import { useFlightResponse } from './use-flight-response'
 import { isStaticGenBailoutError } from '../../client/components/static-generation-bailout'
+import { createServerModuleMap } from './action-utils'
 
 export type GetDynamicParamFromSegment = (
   // [slug] / [[slug]] / [...slug]
@@ -586,27 +587,10 @@ async function renderToHTMLOrFlightImpl(
   // TODO: fix this typescript
   const clientReferenceManifest = renderOpts.clientReferenceManifest!
 
-  const workerName = 'app' + renderOpts.page
-  const serverModuleMap: {
-    [id: string]: {
-      id: string
-      chunks: string[]
-      name: string
-    }
-  } = new Proxy(
-    {},
-    {
-      get: (_, id: string) => {
-        return {
-          id: serverActionsManifest[
-            process.env.NEXT_RUNTIME === 'edge' ? 'edge' : 'node'
-          ][id].workers[workerName],
-          name: id,
-          chunks: [],
-        }
-      },
-    }
-  )
+  const serverModuleMap = createServerModuleMap({
+    serverActionsManifest,
+    pageName: renderOpts.page,
+  })
 
   setReferenceManifestsSingleton({
     clientReferenceManifest,

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -981,6 +981,7 @@ createNextDescribe(
         const res = await next.fetch('/encryption')
         const html = await res.text()
         expect(html).not.toContain('qwerty123')
+        expect(html).not.toContain('some-module-level-encryption-value')
       })
     })
 

--- a/test/e2e/app-dir/actions/app/encryption/page.js
+++ b/test/e2e/app-dir/actions/app/encryption/page.js
@@ -1,3 +1,14 @@
+// Test top-level encryption (happens during the module load phase)
+function wrapAction(value) {
+  return async function () {
+    'use server'
+    console.log(value)
+  }
+}
+
+const action = wrapAction('some-module-level-encryption-value')
+
+// Test runtime encryption (happens during the rendering phase)
 export default function Page() {
   const secret = 'my password is qwerty123'
 
@@ -6,6 +17,7 @@ export default function Page() {
       action={async () => {
         'use server'
         console.log(secret)
+        await action()
         return 'success'
       }}
     >

--- a/test/e2e/app-dir/actions/app/server/actions.js
+++ b/test/e2e/app-dir/actions/app/server/actions.js
@@ -7,9 +7,12 @@ export async function slowInc(value) {
   return value + 1
 }
 
-export default async function dec(value) {
+export const dec = async (value) => {
   return value - 1
 }
+
+// Test case for https://github.com/vercel/next.js/issues/54655
+export default dec
 
 export async function redirectAction(formData) {
   'use server'
@@ -20,3 +23,6 @@ export async function redirectAction(formData) {
       formData.get('hidden-info')
   )
 }
+
+// Test case for https://github.com/vercel/next.js/issues/61183
+export const dummyServerAction = () => new Promise((r) => setTimeout(r, 2000))

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -189,6 +189,7 @@ describe('Switchable runtime', () => {
               '/api/hello': {
                 files: [
                   'server/edge-runtime-webpack.js',
+                  'server/edge-chunks/189.js',
                   'server/pages/api/hello.js',
                 ],
                 name: 'pages/api/hello',
@@ -624,6 +625,7 @@ describe('Switchable runtime', () => {
                 files: [
                   'prerender-manifest.js',
                   'server/edge-runtime-webpack.js',
+                  'server/edge-chunks/189.js',
                   'server/pages/api/hello.js',
                 ],
                 name: 'pages/api/hello',

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -189,7 +189,6 @@ describe('Switchable runtime', () => {
               '/api/hello': {
                 files: expect.arrayContaining([
                   'server/edge-runtime-webpack.js',
-                  'server/edge-chunks/189.js',
                   'server/pages/api/hello.js',
                 ]),
                 name: 'pages/api/hello',

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -625,7 +625,6 @@ describe('Switchable runtime', () => {
                 files: [
                   'prerender-manifest.js',
                   'server/edge-runtime-webpack.js',
-                  'server/edge-chunks/189.js',
                   'server/pages/api/hello.js',
                 ],
                 name: 'pages/api/hello',


### PR DESCRIPTION
### What?
Backports some Server Action changes from Shu to 14.1.1.


[Improve the Server Actions SWC transform ](https://github.com/vercel/next.js/pull/62655/commits/bf6460e985c0ff8e41c03e000cbcb2638bcf99c7)

[Fix Server Reference being double registered](https://github.com/vercel/next.js/pull/62655/commits/ef81b1099856bc7918dfa39e6d272cce53451eaf)


[Improve the Server Actions SWC transform (part 2)](https://github.com/vercel/next.js/pull/62655/commits/6e59c222a84f48edfc958d3327eb5448431e7784)

[Fix module-level Server Action creation with closure-closed values](https://github.com/vercel/next.js/pull/62655/commits/51c6a07ec6a373eca3425ef565a53f4105112099)


[Rename internal utility naming for clarification](https://github.com/vercel/next.js/pull/62655/commits/00d8e6e0612b7afddbce5f944a7330413e548871)

### Why?

### How?

