### PR TITLE
fix(next-core): honor basepath for the metadata property

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_app/app_page_entry.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/app_page_entry.rs
@@ -51,8 +51,10 @@ pub async fn get_app_page_entry(
 
     let server_component_transition = Vc::upcast(NextServerComponentTransition::new());
 
+    let base_path = next_config.await?.base_path.clone();
     let loader_tree =
-        LoaderTreeModule::build(loader_tree, context, server_component_transition).await?;
+        LoaderTreeModule::build(loader_tree, context, server_component_transition, base_path)
+            .await?;
 
     let LoaderTreeModule {
         inner_assets,

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -2435,11 +2435,10 @@
       "app dir - basepath should render usePathname without the basePath",
       "app dir - basepath should successfully hard navigate from pages -> app",
       "app dir - basepath should support Link with basePath prefixed",
-      "app dir - basepath should support `basePath`"
-    ],
-    "failed": [
+      "app dir - basepath should support `basePath`",
       "app dir - basepath should prefix metadata og image with basePath"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
### What?

When we write path for the og metadata, basePath was omitted regardless of config. (Actual asset emission was correct, just writing the path in the metadata route)

PR updates template code to use config's basePath if exists.

Closes PACK-2655