### PR TITLE
Sync types of `NextNodeServer` and `BaseServer`

### DIFF
--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
@@ -504,7 +504,7 @@ declare module 'next/navigation' {
     prefetch<RouteType>(href: __next_route_internal_types__.RouteImpl<RouteType>): void
   }
 
-  export declare function useRouter(): AppRouterInstance;
+  export function useRouter(): AppRouterInstance;
 }
 
 declare module 'next/form' {

--- a/packages/next/src/server/base-http/index.ts
+++ b/packages/next/src/server/base-http/index.ts
@@ -28,7 +28,7 @@ export type FetchMetrics = Array<FetchMetric>
 export abstract class BaseNextRequest<Body = any> {
   protected _cookies: NextApiRequestCookies | undefined
   public abstract headers: IncomingHttpHeaders
-  public abstract fetchMetrics?: FetchMetric[]
+  public abstract fetchMetrics: FetchMetric[] | undefined
 
   constructor(
     public method: string,

--- a/packages/next/src/server/base-http/web.ts
+++ b/packages/next/src/server/base-http/web.ts
@@ -11,7 +11,7 @@ import { InvariantError } from '../../shared/lib/invariant-error'
 export class WebNextRequest extends BaseNextRequest<ReadableStream | null> {
   public request: Request
   public headers: IncomingHttpHeaders
-  public fetchMetrics?: FetchMetrics
+  public fetchMetrics: FetchMetrics | undefined
 
   constructor(request: NextRequestHint) {
     const url = new URL(request.url)

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -321,7 +321,7 @@ export class WrappedBuildError extends Error {
 type ResponsePayload = {
   type: 'html' | 'json' | 'rsc'
   body: RenderResult
-  revalidate?: Revalidate
+  revalidate?: Revalidate | undefined
 }
 
 export type NextEnabledDirectories = {
@@ -398,8 +398,8 @@ export default abstract class Server<
       type: 'html' | 'json' | 'rsc'
       generateEtags: boolean
       poweredByHeader: boolean
-      revalidate?: Revalidate
-      expireTime?: ExpireTime
+      revalidate: Revalidate | undefined
+      expireTime: ExpireTime | undefined
     }
   ): Promise<void>
 

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -477,7 +477,7 @@ export default class NextNodeServer extends BaseServer<
     res: NodeNextResponse,
     options: {
       result: RenderResult
-      type: 'html' | 'json'
+      type: 'html' | 'json' | 'rsc'
       generateEtags: boolean
       poweredByHeader: boolean
       revalidate: Revalidate | undefined

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -31,7 +31,7 @@ import { getBuiltinRequestContext } from '../after/builtin-request-context'
 
 export class NextRequestHint extends NextRequest {
   sourcePage: string
-  fetchMetrics?: FetchEventResult['fetchMetrics']
+  fetchMetrics: FetchEventResult['fetchMetrics'] | undefined
 
   constructor(params: {
     init: RequestInit

--- a/test/production/typescript-basic/typechecking.test.ts
+++ b/test/production/typescript-basic/typechecking.test.ts
@@ -11,7 +11,7 @@ describe('typechecking', () => {
   it('should typecheck', async () => {
     const { status, stdout } = childProcess.spawnSync(
       'pnpm',
-      ['tsc', '--project', 'tsconfig.json', '--skipLibCheck', 'false'],
+      ['tsc', '--project', 'tsconfig.json'],
       {
         cwd: next.testDir,
         encoding: 'utf-8',

--- a/test/production/typescript-basic/typechecking/tsconfig.json
+++ b/test/production/typescript-basic/typechecking/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
+    "exactOptionalPropertyTypes": true,
     "skipLibCheck": false,
     "strict": true,
     "noEmit": true,

--- a/test/production/typescript-basic/typechecking/tsconfig.json
+++ b/test/production/typescript-basic/typechecking/tsconfig.json
@@ -13,8 +13,6 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    // Required for `@types/node`
-    "target": "ES6",
     "plugins": [
       {
         "name": "next"

--- a/test/production/typescript-basic/typechecking/tsconfig.json
+++ b/test/production/typescript-basic/typechecking/tsconfig.json
@@ -13,6 +13,8 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    // Required for `@types/node`
+    "target": "ES6",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
Otherwise these don't pass with `exactOptionalPropertyTypes: true` and `skipLibCheck: false`:

<details>
<summary>TypeScript output</summary>

```
node_modules/next/dist/server/next-server.d.ts:66:15 - error TS2416: Property 'sendRenderResult' in type 'NextNodeServer' is not assignable to the same property in base type 'Server<Options>'.
  Type '(req: NodeNextRequest, res: NodeNextResponse, options: { result: RenderResult<RenderResultMetadata>; type: "json" | "html"; generateEtags: boolean; poweredByHeader: boolean; revalidate: Revalidate | undefined; }) => Promise<...>' is not assignable to type '(req: BaseNextRequest<any>, res: BaseNextResponse<any>, options: { result: RenderResult<RenderResultMetadata>; type: "json" | ... 1 more ... | "rsc"; generateEtags: boolean; poweredByHeader: boolean; revalidate?: Revalidate; }) => Promise<...>'.
    Types of parameters 'options' and 'options' are incompatible.
      Type '{ result: RenderResult<RenderResultMetadata>; type: "json" | "html" | "rsc"; generateEtags: boolean; poweredByHeader: boolean; revalidate?: Revalidate; }' is not assignable to type '{ result: RenderResult<RenderResultMetadata>; type: "json" | "html"; generateEtags: boolean; poweredByHeader: boolean; revalidate: Revalidate | undefined; }'.
        Types of property 'type' are incompatible.
          Type '"json" | "html" | "rsc"' is not assignable to type '"json" | "html"'.
            Type '"rsc"' is not assignable to type '"json" | "html"'.

66     protected sendRenderResult(req: NodeNextRequest, res: NodeNextResponse, options: {
                 ~~~~~~~~~~~~~~~~

node_modules/next/dist/server/next-server.d.ts:82:15 - error TS2416: Property 'renderPageComponent' in type 'NextNodeServer' is not assignable to the same property in base type 'Server<Options>'.
  Type '(ctx: RequestContext, bubbleNoFallback: boolean) => Promise<false | { type: "json" | "html" | "rsc"; body: RenderResult<RenderResultMetadata>; revalidate?: Revalidate | undefined; } | null>' is not assignable to type '(ctx: RequestContext, bubbleNoFallback: boolean) => Promise<false | ResponsePayload | null>'.
    Type 'Promise<false | { type: "json" | "html" | "rsc"; body: RenderResult<RenderResultMetadata>; revalidate?: Revalidate | undefined; } | null>' is not assignable to type 'Promise<false | ResponsePayload | null>'.
      Type 'false | { type: "json" | "html" | "rsc"; body: RenderResult<RenderResultMetadata>; revalidate?: Revalidate | undefined; } | null' is not assignable to type 'false | ResponsePayload | null'.
        Type '{ type: "json" | "html" | "rsc"; body: RenderResult<RenderResultMetadata>; revalidate?: Revalidate | undefined; }' is not assignable to type 'false | ResponsePayload | null'.
          Type '{ type: "json" | "html" | "rsc"; body: RenderResult<RenderResultMetadata>; revalidate?: Revalidate | undefined; }' is not assignable to type 'ResponsePayload' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
            Types of property 'revalidate' are incompatible.
              Type 'Revalidate | undefined' is not assignable to type 'Revalidate'.
                Type 'undefined' is not assignable to type 'Revalidate'.

82     protected renderPageComponent(ctx: RequestContext, bubbleNoFallback: boolean): Promise<false | {
                 ~~~~~~~~~~~~~~~~~~~

node_modules/next/dist/server/next-server.d.ts:135:15 - error TS2416: Property 'renderErrorToResponseImpl' in type 'NextNodeServer' is not assignable to the same property in base type 'Server<Options>'.
  Type '(ctx: RequestContext, err: Error | null) => Promise<{ type: "json" | "html" | "rsc"; body: RenderResult<RenderResultMetadata>; revalidate?: Revalidate | undefined; } | null>' is not assignable to type '(ctx: RequestContext, err: Error | null) => Promise<ResponsePayload | null>'.
    Type 'Promise<{ type: "json" | "html" | "rsc"; body: RenderResult<RenderResultMetadata>; revalidate?: Revalidate | undefined; } | null>' is not assignable to type 'Promise<ResponsePayload | null>'.
      Type '{ type: "json" | "html" | "rsc"; body: RenderResult<RenderResultMetadata>; revalidate?: Revalidate | undefined; } | null' is not assignable to type 'ResponsePayload | null'.
        Type '{ type: "json" | "html" | "rsc"; body: RenderResult<RenderResultMetadata>; revalidate?: Revalidate | undefined; }' is not assignable to type 'ResponsePayload' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
          Types of property 'revalidate' are incompatible.
            Type 'Revalidate | undefined' is not assignable to type 'Revalidate'.

135     protected renderErrorToResponseImpl(ctx: RequestContext, err: Error | null): Promise<{
                  ~~~~~~~~~~~~~~~~~~~~~~~~~
```
</details>

I don't know how to add tests for this, as this repo isn't using `exactOptionalPropertyTypes`.