### PR TITLE
Update to only use preminor when configured

### DIFF
--- a/scripts/start-release.js
+++ b/scripts/start-release.js
@@ -55,7 +55,9 @@ async function main() {
   console.log(`Running pnpm release-${isCanary ? 'canary' : 'stable'}...`)
   const child = execa(
     isCanary
-      ? `pnpm lerna version preminor --preid canary --force-publish -y && pnpm release --pre --skip-questions --show-url`
+      ? `pnpm lerna version ${
+          semverType === 'minor' ? 'preminor' : 'prerelease'
+        } --preid canary --force-publish -y && pnpm release --pre --skip-questions --show-url`
       : `pnpm lerna version ${semverType} --force-publish -y`,
     {
       stdio: 'pipe',


### PR DESCRIPTION
Ensures we don't use preminor every time only when we manually specify to

x-ref: https://github.com/vercel/next.js/actions/runs/8161338410/job/22309868382

Closes NEXT-2716