### PR TITLE
Add param to debug PPR skeleton in dev

### DIFF
--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -150,6 +150,7 @@ export interface RenderOptsPartial {
     swrDelta: SwrDelta | undefined
   }
   postponed?: string
+  isStaticGeneration?: boolean
 }
 
 export type RenderOpts = LoadComponentsReturnType<AppPageModule> &

--- a/test/e2e/app-dir/app/app/skeleton/page.js
+++ b/test/e2e/app-dir/app/app/skeleton/page.js
@@ -1,0 +1,20 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+
+async function Suspend() {
+  await new Promise((resolve) => {
+    setTimeout(resolve, 3000)
+  })
+  cookies()
+  return <p>suspended content</p>
+}
+
+export default function Page() {
+  return (
+    <div>
+      <Suspense fallback={'Skeleton!!!'}>
+        <Suspend />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -20,6 +20,17 @@ createNextDescribe(
     },
   },
   ({ next, isNextDev: isDev, isNextStart, isNextDeploy, isTurbopack }) => {
+    if (isDev && isPPREnabledByDefault) {
+      it('should allow returning just skeleton in dev with query', async () => {
+        const res = await next.fetch('/skeleton?__nextppronly=1')
+        expect(res.status).toBe(200)
+
+        const html = await res.text()
+        expect(html).toContain('Skeleton')
+        expect(html).not.toContain('suspended content')
+      })
+    }
+
     if (process.env.NEXT_EXPERIMENTAL_COMPILE) {
       it('should provide query for getStaticProps page correctly', async () => {
         const res = await next.fetch('/ssg?hello=world')


### PR DESCRIPTION
This adds an experimental query `__nextppronly` to allow debugging PPR skeletons in development to avoid having to do numerous builds to be able to debug this experience. 

x-ref: [slack thread](https://vercel.slack.com/archives/C05KYT5S9FF/p1709151588583179?thread_ts=1708474869.960689&cid=C05KYT5S9FF)