### PR TITLE
feat(next): fallback lightning if swc/wasm loaded

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1087,6 +1087,18 @@ export default async function loadConfig(
       userConfig.experimental.turbo.rules = rules
     }
 
+    if (userConfig.experimental?.useLightningcss) {
+      const { loadBindings } = require('next/dist/build/swc')
+      const isLightningSupported = (await loadBindings())?.css?.lightning
+
+      if (!isLightningSupported) {
+        curLog.warn(
+          `experimental.useLightningcss is set, but the setting is disabled because next-swc/wasm does not support it yet.`
+        )
+        userConfig.experimental.useLightningcss = false
+      }
+    }
+
     onLoadUserConfig?.(userConfig)
     const completeConfig = assignDefaults(
       dir,


### PR DESCRIPTION
### What?

Currently wasm binding cannot build lightningcss, until we can make it work falls back to normal css if lightningcss is enabled + wasm bindings are loaded.



Closes PACK-2678