### PR TITLE
fix(next-core): do not apply ecma transforms for custom js rules

### DIFF
--- a/packages/next-swc/crates/next-core/src/app_segment_config.rs
+++ b/packages/next-swc/crates/next-core/src/app_segment_config.rs
@@ -221,10 +221,11 @@ pub async fn parse_segment_config_from_source(
 
     // Don't try parsing if it's not a javascript file, otherwise it will emit an
     // issue causing the build to "fail".
-    if !(path.path.ends_with(".js")
-        || path.path.ends_with(".jsx")
-        || path.path.ends_with(".ts")
-        || path.path.ends_with(".tsx"))
+    if path.path.ends_with("d.ts")
+        || !(path.path.ends_with(".js")
+            || path.path.ends_with(".jsx")
+            || path.path.ends_with(".ts")
+            || path.path.ends_with(".tsx"))
     {
         return Ok(Default::default());
     }

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/mod.rs
@@ -68,7 +68,12 @@ fn match_js_extension(enable_mdx_rs: bool) -> Vec<ModuleRuleCondition> {
     let mut conditions = vec![
         ModuleRuleCondition::ResourcePathEndsWith(".js".to_string()),
         ModuleRuleCondition::ResourcePathEndsWith(".jsx".to_string()),
-        ModuleRuleCondition::ResourcePathEndsWith(".ts".to_string()),
+        ModuleRuleCondition::All(vec![
+            ModuleRuleCondition::ResourcePathEndsWith(".ts".to_string()),
+            ModuleRuleCondition::Not(Box::new(ModuleRuleCondition::ResourcePathEndsWith(
+                "d.ts".to_string(),
+            ))),
+        ]),
         ModuleRuleCondition::ResourcePathEndsWith(".tsx".to_string()),
         ModuleRuleCondition::ResourcePathEndsWith(".mjs".to_string()),
         ModuleRuleCondition::ResourcePathEndsWith(".cjs".to_string()),


### PR DESCRIPTION
### What

Looks like we allow d.ts to be included in `match_js_extension`, so if custom rules have an ecmatransform it could raise an error with d.ts.

This doesn't make test passes yet, seems there are other issues need to be resolved.

Closes PACK-2653