### PR TITLE
Add test for `createDeferredSuffixStream`

### DIFF
--- a/packages/next/src/server/stream-utils/node-web-streams-helper.test.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.test.ts
@@ -1,6 +1,7 @@
 import { setImmediate } from 'timers/promises'
 import {
   chainStreams,
+  createDeferredSuffixStream,
   streamFromString,
   streamToString,
 } from './node-web-streams-helper'
@@ -182,7 +183,24 @@ describe('node-web-stream-helpers', () => {
   describe('createInsertedHTMLStream', () => {})
   describe('renderToInitialFizzStream', () => {})
   describe('createHeadInsertionTransformStream', () => {})
-  describe('createDeferredSuffixStream', () => {})
+  describe('createDeferredSuffixStream', () => {
+    it('should append suffix to end of input stream', async () => {
+      const encoder = new TextEncoder()
+      const input = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('<fuzz>buzz</fuzz>'))
+          controller.close()
+        },
+      })
+
+      const stream = createDeferredSuffixStream('<foo>bar</foo>')
+      const output = input.pipeThrough(stream)
+      await processReadableStream(output, [
+        encoder.encode('<fuzz>buzz</fuzz>'),
+        encoder.encode('<foo>bar</foo>'),
+      ])
+    })
+  })
   describe('createMergedTransformStream', () => {})
   describe('createMoveSuffixStream', () => {})
   describe('createStripDocumentClosingTagsTransform', () => {})

--- a/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.ts
@@ -244,7 +244,7 @@ function createHeadInsertionTransformStream(
 
 // Suffix after main body content - scripts before </body>,
 // but wait for the major chunks to be enqueued.
-function createDeferredSuffixStream(
+export function createDeferredSuffixStream(
   suffix: string
 ): TransformStream<Uint8Array, Uint8Array> {
   let flushed = false


### PR DESCRIPTION
Add test for `createDeferredSuffixStream`. This function seems incredibly similar to `createInsertedHTMLStream`. They are implemented differently, but do the same thing. Maybe there is some test case that demonstrates how they are different?

Closes NEXT-2752