### PR TITLE
ensure mpa navigations to the same URL work after restoring from bfcache

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -449,6 +449,11 @@ function Router({
         return
       }
 
+      // Clear the pendingMpaPath value so that a subsequent MPA navigation to the same URL can be triggered.
+      // This is necessary because if the browser restored from bfcache, the pendingMpaPath would still be set to the value
+      // of the last MPA navigation.
+      globalMutable.pendingMpaPath = undefined
+
       dispatch({
         type: ACTION_RESTORE,
         url: new URL(window.location.href),

--- a/test/production/bfcache-routing/index.test.ts
+++ b/test/production/bfcache-routing/index.test.ts
@@ -69,5 +69,15 @@ describe('bfcache-routing', () => {
     // we should be back on the test page with no errors
     html = await browser.evalAsync('document.documentElement.innerHTML')
     expect(html).toContain('BFCache Test')
+
+    // After restoring from bfcache, a subsequent mpa navigation to the same URL should work
+    // We trigger the click via `evalAsync` because when restoring from bfcache, our internal
+    // 'waitForElementByCss' method doesn't think the element is attached to the DOM.
+    await browser.evalAsync(
+      `document.querySelector('a[href="https://example.vercel.sh"]').click()`
+    )
+    await browser.waitForCondition(
+      'window.location.origin === "https://example.vercel.sh"'
+    )
   })
 })


### PR DESCRIPTION
### What
When triggering an MPA navigation (also commonly referred to as a "hard navigation"), and then restoring the previous page via the browser's bfcache, subsequent requests to the same link wouldn't navigate until reloading the page or performing a different navigation.

### Why
MPA navigations in app router are handled in a fairly subtle way: the router state is updated with an indication that an external URL was clicked, and once the router sees the pending navigation, it kicks off a `location.replace` or `location.push` with the specified URL **in render**. The router then suspends indefinitely to prevent committing the render. However, the router will only make the `replace`/`push` request if there's not already a pending navigation to that same URL. 

The pending check is needed to avoid continuously calling `push`/`replace` when unrelated router state changes occur (for example, if I hover over a link and trigger a prefetch action and the router re-renders, it shouldn't make another `location.push` call to the same URL that's pending)

However, the source of the bug is that the variable that holds this pending state is also restored by the browser's cache, since it takes a snapshot prior to exiting the page. This means that when clicking the browser back button, `pendingMpaPath` would still be set to the URL we just came from. When clicking the link again, it would see that the requested URL is the same as the pending URL, and not perform any history actions.

### How
This clears the pending value when the router is restored from bfcache.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

[slack x-ref](https://vercel.slack.com/archives/C0676QZBWKS/p1710169967246929)

Closes NEXT-2781
Closes NEXT-2776