### PR TITLE
Ensure dynamic routes dont match _next/static unexpectedly

### DIFF
--- a/packages/next/src/server/future/route-matchers/route-matcher.ts
+++ b/packages/next/src/server/future/route-matchers/route-matcher.ts
@@ -7,6 +7,7 @@ import {
   type RouteMatchFn,
 } from '../../../shared/lib/router/utils/route-matcher'
 import { getRouteRegex } from '../../../shared/lib/router/utils/route-regex'
+import { modifyRouteRegex } from '../../../lib/redirect-status'
 
 type RouteMatchResult = {
   params?: Record<string, string | string[]>
@@ -24,7 +25,13 @@ export class RouteMatcher<D extends RouteDefinition = RouteDefinition> {
 
   constructor(public readonly definition: D) {
     if (isDynamicRoute(definition.pathname)) {
-      this.dynamic = getRouteMatcher(getRouteRegex(definition.pathname))
+      const routeRegex = getRouteRegex(definition.pathname)
+      const origRegex = routeRegex.re.toString()
+      const modifiedRegex = modifyRouteRegex(origRegex, ['/_next/static'])
+      routeRegex.re = new RegExp(
+        modifiedRegex.substring(1, modifiedRegex.length - 1)
+      )
+      this.dynamic = getRouteMatcher(routeRegex)
     }
   }
 

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -3,7 +3,12 @@ import cheerio from 'cheerio'
 import { promisify } from 'util'
 import { join } from 'path'
 import { createNextDescribe } from 'e2e-utils'
-import { check, fetchViaHTTP, normalizeRegEx, waitFor } from 'next-test-utils'
+import {
+  check,
+  fetchViaHTTP,
+  normalizeRouteRegExes,
+  waitFor,
+} from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
 const glob = promisify(globOrig)
@@ -732,13 +737,7 @@ createNextDescribe(
 
         for (const key of Object.keys(curManifest.dynamicRoutes)) {
           const item = curManifest.dynamicRoutes[key]
-
-          if (item.dataRouteRegex) {
-            item.dataRouteRegex = normalizeRegEx(item.dataRouteRegex)
-          }
-          if (item.routeRegex) {
-            item.routeRegex = normalizeRegEx(item.routeRegex)
-          }
+          normalizeRouteRegExes(item)
         }
 
         for (const key of Object.keys(curManifest.routes)) {
@@ -1510,7 +1509,7 @@ createNextDescribe(
                 },
               ],
               "fallback": null,
-              "routeRegex": "^\\/articles\\/([^\\/]+?)(?:\\/)?$",
+              "routeRegex": "^\\/articles\\/([^\\/]+?)?$",
             },
             "/blog/[author]": {
               "dataRoute": "/blog/[author].rsc",
@@ -1527,7 +1526,7 @@ createNextDescribe(
                 },
               ],
               "fallback": false,
-              "routeRegex": "^\\/blog\\/([^\\/]+?)(?:\\/)?$",
+              "routeRegex": "^\\/blog\\/([^\\/]+?)?$",
             },
             "/blog/[author]/[slug]": {
               "dataRoute": "/blog/[author]/[slug].rsc",
@@ -1544,7 +1543,7 @@ createNextDescribe(
                 },
               ],
               "fallback": null,
-              "routeRegex": "^\\/blog\\/([^\\/]+?)\\/([^\\/]+?)(?:\\/)?$",
+              "routeRegex": "^\\/blog\\/([^\\/]+?)\\/([^\\/]+?)?$",
             },
             "/dynamic-error/[id]": {
               "dataRoute": "/dynamic-error/[id].rsc",
@@ -1561,7 +1560,7 @@ createNextDescribe(
                 },
               ],
               "fallback": null,
-              "routeRegex": "^\\/dynamic\\-error\\/([^\\/]+?)(?:\\/)?$",
+              "routeRegex": "^\\/dynamic\\-error\\/([^\\/]+?)?$",
             },
             "/force-static/[slug]": {
               "dataRoute": "/force-static/[slug].rsc",
@@ -1578,7 +1577,7 @@ createNextDescribe(
                 },
               ],
               "fallback": null,
-              "routeRegex": "^\\/force\\-static\\/([^\\/]+?)(?:\\/)?$",
+              "routeRegex": "^\\/force\\-static\\/([^\\/]+?)?$",
             },
             "/gen-params-dynamic-revalidate/[slug]": {
               "dataRoute": "/gen-params-dynamic-revalidate/[slug].rsc",
@@ -1595,7 +1594,7 @@ createNextDescribe(
                 },
               ],
               "fallback": null,
-              "routeRegex": "^\\/gen\\-params\\-dynamic\\-revalidate\\/([^\\/]+?)(?:\\/)?$",
+              "routeRegex": "^\\/gen\\-params\\-dynamic\\-revalidate\\/([^\\/]+?)?$",
             },
             "/hooks/use-pathname/[slug]": {
               "dataRoute": "/hooks/use-pathname/[slug].rsc",
@@ -1612,7 +1611,7 @@ createNextDescribe(
                 },
               ],
               "fallback": null,
-              "routeRegex": "^\\/hooks\\/use\\-pathname\\/([^\\/]+?)(?:\\/)?$",
+              "routeRegex": "^\\/hooks\\/use\\-pathname\\/([^\\/]+?)?$",
             },
             "/partial-gen-params-no-additional-lang/[lang]/[slug]": {
               "dataRoute": "/partial-gen-params-no-additional-lang/[lang]/[slug].rsc",
@@ -1629,7 +1628,7 @@ createNextDescribe(
                 },
               ],
               "fallback": false,
-              "routeRegex": "^\\/partial\\-gen\\-params\\-no\\-additional\\-lang\\/([^\\/]+?)\\/([^\\/]+?)(?:\\/)?$",
+              "routeRegex": "^\\/partial\\-gen\\-params\\-no\\-additional\\-lang\\/([^\\/]+?)\\/([^\\/]+?)?$",
             },
             "/partial-gen-params-no-additional-slug/[lang]/[slug]": {
               "dataRoute": "/partial-gen-params-no-additional-slug/[lang]/[slug].rsc",
@@ -1646,7 +1645,7 @@ createNextDescribe(
                 },
               ],
               "fallback": false,
-              "routeRegex": "^\\/partial\\-gen\\-params\\-no\\-additional\\-slug\\/([^\\/]+?)\\/([^\\/]+?)(?:\\/)?$",
+              "routeRegex": "^\\/partial\\-gen\\-params\\-no\\-additional\\-slug\\/([^\\/]+?)\\/([^\\/]+?)?$",
             },
             "/ssg-draft-mode/[[...route]]": {
               "dataRoute": "/ssg-draft-mode/[[...route]].rsc",
@@ -1663,7 +1662,7 @@ createNextDescribe(
                 },
               ],
               "fallback": null,
-              "routeRegex": "^\\/ssg\\-draft\\-mode(?:\\/(.+?))?(?:\\/)?$",
+              "routeRegex": "^\\/ssg\\-draft\\-mode(?:\\/(.+?))?$",
             },
             "/static-to-dynamic-error-forced/[id]": {
               "dataRoute": "/static-to-dynamic-error-forced/[id].rsc",
@@ -1680,7 +1679,7 @@ createNextDescribe(
                 },
               ],
               "fallback": null,
