### PR TITLE
add experimental client router cache config

### DIFF
--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -171,6 +171,13 @@ export function getDefineEnv({
     'process.env.__NEXT_MIDDLEWARE_MATCHERS': middlewareMatchers ?? [],
     'process.env.__NEXT_MANUAL_CLIENT_BASE_PATH':
       config.experimental.manualClientBasePath ?? false,
+    'process.env.__NEXT_CLIENT_ROUTER_CACHE_STALETIME_MS': JSON.stringify(
+      config.experimental.clientRouterCache
+        ? 31556952000 // 1 year (ms)
+        : config.experimental.clientRouterCache === false
+        ? 0
+        : 30000 // 30 seconds (ms)
+    ),
     'process.env.__NEXT_CLIENT_ROUTER_FILTER_ENABLED':
       config.experimental.clientRouterFilter ?? true,
     'process.env.__NEXT_CLIENT_ROUTER_S_FILTER':

--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -171,13 +171,8 @@ export function getDefineEnv({
     'process.env.__NEXT_MIDDLEWARE_MATCHERS': middlewareMatchers ?? [],
     'process.env.__NEXT_MANUAL_CLIENT_BASE_PATH':
       config.experimental.manualClientBasePath ?? false,
-    'process.env.__NEXT_CLIENT_ROUTER_CACHE_STALETIME_MS': JSON.stringify(
-      config.experimental.clientRouterCache
-        ? 31556952000 // 1 year (ms)
-        : config.experimental.clientRouterCache === false
-        ? 0
-        : 30000 // 30 seconds (ms)
-    ),
+    'process.env.__NEXT_CLIENT_ROUTER_CACHE_MODE':
+      config.experimental.clientRouterCacheMode ?? 'default',
     'process.env.__NEXT_CLIENT_ROUTER_FILTER_ENABLED':
       config.experimental.clientRouterFilter ?? true,
     'process.env.__NEXT_CLIENT_ROUTER_S_FILTER':

--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -171,8 +171,16 @@ export function getDefineEnv({
     'process.env.__NEXT_MIDDLEWARE_MATCHERS': middlewareMatchers ?? [],
     'process.env.__NEXT_MANUAL_CLIENT_BASE_PATH':
       config.experimental.manualClientBasePath ?? false,
-    'process.env.__NEXT_CLIENT_ROUTER_CACHE_MODE':
-      config.experimental.clientRouterCacheMode ?? 'default',
+    'process.env.__NEXT_CLIENT_ROUTER_DYNAMIC_STALETIME': JSON.stringify(
+      isNaN(Number(config.experimental.staleTimes?.dynamic))
+        ? 30 // 30 seconds
+        : config.experimental.staleTimes?.dynamic
+    ),
+    'process.env.__NEXT_CLIENT_ROUTER_STATIC_STALETIME': JSON.stringify(
+      isNaN(Number(config.experimental.staleTimes?.static))
+        ? 5 * 60 // 5 minutes
+        : config.experimental.staleTimes?.static
+    ),
     'process.env.__NEXT_CLIENT_ROUTER_FILTER_ENABLED':
       config.experimental.clientRouterFilter ?? true,
     'process.env.__NEXT_CLIENT_ROUTER_S_FILTER':

--- a/packages/next/src/client/components/router-reducer/prefetch-cache-utils.ts
+++ b/packages/next/src/client/components/router-reducer/prefetch-cache-utils.ts
@@ -8,7 +8,6 @@ import {
   type PrefetchCacheEntry,
   PrefetchKind,
   type ReadonlyReducerState,
-  PREFETCH_CACHE_MODE,
 } from './router-reducer-types'
 import { prefetchQueue } from './reducers/prefetch-reducer'
 
@@ -244,39 +243,38 @@ export function prunePrefetchCache(
   }
 }
 
-const FIVE_MINUTES = 5 * 60 * 1000
-const THIRTY_SECONDS = 30 * 1000
+// These values are set by `define-env-plugin` (based on `nextConfig.experimental.staleTimes`)
+// and default to 5 minutes (static) / 30 seconds (dynamic)
+const DYNAMIC_STALETIME_MS =
+  Number(process.env.__NEXT_CLIENT_ROUTER_DYNAMIC_STALETIME) * 1000
+
+const STATIC_STALETIME_MS =
+  Number(process.env.__NEXT_CLIENT_ROUTER_STATIC_STALETIME) * 1000
 
 function getPrefetchEntryCacheStatus({
   kind,
   prefetchTime,
   lastUsedTime,
 }: PrefetchCacheEntry): PrefetchCacheEntryStatus {
-  if (kind !== PrefetchKind.FULL && PREFETCH_CACHE_MODE === 'live') {
-    // When the cache mode is set to "live", we only want to re-use the loading state. We mark the entry as stale
-    // regardless of the lastUsedTime so that the router will not attempt to apply the cache node data and will instead only
-    // re-use the loading state while lazy fetching the page data.
-    // We don't do this for a full prefetch, as if there's explicit caching intent it should respect existing heuristics.
-    return PrefetchCacheEntryStatus.stale
-  }
-
-  // if the cache entry was prefetched or read less than the specified staletime window, then we want to re-use it
-  if (Date.now() < (lastUsedTime ?? prefetchTime) + THIRTY_SECONDS) {
+  // We will re-use the cache entry data for up to the `dynamic` staletime window.
+  if (Date.now() < (lastUsedTime ?? prefetchTime) + DYNAMIC_STALETIME_MS) {
     return lastUsedTime
       ? PrefetchCacheEntryStatus.reusable
       : PrefetchCacheEntryStatus.fresh
   }
 
-  // if the cache entry was prefetched less than 5 mins ago, then we want to re-use only the loading state
+  // For "auto" prefetching, we'll re-use only the loading boundary for up to `static` staletime window.
+  // A stale entry will only re-use the `loading` boundary, not the full data.
+  // This will trigger a "lazy fetch" for the full data.
   if (kind === 'auto') {
-    if (Date.now() < prefetchTime + FIVE_MINUTES) {
+    if (Date.now() < prefetchTime + STATIC_STALETIME_MS) {
       return PrefetchCacheEntryStatus.stale
     }
   }
 
-  // if the cache entry was prefetched less than 5 mins ago and was a "full" prefetch, then we want to re-use it "full
+  // for "full" prefetching, we'll re-use the cache entry data for up to `static` staletime window.
   if (kind === 'full') {
-    if (Date.now() < prefetchTime + FIVE_MINUTES) {
+    if (Date.now() < prefetchTime + STATIC_STALETIME_MS) {
       return PrefetchCacheEntryStatus.reusable
     }
   }

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -282,11 +282,3 @@ export function isThenable(value: any): value is Promise<AppRouterState> {
     typeof value.then === 'function'
   )
 }
-
-/**
- * A `live` value will indicate that the client router should always fetch the latest data from the server when
- * navigating to a new route when auto prefetching is used. A `default` value will use existing
- * cache heuristics (router cache will persist for 30s before being invalidated). Defaults to `default`.
- */
-export const PREFETCH_CACHE_MODE =
-  process.env.__NEXT_CLIENT_ROUTER_CACHE_MODE === 'live' ? 'live' : 'default'

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -282,3 +282,11 @@ export function isThenable(value: any): value is Promise<AppRouterState> {
     typeof value.then === 'function'
   )
 }
+
+/**
+ * Time (in ms) that a prefetch entry can be reused by the client router cache.
+ */
+export const PREFETCH_STALE_TIME =
+  typeof process.env.__NEXT_CLIENT_ROUTER_CACHE_STALETIME_MS !== 'undefined'
+    ? parseInt(process.env.__NEXT_CLIENT_ROUTER_CACHE_STALETIME_MS, 10)
+    : 30 * 1000 // thirty seconds (in ms)

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -284,9 +284,9 @@ export function isThenable(value: any): value is Promise<AppRouterState> {
 }
 
 /**
- * Time (in ms) that a prefetch entry can be reused by the client router cache.
+ * A `live` value will indicate that the client router should always fetch the latest data from the server when
+ * navigating to a new route when auto prefetching is used. A `default` value will use existing
+ * cache heuristics (router cache will persist for 30s before being invalidated). Defaults to `default`.
  */
-export const PREFETCH_STALE_TIME =
-  typeof process.env.__NEXT_CLIENT_ROUTER_CACHE_STALETIME_MS !== 'undefined'
-    ? parseInt(process.env.__NEXT_CLIENT_ROUTER_CACHE_STALETIME_MS, 10)
-    : 30 * 1000 // thirty seconds (in ms)
+export const PREFETCH_CACHE_MODE =
+  process.env.__NEXT_CLIENT_ROUTER_CACHE_MODE === 'live' ? 'live' : 'default'

--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -21,7 +21,10 @@ import type {
 import { useIntersection } from './use-intersection'
 import { getDomainLocale } from './get-domain-locale'
 import { addBasePath } from './add-base-path'
-import { PrefetchKind } from './components/router-reducer/router-reducer-types'
+import {
+  PREFETCH_STALE_TIME,
+  PrefetchKind,
+} from './components/router-reducer/router-reducer-types'
 
 type Url = string | UrlObject
 type RequiredKeys<T> = {
@@ -307,7 +310,11 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
      * - false: we will not prefetch if in the viewport at all
      */
     const appPrefetchKind =
-      prefetchProp === null ? PrefetchKind.AUTO : PrefetchKind.FULL
+      // If the prefetch staletime is 0, then a full prefetch would be wasteful, as it'd never get used.
+      // These get switched into "auto" so at least the loading state can be re-used.
+      prefetchProp === null || PREFETCH_STALE_TIME === 0
+        ? PrefetchKind.AUTO
+        : PrefetchKind.FULL
 
     if (process.env.NODE_ENV !== 'production') {
       function createPropError(args: {

--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -21,10 +21,7 @@ import type {
 import { useIntersection } from './use-intersection'
 import { getDomainLocale } from './get-domain-locale'
 import { addBasePath } from './add-base-path'
-import {
-  PREFETCH_STALE_TIME,
-  PrefetchKind,
-} from './components/router-reducer/router-reducer-types'
+import { PrefetchKind } from './components/router-reducer/router-reducer-types'
 
 type Url = string | UrlObject
 type RequiredKeys<T> = {
@@ -310,11 +307,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropsReal>(
      * - false: we will not prefetch if in the viewport at all
      */
     const appPrefetchKind =
-      // If the prefetch staletime is 0, then a full prefetch would be wasteful, as it'd never get used.
-      // These get switched into "auto" so at least the loading state can be re-used.
-      prefetchProp === null || PREFETCH_STALE_TIME === 0
-        ? PrefetchKind.AUTO
-        : PrefetchKind.FULL
+      prefetchProp === null ? PrefetchKind.AUTO : PrefetchKind.FULL
 
     if (process.env.NODE_ENV !== 'production') {
       function createPropError(args: {

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -247,6 +247,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
             validator: z.string().optional(),
           })
           .optional(),
+        clientRouterCache: z.boolean().optional(),
         clientRouterFilter: z.boolean().optional(),
         clientRouterFilterRedirects: z.boolean().optional(),
         clientRouterFilterAllowedRate: z.number().optional(),

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -247,10 +247,12 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
             validator: z.string().optional(),
           })
           .optional(),
-        clientRouterCacheMode: z.union([
-          z.literal('default'),
-          z.literal('live'),
-        ]),
+        staleTimes: z
+          .object({
+            dynamic: z.number().optional(),
+            static: z.number().optional(),
+          })
+          .optional(),
         clientRouterFilter: z.boolean().optional(),
         clientRouterFilterRedirects: z.boolean().optional(),
         clientRouterFilterAllowedRate: z.number().optional(),

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -247,7 +247,10 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
             validator: z.string().optional(),
           })
           .optional(),
-        clientRouterCache: z.boolean().optional(),
+        clientRouterCacheMode: z.union([
+          z.literal('default'),
+          z.literal('live'),
+        ]),
         clientRouterFilter: z.boolean().optional(),
         clientRouterFilterRedirects: z.boolean().optional(),
         clientRouterFilterAllowedRate: z.number().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -187,6 +187,13 @@ export interface ExperimentalConfig {
   strictNextHead?: boolean
   clientRouterFilter?: boolean
   clientRouterFilterRedirects?: boolean
+  /**
+   * Used to control the router cache "stale time" value. This value is used to determine
+   * if a cache entry can be re-used, and for how long. `true` means "forever" (implemented as
+   * one year), `false` means "never" (will always fetch from the server), and undefined will use
+   * the existing heuristics (30s for dynamic routes, 5min for static routes)
+   */
+  clientRouterCache?: boolean
   // decimal for percent for possible false positives
   // e.g. 0.01 for 10% potential false matches lower
   // percent increases size of the filter
@@ -926,6 +933,7 @@ export const defaultConfig: NextConfig = {
     missingSuspenseWithCSRBailout: true,
     optimizeServerReact: true,
     useEarlyImport: false,
+    clientRouterCache: undefined,
   },
 }
 

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -188,12 +188,12 @@ export interface ExperimentalConfig {
   clientRouterFilter?: boolean
   clientRouterFilterRedirects?: boolean
   /**
-   * Used to control the router cache "stale time" value. This value is used to determine
-   * if a cache entry can be re-used, and for how long. `true` means "forever" (implemented as
-   * one year), `false` means "never" (will always fetch from the server), and undefined will use
-   * the existing heuristics (30s for dynamic routes, 5min for static routes)
+   * This value can be used to override the cache behavior for the client router. A `live` value
+   * will indicate that the client router should always fetch the latest data from the server when
+   * navigating to a new route when auto prefetching is used. A `default` value will use existing
+   * cache heuristics (router cache will persist for 30s before being invalidated). Defaults to `default`.
    */
-  clientRouterCache?: boolean
+  clientRouterCacheMode?: 'live' | 'default'
   // decimal for percent for possible false positives
   // e.g. 0.01 for 10% potential false matches lower
   // percent increases size of the filter
@@ -933,7 +933,7 @@ export const defaultConfig: NextConfig = {
     missingSuspenseWithCSRBailout: true,
     optimizeServerReact: true,
     useEarlyImport: false,
-    clientRouterCache: undefined,
+    clientRouterCacheMode: 'default',
   },
 }
 

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -188,12 +188,15 @@ export interface ExperimentalConfig {
   clientRouterFilter?: boolean
   clientRouterFilterRedirects?: boolean
   /**
-   * This value can be used to override the cache behavior for the client router. A `live` value
-   * will indicate that the client router should always fetch the latest data from the server when
-   * navigating to a new route when auto prefetching is used. A `default` value will use existing
-   * cache heuristics (router cache will persist for 30s before being invalidated). Defaults to `default`.
+   * This config can be used to override the cache behavior for the client router.
+   * These values indicate the time, in seconds, that the cache should be considered
+   * reusable. When the `prefetch` Link prop is left unspecified, this will use the `dynamic` value.
+   * When the `prefetch` Link prop is set to `true`, this will use the `static` value.
    */
-  clientRouterCacheMode?: 'live' | 'default'
+  staleTimes?: {
+    dynamic?: number
+    static?: number
+  }
   // decimal for percent for possible false positives
   // e.g. 0.01 for 10% potential false matches lower
   // percent increases size of the filter
@@ -933,7 +936,10 @@ export const defaultConfig: NextConfig = {
     missingSuspenseWithCSRBailout: true,
     optimizeServerReact: true,
     useEarlyImport: false,
-    clientRouterCacheMode: 'default',
+    staleTimes: {
+      dynamic: 30,
+      static: 300,
+    },
   },
 }
 

--- a/test/e2e/app-dir/app-client-cache/app/without-loading/[id]/page.js
+++ b/test/e2e/app-dir/app-client-cache/app/without-loading/[id]/page.js
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+
+export default async function Page({ searchParams: { timeout } }) {
+  const randomNumber = await new Promise((resolve) => {
+    setTimeout(
+      () => {
+        resolve(Math.random())
+      },
+      timeout !== undefined ? Number.parseInt(timeout, 10) : 0
+    )
+  })
+
+  return (
+    <>
+      <div>
+        <Link href="/without-loading">Back to Home</Link>
+      </div>
+      <div id="random-number">{randomNumber}</div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-client-cache/app/without-loading/page.js
+++ b/test/e2e/app-dir/app-client-cache/app/without-loading/page.js
@@ -1,37 +1,35 @@
 import Link from 'next/link'
-export default function HomePage() {
+
+export default function Page() {
   return (
     <>
       <div>
-        <Link href="/0?timeout=0" prefetch={true}>
+        <Link href="/without-loading/0?timeout=0" prefetch={true}>
           To Random Number - prefetch: true
         </Link>
       </div>
       <div>
-        <Link href="/0?timeout=1000" prefetch={true}>
+        <Link href="/without-loading/0?timeout=1000" prefetch={true}>
           To Random Number - prefetch: true, slow
         </Link>
       </div>
       <div>
-        <Link href="/1">To Random Number - prefetch: auto</Link>
+        <Link href="/without-loading/1">To Random Number - prefetch: auto</Link>
       </div>
       <div>
-        <Link href="/2" prefetch={false}>
+        <Link href="/without-loading/2" prefetch={false}>
           To Random Number 2 - prefetch: false
         </Link>
       </div>
       <div>
-        <Link href="/2?timeout=1000" prefetch={false}>
+        <Link href="/without-loading/2?timeout=1000" prefetch={false}>
           To Random Number 2 - prefetch: false, slow
         </Link>
       </div>
       <div>
-        <Link href="/1?timeout=1000">
+        <Link href="/without-loading/1?timeout=1000">
           To Random Number - prefetch: auto, slow
         </Link>
-      </div>
-      <div>
-        <Link href="/null-loading">To Null Loading - prefetch: auto</Link>
       </div>
     </>
   )

--- a/test/e2e/app-dir/app-client-cache/client-cache.experimental.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.experimental.test.ts
@@ -1,0 +1,367 @@
+import { nextTestSetup } from 'e2e-utils'
+import { browserConfigWithFixedTime, fastForwardTo } from './test-utils'
+
+describe('app dir client cache semantics (experimental clientRouterCache)', () => {
+  describe('clientRouterCache = true', () => {
+    const { next } = nextTestSetup({
+      files: __dirname,
+      nextConfig: {
+        experimental: { clientRouterCache: true },
+      },
+    })
+
+    describe('prefetch={true}', () => {
+      test('we should get a cached version of the page every request', async () => {
+        const browser = await next.browser('/', browserConfigWithFixedTime)
+
+        const initialRandomNumber = await browser
+          .elementByCss('[href="/0?timeout=0"]')
+          .click()
+          .waitForElementByCss('#random-number')
+          .text()
+
+        await browser.elementByCss('[href="/"]').click()
+
+        let newRandomNumber = await browser
+          .elementByCss('[href="/0?timeout=0"]')
+          .click()
+          .waitForElementByCss('#random-number')
+          .text()
+
+        expect(initialRandomNumber).toBe(newRandomNumber)
+
+        await browser.eval(fastForwardTo, 2 * 60 * 60 * 1000) // fast forward 2 hours
+
+        await browser.elementByCss('[href="/"]').click()
+
+        newRandomNumber = await browser
+          .elementByCss('[href="/0?timeout=0"]')
+          .click()
+          .waitForElementByCss('#random-number')
+          .text()
+
+        expect(initialRandomNumber).toBe(newRandomNumber)
+      })
+    })
+
+    describe('prefetch={false}', () => {
+      test('we should get a loading state before fetching the page, followed by a cached version of the page every request', async () => {
+        const browser = await next.browser('/', browserConfigWithFixedTime)
+        // verify we rendered the loading state
+        await browser
+          .elementByCss('[href="/2?timeout=1000"]')
+          .click()
+          .waitForElementByCss('#loading')
+
+        const initialRandomNumber = await browser
+          .waitForElementByCss('#random-number')
+          .text()
+
+        await browser.elementByCss('[href="/"]').click()
+
+        await browser.eval(fastForwardTo, 2 * 60 * 60 * 1000) // fast forward 2 hours
+
+        const newRandomNumber = await browser
+          .elementByCss('[href="/2?timeout=1000"]')
+          .click()
+          .waitForElementByCss('#random-number')
+          .text()
+
+        expect(initialRandomNumber).toBe(newRandomNumber)
+      })
+
+      describe('without a loading boundary', () => {
+        test('we should get a cached version of the page every request', async () => {
+          const browser = await next.browser(
+            '/without-loading',
+            browserConfigWithFixedTime
+          )
+
+          const initialRandomNumber = await browser
+            .elementByCss('[href="/without-loading/2?timeout=1000"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          await browser.elementByCss('[href="/without-loading"]').click()
+
+          await browser.eval(fastForwardTo, 2 * 60 * 60 * 1000) // fast forward 2 hours
+
+          const newRandomNumber = await browser
+            .elementByCss('[href="/without-loading/2?timeout=1000"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          expect(initialRandomNumber).toBe(newRandomNumber)
+        })
+      })
+    })
+
+    describe('prefetch={undefined} - default', () => {
+      test('we should get a loading state before fetching the page, followed by a cached version of the page every request', async () => {
+        const browser = await next.browser('/', browserConfigWithFixedTime)
+
+        // verify we rendered the loading state
+        await browser
+          .elementByCss('[href="/1?timeout=1000"]')
+          .click()
+          .waitForElementByCss('#loading')
+
+        const initialRandomNumber = await browser
+          .waitForElementByCss('#random-number')
+          .text()
+
+        await browser.elementByCss('[href="/"]').click()
+
+        await browser.eval(fastForwardTo, 2 * 60 * 60 * 1000) // fast forward 2 hours
+
+        const newRandomNumber = await browser
+          .elementByCss('[href="/1?timeout=1000"]')
+          .click()
+          .waitForElementByCss('#random-number')
+          .text()
+
+        expect(initialRandomNumber).toBe(newRandomNumber)
+      })
+
+      describe('without a loading boundary', () => {
+        test('we should get a cached version of the page every request', async () => {
+          const browser = await next.browser(
+            '/without-loading',
+            browserConfigWithFixedTime
+          )
+
+          const initialRandomNumber = await browser
+            .elementByCss('[href="/without-loading/1?timeout=1000"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          await browser.elementByCss('[href="/without-loading"]').click()
+
+          await browser.eval(fastForwardTo, 2 * 60 * 60 * 1000) // fast forward 2 hours
+
+          const newRandomNumber = await browser
+            .elementByCss('[href="/without-loading/1?timeout=1000"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          expect(initialRandomNumber).toBe(newRandomNumber)
+        })
+      })
+    })
+  })
+
+  describe('clientRouterCache = false', () => {
+    const { next } = nextTestSetup({
+      files: __dirname,
+      nextConfig: {
+        experimental: { clientRouterCache: false },
+      },
+    })
+
+    describe('prefetch={true}', () => {
+      test('we should get fresh data on every subsequent navigation', async () => {
+        const browser = await next.browser('/', browserConfigWithFixedTime)
+
+        const initialRandomNumber = await browser
+          .elementByCss('[href="/0?timeout=0"]')
+          .click()
+          .waitForElementByCss('#random-number')
+          .text()
+
+        await browser.elementByCss('[href="/"]').click()
+
+        let newRandomNumber = await browser
+          .elementByCss('[href="/0?timeout=0"]')
+          .click()
+          .waitForElementByCss('#random-number')
+          .text()
+
+        expect(initialRandomNumber).not.toBe(newRandomNumber)
+
+        await browser.eval(fastForwardTo, 5 * 1000) // fast forward 5 seconds
+
+        await browser.elementByCss('[href="/"]').click()
+
+        newRandomNumber = await browser
+          .elementByCss('[href="/0?timeout=0"]')
+          .click()
+          .waitForElementByCss('#random-number')
+          .text()
+
+        expect(initialRandomNumber).not.toBe(newRandomNumber)
+      })
+
+      test('we should get a loading state before fetching the page, followed by fresh data on every subsequent navigation', async () => {
+        const browser = await next.browser('/', browserConfigWithFixedTime)
+
+        // this test introduces an artificial delay in rendering the requested page, so we verify a loading state is rendered
+        await browser
+          .elementByCss('[href="/0?timeout=1000"]')
+          .click()
+          .waitForElementByCss('#loading')
+
+        const initialRandomNumber = await browser
+          .waitForElementByCss('#random-number')
+          .text()
+
+        await browser.elementByCss('[href="/"]').click()
+
+        await browser.eval(fastForwardTo, 5 * 1000) // fast forward 5 seconds
+
+        const newRandomNumber = await browser
+          .elementByCss('[href="/0?timeout=1000"]')
+          .click()
+          .waitForElementByCss('#random-number')
+          .text()
+
+        expect(initialRandomNumber).not.toBe(newRandomNumber)
+      })
+
+      describe('without a loading boundary', () => {
+        test('we should get fresh data on every subsequent navigation', async () => {
+          const browser = await next.browser(
+            '/without-loading',
+            browserConfigWithFixedTime
+          )
+
+          const initialRandomNumber = await browser
+            .elementByCss('[href="/without-loading/0?timeout=1000"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          await browser.elementByCss('[href="/without-loading"]').click()
+
+          let newRandomNumber = await browser
+            .elementByCss('[href="/without-loading/0?timeout=1000"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          expect(initialRandomNumber).not.toBe(newRandomNumber)
+
+          await browser.eval(fastForwardTo, 5 * 1000) // fast forward 5 seconds
+
+          await browser.elementByCss('[href="/without-loading"]').click()
+
+          newRandomNumber = await browser
+            .elementByCss('[href="/without-loading/0?timeout=1000"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          expect(initialRandomNumber).not.toBe(newRandomNumber)
+        })
+      })
+    })
+
+    describe('prefetch={false}', () => {
+      test('we should get a loading state before fetching the page, followed by fresh data on every subsequent navigation', async () => {
+        const browser = await next.browser('/', browserConfigWithFixedTime)
+
+        // this test introduces an artificial delay in rendering the requested page, so we verify a loading state is rendered
+        await browser
+          .elementByCss('[href="/2?timeout=1000"]')
+          .click()
+          .waitForElementByCss('#loading')
+
+        const initialRandomNumber = await browser
+          .waitForElementByCss('#random-number')
+          .text()
+
+        await browser.elementByCss('[href="/"]').click()
+
+        await browser.eval(fastForwardTo, 5 * 1000) // fast forward 5 seconds
+
+        const newRandomNumber = await browser
+          .elementByCss('[href="/2?timeout=1000"]')
+          .click()
+          .waitForElementByCss('#random-number')
+          .text()
+
+        expect(initialRandomNumber).not.toBe(newRandomNumber)
+      })
+
+      describe('without a loading boundary', () => {
+        test('we should get fresh data on every subsequent navigation', async () => {
+          const browser = await next.browser('/', browserConfigWithFixedTime)
+
+          const initialRandomNumber = await browser
+            .elementByCss('[href="/2?timeout=1000"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          await browser.elementByCss('[href="/"]').click()
+
+          await browser.eval(fastForwardTo, 5 * 1000) // fast forward 5 seconds
+
+          const newRandomNumber = await browser
+            .elementByCss('[href="/2?timeout=1000"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          expect(initialRandomNumber).not.toBe(newRandomNumber)
+        })
+      })
+    })
+
+    describe('prefetch={undefined} - default', () => {
+      test('we should get a loading state before fetching the page, followed by fresh data on every subsequent navigation', async () => {
+        const browser = await next.browser('/', browserConfigWithFixedTime)
+
+        // this test introduces an artificial delay in rendering the requested page, so we verify a loading state is rendered
+        await browser
+          .elementByCss('[href="/1?timeout=1000"]')
+          .click()
+          .waitForElementByCss('#loading')
+
+        const initialRandomNumber = await browser
+          .waitForElementByCss('#random-number')
+          .text()
+
+        await browser.elementByCss('[href="/"]').click()
+
+        await browser.eval(fastForwardTo, 5 * 1000) // fast forward 5 seconds
+
+        const newRandomNumber = await browser
+          .elementByCss('[href="/1?timeout=1000"]')
+          .click()
+          .waitForElementByCss('#random-number')
+          .text()
+
+        expect(initialRandomNumber).not.toBe(newRandomNumber)
+      })
+
+      describe('without a loading boundary', () => {
+        test('we should get fresh data on every subsequent navigation', async () => {
+          const browser = await next.browser(
+            '/without-loading',
+            browserConfigWithFixedTime
+          )
+
+          const initialRandomNumber = await browser
+            .elementByCss('[href="/without-loading/1?timeout=1000"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          await browser.elementByCss('[href="/without-loading"]').click()
+
+          const newRandomNumber = await browser
+            .elementByCss('[href="/without-loading/1?timeout=1000"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          expect(initialRandomNumber).not.toBe(newRandomNumber)
+        })
+      })
+    })
+  })
+})

--- a/test/e2e/app-dir/app-client-cache/client-cache.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.test.ts
@@ -1,77 +1,12 @@
 import { createNextDescribe } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import { BrowserInterface } from 'test/lib/browsers/base'
-import type { Request } from 'playwright'
-
-const getPathname = (url: string) => {
-  const urlObj = new URL(url)
-  return urlObj.pathname
-}
-
-const browserConfigWithFixedTime = {
-  beforePageLoad: (page) => {
-    page.addInitScript(() => {
-      const startTime = new Date()
-      const fixedTime = new Date('2023-04-17T00:00:00Z')
-
-      // Override the Date constructor
-      // @ts-ignore
-      // eslint-disable-next-line no-native-reassign
-      Date = class extends Date {
-        constructor() {
-          super()
-          // @ts-ignore
-          return new startTime.constructor(fixedTime)
-        }
-
-        static now() {
-          return fixedTime.getTime()
-        }
-      }
-    })
-  },
-}
-
-const fastForwardTo = (ms) => {
-  // Increment the fixed time by the specified duration
-  const currentTime = new Date()
-  currentTime.setTime(currentTime.getTime() + ms)
-
-  // Update the Date constructor to use the new fixed time
-  // @ts-ignore
-  // eslint-disable-next-line no-native-reassign
-  Date = class extends Date {
-    constructor() {
-      super()
-      // @ts-ignore
-      return new currentTime.constructor(currentTime)
-    }
-
-    static now() {
-      return currentTime.getTime()
-    }
-  }
-}
-
-const createRequestsListener = async (browser: BrowserInterface) => {
-  // wait for network idle
-  await browser.waitForIdleNetwork()
-
-  let requests = []
-
-  browser.on('request', (req: Request) => {
-    requests.push([req.url(), !!req.headers()['next-router-prefetch']])
-  })
-
-  await browser.refresh()
-
-  return {
-    getRequests: () => requests,
-    clearRequests: () => {
-      requests = []
-    },
-  }
-}
+import {
+  browserConfigWithFixedTime,
+  createRequestsListener,
+  fastForwardTo,
+  getPathname,
+} from './test-utils'
 
 createNextDescribe(
   'app dir client cache semantics',

--- a/test/e2e/app-dir/app-client-cache/client-cache.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.test.ts
@@ -1,4 +1,4 @@
-import { NextInstance, createNextDescribe } from 'e2e-utils'
+import { createNextDescribe } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import { BrowserInterface } from 'test/lib/browsers/base'
 import {
@@ -7,394 +7,6 @@ import {
   fastForwardTo,
   getPathname,
 } from './test-utils'
-
-export function runTests(next: NextInstance) {
-  describe('prefetch={true}', () => {
-    let browser: BrowserInterface
-
-    beforeEach(async () => {
-      browser = (await next.browser(
-        '/',
-        browserConfigWithFixedTime
-      )) as BrowserInterface
-    })
-
-    it('should prefetch the full page', async () => {
-      const { getRequests, clearRequests } = await createRequestsListener(
-        browser
-      )
-      await check(() => {
-        return getRequests().some(
-          ([url, didPartialPrefetch]) =>
-            getPathname(url) === '/0' && !didPartialPrefetch
-        )
-          ? 'success'
-          : 'fail'
-      }, 'success')
-
-      clearRequests()
-
-      await browser
-        .elementByCss('[href="/0?timeout=0"]')
-        .click()
-        .waitForElementByCss('#random-number')
-
-      expect(getRequests().every(([url]) => getPathname(url) !== '/0')).toEqual(
-        true
-      )
-    })
-    it('should re-use the cache for the full page, only for 5 mins', async () => {
-      const randomNumber = await browser
-        .elementByCss('[href="/0?timeout=0"]')
-        .click()
-        .waitForElementByCss('#random-number')
-        .text()
-
-      await browser.elementByCss('[href="/"]').click()
-
-      const number = await browser
-        .elementByCss('[href="/0?timeout=0"]')
-        .click()
-        .waitForElementByCss('#random-number')
-        .text()
-
-      expect(number).toBe(randomNumber)
-
-      await browser.eval(fastForwardTo, 5 * 60 * 1000)
-
-      await browser.elementByCss('[href="/"]').click()
-
-      const newNumber = await browser
-        .elementByCss('[href="/0?timeout=0"]')
-        .click()
-        .waitForElementByCss('#random-number')
-        .text()
-
-      expect(newNumber).not.toBe(randomNumber)
-    })
-
-    it('should prefetch again after 5 mins if the link is visible again', async () => {
-      const { getRequests, clearRequests } = await createRequestsListener(
-        browser
-      )
-
-      await check(() => {
-        return getRequests().some(
-          ([url, didPartialPrefetch]) =>
-            getPathname(url) === '/0' && !didPartialPrefetch
-        )
-          ? 'success'
-          : 'fail'
-      }, 'success')
-
-      const randomNumber = await browser
-        .elementByCss('[href="/0?timeout=0"]')
-        .click()
-        .waitForElementByCss('#random-number')
-        .text()
-
-      await browser.eval(fastForwardTo, 5 * 60 * 1000)
-      clearRequests()
-
-      await browser.elementByCss('[href="/"]').click()
-
-      await check(() => {
-        return getRequests().some(
-          ([url, didPartialPrefetch]) =>
-            getPathname(url) === '/0' && !didPartialPrefetch
-        )
-          ? 'success'
-          : 'fail'
-      }, 'success')
-
-      const number = await browser
-        .elementByCss('[href="/0?timeout=0"]')
-        .click()
-        .waitForElementByCss('#random-number')
-        .text()
-
-      expect(number).not.toBe(randomNumber)
-    })
-  })
-  describe('prefetch={false}', () => {
-    let browser: BrowserInterface
-
-    beforeEach(async () => {
-      browser = (await next.browser(
-        '/',
-        browserConfigWithFixedTime
-      )) as BrowserInterface
-    })
-    it('should not prefetch the page at all', async () => {
-      const { getRequests } = await createRequestsListener(browser)
-
-      await browser
-        .elementByCss('[href="/2"]')
-        .click()
-        .waitForElementByCss('#random-number')
-
-      expect(
-        getRequests().filter(([url]) => getPathname(url) === '/2')
-      ).toHaveLength(1)
-
-      expect(
-        getRequests().some(
-          ([url, didPartialPrefetch]) =>
-            getPathname(url) === '/2' && didPartialPrefetch
-        )
-      ).toBe(false)
-    })
-    it('should re-use the cache only for 30 seconds', async () => {
-      const randomNumber = await browser
-        .elementByCss('[href="/2"]')
-        .click()
-        .waitForElementByCss('#random-number')
-        .text()
-
-      await browser.elementByCss('[href="/"]').click()
-
-      const number = await browser
-        .elementByCss('[href="/2"]')
-        .click()
-        .waitForElementByCss('#random-number')
-        .text()
-
-      expect(number).toBe(randomNumber)
-
-      await browser.eval(fastForwardTo, 30 * 1000)
-
-      await browser.elementByCss('[href="/"]').click()
-
-      const newNumber = await browser
-        .elementByCss('[href="/2"]')
-        .click()
-        .waitForElementByCss('#random-number')
-        .text()
-
-      expect(newNumber).not.toBe(randomNumber)
-    })
-  })
-  describe('prefetch={undefined} - default', () => {
-    let browser: BrowserInterface
-
-    beforeEach(async () => {
-      browser = (await next.browser(
-        '/',
-        browserConfigWithFixedTime
-      )) as BrowserInterface
-    })
-
-    it('should prefetch partially a dynamic page', async () => {
-      const { getRequests, clearRequests } = await createRequestsListener(
-        browser
-      )
-
-      await check(() => {
-        return getRequests().some(
-          ([url, didPartialPrefetch]) =>
-            getPathname(url) === '/1' && didPartialPrefetch
-        )
-          ? 'success'
-          : 'fail'
-      }, 'success')
-
-      clearRequests()
-
-      await browser
-        .elementByCss('[href="/1"]')
-        .click()
-        .waitForElementByCss('#random-number')
-
-      expect(
-        getRequests().some(
-          ([url, didPartialPrefetch]) =>
-            getPathname(url) === '/1' && !didPartialPrefetch
-        )
-      ).toBe(true)
-    })
-    it('should re-use the full cache for only 30 seconds', async () => {
-      const randomNumber = await browser
-        .elementByCss('[href="/1"]')
-        .click()
-        .waitForElementByCss('#random-number')
-        .text()
-
-      await browser.elementByCss('[href="/"]').click()
-
-      const number = await browser
-        .elementByCss('[href="/1"]')
-        .click()
-        .waitForElementByCss('#random-number')
-        .text()
-
-      expect(number).toBe(randomNumber)
-
-      await browser.eval(fastForwardTo, 5 * 1000)
-
-      await browser.elementByCss('[href="/"]').click()
-
-      const newNumber = await browser
-        .elementByCss('[href="/1"]')
-        .click()
-        .waitForElementByCss('#random-number')
-        .text()
-
-      expect(newNumber).toBe(randomNumber)
-
-      await browser.eval(fastForwardTo, 30 * 1000)
-
-      await browser.elementByCss('[href="/"]').click()
-
-      const newNumber2 = await browser
-        .elementByCss('[href="/1"]')
-        .click()
-        .waitForElementByCss('#random-number')
-        .text()
-
-      expect(newNumber2).not.toBe(newNumber)
-    })
-
-    it('should renew the 30s cache once the data is revalidated', async () => {
-      // navigate to prefetch-auto page
-      await browser.elementByCss('[href="/1"]').click()
-
-      let initialNumber = await browser.elementById('random-number').text()
-
-      // Navigate back to the index, and then back to the prefetch-auto page
-      await browser.elementByCss('[href="/"]').click()
-      await browser.eval(fastForwardTo, 5 * 1000)
-      await browser.elementByCss('[href="/1"]').click()
-
-      let newNumber = await browser.elementById('random-number').text()
-
-      // the number should be the same, as we navigated within 30s.
-      expect(newNumber).toBe(initialNumber)
-
-      // Fast forward to expire the cache
-      await browser.eval(fastForwardTo, 30 * 1000)
-
-      // Navigate back to the index, and then back to the prefetch-auto page
-      await browser.elementByCss('[href="/"]').click()
-      await browser.elementByCss('[href="/1"]').click()
-
-      newNumber = await browser.elementById('random-number').text()
-
-      // ~35s have passed, so the cache should be expired and the number should be different
-      expect(newNumber).not.toBe(initialNumber)
-
-      // once the number is updated, we should have a renewed 30s cache for this entry
-      // store this new number so we can check that it stays the same
-      initialNumber = newNumber
-
-      await browser.eval(fastForwardTo, 5 * 1000)
-
-      // Navigate back to the index, and then back to the prefetch-auto page
-      await browser.elementByCss('[href="/"]').click()
-      await browser.elementByCss('[href="/1"]').click()
-
-      newNumber = await browser.elementById('random-number').text()
-
-      // the number should be the same, as we navigated within 30s (part 2).
-      expect(newNumber).toBe(initialNumber)
-    })
-
-    it('should refetch below the fold after 30 seconds', async () => {
-      const randomLoadingNumber = await browser
-        .elementByCss('[href="/1?timeout=1000"]')
-        .click()
-        .waitForElementByCss('#loading')
-        .text()
-
-      const randomNumber = await browser
-        .waitForElementByCss('#random-number')
-        .text()
-
-      await browser.elementByCss('[href="/"]').click()
-
-      await browser.eval(fastForwardTo, 30 * 1000)
-
-      const newLoadingNumber = await browser
-        .elementByCss('[href="/1?timeout=1000"]')
-        .click()
-        .waitForElementByCss('#loading')
-        .text()
-
-      const newNumber = await browser
-        .waitForElementByCss('#random-number')
-        .text()
-
-      expect(newLoadingNumber).toBe(randomLoadingNumber)
-
-      expect(newNumber).not.toBe(randomNumber)
-    })
-    it('should refetch the full page after 5 mins', async () => {
-      const randomLoadingNumber = await browser
-        .elementByCss('[href="/1?timeout=1000"]')
-        .click()
-        .waitForElementByCss('#loading')
-        .text()
-
-      const randomNumber = await browser
-        .waitForElementByCss('#random-number')
-        .text()
-
-      await browser.eval(fastForwardTo, 5 * 60 * 1000)
-
-      await browser
-        .elementByCss('[href="/"]')
-        .click()
-        .waitForElementByCss('[href="/1?timeout=1000"]')
-
-      const newLoadingNumber = await browser
-        .elementByCss('[href="/1?timeout=1000"]')
-        .click()
-        .waitForElementByCss('#loading')
-        .text()
-
-      const newNumber = await browser
-        .waitForElementByCss('#random-number')
-        .text()
-
-      expect(newLoadingNumber).not.toBe(randomLoadingNumber)
-
-      expect(newNumber).not.toBe(randomNumber)
-    })
-
-    it('should respect a loading boundary that returns `null`', async () => {
-      await browser.elementByCss('[href="/null-loading"]').click()
-
-      // the page content should disappear immediately
-      expect(
-        await browser.hasElementByCssSelector('[href="/null-loading"]')
-      ).toBeFalse()
-
-      // the root layout should still be visible
-      expect(await browser.hasElementByCssSelector('#root-layout')).toBeTrue()
-
-      // the dynamic content should eventually appear
-      await browser.waitForElementByCss('#random-number')
-      expect(await browser.hasElementByCssSelector('#random-number')).toBeTrue()
-    })
-  })
-  it('should seed the prefetch cache with the fetched page data', async () => {
-    const browser = (await next.browser(
-      '/1',
-      browserConfigWithFixedTime
-    )) as BrowserInterface
-
-    const initialNumber = await browser.elementById('random-number').text()
-
-    // Move forward a few seconds, navigate off the page and then back to it
-    await browser.eval(fastForwardTo, 5 * 1000)
-    await browser.elementByCss('[href="/"]').click()
-    await browser.elementByCss('[href="/1"]').click()
-
-    const newNumber = await browser.elementById('random-number').text()
-
-    // The number should be the same as we've seeded it in the prefetch cache when we loaded the full page
-    expect(newNumber).toBe(initialNumber)
-  })
-}
 
 createNextDescribe(
   'app dir client cache semantics',
@@ -407,7 +19,395 @@ createNextDescribe(
       // we only check the production behavior
       it('should skip dev', () => {})
     } else {
-      runTests(next)
+      describe('prefetch={true}', () => {
+        let browser: BrowserInterface
+
+        beforeEach(async () => {
+          browser = (await next.browser(
+            '/',
+            browserConfigWithFixedTime
+          )) as BrowserInterface
+        })
+
+        it('should prefetch the full page', async () => {
+          const { getRequests, clearRequests } = await createRequestsListener(
+            browser
+          )
+          await check(() => {
+            return getRequests().some(
+              ([url, didPartialPrefetch]) =>
+                getPathname(url) === '/0' && !didPartialPrefetch
+            )
+              ? 'success'
+              : 'fail'
+          }, 'success')
+
+          clearRequests()
+
+          await browser
+            .elementByCss('[href="/0?timeout=0"]')
+            .click()
+            .waitForElementByCss('#random-number')
+
+          expect(
+            getRequests().every(([url]) => getPathname(url) !== '/0')
+          ).toEqual(true)
+        })
+        it('should re-use the cache for the full page, only for 5 mins', async () => {
+          const randomNumber = await browser
+            .elementByCss('[href="/0?timeout=0"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          await browser.elementByCss('[href="/"]').click()
+
+          const number = await browser
+            .elementByCss('[href="/0?timeout=0"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          expect(number).toBe(randomNumber)
+
+          await browser.eval(fastForwardTo, 5 * 60 * 1000)
+
+          await browser.elementByCss('[href="/"]').click()
+
+          const newNumber = await browser
+            .elementByCss('[href="/0?timeout=0"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          expect(newNumber).not.toBe(randomNumber)
+        })
+
+        it('should prefetch again after 5 mins if the link is visible again', async () => {
+          const { getRequests, clearRequests } = await createRequestsListener(
+            browser
+          )
+
+          await check(() => {
+            return getRequests().some(
+              ([url, didPartialPrefetch]) =>
+                getPathname(url) === '/0' && !didPartialPrefetch
+            )
+              ? 'success'
+              : 'fail'
+          }, 'success')
+
+          const randomNumber = await browser
+            .elementByCss('[href="/0?timeout=0"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          await browser.eval(fastForwardTo, 5 * 60 * 1000)
+          clearRequests()
+
+          await browser.elementByCss('[href="/"]').click()
+
+          await check(() => {
+            return getRequests().some(
+              ([url, didPartialPrefetch]) =>
+                getPathname(url) === '/0' && !didPartialPrefetch
+            )
+              ? 'success'
+              : 'fail'
+          }, 'success')
+
+          const number = await browser
+            .elementByCss('[href="/0?timeout=0"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          expect(number).not.toBe(randomNumber)
+        })
+      })
+      describe('prefetch={false}', () => {
+        let browser: BrowserInterface
+
+        beforeEach(async () => {
+          browser = (await next.browser(
+            '/',
+            browserConfigWithFixedTime
+          )) as BrowserInterface
+        })
+        it('should not prefetch the page at all', async () => {
+          const { getRequests } = await createRequestsListener(browser)
+
+          await browser
+            .elementByCss('[href="/2"]')
+            .click()
+            .waitForElementByCss('#random-number')
+
+          expect(
+            getRequests().filter(([url]) => getPathname(url) === '/2')
+          ).toHaveLength(1)
+
+          expect(
+            getRequests().some(
+              ([url, didPartialPrefetch]) =>
+                getPathname(url) === '/2' && didPartialPrefetch
+            )
+          ).toBe(false)
+        })
+        it('should re-use the cache only for 30 seconds', async () => {
+          const randomNumber = await browser
+            .elementByCss('[href="/2"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          await browser.elementByCss('[href="/"]').click()
+
+          const number = await browser
+            .elementByCss('[href="/2"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          expect(number).toBe(randomNumber)
+
+          await browser.eval(fastForwardTo, 30 * 1000)
+
+          await browser.elementByCss('[href="/"]').click()
+
+          const newNumber = await browser
+            .elementByCss('[href="/2"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          expect(newNumber).not.toBe(randomNumber)
+        })
+      })
+      describe('prefetch={undefined} - default', () => {
+        let browser: BrowserInterface
+
+        beforeEach(async () => {
+          browser = (await next.browser(
+            '/',
+            browserConfigWithFixedTime
+          )) as BrowserInterface
+        })
+
+        it('should prefetch partially a dynamic page', async () => {
+          const { getRequests, clearRequests } = await createRequestsListener(
+            browser
+          )
+
+          await check(() => {
+            return getRequests().some(
+              ([url, didPartialPrefetch]) =>
+                getPathname(url) === '/1' && didPartialPrefetch
+            )
+              ? 'success'
+              : 'fail'
+          }, 'success')
+
+          clearRequests()
+
+          await browser
+            .elementByCss('[href="/1"]')
+            .click()
+            .waitForElementByCss('#random-number')
+
+          expect(
+            getRequests().some(
+              ([url, didPartialPrefetch]) =>
+                getPathname(url) === '/1' && !didPartialPrefetch
+            )
+          ).toBe(true)
+        })
+        it('should re-use the full cache for only 30 seconds', async () => {
+          const randomNumber = await browser
+            .elementByCss('[href="/1"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          await browser.elementByCss('[href="/"]').click()
+
+          const number = await browser
+            .elementByCss('[href="/1"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          expect(number).toBe(randomNumber)
+
+          await browser.eval(fastForwardTo, 5 * 1000)
+
+          await browser.elementByCss('[href="/"]').click()
+
+          const newNumber = await browser
+            .elementByCss('[href="/1"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          expect(newNumber).toBe(randomNumber)
+
+          await browser.eval(fastForwardTo, 30 * 1000)
+
+          await browser.elementByCss('[href="/"]').click()
+
+          const newNumber2 = await browser
+            .elementByCss('[href="/1"]')
+            .click()
+            .waitForElementByCss('#random-number')
+            .text()
+
+          expect(newNumber2).not.toBe(newNumber)
+        })
+
+        it('should renew the 30s cache once the data is revalidated', async () => {
+          // navigate to prefetch-auto page
+          await browser.elementByCss('[href="/1"]').click()
+
+          let initialNumber = await browser.elementById('random-number').text()
+
+          // Navigate back to the index, and then back to the prefetch-auto page
+          await browser.elementByCss('[href="/"]').click()
+          await browser.eval(fastForwardTo, 5 * 1000)
+          await browser.elementByCss('[href="/1"]').click()
+
+          let newNumber = await browser.elementById('random-number').text()
+
+          // the number should be the same, as we navigated within 30s.
+          expect(newNumber).toBe(initialNumber)
+
+          // Fast forward to expire the cache
+          await browser.eval(fastForwardTo, 30 * 1000)
+
+          // Navigate back to the index, and then back to the prefetch-auto page
+          await browser.elementByCss('[href="/"]').click()
+          await browser.elementByCss('[href="/1"]').click()
+
+          newNumber = await browser.elementById('random-number').text()
+
+          // ~35s have passed, so the cache should be expired and the number should be different
+          expect(newNumber).not.toBe(initialNumber)
+
+          // once the number is updated, we should have a renewed 30s cache for this entry
+          // store this new number so we can check that it stays the same
+          initialNumber = newNumber
+
+          await browser.eval(fastForwardTo, 5 * 1000)
+
+          // Navigate back to the index, and then back to the prefetch-auto page
+          await browser.elementByCss('[href="/"]').click()
+          await browser.elementByCss('[href="/1"]').click()
+
+          newNumber = await browser.elementById('random-number').text()
+
+          // the number should be the same, as we navigated within 30s (part 2).
+          expect(newNumber).toBe(initialNumber)
+        })
+
+        it('should refetch below the fold after 30 seconds', async () => {
+          const randomLoadingNumber = await browser
+            .elementByCss('[href="/1?timeout=1000"]')
+            .click()
+            .waitForElementByCss('#loading')
+            .text()
+
+          const randomNumber = await browser
+            .waitForElementByCss('#random-number')
+            .text()
+
+          await browser.elementByCss('[href="/"]').click()
+
+          await browser.eval(fastForwardTo, 30 * 1000)
+
+          const newLoadingNumber = await browser
+            .elementByCss('[href="/1?timeout=1000"]')
+            .click()
+            .waitForElementByCss('#loading')
+            .text()
+
+          const newNumber = await browser
+            .waitForElementByCss('#random-number')
+            .text()
+
+          expect(newLoadingNumber).toBe(randomLoadingNumber)
+
+          expect(newNumber).not.toBe(randomNumber)
+        })
+        it('should refetch the full page after 5 mins', async () => {
+          const randomLoadingNumber = await browser
+            .elementByCss('[href="/1?timeout=1000"]')
+            .click()
+            .waitForElementByCss('#loading')
+            .text()
+
+          const randomNumber = await browser
+            .waitForElementByCss('#random-number')
+            .text()
+
+          await browser.eval(fastForwardTo, 5 * 60 * 1000)
+
+          await browser
+            .elementByCss('[href="/"]')
+            .click()
+            .waitForElementByCss('[href="/1?timeout=1000"]')
+
+          const newLoadingNumber = await browser
+            .elementByCss('[href="/1?timeout=1000"]')
+            .click()
+            .waitForElementByCss('#loading')
+            .text()
+
+          const newNumber = await browser
+            .waitForElementByCss('#random-number')
+            .text()
+
+          expect(newLoadingNumber).not.toBe(randomLoadingNumber)
+
+          expect(newNumber).not.toBe(randomNumber)
+        })
+
+        it('should respect a loading boundary that returns `null`', async () => {
+          await browser.elementByCss('[href="/null-loading"]').click()
+
+          // the page content should disappear immediately
+          expect(
+            await browser.hasElementByCssSelector('[href="/null-loading"]')
+          ).toBeFalse()
+
+          // the root layout should still be visible
+          expect(
+            await browser.hasElementByCssSelector('#root-layout')
+          ).toBeTrue()
+
+          // the dynamic content should eventually appear
+          await browser.waitForElementByCss('#random-number')
+          expect(
+            await browser.hasElementByCssSelector('#random-number')
+          ).toBeTrue()
+        })
+      })
+      it('should seed the prefetch cache with the fetched page data', async () => {
+        const browser = (await next.browser(
+          '/1',
+          browserConfigWithFixedTime
+        )) as BrowserInterface
+
+        const initialNumber = await browser.elementById('random-number').text()
+
+        // Move forward a few seconds, navigate off the page and then back to it
+        await browser.eval(fastForwardTo, 5 * 1000)
+        await browser.elementByCss('[href="/"]').click()
+        await browser.elementByCss('[href="/1"]').click()
+
+        const newNumber = await browser.elementById('random-number').text()
+
+        // The number should be the same as we've seeded it in the prefetch cache when we loaded the full page
+        expect(newNumber).toBe(initialNumber)
+      })
     }
   }
 )

--- a/test/e2e/app-dir/app-client-cache/client-cache.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.test.ts
@@ -1,4 +1,4 @@
-import { createNextDescribe } from 'e2e-utils'
+import { NextInstance, createNextDescribe } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import { BrowserInterface } from 'test/lib/browsers/base'
 import {
@@ -7,6 +7,394 @@ import {
   fastForwardTo,
   getPathname,
 } from './test-utils'
+
+export function runTests(next: NextInstance) {
+  describe('prefetch={true}', () => {
+    let browser: BrowserInterface
+
+    beforeEach(async () => {
+      browser = (await next.browser(
+        '/',
+        browserConfigWithFixedTime
+      )) as BrowserInterface
+    })
+
+    it('should prefetch the full page', async () => {
+      const { getRequests, clearRequests } = await createRequestsListener(
+        browser
+      )
+      await check(() => {
+        return getRequests().some(
+          ([url, didPartialPrefetch]) =>
+            getPathname(url) === '/0' && !didPartialPrefetch
+        )
+          ? 'success'
+          : 'fail'
+      }, 'success')
+
+      clearRequests()
+
+      await browser
+        .elementByCss('[href="/0?timeout=0"]')
+        .click()
+        .waitForElementByCss('#random-number')
+
+      expect(getRequests().every(([url]) => getPathname(url) !== '/0')).toEqual(
+        true
+      )
+    })
+    it('should re-use the cache for the full page, only for 5 mins', async () => {
+      const randomNumber = await browser
+        .elementByCss('[href="/0?timeout=0"]')
+        .click()
+        .waitForElementByCss('#random-number')
+        .text()
+
+      await browser.elementByCss('[href="/"]').click()
+
+      const number = await browser
+        .elementByCss('[href="/0?timeout=0"]')
+        .click()
+        .waitForElementByCss('#random-number')
+        .text()
+
+      expect(number).toBe(randomNumber)
+
+      await browser.eval(fastForwardTo, 5 * 60 * 1000)
+
+      await browser.elementByCss('[href="/"]').click()
+
+      const newNumber = await browser
+        .elementByCss('[href="/0?timeout=0"]')
+        .click()
+        .waitForElementByCss('#random-number')
+        .text()
+
+      expect(newNumber).not.toBe(randomNumber)
+    })
+
+    it('should prefetch again after 5 mins if the link is visible again', async () => {
+      const { getRequests, clearRequests } = await createRequestsListener(
+        browser
+      )
+
+      await check(() => {
+        return getRequests().some(
+          ([url, didPartialPrefetch]) =>
+            getPathname(url) === '/0' && !didPartialPrefetch
+        )
+          ? 'success'
+          : 'fail'
+      }, 'success')
+
+      const randomNumber = await browser
+        .elementByCss('[href="/0?timeout=0"]')
+        .click()
+        .waitForElementByCss('#random-number')
+        .text()
+
+      await browser.eval(fastForwardTo, 5 * 60 * 1000)
+      clearRequests()
+
+      await browser.elementByCss('[href="/"]').click()
+
+      await check(() => {
+        return getRequests().some(
+          ([url, didPartialPrefetch]) =>
+            getPathname(url) === '/0' && !didPartialPrefetch
+        )
+          ? 'success'
+          : 'fail'
+      }, 'success')
+
+      const number = await browser
+        .elementByCss('[href="/0?timeout=0"]')
+        .click()
+        .waitForElementByCss('#random-number')
+        .text()
+
+      expect(number).not.toBe(randomNumber)
+    })
+  })
+  describe('prefetch={false}', () => {
+    let browser: BrowserInterface
+
+    beforeEach(async () => {
+      browser = (await next.browser(
+        '/',
+        browserConfigWithFixedTime
+      )) as BrowserInterface
+    })
+    it('should not prefetch the page at all', async () => {
+      const { getRequests } = await createRequestsListener(browser)
+
+      await browser
+        .elementByCss('[href="/2"]')
+        .click()
+        .waitForElementByCss('#random-number')
+
+      expect(
+        getRequests().filter(([url]) => getPathname(url) === '/2')
+      ).toHaveLength(1)
+
+      expect(
+        getRequests().some(
+          ([url, didPartialPrefetch]) =>
+            getPathname(url) === '/2' && didPartialPrefetch
+        )
+      ).toBe(false)
+    })
+    it('should re-use the cache only for 30 seconds', async () => {
+      const randomNumber = await browser
+        .elementByCss('[href="/2"]')
+        .click()
+        .waitForElementByCss('#random-number')
+        .text()
+
+      await browser.elementByCss('[href="/"]').click()
+
+      const number = await browser
+        .elementByCss('[href="/2"]')
+        .click()
+        .waitForElementByCss('#random-number')
+        .text()
+
+      expect(number).toBe(randomNumber)
+
+      await browser.eval(fastForwardTo, 30 * 1000)
+
+      await browser.elementByCss('[href="/"]').click()
+
+      const newNumber = await browser
+        .elementByCss('[href="/2"]')
+        .click()
+        .waitForElementByCss('#random-number')
+        .text()
+
+      expect(newNumber).not.toBe(randomNumber)
+    })
+  })
+  describe('prefetch={undefined} - default', () => {
+    let browser: BrowserInterface
+
+    beforeEach(async () => {
+      browser = (await next.browser(
+        '/',
+        browserConfigWithFixedTime
+      )) as BrowserInterface
+    })
+
+    it('should prefetch partially a dynamic page', async () => {
+      const { getRequests, clearRequests } = await createRequestsListener(
+        browser
+      )
+
+      await check(() => {
+        return getRequests().some(
+          ([url, didPartialPrefetch]) =>
+            getPathname(url) === '/1' && didPartialPrefetch
+        )
+          ? 'success'
+          : 'fail'
+      }, 'success')
+
+      clearRequests()
+
+      await browser
+        .elementByCss('[href="/1"]')
+        .click()
+        .waitForElementByCss('#random-number')
+
+      expect(
+        getRequests().some(
+          ([url, didPartialPrefetch]) =>
+            getPathname(url) === '/1' && !didPartialPrefetch
+        )
+      ).toBe(true)
+    })
+    it('should re-use the full cache for only 30 seconds', async () => {
+      const randomNumber = await browser
+        .elementByCss('[href="/1"]')
+        .click()
+        .waitForElementByCss('#random-number')
+        .text()
+
+      await browser.elementByCss('[href="/"]').click()
+
+      const number = await browser
+        .elementByCss('[href="/1"]')
+        .click()
+        .waitForElementByCss('#random-number')
+        .text()
+
+      expect(number).toBe(randomNumber)
+
+      await browser.eval(fastForwardTo, 5 * 1000)
+
+      await browser.elementByCss('[href="/"]').click()
+
+      const newNumber = await browser
+        .elementByCss('[href="/1"]')
+        .click()
+        .waitForElementByCss('#random-number')
+        .text()
+
+      expect(newNumber).toBe(randomNumber)
+
+      await browser.eval(fastForwardTo, 30 * 1000)
+
+      await browser.elementByCss('[href="/"]').click()
+
+      const newNumber2 = await browser
+        .elementByCss('[href="/1"]')
+        .click()
+        .waitForElementByCss('#random-number')
+        .text()
+
+      expect(newNumber2).not.toBe(newNumber)
+    })
+
+    it('should renew the 30s cache once the data is revalidated', async () => {
+      // navigate to prefetch-auto page
+      await browser.elementByCss('[href="/1"]').click()
+
+      let initialNumber = await browser.elementById('random-number').text()
+
+      // Navigate back to the index, and then back to the prefetch-auto page
+      await browser.elementByCss('[href="/"]').click()
+      await browser.eval(fastForwardTo, 5 * 1000)
+      await browser.elementByCss('[href="/1"]').click()
+
+      let newNumber = await browser.elementById('random-number').text()
+
+      // the number should be the same, as we navigated within 30s.
+      expect(newNumber).toBe(initialNumber)
+
+      // Fast forward to expire the cache
+      await browser.eval(fastForwardTo, 30 * 1000)
+
+      // Navigate back to the index, and then back to the prefetch-auto page
+      await browser.elementByCss('[href="/"]').click()
+      await browser.elementByCss('[href="/1"]').click()
+
+      newNumber = await browser.elementById('random-number').text()
+
+      // ~35s have passed, so the cache should be expired and the number should be different
+      expect(newNumber).not.toBe(initialNumber)
+
+      // once the number is updated, we should have a renewed 30s cache for this entry
+      // store this new number so we can check that it stays the same
+      initialNumber = newNumber
+
+      await browser.eval(fastForwardTo, 5 * 1000)
+
+      // Navigate back to the index, and then back to the prefetch-auto page
+      await browser.elementByCss('[href="/"]').click()
+      await browser.elementByCss('[href="/1"]').click()
+
+      newNumber = await browser.elementById('random-number').text()
+
+      // the number should be the same, as we navigated within 30s (part 2).
+      expect(newNumber).toBe(initialNumber)
+    })
+
+    it('should refetch below the fold after 30 seconds', async () => {
+      const randomLoadingNumber = await browser
+        .elementByCss('[href="/1?timeout=1000"]')
+        .click()
+        .waitForElementByCss('#loading')
+        .text()
+
+      const randomNumber = await browser
+        .waitForElementByCss('#random-number')
+        .text()
+
+      await browser.elementByCss('[href="/"]').click()
+
+      await browser.eval(fastForwardTo, 30 * 1000)
+
+      const newLoadingNumber = await browser
+        .elementByCss('[href="/1?timeout=1000"]')
+        .click()
+        .waitForElementByCss('#loading')
+        .text()
+
+      const newNumber = await browser
+        .waitForElementByCss('#random-number')
+        .text()
+
+      expect(newLoadingNumber).toBe(randomLoadingNumber)
+
+      expect(newNumber).not.toBe(randomNumber)
+    })
+    it('should refetch the full page after 5 mins', async () => {
+      const randomLoadingNumber = await browser
+        .elementByCss('[href="/1?timeout=1000"]')
+        .click()
+        .waitForElementByCss('#loading')
+        .text()
+
+      const randomNumber = await browser
+        .waitForElementByCss('#random-number')
+        .text()
+
+      await browser.eval(fastForwardTo, 5 * 60 * 1000)
+
+      await browser
+        .elementByCss('[href="/"]')
+        .click()
+        .waitForElementByCss('[href="/1?timeout=1000"]')
+
+      const newLoadingNumber = await browser
+        .elementByCss('[href="/1?timeout=1000"]')
+        .click()
+        .waitForElementByCss('#loading')
+        .text()
+
+      const newNumber = await browser
+        .waitForElementByCss('#random-number')
+        .text()
+
+      expect(newLoadingNumber).not.toBe(randomLoadingNumber)
+
+      expect(newNumber).not.toBe(randomNumber)
+    })
+
+    it('should respect a loading boundary that returns `null`', async () => {
+      await browser.elementByCss('[href="/null-loading"]').click()
+
+      // the page content should disappear immediately
+      expect(
+        await browser.hasElementByCssSelector('[href="/null-loading"]')
+      ).toBeFalse()
+
+      // the root layout should still be visible
+      expect(await browser.hasElementByCssSelector('#root-layout')).toBeTrue()
+
+      // the dynamic content should eventually appear
+      await browser.waitForElementByCss('#random-number')
+      expect(await browser.hasElementByCssSelector('#random-number')).toBeTrue()
+    })
+  })
+  it('should seed the prefetch cache with the fetched page data', async () => {
+    const browser = (await next.browser(
+      '/1',
+      browserConfigWithFixedTime
+    )) as BrowserInterface
+
+    const initialNumber = await browser.elementById('random-number').text()
+
+    // Move forward a few seconds, navigate off the page and then back to it
+    await browser.eval(fastForwardTo, 5 * 1000)
+    await browser.elementByCss('[href="/"]').click()
+    await browser.elementByCss('[href="/1"]').click()
+
+    const newNumber = await browser.elementById('random-number').text()
+
+    // The number should be the same as we've seeded it in the prefetch cache when we loaded the full page
+    expect(newNumber).toBe(initialNumber)
+  })
+}
 
 createNextDescribe(
   'app dir client cache semantics',
@@ -19,400 +407,7 @@ createNextDescribe(
       // we only check the production behavior
       it('should skip dev', () => {})
     } else {
-      describe('prefetch={true}', () => {
-        let browser: BrowserInterface
-
-        beforeEach(async () => {
-          browser = (await next.browser(
-            '/',
-            browserConfigWithFixedTime
-          )) as BrowserInterface
-        })
-
-        it('should prefetch the full page', async () => {
-          const { getRequests, clearRequests } = await createRequestsListener(
-            browser
-          )
-          await check(() => {
-            return getRequests().some(
-              ([url, didPartialPrefetch]) =>
-                getPathname(url) === '/0' && !didPartialPrefetch
-            )
-              ? 'success'
-              : 'fail'
-          }, 'success')
-
-          clearRequests()
-
-          await browser
-            .elementByCss('[href="/0?timeout=0"]')
-            .click()
-            .waitForElementByCss('#random-number')
-
-          expect(
-            getRequests().every(([url]) => getPathname(url) !== '/0')
-          ).toEqual(true)
-        })
-        it('should re-use the cache for the full page, only for 5 mins', async () => {
-          const randomNumber = await browser
-            .elementByCss('[href="/0?timeout=0"]')
-            .click()
-            .waitForElementByCss('#random-number')
-            .text()
-
-          await browser.elementByCss('[href="/"]').click()
-
-          const number = await browser
-            .elementByCss('[href="/0?timeout=0"]')
-            .click()
-            .waitForElementByCss('#random-number')
-            .text()
-
-          expect(number).toBe(randomNumber)
-
-          await browser.eval(fastForwardTo, 5 * 60 * 1000)
-
-          await browser.elementByCss('[href="/"]').click()
-
-          const newNumber = await browser
-            .elementByCss('[href="/0?timeout=0"]')
-            .click()
-            .waitForElementByCss('#random-number')
-            .text()
-
-          expect(newNumber).not.toBe(randomNumber)
-        })
-
-        it('should prefetch again after 5 mins if the link is visible again', async () => {
-          const { getRequests, clearRequests } = await createRequestsListener(
-            browser
-          )
-
-          await check(() => {
-            return getRequests().some(
-              ([url, didPartialPrefetch]) =>
-                getPathname(url) === '/0' && !didPartialPrefetch
-            )
-              ? 'success'
-              : 'fail'
-          }, 'success')
-
-          const randomNumber = await browser
-            .elementByCss('[href="/0?timeout=0"]')
-            .click()
-            .waitForElementByCss('#random-number')
-            .text()
-
-          await browser.eval(fastForwardTo, 5 * 60 * 1000)
-          clearRequests()
-
-          await browser.elementByCss('[href="/"]').click()
-
-          await check(() => {
-            return getRequests().some(
-              ([url, didPartialPrefetch]) =>
-                getPathname(url) === '/0' && !didPartialPrefetch
-            )
-              ? 'success'
-              : 'fail'
-          }, 'success')
-
-          const number = await browser
-            .elementByCss('[href="/0?timeout=0"]')
-            .click()
-            .waitForElementByCss('#random-number')
-            .text()
-
-          expect(number).not.toBe(randomNumber)
-        })
-      })
-      describe('prefetch={false}', () => {
-        let browser: BrowserInterface
-
-        beforeEach(async () => {
-          browser = (await next.browser(
-            '/',
-            browserConfigWithFixedTime
-          )) as BrowserInterface
-        })
-        it('should not prefetch the page at all', async () => {
-          const { getRequests } = await createRequestsListener(browser)
-
-          await browser
-            .elementByCss('[href="/2"]')
-            .click()
-            .waitForElementByCss('#random-number')
-
-          expect(
-            getRequests().filter(([url]) => getPathname(url) === '/2')
-          ).toHaveLength(1)
-
-          expect(
-            getRequests().some(
-              ([url, didPartialPrefetch]) =>
-                getPathname(url) === '/2' && didPartialPrefetch
-            )
-          ).toBe(false)
-        })
-        it('should re-use the cache only for 30 seconds', async () => {
-          const randomNumber = await browser
-            .elementByCss('[href="/2"]')
-            .click()
-            .waitForElementByCss('#random-number')
-            .text()
-
-          await browser.elementByCss('[href="/"]').click()
-
-          const number = await browser
-            .elementByCss('[href="/2"]')
-            .click()
-            .waitForElementByCss('#random-number')
-            .text()
-
-          expect(number).toBe(randomNumber)
-
-          await browser.eval(fastForwardTo, 30 * 1000)
-
-          await browser.elementByCss('[href="/"]').click()
-
-          const newNumber = await browser
-            .elementByCss('[href="/2"]')
-            .click()
-            .waitForElementByCss('#random-number')
-            .text()
-
-          expect(newNumber).not.toBe(randomNumber)
-        })
-      })
-      describe('prefetch={undefined} - default', () => {
-        let browser: BrowserInterface
-
-        beforeEach(async () => {
-          browser = (await next.browser(
-            '/',
-            browserConfigWithFixedTime
-          )) as BrowserInterface
-        })
-
-        it('should prefetch partially a dynamic page', async () => {
-          const { getRequests, clearRequests } = await createRequestsListener(
-            browser
-          )
-
-          await check(() => {
-            return getRequests().some(
-              ([url, didPartialPrefetch]) =>
-                getPathname(url) === '/1' && didPartialPrefetch
-            )
-              ? 'success'
-              : 'fail'
-          }, 'success')
-
-          clearRequests()
-
-          await browser
-            .elementByCss('[href="/1"]')
-            .click()
-            .waitForElementByCss('#random-number')
-
-          expect(
-            getRequests().some(
-              ([url, didPartialPrefetch]) =>
-                getPathname(url) === '/1' && !didPartialPrefetch
-            )
-          ).toBe(true)
-        })
-        it('should re-use the full cache for only 30 seconds', async () => {
-          const randomNumber = await browser
-            .elementByCss('[href="/1"]')
-            .click()
-            .waitForElementByCss('#random-number')
-            .text()
-
-          await browser.elementByCss('[href="/"]').click()
-
-          const number = await browser
-            .elementByCss('[href="/1"]')
-            .click()
-            .waitForElementByCss('#random-number')
-            .text()
-
-          expect(number).toBe(randomNumber)
-
-          await browser.eval(fastForwardTo, 5 * 1000)
-
-          await browser.elementByCss('[href="/"]').click()
-
-          const newNumber = await browser
-            .elementByCss('[href="/1"]')
-            .click()
-            .waitForElementByCss('#random-number')
-            .text()
-
-          expect(newNumber).toBe(randomNumber)
-
-          await browser.eval(fastForwardTo, 30 * 1000)
-
-          await browser.elementByCss('[href="/"]').click()
-
-          const newNumber2 = await browser
-            .elementByCss('[href="/1"]')
-            .click()
-            .waitForElementByCss('#random-number')
-            .text()
-
-          expect(newNumber2).not.toBe(newNumber)
-        })
-
-        it('should renew the 30s cache once the data is revalidated', async () => {
-          // navigate to prefetch-auto page
-          await browser.elementByCss('[href="/1"]').click()
-
-          let initialNumber = await browser.elementById('random-number').text()
-
-          // Navigate back to the index, and then back to the prefetch-auto page
-          await browser.elementByCss('[href="/"]').click()
-          await browser.eval(fastForwardTo, 5 * 1000)
-          await browser.elementByCss('[href="/1"]').click()
-
-          let newNumber = await browser.elementById('random-number').text()
-
-          // the number should be the same, as we navigated within 30s.
-          expect(newNumber).toBe(initialNumber)
-
-          // Fast forward to expire the cache
-          await browser.eval(fastForwardTo, 30 * 1000)
-
-          // Navigate back to the index, and then back to the prefetch-auto page
-          await browser.elementByCss('[href="/"]').click()
-          await browser.elementByCss('[href="/1"]').click()
-
-          newNumber = await browser.elementById('random-number').text()
-
-          // ~35s have passed, so the cache should be expired and the number should be different
-          expect(newNumber).not.toBe(initialNumber)
-
-          // once the number is updated, we should have a renewed 30s cache for this entry
-          // store this new number so we can check that it stays the same
-          initialNumber = newNumber
-
-          await browser.eval(fastForwardTo, 5 * 1000)
-
-          // Navigate back to the index, and then back to the prefetch-auto page
-          await browser.elementByCss('[href="/"]').click()
-          await browser.elementByCss('[href="/1"]').click()
-
-          newNumber = await browser.elementById('random-number').text()
-
-          // the number should be the same, as we navigated within 30s (part 2).
-          expect(newNumber).toBe(initialNumber)
-        })
-
-        it('should refetch below the fold after 30 seconds', async () => {
-          const randomLoadingNumber = await browser
-            .elementByCss('[href="/1?timeout=1000"]')
-            .click()
-            .waitForElementByCss('#loading')
-            .text()
-
-          const randomNumber = await browser
-            .waitForElementByCss('#random-number')
-            .text()
-
-          await browser.elementByCss('[href="/"]').click()
-
-          await browser.eval(fastForwardTo, 30 * 1000)
-
-          const newLoadingNumber = await browser
-            .elementByCss('[href="/1?timeout=1000"]')
-            .click()
-            .waitForElementByCss('#loading')
-            .text()
-
-          const newNumber = await browser
-            .waitForElementByCss('#random-number')
-            .text()
-
-          expect(newLoadingNumber).toBe(randomLoadingNumber)
-
-          expect(newNumber).not.toBe(randomNumber)
-        })
-        it('should refetch the full page after 5 mins', async () => {
-          const randomLoadingNumber = await browser
-            .elementByCss('[href="/1?timeout=1000"]')
-            .click()
-            .waitForElementByCss('#loading')
-            .text()
-
-          const randomNumber = await browser
-            .waitForElementByCss('#random-number')
-            .text()
-
-          await browser.eval(fastForwardTo, 5 * 60 * 1000)
-
-          await browser
-            .elementByCss('[href="/"]')
-            .click()
-            .waitForElementByCss('[href="/1?timeout=1000"]')
-
-          const newLoadingNumber = await browser
-            .elementByCss('[href="/1?timeout=1000"]')
-            .click()
-            .waitForElementByCss('#loading')
-            .text()
-
-          const newNumber = await browser
-            .waitForElementByCss('#random-number')
-            .text()
-
-          expect(newLoadingNumber).not.toBe(randomLoadingNumber)
-
-          expect(newNumber).not.toBe(randomNumber)
-        })
-
-        it('should respect a loading boundary that returns `null`', async () => {
-          await browser.elementByCss('[href="/null-loading"]').click()
-
-          // the page content should disappear immediately
-          expect(
-            await browser.hasElementByCssSelector('[href="/null-loading"]')
-          ).toBeFalse()
-
-          // the root layout should still be visible
-          expect(
-            await browser.hasElementByCssSelector('#root-layout')
-          ).toBeTrue()
-
-          // the dynamic content should eventually appear
-          await browser.waitForElementByCss('#random-number')
-          expect(
-            await browser.hasElementByCssSelector('#random-number')
-          ).toBeTrue()
-        })
-      })
-
-      it('should seed the prefetch cache with the fetched page data', async () => {
-        const browser = (await next.browser(
-          '/1',
-          browserConfigWithFixedTime
-        )) as BrowserInterface
-
-        const initialNumber = await browser.elementById('random-number').text()
-
-        // Move forward a few seconds, navigate off the page and then back to it
-        await browser.eval(fastForwardTo, 5 * 1000)
-        await browser.elementByCss('[href="/"]').click()
-        await browser.elementByCss('[href="/1"]').click()
-
-        const newNumber = await browser.elementById('random-number').text()
-
-        // The number should be the same as we've seeded it in the prefetch cache when we loaded the full page
-        expect(newNumber).toBe(initialNumber)
-      })
-      describe('router.push', () => {
-        it('should re-use the cache for 30 seconds', async () => {})
-        it('should fully refetch the page after 30 seconds', async () => {})
-      })
+      runTests(next)
     }
   }
 )

--- a/test/e2e/app-dir/app-client-cache/next.config.js
+++ b/test/e2e/app-dir/app-client-cache/next.config.js
@@ -1,1 +1,0 @@
-module.exports = {}

--- a/test/e2e/app-dir/app-client-cache/test-utils.ts
+++ b/test/e2e/app-dir/app-client-cache/test-utils.ts
@@ -1,0 +1,72 @@
+import { BrowserInterface } from 'test/lib/browsers/base'
+import type { Request } from 'playwright'
+
+export const getPathname = (url: string) => {
+  const urlObj = new URL(url)
+  return urlObj.pathname
+}
+
+export const browserConfigWithFixedTime = {
+  beforePageLoad: (page) => {
+    page.addInitScript(() => {
+      const startTime = new Date()
+      const fixedTime = new Date('2023-04-17T00:00:00Z')
+
+      // Override the Date constructor
+      // @ts-ignore
+      // eslint-disable-next-line no-native-reassign
+      Date = class extends Date {
+        constructor() {
+          super()
+          // @ts-ignore
+          return new startTime.constructor(fixedTime)
+        }
+
+        static now() {
+          return fixedTime.getTime()
+        }
+      }
+    })
+  },
+}
+
+export const fastForwardTo = (ms) => {
+  // Increment the fixed time by the specified duration
+  const currentTime = new Date()
+  currentTime.setTime(currentTime.getTime() + ms)
+
+  // Update the Date constructor to use the new fixed time
+  // @ts-ignore
+  // eslint-disable-next-line no-native-reassign
+  Date = class extends Date {
+    constructor() {
+      super()
+      // @ts-ignore
+      return new currentTime.constructor(currentTime)
+    }
+
+    static now() {
+      return currentTime.getTime()
+    }
+  }
+}
+
+export const createRequestsListener = async (browser: BrowserInterface) => {
+  // wait for network idle
+  await browser.waitForIdleNetwork()
+
+  let requests = []
+
+  browser.on('request', (req: Request) => {
+    requests.push([req.url(), !!req.headers()['next-router-prefetch']])
+  })
+
+  await browser.refresh()
+
+  return {
+    getRequests: () => requests,
+    clearRequests: () => {
+      requests = []
+    },
+  }
+}

--- a/test/ppr-tests-manifest.json
+++ b/test/ppr-tests-manifest.json
@@ -75,7 +75,8 @@
       "test/e2e/app-dir/ppr/**/*",
       "test/e2e/app-dir/ppr-*/**/*",
       "test/e2e/app-dir/app-prefetch*/**/*",
-      "test/e2e/app-dir/searchparams-static-bailout/searchparams-static-bailout.test.ts"
+      "test/e2e/app-dir/searchparams-static-bailout/searchparams-static-bailout.test.ts",
+      "test/e2e/app-dir/app-client-cache/client-cache.experimental.test.ts"
     ]
   }
 }


### PR DESCRIPTION
This introduces an experimental router flag (`experimental.staleTimes`) to change the router cache behavior. Specifically:

```ts
// next.config.js
module.exports = {
  experimental: {
    staleTimes: {
      dynamic: <seconds>,
      static: <seconds>,
    },
  },
};
```

- `dynamic` is the value that is used when the `prefetch` `Link` prop is left unspecified.  (Default 30 seconds)
- `static` is the value that is used when the `prefetch` `Link` prop is `true`. (Default 5 minutes)

Additional details:
- Loading boundaries are considered reusable for the time period indicated by the `static` property (default 5 minutes)
- This doesn't disable partial rendering support, **meaning shared layouts won't automatically be refetched every navigation, only the new segment data**.
- This also doesn't change back/forward caching behavior to ensure things like scroll restoration etc still work nicely.

Please see the original proposal [here](https://github.com/vercel/next.js/discussions/54075#discussioncomment-6754339) for more information. The primary difference is that this is a global configuration, rather than a per-segment configuration, and it isn't applied to layouts. (We expect this to be a "stop-gap" and not the final router caching solution)

Closes NEXT-2703