### PR TITLE
bump @edge-runtime/cookies for Partitioned cookie support

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -137,7 +137,7 @@
     "@babel/traverse": "7.22.5",
     "@babel/types": "7.22.5",
     "@capsizecss/metrics": "2.0.0",
-    "@edge-runtime/cookies": "4.0.2",
+    "@edge-runtime/cookies": "4.1.0",
     "@edge-runtime/ponyfill": "2.4.1",
     "@edge-runtime/primitives": "4.0.2",
     "@hapi/accept": "5.0.2",

--- a/packages/next/src/compiled/@edge-runtime/cookies/index.d.ts
+++ b/packages/next/src/compiled/@edge-runtime/cookies/index.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for cookie 0.5
-// Project: https://github.com/jshttp/cookie
-// Definitions by: Pine Mizune <https://github.com/pine>
-//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 /**
  * Basic HTTP cookie parser and serializer for HTTP servers.
  */
@@ -63,6 +57,17 @@ interface CookieSerializeOptions {
      */
     maxAge?: number | undefined;
     /**
+     * Specifies the `boolean` value for the [`Partitioned` `Set-Cookie`](rfc-cutler-httpbis-partitioned-cookies)
+     * attribute. When truthy, the `Partitioned` attribute is set, otherwise it is not. By default, the
+     * `Partitioned` attribute is not set.
+     *
+     * **note** This is an attribute that has not yet been fully standardized, and may change in the future.
+     * This also means many clients may ignore this attribute until they understand it.
+     *
+     * More information about can be found in [the proposal](https://github.com/privacycg/CHIPS)
+     */
+    partitioned?: boolean | undefined;
+    /**
      * Specifies the value for the {@link https://tools.ietf.org/html/rfc6265#section-5.2.4|`Path` `Set-Cookie` attribute}.
      * By default, the path is considered the "default path".
      */
@@ -114,7 +119,7 @@ interface CookieSerializeOptions {
  * {@link https://wicg.github.io/cookie-store/#dictdef-cookielistitem CookieListItem}
  * as specified by W3C.
  */
-interface CookieListItem extends Pick<CookieSerializeOptions, 'domain' | 'path' | 'secure' | 'sameSite'> {
+interface CookieListItem extends Pick<CookieSerializeOptions, 'domain' | 'path' | 'secure' | 'sameSite' | 'partitioned'> {
     /** A string with the name of a cookie. */
     name: string;
     /** A string containing the value of the cookie. */
@@ -193,4 +198,4 @@ declare function parseCookie(cookie: string): Map<string, string>;
 /** Parse a `Set-Cookie` header value */
 declare function parseSetCookie(setCookie: string): undefined | ResponseCookie;
 
-export { CookieListItem, RequestCookie, RequestCookies, ResponseCookie, ResponseCookies, parseCookie, parseSetCookie, stringifyCookie };
+export { type CookieListItem, type RequestCookie, RequestCookies, type ResponseCookie, ResponseCookies, parseCookie, parseSetCookie, stringifyCookie };

--- a/packages/next/src/compiled/@edge-runtime/cookies/index.js
+++ b/packages/next/src/compiled/@edge-runtime/cookies/index.js
@@ -39,6 +39,7 @@ function stringifyCookie(c) {
     "secure" in c && c.secure && "Secure",
     "httpOnly" in c && c.httpOnly && "HttpOnly",
     "sameSite" in c && c.sameSite && `SameSite=${c.sameSite}`,
+    "partitioned" in c && c.partitioned && "Partitioned",
     "priority" in c && c.priority && `Priority=${c.priority}`
   ].filter(Boolean);
   return `${c.name}=${encodeURIComponent((_a = c.value) != null ? _a : "")}; ${attrs.join("; ")}`;
@@ -74,6 +75,7 @@ function parseSetCookie(setCookie) {
     path,
     samesite,
     secure,
+    partitioned,
     priority
   } = Object.fromEntries(
     attributes.map(([key, value2]) => [key.toLowerCase(), value2])
@@ -88,7 +90,8 @@ function parseSetCookie(setCookie) {
     path,
     ...samesite && { sameSite: parseSameSite(samesite) },
     ...secure && { secure: true },
-    ...priority && { priority: parsePriority(priority) }
+    ...priority && { priority: parsePriority(priority) },
+    ...partitioned && { partitioned: true }
   };
   return compact(cookie);
 }

--- a/packages/next/src/compiled/@edge-runtime/cookies/package.json
+++ b/packages/next/src/compiled/@edge-runtime/cookies/package.json
@@ -1,1 +1,1 @@
-{"name":"@edge-runtime/cookies","version":"4.0.2","main":"./index.js","license":"MPL-2.0"}
+{"name":"@edge-runtime/cookies","version":"4.1.0","main":"./index.js","license":"MPL-2.0"}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -906,8 +906,8 @@ importers:
         specifier: 2.0.0
         version: 2.0.0
       '@edge-runtime/cookies':
-        specifier: 4.0.2
-        version: 4.0.2
+        specifier: 4.1.0
+        version: 4.1.0
       '@edge-runtime/ponyfill':
         specifier: 2.4.1
         version: 2.4.1
@@ -3537,8 +3537,8 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: false
 
-  /@edge-runtime/cookies@4.0.2:
-    resolution: {integrity: sha512-BphVamVz/yt9FN1b60ZXp+iTJVRLUHI0POxKYZG3gn+RsP+M0phqS87Z9JnDn2YOsPx9SRhhrN9AB7yhpexNEw==}
+  /@edge-runtime/cookies@4.1.0:
+    resolution: {integrity: sha512-yygdcJ7Icc38Y3oVGXhb1Xz4dl8YDkYfvtEdfQlmt3gf4daRJfKkTMP0WOhN59CIcjFkCKrwhjwpuNZMvcYiYg==}
     engines: {node: '>=16'}
     dev: true
 


### PR DESCRIPTION
Bumps `@edge-runtime/cookies` to add support for `set-Cookie: Partitioned` attribute

- https://github.com/vercel/edge-runtime/pull/825
- https://developer.mozilla.org/en-US/docs/Web/Privacy/Privacy_sandbox/Partitioned_cookies