-              "routeRegex": "^\\/static\\-to\\-dynamic\\-error\\-forced\\/([^\\/]+?)(?:\\/)?$",
+              "routeRegex": "^\\/static\\-to\\-dynamic\\-error\\-forced\\/([^\\/]+?)?$",
             },
           }
         `)

--- a/test/e2e/edge-pages-support/index.test.ts
+++ b/test/e2e/edge-pages-support/index.test.ts
@@ -1,5 +1,5 @@
 import { createNextDescribe } from 'e2e-utils'
-import { fetchViaHTTP, normalizeRegEx } from 'next-test-utils'
+import { fetchViaHTTP, normalizeRouteRegExes } from 'next-test-utils'
 import cheerio from 'cheerio'
 import { join } from 'path'
 import escapeStringRegexp from 'escape-string-regexp'
@@ -151,31 +151,31 @@ createNextDescribe(
         )
 
         for (const route of manifest.dataRoutes) {
-          route.dataRouteRegex = normalizeRegEx(route.dataRouteRegex)
+          normalizeRouteRegExes(route)
         }
 
-        expect(manifest.dataRoutes).toEqual([
-          {
-            dataRouteRegex: normalizeRegEx(
-              `^/_next/data/${escapeStringRegexp(next.buildId)}/index.json$`
-            ),
-            page: '/',
-          },
-          {
-            dataRouteRegex: normalizeRegEx(
-              `^/_next/data/${escapeStringRegexp(
+        expect(manifest.dataRoutes).toEqual(
+          [
+            {
+              dataRouteRegex: `^/_next/data/${escapeStringRegexp(
                 next.buildId
-              )}/([^/]+?)\\.json$`
-            ),
-            namedDataRouteRegex: `^/_next/data/${escapeStringRegexp(
-              next.buildId
-            )}/(?<nxtPid>[^/]+?)\\.json$`,
-            page: '/[id]',
-            routeKeys: {
-              nxtPid: 'nxtPid',
+              )}/index.json$`,
+              page: '/',
             },
-          },
-        ])
+            {
+              dataRouteRegex: `^/_next/data/${escapeStringRegexp(
+                next.buildId
+              )}/([^/]+?)\\.json$`,
+              namedDataRouteRegex: `^/_next/data/${escapeStringRegexp(
+                next.buildId
+              )}/(?<nxtPid>[^/]+?)\\.json$`,
+              page: '/[id]',
+              routeKeys: {
+                nxtPid: 'nxtPid',
+              },
+            },
+          ].map((item) => normalizeRouteRegExes(item))
+        )
       })
     }
   }

--- a/test/e2e/getserversideprops/test/index.test.ts
+++ b/test/e2e/getserversideprops/test/index.test.ts
@@ -8,7 +8,7 @@ import {
   fetchViaHTTP,
   getBrowserBodyText,
   getRedboxHeader,
-  normalizeRegEx,
+  normalizeRouteRegExes,
   renderViaHTTP,
   waitFor,
 } from 'next-test-utils'
@@ -20,180 +20,6 @@ const appDir = join(__dirname, '../app')
 
 let buildId
 let next: NextInstance
-
-const expectedManifestRoutes = () => [
-  {
-    dataRouteRegex: normalizeRegEx(
-      `^\\/_next\\/data\\/${escapeRegex(buildId)}\\/index.json$`
-    ),
-    page: '/',
-  },
-  {
-    dataRouteRegex: normalizeRegEx(
-      `^\\/_next\\/data\\/${escapeRegex(buildId)}\\/another.json$`
-    ),
-    page: '/another',
-  },
-  {
-    dataRouteRegex: normalizeRegEx(
-      `^\\/_next\\/data\\/${escapeRegex(buildId)}\\/blog.json$`
-    ),
-    page: '/blog',
-  },
-  {
-    namedDataRouteRegex: `^/_next/data/${escapeRegex(
-      buildId
-    )}/blog/(?<nxtPpost>[^/]+?)\\.json$`,
-    dataRouteRegex: normalizeRegEx(
-      `^\\/_next\\/data\\/${escapeRegex(buildId)}\\/blog\\/([^\\/]+?)\\.json$`
-    ),
-    page: '/blog/[post]',
-    routeKeys: {
-      nxtPpost: 'nxtPpost',
-    },
-  },
-  {
-    namedDataRouteRegex: `^/_next/data/${escapeRegex(
-      buildId
-    )}/blog/(?<nxtPpost>[^/]+?)/(?<nxtPcomment>[^/]+?)\\.json$`,
-    dataRouteRegex: normalizeRegEx(
-      `^\\/_next\\/data\\/${escapeRegex(
-        buildId
-      )}\\/blog\\/([^\\/]+?)\\/([^\\/]+?)\\.json$`
-    ),
-    page: '/blog/[post]/[comment]',
-    routeKeys: {
-      nxtPpost: 'nxtPpost',
-      nxtPcomment: 'nxtPcomment',
-    },
-  },
-  {
-    namedDataRouteRegex: `^/_next/data/${escapeRegex(
-      buildId
-    )}/catchall/(?<nxtPpath>.+?)\\.json$`,
-    dataRouteRegex: normalizeRegEx(
-      `^\\/_next\\/data\\/${escapeRegex(buildId)}\\/catchall\\/(.+?)\\.json$`
-    ),
-    page: '/catchall/[...path]',
-    routeKeys: {
-      nxtPpath: 'nxtPpath',
-    },
-  },
-  {
-    dataRouteRegex: normalizeRegEx(
-      `^\\/_next\\/data\\/${escapeRegex(buildId)}\\/custom-cache.json$`
-    ),
-    page: '/custom-cache',
-  },
-  {
-    dataRouteRegex: normalizeRegEx(
-      `^\\/_next\\/data\\/${escapeRegex(buildId)}\\/default-revalidate.json$`
-    ),
-    page: '/default-revalidate',
-  },
-  {
-    dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
-      buildId
-    )}\\/early-request-end.json$`,
-    page: '/early-request-end',
-  },
-  {
-    dataRouteRegex: normalizeRegEx(
-      `^\\/_next\\/data\\/${escapeRegex(buildId)}\\/enoent.json$`
-    ),
-    page: '/enoent',
-  },
-  {
-    dataRouteRegex: normalizeRegEx(
-      `^\\/_next\\/data\\/${escapeRegex(buildId)}\\/invalid-keys.json$`
-    ),
-    page: '/invalid-keys',
-  },
-  {
-    dataRouteRegex: normalizeRegEx(
-      `^\\/_next\\/data\\/${escapeRegex(buildId)}\\/non-json.json$`
-    ),
-    page: '/non-json',
-  },
-  {
-    dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
-      buildId
-    )}\\/not-found.json$`,
-    page: '/not-found',
-  },
-  {
-    dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
-      buildId
-    )}\\/not\\-found\\/([^\\/]+?)\\.json$`,
-    namedDataRouteRegex: `^/_next/data/${escapeRegex(
-      buildId
-    )}/not\\-found/(?<nxtPslug>[^/]+?)\\.json$`,
-    page: '/not-found/[slug]',
-    routeKeys: {
-      nxtPslug: 'nxtPslug',
-    },
-  },
-  {
-    dataRouteRegex: normalizeRegEx(
-      `^\\/_next\\/data\\/${escapeRegex(buildId)}\\/promise.json$`
-    ),
-    page: '/promise',
-  },
-  {
-    dataRouteRegex: normalizeRegEx(
-      `^\\/_next\\/data\\/${escapeRegex(buildId)}\\/promise\\/mutate-res.json$`
-    ),
-    page: '/promise/mutate-res',
-  },
-  {
-    dataRouteRegex: normalizeRegEx(
-      `^\\/_next\\/data\\/${escapeRegex(
-        buildId
-      )}\\/promise\\/mutate-res-no-streaming.json$`
-    ),
-    page: '/promise/mutate-res-no-streaming',
-  },
-  {
-    dataRouteRegex: normalizeRegEx(
-      `^\\/_next\\/data\\/${escapeRegex(
-        buildId
-      )}\\/promise\\/mutate-res-props.json$`
-    ),
-    page: '/promise/mutate-res-props',
-  },
-  {
-    dataRouteRegex: normalizeRegEx(
-      `^\\/_next\\/data\\/${escapeRegex(buildId)}\\/refresh.json$`
-    ),
-    page: '/refresh',
-  },
-  {
-    dataRouteRegex: normalizeRegEx(
-      `^\\/_next\\/data\\/${escapeRegex(buildId)}\\/slow.json$`
-    ),
-    page: '/slow',
-  },
-  {
-    dataRouteRegex: normalizeRegEx(
-      `^\\/_next\\/data\\/${escapeRegex(buildId)}\\/something.json$`
-    ),
-    page: '/something',
-  },
-  {
-    namedDataRouteRegex: `^/_next/data/${escapeRegex(
-      buildId
-    )}/user/(?<nxtPuser>[^/]+?)/profile\\.json$`,
-    dataRouteRegex: normalizeRegEx(
-      `^\\/_next\\/data\\/${escapeRegex(
-        buildId
-      )}\\/user\\/([^\\/]+?)\\/profile\\.json$`
-    ),
-    page: '/user/[user]/profile',
-    routeKeys: {
-      nxtPuser: 'nxtPuser',
-    },
-  },
-]
 
 const navigateTest = () => {
   it('should navigate between pages successfully', async () => {
@@ -789,10 +615,176 @@ const runTests = (isDev = false, isDeploy = false) => {
           await next.readFile('.next/routes-manifest.json')
         )
         for (const route of dataRoutes) {
-          route.dataRouteRegex = normalizeRegEx(route.dataRouteRegex)
+          normalizeRouteRegExes(route)
         }
 
-        expect(dataRoutes).toEqual(expectedManifestRoutes())
+        expect(dataRoutes).toEqual(
+          [
+            {
+              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                buildId
+              )}\\/index.json$`,
+              page: '/',
+            },
+            {
+              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                buildId
+              )}\\/another.json$`,
+              page: '/another',
+            },
+            {
+              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                buildId
+              )}\\/blog.json$`,
+              page: '/blog',
+            },
+            {
+              namedDataRouteRegex: `^/_next/data/${escapeRegex(
+                buildId
+              )}/blog/(?<nxtPpost>[^/]+?)\\.json$`,
+              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                buildId
+              )}\\/blog\\/([^\\/]+?)\\.json$`,
+              page: '/blog/[post]',
+              routeKeys: {
+                nxtPpost: 'nxtPpost',
+              },
+            },
+            {
+              namedDataRouteRegex: `^/_next/data/${escapeRegex(
+                buildId
+              )}/blog/(?<nxtPpost>[^/]+?)/(?<nxtPcomment>[^/]+?)\\.json$`,
+              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                buildId
+              )}\\/blog\\/([^\\/]+?)\\/([^\\/]+?)\\.json$`,
+              page: '/blog/[post]/[comment]',
+              routeKeys: {
+                nxtPpost: 'nxtPpost',
+                nxtPcomment: 'nxtPcomment',
+              },
+            },
+            {
+              namedDataRouteRegex: `^/_next/data/${escapeRegex(
+                buildId
+              )}/catchall/(?<nxtPpath>.+?)\\.json$`,
+              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                buildId
+              )}\\/catchall\\/(.+?)\\.json$`,
+              page: '/catchall/[...path]',
+              routeKeys: {
+                nxtPpath: 'nxtPpath',
+              },
+            },
+            {
+              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                buildId
+              )}\\/custom-cache.json$`,
+              page: '/custom-cache',
+            },
+            {
+              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                buildId
+              )}\\/default-revalidate.json$`,
+              page: '/default-revalidate',
+            },
+            {
+              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                buildId
+              )}\\/early-request-end.json$`,
+              page: '/early-request-end',
+            },
+            {
+              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                buildId
+              )}\\/enoent.json$`,
+              page: '/enoent',
+            },
+            {
+              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                buildId
+              )}\\/invalid-keys.json$`,
+              page: '/invalid-keys',
+            },
+            {
+              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                buildId
+              )}\\/non-json.json$`,
+              page: '/non-json',
+            },
+            {
+              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                buildId
+              )}\\/not-found.json$`,
+              page: '/not-found',
+            },
+            {
+              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                buildId
+              )}\\/not\\-found\\/([^\\/]+?)\\.json$`,
+              namedDataRouteRegex: `^/_next/data/${escapeRegex(
+                buildId
+              )}/not\\-found/(?<nxtPslug>[^/]+?)\\.json$`,
+              page: '/not-found/[slug]',
+              routeKeys: {
+                nxtPslug: 'nxtPslug',
+              },
+            },
+            {
+              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                buildId
+              )}\\/promise.json$`,
+              page: '/promise',
+            },
+            {
+              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                buildId
+              )}\\/promise\\/mutate-res.json$`,
+              page: '/promise/mutate-res',
+            },
+            {
+              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                buildId
+              )}\\/promise\\/mutate-res-no-streaming.json$`,
+              page: '/promise/mutate-res-no-streaming',
+            },
+            {
+              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                buildId
+              )}\\/promise\\/mutate-res-props.json$`,
+              page: '/promise/mutate-res-props',
+            },
+            {
+              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                buildId
+              )}\\/refresh.json$`,
+              page: '/refresh',
+            },
+            {
+              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                buildId
+              )}\\/slow.json$`,
+              page: '/slow',
+            },
+            {
+              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                buildId
+              )}\\/something.json$`,
+              page: '/something',
+            },
+            {
+              namedDataRouteRegex: `^/_next/data/${escapeRegex(
+                buildId
+              )}/user/(?<nxtPuser>[^/]+?)/profile\\.json$`,
+              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                buildId
+              )}\\/user\\/([^\\/]+?)\\/profile\\.json$`,
+              page: '/user/[user]/profile',
+              routeKeys: {
+                nxtPuser: 'nxtPuser',
+              },
+            },
+          ].map((item) => normalizeRouteRegExes(item))
+        )
       })
     }
 

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -11,7 +11,7 @@ import {
   getBrowserBodyText,
   getRedboxHeader,
   hasRedbox,
-  normalizeRegEx,
+  normalizeRouteRegExes,
   renderViaHTTP,
   waitFor,
 } from 'next-test-utils'
