### PR TITLE
improve `chainStreams` comment and add test case for issue

### DIFF
--- a/packages/next/src/server/stream-utils/node-web-streams-helper.test.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.test.ts
@@ -1,20 +1,31 @@
+import { setImmediate } from 'timers/promises'
 import {
   chainStreams,
   streamFromString,
   streamToString,
 } from './node-web-streams-helper'
 
+async function processReadableStream(
+  readableStream: ReadableStream,
+  chunks: unknown[]
+) {
+  const reader = readableStream.getReader()
+  let done, value
+  for (const chunk of chunks) {
+    ;({ done, value } = await reader.read())
+    expect(done).toStrictEqual(false)
+    expect(value).toStrictEqual(chunk)
+  }
+  ;({ done, value } = await reader.read())
+  expect(done).toStrictEqual(true)
+  expect(value).toStrictEqual(undefined)
+}
+
 describe('node-web-stream-helpers', () => {
   describe('streamFromString', () => {
     it('should encode the string into a stream', async () => {
       const stream = streamFromString('abc')
-      const reader = stream.getReader()
-      let { done, value } = await reader.read()
-      expect(done).toStrictEqual(false)
-      expect(value).toStrictEqual(new Uint8Array([97, 98, 99]))
-      ;({ done, value } = await reader.read())
-      expect(done).toStrictEqual(true)
-      expect(value).toStrictEqual(undefined)
+      await processReadableStream(stream, [new Uint8Array([97, 98, 99])])
     })
   })
   describe('streamToString', () => {
@@ -59,15 +70,7 @@ describe('node-web-stream-helpers', () => {
       const inputs = ['abcd', 'efgh', 'ijkl', 'mnop', 'qrst', 'uvwx', 'yz00']
       const streams = inputs.map((input) => createReadableStream(input))
       const stream = chainStreams(...streams)
-      const reader = stream.getReader()
-      for (let i = 0; i < inputs.length; i++) {
-        const { done, value } = await reader.read()
-        expect(done).toStrictEqual(false)
-        expect(value).toStrictEqual(inputs[i])
-      }
-      const { done, value } = await reader.read()
-      expect(done).toStrictEqual(true)
-      expect(value).toStrictEqual(undefined)
+      await processReadableStream(stream, inputs)
     })
     it('should throw errors from chained streams', async () => {
       const r1 = new ReadableStream({
@@ -83,7 +86,7 @@ describe('node-web-stream-helpers', () => {
       })
       const chained = chainStreams(r1, r2)
       const reader = chained.getReader()
-      let { done, value } = await reader.read()
+      const { done, value } = await reader.read()
       expect(done).toStrictEqual(false)
       expect(value).toStrictEqual('abcd')
       try {
@@ -91,6 +94,87 @@ describe('node-web-stream-helpers', () => {
       } catch (err) {
         expect(err).toStrictEqual(new Error('Error from ReadableStream 2'))
       }
+    })
+    it('should skip processing a canceled streams', async () => {
+      const r1 = new ReadableStream({
+        start(controller) {
+          controller.enqueue('abcd')
+          controller.close()
+        },
+      })
+      const r2 = new ReadableStream({
+        start(controller) {
+          controller.enqueue('efgh')
+          controller.close()
+        },
+      })
+      const r3 = new ReadableStream({
+        start(controller) {
+          controller.enqueue('ijkl')
+          controller.close()
+        },
+      })
+      const chained = chainStreams(r1, r2, r3)
+      await r2.cancel()
+      await processReadableStream(chained, ['abcd', 'ijkl'])
+    })
+    describe('chainStreams failure cases', () => {
+      // The following tests demonstrate existing issues with the chainStreams function
+
+      it('should hang reading an input stream that is already read from', async () => {
+        // This test demonstrates the current issue with the chainStreams function
+        // This test will hang at the second read operation of the output stream
+        // because the second input stream is already read.
+        //
+        // Ideally, `chainStreams` should error when it receives a stream thats already locked
+        const r1 = new ReadableStream({
+          start(controller) {
+            controller.enqueue('abcd')
+            controller.close()
+          },
+        })
+        const r2 = new ReadableStream({
+          start(controller) {
+            controller.enqueue('efgh')
+            controller.close()
+          },
+        })
+        const r3 = new ReadableStream({
+          start(controller) {
+            controller.enqueue('ijkl')
+            controller.close()
+          },
+        })
+        // read r2 first, before chaining it
+        await processReadableStream(r2, ['efgh'])
+        // check stream locks - r2 is locked because it was already read
+        expect(r1.locked).toStrictEqual(false)
+        expect(r2.locked).toStrictEqual(true)
+        expect(r3.locked).toStrictEqual(false)
+        // chain - doesn't fail, but probably should
+        const chained = chainStreams(r1, r2, r3)
+        // now r1 is locked too
+        expect(r1.locked).toStrictEqual(true)
+        expect(r2.locked).toStrictEqual(true)
+        expect(r3.locked).toStrictEqual(false)
+        // read from chainStreams output
+        const reader = chained.getReader()
+        const { done, value } = await reader.read()
+        expect(done).toStrictEqual(false)
+        expect(value).toStrictEqual('abcd')
+        // Promise.race will return a promise that settles with the state of
+        // the first promise that settles within the list. In Node.js, timers
+        // are resolved in a separate stack from other async operations. So,
+        // if the chained reader doesn't hang, then `val` will be a normal
+        // readable stream read operation output (`{ done, value }`). Instead,
+        // since it hangs, the `setImmediate` returns the string `'read hangs'`
+        const val = await Promise.race([
+          reader.read(),
+          setImmediate('read hangs'),
+        ])
+
+        expect(val).toStrictEqual('read hangs')
+      })
     })
   })
 

--- a/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.ts
@@ -19,11 +19,12 @@ export type ReactReadableStream = ReadableStream<Uint8Array> & {
 const encoder = new TextEncoder()
 
 /**
- * Attention: ReadableStreams passed to this function will **not** be used
- * until the output ReadableStream is completely read from. The output
- * ReadableStream is not _connected_ to the input streams, meaning that closing
- * an input will cause an error once the output is read from. Furthermore,
- * closing the output will not close any of the inputs.
+ * Attention: ReadableStreams passed to this function will **not** be _read_
+ * until the output ReadableStream is completely read. This leads to some
+ * unexpected behavior. For example, cancelling or reading an input stream
+ * _before_ the output stream is read from will cause the output stream read
+ * operation to hang indefinitely. See the test `chainStreams failure cases`
+ * for more details.
  *
  * Considering this function is used strictly by `server/render.tsx` and
  * `server/app-render.tsx` at the moment, we see no need to fix it. This


### PR DESCRIPTION
This PR improves the `chainStreams` comment and adds a test case for the issue I discovered.

We are not interested in fixing this method right now, but I thought it was important we document and test the discovered issue. 

Closes NEXT-2747