### PR TITLE
Revert "Add experimental config for navigation raf test (#62668)"

### DIFF
--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -194,9 +194,6 @@ export function getDefineEnv({
     'process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE': JSON.stringify(
       config.skipMiddlewareUrlNormalize
     ),
-    'process.env.__NEXT_NAVIGATION_RAF': JSON.stringify(
-      config.experimental.navigationRAF
-    ),
     'process.env.__NEXT_EXTERNAL_MIDDLEWARE_REWRITE_RESOLVE': JSON.stringify(
       config.experimental.externalMiddlewareRewritesResolve
     ),

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -225,38 +225,15 @@ function useChangeByServerResponse(
 function useNavigate(dispatch: React.Dispatch<ReducerActions>): RouterNavigate {
   return useCallback(
     (href, navigateType, shouldScroll) => {
-      const navigateWrapper = process.env.__NEXT_NAVIGATION_RAF
-        ? (cb: () => void) => {
-            let finished = false
+      const url = new URL(addBasePath(href), location.href)
 
-            // if the frame is hidden or requestAnimationFrame
-            // is delayed too long add upper bound timeout
-            setTimeout(() => {
-              if (!finished) {
-                finished = true
-                cb()
-              }
-            }, 1000)
-            requestAnimationFrame(() => {
-              setTimeout(() => {
-                finished = true
-                cb()
-              }, 1)
-            })
-          }
-        : (cb: () => void) => cb()
-
-      navigateWrapper(() => {
-        const url = new URL(addBasePath(href), location.href)
-
-        return dispatch({
-          type: ACTION_NAVIGATE,
-          url,
-          isExternalUrl: isExternalURL(url),
-          locationSearch: location.search,
-          shouldScroll: shouldScroll ?? true,
-          navigateType,
-        })
+      return dispatch({
+        type: ACTION_NAVIGATE,
+        url,
+        isExternalUrl: isExternalURL(url),
+        locationSearch: location.search,
+        shouldScroll: shouldScroll ?? true,
+        navigateType,
       })
     },
     [dispatch]

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -277,7 +277,6 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         manualClientBasePath: z.boolean().optional(),
         middlewarePrefetch: z.enum(['strict', 'flexible']).optional(),
         mergeCssChunks: z.boolean().optional(),
-        navigationRAF: z.boolean().optional(),
         nextScriptWorkers: z.boolean().optional(),
         // The critter option is unknown, use z.any() here
         optimizeCss: z.union([z.boolean(), z.any()]).optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -167,7 +167,6 @@ export interface NextJsWebpackConfig {
 }
 
 export interface ExperimentalConfig {
-  navigationRAF?: boolean
   prerenderEarlyExit?: boolean
   linkNoTouchStart?: boolean
   caseSensitiveRoutes?: boolean
@@ -844,7 +843,6 @@ export const defaultConfig: NextConfig = {
   output: !!process.env.NEXT_PRIVATE_STANDALONE ? 'standalone' : undefined,
   modularizeImports: undefined,
   experimental: {
-    navigationRAF: false,
     prerenderEarlyExit: false,
     serverMinification: true,
     serverSourceMaps: false,

--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -1498,32 +1498,20 @@ export default class Router implements BaseRouter {
     const isErrorRoute = this.pathname === '/404' || this.pathname === '/_error'
 
     try {
-      let [routeInfo] = await Promise.all([
-        this.getRouteInfo({
-          route,
-          pathname,
-          query,
-          as,
-          resolvedAs,
-          routeProps,
-          locale: nextState.locale,
-          isPreview: nextState.isPreview,
-          hasMiddleware: isMiddlewareMatch,
-          unstable_skipClientCache: options.unstable_skipClientCache,
-          isQueryUpdating: isQueryUpdating && !this.isFallback,
-          isMiddlewareRewrite,
-        }),
-        process.env.__NEXT_NAVIGATION_RAF
-          ? new Promise((resolve) => {
-              // if the frame is hidden or requestAnimationFrame
-              // is delayed too long add upper bound timeout
-              setTimeout(resolve, 1000)
-              requestAnimationFrame(() => {
-                setTimeout(resolve, 1)
-              })
-            })
-          : Promise.resolve(),
-      ])
+      let routeInfo = await this.getRouteInfo({
+        route,
+        pathname,
+        query,
+        as,
+        resolvedAs,
+        routeProps,
+        locale: nextState.locale,
+        isPreview: nextState.isPreview,
+        hasMiddleware: isMiddlewareMatch,
+        unstable_skipClientCache: options.unstable_skipClientCache,
+        isQueryUpdating: isQueryUpdating && !this.isFallback,
+        isMiddlewareRewrite,
+      })
 
       if (!isQueryUpdating && !options.shallow) {
         await this._bfl(


### PR DESCRIPTION
Reverting this experimental flag as it should not be used and we are going to investigate experimenting with this further upstream so that it can be done properly.

This reverts commit 2bdcaa0fda09faccbb70c454ef52f2302f84acb2.

x-ref: https://github.com/vercel/next.js/pull/62668



Closes NEXT-2689