### PR TITLE
Fix conflicting-app-page-error test for Turbopack

### DIFF
--- a/test/e2e/conflicting-app-page-error/index.test.ts
+++ b/test/e2e/conflicting-app-page-error/index.test.ts
@@ -3,6 +3,7 @@ import {
   hasRedbox,
   getRedboxSource,
   retry,
+  getRedboxDescription,
 } from 'next-test-utils'
 import { createNextDescribe } from 'e2e-utils'
 
@@ -45,16 +46,17 @@ createNextDescribe(
     async function containConflictsError(browser, conflicts) {
       await retry(async () => {
         expect(await hasRedbox(browser)).toBe(true)
-        const redboxSource = await getRedboxSource(browser)
         if (process.env.TURBOPACK) {
-          expect(redboxSource).toContain(
+          expect(await getRedboxDescription(browser)).toContain(
             'App Router and Pages Router both match path:'
           )
         }
 
         if (!process.env.TURBOPACK) {
           for (const pair of conflicts) {
-            expect(redboxSource).toContain(`"${pair[0]}" - "${pair[1]}"`)
+            expect(await getRedboxSource(browser)).toContain(
+              `"${pair[0]}" - "${pair[1]}"`
+            )
           }
         }
       })

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -4940,13 +4940,13 @@
     "runtimeError": false
   },
   "test/e2e/conflicting-app-page-error/index.test.ts": {
-    "passed": [],
-    "failed": [
+    "passed": [
       "Conflict between app file and pages file should error again when there is new conflict",
       "Conflict between app file and pages file should show error overlay for /",
       "Conflict between app file and pages file should show error overlay for /another",
       "Conflict between app file and pages file should support hmr with conflicts"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [
       "Conflict between app file and pages file should not show error overlay for non conflict pages under app or pages dir"


### PR DESCRIPTION
## What?

Fixes the check for Turbopack. Follow-up to #62531 which fixes the underlying issue but it wasn't checking the right value.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2665