@@ -88,205 +88,6 @@ describe('Prerender', () => {
   function isCachingHeader(cacheControl) {
     return !cacheControl || !/no-store/.test(cacheControl)
   }
-
-  const expectedManifestRoutes = () => ({
-    '/': {
-      dataRoute: `/_next/data/${next.buildId}/index.json`,
-      initialRevalidateSeconds: 2,
-      srcRoute: null,
-    },
-    '/blog/[post3]': {
-      dataRoute: `/_next/data/${next.buildId}/blog/[post3].json`,
-      initialRevalidateSeconds: 10,
-      srcRoute: '/blog/[post]',
-    },
-    '/blog/post-1': {
-      dataRoute: `/_next/data/${next.buildId}/blog/post-1.json`,
-      initialRevalidateSeconds: 10,
-      srcRoute: '/blog/[post]',
-    },
-    '/blog/post-2': {
-      dataRoute: `/_next/data/${next.buildId}/blog/post-2.json`,
-      initialRevalidateSeconds: 10,
-      srcRoute: '/blog/[post]',
-    },
-    '/blog/post-4': {
-      dataRoute: `/_next/data/${next.buildId}/blog/post-4.json`,
-      initialRevalidateSeconds: 10,
-      srcRoute: '/blog/[post]',
-    },
-    '/blog/post-1/comment-1': {
-      dataRoute: `/_next/data/${next.buildId}/blog/post-1/comment-1.json`,
-      initialRevalidateSeconds: 2,
-      srcRoute: '/blog/[post]/[comment]',
-    },
-    '/blog/post-2/comment-2': {
-      dataRoute: `/_next/data/${next.buildId}/blog/post-2/comment-2.json`,
-      initialRevalidateSeconds: 2,
-      srcRoute: '/blog/[post]/[comment]',
-    },
-    '/blog/post.1': {
-      dataRoute: `/_next/data/${next.buildId}/blog/post.1.json`,
-      initialRevalidateSeconds: 10,
-      srcRoute: '/blog/[post]',
-    },
-    '/catchall-explicit/another/value': {
-      dataRoute: `/_next/data/${next.buildId}/catchall-explicit/another/value.json`,
-      initialRevalidateSeconds: 1,
-      srcRoute: '/catchall-explicit/[...slug]',
-    },
-    '/catchall-explicit/first': {
-      dataRoute: `/_next/data/${next.buildId}/catchall-explicit/first.json`,
-      initialRevalidateSeconds: 1,
-      srcRoute: '/catchall-explicit/[...slug]',
-    },
-    '/catchall-explicit/hello/another': {
-      dataRoute: `/_next/data/${next.buildId}/catchall-explicit/hello/another.json`,
-      initialRevalidateSeconds: 1,
-      srcRoute: '/catchall-explicit/[...slug]',
-    },
-    '/catchall-explicit/second': {
-      dataRoute: `/_next/data/${next.buildId}/catchall-explicit/second.json`,
-      initialRevalidateSeconds: 1,
-      srcRoute: '/catchall-explicit/[...slug]',
-    },
-    '/catchall-explicit/[first]/[second]': {
-      dataRoute: `/_next/data/${next.buildId}/catchall-explicit/[first]/[second].json`,
-      initialRevalidateSeconds: 1,
-      srcRoute: '/catchall-explicit/[...slug]',
-    },
-    '/catchall-explicit/[third]/[fourth]': {
-      dataRoute: `/_next/data/${next.buildId}/catchall-explicit/[third]/[fourth].json`,
-      initialRevalidateSeconds: 1,
-      srcRoute: '/catchall-explicit/[...slug]',
-    },
-    '/catchall-optional': {
-      dataRoute: `/_next/data/${next.buildId}/catchall-optional.json`,
-      initialRevalidateSeconds: false,
-      srcRoute: '/catchall-optional/[[...slug]]',
-    },
-    '/catchall-optional/value': {
-      dataRoute: `/_next/data/${next.buildId}/catchall-optional/value.json`,
-      initialRevalidateSeconds: false,
-      srcRoute: '/catchall-optional/[[...slug]]',
-    },
-    '/large-page-data': {
-      dataRoute: `/_next/data/${next.buildId}/large-page-data.json`,
-      initialRevalidateSeconds: false,
-      srcRoute: null,
-    },
-    '/another': {
-      dataRoute: `/_next/data/${next.buildId}/another.json`,
-      initialRevalidateSeconds: 1,
-      srcRoute: null,
-    },
-    '/preview': {
-      dataRoute: `/_next/data/${next.buildId}/preview.json`,
-      initialRevalidateSeconds: false,
-      srcRoute: null,
-    },
-    '/api-docs/first': {
-      dataRoute: `/_next/data/${next.buildId}/api-docs/first.json`,
-      initialRevalidateSeconds: false,
-      srcRoute: '/api-docs/[...slug]',
-    },
-    '/blocking-fallback-once/404-on-manual-revalidate': {
-      dataRoute: `/_next/data/${next.buildId}/blocking-fallback-once/404-on-manual-revalidate.json`,
-      initialRevalidateSeconds: false,
-      srcRoute: '/blocking-fallback-once/[slug]',
-    },
-    '/blocking-fallback-some/a': {
-      dataRoute: `/_next/data/${next.buildId}/blocking-fallback-some/a.json`,
-      initialRevalidateSeconds: 1,
-      srcRoute: '/blocking-fallback-some/[slug]',
-    },
-    '/blocking-fallback-some/b': {
-      dataRoute: `/_next/data/${next.buildId}/blocking-fallback-some/b.json`,
-      initialRevalidateSeconds: 1,
-      srcRoute: '/blocking-fallback-some/[slug]',
-    },
-    '/blocking-fallback/lots-of-data': {
-      dataRoute: `/_next/data/${next.buildId}/blocking-fallback/lots-of-data.json`,
-      initialRevalidateSeconds: false,
-      srcRoute: '/blocking-fallback/[slug]',
-    },
-    '/blocking-fallback/test-errors-1': {
-      dataRoute: `/_next/data/${next.buildId}/blocking-fallback/test-errors-1.json`,
-      initialRevalidateSeconds: 1,
-      srcRoute: '/blocking-fallback/[slug]',
-    },
-    '/blog': {
-      dataRoute: `/_next/data/${next.buildId}/blog.json`,
-      initialRevalidateSeconds: 10,
-      srcRoute: null,
-    },
-    '/default-revalidate': {
-      dataRoute: `/_next/data/${next.buildId}/default-revalidate.json`,
-      initialRevalidateSeconds: false,
-      srcRoute: null,
-    },
-    '/dynamic/[first]': {
-      dataRoute: `/_next/data/${next.buildId}/dynamic/[first].json`,
-      initialRevalidateSeconds: false,
-      srcRoute: '/dynamic/[slug]',
-    },
-    '/dynamic/[second]': {
-      dataRoute: `/_next/data/${next.buildId}/dynamic/[second].json`,
-      initialRevalidateSeconds: false,
-      srcRoute: '/dynamic/[slug]',
-    },
-    // TODO: investigate index/index
-    // '/index': {
-    //   dataRoute: `/_next/data/${next.buildId}/index/index.json`,
-    //   initialRevalidateSeconds: false,
-    //   srcRoute: null,
-    // },
-    '/lang/de/about': {
-      dataRoute: `/_next/data/${next.buildId}/lang/de/about.json`,
-      initialRevalidateSeconds: false,
-      srcRoute: '/lang/[lang]/about',
-    },
-    '/lang/en/about': {
-      dataRoute: `/_next/data/${next.buildId}/lang/en/about.json`,
-      initialRevalidateSeconds: false,
-      srcRoute: '/lang/[lang]/about',
-    },
-    '/lang/es/about': {
-      dataRoute: `/_next/data/${next.buildId}/lang/es/about.json`,
-      initialRevalidateSeconds: false,
-      srcRoute: '/lang/[lang]/about',
-    },
-    '/lang/fr/about': {
-      dataRoute: `/_next/data/${next.buildId}/lang/fr/about.json`,
-      initialRevalidateSeconds: false,
-      srcRoute: '/lang/[lang]/about',
-    },
-    '/something': {
-      dataRoute: `/_next/data/${next.buildId}/something.json`,
-      initialRevalidateSeconds: false,
-      srcRoute: null,
-    },
-    '/catchall/another/value': {
-      dataRoute: `/_next/data/${next.buildId}/catchall/another/value.json`,
-      initialRevalidateSeconds: 1,
-      srcRoute: '/catchall/[...slug]',
-    },
-    '/catchall/first': {
-      dataRoute: `/_next/data/${next.buildId}/catchall/first.json`,
-      initialRevalidateSeconds: 1,
-      srcRoute: '/catchall/[...slug]',
-    },
-    '/catchall/second': {
-      dataRoute: `/_next/data/${next.buildId}/catchall/second.json`,
-      initialRevalidateSeconds: 1,
-      srcRoute: '/catchall/[...slug]',
-    },
-    '/catchall/hello/another': {
-      dataRoute: `/_next/data/${next.buildId}/catchall/hello/another.json`,
-      initialRevalidateSeconds: 1,
-      srcRoute: '/catchall/[...slug]',
-    },
-  })
 
   const navigateTest = (isDev = false) => {
     it('should navigate between pages successfully', async () => {
@@ -1290,303 +1091,263 @@ describe('Prerender', () => {
           )
 
           for (const route of dataRoutes) {
-            route.dataRouteRegex = normalizeRegEx(route.dataRouteRegex)
+            normalizeRouteRegExes(route)
           }
 
-          expect(dataRoutes).toEqual([
-            {
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(next.buildId)}\\/index.json$`
-              ),
-              page: '/',
-            },
-            {
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(
+          expect(dataRoutes).toEqual(
+            [
+              {
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
                   next.buildId
-                )}\\/another.json$`
-              ),
-              page: '/another',
-            },
-            {
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(
-                  next.buildId
-                )}\\/api\\-docs\\/(.+?)\\.json$`
-              ),
-              namedDataRouteRegex: `^/_next/data/${escapeRegex(
-                next.buildId
-              )}/api\\-docs/(?<nxtPslug>.+?)\\.json$`,
-              page: '/api-docs/[...slug]',
-              routeKeys: {
-                nxtPslug: 'nxtPslug',
+                )}\\/index.json$`,
+                page: '/',
               },
-            },
-            {
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(
+              {
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
                   next.buildId
-                )}\\/bad-gssp.json$`
-              ),
-              page: '/bad-gssp',
-            },
-            {
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(
-                  next.buildId
-                )}\\/bad-ssr.json$`
-              ),
-              page: '/bad-ssr',
-            },
-            {
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(
-                  next.buildId
-                )}\\/blocking\\-fallback\\/([^\\/]+?)\\.json$`
-              ),
-              namedDataRouteRegex: `^/_next/data/${escapeRegex(
-                next.buildId
-              )}/blocking\\-fallback/(?<nxtPslug>[^/]+?)\\.json$`,
-              page: '/blocking-fallback/[slug]',
-              routeKeys: { nxtPslug: 'nxtPslug' },
-            },
-            {
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(
-                  next.buildId
-                )}\\/blocking\\-fallback\\-once\\/([^\\/]+?)\\.json$`
-              ),
-              namedDataRouteRegex: `^/_next/data/${escapeRegex(
-                next.buildId
-              )}/blocking\\-fallback\\-once/(?<nxtPslug>[^/]+?)\\.json$`,
-              page: '/blocking-fallback-once/[slug]',
-              routeKeys: { nxtPslug: 'nxtPslug' },
-            },
-            {
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(
-                  next.buildId
-                )}\\/blocking\\-fallback\\-some\\/([^\\/]+?)\\.json$`
-              ),
-              namedDataRouteRegex: `^/_next/data/${escapeRegex(
-                next.buildId
-              )}/blocking\\-fallback\\-some/(?<nxtPslug>[^/]+?)\\.json$`,
-              page: '/blocking-fallback-some/[slug]',
-              routeKeys: { nxtPslug: 'nxtPslug' },
-            },
-            {
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(next.buildId)}\\/blog.json$`
-              ),
-              page: '/blog',
-            },
-            {
-              namedDataRouteRegex: `^/_next/data/${escapeRegex(
-                next.buildId
-              )}/blog/(?<nxtPpost>[^/]+?)\\.json$`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(
-                  next.buildId
-                )}\\/blog\\/([^\\/]+?)\\.json$`
-              ),
-              page: '/blog/[post]',
-              routeKeys: {
-                nxtPpost: 'nxtPpost',
+                )}\\/another.json$`,
+                page: '/another',
               },
-            },
-            {
-              namedDataRouteRegex: `^/_next/data/${escapeRegex(
-                next.buildId
-              )}/blog/(?<nxtPpost>[^/]+?)/(?<nxtPcomment>[^/]+?)\\.json$`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(
+              {
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
                   next.buildId
-                )}\\/blog\\/([^\\/]+?)\\/([^\\/]+?)\\.json$`
-              ),
-              page: '/blog/[post]/[comment]',
-              routeKeys: {
-                nxtPpost: 'nxtPpost',
-                nxtPcomment: 'nxtPcomment',
+                )}\\/api\\-docs\\/(.+?)\\.json$`,
+                namedDataRouteRegex: `^/_next/data/${escapeRegex(
+                  next.buildId
+                )}/api\\-docs/(?<nxtPslug>.+?)\\.json$`,
+                page: '/api-docs/[...slug]',
+                routeKeys: {
+                  nxtPslug: 'nxtPslug',
+                },
               },
-            },
-            {
-              namedDataRouteRegex: `^/_next/data/${escapeRegex(
-                next.buildId
-              )}/catchall/(?<nxtPslug>.+?)\\.json$`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(
+              {
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
                   next.buildId
-                )}\\/catchall\\/(.+?)\\.json$`
-              ),
-              page: '/catchall/[...slug]',
-              routeKeys: {
-                nxtPslug: 'nxtPslug',
+                )}\\/bad-gssp.json$`,
+                page: '/bad-gssp',
               },
-            },
-            {
-              namedDataRouteRegex: `^/_next/data/${escapeRegex(
-                next.buildId
-              )}/catchall\\-explicit/(?<nxtPslug>.+?)\\.json$`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(
+              {
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
                   next.buildId
-                )}\\/catchall\\-explicit\\/(.+?)\\.json$`
-              ),
-              page: '/catchall-explicit/[...slug]',
-              routeKeys: {
-                nxtPslug: 'nxtPslug',
+                )}\\/bad-ssr.json$`,
+                page: '/bad-ssr',
               },
-            },
-            {
-              namedDataRouteRegex: `^/_next/data/${escapeRegex(
-                next.buildId
-              )}/catchall\\-optional(?:/(?<nxtPslug>.+?))?\\.json$`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(
+              {
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
                   next.buildId
-                )}\\/catchall\\-optional(?:\\/(.+?))?\\.json$`
-              ),
-              page: '/catchall-optional/[[...slug]]',
-              routeKeys: {
-                nxtPslug: 'nxtPslug',
+                )}\\/blocking\\-fallback\\/([^\\/]+?)\\.json$`,
+                namedDataRouteRegex: `^/_next/data/${escapeRegex(
+                  next.buildId
+                )}/blocking\\-fallback/(?<nxtPslug>[^/]+?)\\.json$`,
+                page: '/blocking-fallback/[slug]',
+                routeKeys: { nxtPslug: 'nxtPslug' },
               },
-            },
-            {
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(
+              {
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
                   next.buildId
-                )}\\/default-revalidate.json$`
-              ),
-              page: '/default-revalidate',
-            },
-            {
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(
+                )}\\/blocking\\-fallback\\-once\\/([^\\/]+?)\\.json$`,
+                namedDataRouteRegex: `^/_next/data/${escapeRegex(
                   next.buildId
-                )}\\/dynamic\\/([^\\/]+?)\\.json$`
-              ),
-              namedDataRouteRegex: `^/_next/data/${escapeRegex(
-                next.buildId
-              )}/dynamic/(?<nxtPslug>[^/]+?)\\.json$`,
-              page: '/dynamic/[slug]',
-              routeKeys: {
-                nxtPslug: 'nxtPslug',
+                )}/blocking\\-fallback\\-once/(?<nxtPslug>[^/]+?)\\.json$`,
+                page: '/blocking-fallback-once/[slug]',
+                routeKeys: { nxtPslug: 'nxtPslug' },
               },
-            },
-            {
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(
+              {
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
                   next.buildId
-                )}\\/fallback\\-only\\/([^\\/]+?)\\.json$`
-              ),
-              namedDataRouteRegex: `^/_next/data/${escapeRegex(
-                next.buildId
-              )}/fallback\\-only/(?<nxtPslug>[^/]+?)\\.json$`,
-              page: '/fallback-only/[slug]',
-              routeKeys: {
-                nxtPslug: 'nxtPslug',
+                )}\\/blocking\\-fallback\\-some\\/([^\\/]+?)\\.json$`,
+                namedDataRouteRegex: `^/_next/data/${escapeRegex(
+                  next.buildId
+                )}/blocking\\-fallback\\-some/(?<nxtPslug>[^/]+?)\\.json$`,
+                page: '/blocking-fallback-some/[slug]',
+                routeKeys: { nxtPslug: 'nxtPslug' },
               },
-            },
-            // TODO: investigate index/index
-            // {
-            //   dataRouteRegex: normalizeRegEx(
-            //     `^\\/_next\\/data\\/${escapeRegex(
-            //       next.buildId
-            //     )}\\/index\\/index.json$`
-            //   ),
-            //   page: '/index',
-            // },
-            {
-              namedDataRouteRegex: `^/_next/data/${escapeRegex(
-                next.buildId
-              )}/lang/(?<nxtPlang>[^/]+?)/about\\.json$`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(
+              {
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
                   next.buildId
-                )}\\/lang\\/([^\\/]+?)\\/about\\.json$`
-              ),
-              page: '/lang/[lang]/about',
-              routeKeys: {
-                nxtPlang: 'nxtPlang',
+                )}\\/blog.json$`,
+                page: '/blog',
               },
-            },
-            {
-              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
-                next.buildId
-              )}\\/large-page-data.json$`,
-              page: '/large-page-data',
-            },
-            {
-              dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
-                next.buildId
-              )}\\/large-page-data-ssr.json$`,
-              page: '/large-page-data-ssr',
-            },
-            {
-              namedDataRouteRegex: `^/_next/data/${escapeRegex(
-                next.buildId
-              )}/non\\-json/(?<nxtPp>[^/]+?)\\.json$`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(
+              {
+                namedDataRouteRegex: `^/_next/data/${escapeRegex(
                   next.buildId
-                )}\\/non\\-json\\/([^\\/]+?)\\.json$`
-              ),
-              page: '/non-json/[p]',
-              routeKeys: {
-                nxtPp: 'nxtPp',
+                )}/blog/(?<nxtPpost>[^/]+?)\\.json$`,
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                  next.buildId
+                )}\\/blog\\/([^\\/]+?)\\.json$`,
+                page: '/blog/[post]',
+                routeKeys: {
+                  nxtPpost: 'nxtPpost',
+                },
               },
-            },
-            {
-              namedDataRouteRegex: `^/_next/data/${escapeRegex(
-                next.buildId
-              )}/non\\-json\\-blocking/(?<nxtPp>[^/]+?)\\.json$`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(
+              {
+                namedDataRouteRegex: `^/_next/data/${escapeRegex(
                   next.buildId
-                )}\\/non\\-json\\-blocking\\/([^\\/]+?)\\.json$`
-              ),
-              page: '/non-json-blocking/[p]',
-              routeKeys: {
-                nxtPp: 'nxtPp',
+                )}/blog/(?<nxtPpost>[^/]+?)/(?<nxtPcomment>[^/]+?)\\.json$`,
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                  next.buildId
+                )}\\/blog\\/([^\\/]+?)\\/([^\\/]+?)\\.json$`,
+                page: '/blog/[post]/[comment]',
+                routeKeys: {
+                  nxtPpost: 'nxtPpost',
+                  nxtPcomment: 'nxtPcomment',
+                },
               },
