### PR TITLE
Fix handling for getting latest stable tag

### DIFF
--- a/.github/actions/next-stats-action/src/prepare/repo-setup.js
+++ b/.github/actions/next-stats-action/src/prepare/repo-setup.js
@@ -13,23 +13,23 @@ module.exports = (actionInfo) => {
         `git clone ${actionInfo.gitRoot}${repoPath} --single-branch --branch ${branch} --depth=${depth} ${dest}`
       )
     },
-    async getLastStable(repoDir = '') {
-      const { stdout } = await exec(`cd ${repoDir} && git describe`)
-      const tag = stdout.trim()
+    async getLastStable() {
+      const res = await fetch(
+        `https://api.github.com/repos/vercel/next.js/releases/latest`,
+        {
+          headers: {
+            'X-GitHub-Api-Version': '2022-11-28',
+          },
+        }
+      )
 
-      if (!tag || !tag.startsWith('v')) {
-        throw new Error(`Failed to get tag info: "${stdout}"`)
-      }
-      const [major, minor, patch] = tag.split('-canary')[0].split('.')
-      if (!major || !minor || !patch) {
+      if (!res.ok) {
         throw new Error(
-          `Failed to split tag into major/minor/patch: "${stdout}"`
+          `Failed to get latest stable tag ${res.status}: ${await res.text()}`
         )
       }
-      // last stable tag will always be 1 patch less than canary
-      return `${major}.${minor}.${
-        Number(patch) - tag.includes('-canary') ? 1 : 0
-      }`
+      const data = await res.json()
+      return data.tag_name
     },
     async getCommitId(repoDir = '') {
       const { stdout } = await exec(`cd ${repoDir} && git rev-parse HEAD`)


### PR DESCRIPTION
This simplifies our `getLastStable` handling to use our GitHub latest release as the source of truth instead of trying to parse this from the git history as that can be less reliable depending on the checkout depth and the order of releases. 

x-ref: https://github.com/vercel/next.js/actions/runs/8149447058/job/22274305183

Closes NEXT-2704