### PR TITLE
chore: update pnpm version from 8.15.1 to 8.15.4

### DIFF
--- a/.github/actions/next-integration-stat/package.json
+++ b/.github/actions/next-integration-stat/package.json
@@ -22,7 +22,7 @@
   },
   "engines": {
     "node": ">=18.17.0",
-    "pnpm": "8.15.1"
+    "pnpm": "8.15.4"
   },
-  "packageManager": "pnpm@8.15.1"
+  "packageManager": "pnpm@8.15.4"
 }

--- a/.github/actions/next-stats-action/package.json
+++ b/.github/actions/next-stats-action/package.json
@@ -19,7 +19,7 @@
   },
   "engines": {
     "node": ">=18.17.0",
-    "pnpm": "8.15.1"
+    "pnpm": "8.15.4"
   },
-  "packageManager": "pnpm@8.15.1"
+  "packageManager": "pnpm@8.15.4"
 }

--- a/.github/actions/upload-turboyet-data/package.json
+++ b/.github/actions/upload-turboyet-data/package.json
@@ -13,7 +13,7 @@
   },
   "engines": {
     "node": ">=18.17.0",
-    "pnpm": "8.15.1"
+    "pnpm": "8.15.4"
   },
-  "packageManager": "pnpm@8.15.1"
+  "packageManager": "pnpm@8.15.4"
 }

--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
   },
   "engines": {
     "node": ">=18.17.0",
-    "pnpm": "8.15.1"
+    "pnpm": "8.15.4"
   },
-  "packageManager": "pnpm@8.15.1"
+  "packageManager": "pnpm@8.15.4"
 }

--- a/test/.stats-app/package.json
+++ b/test/.stats-app/package.json
@@ -9,7 +9,7 @@
   },
   "engines": {
     "node": ">=18.17.0",
-    "pnpm": "8.15.1"
+    "pnpm": "8.15.4"
   },
-  "packageManager": "pnpm@8.15.1"
+  "packageManager": "pnpm@8.15.4"
 }


### PR DESCRIPTION
Update pnpm version from 8.15.1 to 8.15.4
pnpm 8.15.4 release note https://github.com/pnpm/pnpm/releases/tag/v8.15.4

Previous comment form reviewer  
https://github.com/vercel/next.js/pull/62963#issuecomment-1982010314