### PR TITLE
Fix: missing crossorigin property on manifest link

### DIFF
--- a/packages/next/src/lib/metadata/generate/basic.tsx
+++ b/packages/next/src/lib/metadata/generate/basic.tsx
@@ -61,7 +61,11 @@ export function BasicMeta({ metadata }: { metadata: ResolvedMetadata }) {
         ])
       : []),
     metadata.manifest ? (
-      <link rel="manifest" href={metadata.manifest.toString()} />
+      <link
+        rel="manifest"
+        href={metadata.manifest.toString()}
+        crossOrigin="use-credentials"
+      />
     ) : null,
     Meta({ name: 'generator', content: metadata.generator }),
     Meta({ name: 'keywords', content: metadata.keywords?.join(',') }),

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -228,6 +228,12 @@ createNextDescribe(
           'dns-prefetch': '/dns-prefetch-url',
         })
 
+        // Manifest link should have crossOrigin attribute
+        await matchDom('link', 'rel="manifest"', {
+          href: '/api/manifest',
+          crossOrigin: 'use-credentials',
+        })
+
         await matchDom('meta', 'name="theme-color"', {
           media: '(prefers-color-scheme: dark)',
           content: 'cyan',
@@ -237,6 +243,7 @@ createNextDescribe(
       it('should support other basic tags (edge)', async () => {
         const browser = await next.browser('/basic-edge')
         const matchMultiDom = createMultiDomMatcher(browser)
+        const matchDom = createDomMatcher(browser)
 
         await matchMultiDom('meta', 'name', 'content', {
           generator: 'next.js',
@@ -254,6 +261,12 @@ createNextDescribe(
           preconnect: '/preconnect-url',
           preload: '/api/preload',
           'dns-prefetch': '/dns-prefetch-url',
+        })
+
+        // Manifest link should have crossOrigin attribute
+        await matchDom('link', 'rel="manifest"', {
+          href: '/api/manifest',
+          crossOrigin: 'use-credentials',
         })
       })
 
@@ -880,6 +893,7 @@ createNextDescribe(
       })
 
       it('should support static manifest.webmanifest', async () => {
+        const $ = await next.render$('/')
         const res = await next.fetch('/manifest.webmanifest')
         expect(res.headers.get('content-type')).toBe(
           'application/manifest+json'

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -893,7 +893,6 @@ createNextDescribe(
       })
 
       it('should support static manifest.webmanifest', async () => {
-        const $ = await next.render$('/')
         const res = await next.fetch('/manifest.webmanifest')
         expect(res.headers.get('content-type')).toBe(
           'application/manifest+json'


### PR DESCRIPTION
We didn't set the property of manifest before, this PR fixes the missing prop

> If the manifest requires credentials to fetch, the crossorigin attribute must be set to use-credentials, even if the manifest file is in the same origin as the current page.
x-ref: https://developer.mozilla.org/en-US/docs/Web/Manifest


Fixes NEXT-2706