### PR TITLE
fix(next/image): preload image on prefetch & soft navigations

### DIFF
--- a/packages/next/src/client/image-component.tsx
+++ b/packages/next/src/client/image-component.tsx
@@ -10,8 +10,6 @@ import React, {
   forwardRef,
   version,
 } from 'react'
-import ReactDOM from 'react-dom'
-import Head from '../shared/lib/head'
 import { getImgProps } from '../shared/lib/get-img-props'
 import type {
   ImageProps,
@@ -27,7 +25,6 @@ import type {
 import { imageConfigDefault } from '../shared/lib/image-config'
 import { ImageConfigContext } from '../shared/lib/image-config-context.shared-runtime'
 import { warnOnce } from '../shared/lib/utils/warn-once'
-import { RouterContext } from '../shared/lib/router-context.shared-runtime'
 
 // @ts-ignore - This is replaced by webpack alias
 import defaultLoader from 'next/dist/shared/lib/image-loader'
@@ -313,54 +310,6 @@ const ImageElement = forwardRef<HTMLImageElement | null, ImageElementProps>(
   }
 )
 
-function ImagePreload({
-  isAppRouter,
-  imgAttributes,
-}: {
-  isAppRouter: boolean
-  imgAttributes: ImgProps
-}) {
-  const opts = {
-    as: 'image',
-    imageSrcSet: imgAttributes.srcSet,
-    imageSizes: imgAttributes.sizes,
-    crossOrigin: imgAttributes.crossOrigin,
-    referrerPolicy: imgAttributes.referrerPolicy,
-    ...getDynamicProps(imgAttributes.fetchPriority),
-  }
-
-  if (isAppRouter && ReactDOM.preload) {
-    // See https://github.com/facebook/react/pull/26940
-    ReactDOM.preload(
-      imgAttributes.src,
-      // @ts-expect-error TODO: upgrade to `@types/react-dom@18.3.x`
-      opts
-    )
-    return null
-  }
-
-  return (
-    <Head>
-      <link
-        key={
-          '__nimg-' +
-          imgAttributes.src +
-          imgAttributes.srcSet +
-          imgAttributes.sizes
-        }
-        rel="preload"
-        // Note how we omit the `href` attribute, as it would only be relevant
-        // for browsers that do not support `imagesrcset`, and in those cases
-        // it would cause the incorrect image to be preloaded.
-        //
-        // https://html.spec.whatwg.org/multipage/semantics.html#attr-link-imagesrcset
-        href={imgAttributes.srcSet ? undefined : imgAttributes.src}
-        {...opts}
-      />
-    </Head>
-  )
-}
-
 /**
  * The `Image` component is used to optimize images.
  *
@@ -368,10 +317,6 @@ function ImagePreload({
  */
 export const Image = forwardRef<HTMLImageElement | null, ImageProps>(
   (props, forwardedRef) => {
-    const pagesRouter = useContext(RouterContext)
-    // We're in the app directory if there is no pages router.
-    const isAppRouter = !pagesRouter
-
     const configContext = useContext(ImageConfigContext)
     const config = useMemo(() => {
       const c = configEnv || configContext || imageConfigDefault
@@ -419,12 +364,6 @@ export const Image = forwardRef<HTMLImageElement | null, ImageProps>(
             ref={forwardedRef}
           />
         }
-        {imgMeta.priority ? (
-          <ImagePreload
-            isAppRouter={isAppRouter}
-            imgAttributes={imgAttributes}
-          />
-        ) : null}
       </>
     )
   }

--- a/packages/next/src/shared/lib/image-external.tsx
+++ b/packages/next/src/shared/lib/image-external.tsx
@@ -1,11 +1,16 @@
 import type { ImageConfigComplete, ImageLoaderProps } from './image-config'
 import type { ImageProps, ImageLoader, StaticImageData } from './get-img-props'
 
+import ReactDOM from 'react-dom'
 import { getImgProps } from './get-img-props'
-import { Image } from '../../client/image-component'
+import Head from '../../shared/lib/head'
+import { Image as ClientImage } from '../../client/image-component'
 
 // @ts-ignore - This is replaced by webpack alias
 import defaultLoader from 'next/dist/shared/lib/image-loader'
+
+// This is replaced by webpack define plugin
+const imgConf = process.env.__NEXT_IMAGE_OPTS as any as ImageConfigComplete
 
 /**
  * For more advanced use cases, you can call `getImageProps()`
@@ -31,6 +36,46 @@ export function getImageProps(imgProps: ImageProps) {
   return { props }
 }
 
-export default Image
+export default function Image(imgProps: ImageProps) {
+  const { props } = getImgProps(imgProps, { defaultLoader, imgConf })
+  if (imgProps.priority) {
+    const opts = {
+      as: 'image',
+      imageSrcSet: props.srcSet,
+      imageSizes: props.sizes,
+      crossOrigin: props.crossOrigin,
+      referrerPolicy: props.referrerPolicy,
+      fetchPriority: props.fetchPriority, // TODO: handle fetchpriority Pages Router?
+    }
+
+    if (ReactDOM.preload) {
+      ReactDOM.preload(
+        props.src,
+        // @ts-expect-error TODO: upgrade to `@types/react-dom@18.3.x`
+        opts
+      )
+      return <ClientImage {...imgProps} />
+    }
+    return (
+      <>
+        <Head>
+          <link
+            key={'__nimg-' + props.src + props.srcSet + props.sizes}
+            rel="preload"
+            // Note how we omit the `href` attribute, as it would only be relevant
+            // for browsers that do not support `imagesrcset`, and in those cases
+            // it would cause the incorrect image to be preloaded.
+            //
+            // https://html.spec.whatwg.org/multipage/semantics.html#attr-link-imagesrcset
+            href={props.srcSet ? undefined : props.src}
+            {...opts}
+          />
+        </Head>
+        <ClientImage {...imgProps} />
+      </>
+    )
+  }
+  return <ClientImage {...imgProps} />
+}
 
 export type { ImageProps, ImageLoaderProps, ImageLoader, StaticImageData }


### PR DESCRIPTION
This moves the preload out of the client component so that we can preload images much earlier. This is particular useful when using `next/link` that links to another page that has `next/image` with a `priority` prop, because it means the images can be prefetched on hover. This will make soft navigation faster since it will already have the image downloaded and ready to render.

Closes #55060 

Fixes [NEXT-1562](https://linear.app/vercel/issue/NEXT-1562/)