### PR TITLE
enable `optimizeServerReact` by default

### DIFF
--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -408,7 +408,7 @@ export function getLoaderSWCOptions({
 
   if (optimizeServerReact && isServer && !development) {
     baseOptions.optimizeServerReact = {
-      optimize_use_state: true,
+      optimize_use_state: false,
     }
   }
 

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -900,7 +900,7 @@ export const defaultConfig: NextConfig = {
         : false,
     webpackBuildWorker: undefined,
     missingSuspenseWithCSRBailout: true,
-    optimizeServerReact: false,
+    optimizeServerReact: true,
     useEarlyImport: false,
   },
 }


### PR DESCRIPTION
Enable the `experimental#optimizeServerReact` configuration by default. 

Disable the `optimize_use_state` option for the optimization as this may cause issues in React 19

Closes NEXT-2640