-            },
-            {
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(
+              {
+                namedDataRouteRegex: `^/_next/data/${escapeRegex(
                   next.buildId
-                )}\\/preview.json$`
-              ),
-              page: '/preview',
-            },
-            {
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(
+                )}/catchall/(?<nxtPslug>.+?)\\.json$`,
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
                   next.buildId
-                )}\\/something.json$`
-              ),
-              page: '/something',
-            },
-            {
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(next.buildId)}\\/ssr.json$`
-              ),
-              page: '/ssr',
-            },
-            {
-              namedDataRouteRegex: `^/_next/data/${escapeRegex(
-                next.buildId
-              )}/user/(?<nxtPuser>[^/]+?)/profile\\.json$`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapeRegex(
-                  next.buildId
-                )}\\/user\\/([^\\/]+?)\\/profile\\.json$`
-              ),
-              page: '/user/[user]/profile',
-              routeKeys: {
-                nxtPuser: 'nxtPuser',
+                )}\\/catchall\\/(.+?)\\.json$`,
+                page: '/catchall/[...slug]',
+                routeKeys: {
+                  nxtPslug: 'nxtPslug',
+                },
               },
-            },
-          ])
+              {
+                namedDataRouteRegex: `^/_next/data/${escapeRegex(
+                  next.buildId
+                )}/catchall\\-explicit/(?<nxtPslug>.+?)\\.json$`,
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                  next.buildId
+                )}\\/catchall\\-explicit\\/(.+?)\\.json$`,
+                page: '/catchall-explicit/[...slug]',
+                routeKeys: {
+                  nxtPslug: 'nxtPslug',
+                },
+              },
+              {
+                namedDataRouteRegex: `^/_next/data/${escapeRegex(
+                  next.buildId
+                )}/catchall\\-optional(?:/(?<nxtPslug>.+?))?\\.json$`,
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                  next.buildId
+                )}\\/catchall\\-optional(?:\\/(.+?))?\\.json$`,
+                page: '/catchall-optional/[[...slug]]',
+                routeKeys: {
+                  nxtPslug: 'nxtPslug',
+                },
+              },
+              {
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                  next.buildId
+                )}\\/default-revalidate.json$`,
+                page: '/default-revalidate',
+              },
+              {
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                  next.buildId
+                )}\\/dynamic\\/([^\\/]+?)\\.json$`,
+                namedDataRouteRegex: `^/_next/data/${escapeRegex(
+                  next.buildId
+                )}/dynamic/(?<nxtPslug>[^/]+?)\\.json$`,
+                page: '/dynamic/[slug]',
+                routeKeys: {
+                  nxtPslug: 'nxtPslug',
+                },
+              },
+              {
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                  next.buildId
+                )}\\/fallback\\-only\\/([^\\/]+?)\\.json$`,
+                namedDataRouteRegex: `^/_next/data/${escapeRegex(
+                  next.buildId
+                )}/fallback\\-only/(?<nxtPslug>[^/]+?)\\.json$`,
+                page: '/fallback-only/[slug]',
+                routeKeys: {
+                  nxtPslug: 'nxtPslug',
+                },
+              },
+              // TODO: investigate index/index
+              // {
+              //   dataRouteRegex: (
+              //     `^\\/_next\\/data\\/${escapeRegex(
+              //       next.buildId
+              //     )}\\/index\\/index.json$`
+              //   ),
+              //   page: '/index',
+              // },
+              {
+                namedDataRouteRegex: `^/_next/data/${escapeRegex(
+                  next.buildId
+                )}/lang/(?<nxtPlang>[^/]+?)/about\\.json$`,
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                  next.buildId
+                )}\\/lang\\/([^\\/]+?)\\/about\\.json$`,
+                page: '/lang/[lang]/about',
+                routeKeys: {
+                  nxtPlang: 'nxtPlang',
+                },
+              },
+              {
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                  next.buildId
+                )}\\/large-page-data.json$`,
+                page: '/large-page-data',
+              },
+              {
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                  next.buildId
+                )}\\/large-page-data-ssr.json$`,
+                page: '/large-page-data-ssr',
+              },
+              {
+                namedDataRouteRegex: `^/_next/data/${escapeRegex(
+                  next.buildId
+                )}/non\\-json/(?<nxtPp>[^/]+?)\\.json$`,
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                  next.buildId
+                )}\\/non\\-json\\/([^\\/]+?)\\.json$`,
+                page: '/non-json/[p]',
+                routeKeys: {
+                  nxtPp: 'nxtPp',
+                },
+              },
+              {
+                namedDataRouteRegex: `^/_next/data/${escapeRegex(
+                  next.buildId
+                )}/non\\-json\\-blocking/(?<nxtPp>[^/]+?)\\.json$`,
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                  next.buildId
+                )}\\/non\\-json\\-blocking\\/([^\\/]+?)\\.json$`,
+                page: '/non-json-blocking/[p]',
+                routeKeys: {
+                  nxtPp: 'nxtPp',
+                },
+              },
+              {
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                  next.buildId
+                )}\\/preview.json$`,
+                page: '/preview',
+              },
+              {
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                  next.buildId
+                )}\\/something.json$`,
+                page: '/something',
+              },
+              {
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                  next.buildId
+                )}\\/ssr.json$`,
+                page: '/ssr',
+              },
+              {
+                namedDataRouteRegex: `^/_next/data/${escapeRegex(
+                  next.buildId
+                )}/user/(?<nxtPuser>[^/]+?)/profile\\.json$`,
+                dataRouteRegex: `^\\/_next\\/data\\/${escapeRegex(
+                  next.buildId
+                )}\\/user\\/([^\\/]+?)\\/profile\\.json$`,
+                page: '/user/[user]/profile',
+                routeKeys: {
+                  nxtPuser: 'nxtPuser',
+                },
+              },
+            ].map((item) => normalizeRouteRegExes(item))
+          )
         })
 
         it('outputs a prerender-manifest correctly', async () => {
@@ -1597,162 +1358,315 @@ describe('Prerender', () => {
 
           Object.keys(manifest.dynamicRoutes).forEach((key) => {
             const item = manifest.dynamicRoutes[key]
-
-            if (item.dataRouteRegex) {
-              item.dataRouteRegex = normalizeRegEx(item.dataRouteRegex)
-            }
-            if (item.routeRegex) {
-              item.routeRegex = normalizeRegEx(item.routeRegex)
-            }
+            normalizeRouteRegExes(item)
           })
 
-          expect(manifest.version).toBe(4)
-          expect(manifest.routes).toEqual(expectedManifestRoutes())
-          expect(manifest.dynamicRoutes).toEqual({
+          const expectedDynamicRoutes = {
             '/api-docs/[...slug]': {
               dataRoute: `/_next/data/${next.buildId}/api-docs/[...slug].json`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapedBuildId}\\/api\\-docs\\/(.+?)\\.json$`
-              ),
+              dataRouteRegex: `^\\/_next\\/data\\/${escapedBuildId}\\/api\\-docs\\/(.+?)\\.json$`,
               fallback: '/api-docs/[...slug].html',
-              routeRegex: normalizeRegEx(`^\\/api\\-docs\\/(.+?)(?:\\/)?$`),
+              routeRegex: `^\\/api\\-docs\\/(.+?)(?:\\/)?$`,
             },
             '/blocking-fallback-once/[slug]': {
               dataRoute: `/_next/data/${next.buildId}/blocking-fallback-once/[slug].json`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapedBuildId}\\/blocking\\-fallback\\-once\\/([^\\/]+?)\\.json$`
-              ),
+              dataRouteRegex: `^\\/_next\\/data\\/${escapedBuildId}\\/blocking\\-fallback\\-once\\/([^\\/]+?)\\.json$`,
               fallback: null,
-              routeRegex: normalizeRegEx(
-                '^\\/blocking\\-fallback\\-once\\/([^\\/]+?)(?:\\/)?$'
-              ),
+              routeRegex:
+                '^\\/blocking\\-fallback\\-once\\/([^\\/]+?)(?:\\/)?$',
             },
             '/blocking-fallback-some/[slug]': {
               dataRoute: `/_next/data/${next.buildId}/blocking-fallback-some/[slug].json`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapedBuildId}\\/blocking\\-fallback\\-some\\/([^\\/]+?)\\.json$`
-              ),
+              dataRouteRegex: `^\\/_next\\/data\\/${escapedBuildId}\\/blocking\\-fallback\\-some\\/([^\\/]+?)\\.json$`,
               fallback: null,
-              routeRegex: normalizeRegEx(
-                '^\\/blocking\\-fallback\\-some\\/([^\\/]+?)(?:\\/)?$'
-              ),
+              routeRegex:
+                '^\\/blocking\\-fallback\\-some\\/([^\\/]+?)(?:\\/)?$',
             },
             '/blocking-fallback/[slug]': {
               dataRoute: `/_next/data/${next.buildId}/blocking-fallback/[slug].json`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapedBuildId}\\/blocking\\-fallback\\/([^\\/]+?)\\.json$`
-              ),
+              dataRouteRegex: `^\\/_next\\/data\\/${escapedBuildId}\\/blocking\\-fallback\\/([^\\/]+?)\\.json$`,
               fallback: null,
-              routeRegex: normalizeRegEx(
-                '^\\/blocking\\-fallback\\/([^\\/]+?)(?:\\/)?$'
-              ),
+              routeRegex: '^\\/blocking\\-fallback\\/([^\\/]+?)(?:\\/)?$',
             },
             '/blog/[post]': {
               fallback: '/blog/[post].html',
               dataRoute: `/_next/data/${next.buildId}/blog/[post].json`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapedBuildId}\\/blog\\/([^\\/]+?)\\.json$`
-              ),
-              routeRegex: normalizeRegEx('^\\/blog\\/([^\\/]+?)(?:\\/)?$'),
+              dataRouteRegex: `^\\/_next\\/data\\/${escapedBuildId}\\/blog\\/([^\\/]+?)\\.json$`,
+              routeRegex: '^\\/blog\\/([^\\/]+?)(?:\\/)?$',
             },
             '/blog/[post]/[comment]': {
               fallback: '/blog/[post]/[comment].html',
               dataRoute: `/_next/data/${next.buildId}/blog/[post]/[comment].json`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapedBuildId}\\/blog\\/([^\\/]+?)\\/([^\\/]+?)\\.json$`
-              ),
-              routeRegex: normalizeRegEx(
-                '^\\/blog\\/([^\\/]+?)\\/([^\\/]+?)(?:\\/)?$'
-              ),
+              dataRouteRegex: `^\\/_next\\/data\\/${escapedBuildId}\\/blog\\/([^\\/]+?)\\/([^\\/]+?)\\.json$`,
+              routeRegex: '^\\/blog\\/([^\\/]+?)\\/([^\\/]+?)(?:\\/)?$',
             },
             '/dynamic/[slug]': {
               dataRoute: `/_next/data/${next.buildId}/dynamic/[slug].json`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapedBuildId}\\/dynamic\\/([^\\/]+?)\\.json$`
-              ),
+              dataRouteRegex: `^\\/_next\\/data\\/${escapedBuildId}\\/dynamic\\/([^\\/]+?)\\.json$`,
               fallback: false,
-              routeRegex: normalizeRegEx(`^\\/dynamic\\/([^\\/]+?)(?:\\/)?$`),
+              routeRegex: `^\\/dynamic\\/([^\\/]+?)(?:\\/)?$`,
             },
             '/fallback-only/[slug]': {
               dataRoute: `/_next/data/${next.buildId}/fallback-only/[slug].json`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapedBuildId}\\/fallback\\-only\\/([^\\/]+?)\\.json$`
-              ),
+              dataRouteRegex: `^\\/_next\\/data\\/${escapedBuildId}\\/fallback\\-only\\/([^\\/]+?)\\.json$`,
               fallback: '/fallback-only/[slug].html',
-              routeRegex: normalizeRegEx(
-                '^\\/fallback\\-only\\/([^\\/]+?)(?:\\/)?$'
-              ),
+              routeRegex: '^\\/fallback\\-only\\/([^\\/]+?)(?:\\/)?$',
             },
             '/lang/[lang]/about': {
               dataRoute: `/_next/data/${next.buildId}/lang/[lang]/about.json`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapedBuildId}\\/lang\\/([^\\/]+?)\\/about\\.json$`
-              ),
+              dataRouteRegex: `^\\/_next\\/data\\/${escapedBuildId}\\/lang\\/([^\\/]+?)\\/about\\.json$`,
               fallback: false,
-              routeRegex: normalizeRegEx(
-                '^\\/lang\\/([^\\/]+?)\\/about(?:\\/)?$'
-              ),
+              routeRegex: '^\\/lang\\/([^\\/]+?)\\/about(?:\\/)?$',
             },
             '/non-json-blocking/[p]': {
               dataRoute: `/_next/data/${next.buildId}/non-json-blocking/[p].json`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapedBuildId}\\/non\\-json\\-blocking\\/([^\\/]+?)\\.json$`
-              ),
+              dataRouteRegex: `^\\/_next\\/data\\/${escapedBuildId}\\/non\\-json\\-blocking\\/([^\\/]+?)\\.json$`,
               fallback: null,
