### PR TITLE
feat: display text diff for text mismatch hydration errors

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
@@ -354,6 +354,9 @@ export const styles = css`
   }
   .nextjs__container_errors__extra_code {
     margin: 20px 0;
+    padding: 12px 32px;
+    color: var(--color-ansi-fg);
+    background: var(--color-ansi-bg);
   }
   .nextjs-toast-errors-parent {
     cursor: pointer;

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
@@ -25,7 +25,7 @@ import { VersionStalenessInfo } from '../components/VersionStalenessInfo'
 import type { VersionInfo } from '../../../../../server/dev/parse-version-info'
 import { getErrorSource } from '../../../../../shared/lib/error-source'
 import { HotlinkedText } from '../components/hot-linked-text'
-import { PseudoHtml } from './RuntimeError/component-stack-pseudo-html'
+import { PseudoHtmlDiff } from './RuntimeError/component-stack-pseudo-html'
 import {
   isHtmlTagsWarning,
   type HydrationErrorState,
@@ -274,11 +274,14 @@ export function Errors({
             {hydrationWarning && activeError.componentStackFrames && (
               <>
                 <p id="nextjs__container_errors__extra">{hydrationWarning}</p>
-                <PseudoHtml
+                <PseudoHtmlDiff
                   className="nextjs__container_errors__extra_code"
+                  hydrationMismatchType={
+                    isHtmlTagsWarningTemplate ? 'tag' : 'text'
+                  }
                   componentStackFrames={activeError.componentStackFrames}
-                  serverTagName={isHtmlTagsWarningTemplate ? serverContent : ''}
-                  clientTagName={isHtmlTagsWarningTemplate ? clientContent : ''}
+                  serverContent={serverContent}
+                  clientContent={clientContent}
                 />
               </>
             )}

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/GroupedStackFrames.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/GroupedStackFrames.tsx
@@ -2,9 +2,7 @@ import type { StackFramesGroup } from '../../helpers/group-stack-frames-by-frame
 import { CallStackFrame } from './CallStackFrame'
 import { FrameworkIcon } from './FrameworkIcon'
 
-export function CollapseIcon(
-  { collapsed }: { collapsed?: boolean } = { collapsed: false }
-) {
+export function CollapseIcon({ collapsed }: { collapsed?: boolean } = {}) {
   // If is not collapsed, rotate 90 degrees
   return (
     <svg
@@ -20,7 +18,9 @@ export function CollapseIcon(
       strokeWidth="2"
       viewBox="0 0 24 24"
       // rotate 90 degrees if not collapsed
-      style={{ transform: collapsed ? undefined : 'rotate(90deg)' }}
+      {...(typeof collapsed === 'boolean'
+        ? { style: { transform: collapsed ? undefined : 'rotate(90deg)' } }
+        : {})}
     >
       <path d="M9 18l6-6-6-6" />
     </svg>

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/component-stack-pseudo-html.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/component-stack-pseudo-html.tsx
@@ -73,13 +73,18 @@ export function PseudoHtmlDiff({
           tagNames.includes(prevComponent) ||
           tagNames.includes(nextComponent)
 
+        const isLastFewFrames =
+          !isHtmlTagsWarning && index >= componentList.length - 6
+        const reachedMaxDisplayFrames =
+          nestedHtmlStack.length >= MAX_NON_COLLAPSED_FRAMES
+
         if (
           nestedHtmlStack.length >= MAX_NON_COLLAPSED_FRAMES &&
           isHtmlCollapsed
         ) {
           return
         }
-        if (isHtmlTagsWarning && isRelatedTag) {
+        if ((isHtmlTagsWarning && isRelatedTag) || isLastFewFrames) {
           const codeLine = (
             <span>
               <span>{spaces}</span>
@@ -108,11 +113,7 @@ export function PseudoHtmlDiff({
           )
           nestedHtmlStack.push(wrappedCodeLine)
         } else {
-          if (
-            !isHtmlCollapsed ||
-            (!isHtmlTagsWarning &&
-              nestedHtmlStack.length < MAX_NON_COLLAPSED_FRAMES)
-          ) {
+          if ((isHtmlTagsWarning && !isHtmlCollapsed) || isLastFewFrames) {
             nestedHtmlStack.push(
               <span key={nestedHtmlStack.length}>
                 {spaces}
@@ -124,8 +125,7 @@ export function PseudoHtmlDiff({
             nestedHtmlStack.push(
               <span key={nestedHtmlStack.length}>
                 {spaces}
-                {'...'}
-                {'\n'}
+                {'...\n'}
               </span>
             )
           }

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/component-stack-pseudo-html.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/component-stack-pseudo-html.tsx
@@ -2,6 +2,7 @@ import { useMemo, Fragment, useState } from 'react'
 import type { ComponentStackFrame } from '../../helpers/parse-component-stack'
 import { CollapseIcon } from './GroupedStackFrames'
 
+// In total it will display 6 rows.
 const MAX_NON_COLLAPSED_FRAMES = 6
 
 /**
@@ -56,6 +57,7 @@ export function PseudoHtmlDiff({
     const tagNames = isHtmlTagsWarning ? [serverContent, clientContent] : []
     const nestedHtmlStack: React.ReactNode[] = []
     let lastText = ''
+
     componentStackFrames
       .map((frame) => frame.component)
       .reverse()
@@ -106,14 +108,18 @@ export function PseudoHtmlDiff({
           )
           nestedHtmlStack.push(wrappedCodeLine)
         } else {
-          if (!isHtmlCollapsed) {
+          if (
+            !isHtmlCollapsed ||
+            (!isHtmlTagsWarning &&
+              nestedHtmlStack.length < MAX_NON_COLLAPSED_FRAMES)
+          ) {
             nestedHtmlStack.push(
               <span key={nestedHtmlStack.length}>
                 {spaces}
                 {'<' + component + '>\n'}
               </span>
             )
-          } else if (lastText !== '...') {
+          } else if (isHtmlCollapsed && lastText !== '...') {
             lastText = '...'
             nestedHtmlStack.push(
               <span key={nestedHtmlStack.length}>

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/component-stack-pseudo-html.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/component-stack-pseudo-html.tsx
@@ -78,16 +78,19 @@ export function PseudoHtmlDiff({
           return
         }
         if (isHtmlTagsWarning && isRelatedTag) {
-          const TextWrap = isHighlightedTag ? 'b' : Fragment
           const codeLine = (
             <span>
               <span>{spaces}</span>
-              <TextWrap>
-                {'<'}
-                {component}
-                {'>'}
-                {'\n'}
-              </TextWrap>
+              <span
+                {...(isHighlightedTag
+                  ? {
+                      ['data-nextjs-container-errors-pseudo-html--tag-error']:
+                        true,
+                    }
+                  : undefined)}
+              >
+                {`<${component}>\n`}
+              </span>
             </span>
           )
           lastText = component

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
@@ -192,9 +192,14 @@ export const styles = css`
     position: relative;
     padding-left: var(--size-gap-triple);
   }
