### PR TITLE
docs: replace vercel/otel link to npm

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/09-instrumentation.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/09-instrumentation.mdx
@@ -18,7 +18,7 @@ To set up instrumentation, create `instrumentation.ts|js` file in the **root dir
 
 Then, export a `register` function in the file. This function will be called **once** when a new Next.js server instance is initiated.
 
-For example, to use Next.js with [OpenTelemetry](https://opentelemetry.io/) and [@vercel/otel](https://github.com/vercel/otel):
+For example, to use Next.js with [OpenTelemetry](https://opentelemetry.io/) and [@vercel/otel](https://www.npmjs.com/package/@vercel/otel):
 
 ```ts filename="instrumentation.ts" switcher
 import { registerOTel } from '@vercel/otel'

--- a/docs/02-app/01-building-your-application/06-optimizing/09-instrumentation.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/09-instrumentation.mdx
@@ -18,7 +18,7 @@ To set up instrumentation, create `instrumentation.ts|js` file in the **root dir
 
 Then, export a `register` function in the file. This function will be called **once** when a new Next.js server instance is initiated.
 
-For example, to use Next.js with [OpenTelemetry](https://opentelemetry.io/) and [@vercel/otel](https://www.npmjs.com/package/@vercel/otel):
+For example, to use Next.js with [OpenTelemetry](https://opentelemetry.io/) and [@vercel/otel](https://vercel.com/docs/observability/otel-overview):
 
 ```ts filename="instrumentation.ts" switcher
 import { registerOTel } from '@vercel/otel'


### PR DESCRIPTION
Since the `vercel/otel` repo is not public, replaced with `npm`.