### PR TITLE
fix(cli): respect SIGTERM and SIGINT exit codes in next dev

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -301,7 +301,7 @@ const nextDev = async (
           }
           return startServer(startServerOptions)
         }
-        await handleSessionStop(code, signal)
+        await handleSessionStop(code || 1, signal)
       })
     })
   }

--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -49,17 +49,28 @@ const runAndCaptureOutput = async ({ port }) => {
   return { stdout, stderr }
 }
 
+const exitCodes = (killSignal) => {
+  switch (killSignal) {
+    case 'SIGINT':
+      return 143
+    case 'SIGTERM':
+      return 130
+    default:
+      return 0
+  }
+}
+
 const testExitSignal = async (
   killSignal = '',
   args = [],
   readyRegex = /Creating an optimized production/
 ) => {
+  const exitCode = exitCodes(killSignal)
   let instance
   const killSigint = (inst) => {
     instance = inst
   }
   let output = ''
-
   let cmdPromise = runNextCommand(args, {
     ignoreFail: true,
     instance: killSigint,
@@ -76,7 +87,7 @@ const testExitSignal = async (
   // See: https://nodejs.org/api/process.html#process_signal_events
   const expectedExitSignal = process.platform === `win32` ? killSignal : null
   expect(signal).toBe(expectedExitSignal)
-  expect(code).toBe(0)
+  expect(code).toBe(exitCode)
 }
 
 describe('CLI Usage', () => {


### PR DESCRIPTION
## Changes

- Related → https://github.com/vercel/next.js/pull/62907

Closes NEXT-2733