### PR TITLE
Remove Payload from server-external-packages.json

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/serverComponentsExternalPackages.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/serverComponentsExternalPackages.mdx
@@ -54,7 +54,6 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `next-seo`
 - `node-pty`
 - `node-web-audio-api`
-- `payload`
 - `pg`
 - `playwright`
 - `postcss`

--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -33,7 +33,6 @@
   "next-seo",
   "node-pty",
   "node-web-audio-api",
-  "payload",
   "pg",
   "playwright",
   "postcss",


### PR DESCRIPTION
Payload is moving to ESM, and we need to be removed from the default list of `serverComponentsExternalPackages`. 

This PR simply removes Payload from the default list. Developers can add it back in if they are using older versions of Payload.
