### PR TITLE
chore: Update `swc_core` to `v0.90.21`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.64.16"
+version = "0.64.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8d7e4f6e41b2fdd518562e4a68446ba5c69f6f75da31f84eea56711c34b90a"
+checksum = "3a6dce5324435c74a774df03256a70a84ef5a033da96e282ad01467f9b00994f"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2964,9 +2964,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
@@ -4988,12 +4988,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5226,9 +5226,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.273.16"
+version = "0.273.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f27354a56d32d3fb87aadd289b28f2fce58fae6a090c77fac65b9e90350d15"
+checksum = "c5697e6ea7a715dd5d6606f7e131b6b047277efb7ab720998deff7e8dd47fd0f"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -5272,6 +5272,7 @@ dependencies = [
  "swc_plugin_runner",
  "swc_timer",
  "swc_visit",
+ "tokio",
  "tracing",
  "url",
 ]
@@ -5292,9 +5293,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.225.12"
+version = "0.225.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc0ba0504c82111f14444ad2b452ab9d6d2d723748b059527dbd2c60e86a44a7"
+checksum = "0f5d8dcab6db0bdafb4928cd333464ec3dbc9ae57953910b7a3a05e3a5a3f82c"
 dependencies = [
  "anyhow",
  "crc",
@@ -5371,9 +5372,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7407e6689312053ec2a9f7cd25a0502d099e70ecef23819d32c7eb50235dcd76"
+checksum = "8ca1146aff9655a17a7958f2484a5ca4f81ba9c641410896c0e7bb80c84db2ab"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -5423,9 +5424,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.90.17"
+version = "0.90.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2beeec16e40b7a1cf04955916de48f5897c9a0714930d8d71a214348c28139"
+checksum = "9c498fc0c7bc3a81257e6474636ea8dbfeb372371bfc31b3d95918d336df3822"
 dependencies = [
  "binding_macros",
  "swc",
@@ -5912,9 +5913,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.192.13"
+version = "0.192.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a522264a325d65a9b94583edb294ecd15c255d81194376075ec5e54279709a2"
+checksum = "b108f08d487ce79cfb2599c0532fde6ed30738824da7f8d9f25fce527db75395"
 dependencies = [
  "arrayvec",
  "indexmap 2.2.3",
@@ -6455,9 +6456,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.106.10"
+version = "0.106.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b14361ec99105e0fe4b3d39a7b0a153a2fda4bff4f56c7f7cdf1e4880c7a3b8"
+checksum = "c97d95a259f98f2dbc301ec29fe7204e3008f116a80a2275a8625835e1345966"
 dependencies = [
  "anyhow",
  "enumset",
@@ -6805,9 +6806,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6817,7 +6818,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.4",
+ "socket2 0.5.6",
  "tokio-macros",
  "tracing",
  "windows-sys 0.48.0",
@@ -6835,9 +6836,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.64.17"
+version = "0.64.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6dce5324435c74a774df03256a70a84ef5a033da96e282ad01467f9b00994f"
+checksum = "bd296ea88689d27d3c1e603c54c208c7fe91875b111ebf1ea0cf1ba59ae3787e"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -5226,9 +5226,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.273.17"
+version = "0.273.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5697e6ea7a715dd5d6606f7e131b6b047277efb7ab720998deff7e8dd47fd0f"
+checksum = "c61371c0375d66cbbdb601513f6d2f0713e6fe984deb549ac80a7861fc3c22b2"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -5293,9 +5293,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.225.13"
+version = "0.225.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f5d8dcab6db0bdafb4928cd333464ec3dbc9ae57953910b7a3a05e3a5a3f82c"
+checksum = "0061b48aeff696bf8f1623d843a48dbec83451496dbdaf260f8613220e19e849"
 dependencies = [
  "anyhow",
  "crc",
@@ -5372,9 +5372,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca1146aff9655a17a7958f2484a5ca4f81ba9c641410896c0e7bb80c84db2ab"
+checksum = "b44065d50b699d2d8108edaa9f134e1dc411cd379e3e46e29898e14dcd266d0d"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -5424,9 +5424,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.90.18"
+version = "0.90.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c498fc0c7bc3a81257e6474636ea8dbfeb372371bfc31b3d95918d336df3822"
+checksum = "8651aaebeb5a5c2b29af32cef6eac55861d0e475cdb76a6939c81786de0fce30"
 dependencies = [
  "binding_macros",
  "swc",
@@ -5663,9 +5663,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b78793b8d68a64c4e0c0e2c55f31330fe953b9d38e264bd2a6cc9481e6194d"
+checksum = "fac3f77e07132056bdf7336e6930fdc4365c394466f97c992f29642c3e55793e"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -5680,9 +5680,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_common"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e6db48f9bbde54338832c4c100ba400e773bf5d6357eee599bd8d631b1caa2"
+checksum = "b0a9bf70ce439c6dab8617ebe7691865fe80687d796c806fc39008f6ac102f84"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -5693,9 +5693,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321f1d679d24e894eab81c415828f6c8283fb665fd1639aff1c1eed810657f5b"
+checksum = "0f6705c0d640f42dbbdb43f9da4cd83269bcc19b888cb31433d401a2e68a9d6c"
 dependencies = [
  "arrayvec",
  "indexmap 2.2.3",
@@ -5719,9 +5719,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727983ef362b8a347247bfde562b4f842578585f89ca3a1ccd77b7cbcbfe77ec"
+checksum = "2edefbf5cd69132c3e9dc2bd450e0fb39e82f9eba07ca37b18fc9bcac7d9a8cd"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -5736,9 +5736,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3bd9774bbb0173aa4ecaccc95e98d209f2fbb42e594fe2d9e35cd70bed0bbc"
+checksum = "3455e30c73c79a1e583bf22bdb99c1e766dca2d863e1ea721e9d685b6345e133"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -5754,9 +5754,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a77eac0032cba8696461896a2bf05f1db9b453c3ad1573275bebb5e3bd5dc0"
+checksum = "027190a908e5af75d3a9ccb20ab036a55f82702e6de61ac9341fd40c2855a557"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -5773,9 +5773,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcb35f9478cdc3fab186f1b06f725583bfddca43b66d9e686a5c0dc72110b18"
+checksum = "8dfd12f37aa46c2faa4c542377c1e86d52df6e8c05c59fd43552e6a9d37857a3"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -5789,9 +5789,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36db7815ebe0c6ac65d47f0f31db364824ad501b8262176269a12c79362bc96"
+checksum = "2a2c8bdd554bd4c3d819de7c28f697d5fc23118bb7fcd5e8ea0dc8cb28103094"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -5807,9 +5807,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a98d073aac3e47c5c8b4d4fbf606d9fea008d9ffc36aac170db97016d103b9"
+checksum = "33fdbb6fb08f498189dd95c118f9c583572df4c61fc5ff158b860a8f4338a7c0"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -5823,9 +5823,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec6a3a7b059d4b123b54cdcbe52601f9e83a432c26fff8bcc9b127a60ee705e"
+checksum = "97b10f83e74b21c32de25a9391aabd3b725baf5b31696cd7ce57a971bb71f190"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -5842,9 +5842,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es3"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3d3a090e3f9c4e8c4f2fd0a22321f4389b8a1baa49399d9e0e420b1bce70a3"
+checksum = "7a1ae4cdab0e1d269e8baffa7f16f4808d2bc0e7b898a1b5ec9d90df8d852fe6"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -5857,9 +5857,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.113.10"
+version = "0.113.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91f36c0e3a192d1477d5ab00c7924f85e998eb6f26cd36121255efcb104cf4a"
+checksum = "a2abcbbff3c42d6a4333ac77872958610888305d03f6c38312697c5b076c4f88"
 dependencies = [
  "phf 0.11.2",
  "swc_atoms",
@@ -5871,9 +5871,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.92.15"
+version = "0.92.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53e92d321be276a31e612a7926cfef05484f661bbd08b7ff40b585576015aeb"
+checksum = "7894a057a4c5f240a61955a4f40353b728b5b555800b704f8c5547c63c93b7ed"
 dependencies = [
  "auto_impl",
  "dashmap",
@@ -5913,9 +5913,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.192.14"
+version = "0.192.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b108f08d487ce79cfb2599c0532fde6ed30738824da7f8d9f25fce527db75395"
+checksum = "01d138fa420d6939ca43b87c8cd9bfd5c9e9408b9e8eb80ccd10cf3834aac719"
 dependencies = [
  "arrayvec",
  "indexmap 2.2.3",
@@ -5969,9 +5969,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.206.13"
+version = "0.206.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f6d4e577171a9c21317bba1bc7207830f4f3cef63b5702b1a2ba280c0e3a64"
+checksum = "beb4e0016f42208333dc7edafd6241fb68a1d740d860b6f627a3e797c4870701"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -6024,9 +6024,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.229.13"
+version = "0.229.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b02bdbac1ea925fecaba08292ce2b8b022a0703b74c13b52742c032ed361867e"
+checksum = "047f84ab4c4b7a08a7894e48019d3f0f32a71eadc123186fefba3ea36d5c23af"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6044,9 +6044,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.137.13"
+version = "0.137.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a5d4bc7ba8b19d09d8024e60111041c1e728b38bc1f745859e809e17911a92"
+checksum = "2c36ec1188950c6f5b74fa751db8bcfc7bdd97f231287a34ed43b5fe0752f02d"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.4.0",
@@ -6068,9 +6068,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.126.13"
+version = "0.126.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d90dca67c3eeefe00cf76a783f5cc1ff2614e270d0e71cbe2e0a1e926e34fd84"
+checksum = "c86a23a79abb7e609f17a0ca4ed4060ce911ba5f2055896b45c987574c913e03"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6082,9 +6082,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.163.13"
+version = "0.163.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0935b56a2cfc0977a7abd5922f40816190937f703c45d7d98a3a080e7e1158aa"
+checksum = "e26dfa2fe6a3273ec341de0090f556d037604eebf5f38e07c5ecdcaf2a3435e9"
 dependencies = [
  "arrayvec",
  "indexmap 2.2.3",
@@ -6131,9 +6131,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.180.13"
+version = "0.180.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c0627abb2062203bba6b17198ae4ca27f8e5fe18a99fce2608f3c396d87885a"
+checksum = "b2e25fb5e0627bc17e0f6fcd5c9fb903d98143c2ff0b30906ff5b52abae5930d"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -6158,9 +6158,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.198.13"
+version = "0.198.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf2fcca33fbed8088bdd9978be4b460080662511e50742b32b20347f08296d7"
+checksum = "51052ccc02161109066c40ccbefb96f81d959ef47b2244059ffc24f6f7f294d9"
 dependencies = [
  "dashmap",
  "indexmap 2.2.3",
@@ -6183,9 +6183,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.171.13"
+version = "0.171.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9723deb426703981b232db1f091140cc5a197af68d8090bace6afa5f3e2dbd0"
+checksum = "3a4e8f7b02320dc446d38fc797aa764b9b574839106327295a177ee38ad37da7"
 dependencies = [
  "either",
  "rustc-hash",
@@ -6203,9 +6203,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.183.13"
+version = "0.183.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e62a60e66f7f9e7490c5b7b8ed32c5746447bd7ee4ddda910e3825a369ba49"
+checksum = "36d33e1f84d75e7c1b66433dfbfe9866855a896b9d18c33199ead961d3606a39"
 dependencies = [
  "base64 0.21.4",
  "dashmap",
@@ -6228,9 +6228,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.140.13"
+version = "0.140.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b4bd3473e22f9b326547febf87ba485be8ac1f9c1ad3b82e55ad3b6a21f41a1"
+checksum = "faa66370e89c9a156d5c75c0e5ad33f5e895b8ed3d07d1ea459ad6e7eb58b0b1"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -6254,9 +6254,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.188.13"
+version = "0.188.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60ac06411e6370b545808f80516bec2dd38e0ec573f797802d2f85195e6b4abe"
+checksum = "a591d07a82edaf90b35c0d6c98b60cec1ff1f239035707a19276cebf856c569a"
 dependencies = [
  "ryu-js",
  "serde",
@@ -6271,9 +6271,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "0.23.10"
+version = "0.23.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742aed73c3d3b9b8cfcd6a1a4ff6585a3e1b0f4b487f5dbf7e4fee8a46a174aa"
+checksum = "f6ff1c851a55df4803e8bd56e9a3161b743203b4ef651ac2b1b4dc9b24df11fb"
 dependencies = [
  "indexmap 2.2.3",
  "rustc-hash",
@@ -6288,9 +6288,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.127.10"
+version = "0.127.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f52aae3ab2558cbe9f480bae68a8b3a5233d4a9dd355e1afe833d574b7c05"
+checksum = "fbe5ea2a95bea51461395cb4d7cfcbcb361562981d19cb502b7f90dff35364ac"
 dependencies = [
  "indexmap 2.2.3",
  "num_cpus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,9 +29,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom",
  "once_cell",
@@ -492,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.64.18"
+version = "0.64.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd296ea88689d27d3c1e603c54c208c7fe91875b111ebf1ea0cf1ba59ae3787e"
+checksum = "41e11eeaf03c8608754b14360524b62094bb4f82cbcc8ae9786bf32b857df23b"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -774,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.4.1"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4110a1e6af615a9e6d0a36f805d5c99099f8bab9b8042f5bc1fa220a4a89e36f"
+checksum = "885e4d7d5af40bfb99ae6f9433e292feac98d452dcb3ec3d25dfe7552b77da8c"
 dependencies = [
  "clap",
 ]
@@ -1200,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm_winapi"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
@@ -1934,9 +1934,9 @@ checksum = "c3531d702d6c1a3ba92a5fb55a404c7b8c476c8e7ca249951077afcbe4bc807f"
 
 [[package]]
 name = "h2"
-version = "0.3.16"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -1944,7 +1944,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.9.3",
+ "indexmap 2.2.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -1986,7 +1986,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.6",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -2122,9 +2122,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.25"
+version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2137,7 +2137,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.5.6",
  "tokio",
  "tower-service",
  "tracing",
@@ -3043,9 +3043,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec514d65fce18a959be55e7f683ac89c6cb850fb59b09e25ab777fd5a4a8d9e"
+checksum = "6cf2d74ac66fd1cccb646be75fdd1c1dce8acfe20a68f61566a31da0d3eb9786"
 dependencies = [
  "convert_case 0.6.0",
  "once_cell",
@@ -4871,9 +4871,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -5165,9 +5165,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.73.8"
+version = "0.73.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9215277feaeb625e11469ca0e94f9f76b66c2b99b12fb3314b49f84403aa93f2"
+checksum = "243182797daf80d4ebed2f8ea46c787ac0df5609d10bff5d634dace5375c49b0"
 dependencies = [
  "anyhow",
  "lightningcss",
@@ -5226,9 +5226,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.273.18"
+version = "0.273.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61371c0375d66cbbdb601513f6d2f0713e6fe984deb549ac80a7861fc3c22b2"
+checksum = "e3c21a312d3fb3b52300870b4b03ab4d7046590894aa88ba71ca7027579d816b"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -5293,9 +5293,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.225.14"
+version = "0.225.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0061b48aeff696bf8f1623d843a48dbec83451496dbdaf260f8613220e19e849"
+checksum = "8be45336922aa85774b351ea6a0a1991027113ee26a092f97f003fdc76da510f"
 dependencies = [
  "anyhow",
  "crc",
@@ -5372,9 +5372,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b44065d50b699d2d8108edaa9f134e1dc411cd379e3e46e29898e14dcd266d0d"
+checksum = "0460c65a4952e0792a1b76b99a2a974d7e4185188cb1b67d34919ec6d6b75ea7"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -5424,9 +5424,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.90.19"
+version = "0.90.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8651aaebeb5a5c2b29af32cef6eac55861d0e475cdb76a6939c81786de0fce30"
+checksum = "a4e597e7d4671a7be57c2c0dc9adefc8ca1479b4500e50c71eabe5304c32d253"
 dependencies = [
  "binding_macros",
  "swc",
@@ -5663,9 +5663,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac3f77e07132056bdf7336e6930fdc4365c394466f97c992f29642c3e55793e"
+checksum = "c581b4f71587ea0deb86e132b4eb641b7e6a08ffb9fb62cbbae5719b91d0a81e"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -5693,9 +5693,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6705c0d640f42dbbdb43f9da4cd83269bcc19b888cb31433d401a2e68a9d6c"
+checksum = "ac027a2e1658c57e16ce4136ae7ebaddae418a6d1885c3234f3efc82051e2648"
 dependencies = [
  "arrayvec",
  "indexmap 2.2.3",
@@ -5913,9 +5913,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.192.15"
+version = "0.192.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d138fa420d6939ca43b87c8cd9bfd5c9e9408b9e8eb80ccd10cf3834aac719"
+checksum = "0e2b816091a22b20c96a9870c070bc4a04a3da6b10f649aaf8a7e30be766a545"
 dependencies = [
  "arrayvec",
  "indexmap 2.2.3",
@@ -5969,9 +5969,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.206.14"
+version = "0.206.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beb4e0016f42208333dc7edafd6241fb68a1d740d860b6f627a3e797c4870701"
+checksum = "7925890dc81da4d52e53cc1fb05802498f839802cf342748a8779dd1e61f1c6e"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -6024,9 +6024,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.229.14"
+version = "0.229.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "047f84ab4c4b7a08a7894e48019d3f0f32a71eadc123186fefba3ea36d5c23af"
+checksum = "7985caa4b327c9848464287dcb5d5ccaf78a57cf714b0deae86a9a8d1c057f63"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6082,9 +6082,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.163.14"
+version = "0.163.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26dfa2fe6a3273ec341de0090f556d037604eebf5f38e07c5ecdcaf2a3435e9"
+checksum = "69a27fa74aef5b4832221ac050ba5479667d6e87d89a4eff8dc62d4ee732885a"
 dependencies = [
  "arrayvec",
  "indexmap 2.2.3",
@@ -6131,9 +6131,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.180.14"
+version = "0.180.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e25fb5e0627bc17e0f6fcd5c9fb903d98143c2ff0b30906ff5b52abae5930d"
+checksum = "d8235648ce61a997139ee4f06b251c57798b6ea2fed826009321ce81498d8c55"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -6158,9 +6158,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.198.14"
+version = "0.198.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51052ccc02161109066c40ccbefb96f81d959ef47b2244059ffc24f6f7f294d9"
+checksum = "5c7c0664ddbb96f6ba9704fb11b7e21aa03a46ec7d3097500531782e32d8b16d"
 dependencies = [
  "dashmap",
  "indexmap 2.2.3",
@@ -6183,9 +6183,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.171.14"
+version = "0.171.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a4e8f7b02320dc446d38fc797aa764b9b574839106327295a177ee38ad37da7"
+checksum = "eb39c4788ec628e075617a332ee1a8360ccff4f39d014c4aad86ea2686661b38"
 dependencies = [
  "either",
  "rustc-hash",
@@ -6203,9 +6203,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.183.14"
+version = "0.183.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d33e1f84d75e7c1b66433dfbfe9866855a896b9d18c33199ead961d3606a39"
+checksum = "c11b4742240a61ad757f5caf11ce4823487c963a204d491e40e26019daee9414"
 dependencies = [
  "base64 0.21.4",
  "dashmap",
@@ -6254,9 +6254,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.188.14"
+version = "0.188.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a591d07a82edaf90b35c0d6c98b60cec1ff1f239035707a19276cebf856c569a"
+checksum = "e0b6571b0b2d64267571e3ca7e3e72fe65fc3f0dc95b32e7a92458063f44c2fa"
 dependencies = [
  "ryu-js",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "serde",
  "smallvec",
@@ -3217,7 +3217,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "serde",
@@ -7160,7 +7160,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7192,7 +7192,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7204,7 +7204,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7219,7 +7219,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7233,7 +7233,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7250,7 +7250,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7282,7 +7282,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "base16",
  "hex",
@@ -7294,7 +7294,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7308,7 +7308,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7318,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "mimalloc",
 ]
@@ -7326,7 +7326,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7351,7 +7351,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7384,7 +7384,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7424,7 +7424,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7450,7 +7450,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "clap",
@@ -7469,7 +7469,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7500,7 +7500,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7528,7 +7528,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7565,7 +7565,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7603,7 +7603,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "serde",
  "serde_json",
@@ -7614,7 +7614,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7639,7 +7639,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7656,7 +7656,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7672,7 +7672,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7692,7 +7692,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "serde",
@@ -7707,7 +7707,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7722,7 +7722,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7760,7 +7760,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7784,7 +7784,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7806,7 +7806,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "serde",
@@ -7822,7 +7822,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7833,7 +7833,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -7849,7 +7849,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.5#fcc092d3a42094e9e7dd47fd6b9c8ed1fca1186c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.6#33570fffbb2a4bd6b8e4aaa6bee17d2c568ec17c"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ next-core = { path = "packages/next-swc/crates/next-core" }
 next-custom-transforms = { path = "packages/next-swc/crates/next-custom-transforms" }
 
 # SWC crates
-swc_core = { version = "0.90.18", features = [
+swc_core = { version = "0.90.19", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ next-core = { path = "packages/next-swc/crates/next-core" }
 next-custom-transforms = { path = "packages/next-swc/crates/next-custom-transforms" }
 
 # SWC crates
-swc_core = { version = "0.90.17", features = [
+swc_core = { version = "0.90.18", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.90.21", features = [
 testing = { version = "0.35.20" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240313.5" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240313.6" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240313.5" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240313.6" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240313.5" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240313.6" }
 
 # General Deps
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ next-core = { path = "packages/next-swc/crates/next-core" }
 next-custom-transforms = { path = "packages/next-swc/crates/next-custom-transforms" }
 
 # SWC crates
-swc_core = { version = "0.90.19", features = [
+swc_core = { version = "0.90.21", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -192,7 +192,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.4",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240313.5",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240313.6",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1071,8 +1071,8 @@ importers:
         specifier: 0.26.4
         version: 0.26.4
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240313.5
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240313.5'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240313.6
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240313.6'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -25494,8 +25494,8 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240313.5':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240313.5}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240313.6':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240313.6}
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
### What?

 - Update `swc_core` to fix performance regression caused by the creation of the `tokio` runtime.

This PR practically reverts https://github.com/vercel/next.js/pull/62441.

 - Apply various minifier bug fixes.

   - https://github.com/swc-project/swc/pull/8730
   - https://github.com/swc-project/swc/pull/8733
   - https://github.com/swc-project/swc/pull/8725
   - https://github.com/swc-project/swc/pull/8726
   - https://github.com/swc-project/swc/pull/8727

 - Apply https://github.com/swc-project/plugins/pull/271 (Closes PACK-2714)


### Why?

Someone reported a performance regression. See https://github.com/swc-project/swc/issues/8708

### How?

Closes PACK-2693