### PR TITLE
Ensure PromiseLikeOfReactNode is not included in .d.ts files

### DIFF
--- a/packages/next/src/client/components/error-boundary.tsx
+++ b/packages/next/src/client/components/error-boundary.tsx
@@ -109,7 +109,8 @@ export class ErrorBoundaryHandler extends React.Component<
     this.setState({ error: null })
   }
 
-  render() {
+  // Explicit type is needed to avoid the generated `.d.ts` having a wide return type that could be specific the the `@types/react` version.
+  render(): React.ReactNode {
     if (this.state.error) {
       return (
         <>

--- a/packages/next/src/client/components/react-dev-overlay/pages/ErrorBoundary.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/pages/ErrorBoundary.tsx
@@ -30,7 +30,8 @@ export class ErrorBoundary extends React.PureComponent<
     }
   }
 
-  render() {
+  // Explicit type is needed to avoid the generated `.d.ts` having a wide return type that could be specific the the `@types/react` version.
+  render(): React.ReactNode {
     // The component has to be unmounted or else it would continue to error
     return this.state.error ||
       (this.props.globalOverlay && this.props.isMounted) ? (

--- a/packages/next/src/client/components/redirect-boundary.tsx
+++ b/packages/next/src/client/components/redirect-boundary.tsx
@@ -58,7 +58,8 @@ export class RedirectErrorBoundary extends React.Component<
     throw error
   }
 
-  render() {
+  // Explicit type is needed to avoid the generated `.d.ts` having a wide return type that could be specific the the `@types/react` version.
+  render(): React.ReactNode {
     const { redirect, redirectType } = this.state
     if (redirect !== null && redirectType !== null) {
       return (


### PR DESCRIPTION
Fixes the compile error on all test runs currently: https://github.com/vercel/next.js/actions/runs/8243077904/job/22543375810?pr=63167#step:27:345

The root cause is that `.d.ts` files automatically include inferred return types automatically, in this case `tsc` included React class component `render()` return types in the `.d.ts` for e.g. error-boundary.tsx / redirect-boundary.tsx. This is a problem because yesterday that return type was changed: https://github.com/DefinitelyTyped/DefinitelyTyped/commit/bf659aefa780a8b61b1636bd0296e0723c96d780#diff-1d64e275d9755825ba[…]520436dbd8e1f1fd9fc66a9 and that change also removes one of the previous types that the `.d.ts` in Next.js automatically included.

This PR changes the `render()` return type to be explicit instead of inferred, this makes sure that the `.d.ts` file includes only `: React.ReactNode` instead of the many types of return values allowed.

The reason I went with the explicit type instead of e.g. upgrading `@types/react` is that upgrading the types would cause existing applications that use older versions of `@types/react` would break. The current change ensures it works in both cases.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2787