### PR TITLE
refactor(next/build): add PostCSS types

### DIFF
--- a/packages/next/src/build/webpack/config/blocks/css/index.ts
+++ b/packages/next/src/build/webpack/config/blocks/css/index.ts
@@ -1,4 +1,5 @@
 import curry from 'next/dist/compiled/lodash.curry'
+import type { Postcss, Processor } from 'next/dist/compiled/postcss'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import { loader, plugin } from '../../helpers'
 import { pipe } from '../../utils'
@@ -53,7 +54,13 @@ function markRemovable(r: webpack.RuleSetRule): webpack.RuleSetRule {
   return r
 }
 
-let postcssInstancePromise: Promise<any>
+export type PostcssInstance = {
+  postcss: Postcss
+  postcssWithPlugins: Processor
+}
+
+let postcssInstancePromise: Promise<PostcssInstance> | undefined
+
 export async function lazyPostCSS(
   rootDirectory: string,
   supportedBrowsers: string[] | undefined,
@@ -61,7 +68,7 @@ export async function lazyPostCSS(
 ) {
   if (!postcssInstancePromise) {
     postcssInstancePromise = (async () => {
-      const postcss = require('postcss')
+      const postcss: Postcss = require('postcss')
       // @ts-ignore backwards compat
       postcss.plugin = function postcssPlugin(name, initializer) {
         function creator(...args: any) {

--- a/packages/next/src/build/webpack/config/blocks/css/loaders/global.ts
+++ b/packages/next/src/build/webpack/config/blocks/css/loaders/global.ts
@@ -1,3 +1,4 @@
+import type { PostcssInstance } from '../index'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import type { ConfigurationContext } from '../../../utils'
 
@@ -6,7 +7,7 @@ import { cssFileResolve } from './file-resolve'
 
 export function getGlobalCssLoader(
   ctx: ConfigurationContext,
-  postcss: any,
+  postcss: () => Promise<PostcssInstance>,
   preProcessors: readonly webpack.RuleSetUseItem[] = []
 ): webpack.RuleSetUseItem[] {
   const loaders: webpack.RuleSetUseItem[] = []

--- a/packages/next/src/build/webpack/config/blocks/css/loaders/modules.ts
+++ b/packages/next/src/build/webpack/config/blocks/css/loaders/modules.ts
@@ -1,3 +1,4 @@
+import type { PostcssInstance } from '../index'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import type { ConfigurationContext } from '../../../utils'
 import { getClientStyleLoader } from './client'
@@ -6,7 +7,7 @@ import { getCssModuleLocalIdent } from './getCssModuleLocalIdent'
 
 export function getCssModuleLoader(
   ctx: ConfigurationContext,
-  postcss: any,
+  postcss: () => Promise<PostcssInstance>,
   preProcessors: readonly webpack.RuleSetUseItem[] = []
 ): webpack.RuleSetUseItem[] {
   const loaders: webpack.RuleSetUseItem[] = []

--- a/packages/next/src/build/webpack/config/blocks/css/loaders/next-font.ts
+++ b/packages/next/src/build/webpack/config/blocks/css/loaders/next-font.ts
@@ -1,11 +1,12 @@
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import type { ConfigurationContext } from '../../../utils'
+import type { PostcssInstance } from '../index'
 import { getClientStyleLoader } from './client'
 import { cssFileResolve } from './file-resolve'
 
 export function getNextFontLoader(
   ctx: ConfigurationContext,
-  postcss: any,
+  postcss: () => Promise<PostcssInstance>,
   fontLoaderPath: string
 ): webpack.RuleSetUseItem[] {
   const loaders: webpack.RuleSetUseItem[] = []

--- a/packages/next/types/misc.d.ts
+++ b/packages/next/types/misc.d.ts
@@ -298,6 +298,10 @@ declare module 'next/dist/compiled/semver' {
   import m from 'semver'
   export = m
 }
+declare module 'next/dist/compiled/postcss' {
+  import m from 'postcss'
+  export = m
+}
 declare module 'next/dist/compiled/postcss-scss' {
   import m from 'postcss-scss'
   export = m


### PR DESCRIPTION
### What?

- Declare module for PostCSS types in [`next/types/misc.d.ts`](https://github.com/vercel/next.js/blob/c34dd5e934c20fb4ebabae9579f7d4b222570697/packages/next/types/misc.d.ts#L301)
- Add type for postcss argument in CSS loaders (global, module, next-font)
- Use internal PostCSS types for [`PostcssInstance`](https://github.com/vercel/next.js/blob/c34dd5e934c20fb4ebabae9579f7d4b222570697/packages/next/src/build/webpack/config/blocks/css/index.ts#L57) in `lazyPostCSS()`


### Why?

Better type safety when working with PostCSS plugins and compile-time errors.

### How?

Replacing usages of any with the types in PostCSS (`Postcss`, `Processor`)
