### PR TITLE
fix flakey HMR test

### DIFF
--- a/test/development/basic/hmr.test.ts
+++ b/test/development/basic/hmr.test.ts
@@ -1211,7 +1211,7 @@ describe.each([[''], ['/docs']])(
         ]
         const [, compileTime, timeUnit] = matches
 
-        let compileTimeMs = parseFloat(compileTime[1])
+        let compileTimeMs = parseFloat(compileTime)
         if (timeUnit === 's') {
           compileTimeMs = compileTimeMs * 1000
         }


### PR DESCRIPTION
The "Compiled" HMR log is emitted as follows:

> Compiled in 54ms

When running this string through the matcher, we get:
```
> const matches = "Compiled in 54ms".match(/Compiled.*? in ([\d.]{1,})\s?(?:s|ms)/i) 
console.log(matches[1]); // 54
```

We correctly assign `compileTime` to `matches[1]`. However, we then assign `compileTimeMs` to `parseFloat(compileTime[1])`. This is definitely an error, as `compileTime[1]` would be `4` in the above example.

This means that if the compilation time takes less than a single digit value, it'd be coerced to NaN. 

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2757