### PR TITLE
app layouts/pages depend on shared main files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "serde",
  "smallvec",
@@ -3396,7 +3396,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "serde",
@@ -7373,7 +7373,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7405,7 +7405,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7417,7 +7417,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7432,7 +7432,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7446,7 +7446,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7463,7 +7463,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7495,7 +7495,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "base16",
  "hex",
@@ -7507,7 +7507,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7521,7 +7521,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7531,7 +7531,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "mimalloc",
 ]
@@ -7539,7 +7539,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7564,7 +7564,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7597,7 +7597,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7637,7 +7637,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7663,7 +7663,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "clap 4.4.2",
@@ -7682,7 +7682,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7713,7 +7713,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7741,7 +7741,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7778,7 +7778,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7816,7 +7816,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "serde",
  "serde_json",
@@ -7827,7 +7827,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7852,7 +7852,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7869,7 +7869,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7885,7 +7885,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7905,7 +7905,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "serde",
@@ -7920,7 +7920,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7935,7 +7935,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7973,7 +7973,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7997,7 +7997,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -8019,7 +8019,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "serde",
@@ -8035,7 +8035,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -8046,7 +8046,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -8062,7 +8062,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240307.3#ccde74e172db26aa850cc1f688bb586ca99f2d1e"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240308.2#cf51c13e7be2ff4ab7f758e9cb3c8a6694c07009"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.90.17", features = [
 testing = { version = "0.35.20" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240307.3" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240308.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240307.3" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240308.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240307.3" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240308.2" }
 
 # General Deps
 

