### PR TITLE
correct alternates hreflang example fix #62909

### DIFF
--- a/packages/next/src/lib/metadata/types/metadata-interface.ts
+++ b/packages/next/src/lib/metadata/types/metadata-interface.ts
@@ -219,7 +219,7 @@ interface Metadata extends DeprecatedMetadataFields {
    * { canonical: "https://example.com" }
    * <link rel="canonical" href="https://example.com" />
    *
-   * { canonical: "https://example.com", hreflang: { "en-US": "https://example.com/en-US" } }
+   * { canonical: "https://example.com", languages: { "en-US": "https://example.com/en-US" } }
    * <link rel="canonical" href="https://example.com" />
    * <link rel="alternate" href="https://example.com/en-US" hreflang="en-US" />
    * ```


### PR DESCRIPTION
Closes #62909. The example in the `metadata-interface.d.ts` documentation has been updated to accurately reflect the `AlternateURLs`.