### PR TITLE
Add `continueFizzStream` tests

### DIFF
--- a/packages/next/src/server/stream-utils/node-web-streams-helper.test.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.test.ts
@@ -302,8 +302,13 @@ describe('node-web-stream-helpers', () => {
 
       it('should continue fizz stream operation using default arguments', async () => {
         const input: ReactReadableStream = defaultReactReadableStreamFactory()
-        // TODO: Somehow spy on `input.allReady` and assert it gets awaited
+        let allReadyAwaited = false
+        input.allReady = setImmediate().then(() => {
+          allReadyAwaited = true
+        })
+        expect(allReadyAwaited).toBe(false)
         const output = await continueFizzStream(input, defaultOptionsFactory())
+        expect(allReadyAwaited).toBe(true)
         const expected = encoder.encode(
           '<server-html>Server HTML</server-html>' + // server-inserted happens first
             '<html><head><title>My Website</title></head><body><div><h1>My Website</h1></div>' + // react content
@@ -325,12 +330,17 @@ describe('node-web-stream-helpers', () => {
       it('should continue fizz stream operation using default arguments', async () => {
         const options = {
           ...defaultOptionsFactory(),
-          isStaticGeneration: true, // not always true, but only impacts `allReady` being awaited
+          isStaticGeneration: true, // not always true, but impacts `allReady` being awaited
         }
 
         const input: ReactReadableStream = defaultReactReadableStreamFactory()
-        // TODO: Spy on `input.allReady` and assert it gets awaited
+        let allReadyAwaited = false
+        input.allReady = setImmediate().then(() => {
+          allReadyAwaited = true
+        })
+        expect(allReadyAwaited).toBe(false)
         const output = await continueFizzStream(input, options)
+        expect(allReadyAwaited).toBe(true)
         const expected = encoder.encode(
           '<html><head><title>My Website</title>' + // start react content
             '<server-html>Server HTML</server-html>' + // server-inserted before end of `</head>` tag

--- a/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.ts
@@ -538,6 +538,7 @@ export async function continueFizzStream(
   // If we're generating static HTML and there's an `allReady` promise on the
   // stream, we need to wait for it to resolve before continuing.
   if (isStaticGeneration && 'allReady' in renderStream) {
+    console.log('🧪')
     await renderStream.allReady
   }
 

--- a/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.ts
@@ -538,7 +538,6 @@ export async function continueFizzStream(
   // If we're generating static HTML and there's an `allReady` promise on the
   // stream, we need to wait for it to resolve before continuing.
   if (isStaticGeneration && 'allReady' in renderStream) {
-    console.log('🧪')
     await renderStream.allReady
   }
 


### PR DESCRIPTION
Adds tests for the `continueFizzStream` method that is used throughout both pages and app router. 

The tests are not perfectly exhaustive, and instead try to mimic actual usage. 

Closes NEXT-2755