### PR TITLE
fix dev overlay pseudo html collapsing

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/component-stack-pseudo-html.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/component-stack-pseudo-html.tsx
@@ -2,9 +2,6 @@ import { useMemo, Fragment, useState } from 'react'
 import type { ComponentStackFrame } from '../../helpers/parse-component-stack'
 import { CollapseIcon } from '../../icons/CollapseIcon'
 
-// In total it will display 6 rows.
-const MAX_NON_COLLAPSED_FRAMES = 6
-
 /**
  *
  * Format component stack into pseudo HTML
@@ -157,6 +154,7 @@ export function PseudoHtmlDiff({
     serverContent,
     isHtmlTagsWarning,
     hydrationMismatchType,
+    MAX_NON_COLLAPSED_FRAMES,
   ])
 
   return (

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/component-stack-pseudo-html.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/component-stack-pseudo-html.tsx
@@ -86,7 +86,7 @@ export function PseudoHtmlDiff({
         if ((isHtmlTagsWarning && isRelatedTag) || isLastFewFrames) {
           const codeLine = (
             <span>
-              <span>{spaces}</span>
+              {spaces}
               <span
                 {...(isHighlightedTag
                   ? {
@@ -112,7 +112,7 @@ export function PseudoHtmlDiff({
           )
           nestedHtmlStack.push(wrappedCodeLine)
         } else {
-          if ((isHtmlTagsWarning && !isHtmlCollapsed) || isLastFewFrames) {
+          if (!isHtmlCollapsed || isLastFewFrames) {
             nestedHtmlStack.push(
               <span key={nestedHtmlStack.length}>
                 {spaces}

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/component-stack-pseudo-html.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/component-stack-pseudo-html.tsx
@@ -51,6 +51,8 @@ export function PseudoHtmlDiff({
   hydrationMismatchType: 'tag' | 'text'
 } & React.HTMLAttributes<HTMLPreElement>) {
   const isHtmlTagsWarning = hydrationMismatchType === 'tag'
+  // For text mismatch, mismatched text will take 2 rows, so we display 4 rows of component stack
+  const MAX_NON_COLLAPSED_FRAMES = isHtmlTagsWarning ? 6 : 4
   const shouldCollapse = componentStackFrames.length > MAX_NON_COLLAPSED_FRAMES
   const [isHtmlCollapsed, toggleCollapseHtml] = useState(shouldCollapse)
 
@@ -77,12 +79,6 @@ export function PseudoHtmlDiff({
         const isLastFewFrames =
           !isHtmlTagsWarning && index >= componentList.length - 6
 
-        if (
-          nestedHtmlStack.length >= MAX_NON_COLLAPSED_FRAMES &&
-          isHtmlCollapsed
-        ) {
-          return
-        }
         if ((isHtmlTagsWarning && isRelatedTag) || isLastFewFrames) {
           const codeLine = (
             <span>
@@ -112,6 +108,13 @@ export function PseudoHtmlDiff({
           )
           nestedHtmlStack.push(wrappedCodeLine)
         } else {
+          if (
+            nestedHtmlStack.length >= MAX_NON_COLLAPSED_FRAMES &&
+            isHtmlCollapsed
+          ) {
+            return
+          }
+
           if (!isHtmlCollapsed || isLastFewFrames) {
             nestedHtmlStack.push(
               <span key={nestedHtmlStack.length}>

--- a/test/development/acceptance-app/component-stack.test.ts
+++ b/test/development/acceptance-app/component-stack.test.ts
@@ -27,8 +27,9 @@ describe('Component Stack in error overlay', () => {
               <main>
                 <Component>
                   <div>
-                    "server"
-                    "client""
+                    <p>
+                      "server"
+                      "client""
       `)
 
       await session.toggleCollapseComponentStack()

--- a/test/development/acceptance-app/component-stack.test.ts
+++ b/test/development/acceptance-app/component-stack.test.ts
@@ -31,16 +31,42 @@ describe('Component Stack in error overlay', () => {
                     "client""
       `)
 
-      await session.toggleComponentStack()
+      await session.toggleCollapseComponentStack()
       expect(await session.getRedboxComponentStack()).toMatchInlineSnapshot(`
-        "<InnerLayoutRouter>
-          <Mismatch>
-            <main>
-              <Component>
-                <div>
-                  <p>
-                    "server"
-                    "client""
+        "<Root>
+          <ServerRoot>
+            <AppRouter>
+              <ErrorBoundary>
+                <ErrorBoundaryHandler>
+                  <Router>
+                    <HotReload>
+                      <ReactDevOverlay>
+                        <DevRootNotFoundBoundary>
+                          <NotFoundBoundary>
+                            <NotFoundErrorBoundary>
+                              <RedirectBoundary>
+                                <RedirectErrorBoundary>
+                                  <RootLayout>
+                                    <html>
+                                      <body>
+                                        <OuterLayoutRouter>
+                                          <RenderFromTemplateContext>
+                                            <ScrollAndFocusHandler>
+                                              <InnerScrollAndFocusHandler>
+                                                <ErrorBoundary>
+                                                  <LoadingBoundary>
+                                                    <NotFoundBoundary>
+                                                      <NotFoundErrorBoundary>
+                                                        <RedirectBoundary>
+                                                          <RedirectErrorBoundary>
+                                                            <InnerLayoutRouter>
+                                                              <Mismatch>
+                                                                <main>
+                                                                  <Component>
+                                                                    <div>
+                                                                      <p>
+                                                                        "server"
+                                                                        "client""
       `)
     } else {
       expect(await session.getRedboxComponentStack()).toMatchInlineSnapshot(`

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -493,12 +493,13 @@ describe('Error overlay for hydration errors', () => {
 
     const pseudoHtml = await session.getRedboxComponentStack()
     expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
+      "...
+        <div>
           <div>
             <div>
-              <div>
-                <Mismatch>
-                  <p>
+              <Mismatch>
+                <p>
+                  <span>
                     "server"
                     "client""
     `)
@@ -508,44 +509,44 @@ describe('Error overlay for hydration errors', () => {
     const fullPseudoHtml = await session.getRedboxComponentStack()
     if (isTurbopack) {
       expect(fullPseudoHtml).toMatchInlineSnapshot(`
-      "<Root>
-        <ServerRoot>
-          <AppRouter>
-            <ErrorBoundary>
-              <ErrorBoundaryHandler>
-                <Router>
-                  <HotReload>
-                    <ReactDevOverlay>
-                      <DevRootNotFoundBoundary>
-                        <NotFoundBoundary>
-                          <NotFoundErrorBoundary>
-                            <RedirectBoundary>
-                              <RedirectErrorBoundary>
-                                <RootLayout>
-                                  <html>
-                                    <body>
-                                      <OuterLayoutRouter>
-                                        <RenderFromTemplateContext>
-                                          <ScrollAndFocusHandler>
-                                            <InnerScrollAndFocusHandler>
-                                              <ErrorBoundary>
-                                                <LoadingBoundary>
-                                                  <NotFoundBoundary>
-                                                    <NotFoundErrorBoundary>
-                                                      <RedirectBoundary>
-                                                        <RedirectErrorBoundary>
-                                                          <InnerLayoutRouter>
-                                                            <Page>
-                                                              <div>
-                                                                <div>
-                                                                  <div>
-                                                                    <div>
-                                                                      <Mismatch>
-                                                                        <p>
-                                                                          <span>
-                                                                            "server"
-                                                                            "client""
-      `)
+              "<Root>
+                <ServerRoot>
+                  <AppRouter>
+                    <ErrorBoundary>
+                      <ErrorBoundaryHandler>
+                        <Router>
+                          <HotReload>
+                            <ReactDevOverlay>
+                              <DevRootNotFoundBoundary>
+                                <NotFoundBoundary>
+                                  <NotFoundErrorBoundary>
+                                    <RedirectBoundary>
+                                      <RedirectErrorBoundary>
+                                        <RootLayout>
+                                          <html>
+                                            <body>
+                                              <OuterLayoutRouter>
+                                                <RenderFromTemplateContext>
+                                                  <ScrollAndFocusHandler>
+                                                    <InnerScrollAndFocusHandler>
+                                                      <ErrorBoundary>
+                                                        <LoadingBoundary>
+                                                          <NotFoundBoundary>
+                                                            <NotFoundErrorBoundary>
+                                                              <RedirectBoundary>
+                                                                <RedirectErrorBoundary>
+                                                                  <InnerLayoutRouter>
+                                                                    <Page>
+                                                                      <div>
+                                                                        <div>
+                                                                          <div>
+                                                                            <div>
+                                                                              <Mismatch>
+                                                                                <p>
+                                                                                  <span>
+                                                                                    "server"
+                                                                                    "client""
+            `)
     } else {
       expect(fullPseudoHtml).toMatchInlineSnapshot(`
         "<Page>

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -58,8 +58,9 @@ describe('Error overlay for hydration errors', () => {
               <InnerLayoutRouter>
                 <Mismatch>
                   <div>
-                    "server"
-                    "client""
+                    <main>
+                      "server"
+                      "client""
       `)
     } else {
       expect(pseudoHtml).toMatchInlineSnapshot(`
@@ -430,7 +431,9 @@ describe('Error overlay for hydration errors', () => {
             ^^^
               <span>
                 ...
-                  <span>"
+                  <span>
+                    <p>
+                    ^^^"
       `)
     } else {
       expect(pseudoHtml).toMatchInlineSnapshot(`

--- a/test/development/acceptance/component-stack.test.ts
+++ b/test/development/acceptance/component-stack.test.ts
@@ -22,8 +22,9 @@ createNextDescribe(
                 <main>
                   <Component>
                     <div>
-                      "server"
-                      "client""
+                      <p>
+                        "server"
+                        "client""
         `)
       } else {
         expect(await getRedboxComponentStack(browser)).toMatchInlineSnapshot(`

--- a/test/lib/development-sandbox.ts
+++ b/test/lib/development-sandbox.ts
@@ -9,7 +9,7 @@ import {
   waitFor,
   waitForAndOpenRuntimeError,
   getRedboxDescriptionWarning,
-  toggleComponentStack,
+  toggleCollapseComponentStack,
 } from './next-test-utils'
 import webdriver from './next-webdriver'
 import { NextInstance } from './next-modes/base'
@@ -139,8 +139,8 @@ export async function sandbox(
       async getRedboxComponentStack() {
         return getRedboxComponentStack(browser)
       },
-      async toggleComponentStack() {
-        return toggleComponentStack(browser)
+      async toggleCollapseComponentStack() {
+        return toggleCollapseComponentStack(browser)
       },
       async getVersionCheckerText() {
         return getVersionCheckerText(browser)

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1068,7 +1068,7 @@ export async function getRedboxComponentStack(
   return componentStackFrameTexts.join('\n').trim()
 }
 
-export async function toggleComponentStack(
+export async function toggleCollapseComponentStack(
   browser: BrowserInterface
 ): Promise<void> {
   await browser


### PR DESCRIPTION
Dev overlay should show the full stack trace after clicking the uncollase button to display the full component stack

Closes NEXT-2658