### PR TITLE
Fix trigger_release workflow to not publish empty canaries

### DIFF
--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -50,17 +50,8 @@ jobs:
           node-version: 18
           check-latest: true
 
-      - uses: actions/checkout@v4
-        if: github.event.inputs.releaseType == 'stable'
-        with:
-          fetch-depth: 25
-          persist-credentials: false # to allow start-release to override the git credentials
-
-      # when publishing a canary, we clone via git so we're able to fetch the latest tag
-      # we don't need to use `actions/checkout` unless publishing a stable release/backport
       - name: Clone Next.js repository
-        run: git clone https://github.com/vercel/next.js.git --depth=25 .
-        if: github.event.inputs.releaseType != 'stable'
+        run: git clone https://github.com/vercel/next.js.git --depth=25 --single-branch --branch ${GITHUB_REF_NAME:-canary} .
 
       - name: Get commit of the latest tag
         run: echo "LATEST_TAG_COMMIT=$(git rev-list -n 1 $(git describe --tags --abbrev=0))" >> $GITHUB_ENV

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -51,9 +51,16 @@ jobs:
           check-latest: true
 
       - uses: actions/checkout@v4
+        if: github.event.inputs.releaseType == 'stable'
         with:
           fetch-depth: 25
           persist-credentials: false # to allow start-release to override the git credentials
+
+      # when publishing a canary, we clone via git so we're able to fetch the latest tag
+      # we don't need to use `actions/checkout` unless publishing a stable release/backport
+      - name: Clone Next.js repository
+        run: git clone https://github.com/vercel/next.js.git --depth=25 .
+        if: github.event.inputs.releaseType != 'stable'
 
       - name: Get commit of the latest tag
         run: echo "LATEST_TAG_COMMIT=$(git rev-list -n 1 $(git describe --tags --abbrev=0))" >> $GITHUB_ENV


### PR DESCRIPTION
This fixes our workflow for checking if a new canary should be published. `actions/checkout` won't include the latest tag information so this uses the old clone workflow while still preserving branch specific checkout behavior to support backports

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2784