### PR TITLE
fix: Loose Server Actions runtime check

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-flight-loader/action-validate.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/action-validate.ts
@@ -9,20 +9,5 @@ export function ensureServerEntryExports(actions: any[]) {
         `A "use server" file can only export async functions, found ${typeof action}.\nRead more: https://nextjs.org/docs/messages/invalid-use-server-value`
       )
     }
-
-    if (action.constructor.name !== 'AsyncFunction') {
-      const actionName: string = action.name || ''
-
-      // Note: if it's from library code with `async` being transpiled to returning a promise,
-      // it would be annoying. But users can still wrap it in an async function to work around it.
-      throw new Error(
-        `A "use server" file can only export async functions.${
-          // If the function has a name, we'll make the error message more specific.
-          actionName
-            ? ` Found "${actionName}" that is not an async function.`
-            : ''
-        }\nRead more: https://nextjs.org/docs/messages/invalid-use-server-value`
-      )
-    }
   }
 }

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1,12 +1,6 @@
 /* eslint-disable jest/no-standalone-expect */
 import { createNextDescribe } from 'e2e-utils'
-import {
-  check,
-  waitFor,
-  getRedboxSource,
-  hasRedbox,
-  retry,
-} from 'next-test-utils'
+import { check, waitFor, getRedboxSource, hasRedbox } from 'next-test-utils'
 import type { Request, Response, Route } from 'playwright'
 import fs from 'fs-extra'
 import { join } from 'path'

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -539,54 +539,6 @@ createNextDescribe(
             await next.patchFile(filePath, origContent)
           }
         })
-
-        it('should error when exporting non async functions during runtime', async () => {
-          const logs: string[] = []
-          next.on('stdout', (log) => {
-            logs.push(log)
-          })
-          next.on('stderr', (log) => {
-            logs.push(log)
-          })
-
-          const filePath = 'app/server/actions.js'
-          const origContent = await next.readFile(filePath)
-
-          try {
-            const browser = await next.browser('/server')
-
-            const cnt = await browser.elementById('count').text()
-            expect(cnt).toBe('0')
-
-            // This requires the runtime to catch
-            await next.patchFile(
-              filePath,
-              origContent + '\n\nconst f = () => {}\nexport { f }'
-            )
-
-            await check(
-              () =>
-                logs.some((log) =>
-                  log.includes(
-                    'Error: A "use server" file can only export async functions. Found "f" that is not an async function.'
-                  )
-                )
-                  ? 'true'
-                  : '',
-              'true'
-            )
-          } finally {
-            await next.patchFile(filePath, origContent)
-          }
-
-          // verify the error has gone away after the file is reverted
-          const browser = await next.browser('/server')
-          await retry(async () => {
-            expect(await hasRedbox(browser)).toBe(false)
-            const count = await browser.elementById('count').text()
-            expect(count).toBe('0')
-          })
-        })
       })
 
       describe('HMR', () => {


### PR DESCRIPTION
Addresses some feedback in #62821. This will re-allow implementations like:

```js
'use server'

export const f = wrapper(async () => {})
```

Where `wrapper` creates a sync function that returns a promise. Although it will still be silently converted to an async function under the hood.

Closes NEXT-2790