-
   [data-nextjs-container-errors-pseudo-html-collapse] {
     position: absolute;
     left: 0;
+  }
+  [data-nextjs-container-errors-pseudo-html--diff-add] {
+    color: var(--color-ansi-green);
+  }
+  [data-nextjs-container-errors-pseudo-html--diff-remove] {
+    color: var(--color-ansi-red);
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
@@ -190,11 +190,11 @@ export const styles = css`
 
   [data-nextjs-container-errors-pseudo-html] {
     position: relative;
-    padding-left: var(--size-gap-triple);
   }
   [data-nextjs-container-errors-pseudo-html-collapse] {
     position: absolute;
-    left: 0;
+    left: 10px;
+    top: 10px;
   }
   [data-nextjs-container-errors-pseudo-html--diff-add] {
     color: var(--color-ansi-green);

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
@@ -202,4 +202,8 @@ export const styles = css`
   [data-nextjs-container-errors-pseudo-html--diff-remove] {
     color: var(--color-ansi-red);
   }
+  [data-nextjs-container-errors-pseudo-html--tag-error] {
+    color: var(--color-ansi-red);
+    font-weight: bold;
+  }
 `

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/hydration-error-info.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/hydration-error-info.ts
@@ -6,16 +6,26 @@ export type HydrationErrorState = {
   clientContent?: string
 }
 
+type NullableText = string | null | undefined
+
+export const isHtmlTagsWarning = (msg: NullableText) =>
+  Boolean(msg && htmlTagsWarnings.has(msg))
+
+export const isTextMismatchWarning = (msg: NullableText) =>
+  Boolean(msg && textMismatchWarnings.has(msg))
+
+const isKnownHydrationWarning = (msg: NullableText) =>
+  isHtmlTagsWarning(msg) || isTextMismatchWarning(msg)
+
 export const hydrationErrorState: HydrationErrorState = {}
 
+// https://github.com/facebook/react/blob/main/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js used as a reference
 const htmlTagsWarnings = new Set([
   'Warning: In HTML, %s cannot be a descendant of <%s>.\nThis will cause a hydration error.%s',
   'Warning: Expected server HTML to contain a matching <%s> in <%s>.%s',
   'Warning: Did not expect server HTML to contain a <%s> in <%s>.%s',
 ])
-// https://github.com/facebook/react/blob/main/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js used as a reference
-const knownHydrationWarnings = new Set([
-  ...htmlTagsWarnings,
+const textMismatchWarnings = new Set([
   'Warning: Text content did not match. Server: "%s" Client: "%s"%s',
   'Warning: Expected server HTML to contain a matching text node for "%s" in <%s>.%s',
   'Warning: Did not expect server HTML to contain the text node "%s" in <%s>.%s',
@@ -30,7 +40,7 @@ const knownHydrationWarnings = new Set([
 export function patchConsoleError() {
   const prev = console.error
   console.error = function (msg, serverContent, clientContent, componentStack) {
-    if (knownHydrationWarnings.has(msg)) {
+    if (isKnownHydrationWarning(msg)) {
       hydrationErrorState.warning = [
         // remove the last %s from the message
         msg,
@@ -46,6 +56,3 @@ export function patchConsoleError() {
     prev.apply(console, arguments)
   }
 }
-
-export const isHtmlTagsWarning = (msg: any) =>
-  Boolean(msg && htmlTagsWarnings.has(msg))

--- a/test/development/acceptance-app/component-stack.test.ts
+++ b/test/development/acceptance-app/component-stack.test.ts
@@ -21,48 +21,26 @@ describe('Component Stack in error overlay', () => {
     // If it's too long we can collapse
     if (process.env.TURBOPACK) {
       expect(await session.getRedboxComponentStack()).toMatchInlineSnapshot(`
-        "<Root>
-          <ServerRoot>
-            <AppRouter>
-              <ErrorBoundary>
-                <ErrorBoundaryHandler>
-                  <Router>"
+        "...
+          <InnerLayoutRouter>
+            <Mismatch>
+              <main>
+                <Component>
+                  <div>
+                    "server"
+                    "client""
       `)
 
       await session.toggleComponentStack()
       expect(await session.getRedboxComponentStack()).toMatchInlineSnapshot(`
-        "<Root>
-          <ServerRoot>
-            <AppRouter>
-              <ErrorBoundary>
-                <ErrorBoundaryHandler>
-                  <Router>
-                    <HotReload>
-                      <ReactDevOverlay>
-                        <DevRootNotFoundBoundary>
-                          <NotFoundBoundary>
-                            <NotFoundErrorBoundary>
-                              <RedirectBoundary>
-                                <RedirectErrorBoundary>
-                                  <RootLayout>
-                                    <html>
-                                      <body>
-                                        <OuterLayoutRouter>
-                                          <RenderFromTemplateContext>
-                                            <ScrollAndFocusHandler>
-                                              <InnerScrollAndFocusHandler>
-                                                <ErrorBoundary>
-                                                  <LoadingBoundary>
-                                                    <NotFoundBoundary>
-                                                      <NotFoundErrorBoundary>
-                                                        <RedirectBoundary>
-                                                          <RedirectErrorBoundary>
-                                                            <InnerLayoutRouter>
-                                                              <Mismatch>
-                                                                <main>
-                                                                  <Component>
-                                                                    <div>
-                                                                      <p>"
+        "<InnerLayoutRouter>
+          <Mismatch>
+            <main>
+              <Component>
+                <div>
+                  <p>
+                    "server"
+                    "client""
       `)
     } else {
       expect(await session.getRedboxComponentStack()).toMatchInlineSnapshot(`

--- a/test/development/acceptance-app/component-stack.test.ts
+++ b/test/development/acceptance-app/component-stack.test.ts
@@ -70,7 +70,9 @@ describe('Component Stack in error overlay', () => {
           <main>
             <Component>
               <div>
-                <p>"
+                <p>
+                  "server"
+                  "client""
       `)
     }
 

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -129,13 +129,12 @@ describe('Error overlay for hydration errors', () => {
       `)
     } else {
       expect(pseudoHtml).toMatchInlineSnapshot(`
-      "<Mismatch>
-        <div>
-        ^^^^^
-          <main>
-          ^^^^^^
-      "
-    `)
+        "<Mismatch>
+          <div>
+          ^^^^^
+            <main>
+            ^^^^^^"
+      `)
     }
 
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
@@ -381,13 +380,12 @@ describe('Error overlay for hydration errors', () => {
       `)
     } else {
       expect(pseudoHtml).toMatchInlineSnapshot(`
-      "<Page>
-        <p>
-        ^^^
+        "<Page>
           <p>
           ^^^
-"
-    `)
+            <p>
+            ^^^"
+      `)
     }
 
     await cleanup()

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -68,8 +68,7 @@ describe('Error overlay for hydration errors', () => {
           <div>
             <main>
               "server"
-              "client"
-        "
+              "client""
       `)
     }
 
