### PR TITLE
fix: Enable `getStaticPath` for Page Router to display correct locale in server

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1286,10 +1286,10 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         const invokeQuery = req.headers['x-invoke-query']
 
         if (typeof invokeQuery === 'string') {
-          Object.assign(
-            parsedUrl.query,
-            JSON.parse(decodeURIComponent(invokeQuery))
-          )
+          Object.assign(parsedUrl.query, {
+            ...JSON.parse(decodeURIComponent(invokeQuery)),
+            __nextLocale: parsedUrl.query.__nextLocale,
+          })
         }
 
         finished = await this.normalizeAndAttachMetadata(req, res, parsedUrl)


### PR DESCRIPTION
### What?

Fixes https://github.com/vercel/next.js/issues/62568

Since codes here rewrite `query.__nextLocale` , locale attached are overwritten, and causing locale on server to display default locale.

https://github.com/vercel/next.js/blob/d01d6d9c35a8c2725b3d74c1402ab76d4779a6cf/packages/next/src/server/base-server.ts#L1289-L1292

I also investigate into `x-invoke-query` and here is the code writing `x-invoke-query`

https://github.com/vercel/next.js/blob/d01d6d9c35a8c2725b3d74c1402ab76d4779a6cf/packages/next/src/server/lib/router-utils/resolve-routes.ts#L183-L186

Here `parsedUrl.pathname` is indicating `localhost:3000/_next/data/development/de/page/foo.json` instead of `localhost:3000/de/page/foo` when clicking causing codes here not to be able to get the second segment as locale.

https://github.com/vercel/next.js/blob/d01d6d9c35a8c2725b3d74c1402ab76d4779a6cf/packages/next/src/shared/lib/i18n/normalize-locale-path.ts#L29

I am not investigating inner structure of parsedUrl.query, but I think `__nextLocale` calculated in `handleRequestImpl` should be prioritized over `__nextLocale` calculated in `resolveRoutes` in `resolve-routes.ts`.
And I am also seeing where to add tests now.

---

prettier, lint applied

For locale, test passed

```
pnpm testonly --testPathPattern "integration" -t "locale"
```

For i18n, test not passed for just one case `Custom routes i18n › production mode › should navigate on the client with rewrites correctly` which also fails in canary (not only canary fails but also canary fails more).

```
pnpm testonly --testPathPattern "integration" -t "i18n"
```