### PR TITLE
Add test for `createInsertedHTMLStream`

### DIFF
--- a/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.ts
@@ -155,7 +155,7 @@ export function createBufferedTransformStream(): TransformStream<
   })
 }
 
-function createInsertedHTMLStream(
+export function createInsertedHTMLStream(
   getServerInsertedHTML: () => Promise<string>
 ): TransformStream<Uint8Array, Uint8Array> {
   return new TransformStream({


### PR DESCRIPTION
Adds a test for `createInsertedHTMLStream` by validating it inserts and encodes the HTML string returned by the `getServerInsertedHTML` argument.

Closes NEXT-2750