### PR TITLE
Move timeout to test step and give whole job a bigger timeout

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -72,7 +72,7 @@ env:
 
 jobs:
   build:
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on:
       - 'self-hosted'
       - 'linux'
@@ -171,6 +171,7 @@ jobs:
       - run: turbo run get-test-timings -- --build ${{ github.sha }}
 
       - run: /bin/bash -c "${{ inputs.afterBuild }}"
+        timeout-minutes: 15
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### Why?

Sometimes the turbo build-native command takes longer to restore stealing time from the actual test job


Closes PACK-2681