-              routeRegex: normalizeRegEx(
-                '^\\/non\\-json\\-blocking\\/([^\\/]+?)(?:\\/)?$'
-              ),
+              routeRegex: '^\\/non\\-json\\-blocking\\/([^\\/]+?)(?:\\/)?$',
             },
             '/non-json/[p]': {
               dataRoute: `/_next/data/${next.buildId}/non-json/[p].json`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapedBuildId}\\/non\\-json\\/([^\\/]+?)\\.json$`
-              ),
+              dataRouteRegex: `^\\/_next\\/data\\/${escapedBuildId}\\/non\\-json\\/([^\\/]+?)\\.json$`,
               fallback: '/non-json/[p].html',
-              routeRegex: normalizeRegEx(
-                '^\\/non\\-json\\/([^\\/]+?)(?:\\/)?$'
-              ),
+              routeRegex: '^\\/non\\-json\\/([^\\/]+?)(?:\\/)?$',
             },
             '/user/[user]/profile': {
               fallback: '/user/[user]/profile.html',
               dataRoute: `/_next/data/${next.buildId}/user/[user]/profile.json`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapedBuildId}\\/user\\/([^\\/]+?)\\/profile\\.json$`
-              ),
-              routeRegex: normalizeRegEx(
-                `^\\/user\\/([^\\/]+?)\\/profile(?:\\/)?$`
-              ),
+              dataRouteRegex: `^\\/_next\\/data\\/${escapedBuildId}\\/user\\/([^\\/]+?)\\/profile\\.json$`,
+              routeRegex: `^\\/user\\/([^\\/]+?)\\/profile(?:\\/)?$`,
             },
 
             '/catchall/[...slug]': {
               fallback: '/catchall/[...slug].html',
-              routeRegex: normalizeRegEx('^\\/catchall\\/(.+?)(?:\\/)?$'),
+              routeRegex: '^\\/catchall\\/(.+?)(?:\\/)?$',
               dataRoute: `/_next/data/${next.buildId}/catchall/[...slug].json`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapedBuildId}\\/catchall\\/(.+?)\\.json$`
-              ),
+              dataRouteRegex: `^\\/_next\\/data\\/${escapedBuildId}\\/catchall\\/(.+?)\\.json$`,
             },
             '/catchall-optional/[[...slug]]': {
               dataRoute: `/_next/data/${next.buildId}/catchall-optional/[[...slug]].json`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapedBuildId}\\/catchall\\-optional(?:\\/(.+?))?\\.json$`
-              ),
+              dataRouteRegex: `^\\/_next\\/data\\/${escapedBuildId}\\/catchall\\-optional(?:\\/(.+?))?\\.json$`,
               fallback: false,
-              routeRegex: normalizeRegEx(
-                '^\\/catchall\\-optional(?:\\/(.+?))?(?:\\/)?$'
-              ),
+              routeRegex: '^\\/catchall\\-optional(?:\\/(.+?))?(?:\\/)?$',
             },
             '/catchall-explicit/[...slug]': {
               dataRoute: `/_next/data/${next.buildId}/catchall-explicit/[...slug].json`,
-              dataRouteRegex: normalizeRegEx(
-                `^\\/_next\\/data\\/${escapedBuildId}\\/catchall\\-explicit\\/(.+?)\\.json$`
-              ),
+              dataRouteRegex: `^\\/_next\\/data\\/${escapedBuildId}\\/catchall\\-explicit\\/(.+?)\\.json$`,
               fallback: false,
-              routeRegex: normalizeRegEx(
-                '^\\/catchall\\-explicit\\/(.+?)(?:\\/)?$'
-              ),
+              routeRegex: '^\\/catchall\\-explicit\\/(.+?)(?:\\/)?$',
             },
+          }
+          Object.keys(expectedDynamicRoutes).forEach((key) => {
+            const item = expectedDynamicRoutes[key]
+            normalizeRouteRegExes(item)
           })
+
+          const expectedManifestRoutes = {
+            '/': {
+              dataRoute: `/_next/data/${next.buildId}/index.json`,
+              initialRevalidateSeconds: 2,
+              srcRoute: null,
+            },
+            '/blog/[post3]': {
+              dataRoute: `/_next/data/${next.buildId}/blog/[post3].json`,
+              initialRevalidateSeconds: 10,
+              srcRoute: '/blog/[post]',
+            },
+            '/blog/post-1': {
+              dataRoute: `/_next/data/${next.buildId}/blog/post-1.json`,
+              initialRevalidateSeconds: 10,
+              srcRoute: '/blog/[post]',
+            },
+            '/blog/post-2': {
+              dataRoute: `/_next/data/${next.buildId}/blog/post-2.json`,
+              initialRevalidateSeconds: 10,
+              srcRoute: '/blog/[post]',
+            },
+            '/blog/post-4': {
+              dataRoute: `/_next/data/${next.buildId}/blog/post-4.json`,
+              initialRevalidateSeconds: 10,
+              srcRoute: '/blog/[post]',
+            },
+            '/blog/post-1/comment-1': {
+              dataRoute: `/_next/data/${next.buildId}/blog/post-1/comment-1.json`,
+              initialRevalidateSeconds: 2,
+              srcRoute: '/blog/[post]/[comment]',
+            },
+            '/blog/post-2/comment-2': {
+              dataRoute: `/_next/data/${next.buildId}/blog/post-2/comment-2.json`,
+              initialRevalidateSeconds: 2,
+              srcRoute: '/blog/[post]/[comment]',
+            },
+            '/blog/post.1': {
+              dataRoute: `/_next/data/${next.buildId}/blog/post.1.json`,
+              initialRevalidateSeconds: 10,
+              srcRoute: '/blog/[post]',
+            },
+            '/catchall-explicit/another/value': {
+              dataRoute: `/_next/data/${next.buildId}/catchall-explicit/another/value.json`,
+              initialRevalidateSeconds: 1,
+              srcRoute: '/catchall-explicit/[...slug]',
+            },
+            '/catchall-explicit/first': {
+              dataRoute: `/_next/data/${next.buildId}/catchall-explicit/first.json`,
+              initialRevalidateSeconds: 1,
+              srcRoute: '/catchall-explicit/[...slug]',
+            },
+            '/catchall-explicit/hello/another': {
+              dataRoute: `/_next/data/${next.buildId}/catchall-explicit/hello/another.json`,
+              initialRevalidateSeconds: 1,
+              srcRoute: '/catchall-explicit/[...slug]',
+            },
+            '/catchall-explicit/second': {
+              dataRoute: `/_next/data/${next.buildId}/catchall-explicit/second.json`,
+              initialRevalidateSeconds: 1,
+              srcRoute: '/catchall-explicit/[...slug]',
+            },
+            '/catchall-explicit/[first]/[second]': {
+              dataRoute: `/_next/data/${next.buildId}/catchall-explicit/[first]/[second].json`,
+              initialRevalidateSeconds: 1,
+              srcRoute: '/catchall-explicit/[...slug]',
+            },
+            '/catchall-explicit/[third]/[fourth]': {
+              dataRoute: `/_next/data/${next.buildId}/catchall-explicit/[third]/[fourth].json`,
+              initialRevalidateSeconds: 1,
+              srcRoute: '/catchall-explicit/[...slug]',
+            },
+            '/catchall-optional': {
+              dataRoute: `/_next/data/${next.buildId}/catchall-optional.json`,
+              initialRevalidateSeconds: false,
+              srcRoute: '/catchall-optional/[[...slug]]',
+            },
+            '/catchall-optional/value': {
+              dataRoute: `/_next/data/${next.buildId}/catchall-optional/value.json`,
+              initialRevalidateSeconds: false,
+              srcRoute: '/catchall-optional/[[...slug]]',
+            },
+            '/large-page-data': {
+              dataRoute: `/_next/data/${next.buildId}/large-page-data.json`,
+              initialRevalidateSeconds: false,
+              srcRoute: null,
+            },
+            '/another': {
+              dataRoute: `/_next/data/${next.buildId}/another.json`,
+              initialRevalidateSeconds: 1,
+              srcRoute: null,
+            },
+            '/preview': {
+              dataRoute: `/_next/data/${next.buildId}/preview.json`,
+              initialRevalidateSeconds: false,
+              srcRoute: null,
+            },
+            '/api-docs/first': {
+              dataRoute: `/_next/data/${next.buildId}/api-docs/first.json`,
+              initialRevalidateSeconds: false,
+              srcRoute: '/api-docs/[...slug]',
+            },
+            '/blocking-fallback-once/404-on-manual-revalidate': {
+              dataRoute: `/_next/data/${next.buildId}/blocking-fallback-once/404-on-manual-revalidate.json`,
+              initialRevalidateSeconds: false,
+              srcRoute: '/blocking-fallback-once/[slug]',
+            },
+            '/blocking-fallback-some/a': {
+              dataRoute: `/_next/data/${next.buildId}/blocking-fallback-some/a.json`,
+              initialRevalidateSeconds: 1,
+              srcRoute: '/blocking-fallback-some/[slug]',
+            },
+            '/blocking-fallback-some/b': {
+              dataRoute: `/_next/data/${next.buildId}/blocking-fallback-some/b.json`,
+              initialRevalidateSeconds: 1,
+              srcRoute: '/blocking-fallback-some/[slug]',
+            },
+            '/blocking-fallback/lots-of-data': {
+              dataRoute: `/_next/data/${next.buildId}/blocking-fallback/lots-of-data.json`,
+              initialRevalidateSeconds: false,
+              srcRoute: '/blocking-fallback/[slug]',
+            },
+            '/blocking-fallback/test-errors-1': {
+              dataRoute: `/_next/data/${next.buildId}/blocking-fallback/test-errors-1.json`,
+              initialRevalidateSeconds: 1,
+              srcRoute: '/blocking-fallback/[slug]',
+            },
+            '/blog': {
+              dataRoute: `/_next/data/${next.buildId}/blog.json`,
+              initialRevalidateSeconds: 10,
+              srcRoute: null,
+            },
+            '/default-revalidate': {
+              dataRoute: `/_next/data/${next.buildId}/default-revalidate.json`,
+              initialRevalidateSeconds: false,
+              srcRoute: null,
+            },
+            '/dynamic/[first]': {
+              dataRoute: `/_next/data/${next.buildId}/dynamic/[first].json`,
+              initialRevalidateSeconds: false,
+              srcRoute: '/dynamic/[slug]',
+            },
+            '/dynamic/[second]': {
+              dataRoute: `/_next/data/${next.buildId}/dynamic/[second].json`,
+              initialRevalidateSeconds: false,
+              srcRoute: '/dynamic/[slug]',
+            },
+            // TODO: investigate index/index
+            // '/index': {
+            //   dataRoute: `/_next/data/${next.buildId}/index/index.json`,
+            //   initialRevalidateSeconds: false,
+            //   srcRoute: null,
+            // },
+            '/lang/de/about': {
+              dataRoute: `/_next/data/${next.buildId}/lang/de/about.json`,
+              initialRevalidateSeconds: false,
+              srcRoute: '/lang/[lang]/about',
+            },
+            '/lang/en/about': {
+              dataRoute: `/_next/data/${next.buildId}/lang/en/about.json`,
+              initialRevalidateSeconds: false,
+              srcRoute: '/lang/[lang]/about',
+            },
+            '/lang/es/about': {
+              dataRoute: `/_next/data/${next.buildId}/lang/es/about.json`,
+              initialRevalidateSeconds: false,
+              srcRoute: '/lang/[lang]/about',
+            },
+            '/lang/fr/about': {
+              dataRoute: `/_next/data/${next.buildId}/lang/fr/about.json`,
+              initialRevalidateSeconds: false,
+              srcRoute: '/lang/[lang]/about',
+            },
+            '/something': {
+              dataRoute: `/_next/data/${next.buildId}/something.json`,
+              initialRevalidateSeconds: false,
+              srcRoute: null,
+            },
+            '/catchall/another/value': {
+              dataRoute: `/_next/data/${next.buildId}/catchall/another/value.json`,
+              initialRevalidateSeconds: 1,
+              srcRoute: '/catchall/[...slug]',
+            },
+            '/catchall/first': {
+              dataRoute: `/_next/data/${next.buildId}/catchall/first.json`,
+              initialRevalidateSeconds: 1,
+              srcRoute: '/catchall/[...slug]',
+            },
+            '/catchall/second': {
+              dataRoute: `/_next/data/${next.buildId}/catchall/second.json`,
+              initialRevalidateSeconds: 1,
+              srcRoute: '/catchall/[...slug]',
+            },
+            '/catchall/hello/another': {
+              dataRoute: `/_next/data/${next.buildId}/catchall/hello/another.json`,
+              initialRevalidateSeconds: 1,
+              srcRoute: '/catchall/[...slug]',
+            },
+          }
+          Object.keys(expectedManifestRoutes).forEach((key) => {
+            const item = expectedManifestRoutes[key]
+            normalizeRouteRegExes(item)
+          })
+
+          expect(manifest.version).toBe(4)
+          expect(manifest.routes).toEqual(expectedManifestRoutes)
+          expect(manifest.dynamicRoutes).toEqual(expectedDynamicRoutes)
         })
 
         it('outputs prerendered files correctly', async () => {

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -20,9 +20,9 @@ import {
   renderViaHTTP,
   getBrowserBodyText,
   waitFor,
-  normalizeRegEx,
   hasRedbox,
   check,
+  normalizeRouteRegExes,
 } from 'next-test-utils'
 
 let appDir = join(__dirname, '..')
@@ -1482,17 +1482,16 @@ const runTests = (isDev = false) => {
       )
 
       for (const route of [
+        ...manifest.staticRoutes,
         ...manifest.dynamicRoutes,
         ...manifest.rewrites.beforeFiles,
         ...manifest.rewrites.afterFiles,
         ...manifest.rewrites.fallback,
         ...manifest.redirects,
         ...manifest.headers,
+        ...manifest.dataRoutes,
       ]) {
-        route.regex = normalizeRegEx(route.regex)
-      }
-      for (const route of manifest.dataRoutes) {
-        route.dataRouteRegex = normalizeRegEx(route.dataRouteRegex)
+        normalizeRouteRegExes(route)
       }
 
       expect(manifest).toEqual({
@@ -1502,11 +1501,9 @@ const runTests = (isDev = false) => {
         basePath: '',
         dataRoutes: [
           {
-            dataRouteRegex: normalizeRegEx(
-              `^/_next/data/${escapeRegex(
-                buildId
-              )}/blog\\-catchall/(.+?)\\.json$`
-            ),
+            dataRouteRegex: `^/_next/data/${escapeRegex(
+              buildId
+            )}/blog\\-catchall/(.+?)\\.json$`,
             namedDataRouteRegex: `^/_next/data/${escapeRegex(
               buildId
             )}/blog\\-catchall/(?<nxtPslug>.+?)\\.json$`,
@@ -1527,13 +1524,11 @@ const runTests = (isDev = false) => {
               nxtPslug: 'nxtPslug',
             },
           },
-        ],
+        ].map((item) => normalizeRouteRegExes(item)),
         redirects: [
           {
             destination: '/:path+',
-            regex: normalizeRegEx(
-              '^(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))\\/$'
-            ),
+            regex: '^(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))\\/$',
             source: '/:path+/',
             statusCode: 308,
             internal: true,
@@ -1547,9 +1542,7 @@ const runTests = (isDev = false) => {
                 value: '(?<myHeader>.*)',
               },
             ],
-            regex: normalizeRegEx(
-              '^(?!\\/_next)\\/missing-redirect-1(?:\\/)?$'
-            ),
+            regex: '^(?!\\/_next)\\/missing-redirect-1(?:\\/)?$',
             source: '/missing-redirect-1',
             statusCode: 307,
           },
@@ -1561,9 +1554,7 @@ const runTests = (isDev = false) => {
                 type: 'query',
               },
             ],
-            regex: normalizeRegEx(
-              '^(?!\\/_next)\\/missing-redirect-2(?:\\/)?$'
-            ),
+            regex: '^(?!\\/_next)\\/missing-redirect-2(?:\\/)?$',
             source: '/missing-redirect-2',
             statusCode: 307,
           },
@@ -1576,17 +1567,14 @@ const runTests = (isDev = false) => {
                 value: '(?<loggedIn>true)',
               },
             ],
-            regex: normalizeRegEx(
-              '^(?!\\/_next)\\/missing-redirect-3(?:\\/)?$'
-            ),
+            regex: '^(?!\\/_next)\\/missing-redirect-3(?:\\/)?$',
             source: '/missing-redirect-3',
             statusCode: 307,
           },
           {
             destination: '/:lang/about',
-            regex: normalizeRegEx(
-              '^(?!\\/_next)\\/redirect\\/me\\/to-about(?:\\/([^\\/]+?))(?:\\/)?$'
-            ),
+            regex:
+              '^(?!\\/_next)\\/redirect\\/me\\/to-about(?:\\/([^\\/]+?))(?:\\/)?$',
             source: '/redirect/me/to-about/:lang',
             statusCode: 307,
           },
