### PR TITLE
[PPR] Support rewrites in middleware

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -949,7 +949,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
             'http://localhost'
           )
 
-          const { pathname: urlPathname } = new URL(req.url, 'http://localhost')
+          let { pathname: urlPathname } = new URL(req.url, 'http://localhost')
 
           // For ISR  the URL is normalized to the prerenderPath so if
           // it's a data request the URL path will be the data URL,
@@ -973,6 +973,17 @@ export default abstract class Server<ServerOptions extends Options = Options> {
             const postponed = Buffer.concat(body).toString('utf8')
 
             addRequestMeta(req, 'postponed', postponed)
+
+            // If the request does not have the `x-now-route-matches` header,
+            // it means that the request has it's exact path specified in the
+            // `x-matched-path` header. In this case, we should update the
+            // pathname to the matched path.
+            if (!req.headers['x-now-route-matches']) {
+              urlPathname = this.normalizers.postponed.normalize(
+                matchedPath,
+                true
+              )
+            }
           }
 
           matchedPath = this.normalize(matchedPath)

--- a/test/production/standalone-mode/required-server-files/app/rewrite/[slug]/page.js
+++ b/test/production/standalone-mode/required-server-files/app/rewrite/[slug]/page.js
@@ -1,0 +1,25 @@
+import { Suspense } from 'react'
+import { unstable_noStore } from 'next/cache'
+
+export function generateStaticParams() {
+  return [{ slug: 'first-cookie' }]
+}
+
+function Postpone({ children }) {
+  unstable_noStore()
+  return children
+}
+
+export default async function Page({ params }) {
+  return (
+    <>
+      <Suspense>
+        <Postpone>
+          <p id="page">/rewrite/[slug]</p>
+          <p id="params">{JSON.stringify(params)}</p>
+          <p id="now">{Date.now()}</p>
+        </Postpone>
+      </Suspense>
+    </>
+  )
+}


### PR DESCRIPTION
### What?

This fixes a special case where rewrites wouldn't work when resuming a dynamic page.

### Why?

Previously, as routes would direct-match against entries in the cache, this takes the `x-matched-path` as the source of truth for these requests if the `x-now-route-matches` header is not present.
