### PR TITLE
Update canary semver handling

### DIFF
--- a/scripts/start-release.js
+++ b/scripts/start-release.js
@@ -55,7 +55,7 @@ async function main() {
   console.log(`Running pnpm release-${isCanary ? 'canary' : 'stable'}...`)
   const child = execa(
     isCanary
-      ? `pnpm lerna version prerelease --preid canary --force-publish -y && pnpm release --pre --skip-questions --show-url`
+      ? `pnpm lerna version preminor --preid canary --force-publish -y && pnpm release --pre --skip-questions --show-url`
       : `pnpm lerna version ${semverType} --force-publish -y`,
     {
       stdio: 'pipe',


### PR DESCRIPTION
As discussed this updates our canary semver bumping to use `preminor` instead of `prerelease` to avoid overlap with patches/backports and make it more clear for users which versions go along together. 

x-ref: [slack thread](https://vercel.slack.com/archives/C04DUD7EB1B/p1709583075769789)

Closes NEXT-2701