### PR TITLE
Update error handling in publish scripts

### DIFF
--- a/scripts/publish-native.js
+++ b/scripts/publish-native.js
@@ -24,6 +24,7 @@ const cwd = process.cwd()
     await Promise.all(
       platforms.map(async (platform) => {
         await publishSema.acquire()
+        let output = ''
 
         try {
           let binaryName = `next-swc.${platform}.node`
@@ -41,7 +42,7 @@ const cwd = process.cwd()
             path.join(nativePackagesDir, platform, 'package.json'),
             JSON.stringify(pkg, null, 2)
           )
-          await execa(
+          const child = execa(
             `npm`,
             [
               `publish`,
@@ -52,14 +53,20 @@ const cwd = process.cwd()
             ],
             { stdio: 'inherit' }
           )
+          const handleData = (type) => (chunk) => {
+            process[type].write(chunk)
+            output += chunk.toString()
+          }
+          child.stdout?.on('data', handleData('stdout'))
+          child.stderr?.on('data', handleData('stderr'))
+          await child
         } catch (err) {
           // don't block publishing other versions on single platform error
           console.error(`Failed to publish`, platform, err)
 
           if (
-            err.message &&
-            err.message.includes(
-              'You cannot publish over the previously published versions'
+            output.includes(
+              'cannot publish over the previously published versions'
             )
           ) {
             console.error('Ignoring already published error', platform, err)

--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -42,9 +42,10 @@ const cwd = process.cwd()
   const publishSema = new Sema(2)
 
   const publish = async (pkg, retry = 0) => {
+    let output = ''
     try {
       await publishSema.acquire()
-      await execa(
+      const child = execa(
         `npm`,
         [
           'publish',
@@ -54,18 +55,21 @@ const cwd = process.cwd()
           '--ignore-scripts',
           ...(isCanary ? ['--tag', 'canary'] : []),
         ],
-        { stdio: 'inherit' }
+        { stdio: 'pipe' }
       )
+      const handleData = (type) => (chunk) => {
+        process[type].write(chunk)
+        output += chunk.toString()
+      }
+      child.stdout?.on('data', handleData('stdout'))
+      child.stderr?.on('data', handleData('stderr'))
       // Return here to avoid retry logic
-      return
+      return await child
     } catch (err) {
       console.error(`Failed to publish ${pkg}`, err)
 
       if (
-        err.message &&
-        err.message.includes(
-          'You cannot publish over the previously published versions'
-        )
+        output.includes('cannot publish over the previously published versions')
       ) {
         console.error('Ignoring already published error', pkg)
         return


### PR DESCRIPTION
Seems we aren't ignoring the already published error correctly.

x-ref: https://github.com/vercel/next.js/actions/runs/8118349923/job/22192598805

Closes NEXT-2668