### PR TITLE
fix(next-core): throw on invalid metadata handler

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_app/metadata/route.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/metadata/route.rs
@@ -143,6 +143,8 @@ async fn dynamic_text_route_source(path: Vc<FileSystemPath>) -> Result<Vc<Box<dy
 
     let content_type = get_content_type(path).await?;
 
+    // refer https://github.com/vercel/next.js/blob/7b2b9823432fb1fa28ae0ac3878801d638d93311/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts#L84
+    // for the original template.
     let code = formatdoc! {
         r#"
             import {{ NextResponse }} from 'next/server'
@@ -153,6 +155,10 @@ async fn dynamic_text_route_source(path: Vc<FileSystemPath>) -> Result<Vc<Box<dy
             const contentType = {content_type}
             const cacheControl = {cache_control}
             const fileType = {file_type}
+
+            if (typeof handler !== 'function') {{
+                throw new Error('Default export is missing in {resource_path}')
+            }}
 
             export async function GET() {{
               const data = await handler()


### PR DESCRIPTION
### What

Align with original route loader, explicitly throw on invalid handler import.

This does not fixes test currently - other failures on the specific test need to be solved.

Closes PACK-2652