### PR TITLE
feat(error-overlay): version staleness in Pages Router

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/pages/ReactDevOverlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/pages/ReactDevOverlay.tsx
@@ -9,6 +9,7 @@ import { ErrorBoundary } from './ErrorBoundary'
 import { Base } from '../internal/styles/Base'
 import { ComponentStyles } from '../internal/styles/ComponentStyles'
 import { CssReset } from '../internal/styles/CssReset'
+import type { VersionInfo } from '../../../../server/dev/parse-version-info'
 
 type RefreshState =
   | {
@@ -27,6 +28,7 @@ type OverlayState = {
   buildError: string | null
   errors: SupportedErrorEvent[]
   refreshState: RefreshState
+  versionInfo: VersionInfo
 }
 
 function pushErrorFilterDuplicates(
@@ -102,6 +104,9 @@ function reducer(state: OverlayState, ev: Bus.BusEvent): OverlayState {
           return state
       }
     }
+    case Bus.TYPE_VERSION_INFO: {
+      return { ...state, versionInfo: ev.versionInfo }
+    }
     default: {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const _: never = ev
@@ -139,6 +144,7 @@ const ReactDevOverlay: React.FunctionComponent<ReactDevOverlayProps> =
       refreshState: {
         type: 'idle',
       },
+      versionInfo: { installed: '0.0.0', staleness: 'unknown' },
     })
 
     React.useEffect(() => {
@@ -182,12 +188,16 @@ const ReactDevOverlay: React.FunctionComponent<ReactDevOverlayProps> =
             <ComponentStyles />
 
             {displayPrevented ? null : hasBuildError ? (
-              <BuildError message={state.buildError!} />
+              <BuildError
+                message={state.buildError!}
+                versionInfo={state.versionInfo}
+              />
             ) : hasRuntimeErrors ? (
               <Errors
                 isAppDir={false}
                 errors={state.errors}
                 initialDisplayState={'fullscreen'}
+                versionInfo={state.versionInfo}
               />
             ) : undefined}
           </ShadowPortal>

--- a/packages/next/src/client/components/react-dev-overlay/pages/bus.ts
+++ b/packages/next/src/client/components/react-dev-overlay/pages/bus.ts
@@ -1,5 +1,6 @@
 import type { StackFrame } from 'next/dist/compiled/stacktrace-parser'
 import type { ComponentStackFrame } from '../internal/helpers/parse-component-stack'
+import type { VersionInfo } from '../../../../server/dev/parse-version-info'
 
 export const TYPE_BUILD_OK = 'build-ok'
 export const TYPE_BUILD_ERROR = 'build-error'
@@ -7,6 +8,7 @@ export const TYPE_REFRESH = 'fast-refresh'
 export const TYPE_BEFORE_REFRESH = 'before-fast-refresh'
 export const TYPE_UNHANDLED_ERROR = 'unhandled-error'
 export const TYPE_UNHANDLED_REJECTION = 'unhandled-rejection'
+export const TYPE_VERSION_INFO = 'version-info'
 
 export type BuildOk = { type: typeof TYPE_BUILD_OK }
 export type BuildError = {
@@ -26,6 +28,12 @@ export type UnhandledRejection = {
   reason: Error
   frames: StackFrame[]
 }
+
+export type VersionInfoEvent = {
+  type: typeof TYPE_VERSION_INFO
+  versionInfo: VersionInfo
+}
+
 export type BusEvent =
   | BuildOk
   | BuildError
@@ -33,6 +41,7 @@ export type BusEvent =
   | BeforeFastRefresh
   | UnhandledError
   | UnhandledRejection
+  | VersionInfoEvent
 
 export type BusEventHandler = (ev: BusEvent) => void
 

--- a/packages/next/src/client/components/react-dev-overlay/pages/client.ts
+++ b/packages/next/src/client/components/react-dev-overlay/pages/client.ts
@@ -5,6 +5,7 @@ import {
   hydrationErrorState,
   patchConsoleError,
 } from '../internal/helpers/hydration-error-info'
+import type { VersionInfo } from '../../../../server/dev/parse-version-info'
 
 // Patch console.error to collect information about hydration errors
 patchConsoleError()
@@ -121,6 +122,10 @@ function onBeforeRefresh() {
   Bus.emit({ type: Bus.TYPE_BEFORE_REFRESH })
 }
 
+function onVersionInfo(versionInfo: VersionInfo) {
+  Bus.emit({ type: Bus.TYPE_VERSION_INFO, versionInfo })
+}
+
 export { getErrorByType } from '../internal/helpers/getErrorByType'
 export { getServerError } from '../internal/helpers/nodeStackFrames'
 export { default as ReactDevOverlay } from './ReactDevOverlay'
@@ -131,4 +136,5 @@ export {
   unregister,
   onBeforeRefresh,
   onRefresh,
+  onVersionInfo,
 }

--- a/packages/next/src/client/dev/error-overlay/hot-dev-client.ts
+++ b/packages/next/src/client/dev/error-overlay/hot-dev-client.ts
@@ -34,6 +34,7 @@ import {
   onBuildOk,
   onBeforeRefresh,
   onRefresh,
+  onVersionInfo,
 } from '../../components/react-dev-overlay/pages/client'
 import stripAnsi from 'next/dist/compiled/strip-ansi'
 import { addMessageListener, sendMessage } from './websocket'
@@ -278,6 +279,10 @@ function processMessage(obj: HMR_ACTION_TYPES) {
       }
 
       const { errors, warnings } = obj
+
+      // Is undefined when it's a 'built' event
+      if ('versionInfo' in obj) onVersionInfo(obj.versionInfo)
+
       const hasErrors = Boolean(errors && errors.length)
       if (hasErrors) {
         sendMessage(

--- a/test/development/basic/hmr.test.ts
+++ b/test/development/basic/hmr.test.ts
@@ -728,11 +728,9 @@ describe.each([[''], ['/docs']])(
           )
 
           expect(await hasRedbox(browser)).toBe(true)
-          expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(`
-                      Error: The default export is not a React Component in page: "/hmr/about5"
-
-                      This error happened while generating the page. Any console logs will be displayed in the terminal window."
-                  `)
+          expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
+            `"Error: The default export is not a React Component in page: "/hmr/about5"`
+          )
 
           await next.patchFile(aboutPage, aboutContent)
 
@@ -828,11 +826,9 @@ describe.each([[''], ['/docs']])(
           )
 
           expect(await hasRedbox(browser)).toBe(true)
-          expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(`
-                      Error: The default export is not a React Component in page: "/hmr/about7"
-
-                      This error happened while generating the page. Any console logs will be displayed in the terminal window."
-                  `)
+          expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
+            `"Error: The default export is not a React Component in page: "/hmr/about7"`
+          )
 
           await next.patchFile(aboutPage, aboutContent)
 
@@ -1014,9 +1010,9 @@ describe.each([[''], ['/docs']])(
           await browser.elementByCss('#error-in-gip-link').click()
 
           expect(await hasRedbox(browser)).toBe(true)
-          expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(`
-            Error: an-expected-error-in-gip"
-          `)
+          expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
+            `"Error: an-expected-error-in-gip"`
+          )
 
           await next.patchFile(
             erroredPage,
@@ -1055,11 +1051,9 @@ describe.each([[''], ['/docs']])(
           browser = await webdriver(next.url, basePath + '/hmr/error-in-gip')
 
           expect(await hasRedbox(browser)).toBe(true)
-          expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(`
-                      Error: an-expected-error-in-gip
-
-                      This error happened while generating the page. Any console logs will be displayed in the terminal window."
-                  `)
+          expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
+            `"Error: an-expected-error-in-gip"`
+          )
 
           const erroredPage = join('pages', 'hmr', 'error-in-gip.js')
 

--- a/test/development/basic/hmr.test.ts
+++ b/test/development/basic/hmr.test.ts
@@ -729,7 +729,7 @@ describe.each([[''], ['/docs']])(
 
           expect(await hasRedbox(browser)).toBe(true)
           expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
-            `"Error: The default export is not a React Component in page: "/hmr/about5"`
+            `"Error: The default export is not a React Component in page: "/hmr/about5""`
           )
 
           await next.patchFile(aboutPage, aboutContent)
@@ -827,7 +827,7 @@ describe.each([[''], ['/docs']])(
 
           expect(await hasRedbox(browser)).toBe(true)
           expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
-            `"Error: The default export is not a React Component in page: "/hmr/about7"`
+            `"Error: The default export is not a React Component in page: "/hmr/about7""`
           )
 
           await next.patchFile(aboutPage, aboutContent)

--- a/test/development/basic/hmr.test.ts
+++ b/test/development/basic/hmr.test.ts
@@ -5,6 +5,7 @@ import {
   check,
   getBrowserBodyText,
   getRedboxHeader,
+  getRedboxDescription,
   getRedboxSource,
   hasRedbox,
   renderViaHTTP,
@@ -727,10 +728,7 @@ describe.each([[''], ['/docs']])(
           )
 
           expect(await hasRedbox(browser)).toBe(true)
-          expect(await getRedboxHeader(browser)).toMatchInlineSnapshot(`
-                      "1 of 1 unhandled error
-                      Server Error
-
+          expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(`
                       Error: The default export is not a React Component in page: "/hmr/about5"
 
                       This error happened while generating the page. Any console logs will be displayed in the terminal window."
@@ -830,10 +828,7 @@ describe.each([[''], ['/docs']])(
           )
 
           expect(await hasRedbox(browser)).toBe(true)
-          expect(await getRedboxHeader(browser)).toMatchInlineSnapshot(`
-                      "1 of 1 unhandled error
-                      Server Error
-
+          expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(`
                       Error: The default export is not a React Component in page: "/hmr/about7"
 
                       This error happened while generating the page. Any console logs will be displayed in the terminal window."
@@ -885,9 +880,7 @@ describe.each([[''], ['/docs']])(
           )
 
           expect(await hasRedbox(browser)).toBe(true)
-          expect(await getRedboxHeader(browser)).toMatchInlineSnapshot(
-            `"Failed to compile"`
-          )
+          expect(await getRedboxHeader(browser)).toMatch('Failed to compile')
           expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
                       "./components/parse-error.xyz
                       Module parse failed: Unexpected token (3:0)
@@ -949,9 +942,7 @@ describe.each([[''], ['/docs']])(
           )
 
           expect(await hasRedbox(browser)).toBe(true)
-          expect(await getRedboxHeader(browser)).toMatchInlineSnapshot(
-            `"Failed to compile"`
-          )
+          expect(await getRedboxHeader(browser)).toMatch('Failed to compile')
           let redboxSource = await getRedboxSource(browser)
 
           redboxSource = redboxSource.replace(`${next.testDir}`, '.')
@@ -1023,10 +1014,7 @@ describe.each([[''], ['/docs']])(
           await browser.elementByCss('#error-in-gip-link').click()
 
           expect(await hasRedbox(browser)).toBe(true)
-          expect(await getRedboxHeader(browser)).toMatchInlineSnapshot(`
-            "1 of 1 unhandled error
-            Unhandled Runtime Error
-
+          expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(`
             Error: an-expected-error-in-gip"
           `)
 
@@ -1067,10 +1055,7 @@ describe.each([[''], ['/docs']])(
           browser = await webdriver(next.url, basePath + '/hmr/error-in-gip')
 
           expect(await hasRedbox(browser)).toBe(true)
-          expect(await getRedboxHeader(browser)).toMatchInlineSnapshot(`
-                      "1 of 1 unhandled error
-                      Server Error
-
+          expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(`
                       Error: an-expected-error-in-gip
 
                       This error happened while generating the page. Any console logs will be displayed in the terminal window."

--- a/test/integration/next-image-new/invalid-image-import/test/index.test.ts
+++ b/test/integration/next-image-new/invalid-image-import/test/index.test.ts
@@ -23,7 +23,7 @@ function runTests({ isDev }) {
     if (isDev) {
       const browser = await webdriver(appPort, '/')
       expect(await hasRedbox(browser)).toBe(true)
-      expect(await getRedboxHeader(browser)).toBe('Failed to compile')
+      expect(await getRedboxHeader(browser)).toMatch('Failed to compile')
       const source = await getRedboxSource(browser)
       if (process.env.TURBOPACK) {
         expect(source).toMatchInlineSnapshot(`


### PR DESCRIPTION
### What?

Before:
![image](https://github.com/vercel/next.js/assets/18369201/049760a5-8aeb-4b77-9bca-059de9a3a17f)

After:
![image](https://github.com/vercel/next.js/assets/18369201/c4b727ec-2765-43fd-973d-29f50468f9f9)

### Why?

The same way we indicate version staleness to the user in the App Router, we should do the same in the Pages Router for a better DX.

### How?

The server already sent this info to the Pages error overlay, but we did not handle it correctly previously. During a sync event with the server, we now emit the version info and properly pass it to the error overlay components.

Note: Currently the Pages/App overlays duplicate a lot of code. To prevent out-of-sync behavior in the future like this, I started another PR #62939 that will unify the repeated parts.


[Slack thread](https://vercel.slack.com/archives/C04CAN8CGCE/p1709644807257459)
Closes NEXT-2711