### PR TITLE
Fix the plugin state for async modules in webpack plugins

### DIFF
--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -238,12 +238,11 @@ export class FlightClientEntryPlugin {
           if (compilation.moduleGraph.isAsync(mod)) {
             // The module must has resolved resource path so it's not a new entry created with loader.
             // Checking the module layer to make sure it's from client layers (SSR or browser, not RSC).
-            const modPath = mod.resourceResolveData?.path
-            if (modPath) pluginState.ASYNC_CLIENT_MODULES.add(modPath)
+            if (mod.resource) pluginState.ASYNC_CLIENT_MODULES.add(mod.resource)
           }
         }
 
-        recordModule(modId, mod)
+        if (modId) recordModule(modId, mod)
       })
     })
 
@@ -545,8 +544,8 @@ export class FlightClientEntryPlugin {
         // We have to always use the resolved request here to make sure the
         // server and client are using the same module path (required by RSC), as
         // the server compiler and client compiler have different resolve configs.
-        let modRequest: string | undefined =
-          modPath + mod.resourceResolveData?.query
+        let modRequest: string =
+          modPath + (mod.resourceResolveData?.query || '')
 
         // For the barrel optimization, we need to use the match resource instead
         // because there will be 2 modules for the same file (same resource path)
@@ -949,6 +948,7 @@ export class FlightClientEntryPlugin {
       if (
         chunkGroup.name &&
         mod.request &&
+        modId &&
         /next-flight-action-entry-loader/.test(mod.request)
       ) {
         const fromClient = /&__client_imported__=true/.test(mod.request)

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -96,7 +96,8 @@ const pluginState = getProxiedPluginState({
   // Collect modules from server/edge compiler in client layer,
   // and detect if it's been used, and mark it as `async: true` for react.
   // So that react could unwrap the async module from promise and render module itself.
-  ASYNC_CLIENT_MODULES: new Set() as Set<string[]>,
+  // Use an object to simulate Set lookup
+  ASYNC_CLIENT_MODULES: {} as Record<string, boolean>,
 
   injectedClientEntries: {} as Record<string, string>,
 })
@@ -234,11 +235,11 @@ export class FlightClientEntryPlugin {
       }
 
       traverseModules(compilation, (mod, _chunk, _chunkGroup, modId) => {
-        if (mod && !isWebpackServerOnlyLayer(mod.layer)) {
+        if (mod && mod.resource && !isWebpackServerOnlyLayer(mod.layer)) {
           if (compilation.moduleGraph.isAsync(mod)) {
             // The module must has resolved resource path so it's not a new entry created with loader.
             // Checking the module layer to make sure it's from client layers (SSR or browser, not RSC).
-            if (mod.resource) pluginState.ASYNC_CLIENT_MODULES.add(mod.resource)
+            pluginState.ASYNC_CLIENT_MODULES[mod.resource] = true
           }
         }
 

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -22,6 +22,7 @@ import {
   DEFAULT_RUNTIME_WEBPACK,
   EDGE_RUNTIME_WEBPACK,
   SERVER_REFERENCE_MANIFEST,
+  UNDERSCORE_NOT_FOUND_ROUTE_ENTRY,
 } from '../../../shared/lib/constants'
 import {
   getActions,
@@ -335,6 +336,23 @@ export class FlightClientEntryPlugin {
           bundlePath,
           absolutePagePath: entryRequest,
         })
+
+        // The webpack implementation of writing the client reference manifest relies on all entrypoints writing a page.js even when there is no client components in the page.
+        // It needs the file in order to write the reference manifest for the path in the `.next/server` folder.
+        // TODO-APP: This could be better handled, however Turbopack does not have the same problem as we resolve client components in a single graph.
+        if (
+          name === `app${UNDERSCORE_NOT_FOUND_ROUTE_ENTRY}` &&
+          bundlePath === 'app/not-found'
+        ) {
+          clientEntriesToInject.push({
+            compiler,
+            compilation,
+            entryName: name,
+            clientComponentImports: {},
+            bundlePath: `app${UNDERSCORE_NOT_FOUND_ROUTE_ENTRY}`,
+            absolutePagePath: entryRequest,
+          })
+        }
       }
 
       // Make sure CSS imports are deduplicated before injecting the client entry

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -40,7 +40,8 @@ export type ManifestChunks = Array<string>
 const pluginState = getProxiedPluginState({
   serverModuleIds: {} as Record<string, string | number>,
   edgeServerModuleIds: {} as Record<string, string | number>,
-  ASYNC_CLIENT_MODULES: new Set() as Set<string>,
+  // Use an object to simulate Set lookup
+  ASYNC_CLIENT_MODULES: {} as Record<string, boolean>,
 })
 
 export interface ManifestNode {
@@ -300,7 +301,7 @@ export class ClientReferenceManifestPlugin {
         if (!ssrNamedModuleId.startsWith('.'))
           ssrNamedModuleId = `./${ssrNamedModuleId.replace(/\\/g, '/')}`
 
-        const isAsyncModule = pluginState.ASYNC_CLIENT_MODULES.has(mod.resource)
+        const isAsyncModule = !!pluginState.ASYNC_CLIENT_MODULES[mod.resource]
 
         // The client compiler will always use the CJS Next.js build, so here we
         // also add the mapping for the ESM build (Edge runtime) to consume.
@@ -496,6 +497,6 @@ export class ClientReferenceManifestPlugin {
       ) as unknown as webpack.sources.RawSource
     }
 
-    pluginState.ASYNC_CLIENT_MODULES = new Set<string>()
+    pluginState.ASYNC_CLIENT_MODULES = {}
   }
 }

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -300,8 +300,7 @@ export class ClientReferenceManifestPlugin {
         if (!ssrNamedModuleId.startsWith('.'))
           ssrNamedModuleId = `./${ssrNamedModuleId.replace(/\\/g, '/')}`
 
-        const modResource = mod.resourceResolveData?.path || ''
-        const isAsyncModule = pluginState.ASYNC_CLIENT_MODULES.has(modResource)
+        const isAsyncModule = pluginState.ASYNC_CLIENT_MODULES.has(mod.resource)
 
         // The client compiler will always use the CJS Next.js build, so here we
         // also add the mapping for the ESM build (Edge runtime) to consume.

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -40,7 +40,7 @@ export type ManifestChunks = Array<string>
 const pluginState = getProxiedPluginState({
   serverModuleIds: {} as Record<string, string | number>,
   edgeServerModuleIds: {} as Record<string, string | number>,
-  ASYNC_CLIENT_MODULES: [] as string[],
+  ASYNC_CLIENT_MODULES: new Set() as Set<string>,
 })
 
 export interface ManifestNode {
@@ -175,13 +175,11 @@ export class ClientReferenceManifestPlugin {
   dev: Options['dev'] = false
   appDir: Options['appDir']
   appDirBase: string
-  ASYNC_CLIENT_MODULES: Set<string>
 
   constructor(options: Options) {
     this.dev = options.dev
     this.appDir = options.appDir
     this.appDirBase = path.dirname(this.appDir) + path.sep
-    this.ASYNC_CLIENT_MODULES = new Set(pluginState.ASYNC_CLIENT_MODULES)
   }
 
   apply(compiler: webpack.Compiler) {
@@ -276,7 +274,7 @@ export class ClientReferenceManifestPlugin {
         .filter((f) => !f.startsWith('static/css/pages/') && f.endsWith('.css'))
 
       const requiredChunks = getAppPathRequiredChunks(entrypoint, rootMainFiles)
-      const recordModule = (id: ModuleId, mod: webpack.NormalModule) => {
+      const recordModule = (modId: ModuleId, mod: webpack.NormalModule) => {
         let resource =
           mod.type === 'css/mini-extract'
             ? // @ts-expect-error TODO: use `identifier()` instead.
@@ -302,7 +300,8 @@ export class ClientReferenceManifestPlugin {
         if (!ssrNamedModuleId.startsWith('.'))
           ssrNamedModuleId = `./${ssrNamedModuleId.replace(/\\/g, '/')}`
 
-        const isAsyncModule = this.ASYNC_CLIENT_MODULES.has(mod.resource)
+        const modResource = mod.resourceResolveData?.path || ''
+        const isAsyncModule = pluginState.ASYNC_CLIENT_MODULES.has(modResource)
 
         // The client compiler will always use the CJS Next.js build, so here we
         // also add the mapping for the ESM build (Edge runtime) to consume.
@@ -328,7 +327,7 @@ export class ClientReferenceManifestPlugin {
         function addClientReference() {
           const exportName = resource
           manifest.clientModules[exportName] = {
-            id,
+            id: modId,
             name: '*',
             chunks: requiredChunks,
             async: isAsyncModule,
@@ -345,8 +344,8 @@ export class ClientReferenceManifestPlugin {
           if (
             typeof pluginState.serverModuleIds[ssrNamedModuleId] !== 'undefined'
           ) {
-            moduleIdMapping[id] = moduleIdMapping[id] || {}
-            moduleIdMapping[id]['*'] = {
+            moduleIdMapping[modId] = moduleIdMapping[modId] || {}
+            moduleIdMapping[modId]['*'] = {
               ...manifest.clientModules[exportName],
               // During SSR, we don't have external chunks to load on the server
               // side with our architecture of Webpack / Turbopack. We can keep
@@ -360,8 +359,8 @@ export class ClientReferenceManifestPlugin {
             typeof pluginState.edgeServerModuleIds[ssrNamedModuleId] !==
             'undefined'
           ) {
-            edgeModuleIdMapping[id] = edgeModuleIdMapping[id] || {}
-            edgeModuleIdMapping[id]['*'] = {
+            edgeModuleIdMapping[modId] = edgeModuleIdMapping[modId] || {}
+            edgeModuleIdMapping[modId]['*'] = {
               ...manifest.clientModules[exportName],
               // During SSR, we don't have external chunks to load on the server
               // side with our architecture of Webpack / Turbopack. We can keep
@@ -498,6 +497,6 @@ export class ClientReferenceManifestPlugin {
       ) as unknown as webpack.sources.RawSource
     }
 
-    pluginState.ASYNC_CLIENT_MODULES = []
+    pluginState.ASYNC_CLIENT_MODULES = new Set<string>()
   }
 }

--- a/packages/next/src/build/webpack/utils.ts
+++ b/packages/next/src/build/webpack/utils.ts
@@ -7,7 +7,7 @@ export function traverseModules(
     mod: any,
     chunk: webpack.Chunk,
     chunkGroup: (typeof compilation.chunkGroups)[0],
-    modId: string | number
+    modId: string
   ) => any,
   filterChunkGroup?: (chunkGroup: webpack.ChunkGroup) => boolean
 ) {
@@ -21,7 +21,7 @@ export function traverseModules(
         // TODO: Update type so that it doesn't have to be cast.
       ) as Iterable<webpack.NormalModule>
       for (const mod of chunkModules) {
-        const modId = compilation.chunkGraph.getModuleId(mod)
+        const modId = compilation.chunkGraph.getModuleId(mod).toString()
         callback(mod, chunk, chunkGroup, modId)
         const anyModule = mod as any
         if (anyModule.modules) {

--- a/packages/next/src/build/webpack/utils.ts
+++ b/packages/next/src/build/webpack/utils.ts
@@ -7,7 +7,7 @@ export function traverseModules(
     mod: any,
     chunk: webpack.Chunk,
     chunkGroup: (typeof compilation.chunkGroups)[0],
-    modId: string
+    modId: string | null
   ) => any,
   filterChunkGroup?: (chunkGroup: webpack.ChunkGroup) => boolean
 ) {
@@ -21,7 +21,7 @@ export function traverseModules(
         // TODO: Update type so that it doesn't have to be cast.
       ) as Iterable<webpack.NormalModule>
       for (const mod of chunkModules) {
-        const modId = compilation.chunkGraph.getModuleId(mod).toString()
+        const modId = compilation.chunkGraph.getModuleId(mod)?.toString()
         callback(mod, chunk, chunkGroup, modId)
         const anyModule = mod as any
         if (anyModule.modules) {


### PR DESCRIPTION
### What

Use the plugin state directly in flight plugins to access the async modules collection

### Why

This change is cherry-picked from #62349 , where I found the plugin state didn't store the async modules reousces properly due to the clone of the array in flight manifest plugin. So for flight manifestp plugin itself, it's holding a different instance rather than the one from proxy state.

Closes NEXT-2743