### PR TITLE
Fix generateMetadata race condition

### DIFF
--- a/test/e2e/app-dir/metadata/app/(dynamic-meta)/dynamic-meta/page.tsx
+++ b/test/e2e/app-dir/metadata/app/(dynamic-meta)/dynamic-meta/page.tsx
@@ -1,0 +1,17 @@
+import type { ResolvingMetadata } from 'next'
+import { notFound } from 'next/navigation'
+
+process.on('unhandledRejection', (rej) => {
+  console.log('unhandledRejection', rej)
+  process.exit(1)
+})
+
+export const revalidate = 0
+
+export default function Page() {
+  return notFound()
+}
+
+export async function generateMetadata(_, __: ResolvingMetadata) {
+  return notFound()
+}

--- a/test/e2e/app-dir/metadata/app/(dynamic-meta)/layout.tsx
+++ b/test/e2e/app-dir/metadata/app/(dynamic-meta)/layout.tsx
@@ -1,0 +1,24 @@
+process.on('unhandledRejection', (rej) => {
+  console.log('unhandledRejection', rej)
+  process.exit(1)
+})
+
+export const revalidate = 0
+
+export default function Layout({ children }) {
+  return (
+    <>
+      <p>Layout</p>
+      {children}
+    </>
+  )
+}
+
+export async function generateMetadata() {
+  await new Promise((resolve) => {
+    setTimeout(() => {
+      process.nextTick(resolve)
+    }, 2_000)
+  })
+  return {}
+}

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -1000,5 +1000,10 @@ createNextDescribe(
       expect(iconHtml).toContain('pages-icon-page')
       expect(ogHtml).toContain('pages-opengraph-image-page')
     })
+
+    it('should not crash from error thrown during preloading nested generateMetadata', async () => {
+      const res = await next.fetch('/dynamic-meta')
+      expect(res.status).toBe(404)
+    })
   }
 )


### PR DESCRIPTION
This ensures we properly catch/handle `generateMetadata` errors during eager evaluating of nested `generateMetadata` functions in the tree. Previously if we eager evaluated a child metadata function that threw an error e.g. `notFound()` and but the parent metadata function took longer the thrown error would be an unhandled rejection causing the process to crash depending on the environment. 

Fixes: NEXT-2588


Closes NEXT-2786