### PR TITLE
add support for assets in edge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "serde",
  "smallvec",
@@ -3217,7 +3217,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "serde",
@@ -7159,7 +7159,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7191,7 +7191,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7203,7 +7203,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7218,7 +7218,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7232,7 +7232,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7249,7 +7249,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7281,7 +7281,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "base16",
  "hex",
@@ -7293,7 +7293,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7307,7 +7307,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7317,7 +7317,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "mimalloc",
 ]
@@ -7325,7 +7325,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7350,7 +7350,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7383,7 +7383,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7423,7 +7423,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7449,7 +7449,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "clap",
@@ -7468,7 +7468,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7499,7 +7499,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7527,7 +7527,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7564,7 +7564,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7602,7 +7602,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "serde",
  "serde_json",
@@ -7613,7 +7613,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7638,7 +7638,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7655,7 +7655,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7671,7 +7671,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7691,7 +7691,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "serde",
@@ -7706,7 +7706,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7721,7 +7721,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7759,7 +7759,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7783,7 +7783,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7805,7 +7805,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "serde",
@@ -7821,7 +7821,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7832,7 +7832,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -7848,7 +7848,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.4#77bdb61a9371f3db9a2b9180aa6cf6676dfebaa5"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.90.17", features = [
 testing = { version = "0.35.20" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240312.4" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240312.5" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240312.4" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240312.5" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240312.4" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240312.5" }
 
 # General Deps
 

