### PR TITLE
Fix flaky test by removing unecessary NODE_OPTIONS='--inspect'

### DIFF
--- a/test/integration/config-mjs/test/index.test.js
+++ b/test/integration/config-mjs/test/index.test.js
@@ -18,9 +18,6 @@ describe('Configuration', () => {
 
     context.appPort = await findPort()
     context.server = await launchApp(join(__dirname, '../'), context.appPort, {
-      env: {
-        NODE_OPTIONS: '--inspect',
-      },
       onStdout: handleOutput,
       onStderr: handleOutput,
     })

--- a/test/integration/config/test/index.test.js
+++ b/test/integration/config/test/index.test.js
@@ -18,9 +18,6 @@ describe('Configuration', () => {
 
     context.appPort = await findPort()
     context.server = await launchApp(join(__dirname, '../'), context.appPort, {
-      env: {
-        NODE_OPTIONS: '--inspect',
-      },
       onStdout: handleOutput,
       onStderr: handleOutput,
     })


### PR DESCRIPTION
## Why?

We have a flaky test with `NODE_OPTIONS='--inspect'` test in https://github.com/vercel/next.js/blob/canary/test/integration/cli/test/index.test.js because with Turbopack, we run several integration tests concurrently.

Our integration tests are ran concurrently, so anything that adds `NODE_OPTIONS='--inspect'` can clash with another when `run-tests.js` is ran. Hence, the result below.

- https://github.com/vercel/next.js/actions/runs/8189378285/job/22394053022?pr=62999

You can confirm this locally by running `TURBOPACK=1 node run-tests.js --test-pattern "test\\/integration\\/(cli|config-mjs)\\/test\\/index\\.test\\.js"`.

## Changes

Both https://github.com/vercel/next.js/blob/canary/test/integration/config-mjs/test/index.test.js and https://github.com/vercel/next.js/blob/canary/test/integration/config/test/index.test.js add a now unnecessary `NODE_OPTIONS='--inspect'` because the minimum version of Node is now [v18](https://nextjs.org/docs/app/building-your-application/upgrading/app-router-migration#nodejs-version), so we should be good to remove them.

x-ref: https://github.com/vercel/next.js/pull/25876

Closes NEXT-2759