### PR TITLE
Remove unnecessary 'await' from writeSema.release() call

### DIFF
--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -112,7 +112,7 @@ export const installTemplate = async ({
             ).replace(`@/`, `${importAlias.replace(/\*/g, "")}`),
           );
         }
-        await writeSema.release();
+        writeSema.release();
       }),
     );
   }


### PR DESCRIPTION
### What?
This PR removes an unnecessary await keyword from the writeSema.release() call. The release method does not return a promise, hence awaiting it is not required.

### Why?
Awaiting on writeSema.release() which does not return a promise can lead to confusion and potentially hinder performance. By removing the await keyword, the code is simplified and aligns with the intended synchronous nature of the release method.

### How?
Reviewed the writeSema.release() method implementation to confirm it does not return a promise.
Removed the await keyword from the writeSema.release() call to ensure the code correctly reflects the synchronous operation.