### PR TITLE
refactor(ts): type `fastRefresh`

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -391,7 +391,6 @@ function Router({
           })
         })
       },
-      // @ts-ignore we don't want to expose this method at all
       fastRefresh: () => {
         if (process.env.NODE_ENV !== 'development') {
           throw new Error(

--- a/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
@@ -126,6 +126,11 @@ export interface AppRouterInstance {
    */
   refresh(): void
   /**
+   * Refresh the current page. Use in development only.
+   * @internal
+   */
+  fastRefresh(): void
+  /**
    * Navigate to the provided href.
    * Pushes a new history entry.
    */

--- a/packages/next/src/shared/lib/router/adapters.tsx
+++ b/packages/next/src/shared/lib/router/adapters.tsx
@@ -1,7 +1,4 @@
-import type {
-  AppRouterInstance,
-  NavigateOptions,
-} from '../app-router-context.shared-runtime'
+import type { AppRouterInstance } from '../app-router-context.shared-runtime'
 import type { Params } from './utils/route-matcher'
 import type { NextRouter } from './router'
 
@@ -11,33 +8,29 @@ import { isDynamicRoute } from './utils'
 import { asPathToSearchParams } from './utils/as-path-to-search-params'
 import { getRouteRegex } from './utils/route-regex'
 
-/**
- * adaptForAppRouterInstance implements the AppRouterInstance with a NextRouter.
- *
- * @param router the NextRouter to adapt
- * @returns an AppRouterInstance
- */
+/** It adapts a Pages Router (`NextRouter`) to the App Router Instance. */
 export function adaptForAppRouterInstance(
-  router: NextRouter
+  pagesRouter: NextRouter
 ): AppRouterInstance {
   return {
-    back(): void {
-      router.back()
+    back() {
+      pagesRouter.back()
     },
-    forward(): void {
-      router.forward()
+    forward() {
+      pagesRouter.forward()
     },
-    refresh(): void {
-      router.reload()
+    refresh() {
+      pagesRouter.reload()
     },
-    push(href: string, { scroll }: NavigateOptions = {}): void {
-      void router.push(href, undefined, { scroll })
+    fastRefresh() {},
+    push(href, { scroll } = {}) {
+      void pagesRouter.push(href, undefined, { scroll })
     },
-    replace(href: string, { scroll }: NavigateOptions = {}): void {
-      void router.replace(href, undefined, { scroll })
+    replace(href, { scroll } = {}) {
+      void pagesRouter.replace(href, undefined, { scroll })
     },
-    prefetch(href: string): void {
-      void router.prefetch(href)
+    prefetch(href) {
+      void pagesRouter.prefetch(href)
     },
   }
 }


### PR DESCRIPTION
Separated from https://github.com/vercel/next.js/pull/62815

Instead of `@ts-ignore` ing this internal method and making it harder for ourselves to use, we can type it correctly and add the `@internal` directive that will make sure its type is not emitted to userland. Same behavior, but we get type-hints.

Before:
![image](https://github.com/vercel/next.js/assets/18369201/2182a4fd-57b7-4715-abe3-f3f21a4e07cb)

After:
![image](https://github.com/vercel/next.js/assets/18369201/63f23e0e-9678-448d-b238-3416a3455ea0)

Userland, still no suggestion:

![image](https://github.com/vercel/next.js/assets/18369201/68cddb1a-e51c-4c6c-a7bc-66b8b031c05f)

Closes NEXT-2698
[Slack thread](https://vercel.slack.com/archives/C04DUD7EB1B/p1709766293275549)