### PR TITLE
fix(next-api): correct font manifest generation

### DIFF
--- a/packages/next-swc/crates/next-api/src/app.rs
+++ b/packages/next-swc/crates/next-api/src/app.rs
@@ -822,6 +822,7 @@ impl AppEndpoint {
             this.app_project.app_dir(),
             &app_entry.original_name,
             &app_entry.original_name,
+            &app_entry.original_name,
             client_assets,
             true,
         )

--- a/packages/next-swc/crates/next-api/src/font.rs
+++ b/packages/next-swc/crates/next-api/src/font.rs
@@ -18,17 +18,20 @@ pub(crate) async fn create_font_manifest(
     dir: Vc<FileSystemPath>,
     original_name: &str,
     manifest_path_prefix: &str,
+    pathname: &str,
     client_assets: Vc<OutputAssets>,
     app_dir: bool,
 ) -> Result<Vc<Box<dyn OutputAsset>>> {
-    // `_next` gets added again later, so we "strip" it here via
-    // `get_font_paths_from_root`.
-    let client_root_value = client_root.join("_next".to_string()).await?;
-
     let all_client_output_assets = all_assets_from_entries(client_assets).await?;
 
-    let font_paths =
-        get_font_paths_from_root(&client_root_value, &all_client_output_assets).await?;
+    // `_next` gets added again later, so we "strip" it here via
+    // `get_font_paths_from_root`.
+    let font_paths: Vec<String> =
+        get_font_paths_from_root(&*client_root.await?, &all_client_output_assets)
+            .await?
+            .iter()
+            .filter_map(|p| p.split("_next/").last().map(|f| f.to_string()))
+            .collect();
 
     let path = if app_dir {
         node_root.join(format!(
@@ -60,9 +63,7 @@ pub(crate) async fn create_font_manifest(
         }
     } else {
         NextFontManifest {
-            pages: [(original_name.to_string(), font_paths)]
-                .into_iter()
-                .collect(),
+            pages: [(pathname.to_string(), font_paths)].into_iter().collect(),
             pages_using_size_adjust: using_size_adjust,
             ..Default::default()
         }

--- a/packages/next-swc/crates/next-api/src/pages.rs
+++ b/packages/next-swc/crates/next-api/src/pages.rs
@@ -1020,6 +1020,7 @@ impl PageEndpoint {
             this.pages_project.pages_dir(),
             &original_name,
             &get_asset_prefix_from_pathname(&pathname),
+            &pathname,
             client_assets,
             false,
         )

--- a/test/e2e/next-font/basepath.test.ts
+++ b/test/e2e/next-font/basepath.test.ts
@@ -40,13 +40,17 @@ describe('next/font/google basepath', () => {
 
     // Preload
     expect($('link[as="font"]').length).toBe(1)
-    expect($('link[as="font"]').get(0).attribs).toEqual({
-      as: 'font',
-      crossorigin: 'anonymous',
-      href: '/dashboard/_next/static/media/0812efcfaefec5ea-s.p.woff2',
-      rel: 'preload',
-      type: 'font/woff2',
-      'data-next-font': 'size-adjust',
-    })
+    expect($('link[as="font"]').get(0).attribs).toEqual(
+      expect.objectContaining({
+        as: 'font',
+        crossorigin: 'anonymous',
+        href: expect.stringMatching(
+          /\/dashboard\/_next\/static\/media\/.*.p.*.woff2/
+        ),
+        rel: 'preload',
+        type: 'font/woff2',
+        'data-next-font': 'size-adjust',
+      })
+    )
   })
 })

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -6259,8 +6259,8 @@
     "runtimeError": false
   },
   "test/e2e/next-font/basepath.test.ts": {
-    "passed": [],
-    "failed": ["next/font/google basepath preload correct files"],
+    "passed": ["next/font/google basepath preload correct files"],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
### What

I noticed the font manifest generated by Turbopack was always empty. Debugging showed that the path to the client_root was always incorrect when calculating `get_font_paths_from_root`. And also fixed an issue where for certain paths, the (`/index`) manifest key should contain the original path.

Closes PACK-2666