### PR TITLE
Add JSM (ESM) support for next/lib/find-config

### DIFF
--- a/packages/next/src/lib/find-config.test.ts
+++ b/packages/next/src/lib/find-config.test.ts
@@ -30,7 +30,7 @@ describe('findConfig()', () => {
 
   for (const pkgConfigType of testPatterns.pkgConfigTypes) {
     for (const ext of testPatterns.exts) {
-      it(`should not append message several times (type: "${pkgConfigType}", config: ${
+      it(`should load config properly (type: "${pkgConfigType}", config: ${
         ext === 'package.json' ? 'package.json' : `awsome.config.${ext}`
       })`, async () => {
         // Create fixtures

--- a/packages/next/src/lib/find-config.test.ts
+++ b/packages/next/src/lib/find-config.test.ts
@@ -1,0 +1,68 @@
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { findConfig } from './find-config'
+
+describe('findConfig()', () => {
+  const exampleConfig = {
+    basePath: '/docs',
+  }
+  const configCode = {
+    mjs: `
+      const config = ${JSON.stringify(exampleConfig)}
+
+      export default config;
+    `,
+    cjs: `
+      const config = ${JSON.stringify(exampleConfig)}
+
+      module.exports = config;
+    `,
+  }
+  type TestPatterns = {
+    pkgConfigTypes: ('module' | 'commonjs')[]
+    exts: ('js' | 'mjs' | 'cjs' | 'package.json')[]
+  }
+  const testPatterns: TestPatterns = {
+    pkgConfigTypes: ['module', 'commonjs'],
+    exts: ['js', 'mjs', 'cjs', 'package.json'],
+  }
+
+  for (const pkgConfigType of testPatterns.pkgConfigTypes) {
+    for (const ext of testPatterns.exts) {
+      it(`should not append message several times (type: "${pkgConfigType}", config: ${
+        ext === 'package.json' ? 'package.json' : `awsome.config.${ext}`
+      })`, async () => {
+        // Create fixtures
+        const tmpDir = await mkdtemp(join(tmpdir(), 'nextjs-test-'))
+
+        await writeFile(
+          join(tmpDir, 'package.json'),
+          JSON.stringify({
+            name: 'nextjs-test',
+            type: pkgConfigType,
+            ...(ext === 'package.json'
+              ? { awsome: { basePath: '/docs' } }
+              : {}),
+          })
+        )
+
+        if (ext !== 'package.json') {
+          let configCodeType = ext
+          if (configCodeType === 'js') {
+            configCodeType = pkgConfigType === 'module' ? 'mjs' : 'cjs'
+          }
+
+          await writeFile(
+            join(tmpDir, `awsome.config.${ext}`),
+            configCode[configCodeType]
+          )
+        }
+
+        // Test
+        const actualConfig = await findConfig(tmpDir, 'awsome')
+        expect(actualConfig).toStrictEqual(exampleConfig)
+      })
+    }
+  }
+})

--- a/packages/next/src/lib/find-config.ts
+++ b/packages/next/src/lib/find-config.ts
@@ -37,7 +37,7 @@ export async function findConfig<T>(
 ): Promise<RecursivePartial<T> | null> {
   // `package.json` configuration always wins. Let's check that first.
   const packageJsonPath = await findUp('package.json', { cwd: directory })
-  let isJSM = false
+  let isESM = false
 
   if (packageJsonPath) {
     try {
@@ -51,7 +51,7 @@ export async function findConfig<T>(
       }
 
       if (packageJson.type === 'module') {
-        isJSM = true
+        isESM = true
       }
 
       if (packageJson[key] != null && typeof packageJson[key] === 'object') {
@@ -66,7 +66,7 @@ export async function findConfig<T>(
 
   if (filePath) {
     if (filePath.endsWith('.js')) {
-      return isJSM ? (await import(filePath)).default : require(filePath)
+      return isESM ? (await import(filePath)).default : require(filePath)
     } else if (filePath.endsWith('.mjs')) {
       return (await import(filePath)).default
     } else if (filePath.endsWith('.cjs')) {

--- a/packages/next/src/lib/find-config.ts
+++ b/packages/next/src/lib/find-config.ts
@@ -57,7 +57,7 @@ export async function findConfig<T>(
       if (packageJson[key] != null && typeof packageJson[key] === 'object') {
         return packageJson[key]
       }
-    } catch (err) {
+    } catch {
       // Ignore error and continue
     }
   }

--- a/packages/next/src/lib/find-config.ts
+++ b/packages/next/src/lib/find-config.ts
@@ -1,5 +1,5 @@
 import findUp from 'next/dist/compiled/find-up'
-import fs from 'fs'
+import { readFile } from 'fs/promises'
 import JSON5 from 'next/dist/compiled/json5'
 
 type RecursivePartial<T> = {
@@ -52,7 +52,7 @@ export async function findConfig<T>(
 
     // We load JSON contents with JSON5 to allow users to comment in their
     // configuration file. This pattern was popularized by TypeScript.
-    const fileContents = fs.readFileSync(filePath, 'utf8')
+    const fileContents = await readFile(filePath, 'utf8')
     return JSON5.parse(fileContents)
   }
 


### PR DESCRIPTION
Fixes #34448

Before this PR, next/lib/find-config fails to load \*.config.mjs files and \*.config.js files when `"type": "module"` is set in package.json. It expects CommonJS files although the \*.config.{js|mjs} files are written in JS modules format (i.e. using `import` and `export`).
This PR fixes it so that it can load configs written in JS modules format.