### PR TITLE
fix: Server locale to be displayed correctly with middleware

### DIFF
--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -403,6 +403,17 @@ export function getResolveRoutes(
 
               parsedUrl.pathname = normalized
             }
+
+            if (config.i18n) {
+              const curLocaleResult = normalizeLocalePath(
+                parsedUrl.pathname || '',
+                config.i18n.locales
+              )
+
+              if (curLocaleResult.detectedLocale) {
+                parsedUrl.query.__nextLocale = curLocaleResult.detectedLocale
+              }
+            }
           }
         }
 


### PR DESCRIPTION
### What?
Fixes https://github.com/vercel/next.js/issues/62568

Since creation of `server/lib/router-utils/resolve-routes.ts` below around [v13.4.13-canary.1](https://github.com/vercel/next.js/compare/v13.4.12...v13.4.13-canary.1), this issue occured In my observation.

If need investigation, I encourage you to look into diffs between v13.4.13-canary.1 and v13.4.12 .

https://github.com/vercel/next.js/blob/87acd0432a5332acaafe5f781b127dca007aa9ef/packages/next/src/server/lib/router-utils/resolve-routes.ts#L347-L376

Below is my investigation.
For normal non-middleware next data route, [handleNextDataRequest](https://github.com/vercel/next.js/blob/af5b4db98ac1acccc3f167cc6aba2f0c9e7094df/packages/next/src/server/base-server.ts#L606) stores __nextLocale as correct locale. However for middleware next data route, since [handleRoute for middleware_next_data](https://github.com/vercel/next.js/blob/af5b4db98ac1acccc3f167cc6aba2f0c9e7094df/packages/next/src/server/lib/router-utils/resolve-routes.ts#L374-L407) strips pathname, [handleNextDataRequest](https://github.com/vercel/next.js/blob/af5b4db98ac1acccc3f167cc6aba2f0c9e7094df/packages/next/src/server/base-server.ts#L606) cannot store __nextLocale as correct locale, and this problem happens (`invokeQuery` which stores __nextLocale as en is prioritized).

So, I store invokeQuery.__nextLocale as i18n detected locale. This fix only affects middleware next data route.