@@ -1594,141 +1582,127 @@ const runTests = (isDev = false) => {
             source: '/docs/router-status/:code',
             destination: '/docs/v2/network/status-codes#:code',
             statusCode: 301,
-            regex: normalizeRegEx(
-              '^(?!\\/_next)\\/docs\\/router-status(?:\\/([^\\/]+?))(?:\\/)?$'
-            ),
+            regex:
+              '^(?!\\/_next)\\/docs\\/router-status(?:\\/([^\\/]+?))(?:\\/)?$',
           },
           {
             source: '/docs/github',
             destination: '/docs/v2/advanced/now-for-github',
             statusCode: 301,
-            regex: normalizeRegEx('^(?!\\/_next)\\/docs\\/github(?:\\/)?$'),
+            regex: '^(?!\\/_next)\\/docs\\/github(?:\\/)?$',
           },
           {
             source: '/docs/v2/advanced/:all(.*)',
             destination: '/docs/v2/more/:all',
             statusCode: 301,
-            regex: normalizeRegEx(
-              '^(?!\\/_next)\\/docs\\/v2\\/advanced(?:\\/(.*))(?:\\/)?$'
-            ),
+            regex: '^(?!\\/_next)\\/docs\\/v2\\/advanced(?:\\/(.*))(?:\\/)?$',
           },
           {
             source: '/hello/:id/another',
             destination: '/blog/:id',
             statusCode: 307,
-            regex: normalizeRegEx(
-              '^(?!\\/_next)\\/hello(?:\\/([^\\/]+?))\\/another(?:\\/)?$'
-            ),
+            regex: '^(?!\\/_next)\\/hello(?:\\/([^\\/]+?))\\/another(?:\\/)?$',
           },
           {
             source: '/redirect1',
             destination: '/',
             statusCode: 307,
-            regex: normalizeRegEx('^(?!\\/_next)\\/redirect1(?:\\/)?$'),
+            regex: '^(?!\\/_next)\\/redirect1(?:\\/)?$',
           },
           {
             source: '/redirect2',
             destination: '/',
             statusCode: 301,
-            regex: normalizeRegEx('^(?!\\/_next)\\/redirect2(?:\\/)?$'),
+            regex: '^(?!\\/_next)\\/redirect2(?:\\/)?$',
           },
           {
             source: '/redirect3',
             destination: '/another',
             statusCode: 302,
-            regex: normalizeRegEx('^(?!\\/_next)\\/redirect3(?:\\/)?$'),
+            regex: '^(?!\\/_next)\\/redirect3(?:\\/)?$',
           },
           {
             source: '/redirect4',
             destination: '/',
             statusCode: 308,
-            regex: normalizeRegEx('^(?!\\/_next)\\/redirect4(?:\\/)?$'),
+            regex: '^(?!\\/_next)\\/redirect4(?:\\/)?$',
           },
           {
             source: '/redir-chain1',
             destination: '/redir-chain2',
             statusCode: 301,
-            regex: normalizeRegEx('^(?!\\/_next)\\/redir-chain1(?:\\/)?$'),
+            regex: '^(?!\\/_next)\\/redir-chain1(?:\\/)?$',
           },
           {
             source: '/redir-chain2',
             destination: '/redir-chain3',
             statusCode: 302,
-            regex: normalizeRegEx('^(?!\\/_next)\\/redir-chain2(?:\\/)?$'),
+            regex: '^(?!\\/_next)\\/redir-chain2(?:\\/)?$',
           },
           {
             source: '/redir-chain3',
             destination: '/',
             statusCode: 303,
-            regex: normalizeRegEx('^(?!\\/_next)\\/redir-chain3(?:\\/)?$'),
+            regex: '^(?!\\/_next)\\/redir-chain3(?:\\/)?$',
           },
           {
             destination: 'https://google.com',
-            regex: normalizeRegEx('^(?!\\/_next)\\/to-external(?:\\/)?$'),
+            regex: '^(?!\\/_next)\\/to-external(?:\\/)?$',
             source: '/to-external',
             statusCode: 307,
           },
           {
             destination: '/with-params?first=:section&second=:name',
-            regex: normalizeRegEx(
-              '^(?!\\/_next)\\/query-redirect(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))(?:\\/)?$'
-            ),
+            regex:
+              '^(?!\\/_next)\\/query-redirect(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))(?:\\/)?$',
             source: '/query-redirect/:section/:name',
             statusCode: 307,
           },
           {
             destination: '/got-unnamed',
-            regex: normalizeRegEx(
-              '^(?!\\/_next)\\/unnamed(?:\\/(first|second))(?:\\/(.*))(?:\\/)?$'
-            ),
+            regex:
+              '^(?!\\/_next)\\/unnamed(?:\\/(first|second))(?:\\/(.*))(?:\\/)?$',
             source: '/unnamed/(first|second)/(.*)',
             statusCode: 307,
           },
           {
             destination: '/:0',
-            regex: normalizeRegEx(
-              '^(?!\\/_next)\\/named-like-unnamed(?:\\/([^\\/]+?))(?:\\/)?$'
-            ),
+            regex:
+              '^(?!\\/_next)\\/named-like-unnamed(?:\\/([^\\/]+?))(?:\\/)?$',
             source: '/named-like-unnamed/:0',
             statusCode: 307,
           },
           {
             destination: '/thank-you-next',
-            regex: normalizeRegEx('^(?!\\/_next)\\/redirect-override(?:\\/)?$'),
+            regex: '^(?!\\/_next)\\/redirect-override(?:\\/)?$',
             source: '/redirect-override',
             statusCode: 307,
           },
           {
             destination: '/:first/:second',
-            regex: normalizeRegEx(
-              '^(?!\\/_next)\\/docs(?:\\/(integrations|now-cli))\\/v2(.*)(?:\\/)?$'
-            ),
+            regex:
+              '^(?!\\/_next)\\/docs(?:\\/(integrations|now-cli))\\/v2(.*)(?:\\/)?$',
             source: '/docs/:first(integrations|now-cli)/v2:second(.*)',
             statusCode: 307,
           },
           {
             destination: '/somewhere',
-            regex: normalizeRegEx(
-              '^(?!\\/_next)\\/catchall-redirect(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$'
-            ),
+            regex:
+              '^(?!\\/_next)\\/catchall-redirect(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$',
             source: '/catchall-redirect/:path*',
             statusCode: 307,
           },
           {
             destination:
               'https://authserver.example.com/set-password?returnUrl=https%3A%2F%2Fwww.example.com/login',
-            regex: normalizeRegEx(
-              '^(?!\\/_next)\\/to-external-with-query(?:\\/)?$'
-            ),
+            regex: '^(?!\\/_next)\\/to-external-with-query(?:\\/)?$',
             source: '/to-external-with-query',
             statusCode: 307,
           },
           {
             destination:
               'https://authserver.example.com/set-password?returnUrl=https://www.example.com/login',
-            regex: normalizeRegEx(
-              '^(?!\\/_next)\\/to-external-with-query-2(?:\\/)?$'
-            ),
+            regex: '^(?!\\/_next)\\/to-external-with-query-2(?:\\/)?$',
             source: '/to-external-with-query-2',
             statusCode: 307,
           },
@@ -1741,7 +1715,7 @@ const runTests = (isDev = false) => {
                 value: '(?<myHeader>.*)',
               },
             ],
-            regex: normalizeRegEx('^(?!\\/_next)\\/has-redirect-1(?:\\/)?$'),
+            regex: '^(?!\\/_next)\\/has-redirect-1(?:\\/)?$',
             source: '/has-redirect-1',
             statusCode: 307,
           },
@@ -1753,7 +1727,7 @@ const runTests = (isDev = false) => {
                 type: 'query',
               },
             ],
-            regex: normalizeRegEx('^(?!\\/_next)\\/has-redirect-2(?:\\/)?$'),
+            regex: '^(?!\\/_next)\\/has-redirect-2(?:\\/)?$',
             source: '/has-redirect-2',
             statusCode: 307,
           },
@@ -1766,7 +1740,7 @@ const runTests = (isDev = false) => {
                 value: 'true',
               },
             ],
-            regex: normalizeRegEx('^(?!\\/_next)\\/has-redirect-3(?:\\/)?$'),
+            regex: '^(?!\\/_next)\\/has-redirect-3(?:\\/)?$',
             source: '/has-redirect-3',
             statusCode: 307,
           },
@@ -1778,7 +1752,7 @@ const runTests = (isDev = false) => {
                 value: 'example.com',
               },
             ],
-            regex: normalizeRegEx('^(?!\\/_next)\\/has-redirect-4(?:\\/)?$'),
+            regex: '^(?!\\/_next)\\/has-redirect-4(?:\\/)?$',
             source: '/has-redirect-4',
             statusCode: 307,
           },
@@ -1790,9 +1764,7 @@ const runTests = (isDev = false) => {
                 type: 'header',
               },
             ],
-            regex: normalizeRegEx(
-              '^(?!\\/_next)(?:\\/([^\\/]+?))\\/has-redirect-5(?:\\/)?$'
-            ),
+            regex: '^(?!\\/_next)(?:\\/([^\\/]+?))\\/has-redirect-5(?:\\/)?$',
             source: '/:path/has-redirect-5',
             statusCode: 307,
           },
@@ -1804,13 +1776,13 @@ const runTests = (isDev = false) => {
                 value: '(?<subdomain>.*)-test.example.com',
               },
             ],
-            regex: normalizeRegEx('^(?!\\/_next)\\/has-redirect-6(?:\\/)?$'),
+            regex: '^(?!\\/_next)\\/has-redirect-6(?:\\/)?$',
             source: '/has-redirect-6',
             statusCode: 307,
           },
           {
             source: '/has-redirect-7',
-            regex: normalizeRegEx('^(?!\\/_next)\\/has-redirect-7(?:\\/)?$'),
+            regex: '^(?!\\/_next)\\/has-redirect-7(?:\\/)?$',
             has: [
               {
                 type: 'query',
@@ -1821,7 +1793,7 @@ const runTests = (isDev = false) => {
             destination: '/somewhere?value=:hello',
             statusCode: 307,
           },
-        ],
+        ].map((item) => normalizeRouteRegExes(item)),
         headers: [
           {
             headers: [
@@ -1837,7 +1809,7 @@ const runTests = (isDev = false) => {
                 value: '(?<myHeader>.*)',
               },
             ],
-            regex: normalizeRegEx('^\\/missing-headers-1(?:\\/)?$'),
+            regex: '^\\/missing-headers-1(?:\\/)?$',
             source: '/missing-headers-1',
           },
           {
@@ -1853,7 +1825,7 @@ const runTests = (isDev = false) => {
                 type: 'query',
               },
             ],
-            regex: normalizeRegEx('^\\/missing-headers-2(?:\\/)?$'),
+            regex: '^\\/missing-headers-2(?:\\/)?$',
             source: '/missing-headers-2',
           },
           {
@@ -1870,7 +1842,7 @@ const runTests = (isDev = false) => {
                 value: '(?<loggedIn>true)',
               },
             ],
-            regex: normalizeRegEx('^\\/missing-headers-3(?:\\/)?$'),
+            regex: '^\\/missing-headers-3(?:\\/)?$',
             source: '/missing-headers-3',
           },
           {
@@ -1884,7 +1856,7 @@ const runTests = (isDev = false) => {
                 value: 'hello again',
               },
             ],
