### PR TITLE
docs(link): add good to know comment about scroll behavior

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/03-linking-and-navigating.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/03-linking-and-navigating.mdx
@@ -143,7 +143,7 @@ If you'd like to scroll to a specific `id` on navigation, you can append your UR
 
 > **Good to know**:
 >
-> - If `{children}` from a Layout is not present in the current viewport, Next.js will instead scroll to the top of the `{children}`.
+> - Next.js will scroll to the [Page](/docs/app/building-your-application/routing/pages-and-layouts#pages) if it is not visible in the viewport upon navigation.
 
 #### Disabling scroll restoration
 

--- a/docs/02-app/01-building-your-application/01-routing/03-linking-and-navigating.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/03-linking-and-navigating.mdx
@@ -130,7 +130,7 @@ export function Links() {
 
 #### Scrolling to an `id`
 
-The default behavior of the Next.js App Router is to scroll to the top of a new route or to maintain the scroll position for backwards and forwards navigation.
+The default behavior of the Next.js App Router is to **scroll to the top of a new route or to maintain the scroll position for backwards and forwards navigation.**
 
 If you'd like to scroll to a specific `id` on navigation, you can append your URL with a `#` hash link or just pass a hash link to the `href` prop. This is possible since `<Link>` renders to an `<a>` element.
 
@@ -141,9 +141,13 @@ If you'd like to scroll to a specific `id` on navigation, you can append your UR
 <a href="/dashboard#settings">Settings</a>
 ```
 
+> **Good to know**:
+>
+> - If `{children}` from a Layout is not present in the current viewport, Next.js will scroll to the top of the `{children}` instead.
+
 #### Disabling scroll restoration
 
-The default behavior of the Next.js App Router is to scroll to the top of a new route or to maintain the scroll position for backwards and forwards navigation. If you'd like to disable this behavior, you can pass `scroll={false}` to the `<Link>` component, or `scroll: false` to `router.push()` or `router.replace()`.
+The default behavior of the Next.js App Router is to **scroll to the top of a new route or to maintain the scroll position for backwards and forwards navigation.** If you'd like to disable this behavior, you can pass `scroll={false}` to the `<Link>` component, or `scroll: false` to `router.push()` or `router.replace()`.
 
 ```jsx
 // next/link

--- a/docs/02-app/01-building-your-application/01-routing/03-linking-and-navigating.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/03-linking-and-navigating.mdx
@@ -143,7 +143,7 @@ If you'd like to scroll to a specific `id` on navigation, you can append your UR
 
 > **Good to know**:
 >
-> - If `{children}` from a Layout is not present in the current viewport, Next.js will scroll to the top of the `{children}` instead.
+> - If `{children}` from a Layout is not present in the current viewport, Next.js will instead scroll to the top of the `{children}`.
 
 #### Disabling scroll restoration
 

--- a/docs/02-app/02-api-reference/01-components/link.mdx
+++ b/docs/02-app/02-api-reference/01-components/link.mdx
@@ -181,7 +181,7 @@ export default function Page() {
 
 > **Good to know**:
 >
-> - If `{children}` from a Layout is not present in the current viewport, Next.js will scroll to the top of the `{children}` instead.
+> - If `{children}` from a Layout is not present in the current viewport, Next.js will instead scroll to the top of the `{children}`.
 
 ### `prefetch`
 

--- a/docs/02-app/02-api-reference/01-components/link.mdx
+++ b/docs/02-app/02-api-reference/01-components/link.mdx
@@ -181,7 +181,7 @@ export default function Page() {
 
 > **Good to know**:
 >
-> - If `{children}` from a Layout is not present in the current viewport, Next.js will instead scroll to the top of the `{children}`.
+> - Next.js will scroll to the [Page](/docs/app/building-your-application/routing/pages-and-layouts#pages) if it is not visible in the viewport upon navigation.
 
 ### `prefetch`
 

--- a/docs/02-app/02-api-reference/01-components/link.mdx
+++ b/docs/02-app/02-api-reference/01-components/link.mdx
@@ -153,7 +153,7 @@ export default function Page() {
 
 ### `scroll`
 
-**Defaults to `true`.** The default behavior of `<Link>` is to scroll to the top of a new route or to maintain the scroll position for backwards and forwards navigation. When `false`, `next/link` will _not_ scroll to the top of the page after a navigation.
+**Defaults to `true`.** The default behavior of `<Link>` **is to scroll to the top of a new route or to maintain the scroll position for backwards and forwards navigation.** When `false`, `next/link` will _not_ scroll to the top of the page after a navigation.
 
 ```tsx filename="app/page.tsx" switcher
 import Link from 'next/link'
@@ -178,6 +178,10 @@ export default function Page() {
   )
 }
 ```
+
+> **Good to know**:
+>
+> - If `{children}` from a Layout is not present in the current viewport, Next.js will scroll to the top of the `{children}` instead.
 
 ### `prefetch`
 


### PR DESCRIPTION
## Why?

We need to clarify that we are scrolling to the top of `{children}` when it is not shown in the current viewport.

Closes NEXT-2780