--- a/packages/next-swc/crates/next-api/src/app.rs
+++ b/packages/next-swc/crates/next-api/src/app.rs
@@ -11,7 +11,7 @@ use next_core::{
     get_edge_resolve_options_context,
     next_app::{
         app_client_references_chunks::get_app_server_reference_modules,
-        get_app_client_references_chunks, get_app_client_shared_chunks, get_app_page_entry,
+        get_app_client_references_chunks, get_app_client_shared_chunk_group, get_app_page_entry,
         get_app_route_entry, metadata::route::get_app_metadata_route_entry, AppEntry, AppPage,
     },
     next_client::{
@@ -579,17 +579,18 @@ impl AppEndpoint {
         // .await?;
 
         let app_server_reference_modules = if process_client {
-            let client_shared_chunks = get_app_client_shared_chunks(
+            let client_shared_chunk_group = get_app_client_shared_chunk_group(
                 app_entry
                     .rsc_entry
                     .ident()
                     .with_modifier(Vc::cell("client_shared_chunks".to_string())),
                 this.app_project.client_runtime_entries(),
                 this.app_project.project().client_chunking_context(),
-            );
+            )
+            .await?;
 
             let mut client_shared_chunks_paths = vec![];
-            for chunk in client_shared_chunks.await?.iter().copied() {
+            for chunk in client_shared_chunk_group.assets.await?.iter().copied() {
                 client_assets.push(chunk);
 
                 let chunk_path = chunk.ident().path().await?;
@@ -599,6 +600,7 @@ impl AppEndpoint {
                     }
                 }
             }
+            let client_shared_availability_info = client_shared_chunk_group.availability_info;
 
             let client_reference_graph = ClientReferenceGraph::new(Vc::cell(vec![rsc_entry_asset]));
             let client_reference_types = client_reference_graph.types();
@@ -618,6 +620,7 @@ impl AppEndpoint {
             let client_references_chunks = get_app_client_references_chunks(
                 client_references,
                 this.app_project.project().client_chunking_context(),
+                Value::new(client_shared_availability_info),
                 ssr_chunking_context,
             );
             let client_references_chunks_ref = client_references_chunks.await?;

--- a/packages/next-swc/crates/next-api/src/app.rs
+++ b/packages/next-swc/crates/next-api/src/app.rs
@@ -51,8 +51,10 @@ use turbopack_binding::{
         },
         nodejs::EntryChunkGroupResult,
         turbopack::{
-            module_options::ModuleOptionsContext, resolve_options_context::ResolveOptionsContext,
-            transition::ContextTransition, ModuleAssetContext,
+            module_options::ModuleOptionsContext,
+            resolve_options_context::ResolveOptionsContext,
+            transition::{ContextTransition, FullContextTransition},
+            ModuleAssetContext,
         },
     },
 };
@@ -156,13 +158,9 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    fn client_transition(self: Vc<Self>) -> Vc<ContextTransition> {
-        ContextTransition::new(
-            self.project().client_compile_time_info(),
-            self.client_module_options_context(),
-            self.client_resolve_options_context(),
-            Vc::cell("app-client".to_string()),
-        )
+    async fn client_transition(self: Vc<Self>) -> Result<Vc<FullContextTransition>> {
+        let module_context = self.client_module_context();
+        Ok(FullContextTransition::new(module_context))
     }
 
     #[turbo_tasks::function]
@@ -204,13 +202,15 @@ impl AppProject {
             (
                 ECMASCRIPT_CLIENT_TRANSITION_NAME.to_string(),
                 Vc::upcast(NextEcmascriptClientReferenceTransition::new(
-                    self.client_transition(),
+                    Vc::upcast(self.client_transition()),
                     self.ssr_transition(),
                 )),
             ),
             (
                 "next-dynamic".to_string(),
-                Vc::upcast(NextDynamicTransition::new(self.client_transition())),
+                Vc::upcast(NextDynamicTransition::new(Vc::upcast(
+                    self.client_transition(),
+                ))),
             ),
             ("next-ssr".to_string(), Vc::upcast(self.ssr_transition())),
         ]
@@ -231,13 +231,15 @@ impl AppProject {
             (
                 ECMASCRIPT_CLIENT_TRANSITION_NAME.to_string(),
                 Vc::upcast(NextEcmascriptClientReferenceTransition::new(
-                    self.client_transition(),
+                    Vc::upcast(self.client_transition()),
                     self.edge_ssr_transition(),
                 )),
             ),
             (
                 "next-dynamic".to_string(),
-                Vc::upcast(NextDynamicTransition::new(self.client_transition())),
+                Vc::upcast(NextDynamicTransition::new(Vc::upcast(
+                    self.client_transition(),
+                ))),
             ),
             (
                 "next-ssr".to_string(),

--- a/packages/next-swc/crates/next-api/src/pages.rs
+++ b/packages/next-swc/crates/next-api/src/pages.rs
@@ -265,7 +265,9 @@ impl PagesProject {
         Vc::cell(
             [(
                 "next-dynamic".to_string(),
-                Vc::upcast(NextDynamicTransition::new(self.client_transition())),
+                Vc::upcast(NextDynamicTransition::new(Vc::upcast(
+                    self.client_transition(),
+                ))),
             )]
             .into_iter()
             .collect(),

--- a/packages/next-swc/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -45,6 +45,7 @@ pub struct ClientReferencesChunks {
 pub async fn get_app_client_references_chunks(
     app_client_references: Vc<ClientReferenceGraphResult>,
     client_chunking_context: Vc<Box<dyn EcmascriptChunkingContext>>,
+    client_availability_info: Value<AvailabilityInfo>,
     ssr_chunking_context: Option<Vc<Box<dyn EcmascriptChunkingContext>>>,
 ) -> Result<Vc<ClientReferencesChunks>> {
     async move {
@@ -130,7 +131,7 @@ pub async fn get_app_client_references_chunks(
                 list.extend(framework_reference_types);
             }
 
-            let mut current_client_availability_info = AvailabilityInfo::Root;
+            let mut current_client_availability_info = client_availability_info.into_value();
             let mut current_client_chunks = OutputAssets::empty();
             let mut current_ssr_availability_info = AvailabilityInfo::Root;
             let mut current_ssr_chunks = OutputAssets::empty();

--- a/packages/next-swc/crates/next-core/src/next_app/app_client_shared_chunks.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/app_client_shared_chunks.rs
@@ -2,7 +2,10 @@ use anyhow::Result;
 use turbo_tasks::{Value, Vc};
 use turbopack_binding::turbopack::{
     core::{
-        chunk::{availability_info::AvailabilityInfo, ChunkingContextExt, EvaluatableAssets},
+        chunk::{
+            availability_info::AvailabilityInfo, ChunkGroupResult, ChunkingContext,
+            EvaluatableAssets,
+        },
         ident::AssetIdent,
         output::OutputAssets,
     },
@@ -10,20 +13,24 @@ use turbopack_binding::turbopack::{
 };
 
 #[turbo_tasks::function]
-pub async fn get_app_client_shared_chunks(
+pub async fn get_app_client_shared_chunk_group(
     ident: Vc<AssetIdent>,
     app_client_runtime_entries: Vc<EvaluatableAssets>,
     client_chunking_context: Vc<Box<dyn EcmascriptChunkingContext>>,
-) -> Result<Vc<OutputAssets>> {
+) -> Result<Vc<ChunkGroupResult>> {
     if app_client_runtime_entries.await?.is_empty() {
-        return Ok(OutputAssets::empty());
+        return Ok(ChunkGroupResult {
+            assets: OutputAssets::empty(),
+            availability_info: AvailabilityInfo::Root,
+        }
+        .cell());
     }
 
-    let app_client_shared_chunks = client_chunking_context.evaluated_chunk_group_assets(
+    let app_client_shared_chunk_grou = client_chunking_context.evaluated_chunk_group(
         ident,
         app_client_runtime_entries,
         Value::new(AvailabilityInfo::Root),
     );
 
-    Ok(app_client_shared_chunks)
+    Ok(app_client_shared_chunk_grou)
 }

--- a/packages/next-swc/crates/next-core/src/next_app/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/mod.rs
@@ -18,7 +18,7 @@ use turbo_tasks::{trace::TraceRawVcs, TaskInput};
 
 pub use crate::next_app::{
     app_client_references_chunks::{get_app_client_references_chunks, ClientReferencesChunks},
-    app_client_shared_chunks::get_app_client_shared_chunks,
+    app_client_shared_chunks::get_app_client_shared_chunk_group,
     app_entry::AppEntry,
     app_page_entry::get_app_page_entry,
     app_route_entry::get_app_route_entry,

--- a/packages/next-swc/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
+++ b/packages/next-swc/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
@@ -18,7 +18,7 @@ use super::ecmascript_client_reference_proxy_module::EcmascriptClientReferencePr
 
 #[turbo_tasks::value(shared)]
 pub struct NextEcmascriptClientReferenceTransition {
-    client_transition: Vc<ContextTransition>,
+    client_transition: Vc<Box<dyn Transition>>,
     ssr_transition: Vc<ContextTransition>,
 }
 
@@ -26,7 +26,7 @@ pub struct NextEcmascriptClientReferenceTransition {
 impl NextEcmascriptClientReferenceTransition {
     #[turbo_tasks::function]
     pub fn new(
-        client_transition: Vc<ContextTransition>,
+        client_transition: Vc<Box<dyn Transition>>,
         ssr_transition: Vc<ContextTransition>,
     ) -> Vc<Self> {
         NextEcmascriptClientReferenceTransition {

--- a/packages/next-swc/crates/next-core/src/next_dynamic/dynamic_transition.rs
+++ b/packages/next-swc/crates/next-core/src/next_dynamic/dynamic_transition.rs
@@ -2,10 +2,7 @@ use anyhow::Result;
 use turbo_tasks::{Value, Vc};
 use turbopack_binding::turbopack::{
     core::{context::ProcessResult, reference_type::ReferenceType, source::Source},
-    turbopack::{
-        transition::{ContextTransition, Transition},
-        ModuleAssetContext,
-    },
+    turbopack::{transition::Transition, ModuleAssetContext},
 };
 
 use super::NextDynamicEntryModule;
@@ -15,13 +12,13 @@ use super::NextDynamicEntryModule;
 /// create the dynamic entry, and the dynamic manifest entry.
 #[turbo_tasks::value]
 pub struct NextDynamicTransition {
-    client_transition: Vc<ContextTransition>,
+    client_transition: Vc<Box<dyn Transition>>,
 }
 
 #[turbo_tasks::value_impl]
 impl NextDynamicTransition {
     #[turbo_tasks::function]
-    pub fn new(client_transition: Vc<ContextTransition>) -> Vc<Self> {
+    pub fn new(client_transition: Vc<Box<dyn Transition>>) -> Vc<Self> {
         NextDynamicTransition { client_transition }.cell()
     }
 }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -192,7 +192,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.4",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240307.3",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240308.2",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1071,8 +1071,8 @@ importers:
         specifier: 0.26.4
         version: 0.26.4
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240307.3
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240307.3'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240308.2
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240308.2'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -25492,8 +25492,8 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240307.3':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240307.3}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240308.2':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240308.2}
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
### What?

avoid duplication of next.js internals in app dir

For the example/hello-world:

Before:

```
Route (app)                                          Size     First Load JS
┌ ○ /                                                15 kB           184 kB
└ ○ /_not-found                                      15 kB           184 kB
+ First Load JS shared by all                        169 kB
  ├ chunks/[project]__929616._.js                    85.2 kB
  ├ chunks/[project]_packages_next_dist_0f911b._.js  83.2 kB
  └ other shared chunks (total)                      230 B
```

After:

```
Route (app)                                          Size     First Load JS
┌ ○ /                                                15 kB           104 kB
└ ○ /_not-found                                      15 kB           104 kB
+ First Load JS shared by all                        88.9 kB
  ├ chunks/[project]_packages_next_dist_0f911b._.js  83.2 kB
  └ other shared chunks (total)                      5.7 kB
```


Closes PACK-2695

### Turbopack changes

* https://github.com/vercel/turbo/pull/7617 <!-- OJ Kwon - feat(turbopack): add missing webpack context property  -->
* https://github.com/vercel/turbo/pull/7676 <!-- Tim Neutkens - Implement minify for Turbopack runtime file  -->
* https://github.com/vercel/turbo/pull/7677 <!-- Tobias Koppers - add FullContextTransition  -->