-            regex: normalizeRegEx('^\\/add-header(?:\\/)?$'),
+            regex: '^\\/add-header(?:\\/)?$',
             source: '/add-header',
           },
           {
@@ -1898,7 +1870,7 @@ const runTests = (isDev = false) => {
                 value: 'second',
               },
             ],
-            regex: normalizeRegEx('^\\/my-headers(?:\\/(.*))(?:\\/)?$'),
+            regex: '^\\/my-headers(?:\\/(.*))(?:\\/)?$',
             source: '/my-headers/(.*)',
           },
           {
@@ -1953,9 +1925,7 @@ const runTests = (isDev = false) => {
                   "default-src 'self'; img-src *; media-src media1.com media2.com; script-src userscripts.example.com/:path",
               },
             ],
-            regex: normalizeRegEx(
-              '^\\/my-other-header(?:\\/([^\\/]+?))(?:\\/)?$'
-            ),
+            regex: '^\\/my-other-header(?:\\/([^\\/]+?))(?:\\/)?$',
             source: '/my-other-header/:path',
           },
           {
@@ -1965,7 +1935,7 @@ const runTests = (isDev = false) => {
                 value: 'https://example.com',
               },
             ],
-            regex: normalizeRegEx('^\\/without-params\\/url(?:\\/)?$'),
+            regex: '^\\/without-params\\/url(?:\\/)?$',
             source: '/without-params/url',
           },
           {
@@ -1975,9 +1945,8 @@ const runTests = (isDev = false) => {
                 value: 'https://example.com/:path*',
               },
             ],
-            regex: normalizeRegEx(
-              '^\\/with-params\\/url(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$'
-            ),
+            regex:
+              '^\\/with-params\\/url(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$',
             source: '/with-params/url/:path*',
           },
           {
@@ -1987,9 +1956,8 @@ const runTests = (isDev = false) => {
                 value: 'https://example.com:8080?hello=:path*',
               },
             ],
-            regex: normalizeRegEx(
-              '^\\/with-params\\/url2(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$'
-            ),
+            regex:
+              '^\\/with-params\\/url2(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$',
             source: '/with-params/url2/:path*',
           },
           {
@@ -1999,9 +1967,7 @@ const runTests = (isDev = false) => {
                 value: 'applied-everywhere',
               },
             ],
-            regex: normalizeRegEx(
-              '^(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$'
-            ),
+            regex: '^(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$',
             source: '/:path*',
           },
           {
@@ -2015,7 +1981,7 @@ const runTests = (isDev = false) => {
                 value: 'end',
               },
             ],
-            regex: normalizeRegEx('^\\/named-pattern(?:\\/(.*))(?:\\/)?$'),
+            regex: '^\\/named-pattern(?:\\/(.*))(?:\\/)?$',
             source: '/named-pattern/:path(.*)',
           },
           {
@@ -2025,9 +1991,8 @@ const runTests = (isDev = false) => {
                 value: ':path*',
               },
             ],
-            regex: normalizeRegEx(
-              '^\\/catchall-header(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$'
-            ),
+            regex:
+              '^\\/catchall-header(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$',
             source: '/catchall-header/:path*',
           },
           {
@@ -2044,7 +2009,7 @@ const runTests = (isDev = false) => {
                 value: 'header',
               },
             ],
-            regex: normalizeRegEx('^\\/has-header-1(?:\\/)?$'),
+            regex: '^\\/has-header-1(?:\\/)?$',
             source: '/has-header-1',
           },
           {
@@ -2060,7 +2025,7 @@ const runTests = (isDev = false) => {
                 value: 'value',
               },
             ],
-            regex: normalizeRegEx('^\\/has-header-2(?:\\/)?$'),
+            regex: '^\\/has-header-2(?:\\/)?$',
             source: '/has-header-2',
           },
           {
@@ -2077,7 +2042,7 @@ const runTests = (isDev = false) => {
                 value: 'yuuuup',
               },
             ],
-            regex: normalizeRegEx('^\\/has-header-3(?:\\/)?$'),
+            regex: '^\\/has-header-3(?:\\/)?$',
             source: '/has-header-3',
           },
           {
@@ -2093,10 +2058,10 @@ const runTests = (isDev = false) => {
                 value: 'yuuuup',
               },
             ],
-            regex: normalizeRegEx('^\\/has-header-4(?:\\/)?$'),
+            regex: '^\\/has-header-4(?:\\/)?$',
             source: '/has-header-4',
           },
-        ],
+        ].map((item) => normalizeRouteRegExes(item)),
         rewrites: {
           beforeFiles: [
             {
@@ -2107,188 +2072,174 @@ const runTests = (isDev = false) => {
                   type: 'query',
                 },
               ],
-              regex: normalizeRegEx('^\\/hello(?:\\/)?$'),
+              regex: '^\\/hello(?:\\/)?$',
               source: '/hello',
             },
             {
               destination: '/blog/:path*',
-              regex: normalizeRegEx(
-                '^\\/old-blog(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$'
-              ),
+              regex:
+                '^\\/old-blog(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$',
               source: '/old-blog/:path*',
             },
             {
               destination: 'https://example.vercel.sh',
-              regex: normalizeRegEx('^\\/overridden(?:\\/)?$'),
+              regex: '^\\/overridden(?:\\/)?$',
               source: '/overridden',
             },
             {
               destination: '/_sport/nfl/:path*',
-              regex: normalizeRegEx(
-                '^\\/nfl(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$'
-              ),
+              regex:
+                '^\\/nfl(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$',
               source: '/nfl/:path*',
             },
-          ],
+          ].map((item) => normalizeRouteRegExes(item)),
           afterFiles: [
             {
               destination: `http://localhost:${externalServerPort}/_next/webpack-hmr?page=/about`,
-              regex: normalizeRegEx('^\\/to-websocket(?:\\/)?$'),
+              regex: '^\\/to-websocket(?:\\/)?$',
               source: '/to-websocket',
             },
             {
               destination: '/hello',
-              regex: normalizeRegEx('^\\/websocket-to-page(?:\\/)?$'),
+              regex: '^\\/websocket-to-page(?:\\/)?$',
               source: '/websocket-to-page',
             },
             {
               destination: 'http://localhost:12233',
-              regex: normalizeRegEx('^\\/to-nowhere(?:\\/)?$'),
+              regex: '^\\/to-nowhere(?:\\/)?$',
               source: '/to-nowhere',
             },
             {
               destination: '/auto-export/hello?rewrite=1',
-              regex: normalizeRegEx('^\\/rewriting-to-auto-export(?:\\/)?$'),
+              regex: '^\\/rewriting-to-auto-export(?:\\/)?$',
               source: '/rewriting-to-auto-export',
             },
             {
               destination: '/auto-export/another?rewrite=1',
-              regex: normalizeRegEx(
-                '^\\/rewriting-to-another-auto-export(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$'
-              ),
+              regex:
+                '^\\/rewriting-to-another-auto-export(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$',
               source: '/rewriting-to-another-auto-export/:path*',
             },
             {
               destination: '/another/one',
-              regex: normalizeRegEx('^\\/to-another(?:\\/)?$'),
+              regex: '^\\/to-another(?:\\/)?$',
               source: '/to-another',
             },
             {
               destination: '/404',
-              regex: normalizeRegEx('^\\/nav(?:\\/)?$'),
+              regex: '^\\/nav(?:\\/)?$',
               source: '/nav',
             },
             {
               source: '/hello-world',
               destination: '/static/hello.txt',
-              regex: normalizeRegEx('^\\/hello-world(?:\\/)?$'),
+              regex: '^\\/hello-world(?:\\/)?$',
             },
             {
               source: '/',
               destination: '/another',
-              regex: normalizeRegEx('^\\/(?:\\/)?$'),
+              regex: '^\\/(?:\\/)?$',
             },
             {
               source: '/another',
               destination: '/multi-rewrites',
-              regex: normalizeRegEx('^\\/another(?:\\/)?$'),
+              regex: '^\\/another(?:\\/)?$',
             },
             {
               source: '/first',
               destination: '/hello',
-              regex: normalizeRegEx('^\\/first(?:\\/)?$'),
+              regex: '^\\/first(?:\\/)?$',
             },
             {
               source: '/second',
               destination: '/hello-again',
-              regex: normalizeRegEx('^\\/second(?:\\/)?$'),
+              regex: '^\\/second(?:\\/)?$',
             },
             {
               destination: '/hello',
-              regex: normalizeRegEx('^\\/to-hello(?:\\/)?$'),
+              regex: '^\\/to-hello(?:\\/)?$',
               source: '/to-hello',
             },
             {
               destination: '/blog/post-2',
-              regex: normalizeRegEx('^\\/blog\\/post-1(?:\\/)?$'),
+              regex: '^\\/blog\\/post-1(?:\\/)?$',
               source: '/blog/post-1',
             },
             {
               source: '/test/:path',
               destination: '/:path',
-              regex: normalizeRegEx('^\\/test(?:\\/([^\\/]+?))(?:\\/)?$'),
+              regex: '^\\/test(?:\\/([^\\/]+?))(?:\\/)?$',
             },
             {
               source: '/test-overwrite/:something/:another',
               destination: '/params/this-should-be-the-value',
-              regex: normalizeRegEx(
-                '^\\/test-overwrite(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))(?:\\/)?$'
-              ),
+              regex:
+                '^\\/test-overwrite(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))(?:\\/)?$',
             },
             {
               source: '/params/:something',
               destination: '/with-params',
-              regex: normalizeRegEx('^\\/params(?:\\/([^\\/]+?))(?:\\/)?$'),
+              regex: '^\\/params(?:\\/([^\\/]+?))(?:\\/)?$',
             },
             {
               destination: '/with-params?first=:section&second=:name',
-              regex: normalizeRegEx(
-                '^\\/query-rewrite(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))(?:\\/)?$'
-              ),
+              regex:
+                '^\\/query-rewrite(?:\\/([^\\/]+?))(?:\\/([^\\/]+?))(?:\\/)?$',
               source: '/query-rewrite/:section/:name',
             },
             {
               destination: '/_next/:path*',
-              regex: normalizeRegEx(
-                '^\\/hidden\\/_next(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$'
-              ),
+              regex:
+                '^\\/hidden\\/_next(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$',
               source: '/hidden/_next/:path*',
             },
             {
               destination: `http://localhost:${externalServerPort}/:path*`,
-              regex: normalizeRegEx(
-                '^\\/proxy-me(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$'
-              ),
+              regex:
+                '^\\/proxy-me(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$',
               source: '/proxy-me/:path*',
             },
             {
               destination: '/api/hello',
-              regex: normalizeRegEx('^\\/api-hello(?:\\/)?$'),
+              regex: '^\\/api-hello(?:\\/)?$',
               source: '/api-hello',
             },
             {
               destination: '/api/hello?name=:first*',
-              regex: normalizeRegEx('^\\/api-hello-regex(?:\\/(.*))(?:\\/)?$'),
+              regex: '^\\/api-hello-regex(?:\\/(.*))(?:\\/)?$',
               source: '/api-hello-regex/:first(.*)',
             },
             {
               destination: '/api/hello?hello=:name',
-              regex: normalizeRegEx(
-                '^\\/api-hello-param(?:\\/([^\\/]+?))(?:\\/)?$'
-              ),
+              regex: '^\\/api-hello-param(?:\\/([^\\/]+?))(?:\\/)?$',
               source: '/api-hello-param/:name',
             },
             {
               destination: '/api/dynamic/:name?hello=:name',
-              regex: normalizeRegEx(
-                '^\\/api-dynamic-param(?:\\/([^\\/]+?))(?:\\/)?$'
-              ),
+              regex: '^\\/api-dynamic-param(?:\\/([^\\/]+?))(?:\\/)?$',
               source: '/api-dynamic-param/:name',
             },
             {
               destination: '/with-params',
-              regex: normalizeRegEx('^(?:\\/([^\\/]+?))\\/post-321(?:\\/)?$'),
+              regex: '^(?:\\/([^\\/]+?))\\/post-321(?:\\/)?$',
               source: '/:path/post-321',
             },
             {
               destination: '/with-params',
-              regex: normalizeRegEx(
-                '^\\/unnamed-params\\/nested(?:\\/(.*))(?:\\/([^\\/]+?))(?:\\/(.*))(?:\\/)?$'
-              ),
+              regex:
+                '^\\/unnamed-params\\/nested(?:\\/(.*))(?:\\/([^\\/]+?))(?:\\/(.*))(?:\\/)?$',
               source: '/unnamed-params/nested/(.*)/:test/(.*)',
             },
             {
               destination: '/with-params',
-              regex: normalizeRegEx(
-                '^\\/catchall-rewrite(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$'
-              ),
+              regex:
+                '^\\/catchall-rewrite(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$',
               source: '/catchall-rewrite/:path*',
             },
             {
               destination: '/with-params?another=:path*',
-              regex: normalizeRegEx(
-                '^\\/catchall-query(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$'
-              ),
+              regex:
+                '^\\/catchall-query(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$',
               source: '/catchall-query/:path*',
             },
             {
@@ -2300,7 +2251,7 @@ const runTests = (isDev = false) => {
                   value: '(?<myHeader>.*)',
                 },
               ],
-              regex: normalizeRegEx('^\\/has-rewrite-1(?:\\/)?$'),
+              regex: '^\\/has-rewrite-1(?:\\/)?$',
               source: '/has-rewrite-1',
             },
             {
@@ -2311,7 +2262,7 @@ const runTests = (isDev = false) => {
                   type: 'query',
                 },
               ],