@@ -123,18 +122,18 @@ describe('Error overlay for hydration errors', () => {
         "...
           <Mismatch>
             <div>
-            ^^^
+            ^^^^^
               <main>
-              ^^^
+              ^^^^^^
         "
       `)
     } else {
       expect(pseudoHtml).toMatchInlineSnapshot(`
       "<Mismatch>
         <div>
-        ^^^
+        ^^^^^
           <main>
-          ^^^
+          ^^^^^^
       "
     `)
     }
@@ -387,7 +386,7 @@ describe('Error overlay for hydration errors', () => {
         ^^^
           <p>
           ^^^
-      "
+"
     `)
     }
 
@@ -441,15 +440,14 @@ describe('Error overlay for hydration errors', () => {
       `)
     } else {
       expect(pseudoHtml).toMatchInlineSnapshot(`
-      "<Page>
-        <p>
-        ^^^
-          <span>
-            ...
-              <span>
-                <p>
-                ^^^
-      "
+        "<Page>
+          <p>
+          ^^^
+            <span>
+              ...
+                <span>
+                  <p>
+                  ^^^"
     `)
     }
 

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -52,15 +52,14 @@ describe('Error overlay for hydration errors', () => {
 
     if (isTurbopack) {
       expect(pseudoHtml).toMatchInlineSnapshot(`
-        "<Root>
-          <ServerRoot>
-            <AppRouter>
-              <ErrorBoundary>
-                <ErrorBoundaryHandler>
-                  <Router>
+        "...
+          <RedirectBoundary>
+            <RedirectErrorBoundary>
+              <InnerLayoutRouter>
+                <Mismatch>
+                  <div>
                     "server"
-                    "client"
-        "
+                    "client""
       `)
     } else {
       expect(pseudoHtml).toMatchInlineSnapshot(`
@@ -124,8 +123,7 @@ describe('Error overlay for hydration errors', () => {
             <div>
             ^^^^^
               <main>
-              ^^^^^^
-        "
+              ^^^^^^"
       `)
     } else {
       expect(pseudoHtml).toMatchInlineSnapshot(`
@@ -375,8 +373,7 @@ describe('Error overlay for hydration errors', () => {
             <p>
             ^^^
               <p>
-              ^^^
-        "
+              ^^^"
       `)
     } else {
       expect(pseudoHtml).toMatchInlineSnapshot(`
@@ -433,8 +430,7 @@ describe('Error overlay for hydration errors', () => {
             ^^^
               <span>
                 ...
-                  <span>
-        "
+                  <span>"
       `)
     } else {
       expect(pseudoHtml).toMatchInlineSnapshot(`

--- a/test/development/acceptance/component-stack.test.ts
+++ b/test/development/acceptance/component-stack.test.ts
@@ -16,12 +16,14 @@ createNextDescribe(
 
       if (process.env.TURBOPACK) {
         expect(await getRedboxComponentStack(browser)).toMatchInlineSnapshot(`
-          "<Root>
-            <AppContainer>
-              <Container>
-                <ReactDevOverlay>
-                  <ErrorBoundary>
-                    <PathnameContextProviderAdapter>"
+          "...
+            <App>
+              <Mismatch>
+                <main>
+                  <Component>
+                    <div>
+                      "server"
+                      "client""
         `)
       } else {
         expect(await getRedboxComponentStack(browser)).toMatchInlineSnapshot(`
@@ -29,7 +31,9 @@ createNextDescribe(
             <main>
               <Component>
                 <div>
-                  <p>"
+                  <p>
+                    "server"
+                    "client""
         `)
       }
     })

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1079,12 +1079,12 @@ export async function getRedboxComponentStack(
   browser: BrowserInterface
 ): Promise<string> {
   await browser.waitForElementByCss(
-    '[data-nextjs-container-errors-pseudo-html]',
+    '[data-nextjs-container-errors-pseudo-html] code',
     30000
   )
   // TODO: the type for elementsByCss is incorrect
   const componentStackFrameElements: any = await browser.elementsByCss(
-    '[data-nextjs-container-errors-pseudo-html]'
+    '[data-nextjs-container-errors-pseudo-html] code'
   )
   const componentStackFrameTexts = await Promise.all(
     componentStackFrameElements.map((f) => f.innerText())


### PR DESCRIPTION
### What

Keep improving the hydration erros. Currently we divide the hydration mismatch types into two categories, html tag mismatch and text mismatch. We're displaying the mismatched text content between server and client here since we have it in the component stack and warnings.

We've already made some improvements in #62590 , here we carry on improving the highlited text into red and bold that is much easier for you to spot on.

This updated a few long snapshots that we could collapse and show only the text content difference instead of all the component stack.

### Screenshots

(Dark and light modes)

#### Mismatch html tags
<img width="360" src="https://github.com/vercel/next.js/assets/4800338/f721b374-69cc-4600-a09d-bef87e885fab"><img width="360" src="https://github.com/vercel/next.js/assets/4800338/1abf2572-2be8-4359-a652-8ba39aaccfd3">


#### Mismatch text content
<img width="360" src="https://github.com/vercel/next.js/assets/4800338/7f0d2215-8bc0-4fba-9c92-6c44efa29531"><img width="360" src="https://github.com/vercel/next.js/assets/4800338/656d1e1a-3157-4bcf-a239-74bb81fcb4c4">


#### Large content mismatch

### Why

I was intended to bring a html diff between server and client html content but turns out the diff result could be giant and not ideal due to few reasons. So we switched to the path of leveraging component stack and mismatch contents.
React reordering the tags after hydration. For instance the `script` or `link` tags could be hoist by React Float, so the lines of html is are to preserved. so the diff is hard to be super accurate unless your mismatch is small. If you're mismatch a component with rich html content, it could be a pretty large diff.

Another case is if you have a bad nesting html like `<p> ...<span>... <p>my text</p> ...</span>... <p>` where there're many span in between, the final different could also be hudge as browser will close the first `<p>` tag and the rest content will go into the diff. Hence we're going with the component and text content diff.


Closes NEXT-2645