--- a/packages/next-swc/crates/next-api/src/app.rs
+++ b/packages/next-swc/crates/next-api/src/app.rs
@@ -519,19 +519,19 @@ impl AppEndpoint {
     async fn output(self: Vc<Self>) -> Result<Vc<AppEndpointOutput>> {
         let this = self.await?;
 
-        let (app_entry, process_client, process_ssr, api_route) = match this.ty {
+        let (app_entry, process_client, process_ssr, has_client_side_assets) = match this.ty {
             AppEndpointType::Page { ty, loader_tree } => (
                 self.app_page_entry(loader_tree),
                 true,
                 matches!(ty, AppPageEndpointType::Html),
-                false,
+                true,
             ),
             // NOTE(alexkirsz) For routes, technically, a lot of the following code is not needed,
             // as we know we won't have any client references. However, for now, for simplicity's
             // sake, we just do the same thing as for pages.
-            AppEndpointType::Route { path } => (self.app_route_entry(path), false, false, true),
+            AppEndpointType::Route { path } => (self.app_route_entry(path), false, false, false),
             AppEndpointType::Metadata { metadata } => {
-                (self.app_metadata_entry(metadata), false, false, true)
+                (self.app_metadata_entry(metadata), false, false, false)
             }
         };
 
@@ -614,9 +614,10 @@ impl AppEndpoint {
                     NextRuntime::NodeJs => {
                         Vc::upcast(this.app_project.project().server_chunking_context())
                     }
-                    NextRuntime::Edge => {
-                        this.app_project.project().edge_chunking_context(api_route)
-                    }
+                    NextRuntime::Edge => this
+                        .app_project
+                        .project()
+                        .edge_chunking_context(has_client_side_assets),
                 })
             } else {
                 None
@@ -840,7 +841,10 @@ impl AppEndpoint {
         let endpoint_output = match runtime {
             NextRuntime::Edge => {
                 // create edge chunks
-                let chunking_context = this.app_project.project().edge_chunking_context(api_route);
+                let chunking_context = this
+                    .app_project
+                    .project()
+                    .edge_chunking_context(has_client_side_assets);
                 let mut evaluatable_assets = this
                     .app_project
                     .edge_rsc_runtime_entries()

--- a/packages/next-swc/crates/next-api/src/app.rs
+++ b/packages/next-swc/crates/next-api/src/app.rs
@@ -519,18 +519,19 @@ impl AppEndpoint {
     async fn output(self: Vc<Self>) -> Result<Vc<AppEndpointOutput>> {
         let this = self.await?;
 
-        let (app_entry, process_client, process_ssr) = match this.ty {
+        let (app_entry, process_client, process_ssr, api_route) = match this.ty {
             AppEndpointType::Page { ty, loader_tree } => (
                 self.app_page_entry(loader_tree),
                 true,
                 matches!(ty, AppPageEndpointType::Html),
+                false,
             ),
             // NOTE(alexkirsz) For routes, technically, a lot of the following code is not needed,
             // as we know we won't have any client references. However, for now, for simplicity's
             // sake, we just do the same thing as for pages.
-            AppEndpointType::Route { path } => (self.app_route_entry(path), false, false),
+            AppEndpointType::Route { path } => (self.app_route_entry(path), false, false, true),
             AppEndpointType::Metadata { metadata } => {
-                (self.app_metadata_entry(metadata), false, false)
+                (self.app_metadata_entry(metadata), false, false, true)
             }
         };
 
@@ -613,7 +614,9 @@ impl AppEndpoint {
                     NextRuntime::NodeJs => {
                         Vc::upcast(this.app_project.project().server_chunking_context())
                     }
-                    NextRuntime::Edge => this.app_project.project().edge_chunking_context(),
+                    NextRuntime::Edge => {
+                        this.app_project.project().edge_chunking_context(api_route)
+                    }
                 })
             } else {
                 None
@@ -837,7 +840,7 @@ impl AppEndpoint {
         let endpoint_output = match runtime {
             NextRuntime::Edge => {
                 // create edge chunks
-                let chunking_context = this.app_project.project().edge_chunking_context();
+                let chunking_context = this.app_project.project().edge_chunking_context(api_route);
                 let mut evaluatable_assets = this
                     .app_project
                     .edge_rsc_runtime_entries()

--- a/packages/next-swc/crates/next-api/src/instrumentation.rs
+++ b/packages/next-swc/crates/next-api/src/instrumentation.rs
@@ -95,7 +95,7 @@ impl InstrumentationEndpoint {
         };
         evaluatable_assets.push(evaluatable);
 
-        let edge_chunking_context = self.project.edge_chunking_context();
+        let edge_chunking_context = self.project.edge_chunking_context(true);
 
         let edge_files = edge_chunking_context.evaluated_chunk_group_assets(
             module.ident(),

--- a/packages/next-swc/crates/next-api/src/instrumentation.rs
+++ b/packages/next-swc/crates/next-api/src/instrumentation.rs
@@ -95,7 +95,7 @@ impl InstrumentationEndpoint {
         };
         evaluatable_assets.push(evaluatable);
 
-        let edge_chunking_context = self.project.edge_chunking_context(true);
+        let edge_chunking_context = self.project.edge_chunking_context(false);
 
         let edge_files = edge_chunking_context.evaluated_chunk_group_assets(
             module.ident(),

--- a/packages/next-swc/crates/next-api/src/middleware.rs
+++ b/packages/next-swc/crates/next-api/src/middleware.rs
@@ -97,7 +97,7 @@ impl MiddlewareEndpoint {
             .context("Entry module must be evaluatable")?;
         evaluatable_assets.push(evaluatable);
 
-        let edge_chunking_context = self.project.edge_chunking_context();
+        let edge_chunking_context = self.project.edge_chunking_context(false);
 
         let edge_files = edge_chunking_context.evaluated_chunk_group_assets(
             module.ident(),

--- a/packages/next-swc/crates/next-api/src/middleware.rs
+++ b/packages/next-swc/crates/next-api/src/middleware.rs
@@ -97,7 +97,7 @@ impl MiddlewareEndpoint {
             .context("Entry module must be evaluatable")?;
         evaluatable_assets.push(evaluatable);
 
-        let edge_chunking_context = self.project.edge_chunking_context(false);
+        let edge_chunking_context = self.project.edge_chunking_context(true);
 
         let edge_files = edge_chunking_context.evaluated_chunk_group_assets(
             module.ident(),

--- a/packages/next-swc/crates/next-api/src/pages.rs
+++ b/packages/next-swc/crates/next-api/src/pages.rs
@@ -795,7 +795,7 @@ impl PageEndpoint {
             this.pages_project.ssr_module_context(),
             this.pages_project.edge_ssr_module_context(),
             this.pages_project.project().server_chunking_context(),
-            this.pages_project.project().edge_chunking_context(false),
+            this.pages_project.project().edge_chunking_context(true),
             this.pages_project.ssr_runtime_entries(),
             this.pages_project.edge_ssr_runtime_entries(),
         ))
@@ -815,7 +815,7 @@ impl PageEndpoint {
             this.pages_project.ssr_data_module_context(),
             this.pages_project.edge_ssr_data_module_context(),
             this.pages_project.project().server_chunking_context(),
-            this.pages_project.project().edge_chunking_context(false),
+            this.pages_project.project().edge_chunking_context(true),
             this.pages_project.ssr_data_runtime_entries(),
             this.pages_project.edge_ssr_data_runtime_entries(),
         ))
@@ -835,7 +835,7 @@ impl PageEndpoint {
             this.pages_project.api_module_context(),
             this.pages_project.edge_api_module_context(),
             this.pages_project.project().server_chunking_context(),
-            this.pages_project.project().edge_chunking_context(true),
+            this.pages_project.project().edge_chunking_context(false),
             this.pages_project.ssr_runtime_entries(),
             this.pages_project.edge_ssr_runtime_entries(),
         ))

--- a/packages/next-swc/crates/next-api/src/pages.rs
+++ b/packages/next-swc/crates/next-api/src/pages.rs
@@ -795,7 +795,7 @@ impl PageEndpoint {
             this.pages_project.ssr_module_context(),
             this.pages_project.edge_ssr_module_context(),
             this.pages_project.project().server_chunking_context(),
-            this.pages_project.project().edge_chunking_context(),
+            this.pages_project.project().edge_chunking_context(false),
             this.pages_project.ssr_runtime_entries(),
             this.pages_project.edge_ssr_runtime_entries(),
         ))
@@ -815,7 +815,7 @@ impl PageEndpoint {
             this.pages_project.ssr_data_module_context(),
             this.pages_project.edge_ssr_data_module_context(),
             this.pages_project.project().server_chunking_context(),
-            this.pages_project.project().edge_chunking_context(),
+            this.pages_project.project().edge_chunking_context(false),
             this.pages_project.ssr_data_runtime_entries(),
             this.pages_project.edge_ssr_data_runtime_entries(),
         ))
@@ -835,7 +835,7 @@ impl PageEndpoint {
             this.pages_project.api_module_context(),
             this.pages_project.edge_api_module_context(),
             this.pages_project.project().server_chunking_context(),
-            this.pages_project.project().edge_chunking_context(),
+            this.pages_project.project().edge_chunking_context(true),
             this.pages_project.ssr_runtime_entries(),
             this.pages_project.edge_ssr_runtime_entries(),
         ))

--- a/packages/next-swc/crates/next-api/src/project.rs
+++ b/packages/next-swc/crates/next-api/src/project.rs
@@ -571,13 +571,18 @@ impl Project {
     #[turbo_tasks::function]
     pub(super) fn edge_chunking_context(
         self: Vc<Self>,
+        api_route: bool,
     ) -> Result<Vc<Box<dyn EcmascriptChunkingContext>>> {
         Ok(get_edge_chunking_context(
             self.next_mode(),
             self.project_path(),
             self.node_root(),
             self.client_relative_path(),
-            self.next_config().computed_asset_prefix(),
+            if api_route {
+                Vc::cell(Some("blob:".to_string()))
+            } else {
+                self.next_config().computed_asset_prefix()
+            },
             self.edge_compile_time_info().environment(),
         ))
     }

--- a/packages/next-swc/crates/next-api/src/project.rs
+++ b/packages/next-swc/crates/next-api/src/project.rs
@@ -5,8 +5,8 @@ use indexmap::{map::Entry, IndexMap};
 use next_core::{
     all_assets_from_entries,
     app_structure::find_app_dir,
-    emit_assets, get_edge_chunking_context, get_edge_compile_time_info,
-    get_edge_resolve_options_context,
+    emit_assets, get_edge_chunking_context, get_edge_chunking_context_with_client_assets,
+    get_edge_compile_time_info, get_edge_resolve_options_context,
     instrumentation::instrumentation_files,
     middleware::middleware_files,
     mode::NextMode,
@@ -571,20 +571,24 @@ impl Project {
     #[turbo_tasks::function]
     pub(super) fn edge_chunking_context(
         self: Vc<Self>,
-        api_route: bool,
+        client_assets: bool,
     ) -> Result<Vc<Box<dyn EcmascriptChunkingContext>>> {
-        Ok(get_edge_chunking_context(
-            self.next_mode(),
-            self.project_path(),
-            self.node_root(),
-            self.client_relative_path(),
-            if api_route {
-                Vc::cell(Some("blob:".to_string()))
-            } else {
-                self.next_config().computed_asset_prefix()
-            },
-            self.edge_compile_time_info().environment(),
-        ))
+        Ok(if client_assets {
+            get_edge_chunking_context_with_client_assets(
+                self.next_mode(),
+                self.project_path(),
+                self.node_root(),
+                self.client_relative_path(),
+                self.next_config().computed_asset_prefix(),
+                self.edge_compile_time_info().environment(),
+            )
+        } else {
+            get_edge_chunking_context(
+                self.project_path(),
+                self.node_root(),
+                self.edge_compile_time_info().environment(),
+            )
+        })
     }
 
     /// Emit a telemetry event corresponding to [webpack configuration telemetry](https://github.com/vercel/next.js/blob/9da305fe320b89ee2f8c3cfb7ecbf48856368913/packages/next/src/build/webpack-config.ts#L2516)

--- a/packages/next-swc/crates/next-core/src/lib.rs
+++ b/packages/next-swc/crates/next-core/src/lib.rs
@@ -46,7 +46,8 @@ pub use app_segment_config::{
 };
 pub use emit::{all_assets_from_entries, emit_all_assets, emit_assets, emit_client_assets};
 pub use next_edge::context::{
-    get_edge_chunking_context, get_edge_compile_time_info, get_edge_resolve_options_context,
+    get_edge_chunking_context, get_edge_chunking_context_with_client_assets,
+    get_edge_compile_time_info, get_edge_resolve_options_context,
 };
 pub use page_loader::{create_page_loader_entry_module, PageLoaderAsset};
 use turbopack_binding::{turbo, turbopack};

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -616,6 +616,7 @@ pub async fn get_server_module_options_context(
             next_server_rules.extend(source_transform_rules);
 
             let module_options_context = ModuleOptionsContext {
+                esm_url_rewrite_behavior: Some(UrlRewriteBehavior::Full),
                 ..module_options_context
             };
             let foreign_code_module_options_context = ModuleOptionsContext {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -192,7 +192,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.4",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240312.4",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240312.5",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1422,7 +1422,7 @@ export default class NextNodeServer extends BaseServer {
     name: string
     paths: string[]
     wasm: { filePath: string; name: string }[]
-    assets: { filePath: string; name: string }[]
+    assets?: { filePath: string; name: string }[]
   } | null {
     const manifest = this.getMiddlewareManifest()
     if (!manifest) {
@@ -1455,12 +1455,14 @@ export default class NextNodeServer extends BaseServer {
         ...binding,
         filePath: join(this.distDir, binding.filePath),
       })),
-      assets: (pageInfo.assets ?? []).map((binding) => {
-        return {
-          ...binding,
-          filePath: join(this.distDir, binding.filePath),
-        }
-      }),
+      assets:
+        pageInfo.assets &&
+        pageInfo.assets.map((binding) => {
+          return {
+            ...binding,
+            filePath: join(this.distDir, binding.filePath),
+          }
+        }),
     }
   }
 

--- a/packages/next/src/server/web/sandbox/fetch-inline-assets.ts
+++ b/packages/next/src/server/web/sandbox/fetch-inline-assets.ts
@@ -19,8 +19,13 @@ export async function fetchInlineAsset(options: {
     return
   }
 
-  const hash = inputString.replace('blob:', '')
-  const asset = options.assets?.find((x) => x.name === hash)
+  const name = inputString.replace('blob:', '')
+  const asset = options.assets
+    ? options.assets.find((x) => x.name === name)
+    : {
+        name,
+        filePath: name,
+      }
   if (!asset) {
     return
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1071,8 +1071,8 @@ importers:
         specifier: 0.26.4
         version: 0.26.4
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240312.4
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240312.4'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240312.5
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240312.5'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -2154,6 +2154,7 @@ packages:
   /@babel/plugin-proposal-dynamic-import@7.16.7(@babel/core@7.22.5):
     resolution: {integrity: sha512-I8SW9Ho3/8DRSdmDdH3gORdyUuYnk1m4cMxUAdu5oy4n3OfN8flDEH+d60iG7dUfi0KkYwSvoalHzzdRzpWHTg==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-dynamic-import instead.
     peerDependencies:
       '@babel/core': 7.22.5
     dependencies:
@@ -2165,6 +2166,7 @@ packages:
   /@babel/plugin-proposal-export-namespace-from@7.16.7(@babel/core@7.22.5):
     resolution: {integrity: sha512-ZxdtqDXLRGBL64ocZcs7ovt71L3jhC1RGSyR996svrCi3PYqHNkb3SwPJCs8RIzD86s+WPpt2S73+EHCGO+NUA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-export-namespace-from instead.
     peerDependencies:
       '@babel/core': 7.22.5
     dependencies:
@@ -2188,6 +2190,7 @@ packages:
   /@babel/plugin-proposal-logical-assignment-operators@7.16.7(@babel/core@7.22.5):
     resolution: {integrity: sha512-K3XzyZJGQCr00+EtYtrDjmwX7o7PLK6U9bi1nCwkQioRFVUv6dJoxbQjtWVtP+bCPy82bONBKG8NPyQ4+i6yjg==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-logical-assignment-operators instead.
     peerDependencies:
       '@babel/core': 7.22.5
     dependencies:
@@ -2210,6 +2213,7 @@ packages:
   /@babel/plugin-proposal-numeric-separator@7.16.7(@babel/core@7.22.5):
     resolution: {integrity: sha512-vQgPMknOIgiuVqbokToyXbkY/OmmjAzr/0lhSIbG/KmnzXPGwW/AdhdKpi+O4X/VkWiWjnkKOBiqJrTaC98VKw==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.
     peerDependencies:
       '@babel/core': 7.22.5
     dependencies:
@@ -2260,6 +2264,7 @@ packages:
   /@babel/plugin-proposal-private-methods@7.16.11(@babel/core@7.22.5):
     resolution: {integrity: sha512-F/2uAkPlXDr8+BHpZvo19w3hLFKge+k75XUprE6jaqKxjGkSYcK+4c+bup5PdW/7W/Rpjwql7FTVEDW+fRAQsw==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
     peerDependencies:
       '@babel/core': 7.22.5
     dependencies:
@@ -25489,8 +25494,8 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240312.4':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240312.4}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240312.5':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240312.5}
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -6491,12 +6491,11 @@
     "passed": [
       "og-api should respond from index",
       "og-api should throw error when returning a response object in pages/api in node runtime",
-      "og-api should work in app route in node runtime"
-    ],
-    "failed": [
+      "og-api should work in app route in node runtime",
       "og-api should work in app route",
       "og-api should work in pages/api"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
### What?

add support for `new URL(..., import.meta.url)` assets in edge. e. g. needed for og-image.

### Why?

### Turbopack Changes

* https://github.com/vercel/turbo/pull/7712 <!-- Tobias Koppers - allow to use full urls in browser runtime  -->

Closes PACK-2725