-              regex: normalizeRegEx('^\\/has-rewrite-2(?:\\/)?$'),
+              regex: '^\\/has-rewrite-2(?:\\/)?$',
               source: '/has-rewrite-2',
             },
             {
@@ -2323,7 +2274,7 @@ const runTests = (isDev = false) => {
                   value: '(?<loggedIn>true)',
                 },
               ],
-              regex: normalizeRegEx('^\\/has-rewrite-3(?:\\/)?$'),
+              regex: '^\\/has-rewrite-3(?:\\/)?$',
               source: '/has-rewrite-3',
             },
             {
@@ -2334,7 +2285,7 @@ const runTests = (isDev = false) => {
                   value: 'example.com',
                 },
               ],
-              regex: normalizeRegEx('^\\/has-rewrite-4(?:\\/)?$'),
+              regex: '^\\/has-rewrite-4(?:\\/)?$',
               source: '/has-rewrite-4',
             },
             {
@@ -2345,7 +2296,7 @@ const runTests = (isDev = false) => {
                   type: 'query',
                 },
               ],
-              regex: normalizeRegEx('^\\/has-rewrite-5(?:\\/)?$'),
+              regex: '^\\/has-rewrite-5(?:\\/)?$',
               source: '/has-rewrite-5',
             },
             {
@@ -2357,7 +2308,7 @@ const runTests = (isDev = false) => {
                   value: 'with-params',
                 },
               ],
-              regex: normalizeRegEx('^\\/has-rewrite-6(?:\\/)?$'),
+              regex: '^\\/has-rewrite-6(?:\\/)?$',
               source: '/has-rewrite-6',
             },
             {
@@ -2369,7 +2320,7 @@ const runTests = (isDev = false) => {
                   value: '(?<idk>with-params|hello)',
                 },
               ],
-              regex: normalizeRegEx('^\\/has-rewrite-7(?:\\/)?$'),
+              regex: '^\\/has-rewrite-7(?:\\/)?$',
               source: '/has-rewrite-7',
             },
             {
@@ -2380,7 +2331,7 @@ const runTests = (isDev = false) => {
                   type: 'query',
                 },
               ],
-              regex: normalizeRegEx('^\\/has-rewrite-8(?:\\/)?$'),
+              regex: '^\\/has-rewrite-8(?:\\/)?$',
               source: '/has-rewrite-8',
             },
             {
@@ -2392,7 +2343,7 @@ const runTests = (isDev = false) => {
                   value: '(?<myHeader>.*)',
                 },
               ],
-              regex: normalizeRegEx('^\\/missing-rewrite-1(?:\\/)?$'),
+              regex: '^\\/missing-rewrite-1(?:\\/)?$',
               source: '/missing-rewrite-1',
             },
             {
@@ -2403,7 +2354,7 @@ const runTests = (isDev = false) => {
                   type: 'query',
                 },
               ],
-              regex: normalizeRegEx('^\\/missing-rewrite-2(?:\\/)?$'),
+              regex: '^\\/missing-rewrite-2(?:\\/)?$',
               source: '/missing-rewrite-2',
             },
             {
@@ -2415,12 +2366,12 @@ const runTests = (isDev = false) => {
                   value: '(?<loggedIn>true)',
                 },
               ],
-              regex: normalizeRegEx('^\\/missing-rewrite-3(?:\\/)?$'),
+              regex: '^\\/missing-rewrite-3(?:\\/)?$',
               source: '/missing-rewrite-3',
             },
             {
               destination: '/hello',
-              regex: normalizeRegEx('^\\/blog\\/about(?:\\/)?$'),
+              regex: '^\\/blog\\/about(?:\\/)?$',
               source: '/blog/about',
             },
             {
@@ -2429,14 +2380,14 @@ const runTests = (isDev = false) => {
                 '^\\/overridden(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?(?:\\/)?$',
               source: '/overridden/:path*',
             },
-          ],
+          ].map((item) => normalizeRouteRegExes(item)),
           fallback: [],
         },
         dynamicRoutes: [
           {
             namedRegex: '^/_sport/(?<nxtPslug>[^/]+?)(?:/)?$',
             page: '/_sport/[slug]',
-            regex: normalizeRegEx('^\\/_sport\\/([^\\/]+?)(?:\\/)?$'),
+            regex: '^\\/_sport\\/([^\\/]+?)(?:\\/)?$',
             routeKeys: {
               nxtPslug: 'nxtPslug',
             },
@@ -2444,7 +2395,7 @@ const runTests = (isDev = false) => {
           {
             namedRegex: '^/_sport/(?<nxtPslug>[^/]+?)/test(?:/)?$',
             page: '/_sport/[slug]/test',
-            regex: normalizeRegEx('^\\/_sport\\/([^\\/]+?)\\/test(?:\\/)?$'),
+            regex: '^\\/_sport\\/([^\\/]+?)\\/test(?:\\/)?$',
             routeKeys: {
               nxtPslug: 'nxtPslug',
             },
@@ -2452,7 +2403,7 @@ const runTests = (isDev = false) => {
           {
             namedRegex: '^/another/(?<nxtPid>[^/]+?)(?:/)?$',
             page: '/another/[id]',
-            regex: normalizeRegEx('^\\/another\\/([^\\/]+?)(?:\\/)?$'),
+            regex: '^\\/another\\/([^\\/]+?)(?:\\/)?$',
             routeKeys: {
               nxtPid: 'nxtPid',
             },
@@ -2460,7 +2411,7 @@ const runTests = (isDev = false) => {
           {
             namedRegex: '^/api/dynamic/(?<nxtPslug>[^/]+?)(?:/)?$',
             page: '/api/dynamic/[slug]',
-            regex: normalizeRegEx('^\\/api\\/dynamic\\/([^\\/]+?)(?:\\/)?$'),
+            regex: '^\\/api\\/dynamic\\/([^\\/]+?)(?:\\/)?$',
             routeKeys: {
               nxtPslug: 'nxtPslug',
             },
@@ -2468,7 +2419,7 @@ const runTests = (isDev = false) => {
           {
             namedRegex: '^/auto\\-export/(?<nxtPslug>[^/]+?)(?:/)?$',
             page: '/auto-export/[slug]',
-            regex: normalizeRegEx('^\\/auto\\-export\\/([^\\/]+?)(?:\\/)?$'),
+            regex: '^\\/auto\\-export\\/([^\\/]+?)(?:\\/)?$',
             routeKeys: {
               nxtPslug: 'nxtPslug',
             },
@@ -2476,7 +2427,7 @@ const runTests = (isDev = false) => {
           {
             namedRegex: '^/blog/(?<nxtPpost>[^/]+?)(?:/)?$',
             page: '/blog/[post]',
-            regex: normalizeRegEx('^\\/blog\\/([^\\/]+?)(?:\\/)?$'),
+            regex: '^\\/blog\\/([^\\/]+?)(?:\\/)?$',
             routeKeys: {
               nxtPpost: 'nxtPpost',
             },
@@ -2484,7 +2435,7 @@ const runTests = (isDev = false) => {
           {
             namedRegex: '^/blog\\-catchall/(?<nxtPslug>.+?)(?:/)?$',
             page: '/blog-catchall/[...slug]',
-            regex: normalizeRegEx('^\\/blog\\-catchall\\/(.+?)(?:\\/)?$'),
+            regex: '^\\/blog\\-catchall\\/(.+?)(?:\\/)?$',
             routeKeys: {
               nxtPslug: 'nxtPslug',
             },
@@ -2497,7 +2448,7 @@ const runTests = (isDev = false) => {
               nxtPslug: 'nxtPslug',
             },
           },
-        ],
+        ].map((item) => normalizeRouteRegExes(item)),
         staticRoutes: [
           {
             namedRegex: '^/auto\\-export/another(?:/)?$',
@@ -2553,7 +2504,7 @@ const runTests = (isDev = false) => {
             regex: '^/with\\-params(?:/)?$',
             routeKeys: {},
           },
-        ],
+        ].map((item) => normalizeRouteRegExes(item)),
         rsc: {
           header: 'RSC',
           contentTypeHeader: 'text/x-component',

--- a/test/integration/dynamic-routing/pages/[name]/[comment]/[...rest].js
+++ b/test/integration/dynamic-routing/pages/[name]/[comment]/[...rest].js
@@ -1,7 +1,15 @@
 // this checks priority issues with catch-all routes that
 // can match `_next/data/build-id/path.json
 
-export function getServerSideProps() {
+export function getServerSideProps({ req }) {
+  if (req.url.startsWith('/_next/static')) {
+    return {
+      props: {
+        now: Date.now(),
+      },
+    }
+  }
+
   return {
     notFound: true,
   }

--- a/test/integration/i18n-support/test/shared.js
+++ b/test/integration/i18n-support/test/shared.js
@@ -12,8 +12,8 @@ import {
   fetchViaHTTP,
   renderViaHTTP,
   waitFor,
-  normalizeRegEx,
   check,
+  normalizeRouteRegExes,
 } from 'next-test-utils'
 
 const domainLocales = ['go', 'go-BE', 'do', 'do-BE']
@@ -767,9 +767,7 @@ export function runTests(ctx) {
 
       for (const key of Object.keys(prerenderManifest.dynamicRoutes).sort()) {
         const item = prerenderManifest.dynamicRoutes[key]
-        item.routeRegex = normalizeRegEx(item.routeRegex)
-        item.dataRouteRegex = normalizeRegEx(item.dataRouteRegex)
-        dynamicRoutes[key] = item
+        dynamicRoutes[key] = normalizeRouteRegExes(item)
       }
 
       expect(
@@ -1167,25 +1165,25 @@ export function runTests(ctx) {
       ).toMatchInlineSnapshot(`
         "{
           "/gsp/fallback/[slug]": {
-            "routeRegex": "^\\/gsp\\/fallback\\/([^\\/]+?)(?:\\/)?$",
+            "routeRegex": "^\\/gsp\\/fallback\\/([^\\/]+?)?$",
             "dataRoute": "/_next/data/BUILD_ID/gsp/fallback/[slug].json",
             "fallback": "/gsp/fallback/[slug].html",
             "dataRouteRegex": "^\\/_next\\/data\\/BUILD_ID\\/gsp\\/fallback\\/([^\\/]+?)\\.json$"
           },
           "/gsp/no-fallback/[slug]": {
-            "routeRegex": "^\\/gsp\\/no\\-fallback\\/([^\\/]+?)(?:\\/)?$",
+            "routeRegex": "^\\/gsp\\/no\\-fallback\\/([^\\/]+?)?$",
             "dataRoute": "/_next/data/BUILD_ID/gsp/no-fallback/[slug].json",
             "fallback": false,
             "dataRouteRegex": "^\\/_next\\/data\\/BUILD_ID\\/gsp\\/no\\-fallback\\/([^\\/]+?)\\.json$"
           },
           "/not-found/blocking-fallback/[slug]": {
-            "routeRegex": "^\\/not\\-found\\/blocking\\-fallback\\/([^\\/]+?)(?:\\/)?$",
+            "routeRegex": "^\\/not\\-found\\/blocking\\-fallback\\/([^\\/]+?)?$",
             "dataRoute": "/_next/data/BUILD_ID/not-found/blocking-fallback/[slug].json",
             "fallback": null,
             "dataRouteRegex": "^\\/_next\\/data\\/BUILD_ID\\/not\\-found\\/blocking\\-fallback\\/([^\\/]+?)\\.json$"
           },
           "/not-found/fallback/[slug]": {
-            "routeRegex": "^\\/not\\-found\\/fallback\\/([^\\/]+?)(?:\\/)?$",
+            "routeRegex": "^\\/not\\-found\\/fallback\\/([^\\/]+?)?$",
             "dataRoute": "/_next/data/BUILD_ID/not-found/fallback/[slug].json",
             "fallback": "/not-found/fallback/[slug].html",
             "dataRouteRegex": "^\\/_next\\/data\\/BUILD_ID\\/not\\-found\\/fallback\\/([^\\/]+?)\\.json$"

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -860,7 +860,32 @@ export function getBrowserBodyText(browser: BrowserInterface) {
 }
 
 export function normalizeRegEx(src: string) {
-  return new RegExp(src).source.replace(/\^\//g, '^\\/')
+  return (
+    new RegExp(src).source
+      .replace(/\^\//g, '^\\/')
+      // normalize our ignores at the top-level so each
+      // snapshot doesn't need to be updated each time
+      .replace('(?!\\/_next\\/static)', '')
+      .replace('?(?:\\/)?$', '?$')
+      .replace('(?:\\/)?$', '?$')
+  )
+}
+
+export const normalizeRouteRegExes = (item: any) => {
+  const fields = [
+    'regex',
+    'routeRegex',
+    'namedRegex',
+    'namedDataRouteRegex',
+    'dataRouteRegex',
+  ]
+
+  for (const field of fields) {
+    if (typeof item[field] === 'string') {
+      item[field] = normalizeRegEx(item[field])
+    }
+  }
+  return item
 }
 
 function readJson(path: string) {


### PR DESCRIPTION
This ensures our dynamic routes that have the same specificity as _next/static/:path* don't get matched unexpectedly when the _next/static asset doesn't exist. We were holding off on making this change explicit due to compatibility concerns but these are no longer a concern and the unexpected matching is more of a concern.

Relands: https://github.com/vercel/next.js/pull/62559

Closes NEXT-2785