### PR TITLE
refactor(test): drop `global as any` from tests

### DIFF
--- a/test/development/app-dir/dynamic-error-trace/index.test.ts
+++ b/test/development/app-dir/dynamic-error-trace/index.test.ts
@@ -1,4 +1,4 @@
-import { createNextDescribe } from 'e2e-utils'
+import { createNextDescribe, isNextDev } from 'e2e-utils'
 import {
   getRedboxCallStack,
   hasRedbox,
@@ -22,7 +22,7 @@ createNextDescribe(
       },
     },
     installCommand: 'pnpm install',
-    startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
+    startCommand: isNextDev ? 'pnpm dev' : 'pnpm start',
     buildCommand: 'pnpm build',
     skipDeployment: true,
   },

--- a/test/development/basic/next-dynamic.test.ts
+++ b/test/development/basic/next-dynamic.test.ts
@@ -245,7 +245,7 @@ describe.each([
               }
             })
 
-            if (!next.isDev) {
+            if (!next.isNextDev) {
               it('should not include ssr:false imports to server trace', async () => {
                 const trace = JSON.parse(
                   await next.readFile(

--- a/test/development/basic/next-dynamic.test.ts
+++ b/test/development/basic/next-dynamic.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDev } from 'e2e-utils'
 import { renderViaHTTP, check, hasRedbox } from 'next-test-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 
@@ -245,7 +245,7 @@ describe.each([
               }
             })
 
-            if (!next.isNextDev) {
+            if (!isNextDev) {
               it('should not include ssr:false imports to server trace', async () => {
                 const trace = JSON.parse(
                   await next.readFile(

--- a/test/development/basic/next-dynamic.test.ts
+++ b/test/development/basic/next-dynamic.test.ts
@@ -245,7 +245,7 @@ describe.each([
               }
             })
 
-            if (!(global as any).isNextDev) {
+            if (!next.isDev) {
               it('should not include ssr:false imports to server trace', async () => {
                 const trace = JSON.parse(
                   await next.readFile(

--- a/test/e2e/404-page-router/index.test.ts
+++ b/test/e2e/404-page-router/index.test.ts
@@ -51,7 +51,7 @@ describe('404-page-router', () => {
   describe.each(table)(
     '404-page-router with basePath of $basePath and i18n of $i18n and middleware $middleware',
     (options) => {
-      const { isDev, isDeploy } = next
+      const { isNextDev: isDev, isNextDeploy: isDeploy } = next
 
       if (isDeploy) {
         // TODO: investigate condensing these tests to avoid

--- a/test/e2e/404-page-router/index.test.ts
+++ b/test/e2e/404-page-router/index.test.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import fs from 'fs-extra'
 import webdriver from 'next-webdriver'
-import { createNext, FileRef, isNextDev } from 'e2e-utils'
+import { createNext, FileRef, isNextDeploy, isNextDev } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import { type NextInstance } from 'test/lib/next-modes/base'
 
@@ -51,9 +51,7 @@ describe('404-page-router', () => {
   describe.each(table)(
     '404-page-router with basePath of $basePath and i18n of $i18n and middleware $middleware',
     (options) => {
-      const { isNextDev: isDev, isNextDeploy: isDeploy } = next
-
-      if (isDeploy) {
+      if (isNextDeploy) {
         // TODO: investigate condensing these tests to avoid
         // 5 separate deploys for this one test
         it('should skip for deploy', () => {})
@@ -117,7 +115,7 @@ describe('404-page-router', () => {
 
       // Only include the /_error tests in production because in development we
       // have the error overlay.
-      if (!isDev) {
+      if (!isNextDev) {
         urls.push(...translate('/_error', options.basePath))
       }
 

--- a/test/e2e/404-page-router/index.test.ts
+++ b/test/e2e/404-page-router/index.test.ts
@@ -15,20 +15,6 @@ const pathnames = {
 
 const basePath = '/docs'
 
-const table = [
-  { basePath: false, i18n: true, middleware: false },
-  { basePath: true, i18n: false, middleware: false },
-  { basePath: true, i18n: true, middleware: false },
-  { basePath: false, i18n: false, middleware: false },
-
-  ...((global as any).isNextDev
-    ? []
-    : [
-        // TODO: investigate this failure in development
-        { basePath: false, i18n: false, middleware: true },
-      ]),
-]
-
 const baseNextConfig = `
 module.exports = {
   BASE_PATH
@@ -38,6 +24,20 @@ module.exports = {
 
 describe('404-page-router', () => {
   let next: NextInstance
+
+  const table = [
+    { basePath: false, i18n: true, middleware: false },
+    { basePath: true, i18n: false, middleware: false },
+    { basePath: true, i18n: true, middleware: false },
+    { basePath: false, i18n: false, middleware: false },
+
+    ...(next.isDev
+      ? []
+      : [
+          // TODO: investigate this failure in development
+          { basePath: false, i18n: false, middleware: true },
+        ]),
+  ]
 
   beforeAll(async () => {
     const files = {
@@ -51,9 +51,9 @@ describe('404-page-router', () => {
   describe.each(table)(
     '404-page-router with basePath of $basePath and i18n of $i18n and middleware $middleware',
     (options) => {
-      const isDev = (global as any).isNextDev
+      const { isDev, isDeploy } = next
 
-      if ((global as any).isNextDeploy) {
+      if (isDeploy) {
         // TODO: investigate condensing these tests to avoid
         // 5 separate deploys for this one test
         it('should skip for deploy', () => {})

--- a/test/e2e/404-page-router/index.test.ts
+++ b/test/e2e/404-page-router/index.test.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import fs from 'fs-extra'
 import webdriver from 'next-webdriver'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDev } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import { type NextInstance } from 'test/lib/next-modes/base'
 
@@ -15,6 +15,20 @@ const pathnames = {
 
 const basePath = '/docs'
 
+const table = [
+  { basePath: false, i18n: true, middleware: false },
+  { basePath: true, i18n: false, middleware: false },
+  { basePath: true, i18n: true, middleware: false },
+  { basePath: false, i18n: false, middleware: false },
+
+  ...(isNextDev
+    ? []
+    : [
+        // TODO: investigate this failure in development
+        { basePath: false, i18n: false, middleware: true },
+      ]),
+]
+
 const baseNextConfig = `
 module.exports = {
   BASE_PATH
@@ -24,20 +38,6 @@ module.exports = {
 
 describe('404-page-router', () => {
   let next: NextInstance
-
-  const table = [
-    { basePath: false, i18n: true, middleware: false },
-    { basePath: true, i18n: false, middleware: false },
-    { basePath: true, i18n: true, middleware: false },
-    { basePath: false, i18n: false, middleware: false },
-
-    ...(next.isDev
-      ? []
-      : [
-          // TODO: investigate this failure in development
-          { basePath: false, i18n: false, middleware: true },
-        ]),
-  ]
 
   beforeAll(async () => {
     const files = {

--- a/test/e2e/app-dir/app-edge/app-edge.test.ts
+++ b/test/e2e/app-dir/app-edge/app-edge.test.ts
@@ -1,4 +1,4 @@
-import { createNextDescribe } from 'e2e-utils'
+import { createNextDescribe, isNextDev } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
 createNextDescribe(
@@ -26,7 +26,7 @@ createNextDescribe(
       expect(appHtml).toContain('the /index route')
     })
 
-    if ((globalThis as any).isNextDev) {
+    if (isNextDev) {
       it('should warn about the re-export of a pages runtime/preferredRegion config', async () => {
         const logs = []
         next.on('stderr', (log) => {

--- a/test/e2e/app-dir/app-external/app-external.test.ts
+++ b/test/e2e/app-dir/app-external/app-external.test.ts
@@ -30,7 +30,7 @@ createNextDescribe(
       },
     },
     installCommand: 'pnpm i',
-    startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
+    startCommand: next.isDev ? 'pnpm dev' : 'pnpm start',
     buildCommand: 'pnpm build',
     skipDeployment: true,
   },

--- a/test/e2e/app-dir/app-external/app-external.test.ts
+++ b/test/e2e/app-dir/app-external/app-external.test.ts
@@ -1,4 +1,4 @@
-import { createNextDescribe } from 'e2e-utils'
+import { createNextDescribe, isNextDev } from 'e2e-utils'
 import { check, hasRedbox, retry, shouldRunTurboDevTest } from 'next-test-utils'
 
 async function resolveStreamResponse(response: any, onData?: any) {
@@ -30,7 +30,7 @@ createNextDescribe(
       },
     },
     installCommand: 'pnpm i',
-    startCommand: next.isDev ? 'pnpm dev' : 'pnpm start',
+    startCommand: isNextDev ? 'pnpm dev' : 'pnpm start',
     buildCommand: 'pnpm build',
     skipDeployment: true,
   },

--- a/test/e2e/app-dir/app-fetch-deduping/app-fetch-deduping.test.ts
+++ b/test/e2e/app-dir/app-fetch-deduping/app-fetch-deduping.test.ts
@@ -4,7 +4,7 @@ import { outdent } from 'outdent'
 import { FileRef, createNext } from 'e2e-utils'
 
 describe('app-fetch-deduping', () => {
-  if ((global as any).isNextStart) {
+  if (next.isStart) {
     describe('during static generation', () => {
       let externalServerPort: number
       let externalServer: http.Server
@@ -50,7 +50,7 @@ describe('app-fetch-deduping', () => {
         await next.destroy()
       })
     })
-  } else if ((global as any).isNextDev) {
+  } else if (next.isDev) {
     describe('during next dev', () => {
       it('should dedupe requests called from the same component', async () => {
         const next = await createNext({

--- a/test/e2e/app-dir/app-fetch-deduping/app-fetch-deduping.test.ts
+++ b/test/e2e/app-dir/app-fetch-deduping/app-fetch-deduping.test.ts
@@ -1,10 +1,10 @@
 import { findPort, waitFor } from 'next-test-utils'
 import http from 'http'
 import { outdent } from 'outdent'
-import { FileRef, createNext } from 'e2e-utils'
+import { FileRef, createNext, isNextDev, isNextStart } from 'e2e-utils'
 
 describe('app-fetch-deduping', () => {
-  if (next.isStart) {
+  if (isNextStart) {
     describe('during static generation', () => {
       let externalServerPort: number
       let externalServer: http.Server
@@ -50,7 +50,7 @@ describe('app-fetch-deduping', () => {
         await next.destroy()
       })
     })
-  } else if (next.isDev) {
+  } else if (isNextDev) {
     describe('during next dev', () => {
       it('should dedupe requests called from the same component', async () => {
         const next = await createNext({

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -283,7 +283,7 @@ createNextDescribe(
             )
             const cacheHeader = newRes.headers.get('x-nextjs-cache')
 
-            if ((global as any).isNextStart && cacheHeader) {
+            if (isNextStart && cacheHeader) {
               expect(cacheHeader).toBe('MISS')
             }
             const newHtml = await newRes.text()
@@ -319,7 +319,7 @@ createNextDescribe(
 
     // On-Demand Revalidate has not effect in dev since app routes
     // aren't considered static until prerendering
-    if (!(global as any).isNextDev && !process.env.CUSTOM_CACHE_HANDLER) {
+    if (!isDev && !process.env.CUSTOM_CACHE_HANDLER) {
       it('should not revalidate / when revalidate is not used', async () => {
         let prevData
 
@@ -393,7 +393,7 @@ createNextDescribe(
     }
 
     // On-Demand Revalidate has not effect in dev
-    if (!(global as any).isNextDev && !process.env.CUSTOM_CACHE_HANDLER) {
+    if (!isDev && !process.env.CUSTOM_CACHE_HANDLER) {
       it('should revalidate all fetches during on-demand revalidate', async () => {
         const initRes = await next.fetch(
           '/variable-revalidate/revalidate-360-isr'
@@ -2572,7 +2572,7 @@ createNextDescribe(
 
       const firstTime = $('#now').text()
 
-      if (!(global as any).isNextDev) {
+      if (!isDev) {
         const res2 = await next.fetch('/force-static')
         expect(res2.status).toBe(200)
 
@@ -2663,7 +2663,7 @@ createNextDescribe(
 
         const firstTime = $('#now').text()
 
-        if (!(global as any).isNextDev) {
+        if (!isDev) {
           const res2 = await next.fetch('/force-static/first')
           expect(res2.status).toBe(200)
 
@@ -2685,7 +2685,7 @@ createNextDescribe(
 
         const firstTime = $('#now').text()
 
-        if (!(global as any).isNextDev) {
+        if (!isDev) {
           const res2 = await next.fetch('/force-static/random')
           expect(res2.status).toBe(200)
 
@@ -2972,7 +2972,7 @@ createNextDescribe(
         })
 
         // TODO-APP: re-enable after investigating rewrite params
-        if (!(global as any).isNextDeploy) {
+        if (!isNextDeploy) {
           it('should have values from canonical url on rewrite', async () => {
             const browser = await next.browser(
               '/rewritten-use-search-params?first=a&second=b&third=c'

--- a/test/e2e/app-dir/app/experimental-compile.test.ts
+++ b/test/e2e/app-dir/app/experimental-compile.test.ts
@@ -1,4 +1,3 @@
-import 'e2e-utils'
 import { isNextStart } from 'e2e-utils'
 
 process.env.NEXT_EXPERIMENTAL_COMPILE = '1'

--- a/test/e2e/app-dir/app/experimental-compile.test.ts
+++ b/test/e2e/app-dir/app/experimental-compile.test.ts
@@ -1,8 +1,9 @@
 import 'e2e-utils'
+import { isNextStart } from 'e2e-utils'
 
 process.env.NEXT_EXPERIMENTAL_COMPILE = '1'
 
-if ((global as any).isNextStart) {
+if (isNextStart) {
   require('./index.test')
 } else {
   it('should skip', () => {})

--- a/test/e2e/app-dir/app/standalone-gsp.test.ts
+++ b/test/e2e/app-dir/app/standalone-gsp.test.ts
@@ -1,4 +1,4 @@
-import { createNextDescribe } from 'e2e-utils'
+import { createNextDescribe, isNextStart } from 'e2e-utils'
 import fs from 'fs-extra'
 import os from 'os'
 import path from 'path'
@@ -9,7 +9,7 @@ import {
   fetchViaHTTP,
 } from 'next-test-utils'
 
-if (!(globalThis as any).isNextStart) {
+if (!isNextStart) {
   it('should skip for non-next start', () => {})
 } else {
   createNextDescribe(

--- a/test/e2e/app-dir/app/standalone.test.ts
+++ b/test/e2e/app-dir/app/standalone.test.ts
@@ -1,4 +1,4 @@
-import { createNextDescribe } from 'e2e-utils'
+import { createNextDescribe, isNextStart } from 'e2e-utils'
 import fs from 'fs-extra'
 import os from 'os'
 import path from 'path'
@@ -9,7 +9,7 @@ import {
   fetchViaHTTP,
 } from 'next-test-utils'
 
-if (!(globalThis as any).isNextStart) {
+if (!isNextStart) {
   it('should skip for non-next start', () => {})
 } else {
   createNextDescribe(

--- a/test/e2e/app-dir/app/vercel-speed-insights.test.ts
+++ b/test/e2e/app-dir/app/vercel-speed-insights.test.ts
@@ -34,7 +34,7 @@ describe('vercel speed insights', () => {
     afterAll(() => next.destroy())
 
     // Analytics events are only sent in production
-    ;(next.isDev ? describe.skip : describe)('Vercel analytics', () => {
+    ;(next.isNextDev ? describe.skip : describe)('Vercel analytics', () => {
       it('should send web vitals to Vercel analytics', async () => {
         expect(next.cliOutput).toMatch(
           '`config.analyticsId` is deprecated and will be removed in next major version. Read more: https://nextjs.org/docs/messages/deprecated-analyticsid'

--- a/test/e2e/app-dir/app/vercel-speed-insights.test.ts
+++ b/test/e2e/app-dir/app/vercel-speed-insights.test.ts
@@ -1,4 +1,4 @@
-import { createNext, isNextDeploy } from 'e2e-utils'
+import { createNext, isNextDeploy, isNextDev } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { check } from 'next-test-utils'
 
@@ -34,7 +34,7 @@ describe('vercel speed insights', () => {
     afterAll(() => next.destroy())
 
     // Analytics events are only sent in production
-    ;(next.isNextDev ? describe.skip : describe)('Vercel analytics', () => {
+    ;(isNextDev ? describe.skip : describe)('Vercel analytics', () => {
       it('should send web vitals to Vercel analytics', async () => {
         expect(next.cliOutput).toMatch(
           '`config.analyticsId` is deprecated and will be removed in next major version. Read more: https://nextjs.org/docs/messages/deprecated-analyticsid'

--- a/test/e2e/app-dir/app/vercel-speed-insights.test.ts
+++ b/test/e2e/app-dir/app/vercel-speed-insights.test.ts
@@ -3,9 +3,9 @@ import { NextInstance } from 'test/lib/next-modes/base'
 import { check } from 'next-test-utils'
 
 describe('vercel speed insights', () => {
-  const isDev = (global as any).isNextDev
+  const isDev = next.isDev
 
-  if ((global as any).isNextDeploy) {
+  if (next.isDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }

--- a/test/e2e/app-dir/app/vercel-speed-insights.test.ts
+++ b/test/e2e/app-dir/app/vercel-speed-insights.test.ts
@@ -1,11 +1,9 @@
-import { createNext } from 'e2e-utils'
+import { createNext, isNextDeploy } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { check } from 'next-test-utils'
 
 describe('vercel speed insights', () => {
-  const isDev = next.isDev
-
-  if (next.isDeploy) {
+  if (isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }
@@ -36,7 +34,7 @@ describe('vercel speed insights', () => {
     afterAll(() => next.destroy())
 
     // Analytics events are only sent in production
-    ;(isDev ? describe.skip : describe)('Vercel analytics', () => {
+    ;(next.isDev ? describe.skip : describe)('Vercel analytics', () => {
       it('should send web vitals to Vercel analytics', async () => {
         expect(next.cliOutput).toMatch(
           '`config.analyticsId` is deprecated and will be removed in next major version. Read more: https://nextjs.org/docs/messages/deprecated-analyticsid'

--- a/test/e2e/app-dir/create-root-layout/create-root-layout.test.ts
+++ b/test/e2e/app-dir/create-root-layout/create-root-layout.test.ts
@@ -6,9 +6,9 @@ import stripAnsi from 'strip-ansi'
 ;(process.env.TURBOPACK ? describe.skip : describe)(
   'app-dir create root layout',
   () => {
-    const isDev = (global as any).isNextDev
+    const isDev = next.isDev
 
-    if ((global as any).isNextDeploy) {
+    if (next.isDeploy) {
       it('should skip next deploy for now', () => {})
       return
     }

--- a/test/e2e/app-dir/create-root-layout/create-root-layout.test.ts
+++ b/test/e2e/app-dir/create-root-layout/create-root-layout.test.ts
@@ -1,21 +1,19 @@
 import path from 'path'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDeploy, isNextDev } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { check } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 ;(process.env.TURBOPACK ? describe.skip : describe)(
   'app-dir create root layout',
   () => {
-    const isDev = next.isDev
-
-    if (next.isDeploy) {
+    if (isNextDeploy) {
       it('should skip next deploy for now', () => {})
       return
     }
 
     let next: NextInstance
 
-    if (isDev) {
+    if (isNextDev) {
       describe('page.js', () => {
         describe('root layout in app', () => {
           beforeAll(async () => {

--- a/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
+++ b/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
@@ -42,7 +42,7 @@ describe('navigation between pages and app dir', () => {
   })
 
   // TODO: re-enable after 404 transition bug is addressed
-  if (!(global as any).isNextDeploy) {
+  if (!next.isDeploy) {
     it('It should be able to navigate pages -> app and go back an forward', async () => {
       const browser = await webdriver(next.url, '/pages')
       await browser

--- a/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
+++ b/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
@@ -1,4 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDeploy } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import webdriver from 'next-webdriver'
 
@@ -42,7 +42,7 @@ describe('navigation between pages and app dir', () => {
   })
 
   // TODO: re-enable after 404 transition bug is addressed
-  if (!next.isNextDeploy) {
+  if (!isNextDeploy) {
     it('It should be able to navigate pages -> app and go back an forward', async () => {
       const browser = await webdriver(next.url, '/pages')
       await browser

--- a/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
+++ b/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
@@ -42,7 +42,7 @@ describe('navigation between pages and app dir', () => {
   })
 
   // TODO: re-enable after 404 transition bug is addressed
-  if (!next.isDeploy) {
+  if (!next.isNextDeploy) {
     it('It should be able to navigate pages -> app and go back an forward', async () => {
       const browser = await webdriver(next.url, '/pages')
       await browser

--- a/test/e2e/app-dir/logging/fetch-logging.test.ts
+++ b/test/e2e/app-dir/logging/fetch-logging.test.ts
@@ -2,252 +2,249 @@ import path from 'path'
 import fs from 'fs'
 import stripAnsi from 'strip-ansi'
 import { retry } from 'next-test-utils'
-import { nextTestSetup } from 'e2e-utils'
+import { createNextDescribe } from 'e2e-utils'
 
 function parseLogsFromCli(cliOutput: string) {
-  function cacheReasonTest(log: string) {
-    return /Cache (missed|skipped) reason/.test(log)
-  }
-  interface ParsedLog {
-    method: string
-    url: string
-    statusCode: number
-    responseTime: number
-    cache: string
-  }
   const logs = stripAnsi(cliOutput)
     .split('\n')
-    .filter((log) => cacheReasonTest(log) || log.includes('GET'))
+    .filter((log) => log.includes('Cache missed reason') || log.includes('GET'))
 
-  return logs.reduce<ParsedLog[]>((parsedLogs, log) => {
-    if (cacheReasonTest(log)) {
-      // cache miss/skip reason
-      const reasonSegment = (log.split('Cache missed reason: ', 2) ??
-        log.split('Cache skipped reason: ', 2))[1].trim()
+  return logs.reduce((parsedLogs, log) => {
+    if (log.includes('Cache missed reason')) {
+      // cache miss reason
+      const reasonSegment = log.split('Cache missed reason: ', 2)[1].trim()
       const reason = reasonSegment.slice(1, -1)
       parsedLogs[parsedLogs.length - 1].cache = reason
     } else {
       // request info
       const trimmedLog = log.replace(/^[^a-zA-Z]+/, '')
-      const [method, url, statusCode, responseTime] = trimmedLog.split(' ', 5)
+      const parts = trimmedLog.split(' ', 5)
+      const method = parts[0]
+      const url = parts[1]
+      const statusCode = parseInt(parts[2])
+      const responseTime = parseInt(parts[4])
 
-      parsedLogs.push({
+      const parsedLog = {
         method,
         url,
-        statusCode: parseInt(statusCode, 10),
-        responseTime: parseInt(responseTime, 10),
+        statusCode,
+        responseTime,
         cache: undefined,
-      })
+      }
+      parsedLogs.push(parsedLog)
     }
     return parsedLogs
-  }, [])
+  }, [] as any[])
 }
 
-describe('app-dir - logging', () => {
-  const { next, isNextDev } = nextTestSetup({
+createNextDescribe(
+  'app-dir - logging',
+  {
     skipDeployment: true,
     files: __dirname,
-  })
-  function runTests({
-    withFetchesLogging,
-    withFullUrlFetches = false,
-  }: {
-    withFetchesLogging: boolean
-    withFullUrlFetches?: boolean
-  }) {
-    if (withFetchesLogging) {
-      it('should only log requests in dev mode', async () => {
-        const outputIndex = next.cliOutput.length
-        await next.fetch('/default-cache')
-
-        await retry(() => {
-          const logs = stripAnsi(next.cliOutput.slice(outputIndex))
-          const hasLogs = logs.includes('GET /default-cache 200')
-
-          expect(isNextDev ? hasLogs : !hasLogs).toBe(true)
-        })
-      })
-
-      if (isNextDev) {
-        it("should log 'skip' cache status with a reason when cache: 'no-cache' is used", async () => {
-          const outputIndex = next.cliOutput.length
-          await next.fetch('/default-cache')
-
-          await retry(() => {
-            const logs = parseLogsFromCli(next.cliOutput.slice(outputIndex))
-
-            const logEntry = logs.find((log) =>
-              log.url.includes('api/random?no-cache')
-            )
-
-            expect(logs.some((log) => log.url.includes('..'))).toBe(
-              !withFullUrlFetches
-            )
-
-            expect(logEntry?.cache).toBe('cache: no-cache')
-          })
-        })
-
-        it("should log 'skip' cache status with a reason when revalidate: 0 is used", async () => {
-          const outputIndex = next.cliOutput.length
-          await next.fetch('/default-cache')
-          await retry(() => {
-            const logs = parseLogsFromCli(next.cliOutput.slice(outputIndex))
-
-            const logEntry = logs.find((log) =>
-              log.url.includes('api/random?revalidate-0')
-            )
-
-            expect(logEntry?.cache).toBe('revalidate: 0')
-          })
-        })
-
-        it("should log 'skip' cache status with a reason when the browser indicates caching should be ignored", async () => {
-          const outputIndex = next.cliOutput.length
-          await next.fetch('/default-cache', {
-            headers: { 'Cache-Control': 'no-cache' },
-          })
-          await retry(() => {
-            const logs = parseLogsFromCli(next.cliOutput.slice(outputIndex))
-
-            const logEntry = logs.find((log) =>
-              log.url.includes('api/random?auto-cache')
-            )
-
-            expect(logEntry?.cache).toBe(
-              'cache-control: no-cache (hard refresh)'
-            )
-          })
-        })
-
-        it('should log requests with correct indentation', async () => {
+  },
+  ({ next, isNextDev }) => {
+    function runTests({
+      withFetchesLogging,
+      withFullUrlFetches = false,
+    }: {
+      withFetchesLogging: boolean
+      withFullUrlFetches?: boolean
+    }) {
+      if (withFetchesLogging) {
+        it('should only log requests in dev mode', async () => {
           const outputIndex = next.cliOutput.length
           await next.fetch('/default-cache')
 
           await retry(() => {
             const logs = stripAnsi(next.cliOutput.slice(outputIndex))
-            const hasLogs =
-              logs.includes(' GET /default-cache') &&
-              logs.includes('  │ GET ') &&
-              logs.includes('  │  │ GET ') &&
-              logs.includes('  │  │  Cache missed reason')
+            const hasLogs = logs.includes('GET /default-cache 200')
 
-            expect(hasLogs).toBe(true)
+            expect(isNextDev ? hasLogs : !hasLogs).toBe(true)
           })
         })
 
-        it('should show cache reason of noStore when use with fetch', async () => {
-          const logLength = next.cliOutput.length
-          await next.fetch('/no-store')
+        if (isNextDev) {
+          it("should log 'skip' cache status with a reason when cache: 'no-cache' is used", async () => {
+            const outputIndex = next.cliOutput.length
+            await next.fetch('/default-cache')
 
-          await retry(() => {
-            const output = stripAnsi(next.cliOutput.slice(logLength))
-            expect(output).toContain('Cache skipped reason: (noStore call)')
+            await retry(() => {
+              const logs = parseLogsFromCli(next.cliOutput.slice(outputIndex))
+
+              const logEntry = logs.find((log) =>
+                log.url.includes('api/random?no-cache')
+              )
+
+              expect(logs.some((log) => log.url.includes('..'))).toBe(
+                !withFullUrlFetches
+              )
+
+              expect(logEntry?.cache).toBe('cache: no-cache')
+            })
           })
-        })
 
-        it('should respect request.init.cache when use with fetch input is instance', async () => {
-          const logLength = next.cliOutput.length
-          await next.fetch('/fetch-no-store')
+          it("should log 'skip' cache status with a reason when revalidate: 0 is used", async () => {
+            const outputIndex = next.cliOutput.length
+            await next.fetch('/default-cache')
+            await retry(() => {
+              const logs = parseLogsFromCli(next.cliOutput.slice(outputIndex))
+
+              const logEntry = logs.find((log) =>
+                log.url.includes('api/random?revalidate-0')
+              )
+
+              expect(logEntry?.cache).toBe('revalidate: 0')
+            })
+          })
+
+          it("should log 'skip' cache status with a reason when the browser indicates caching should be ignored", async () => {
+            const outputIndex = next.cliOutput.length
+            await next.fetch('/default-cache', {
+              headers: { 'Cache-Control': 'no-cache' },
+            })
+            await retry(() => {
+              const logs = parseLogsFromCli(next.cliOutput.slice(outputIndex))
+
+              const logEntry = logs.find((log) =>
+                log.url.includes('api/random?auto-cache')
+              )
+
+              expect(logEntry?.cache).toBe(
+                'cache-control: no-cache (hard refresh)'
+              )
+            })
+          })
+
+          it('should log requests with correct indentation', async () => {
+            const outputIndex = next.cliOutput.length
+            await next.fetch('/default-cache')
+
+            await retry(() => {
+              const logs = stripAnsi(next.cliOutput.slice(outputIndex))
+              const hasLogs =
+                logs.includes(' GET /default-cache') &&
+                logs.includes('  │ GET ') &&
+                logs.includes('  │  │ GET ') &&
+                logs.includes('  │  │  Cache missed reason')
+
+              expect(hasLogs).toBe(true)
+            })
+          })
+
+          it('should show cache reason of noStore when use with fetch', async () => {
+            const logLength = next.cliOutput.length
+            await next.fetch('/no-store')
+
+            await retry(() => {
+              const output = stripAnsi(next.cliOutput.slice(logLength))
+              expect(output).toContain('Cache missed reason: (noStore call)')
+            })
+          })
+
+          it('should respect request.init.cache when use with fetch input is instance', async () => {
+            const logLength = next.cliOutput.length
+            await next.fetch('/fetch-no-store')
+
+            await retry(() => {
+              const output = stripAnsi(next.cliOutput.slice(logLength))
+              expect(output).toContain('Cache missed reason: (cache: no-store)')
+            })
+          })
+        }
+      } else {
+        // No fetches logging enabled
+        it('should not log fetch requests at all', async () => {
+          const outputIndex = next.cliOutput.length
+          await next.fetch('/default-cache')
 
           await retry(() => {
-            const output = stripAnsi(next.cliOutput.slice(logLength))
-            expect(output).toContain('Cache skipped reason: (cache: no-store)')
+            const logs = stripAnsi(next.cliOutput.slice(outputIndex))
+            expect(logs).not.toContain('GET /default-cache 200')
           })
         })
       }
-    } else {
-      // No fetches logging enabled
-      it('should not log fetch requests at all', async () => {
-        const outputIndex = next.cliOutput.length
-        await next.fetch('/default-cache')
 
-        await retry(() => {
-          const logs = stripAnsi(next.cliOutput.slice(outputIndex))
-          expect(logs).not.toContain('GET /default-cache 200')
+      if (isNextDev) {
+        it('should not contain trailing word page for app router routes', async () => {
+          const logLength = next.cliOutput.length
+          await next.fetch('/')
+
+          await retry(() => {
+            const output = stripAnsi(next.cliOutput.slice(logLength))
+            expect(output).toContain('/')
+            expect(output).not.toContain('/page')
+          })
         })
-      })
+
+        it('should not contain metadata internal segments for dynamic metadata routes', async () => {
+          const logLength = next.cliOutput.length
+          await next.fetch('/dynamic/big/icon')
+
+          await retry(() => {
+            const output = stripAnsi(next.cliOutput.slice(logLength))
+            expect(output).toContain('/dynamic/[slug]/icon')
+            expect(output).not.toContain('/(group)')
+            expect(output).not.toContain('[[...__metadata_id__]]')
+            expect(output).not.toContain('/route')
+          })
+        })
+      }
     }
 
-    if (isNextDev) {
-      it('should not contain trailing word page for app router routes', async () => {
-        const logLength = next.cliOutput.length
-        await next.fetch('/')
+    describe('with fetches verbose logging', () => {
+      runTests({ withFetchesLogging: true, withFullUrlFetches: true })
+    })
 
-        await retry(() => {
-          const output = stripAnsi(next.cliOutput.slice(logLength))
-          expect(output).toContain('/')
-          expect(output).not.toContain('/page')
-        })
+    describe('with fetches default logging', () => {
+      const curNextConfig = fs.readFileSync(
+        path.join(__dirname, 'next.config.js'),
+        { encoding: 'utf-8' }
+      )
+      beforeAll(async () => {
+        await next.stop()
+        await next.patchFile(
+          'next.config.js',
+          curNextConfig.replace('fullUrl: true', 'fullUrl: false')
+        )
+        await next.start()
+      })
+      afterAll(async () => {
+        await next.patchFile('next.config.js', curNextConfig)
       })
 
-      it('should not contain metadata internal segments for dynamic metadata routes', async () => {
-        const logLength = next.cliOutput.length
-        await next.fetch('/dynamic/big/icon')
+      runTests({ withFetchesLogging: true, withFullUrlFetches: false })
+    })
 
-        await retry(() => {
-          const output = stripAnsi(next.cliOutput.slice(logLength))
-          expect(output).toContain('/dynamic/[slug]/icon')
-          expect(output).not.toContain('/(group)')
-          expect(output).not.toContain('[[...__metadata_id__]]')
-          expect(output).not.toContain('/route')
-        })
+    describe('with verbose logging for edge runtime', () => {
+      beforeAll(async () => {
+        await next.stop()
+        const layoutContent = await next.readFile('app/layout.js')
+        await next.patchFile(
+          'app/layout.js',
+          layoutContent + `\nexport const runtime = 'edge'`
+        )
+        await next.start()
       })
-    }
+
+      runTests({ withFetchesLogging: false })
+    })
+
+    describe('with default logging', () => {
+      const curNextConfig = fs.readFileSync(
+        path.join(__dirname, 'next.config.js'),
+        { encoding: 'utf-8' }
+      )
+      beforeAll(async () => {
+        await next.stop()
+        await next.deleteFile('next.config.js')
+        await next.start()
+      })
+      afterAll(async () => {
+        await next.patchFile('next.config.js', curNextConfig)
+      })
+
+      runTests({ withFetchesLogging: false })
+    })
   }
-
-  describe('with fetches verbose logging', () => {
-    runTests({ withFetchesLogging: true, withFullUrlFetches: true })
-  })
-
-  describe('with fetches default logging', () => {
-    const curNextConfig = fs.readFileSync(
-      path.join(__dirname, 'next.config.js'),
-      { encoding: 'utf-8' }
-    )
-    beforeAll(async () => {
-      await next.stop()
-      await next.patchFile(
-        'next.config.js',
-        curNextConfig.replace('fullUrl: true', 'fullUrl: false')
-      )
-      await next.start()
-    })
-    afterAll(async () => {
-      await next.patchFile('next.config.js', curNextConfig)
-    })
-
-    runTests({ withFetchesLogging: true, withFullUrlFetches: false })
-  })
-
-  describe('with verbose logging for edge runtime', () => {
-    beforeAll(async () => {
-      await next.stop()
-      const layoutContent = await next.readFile('app/layout.js')
-      await next.patchFile(
-        'app/layout.js',
-        layoutContent + `\nexport const runtime = 'edge'`
-      )
-      await next.start()
-    })
-
-    runTests({ withFetchesLogging: false })
-  })
-
-  describe('with default logging', () => {
-    const curNextConfig = fs.readFileSync(
-      path.join(__dirname, 'next.config.js'),
-      { encoding: 'utf-8' }
-    )
-    beforeAll(async () => {
-      await next.stop()
-      await next.deleteFile('next.config.js')
-      await next.start()
-    })
-    afterAll(async () => {
-      await next.patchFile('next.config.js', curNextConfig)
-    })
-
-    runTests({ withFetchesLogging: false })
-  })
-})
+)

--- a/test/e2e/app-dir/logging/fetch-logging.test.ts
+++ b/test/e2e/app-dir/logging/fetch-logging.test.ts
@@ -2,249 +2,252 @@ import path from 'path'
 import fs from 'fs'
 import stripAnsi from 'strip-ansi'
 import { retry } from 'next-test-utils'
-import { createNextDescribe } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 
 function parseLogsFromCli(cliOutput: string) {
+  function cacheReasonTest(log: string) {
+    return /Cache (missed|skipped) reason/.test(log)
+  }
+  interface ParsedLog {
+    method: string
+    url: string
+    statusCode: number
+    responseTime: number
+    cache: string
+  }
   const logs = stripAnsi(cliOutput)
     .split('\n')
-    .filter((log) => log.includes('Cache missed reason') || log.includes('GET'))
+    .filter((log) => cacheReasonTest(log) || log.includes('GET'))
 
-  return logs.reduce((parsedLogs, log) => {
-    if (log.includes('Cache missed reason')) {
-      // cache miss reason
-      const reasonSegment = log.split('Cache missed reason: ', 2)[1].trim()
+  return logs.reduce<ParsedLog[]>((parsedLogs, log) => {
+    if (cacheReasonTest(log)) {
+      // cache miss/skip reason
+      const reasonSegment = (log.split('Cache missed reason: ', 2) ??
+        log.split('Cache skipped reason: ', 2))[1].trim()
       const reason = reasonSegment.slice(1, -1)
       parsedLogs[parsedLogs.length - 1].cache = reason
     } else {
       // request info
       const trimmedLog = log.replace(/^[^a-zA-Z]+/, '')
-      const parts = trimmedLog.split(' ', 5)
-      const method = parts[0]
-      const url = parts[1]
-      const statusCode = parseInt(parts[2])
-      const responseTime = parseInt(parts[4])
+      const [method, url, statusCode, responseTime] = trimmedLog.split(' ', 5)
 
-      const parsedLog = {
+      parsedLogs.push({
         method,
         url,
-        statusCode,
-        responseTime,
+        statusCode: parseInt(statusCode, 10),
+        responseTime: parseInt(responseTime, 10),
         cache: undefined,
-      }
-      parsedLogs.push(parsedLog)
+      })
     }
     return parsedLogs
-  }, [] as any[])
+  }, [])
 }
 
-createNextDescribe(
-  'app-dir - logging',
-  {
+describe('app-dir - logging', () => {
+  const { next, isNextDev } = nextTestSetup({
     skipDeployment: true,
     files: __dirname,
-  },
-  ({ next, isNextDev }) => {
-    function runTests({
-      withFetchesLogging,
-      withFullUrlFetches = false,
-    }: {
-      withFetchesLogging: boolean
-      withFullUrlFetches?: boolean
-    }) {
-      if (withFetchesLogging) {
-        it('should only log requests in dev mode', async () => {
-          const outputIndex = next.cliOutput.length
-          await next.fetch('/default-cache')
+  })
+  function runTests({
+    withFetchesLogging,
+    withFullUrlFetches = false,
+  }: {
+    withFetchesLogging: boolean
+    withFullUrlFetches?: boolean
+  }) {
+    if (withFetchesLogging) {
+      it('should only log requests in dev mode', async () => {
+        const outputIndex = next.cliOutput.length
+        await next.fetch('/default-cache')
 
-          await retry(() => {
-            const logs = stripAnsi(next.cliOutput.slice(outputIndex))
-            const hasLogs = logs.includes('GET /default-cache 200')
+        await retry(() => {
+          const logs = stripAnsi(next.cliOutput.slice(outputIndex))
+          const hasLogs = logs.includes('GET /default-cache 200')
 
-            expect(isNextDev ? hasLogs : !hasLogs).toBe(true)
-          })
+          expect(isNextDev ? hasLogs : !hasLogs).toBe(true)
         })
-
-        if (isNextDev) {
-          it("should log 'skip' cache status with a reason when cache: 'no-cache' is used", async () => {
-            const outputIndex = next.cliOutput.length
-            await next.fetch('/default-cache')
-
-            await retry(() => {
-              const logs = parseLogsFromCli(next.cliOutput.slice(outputIndex))
-
-              const logEntry = logs.find((log) =>
-                log.url.includes('api/random?no-cache')
-              )
-
-              expect(logs.some((log) => log.url.includes('..'))).toBe(
-                !withFullUrlFetches
-              )
-
-              expect(logEntry?.cache).toBe('cache: no-cache')
-            })
-          })
-
-          it("should log 'skip' cache status with a reason when revalidate: 0 is used", async () => {
-            const outputIndex = next.cliOutput.length
-            await next.fetch('/default-cache')
-            await retry(() => {
-              const logs = parseLogsFromCli(next.cliOutput.slice(outputIndex))
-
-              const logEntry = logs.find((log) =>
-                log.url.includes('api/random?revalidate-0')
-              )
-
-              expect(logEntry?.cache).toBe('revalidate: 0')
-            })
-          })
-
-          it("should log 'skip' cache status with a reason when the browser indicates caching should be ignored", async () => {
-            const outputIndex = next.cliOutput.length
-            await next.fetch('/default-cache', {
-              headers: { 'Cache-Control': 'no-cache' },
-            })
-            await retry(() => {
-              const logs = parseLogsFromCli(next.cliOutput.slice(outputIndex))
-
-              const logEntry = logs.find((log) =>
-                log.url.includes('api/random?auto-cache')
-              )
-
-              expect(logEntry?.cache).toBe(
-                'cache-control: no-cache (hard refresh)'
-              )
-            })
-          })
-
-          it('should log requests with correct indentation', async () => {
-            const outputIndex = next.cliOutput.length
-            await next.fetch('/default-cache')
-
-            await retry(() => {
-              const logs = stripAnsi(next.cliOutput.slice(outputIndex))
-              const hasLogs =
-                logs.includes(' GET /default-cache') &&
-                logs.includes('  │ GET ') &&
-                logs.includes('  │  │ GET ') &&
-                logs.includes('  │  │  Cache missed reason')
-
-              expect(hasLogs).toBe(true)
-            })
-          })
-
-          it('should show cache reason of noStore when use with fetch', async () => {
-            const logLength = next.cliOutput.length
-            await next.fetch('/no-store')
-
-            await retry(() => {
-              const output = stripAnsi(next.cliOutput.slice(logLength))
-              expect(output).toContain('Cache missed reason: (noStore call)')
-            })
-          })
-
-          it('should respect request.init.cache when use with fetch input is instance', async () => {
-            const logLength = next.cliOutput.length
-            await next.fetch('/fetch-no-store')
-
-            await retry(() => {
-              const output = stripAnsi(next.cliOutput.slice(logLength))
-              expect(output).toContain('Cache missed reason: (cache: no-store)')
-            })
-          })
-        }
-      } else {
-        // No fetches logging enabled
-        it('should not log fetch requests at all', async () => {
-          const outputIndex = next.cliOutput.length
-          await next.fetch('/default-cache')
-
-          await retry(() => {
-            const logs = stripAnsi(next.cliOutput.slice(outputIndex))
-            expect(logs).not.toContain('GET /default-cache 200')
-          })
-        })
-      }
+      })
 
       if (isNextDev) {
-        it('should not contain trailing word page for app router routes', async () => {
-          const logLength = next.cliOutput.length
-          await next.fetch('/')
+        it("should log 'skip' cache status with a reason when cache: 'no-cache' is used", async () => {
+          const outputIndex = next.cliOutput.length
+          await next.fetch('/default-cache')
 
           await retry(() => {
-            const output = stripAnsi(next.cliOutput.slice(logLength))
-            expect(output).toContain('/')
-            expect(output).not.toContain('/page')
+            const logs = parseLogsFromCli(next.cliOutput.slice(outputIndex))
+
+            const logEntry = logs.find((log) =>
+              log.url.includes('api/random?no-cache')
+            )
+
+            expect(logs.some((log) => log.url.includes('..'))).toBe(
+              !withFullUrlFetches
+            )
+
+            expect(logEntry?.cache).toBe('cache: no-cache')
           })
         })
 
-        it('should not contain metadata internal segments for dynamic metadata routes', async () => {
+        it("should log 'skip' cache status with a reason when revalidate: 0 is used", async () => {
+          const outputIndex = next.cliOutput.length
+          await next.fetch('/default-cache')
+          await retry(() => {
+            const logs = parseLogsFromCli(next.cliOutput.slice(outputIndex))
+
+            const logEntry = logs.find((log) =>
+              log.url.includes('api/random?revalidate-0')
+            )
+
+            expect(logEntry?.cache).toBe('revalidate: 0')
+          })
+        })
+
+        it("should log 'skip' cache status with a reason when the browser indicates caching should be ignored", async () => {
+          const outputIndex = next.cliOutput.length
+          await next.fetch('/default-cache', {
+            headers: { 'Cache-Control': 'no-cache' },
+          })
+          await retry(() => {
+            const logs = parseLogsFromCli(next.cliOutput.slice(outputIndex))
+
+            const logEntry = logs.find((log) =>
+              log.url.includes('api/random?auto-cache')
+            )
+
+            expect(logEntry?.cache).toBe(
+              'cache-control: no-cache (hard refresh)'
+            )
+          })
+        })
+
+        it('should log requests with correct indentation', async () => {
+          const outputIndex = next.cliOutput.length
+          await next.fetch('/default-cache')
+
+          await retry(() => {
+            const logs = stripAnsi(next.cliOutput.slice(outputIndex))
+            const hasLogs =
+              logs.includes(' GET /default-cache') &&
+              logs.includes('  │ GET ') &&
+              logs.includes('  │  │ GET ') &&
+              logs.includes('  │  │  Cache missed reason')
+
+            expect(hasLogs).toBe(true)
+          })
+        })
+
+        it('should show cache reason of noStore when use with fetch', async () => {
           const logLength = next.cliOutput.length
-          await next.fetch('/dynamic/big/icon')
+          await next.fetch('/no-store')
 
           await retry(() => {
             const output = stripAnsi(next.cliOutput.slice(logLength))
-            expect(output).toContain('/dynamic/[slug]/icon')
-            expect(output).not.toContain('/(group)')
-            expect(output).not.toContain('[[...__metadata_id__]]')
-            expect(output).not.toContain('/route')
+            expect(output).toContain('Cache skipped reason: (noStore call)')
+          })
+        })
+
+        it('should respect request.init.cache when use with fetch input is instance', async () => {
+          const logLength = next.cliOutput.length
+          await next.fetch('/fetch-no-store')
+
+          await retry(() => {
+            const output = stripAnsi(next.cliOutput.slice(logLength))
+            expect(output).toContain('Cache skipped reason: (cache: no-store)')
           })
         })
       }
+    } else {
+      // No fetches logging enabled
+      it('should not log fetch requests at all', async () => {
+        const outputIndex = next.cliOutput.length
+        await next.fetch('/default-cache')
+
+        await retry(() => {
+          const logs = stripAnsi(next.cliOutput.slice(outputIndex))
+          expect(logs).not.toContain('GET /default-cache 200')
+        })
+      })
     }
 
-    describe('with fetches verbose logging', () => {
-      runTests({ withFetchesLogging: true, withFullUrlFetches: true })
-    })
+    if (isNextDev) {
+      it('should not contain trailing word page for app router routes', async () => {
+        const logLength = next.cliOutput.length
+        await next.fetch('/')
 
-    describe('with fetches default logging', () => {
-      const curNextConfig = fs.readFileSync(
-        path.join(__dirname, 'next.config.js'),
-        { encoding: 'utf-8' }
-      )
-      beforeAll(async () => {
-        await next.stop()
-        await next.patchFile(
-          'next.config.js',
-          curNextConfig.replace('fullUrl: true', 'fullUrl: false')
-        )
-        await next.start()
-      })
-      afterAll(async () => {
-        await next.patchFile('next.config.js', curNextConfig)
+        await retry(() => {
+          const output = stripAnsi(next.cliOutput.slice(logLength))
+          expect(output).toContain('/')
+          expect(output).not.toContain('/page')
+        })
       })
 
-      runTests({ withFetchesLogging: true, withFullUrlFetches: false })
-    })
+      it('should not contain metadata internal segments for dynamic metadata routes', async () => {
+        const logLength = next.cliOutput.length
+        await next.fetch('/dynamic/big/icon')
 
-    describe('with verbose logging for edge runtime', () => {
-      beforeAll(async () => {
-        await next.stop()
-        const layoutContent = await next.readFile('app/layout.js')
-        await next.patchFile(
-          'app/layout.js',
-          layoutContent + `\nexport const runtime = 'edge'`
-        )
-        await next.start()
+        await retry(() => {
+          const output = stripAnsi(next.cliOutput.slice(logLength))
+          expect(output).toContain('/dynamic/[slug]/icon')
+          expect(output).not.toContain('/(group)')
+          expect(output).not.toContain('[[...__metadata_id__]]')
+          expect(output).not.toContain('/route')
+        })
       })
-
-      runTests({ withFetchesLogging: false })
-    })
-
-    describe('with default logging', () => {
-      const curNextConfig = fs.readFileSync(
-        path.join(__dirname, 'next.config.js'),
-        { encoding: 'utf-8' }
-      )
-      beforeAll(async () => {
-        await next.stop()
-        await next.deleteFile('next.config.js')
-        await next.start()
-      })
-      afterAll(async () => {
-        await next.patchFile('next.config.js', curNextConfig)
-      })
-
-      runTests({ withFetchesLogging: false })
-    })
+    }
   }
-)
+
+  describe('with fetches verbose logging', () => {
+    runTests({ withFetchesLogging: true, withFullUrlFetches: true })
+  })
+
+  describe('with fetches default logging', () => {
+    const curNextConfig = fs.readFileSync(
+      path.join(__dirname, 'next.config.js'),
+      { encoding: 'utf-8' }
+    )
+    beforeAll(async () => {
+      await next.stop()
+      await next.patchFile(
+        'next.config.js',
+        curNextConfig.replace('fullUrl: true', 'fullUrl: false')
+      )
+      await next.start()
+    })
+    afterAll(async () => {
+      await next.patchFile('next.config.js', curNextConfig)
+    })
+
+    runTests({ withFetchesLogging: true, withFullUrlFetches: false })
+  })
+
+  describe('with verbose logging for edge runtime', () => {
+    beforeAll(async () => {
+      await next.stop()
+      const layoutContent = await next.readFile('app/layout.js')
+      await next.patchFile(
+        'app/layout.js',
+        layoutContent + `\nexport const runtime = 'edge'`
+      )
+      await next.start()
+    })
+
+    runTests({ withFetchesLogging: false })
+  })
+
+  describe('with default logging', () => {
+    const curNextConfig = fs.readFileSync(
+      path.join(__dirname, 'next.config.js'),
+      { encoding: 'utf-8' }
+    )
+    beforeAll(async () => {
+      await next.stop()
+      await next.deleteFile('next.config.js')
+      await next.start()
+    })
+    afterAll(async () => {
+      await next.patchFile('next.config.js', curNextConfig)
+    })
+
+    runTests({ withFetchesLogging: false })
+  })
+})

--- a/test/e2e/app-dir/ppr-navigations/avoid-popstate-flash/avoid-popstate-flash.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/avoid-popstate-flash/avoid-popstate-flash.test.ts
@@ -4,7 +4,7 @@ import { createTestDataServer } from 'test-data-service/writer'
 import { createTestLog } from 'test-log'
 
 describe('avoid-popstate-flash', () => {
-  if ((global as any).isNextDev) {
+  if (next.isDev) {
     test('ppr is disabled in dev', () => {})
     return
   }

--- a/test/e2e/app-dir/ppr-navigations/avoid-popstate-flash/avoid-popstate-flash.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/avoid-popstate-flash/avoid-popstate-flash.test.ts
@@ -1,10 +1,10 @@
-import { createNext } from 'e2e-utils'
+import { createNext, isNextDev } from 'e2e-utils'
 import { findPort } from 'next-test-utils'
 import { createTestDataServer } from 'test-data-service/writer'
 import { createTestLog } from 'test-log'
 
 describe('avoid-popstate-flash', () => {
-  if (next.isDev) {
+  if (isNextDev) {
     test('ppr is disabled in dev', () => {})
     return
   }

--- a/test/e2e/app-dir/ppr-navigations/loading-tsx-no-partial-rendering/loading-tsx-no-partial-rendering.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/loading-tsx-no-partial-rendering/loading-tsx-no-partial-rendering.test.ts
@@ -4,7 +4,7 @@ import { createTestDataServer } from 'test-data-service/writer'
 import { createTestLog } from 'test-log'
 
 describe('loading-tsx-no-partial-rendering', () => {
-  if ((global as any).isNextDev) {
+  if (next.isDev) {
     test('ppr is disabled in dev', () => {})
     return
   }

--- a/test/e2e/app-dir/ppr-navigations/loading-tsx-no-partial-rendering/loading-tsx-no-partial-rendering.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/loading-tsx-no-partial-rendering/loading-tsx-no-partial-rendering.test.ts
@@ -1,10 +1,10 @@
-import { createNext } from 'e2e-utils'
+import { createNext, isNextDev } from 'e2e-utils'
 import { findPort } from 'next-test-utils'
 import { createTestDataServer } from 'test-data-service/writer'
 import { createTestLog } from 'test-log'
 
 describe('loading-tsx-no-partial-rendering', () => {
-  if (next.isDev) {
+  if (isNextDev) {
     test('ppr is disabled in dev', () => {})
     return
   }

--- a/test/e2e/app-dir/ppr-navigations/search-params/search-params.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/search-params/search-params.test.ts
@@ -1,7 +1,7 @@
-import { createNext } from 'e2e-utils'
+import { createNext, isNextDev } from 'e2e-utils'
 
 describe('search-params', () => {
-  if (next.isDev) {
+  if (isNextDev) {
     test('ppr is disabled in dev', () => {})
     return
   }

--- a/test/e2e/app-dir/ppr-navigations/search-params/search-params.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/search-params/search-params.test.ts
@@ -1,7 +1,7 @@
 import { createNext } from 'e2e-utils'
 
 describe('search-params', () => {
-  if ((global as any).isNextDev) {
+  if (next.isDev) {
     test('ppr is disabled in dev', () => {})
     return
   }

--- a/test/e2e/app-dir/ppr-navigations/stale-prefetch-entry/stale-prefetch-entry.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/stale-prefetch-entry/stale-prefetch-entry.test.ts
@@ -4,7 +4,7 @@ import { createTestDataServer } from 'test-data-service/writer'
 import { createTestLog } from 'test-log'
 
 describe('stale-prefetch-entry', () => {
-  if ((global as any).isNextDev) {
+  if (next.isDev) {
     test('ppr is disabled in dev', () => {})
     return
   }

--- a/test/e2e/app-dir/ppr-navigations/stale-prefetch-entry/stale-prefetch-entry.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/stale-prefetch-entry/stale-prefetch-entry.test.ts
@@ -1,10 +1,10 @@
-import { createNext } from 'e2e-utils'
+import { createNext, isNextDev } from 'e2e-utils'
 import { findPort } from 'next-test-utils'
 import { createTestDataServer } from 'test-data-service/writer'
 import { createTestLog } from 'test-log'
 
 describe('stale-prefetch-entry', () => {
-  if (next.isDev) {
+  if (isNextDev) {
     test('ppr is disabled in dev', () => {})
     return
   }

--- a/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
+++ b/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
@@ -14,7 +14,7 @@ createNextDescribe(
   },
   ({ next }) => {
     // TODO: investigate test failures on deploy
-    if (next.isDeploy) {
+    if (next.isNextDeploy) {
       it('should skip for deploy', () => {})
       return
     }

--- a/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
+++ b/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
@@ -1,4 +1,4 @@
-import { createNextDescribe } from 'e2e-utils'
+import { createNextDescribe, isNextDeploy } from 'e2e-utils'
 
 createNextDescribe(
   'redirects and rewrites',
@@ -14,7 +14,7 @@ createNextDescribe(
   },
   ({ next }) => {
     // TODO: investigate test failures on deploy
-    if (next.isNextDeploy) {
+    if (isNextDeploy) {
       it('should skip for deploy', () => {})
       return
     }

--- a/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
+++ b/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
@@ -14,7 +14,7 @@ createNextDescribe(
   },
   ({ next }) => {
     // TODO: investigate test failures on deploy
-    if ((global as any).isNextDeploy) {
+    if (next.isDeploy) {
       it('should skip for deploy', () => {})
       return
     }

--- a/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+++ b/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
@@ -137,7 +137,7 @@ createNextDescribe(
       })
 
       // Test hot reloading only in development
-      ;(next.isNextDev ? it : it.skip)(
+      ;(isNextDev ? it : it.skip)(
         'should not scroll the page when we hot reload',
         async () => {
           const browser = await webdriver(next.url, '/10/10000/100/1000/page1')

--- a/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+++ b/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
@@ -137,7 +137,7 @@ createNextDescribe(
       })
 
       // Test hot reloading only in development
-      ;((global as any).isDev ? it : it.skip)(
+      ;(next.isDev ? it : it.skip)(
         'should not scroll the page when we hot reload',
         async () => {
           const browser = await webdriver(next.url, '/10/10000/100/1000/page1')

--- a/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+++ b/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
@@ -137,7 +137,7 @@ createNextDescribe(
       })
 
       // Test hot reloading only in development
-      ;(next.isDev ? it : it.skip)(
+      ;(next.isNextDev ? it : it.skip)(
         'should not scroll the page when we hot reload',
         async () => {
           const browser = await webdriver(next.url, '/10/10000/100/1000/page1')

--- a/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+++ b/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
@@ -148,14 +148,18 @@ createNextDescribe(
             'app/[layoutPaddingWidth]/[layoutPaddingHeight]/[pageWidth]/[pageHeight]/[param]/page.tsx'
 
           await browser.eval(`window.router.refresh()`)
-          await next.patchFile(
-            pagePath,
-            (await next.readFile(pagePath)) +
+          let originalContent: string
+          await next.patchFile(pagePath, (content) => {
+            originalContent = content
+            return (
+              content +
               `
         \\\\ Add this meaningless comment to force refresh
         `
-          )
+            )
+          })
           await waitForScrollToComplete(browser, { x: 0, y: 12000 })
+          await next.patchFile(pagePath, originalContent)
         }
       )
     })

--- a/test/e2e/app-dir/scss/invalid-global-module/invalid-global-module.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global-module/invalid-global-module.test.ts
@@ -6,7 +6,7 @@ import { join } from 'path'
 import { isNextStart } from 'e2e-utils'
 
 describe.skip('Invalid CSS Global Module Usage in node_modules', () => {
-  ;(Boolean(isNextStart) ? describe : describe.skip)('production only', () => {
+  ;(isNextStart ? describe : describe.skip)('production only', () => {
     const appDir = __dirname
 
     beforeAll(async () => {

--- a/test/e2e/app-dir/scss/invalid-global-module/invalid-global-module.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global-module/invalid-global-module.test.ts
@@ -7,29 +7,26 @@ import { join } from 'path'
 import 'e2e-utils'
 
 describe.skip('Invalid CSS Global Module Usage in node_modules', () => {
-  ;(Boolean((global as any).isNextStart) ? describe : describe.skip)(
-    'production only',
-    () => {
-      const appDir = __dirname
+  ;(Boolean(next.isStart) ? describe : describe.skip)('production only', () => {
+    const appDir = __dirname
 
-      beforeAll(async () => {
-        await remove(join(appDir, '.next'))
-      })
+    beforeAll(async () => {
+      await remove(join(appDir, '.next'))
+    })
 
-      it('should fail to build', async () => {
-        const { code, stderr } = await nextBuild(appDir, [], {
-          stderr: true,
-        })
-        expect(code).not.toBe(0)
-        expect(stderr).toContain('Failed to compile')
-        expect(stderr).toContain('node_modules/example/index.scss')
-        expect(stderr).toMatch(
-          /Global CSS.*cannot.*be imported from within.*node_modules/
-        )
-        expect(stderr).toMatch(
-          /Location:.*node_modules[\\/]example[\\/]index\.mjs/
-        )
+    it('should fail to build', async () => {
+      const { code, stderr } = await nextBuild(appDir, [], {
+        stderr: true,
       })
-    }
-  )
+      expect(code).not.toBe(0)
+      expect(stderr).toContain('Failed to compile')
+      expect(stderr).toContain('node_modules/example/index.scss')
+      expect(stderr).toMatch(
+        /Global CSS.*cannot.*be imported from within.*node_modules/
+      )
+      expect(stderr).toMatch(
+        /Location:.*node_modules[\\/]example[\\/]index\.mjs/
+      )
+    })
+  })
 })

--- a/test/e2e/app-dir/scss/invalid-global-module/invalid-global-module.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global-module/invalid-global-module.test.ts
@@ -3,11 +3,10 @@
 import { remove } from 'fs-extra'
 import { nextBuild } from 'next-test-utils'
 import { join } from 'path'
-// In order for the global isNextStart to be set
-import 'e2e-utils'
+import { isNextStart } from 'e2e-utils'
 
 describe.skip('Invalid CSS Global Module Usage in node_modules', () => {
-  ;(Boolean(next.isStart) ? describe : describe.skip)('production only', () => {
+  ;(Boolean(isNextStart) ? describe : describe.skip)('production only', () => {
     const appDir = __dirname
 
     beforeAll(async () => {

--- a/test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts
@@ -3,11 +3,10 @@
 import { remove } from 'fs-extra'
 import { nextBuild } from 'next-test-utils'
 import { join } from 'path'
-// In order for the global isNextStart to be set
-import 'e2e-utils'
+import { isNextStart } from 'e2e-utils'
 
 describe('Invalid Global CSS with Custom App', () => {
-  ;(Boolean(next.isStart) ? describe : describe.skip)('production only', () => {
+  ;(Boolean(isNextStart) ? describe : describe.skip)('production only', () => {
     const appDir = __dirname
 
     beforeAll(async () => {

--- a/test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts
@@ -6,7 +6,7 @@ import { join } from 'path'
 import { isNextStart } from 'e2e-utils'
 
 describe('Invalid Global CSS with Custom App', () => {
-  ;(Boolean(isNextStart) ? describe : describe.skip)('production only', () => {
+  ;(isNextStart ? describe : describe.skip)('production only', () => {
     const appDir = __dirname
 
     beforeAll(async () => {

--- a/test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts
@@ -7,27 +7,24 @@ import { join } from 'path'
 import 'e2e-utils'
 
 describe('Invalid Global CSS with Custom App', () => {
-  ;(Boolean((global as any).isNextStart) ? describe : describe.skip)(
-    'production only',
-    () => {
-      const appDir = __dirname
+  ;(Boolean(next.isStart) ? describe : describe.skip)('production only', () => {
+    const appDir = __dirname
 
-      beforeAll(async () => {
-        await remove(join(appDir, '.next'))
-      })
+    beforeAll(async () => {
+      await remove(join(appDir, '.next'))
+    })
 
-      it('should fail to build', async () => {
-        const { code, stderr } = await nextBuild(appDir, [], {
-          stderr: true,
-        })
-        expect(code).not.toBe(0)
-        expect(stderr).toContain('Failed to compile')
-        expect(stderr).toContain('styles/global.scss')
-        expect(stderr).toMatch(
-          /Please move all first-party global CSS imports.*?pages(\/|\\)_app/
-        )
-        expect(stderr).toMatch(/Location:.*pages[\\/]index\.js/)
+    it('should fail to build', async () => {
+      const { code, stderr } = await nextBuild(appDir, [], {
+        stderr: true,
       })
-    }
-  )
+      expect(code).not.toBe(0)
+      expect(stderr).toContain('Failed to compile')
+      expect(stderr).toContain('styles/global.scss')
+      expect(stderr).toMatch(
+        /Please move all first-party global CSS imports.*?pages(\/|\\)_app/
+      )
+      expect(stderr).toMatch(/Location:.*pages[\\/]index\.js/)
+    })
+  })
 })

--- a/test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts
@@ -6,7 +6,7 @@ import { join } from 'path'
 import { isNextStart } from 'e2e-utils'
 
 describe('Invalid Global CSS', () => {
-  ;(Boolean(isNextStart) ? describe : describe.skip)('production only', () => {
+  ;(isNextStart ? describe : describe.skip)('production only', () => {
     const appDir = __dirname
 
     beforeAll(async () => {

--- a/test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts
@@ -3,11 +3,10 @@
 import { remove } from 'fs-extra'
 import { nextBuild } from 'next-test-utils'
 import { join } from 'path'
-// In order for the global isNextStart to be set
-import 'e2e-utils'
+import { isNextStart } from 'e2e-utils'
 
 describe('Invalid Global CSS', () => {
-  ;(Boolean(next.isStart) ? describe : describe.skip)('production only', () => {
+  ;(Boolean(isNextStart) ? describe : describe.skip)('production only', () => {
     const appDir = __dirname
 
     beforeAll(async () => {

--- a/test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts
@@ -7,27 +7,24 @@ import { join } from 'path'
 import 'e2e-utils'
 
 describe('Invalid Global CSS', () => {
-  ;(Boolean((global as any).isNextStart) ? describe : describe.skip)(
-    'production only',
-    () => {
-      const appDir = __dirname
+  ;(Boolean(next.isStart) ? describe : describe.skip)('production only', () => {
+    const appDir = __dirname
 
-      beforeAll(async () => {
-        await remove(join(appDir, '.next'))
-      })
+    beforeAll(async () => {
+      await remove(join(appDir, '.next'))
+    })
 
-      it('should fail to build', async () => {
-        const { code, stderr } = await nextBuild(appDir, [], {
-          stderr: true,
-        })
-        expect(code).not.toBe(0)
-        expect(stderr).toContain('Failed to compile')
-        expect(stderr).toContain('styles/global.scss')
-        expect(stderr).toMatch(
-          /Please move all first-party global CSS imports.*?pages(\/|\\)_app/
-        )
-        expect(stderr).toMatch(/Location:.*pages[\\/]index\.js/)
+    it('should fail to build', async () => {
+      const { code, stderr } = await nextBuild(appDir, [], {
+        stderr: true,
       })
-    }
-  )
+      expect(code).not.toBe(0)
+      expect(stderr).toContain('Failed to compile')
+      expect(stderr).toContain('styles/global.scss')
+      expect(stderr).toMatch(
+        /Please move all first-party global CSS imports.*?pages(\/|\\)_app/
+      )
+      expect(stderr).toMatch(/Location:.*pages[\\/]index\.js/)
+    })
+  })
 })

--- a/test/e2e/app-dir/scss/invalid-module-document/invalid-module-document.test.ts
+++ b/test/e2e/app-dir/scss/invalid-module-document/invalid-module-document.test.ts
@@ -6,7 +6,7 @@ import { join } from 'path'
 import { isNextStart } from 'e2e-utils'
 
 describe('Invalid SCSS in _document', () => {
-  ;(Boolean(isNextStart) ? describe : describe.skip)('production only', () => {
+  ;(isNextStart ? describe : describe.skip)('production only', () => {
     const appDir = __dirname
 
     beforeAll(async () => {

--- a/test/e2e/app-dir/scss/invalid-module-document/invalid-module-document.test.ts
+++ b/test/e2e/app-dir/scss/invalid-module-document/invalid-module-document.test.ts
@@ -3,11 +3,10 @@
 import { remove } from 'fs-extra'
 import { nextBuild } from 'next-test-utils'
 import { join } from 'path'
-// In order for the global isNextStart to be set
-import 'e2e-utils'
+import { isNextStart } from 'e2e-utils'
 
 describe('Invalid SCSS in _document', () => {
-  ;(Boolean(next.isStart) ? describe : describe.skip)('production only', () => {
+  ;(Boolean(isNextStart) ? describe : describe.skip)('production only', () => {
     const appDir = __dirname
 
     beforeAll(async () => {

--- a/test/e2e/app-dir/scss/invalid-module-document/invalid-module-document.test.ts
+++ b/test/e2e/app-dir/scss/invalid-module-document/invalid-module-document.test.ts
@@ -7,27 +7,24 @@ import { join } from 'path'
 import 'e2e-utils'
 
 describe('Invalid SCSS in _document', () => {
-  ;(Boolean((global as any).isNextStart) ? describe : describe.skip)(
-    'production only',
-    () => {
-      const appDir = __dirname
+  ;(Boolean(next.isStart) ? describe : describe.skip)('production only', () => {
+    const appDir = __dirname
 
-      beforeAll(async () => {
-        await remove(join(appDir, '.next'))
-      })
+    beforeAll(async () => {
+      await remove(join(appDir, '.next'))
+    })
 
-      it('should fail to build', async () => {
-        const { code, stderr } = await nextBuild(appDir, [], {
-          stderr: true,
-        })
-        expect(code).not.toBe(0)
-        expect(stderr).toContain('Failed to compile')
-        expect(stderr).toContain('styles.module.scss')
-        expect(stderr).toMatch(
-          /CSS.*cannot.*be imported within.*pages[\\/]_document\.js/
-        )
-        expect(stderr).toMatch(/Location:.*pages[\\/]_document\.js/)
+    it('should fail to build', async () => {
+      const { code, stderr } = await nextBuild(appDir, [], {
+        stderr: true,
       })
-    }
-  )
+      expect(code).not.toBe(0)
+      expect(stderr).toContain('Failed to compile')
+      expect(stderr).toContain('styles.module.scss')
+      expect(stderr).toMatch(
+        /CSS.*cannot.*be imported within.*pages[\\/]_document\.js/
+      )
+      expect(stderr).toMatch(/Location:.*pages[\\/]_document\.js/)
+    })
+  })
 })

--- a/test/e2e/app-dir/scss/invalid-module/invalid-module.test.ts
+++ b/test/e2e/app-dir/scss/invalid-module/invalid-module.test.ts
@@ -6,7 +6,7 @@ import { join } from 'path'
 import { isNextStart } from 'e2e-utils'
 
 describe.skip('Invalid CSS Module Usage in node_modules', () => {
-  ;(Boolean(isNextStart) ? describe : describe.skip)('production only', () => {
+  ;(isNextStart ? describe : describe.skip)('production only', () => {
     const appDir = __dirname
 
     beforeAll(async () => {

--- a/test/e2e/app-dir/scss/invalid-module/invalid-module.test.ts
+++ b/test/e2e/app-dir/scss/invalid-module/invalid-module.test.ts
@@ -7,29 +7,26 @@ import { join } from 'path'
 import 'e2e-utils'
 
 describe.skip('Invalid CSS Module Usage in node_modules', () => {
-  ;(Boolean((global as any).isNextStart) ? describe : describe.skip)(
-    'production only',
-    () => {
-      const appDir = __dirname
+  ;(Boolean(next.isStart) ? describe : describe.skip)('production only', () => {
+    const appDir = __dirname
 
-      beforeAll(async () => {
-        await remove(join(appDir, '.next'))
-      })
+    beforeAll(async () => {
+      await remove(join(appDir, '.next'))
+    })
 
-      it('should fail to build', async () => {
-        const { code, stderr } = await nextBuild(appDir, [], {
-          stderr: true,
-        })
-        expect(code).not.toBe(0)
-        expect(stderr).toContain('Failed to compile')
-        expect(stderr).toContain('node_modules/example/index.module.scss')
-        expect(stderr).toMatch(
-          /CSS Modules.*cannot.*be imported from within.*node_modules/
-        )
-        expect(stderr).toMatch(
-          /Location:.*node_modules[\\/]example[\\/]index\.mjs/
-        )
+    it('should fail to build', async () => {
+      const { code, stderr } = await nextBuild(appDir, [], {
+        stderr: true,
       })
-    }
-  )
+      expect(code).not.toBe(0)
+      expect(stderr).toContain('Failed to compile')
+      expect(stderr).toContain('node_modules/example/index.module.scss')
+      expect(stderr).toMatch(
+        /CSS Modules.*cannot.*be imported from within.*node_modules/
+      )
+      expect(stderr).toMatch(
+        /Location:.*node_modules[\\/]example[\\/]index\.mjs/
+      )
+    })
+  })
 })

--- a/test/e2e/app-dir/scss/invalid-module/invalid-module.test.ts
+++ b/test/e2e/app-dir/scss/invalid-module/invalid-module.test.ts
@@ -3,11 +3,10 @@
 import { remove } from 'fs-extra'
 import { nextBuild } from 'next-test-utils'
 import { join } from 'path'
-// In order for the global isNextStart to be set
-import 'e2e-utils'
+import { isNextStart } from 'e2e-utils'
 
 describe.skip('Invalid CSS Module Usage in node_modules', () => {
-  ;(Boolean(next.isStart) ? describe : describe.skip)('production only', () => {
+  ;(Boolean(isNextStart) ? describe : describe.skip)('production only', () => {
     const appDir = __dirname
 
     beforeAll(async () => {

--- a/test/e2e/app-dir/scss/npm-import-bad/npm-import-bad.test.ts
+++ b/test/e2e/app-dir/scss/npm-import-bad/npm-import-bad.test.ts
@@ -3,13 +3,12 @@
 import { remove } from 'fs-extra'
 import { nextBuild } from 'next-test-utils'
 import { join } from 'path'
-// In order for the global isNextStart to be set
-import 'e2e-utils'
+import { isNextStart } from 'e2e-utils'
 
 console.log({ global })
 
 describe('CSS Import from node_modules', () => {
-  ;(Boolean(next.isStart) ? describe : describe.skip)('production only', () => {
+  ;(Boolean(isNextStart) ? describe : describe.skip)('production only', () => {
     const appDir = __dirname
 
     beforeAll(async () => {

--- a/test/e2e/app-dir/scss/npm-import-bad/npm-import-bad.test.ts
+++ b/test/e2e/app-dir/scss/npm-import-bad/npm-import-bad.test.ts
@@ -8,7 +8,7 @@ import { isNextStart } from 'e2e-utils'
 console.log({ global })
 
 describe('CSS Import from node_modules', () => {
-  ;(Boolean(isNextStart) ? describe : describe.skip)('production only', () => {
+  ;(isNextStart ? describe : describe.skip)('production only', () => {
     const appDir = __dirname
 
     beforeAll(async () => {

--- a/test/e2e/app-dir/scss/npm-import-bad/npm-import-bad.test.ts
+++ b/test/e2e/app-dir/scss/npm-import-bad/npm-import-bad.test.ts
@@ -9,22 +9,19 @@ import 'e2e-utils'
 console.log({ global })
 
 describe('CSS Import from node_modules', () => {
-  ;(Boolean((global as any).isNextStart) ? describe : describe.skip)(
-    'production only',
-    () => {
-      const appDir = __dirname
+  ;(Boolean(next.isStart) ? describe : describe.skip)('production only', () => {
+    const appDir = __dirname
 
-      beforeAll(async () => {
-        await remove(join(appDir, '.next'))
-      })
+    beforeAll(async () => {
+      await remove(join(appDir, '.next'))
+    })
 
-      it('should fail the build', async () => {
-        const { code, stderr } = await nextBuild(appDir, [], { stderr: true })
+    it('should fail the build', async () => {
+      const { code, stderr } = await nextBuild(appDir, [], { stderr: true })
 
-        expect(code).toBe(0)
-        expect(stderr).not.toMatch(/Can't resolve '[^']*?nprogress[^']*?'/)
-        expect(stderr).not.toMatch(/Build error occurred/)
-      })
-    }
-  )
+      expect(code).toBe(0)
+      expect(stderr).not.toMatch(/Can't resolve '[^']*?nprogress[^']*?'/)
+      expect(stderr).not.toMatch(/Build error occurred/)
+    })
+  })
 })

--- a/test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts
+++ b/test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts
@@ -6,7 +6,7 @@ import { join } from 'path'
 import { isNextStart } from 'e2e-utils'
 
 describe('Valid and Invalid Global CSS with Custom App', () => {
-  ;(Boolean(isNextStart) ? describe : describe.skip)('production only', () => {
+  ;(isNextStart ? describe : describe.skip)('production only', () => {
     const appDir = __dirname
 
     beforeAll(async () => {

--- a/test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts
+++ b/test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts
@@ -3,11 +3,10 @@
 import { remove } from 'fs-extra'
 import { nextBuild } from 'next-test-utils'
 import { join } from 'path'
-// In order for the global isNextStart to be set
-import 'e2e-utils'
+import { isNextStart } from 'e2e-utils'
 
 describe('Valid and Invalid Global CSS with Custom App', () => {
-  ;(Boolean(next.isStart) ? describe : describe.skip)('production only', () => {
+  ;(Boolean(isNextStart) ? describe : describe.skip)('production only', () => {
     const appDir = __dirname
 
     beforeAll(async () => {

--- a/test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts
+++ b/test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts
@@ -7,27 +7,22 @@ import { join } from 'path'
 import 'e2e-utils'
 
 describe('Valid and Invalid Global CSS with Custom App', () => {
-  ;(Boolean((global as any).isNextStart) ? describe : describe.skip)(
-    'production only',
-    () => {
-      const appDir = __dirname
+  ;(Boolean(next.isStart) ? describe : describe.skip)('production only', () => {
+    const appDir = __dirname
 
-      beforeAll(async () => {
-        await remove(join(appDir, '.next'))
-      })
+    beforeAll(async () => {
+      await remove(join(appDir, '.next'))
+    })
 
-      it('should fail to build', async () => {
-        const { code, stderr } = await nextBuild(appDir, [], {
-          stderr: true,
-        })
-        expect(code).not.toBe(0)
-        expect(stderr).toContain('Failed to compile')
-        expect(stderr).toContain('styles/global.scss')
-        expect(stderr).toContain(
-          'Please move all first-party global CSS imports'
-        )
-        expect(stderr).toMatch(/Location:.*pages[\\/]index\.js/)
+    it('should fail to build', async () => {
+      const { code, stderr } = await nextBuild(appDir, [], {
+        stderr: true,
       })
-    }
-  )
+      expect(code).not.toBe(0)
+      expect(stderr).toContain('Failed to compile')
+      expect(stderr).toContain('styles/global.scss')
+      expect(stderr).toContain('Please move all first-party global CSS imports')
+      expect(stderr).toMatch(/Location:.*pages[\\/]index\.js/)
+    })
+  })
 })

--- a/test/e2e/app-dir/scss/webpack-error/webpack-error.test.ts
+++ b/test/e2e/app-dir/scss/webpack-error/webpack-error.test.ts
@@ -7,7 +7,7 @@ import { quote as shellQuote } from 'shell-quote'
 import { isNextStart } from 'e2e-utils'
 
 describe('SCSS Support', () => {
-  ;(Boolean(isNextStart) ? describe : describe.skip)('production only', () => {
+  ;(isNextStart ? describe : describe.skip)('production only', () => {
     describe('Friendly Webpack Error', () => {
       const appDir = __dirname
 

--- a/test/e2e/app-dir/scss/webpack-error/webpack-error.test.ts
+++ b/test/e2e/app-dir/scss/webpack-error/webpack-error.test.ts
@@ -8,42 +8,39 @@ import { quote as shellQuote } from 'shell-quote'
 import 'e2e-utils'
 
 describe('SCSS Support', () => {
-  ;(Boolean((global as any).isNextStart) ? describe : describe.skip)(
-    'production only',
-    () => {
-      describe('Friendly Webpack Error', () => {
-        const appDir = __dirname
+  ;(Boolean(next.isStart) ? describe : describe.skip)('production only', () => {
+    describe('Friendly Webpack Error', () => {
+      const appDir = __dirname
 
-        const mockFile = join(appDir, 'mock.js')
+      const mockFile = join(appDir, 'mock.js')
 
-        beforeAll(async () => {
-          await remove(join(appDir, '.next'))
-        })
-        it('should be a friendly error successfully', async () => {
-          const { code, stderr } = await nextBuild(appDir, [], {
-            env: { NODE_OPTIONS: shellQuote([`--require`, mockFile]) },
-            stderr: true,
-          })
-          let cleanScssErrMsg =
-            '\n\n' +
-            './styles/global.scss\n' +
-            "To use Next.js' built-in Sass support, you first need to install `sass`.\n" +
-            'Run `npm i sass` or `yarn add sass` inside your workspace.\n' +
-            '\n' +
-            'Learn more: https://nextjs.org/docs/messages/install-sass\n'
-
-          // eslint-disable-next-line
-          expect(code).toBe(1)
-          // eslint-disable-next-line
-          expect(stderr).toContain('Failed to compile.')
-          // eslint-disable-next-line
-          expect(stderr).toContain(cleanScssErrMsg)
-          // eslint-disable-next-line
-          expect(stderr).not.toContain('css-loader')
-          // eslint-disable-next-line
-          expect(stderr).not.toContain('sass-loader')
-        })
+      beforeAll(async () => {
+        await remove(join(appDir, '.next'))
       })
-    }
-  )
+      it('should be a friendly error successfully', async () => {
+        const { code, stderr } = await nextBuild(appDir, [], {
+          env: { NODE_OPTIONS: shellQuote([`--require`, mockFile]) },
+          stderr: true,
+        })
+        let cleanScssErrMsg =
+          '\n\n' +
+          './styles/global.scss\n' +
+          "To use Next.js' built-in Sass support, you first need to install `sass`.\n" +
+          'Run `npm i sass` or `yarn add sass` inside your workspace.\n' +
+          '\n' +
+          'Learn more: https://nextjs.org/docs/messages/install-sass\n'
+
+        // eslint-disable-next-line
+        expect(code).toBe(1)
+        // eslint-disable-next-line
+        expect(stderr).toContain('Failed to compile.')
+        // eslint-disable-next-line
+        expect(stderr).toContain(cleanScssErrMsg)
+        // eslint-disable-next-line
+        expect(stderr).not.toContain('css-loader')
+        // eslint-disable-next-line
+        expect(stderr).not.toContain('sass-loader')
+      })
+    })
+  })
 })

--- a/test/e2e/app-dir/scss/webpack-error/webpack-error.test.ts
+++ b/test/e2e/app-dir/scss/webpack-error/webpack-error.test.ts
@@ -4,11 +4,10 @@ import { remove } from 'fs-extra'
 import { nextBuild } from 'next-test-utils'
 import { join } from 'path'
 import { quote as shellQuote } from 'shell-quote'
-// In order for the global isNextStart to be set
-import 'e2e-utils'
+import { isNextStart } from 'e2e-utils'
 
 describe('SCSS Support', () => {
-  ;(Boolean(next.isStart) ? describe : describe.skip)('production only', () => {
+  ;(Boolean(isNextStart) ? describe : describe.skip)('production only', () => {
     describe('Friendly Webpack Error', () => {
       const appDir = __dirname
 

--- a/test/e2e/basepath-trailing-slash.test.ts
+++ b/test/e2e/basepath-trailing-slash.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDev } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { hasRedbox } from 'next-test-utils'
 
@@ -96,5 +96,5 @@ describe('basePath + trailingSlash', () => {
       }
     })
   }
-  runTests(next.isNextDev)
+  runTests(isNextDev)
 })

--- a/test/e2e/basepath-trailing-slash.test.ts
+++ b/test/e2e/basepath-trailing-slash.test.ts
@@ -96,5 +96,5 @@ describe('basePath + trailingSlash', () => {
       }
     })
   }
-  runTests((global as any).isDev)
+  runTests(next.isDev)
 })

--- a/test/e2e/basepath-trailing-slash.test.ts
+++ b/test/e2e/basepath-trailing-slash.test.ts
@@ -96,5 +96,5 @@ describe('basePath + trailingSlash', () => {
       }
     })
   }
-  runTests(next.isDev)
+  runTests(next.isNextDev)
 })

--- a/test/e2e/basepath.test.ts
+++ b/test/e2e/basepath.test.ts
@@ -223,7 +223,7 @@ describe('basePath', () => {
     })
 
     if (!isDev) {
-      if (!next.isDeploy) {
+      if (!next.isNextDeploy) {
         it('should add basePath to routes-manifest', async () => {
           const routesManifest = JSON.parse(
             await next.readFile('.next/routes-manifest.json')
@@ -613,7 +613,7 @@ describe('basePath', () => {
       )
     })
 
-    if (!next.isDeploy) {
+    if (!next.isNextDeploy) {
       it('should navigate an absolute local url with basePath', async () => {
         const browser = await webdriver(
           next.url,
@@ -993,5 +993,5 @@ describe('basePath', () => {
       }
     })
   }
-  runTests(next.isDev, next.isDeploy)
+  runTests(next.isNextDev, next.isNextDeploy)
 })

--- a/test/e2e/basepath.test.ts
+++ b/test/e2e/basepath.test.ts
@@ -223,7 +223,7 @@ describe('basePath', () => {
     })
 
     if (!isDev) {
-      if (!(global as any).isNextDeploy) {
+      if (!next.isDeploy) {
         it('should add basePath to routes-manifest', async () => {
           const routesManifest = JSON.parse(
             await next.readFile('.next/routes-manifest.json')
@@ -613,7 +613,7 @@ describe('basePath', () => {
       )
     })
 
-    if (!(global as any).isNextDeploy) {
+    if (!next.isDeploy) {
       it('should navigate an absolute local url with basePath', async () => {
         const browser = await webdriver(
           next.url,
@@ -993,5 +993,5 @@ describe('basePath', () => {
       }
     })
   }
-  runTests((global as any).isNextDev, (global as any).isNextDeploy)
+  runTests(next.isDev, next.isDeploy)
 })

--- a/test/e2e/basepath.test.ts
+++ b/test/e2e/basepath.test.ts
@@ -3,7 +3,7 @@ import { join } from 'path'
 import assert from 'assert'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDeploy, isNextDev } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import {
   check,
@@ -223,7 +223,7 @@ describe('basePath', () => {
     })
 
     if (!isDev) {
-      if (!next.isNextDeploy) {
+      if (!isNextDeploy) {
         it('should add basePath to routes-manifest', async () => {
           const routesManifest = JSON.parse(
             await next.readFile('.next/routes-manifest.json')
@@ -613,7 +613,7 @@ describe('basePath', () => {
       )
     })
 
-    if (!next.isNextDeploy) {
+    if (!isNextDeploy) {
       it('should navigate an absolute local url with basePath', async () => {
         const browser = await webdriver(
           next.url,
@@ -993,5 +993,5 @@ describe('basePath', () => {
       }
     })
   }
-  runTests(next.isNextDev, next.isNextDeploy)
+  runTests(isNextDev, isNextDeploy)
 })

--- a/test/e2e/edge-can-use-wasm-files/index.test.ts
+++ b/test/e2e/edge-can-use-wasm-files/index.test.ts
@@ -99,7 +99,7 @@ describe('middleware can use wasm files', () => {
     })
   })
 
-  if (!next.isDeploy) {
+  if (!next.isNextDeploy) {
     it('lists the necessary wasm bindings in the manifest', async () => {
       const manifestPath = path.join(
         next.testDir,

--- a/test/e2e/edge-can-use-wasm-files/index.test.ts
+++ b/test/e2e/edge-can-use-wasm-files/index.test.ts
@@ -99,7 +99,7 @@ describe('middleware can use wasm files', () => {
     })
   })
 
-  if (!(global as any).isNextDeploy) {
+  if (!next.isDeploy) {
     it('lists the necessary wasm bindings in the manifest', async () => {
       const manifestPath = path.join(
         next.testDir,

--- a/test/e2e/edge-can-use-wasm-files/index.test.ts
+++ b/test/e2e/edge-can-use-wasm-files/index.test.ts
@@ -1,4 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDeploy } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { fetchViaHTTP } from 'next-test-utils'
 import path from 'path'
@@ -99,7 +99,7 @@ describe('middleware can use wasm files', () => {
     })
   })
 
-  if (!next.isNextDeploy) {
+  if (!isNextDeploy) {
     it('lists the necessary wasm bindings in the manifest', async () => {
       const manifestPath = path.join(
         next.testDir,

--- a/test/e2e/edge-compiler-can-import-blob-assets/index.test.ts
+++ b/test/e2e/edge-compiler-can-import-blob-assets/index.test.ts
@@ -1,4 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDeploy } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 import path from 'path'
@@ -12,7 +12,7 @@ describe.skip('Edge Compiler can import asset assets', () => {
   let next: NextInstance
 
   // TODO: remove after this is supported for deploy
-  if (next.isNextDeploy) {
+  if (isNextDeploy) {
     it('should skip for deploy for now', () => {})
     return
   }

--- a/test/e2e/edge-compiler-can-import-blob-assets/index.test.ts
+++ b/test/e2e/edge-compiler-can-import-blob-assets/index.test.ts
@@ -12,7 +12,7 @@ describe.skip('Edge Compiler can import asset assets', () => {
   let next: NextInstance
 
   // TODO: remove after this is supported for deploy
-  if (next.isDeploy) {
+  if (next.isNextDeploy) {
     it('should skip for deploy for now', () => {})
     return
   }

--- a/test/e2e/edge-compiler-can-import-blob-assets/index.test.ts
+++ b/test/e2e/edge-compiler-can-import-blob-assets/index.test.ts
@@ -12,7 +12,7 @@ describe.skip('Edge Compiler can import asset assets', () => {
   let next: NextInstance
 
   // TODO: remove after this is supported for deploy
-  if ((global as any).isNextDeploy) {
+  if (next.isDeploy) {
     it('should skip for deploy for now', () => {})
     return
   }

--- a/test/e2e/edge-compiler-module-exports-preference/index.test.ts
+++ b/test/e2e/edge-compiler-module-exports-preference/index.test.ts
@@ -1,4 +1,4 @@
-import { createNext } from 'e2e-utils'
+import { createNext, isNextDev } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { fetchViaHTTP, shouldRunTurboDevTest } from 'next-test-utils'
 
@@ -42,7 +42,7 @@ describe('Edge compiler module exports preference', () => {
         },
       },
       installCommand: 'pnpm i',
-      startCommand: next.isNextDev ? 'pnpm dev' : 'pnpm start',
+      startCommand: isNextDev ? 'pnpm dev' : 'pnpm start',
       buildCommand: 'pnpm run build',
       dependencies: {},
     })

--- a/test/e2e/edge-compiler-module-exports-preference/index.test.ts
+++ b/test/e2e/edge-compiler-module-exports-preference/index.test.ts
@@ -42,7 +42,7 @@ describe('Edge compiler module exports preference', () => {
         },
       },
       installCommand: 'pnpm i',
-      startCommand: next.isDev ? 'pnpm dev' : 'pnpm start',
+      startCommand: next.isNextDev ? 'pnpm dev' : 'pnpm start',
       buildCommand: 'pnpm run build',
       dependencies: {},
     })

--- a/test/e2e/edge-compiler-module-exports-preference/index.test.ts
+++ b/test/e2e/edge-compiler-module-exports-preference/index.test.ts
@@ -42,7 +42,7 @@ describe('Edge compiler module exports preference', () => {
         },
       },
       installCommand: 'pnpm i',
-      startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
+      startCommand: next.isDev ? 'pnpm dev' : 'pnpm start',
       buildCommand: 'pnpm run build',
       dependencies: {},
     })

--- a/test/e2e/edge-configurable-runtime/index.test.ts
+++ b/test/e2e/edge-configurable-runtime/index.test.ts
@@ -15,7 +15,7 @@ const apiPath = 'pages/api/edge.js'
   const page = new File(join(appDir, pagePath))
   const api = new File(join(appDir, apiPath))
 
-  if (next.isDev) {
+  if (next.isNextDev) {
     describe('In dev mode', () => {
       beforeAll(async () => {
         next = await createNext({
@@ -91,7 +91,7 @@ const apiPath = 'pages/api/edge.js'
         expect(next.cliOutput).not.toInclude('warn')
       })
     })
-  } else if (next.isStart) {
+  } else if (next.isNextStart) {
     describe('In start mode', () => {
       // TODO because createNext runs process.exit() without any log info on build failure, rely on good old nextBuild()
       afterEach(async () => {

--- a/test/e2e/edge-configurable-runtime/index.test.ts
+++ b/test/e2e/edge-configurable-runtime/index.test.ts
@@ -15,7 +15,7 @@ const apiPath = 'pages/api/edge.js'
   const page = new File(join(appDir, pagePath))
   const api = new File(join(appDir, apiPath))
 
-  if ((global as any).isNextDev) {
+  if (next.isDev) {
     describe('In dev mode', () => {
       beforeAll(async () => {
         next = await createNext({
@@ -91,7 +91,7 @@ const apiPath = 'pages/api/edge.js'
         expect(next.cliOutput).not.toInclude('warn')
       })
     })
-  } else if ((global as any).isNextStart) {
+  } else if (next.isStart) {
     describe('In start mode', () => {
       // TODO because createNext runs process.exit() without any log info on build failure, rely on good old nextBuild()
       afterEach(async () => {

--- a/test/e2e/edge-configurable-runtime/index.test.ts
+++ b/test/e2e/edge-configurable-runtime/index.test.ts
@@ -1,4 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDev, isNextStart } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { fetchViaHTTP, File, nextBuild } from 'next-test-utils'
 import { join } from 'path'
@@ -15,7 +15,7 @@ const apiPath = 'pages/api/edge.js'
   const page = new File(join(appDir, pagePath))
   const api = new File(join(appDir, apiPath))
 
-  if (next.isNextDev) {
+  if (isNextDev) {
     describe('In dev mode', () => {
       beforeAll(async () => {
         next = await createNext({
@@ -91,7 +91,7 @@ const apiPath = 'pages/api/edge.js'
         expect(next.cliOutput).not.toInclude('warn')
       })
     })
-  } else if (next.isNextStart) {
+  } else if (isNextStart) {
     describe('In start mode', () => {
       // TODO because createNext runs process.exit() without any log info on build failure, rely on good old nextBuild()
       afterEach(async () => {

--- a/test/e2e/edge-pages-support/index.test.ts
+++ b/test/e2e/edge-pages-support/index.test.ts
@@ -11,7 +11,7 @@ createNextDescribe(
     files: join(__dirname, 'app'),
   },
   ({ next }) => {
-    if (next.isStart) {
+    if (next.isNextStart) {
       it('should not output trace files for edge routes', async () => {
         expect(await fs.pathExists(join(next.testDir, '.next/pages'))).toBe(
           false
@@ -144,7 +144,7 @@ createNextDescribe(
       expect(props.params).toEqual({ id: '321' })
     })
 
-    if (next.isStart) {
+    if (next.isNextStart) {
       it('should have data routes in routes-manifest', async () => {
         const manifest = JSON.parse(
           await next.readFile('.next/routes-manifest.json')

--- a/test/e2e/edge-pages-support/index.test.ts
+++ b/test/e2e/edge-pages-support/index.test.ts
@@ -11,7 +11,7 @@ createNextDescribe(
     files: join(__dirname, 'app'),
   },
   ({ next }) => {
-    if ((global as any).isNextStart) {
+    if (next.isStart) {
       it('should not output trace files for edge routes', async () => {
         expect(await fs.pathExists(join(next.testDir, '.next/pages'))).toBe(
           false
@@ -144,7 +144,7 @@ createNextDescribe(
       expect(props.params).toEqual({ id: '321' })
     })
 
-    if ((global as any).isNextStart) {
+    if (next.isStart) {
       it('should have data routes in routes-manifest', async () => {
         const manifest = JSON.parse(
           await next.readFile('.next/routes-manifest.json')

--- a/test/e2e/edge-pages-support/index.test.ts
+++ b/test/e2e/edge-pages-support/index.test.ts
@@ -1,4 +1,4 @@
-import { createNextDescribe } from 'e2e-utils'
+import { createNextDescribe, isNextStart } from 'e2e-utils'
 import { fetchViaHTTP, normalizeRegEx } from 'next-test-utils'
 import cheerio from 'cheerio'
 import { join } from 'path'
@@ -11,7 +11,7 @@ createNextDescribe(
     files: join(__dirname, 'app'),
   },
   ({ next }) => {
-    if (next.isNextStart) {
+    if (isNextStart) {
       it('should not output trace files for edge routes', async () => {
         expect(await fs.pathExists(join(next.testDir, '.next/pages'))).toBe(
           false
@@ -144,7 +144,7 @@ createNextDescribe(
       expect(props.params).toEqual({ id: '321' })
     })
 
-    if (next.isNextStart) {
+    if (isNextStart) {
       it('should have data routes in routes-manifest', async () => {
         const manifest = JSON.parse(
           await next.readFile('.next/routes-manifest.json')

--- a/test/e2e/edge-runtime-uses-edge-light-import-specifier-for-packages/edge-runtime-uses-edge-light-import-specifier-for-packages.test.ts
+++ b/test/e2e/edge-runtime-uses-edge-light-import-specifier-for-packages/edge-runtime-uses-edge-light-import-specifier-for-packages.test.ts
@@ -1,4 +1,4 @@
-import { createNextDescribe } from 'e2e-utils'
+import { createNextDescribe, isNextDev } from 'e2e-utils'
 import { shouldRunTurboDevTest } from '../../lib/next-test-utils'
 
 createNextDescribe(
@@ -13,7 +13,7 @@ createNextDescribe(
       },
     },
     installCommand: 'pnpm i',
-    startCommand: next.isDev ? 'pnpm dev' : 'pnpm start',
+    startCommand: isNextDev ? 'pnpm dev' : 'pnpm start',
     buildCommand: 'pnpm build',
     skipDeployment: true,
   },

--- a/test/e2e/edge-runtime-uses-edge-light-import-specifier-for-packages/edge-runtime-uses-edge-light-import-specifier-for-packages.test.ts
+++ b/test/e2e/edge-runtime-uses-edge-light-import-specifier-for-packages/edge-runtime-uses-edge-light-import-specifier-for-packages.test.ts
@@ -13,7 +13,7 @@ createNextDescribe(
       },
     },
     installCommand: 'pnpm i',
-    startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
+    startCommand: next.isDev ? 'pnpm dev' : 'pnpm start',
     buildCommand: 'pnpm build',
     skipDeployment: true,
   },

--- a/test/e2e/getserversideprops/test/index.test.ts
+++ b/test/e2e/getserversideprops/test/index.test.ts
@@ -859,5 +859,5 @@ describe('getServerSideProps', () => {
   })
   afterAll(() => next.destroy())
 
-  runTests(next.isDev, next.isDeploy)
+  runTests(next.isNextDev, next.isNextDeploy)
 })

--- a/test/e2e/getserversideprops/test/index.test.ts
+++ b/test/e2e/getserversideprops/test/index.test.ts
@@ -859,5 +859,5 @@ describe('getServerSideProps', () => {
   })
   afterAll(() => next.destroy())
 
-  runTests((global as any).isNextDev, (global as any).isNextDeploy)
+  runTests(next.isDev, next.isDeploy)
 })

--- a/test/e2e/getserversideprops/test/index.test.ts
+++ b/test/e2e/getserversideprops/test/index.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 import cheerio from 'cheerio'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDeploy, isNextDev } from 'e2e-utils'
 import escapeRegex from 'escape-string-regexp'
 import {
   check,
@@ -859,5 +859,5 @@ describe('getServerSideProps', () => {
   })
   afterAll(() => next.destroy())
 
-  runTests(next.isNextDev, next.isNextDeploy)
+  runTests(isNextDev, isNextDeploy)
 })

--- a/test/e2e/i18n-api-support/index.test.ts
+++ b/test/e2e/i18n-api-support/index.test.ts
@@ -55,7 +55,7 @@ describe('i18n API support', () => {
   })
 
   // TODO: re-enable after this is fixed to match on Vercel
-  if (!(global as any).isNextDeploy) {
+  if (!next.isDeploy) {
     it('should fallback rewrite non-matching API request', async () => {
       const paths = [
         '/fr/api/hello',

--- a/test/e2e/i18n-api-support/index.test.ts
+++ b/test/e2e/i18n-api-support/index.test.ts
@@ -55,7 +55,7 @@ describe('i18n API support', () => {
   })
 
   // TODO: re-enable after this is fixed to match on Vercel
-  if (!next.isDeploy) {
+  if (!next.isNextDeploy) {
     it('should fallback rewrite non-matching API request', async () => {
       const paths = [
         '/fr/api/hello',

--- a/test/e2e/i18n-api-support/index.test.ts
+++ b/test/e2e/i18n-api-support/index.test.ts
@@ -1,4 +1,4 @@
-import { createNext } from 'e2e-utils'
+import { createNext, isNextDeploy } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 
@@ -55,7 +55,7 @@ describe('i18n API support', () => {
   })
 
   // TODO: re-enable after this is fixed to match on Vercel
-  if (!next.isNextDeploy) {
+  if (!isNextDeploy) {
     it('should fallback rewrite non-matching API request', async () => {
       const paths = [
         '/fr/api/hello',

--- a/test/e2e/i18n-data-fetching-redirect/index.test.ts
+++ b/test/e2e/i18n-data-fetching-redirect/index.test.ts
@@ -8,7 +8,7 @@ describe('i18n-data-fetching-redirect', () => {
   let next: NextInstance
 
   // TODO: investigate tests failures on deploy
-  if ((global as any).isNextDeploy) {
+  if (next.isDeploy) {
     it('should skip temporarily', () => {})
     return
   }

--- a/test/e2e/i18n-data-fetching-redirect/index.test.ts
+++ b/test/e2e/i18n-data-fetching-redirect/index.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'path'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDeploy } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { check } from 'next-test-utils'
 import webdriver from 'next-webdriver'
@@ -8,7 +8,7 @@ describe('i18n-data-fetching-redirect', () => {
   let next: NextInstance
 
   // TODO: investigate tests failures on deploy
-  if (next.isNextDeploy) {
+  if (isNextDeploy) {
     it('should skip temporarily', () => {})
     return
   }

--- a/test/e2e/i18n-data-fetching-redirect/index.test.ts
+++ b/test/e2e/i18n-data-fetching-redirect/index.test.ts
@@ -8,7 +8,7 @@ describe('i18n-data-fetching-redirect', () => {
   let next: NextInstance
 
   // TODO: investigate tests failures on deploy
-  if (next.isDeploy) {
+  if (next.isNextDeploy) {
     it('should skip temporarily', () => {})
     return
   }

--- a/test/e2e/i18n-ignore-rewrite-source-locale/rewrites-with-basepath.test.ts
+++ b/test/e2e/i18n-ignore-rewrite-source-locale/rewrites-with-basepath.test.ts
@@ -1,4 +1,4 @@
-import { createNext } from 'e2e-utils'
+import { createNext, isNextDeploy } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 import path from 'path'
@@ -71,7 +71,7 @@ describe('i18n-ignore-rewrite-source-locale with basepath', () => {
   )
 
   // build artifacts aren't available on deploy
-  if (!next.isNextDeploy) {
+  if (!isNextDeploy) {
     // chunks are not written to disk with TURBOPACK
     ;(process.env.TURBOPACK ? it.skip.each : it.each)(locales)(
       'get _next/static/ files by skipping locale in rewrite, locale: %s',

--- a/test/e2e/i18n-ignore-rewrite-source-locale/rewrites-with-basepath.test.ts
+++ b/test/e2e/i18n-ignore-rewrite-source-locale/rewrites-with-basepath.test.ts
@@ -71,7 +71,7 @@ describe('i18n-ignore-rewrite-source-locale with basepath', () => {
   )
 
   // build artifacts aren't available on deploy
-  if (!next.isDeploy) {
+  if (!next.isNextDeploy) {
     // chunks are not written to disk with TURBOPACK
     ;(process.env.TURBOPACK ? it.skip.each : it.each)(locales)(
       'get _next/static/ files by skipping locale in rewrite, locale: %s',

--- a/test/e2e/i18n-ignore-rewrite-source-locale/rewrites-with-basepath.test.ts
+++ b/test/e2e/i18n-ignore-rewrite-source-locale/rewrites-with-basepath.test.ts
@@ -71,7 +71,7 @@ describe('i18n-ignore-rewrite-source-locale with basepath', () => {
   )
 
   // build artifacts aren't available on deploy
-  if (!(global as any).isNextDeploy) {
+  if (!next.isDeploy) {
     // chunks are not written to disk with TURBOPACK
     ;(process.env.TURBOPACK ? it.skip.each : it.each)(locales)(
       'get _next/static/ files by skipping locale in rewrite, locale: %s',

--- a/test/e2e/i18n-ignore-rewrite-source-locale/rewrites.test.ts
+++ b/test/e2e/i18n-ignore-rewrite-source-locale/rewrites.test.ts
@@ -67,7 +67,7 @@ describe('i18n-ignore-rewrite-source-locale', () => {
   )
 
   // build artifacts aren't available on deploy
-  if (!next.isDeploy) {
+  if (!next.isNextDeploy) {
     // chunks are not written to disk with TURBOPACK
     ;(process.env.TURBOPACK ? it.skip.each : it.each)(locales)(
       'get _next/static/ files by skipping locale in rewrite, locale: %s',

--- a/test/e2e/i18n-ignore-rewrite-source-locale/rewrites.test.ts
+++ b/test/e2e/i18n-ignore-rewrite-source-locale/rewrites.test.ts
@@ -1,4 +1,4 @@
-import { createNext } from 'e2e-utils'
+import { createNext, isNextDeploy } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 import path from 'path'
@@ -67,7 +67,7 @@ describe('i18n-ignore-rewrite-source-locale', () => {
   )
 
   // build artifacts aren't available on deploy
-  if (!next.isNextDeploy) {
+  if (!isNextDeploy) {
     // chunks are not written to disk with TURBOPACK
     ;(process.env.TURBOPACK ? it.skip.each : it.each)(locales)(
       'get _next/static/ files by skipping locale in rewrite, locale: %s',

--- a/test/e2e/i18n-ignore-rewrite-source-locale/rewrites.test.ts
+++ b/test/e2e/i18n-ignore-rewrite-source-locale/rewrites.test.ts
@@ -67,7 +67,7 @@ describe('i18n-ignore-rewrite-source-locale', () => {
   )
 
   // build artifacts aren't available on deploy
-  if (!(global as any).isNextDeploy) {
+  if (!next.isDeploy) {
     // chunks are not written to disk with TURBOPACK
     ;(process.env.TURBOPACK ? it.skip.each : it.each)(locales)(
       'get _next/static/ files by skipping locale in rewrite, locale: %s',

--- a/test/e2e/manual-client-base-path/index.test.ts
+++ b/test/e2e/manual-client-base-path/index.test.ts
@@ -8,7 +8,7 @@ import assert from 'assert'
 import { check, renderViaHTTP, waitFor } from 'next-test-utils'
 
 describe('manual-client-base-path', () => {
-  if ((global as any).isNextDeploy) {
+  if (next.isDeploy) {
     it('should skip deploy', () => {})
     return
   }

--- a/test/e2e/manual-client-base-path/index.test.ts
+++ b/test/e2e/manual-client-base-path/index.test.ts
@@ -1,4 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDeploy } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import httpProxy from 'http-proxy'
 import { join } from 'path'
@@ -8,7 +8,7 @@ import assert from 'assert'
 import { check, renderViaHTTP, waitFor } from 'next-test-utils'
 
 describe('manual-client-base-path', () => {
-  if (next.isDeploy) {
+  if (isNextDeploy) {
     it('should skip deploy', () => {})
     return
   }

--- a/test/e2e/middleware-fetches-with-body/index.test.ts
+++ b/test/e2e/middleware-fetches-with-body/index.test.ts
@@ -1,4 +1,4 @@
-import { createNext } from 'e2e-utils'
+import { createNext, isNextDeploy } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { fetchViaHTTP } from 'next-test-utils'
 
@@ -66,7 +66,7 @@ describe('Middleware fetches with body', () => {
       try {
         expect(res.status).toBe(413)
 
-        if (!next.isNextDeploy) {
+        if (!isNextDeploy) {
           expect(res.statusText).toBe('Body exceeded 1mb limit')
         }
       } catch (err) {
@@ -142,7 +142,7 @@ describe('Middleware fetches with body', () => {
       try {
         expect(res.status).toBe(413)
 
-        if (!next.isNextDeploy) {
+        if (!isNextDeploy) {
           expect(res.statusText).toBe('Body exceeded 5kb limit')
         }
       } catch (err) {
@@ -195,7 +195,7 @@ describe('Middleware fetches with body', () => {
       try {
         expect(res.status).toBe(413)
 
-        if (!next.isNextDeploy) {
+        if (!isNextDeploy) {
           expect(res.statusText).toBe('Body exceeded 5mb limit')
         }
       } catch (err) {
@@ -207,7 +207,7 @@ describe('Middleware fetches with body', () => {
       }
     })
 
-    if (!next.isNextDeploy) {
+    if (!isNextDeploy) {
       it('should be able to send and return body size equal to 5mb', async () => {
         const bodySize = 5 * 1024 * 1024
         const body = 'FGHI1J2K3L4M5N6O7P8Q9R0SaTbUcVdW'.repeat(bodySize / 32)
@@ -297,7 +297,7 @@ describe('Middleware fetches with body', () => {
     try {
       expect(res.status).toBe(413)
 
-      if (!next.isNextDeploy) {
+      if (!isNextDeploy) {
         expect(res.statusText).toBe('Body exceeded 5mb limit')
       }
     } catch (err) {

--- a/test/e2e/middleware-fetches-with-body/index.test.ts
+++ b/test/e2e/middleware-fetches-with-body/index.test.ts
@@ -66,7 +66,7 @@ describe('Middleware fetches with body', () => {
       try {
         expect(res.status).toBe(413)
 
-        if (!(global as any).isNextDeploy) {
+        if (!next.isDeploy) {
           expect(res.statusText).toBe('Body exceeded 1mb limit')
         }
       } catch (err) {
@@ -142,7 +142,7 @@ describe('Middleware fetches with body', () => {
       try {
         expect(res.status).toBe(413)
 
-        if (!(global as any).isNextDeploy) {
+        if (!next.isDeploy) {
           expect(res.statusText).toBe('Body exceeded 5kb limit')
         }
       } catch (err) {
@@ -195,7 +195,7 @@ describe('Middleware fetches with body', () => {
       try {
         expect(res.status).toBe(413)
 
-        if (!(global as any).isNextDeploy) {
+        if (!next.isDeploy) {
           expect(res.statusText).toBe('Body exceeded 5mb limit')
         }
       } catch (err) {
@@ -207,7 +207,7 @@ describe('Middleware fetches with body', () => {
       }
     })
 
-    if (!(global as any).isNextDeploy) {
+    if (!next.isDeploy) {
       it('should be able to send and return body size equal to 5mb', async () => {
         const bodySize = 5 * 1024 * 1024
         const body = 'FGHI1J2K3L4M5N6O7P8Q9R0SaTbUcVdW'.repeat(bodySize / 32)
@@ -297,7 +297,7 @@ describe('Middleware fetches with body', () => {
     try {
       expect(res.status).toBe(413)
 
-      if (!(global as any).isNextDeploy) {
+      if (!next.isDeploy) {
         expect(res.statusText).toBe('Body exceeded 5mb limit')
       }
     } catch (err) {

--- a/test/e2e/middleware-fetches-with-body/index.test.ts
+++ b/test/e2e/middleware-fetches-with-body/index.test.ts
@@ -66,7 +66,7 @@ describe('Middleware fetches with body', () => {
       try {
         expect(res.status).toBe(413)
 
-        if (!next.isDeploy) {
+        if (!next.isNextDeploy) {
           expect(res.statusText).toBe('Body exceeded 1mb limit')
         }
       } catch (err) {
@@ -142,7 +142,7 @@ describe('Middleware fetches with body', () => {
       try {
         expect(res.status).toBe(413)
 
-        if (!next.isDeploy) {
+        if (!next.isNextDeploy) {
           expect(res.statusText).toBe('Body exceeded 5kb limit')
         }
       } catch (err) {
@@ -195,7 +195,7 @@ describe('Middleware fetches with body', () => {
       try {
         expect(res.status).toBe(413)
 
-        if (!next.isDeploy) {
+        if (!next.isNextDeploy) {
           expect(res.statusText).toBe('Body exceeded 5mb limit')
         }
       } catch (err) {
@@ -207,7 +207,7 @@ describe('Middleware fetches with body', () => {
       }
     })
 
-    if (!next.isDeploy) {
+    if (!next.isNextDeploy) {
       it('should be able to send and return body size equal to 5mb', async () => {
         const bodySize = 5 * 1024 * 1024
         const body = 'FGHI1J2K3L4M5N6O7P8Q9R0SaTbUcVdW'.repeat(bodySize / 32)
@@ -297,7 +297,7 @@ describe('Middleware fetches with body', () => {
     try {
       expect(res.status).toBe(413)
 
-      if (!next.isDeploy) {
+      if (!next.isNextDeploy) {
         expect(res.statusText).toBe('Body exceeded 5mb limit')
       }
     } catch (err) {

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -82,7 +82,7 @@ describe('Middleware Runtime', () => {
             start: 'next start',
           },
         },
-        startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
+        startCommand: next.isDev ? 'pnpm dev' : 'pnpm start',
         buildCommand: 'pnpm build',
         env: {
           ANOTHER_MIDDLEWARE_TEST: 'asdf2',
@@ -128,7 +128,7 @@ describe('Middleware Runtime', () => {
       expect(await res.text()).toContain('Example Domain')
     })
 
-    if ((global as any).isNextDev) {
+    if (next.isDev) {
       it('refreshes the page when middleware changes ', async () => {
         const browser = await webdriver(next.url, `/about`)
         await browser.eval('window.didrefresh = "hello"')
@@ -161,7 +161,7 @@ describe('Middleware Runtime', () => {
       })
     }
 
-    if ((global as any).isNextStart) {
+    if (next.isStart) {
       it('should have valid middleware field in manifest', async () => {
         const manifest = await fs.readJSON(
           join(next.testDir, '.next/server/middleware-manifest.json')
@@ -485,12 +485,12 @@ describe('Middleware Runtime', () => {
       const res = await fetchViaHTTP(next.url, `/%2`)
       expect(res.status).toBe(400)
 
-      if ((global as any).isNextStart) {
+      if (next.isStart) {
         expect(await res.text()).toContain('Bad Request')
       }
     })
 
-    if (!(global as any).isNextDeploy) {
+    if (!next.isDeploy) {
       // user agent differs on Vercel
       it('should set fetch user agent correctly', async () => {
         const res = await fetchViaHTTP(next.url, `/fetch-user-agent-default`)
@@ -514,7 +514,7 @@ describe('Middleware Runtime', () => {
         ANOTHER_MIDDLEWARE_TEST: 'asdf2',
         STRING_ENV_VAR: 'asdf3',
         MIDDLEWARE_TEST: 'asdf',
-        ...((global as any).isNextDeploy
+        ...(next.isDeploy
           ? {}
           : {
               NEXT_RUNTIME: 'edge',
@@ -534,7 +534,7 @@ describe('Middleware Runtime', () => {
       expect('error' in readMiddlewareJSON(res)).toBe(false)
     })
 
-    if (!(global as any).isNextDeploy) {
+    if (!next.isDeploy) {
       it(`should accept a URL instance for fetch`, async () => {
         const response = await fetchViaHTTP(next.url, '/fetch-url')
         // TODO: why is an error expected here if it should work?
@@ -626,7 +626,7 @@ describe('Middleware Runtime', () => {
       expect(readMiddlewareError(response)).toContain(urlsError)
     })
 
-    if (!(global as any).isNextDeploy) {
+    if (!next.isDeploy) {
       // these errors differ on Vercel
       it('should throw when using Request with a relative URL', async () => {
         const response = await fetchViaHTTP(next.url, `/url/relative-request`)

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -82,7 +82,7 @@ describe('Middleware Runtime', () => {
             start: 'next start',
           },
         },
-        startCommand: next.isDev ? 'pnpm dev' : 'pnpm start',
+        startCommand: next.isNextDev ? 'pnpm dev' : 'pnpm start',
         buildCommand: 'pnpm build',
         env: {
           ANOTHER_MIDDLEWARE_TEST: 'asdf2',
@@ -128,7 +128,7 @@ describe('Middleware Runtime', () => {
       expect(await res.text()).toContain('Example Domain')
     })
 
-    if (next.isDev) {
+    if (next.isNextDev) {
       it('refreshes the page when middleware changes ', async () => {
         const browser = await webdriver(next.url, `/about`)
         await browser.eval('window.didrefresh = "hello"')
@@ -161,7 +161,7 @@ describe('Middleware Runtime', () => {
       })
     }
 
-    if (next.isStart) {
+    if (next.isNextStart) {
       it('should have valid middleware field in manifest', async () => {
         const manifest = await fs.readJSON(
           join(next.testDir, '.next/server/middleware-manifest.json')
@@ -485,12 +485,12 @@ describe('Middleware Runtime', () => {
       const res = await fetchViaHTTP(next.url, `/%2`)
       expect(res.status).toBe(400)
 
-      if (next.isStart) {
+      if (next.isNextStart) {
         expect(await res.text()).toContain('Bad Request')
       }
     })
 
-    if (!next.isDeploy) {
+    if (!next.isNextDeploy) {
       // user agent differs on Vercel
       it('should set fetch user agent correctly', async () => {
         const res = await fetchViaHTTP(next.url, `/fetch-user-agent-default`)
@@ -514,7 +514,7 @@ describe('Middleware Runtime', () => {
         ANOTHER_MIDDLEWARE_TEST: 'asdf2',
         STRING_ENV_VAR: 'asdf3',
         MIDDLEWARE_TEST: 'asdf',
-        ...(next.isDeploy
+        ...(next.isNextDeploy
           ? {}
           : {
               NEXT_RUNTIME: 'edge',
@@ -534,7 +534,7 @@ describe('Middleware Runtime', () => {
       expect('error' in readMiddlewareJSON(res)).toBe(false)
     })
 
-    if (!next.isDeploy) {
+    if (!next.isNextDeploy) {
       it(`should accept a URL instance for fetch`, async () => {
         const response = await fetchViaHTTP(next.url, '/fetch-url')
         // TODO: why is an error expected here if it should work?
@@ -626,7 +626,7 @@ describe('Middleware Runtime', () => {
       expect(readMiddlewareError(response)).toContain(urlsError)
     })
 
-    if (!next.isDeploy) {
+    if (!next.isNextDeploy) {
       // these errors differ on Vercel
       it('should throw when using Request with a relative URL', async () => {
         const response = await fetchViaHTTP(next.url, `/url/relative-request`)

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -10,7 +10,13 @@ import {
   shouldRunTurboDevTest,
   waitFor,
 } from 'next-test-utils'
-import { createNext, FileRef } from 'e2e-utils'
+import {
+  createNext,
+  FileRef,
+  isNextDeploy,
+  isNextDev,
+  isNextStart,
+} from 'e2e-utils'
 
 const urlsError = 'Please use only absolute URLs'
 
@@ -82,7 +88,7 @@ describe('Middleware Runtime', () => {
             start: 'next start',
           },
         },
-        startCommand: next.isNextDev ? 'pnpm dev' : 'pnpm start',
+        startCommand: isNextDev ? 'pnpm dev' : 'pnpm start',
         buildCommand: 'pnpm build',
         env: {
           ANOTHER_MIDDLEWARE_TEST: 'asdf2',
@@ -128,7 +134,7 @@ describe('Middleware Runtime', () => {
       expect(await res.text()).toContain('Example Domain')
     })
 
-    if (next.isNextDev) {
+    if (isNextDev) {
       it('refreshes the page when middleware changes ', async () => {
         const browser = await webdriver(next.url, `/about`)
         await browser.eval('window.didrefresh = "hello"')
@@ -161,7 +167,7 @@ describe('Middleware Runtime', () => {
       })
     }
 
-    if (next.isNextStart) {
+    if (isNextStart) {
       it('should have valid middleware field in manifest', async () => {
         const manifest = await fs.readJSON(
           join(next.testDir, '.next/server/middleware-manifest.json')
@@ -485,12 +491,12 @@ describe('Middleware Runtime', () => {
       const res = await fetchViaHTTP(next.url, `/%2`)
       expect(res.status).toBe(400)
 
-      if (next.isNextStart) {
+      if (isNextStart) {
         expect(await res.text()).toContain('Bad Request')
       }
     })
 
-    if (!next.isNextDeploy) {
+    if (!isNextDeploy) {
       // user agent differs on Vercel
       it('should set fetch user agent correctly', async () => {
         const res = await fetchViaHTTP(next.url, `/fetch-user-agent-default`)
@@ -514,7 +520,7 @@ describe('Middleware Runtime', () => {
         ANOTHER_MIDDLEWARE_TEST: 'asdf2',
         STRING_ENV_VAR: 'asdf3',
         MIDDLEWARE_TEST: 'asdf',
-        ...(next.isNextDeploy
+        ...(isNextDeploy
           ? {}
           : {
               NEXT_RUNTIME: 'edge',
@@ -534,7 +540,7 @@ describe('Middleware Runtime', () => {
       expect('error' in readMiddlewareJSON(res)).toBe(false)
     })
 
-    if (!next.isNextDeploy) {
+    if (!isNextDeploy) {
       it(`should accept a URL instance for fetch`, async () => {
         const response = await fetchViaHTTP(next.url, '/fetch-url')
         // TODO: why is an error expected here if it should work?
@@ -626,7 +632,7 @@ describe('Middleware Runtime', () => {
       expect(readMiddlewareError(response)).toContain(urlsError)
     })
 
-    if (!next.isNextDeploy) {
+    if (!isNextDeploy) {
       // these errors differ on Vercel
       it('should throw when using Request with a relative URL', async () => {
         const response = await fetchViaHTTP(next.url, `/url/relative-request`)

--- a/test/e2e/middleware-matcher/index.test.ts
+++ b/test/e2e/middleware-matcher/index.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable jest/no-identical-title */
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDev } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { check, fetchViaHTTP } from 'next-test-utils'
 import { join } from 'path'
@@ -99,7 +99,7 @@ describe('Middleware can set the matcher in its config', () => {
 
     await check(async () => {
       const matchers = await browser.eval(
-        next.isNextDev
+        isNextDev
           ? 'window.__DEV_MIDDLEWARE_MATCHERS'
           : 'window.__MIDDLEWARE_MATCHERS'
       )

--- a/test/e2e/middleware-matcher/index.test.ts
+++ b/test/e2e/middleware-matcher/index.test.ts
@@ -99,7 +99,7 @@ describe('Middleware can set the matcher in its config', () => {
 
     await check(async () => {
       const matchers = await browser.eval(
-        (global as any).isNextDev
+        next.isDev
           ? 'window.__DEV_MIDDLEWARE_MATCHERS'
           : 'window.__MIDDLEWARE_MATCHERS'
       )

--- a/test/e2e/middleware-matcher/index.test.ts
+++ b/test/e2e/middleware-matcher/index.test.ts
@@ -99,7 +99,7 @@ describe('Middleware can set the matcher in its config', () => {
 
     await check(async () => {
       const matchers = await browser.eval(
-        next.isDev
+        next.isNextDev
           ? 'window.__DEV_MIDDLEWARE_MATCHERS'
           : 'window.__MIDDLEWARE_MATCHERS'
       )

--- a/test/e2e/middleware-responses/test/index.test.ts
+++ b/test/e2e/middleware-responses/test/index.test.ts
@@ -33,7 +33,7 @@ describe('Middleware Responses', () => {
       const res = await fetchViaHTTP(next.url, `${locale}/stream-a-response`)
       expect(res.status).toBe(200)
 
-      if (!(global as any).isNextDeploy) {
+      if (!next.isDeploy) {
         expect(next.cliOutput).not.toContain(
           `A middleware can not alter response's body. Learn more: https://nextjs.org/docs/messages/returning-response-body-in-middleware`
         )
@@ -44,7 +44,7 @@ describe('Middleware Responses', () => {
       const res = await fetchViaHTTP(next.url, `${locale}/send-response`)
       expect(res.status).toBe(200)
 
-      if (!(global as any).isNextDeploy) {
+      if (!next.isDeploy) {
         expect(next.cliOutput).not.toContain(
           `A middleware can not alter response's body. Learn more: https://nextjs.org/docs/messages/returning-response-body-in-middleware`
         )

--- a/test/e2e/middleware-responses/test/index.test.ts
+++ b/test/e2e/middleware-responses/test/index.test.ts
@@ -33,7 +33,7 @@ describe('Middleware Responses', () => {
       const res = await fetchViaHTTP(next.url, `${locale}/stream-a-response`)
       expect(res.status).toBe(200)
 
-      if (!next.isDeploy) {
+      if (!next.isNextDeploy) {
         expect(next.cliOutput).not.toContain(
           `A middleware can not alter response's body. Learn more: https://nextjs.org/docs/messages/returning-response-body-in-middleware`
         )
@@ -44,7 +44,7 @@ describe('Middleware Responses', () => {
       const res = await fetchViaHTTP(next.url, `${locale}/send-response`)
       expect(res.status).toBe(200)
 
-      if (!next.isDeploy) {
+      if (!next.isNextDeploy) {
         expect(next.cliOutput).not.toContain(
           `A middleware can not alter response's body. Learn more: https://nextjs.org/docs/messages/returning-response-body-in-middleware`
         )

--- a/test/e2e/middleware-responses/test/index.test.ts
+++ b/test/e2e/middleware-responses/test/index.test.ts
@@ -3,7 +3,7 @@
 import { join } from 'path'
 import { fetchViaHTTP } from 'next-test-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDeploy } from 'e2e-utils'
 
 describe('Middleware Responses', () => {
   let next: NextInstance
@@ -33,7 +33,7 @@ describe('Middleware Responses', () => {
       const res = await fetchViaHTTP(next.url, `${locale}/stream-a-response`)
       expect(res.status).toBe(200)
 
-      if (!next.isNextDeploy) {
+      if (!isNextDeploy) {
         expect(next.cliOutput).not.toContain(
           `A middleware can not alter response's body. Learn more: https://nextjs.org/docs/messages/returning-response-body-in-middleware`
         )
@@ -44,7 +44,7 @@ describe('Middleware Responses', () => {
       const res = await fetchViaHTTP(next.url, `${locale}/send-response`)
       expect(res.status).toBe(200)
 
-      if (!next.isNextDeploy) {
+      if (!isNextDeploy) {
         expect(next.cliOutput).not.toContain(
           `A middleware can not alter response's body. Learn more: https://nextjs.org/docs/messages/returning-response-body-in-middleware`
         )

--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -127,7 +127,7 @@ describe('Middleware Rewrite', () => {
     it('should have props for afterFiles rewrite to SSG page', async () => {
       // TODO: investigate test failure during client navigation
       // on deployment
-      if ((global as any).isNextDeploy) {
+      if (next.isDeploy) {
         return
       }
       let browser = await webdriver(next.url, '/')
@@ -338,7 +338,7 @@ describe('Middleware Rewrite', () => {
       expect(await element.text()).toEqual('About Bypassed Page')
     })
 
-    if (!(global as any).isNextDev) {
+    if (!next.isDev) {
       it('should not prefetch non-SSG routes', async () => {
         const browser = await webdriver(next.url, '/')
 
@@ -767,7 +767,7 @@ describe('Middleware Rewrite', () => {
       }
     })
 
-    if (!(global as any).isNextDeploy) {
+    if (!next.isDeploy) {
       it(`${label}should rewrite when not using localhost`, async () => {
         const customUrl = new URL(next.url)
         customUrl.hostname = 'localtest.me'

--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -5,7 +5,7 @@ import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { check, fetchViaHTTP } from 'next-test-utils'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDeploy, isNextDev } from 'e2e-utils'
 import escapeStringRegexp from 'escape-string-regexp'
 
 describe('Middleware Rewrite', () => {
@@ -127,7 +127,7 @@ describe('Middleware Rewrite', () => {
     it('should have props for afterFiles rewrite to SSG page', async () => {
       // TODO: investigate test failure during client navigation
       // on deployment
-      if (next.isNextDeploy) {
+      if (isNextDeploy) {
         return
       }
       let browser = await webdriver(next.url, '/')
@@ -338,7 +338,7 @@ describe('Middleware Rewrite', () => {
       expect(await element.text()).toEqual('About Bypassed Page')
     })
 
-    if (!next.isNextDev) {
+    if (!isNextDev) {
       it('should not prefetch non-SSG routes', async () => {
         const browser = await webdriver(next.url, '/')
 
@@ -767,7 +767,7 @@ describe('Middleware Rewrite', () => {
       }
     })
 
-    if (!next.isNextDeploy) {
+    if (!isNextDeploy) {
       it(`${label}should rewrite when not using localhost`, async () => {
         const customUrl = new URL(next.url)
         customUrl.hostname = 'localtest.me'

--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -127,7 +127,7 @@ describe('Middleware Rewrite', () => {
     it('should have props for afterFiles rewrite to SSG page', async () => {
       // TODO: investigate test failure during client navigation
       // on deployment
-      if (next.isDeploy) {
+      if (next.isNextDeploy) {
         return
       }
       let browser = await webdriver(next.url, '/')
@@ -338,7 +338,7 @@ describe('Middleware Rewrite', () => {
       expect(await element.text()).toEqual('About Bypassed Page')
     })
 
-    if (!next.isDev) {
+    if (!next.isNextDev) {
       it('should not prefetch non-SSG routes', async () => {
         const browser = await webdriver(next.url, '/')
 
@@ -767,7 +767,7 @@ describe('Middleware Rewrite', () => {
       }
     })
 
-    if (!next.isDeploy) {
+    if (!next.isNextDeploy) {
       it(`${label}should rewrite when not using localhost`, async () => {
         const customUrl = new URL(next.url)
         customUrl.hostname = 'localtest.me'

--- a/test/e2e/middleware-trailing-slash/test/index.test.ts
+++ b/test/e2e/middleware-trailing-slash/test/index.test.ts
@@ -80,7 +80,7 @@ describe('Middleware Runtime trailing slash', () => {
       })
     })
 
-    if ((global as any).isNextDev) {
+    if (next.isDev) {
       it('refreshes the page when middleware changes ', async () => {
         const browser = await webdriver(next.url, `/about/`)
         await browser.eval('window.didrefresh = "hello"')
@@ -104,7 +104,7 @@ describe('Middleware Runtime trailing slash', () => {
       })
     }
 
-    if ((global as any).isNextStart) {
+    if (next.isStart) {
       it('should have valid middleware field in manifest', async () => {
         const manifest = await fs.readJSON(
           join(next.testDir, '.next/server/middleware-manifest.json')
@@ -383,7 +383,7 @@ describe('Middleware Runtime trailing slash', () => {
       const res = await fetchViaHTTP(next.url, `/%2/`)
       expect(res.status).toBe(400)
 
-      if ((global as any).isNextStart) {
+      if (next.isStart) {
         expect(await res.text()).toContain('Bad Request')
       }
     })

--- a/test/e2e/middleware-trailing-slash/test/index.test.ts
+++ b/test/e2e/middleware-trailing-slash/test/index.test.ts
@@ -3,7 +3,7 @@
 import fs from 'fs-extra'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDev, isNextStart } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { check, fetchViaHTTP, waitFor } from 'next-test-utils'
 
@@ -80,7 +80,7 @@ describe('Middleware Runtime trailing slash', () => {
       })
     })
 
-    if (next.isNextDev) {
+    if (isNextDev) {
       it('refreshes the page when middleware changes ', async () => {
         const browser = await webdriver(next.url, `/about/`)
         await browser.eval('window.didrefresh = "hello"')
@@ -104,7 +104,7 @@ describe('Middleware Runtime trailing slash', () => {
       })
     }
 
-    if (next.isNextStart) {
+    if (isNextStart) {
       it('should have valid middleware field in manifest', async () => {
         const manifest = await fs.readJSON(
           join(next.testDir, '.next/server/middleware-manifest.json')
@@ -383,7 +383,7 @@ describe('Middleware Runtime trailing slash', () => {
       const res = await fetchViaHTTP(next.url, `/%2/`)
       expect(res.status).toBe(400)
 
-      if (next.isNextStart) {
+      if (isNextStart) {
         expect(await res.text()).toContain('Bad Request')
       }
     })

--- a/test/e2e/middleware-trailing-slash/test/index.test.ts
+++ b/test/e2e/middleware-trailing-slash/test/index.test.ts
@@ -80,7 +80,7 @@ describe('Middleware Runtime trailing slash', () => {
       })
     })
 
-    if (next.isDev) {
+    if (next.isNextDev) {
       it('refreshes the page when middleware changes ', async () => {
         const browser = await webdriver(next.url, `/about/`)
         await browser.eval('window.didrefresh = "hello"')
@@ -104,7 +104,7 @@ describe('Middleware Runtime trailing slash', () => {
       })
     }
 
-    if (next.isStart) {
+    if (next.isNextStart) {
       it('should have valid middleware field in manifest', async () => {
         const manifest = await fs.readJSON(
           join(next.testDir, '.next/server/middleware-manifest.json')
@@ -383,7 +383,7 @@ describe('Middleware Runtime trailing slash', () => {
       const res = await fetchViaHTTP(next.url, `/%2/`)
       expect(res.status).toBe(400)
 
-      if (next.isStart) {
+      if (next.isNextStart) {
         expect(await res.text()).toContain('Bad Request')
       }
     })

--- a/test/e2e/multi-zone/multi-zone.test.ts
+++ b/test/e2e/multi-zone/multi-zone.test.ts
@@ -8,7 +8,7 @@ createNextDescribe(
     files: path.join(__dirname, 'app'),
     skipDeployment: true,
     buildCommand: 'pnpm build',
-    startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
+    startCommand: next.isDev ? 'pnpm dev' : 'pnpm start',
     packageJson: {
       scripts: {
         dev: 'node server.js',

--- a/test/e2e/multi-zone/multi-zone.test.ts
+++ b/test/e2e/multi-zone/multi-zone.test.ts
@@ -1,4 +1,4 @@
-import { createNextDescribe } from 'e2e-utils'
+import { createNextDescribe, isNextDev } from 'e2e-utils'
 import { check, waitFor } from 'next-test-utils'
 import path from 'path'
 
@@ -8,7 +8,7 @@ createNextDescribe(
     files: path.join(__dirname, 'app'),
     skipDeployment: true,
     buildCommand: 'pnpm build',
-    startCommand: next.isDev ? 'pnpm dev' : 'pnpm start',
+    startCommand: isNextDev ? 'pnpm dev' : 'pnpm start',
     packageJson: {
       scripts: {
         dev: 'node server.js',

--- a/test/e2e/new-link-behavior/child-a-tag-error.test.ts
+++ b/test/e2e/new-link-behavior/child-a-tag-error.test.ts
@@ -1,4 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDev } from 'e2e-utils'
 import { getRedboxSource, hasRedbox } from 'next-test-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import webdriver from 'next-webdriver'
@@ -30,7 +30,7 @@ describe('New Link Behavior with <a> child', () => {
     const msg =
       'Error: Invalid <Link> with <a> child. Please remove <a> or use <Link legacyBehavior>'
 
-    if (next.isNextDev) {
+    if (isNextDev) {
       expect(next.cliOutput).toContain(msg)
       expect(await hasRedbox(browser)).toBe(true)
       expect(await getRedboxSource(browser)).toContain(msg)

--- a/test/e2e/new-link-behavior/child-a-tag-error.test.ts
+++ b/test/e2e/new-link-behavior/child-a-tag-error.test.ts
@@ -30,7 +30,7 @@ describe('New Link Behavior with <a> child', () => {
     const msg =
       'Error: Invalid <Link> with <a> child. Please remove <a> or use <Link legacyBehavior>'
 
-    if (next.isDev) {
+    if (next.isNextDev) {
       expect(next.cliOutput).toContain(msg)
       expect(await hasRedbox(browser)).toBe(true)
       expect(await getRedboxSource(browser)).toContain(msg)

--- a/test/e2e/new-link-behavior/child-a-tag-error.test.ts
+++ b/test/e2e/new-link-behavior/child-a-tag-error.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef, isNextDev } from 'e2e-utils'
-import { getRedboxSource, hasRedbox } from 'next-test-utils'
+import { getRedboxDescription, hasRedbox } from 'next-test-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import webdriver from 'next-webdriver'
 import path from 'path'
@@ -33,10 +33,10 @@ describe('New Link Behavior with <a> child', () => {
     if (isNextDev) {
       expect(next.cliOutput).toContain(msg)
       expect(await hasRedbox(browser)).toBe(true)
-      expect(await getRedboxSource(browser)).toContain(msg)
-      expect(link).not.toBeDefined()
+      expect(await getRedboxDescription(browser)).toContain(msg)
+      expect(link.length).toBe(0)
     } else {
-      expect(link).toBeDefined()
+      expect(link.length).toBeGreaterThan(0)
     }
   })
 })

--- a/test/e2e/new-link-behavior/child-a-tag-error.test.ts
+++ b/test/e2e/new-link-behavior/child-a-tag-error.test.ts
@@ -30,7 +30,7 @@ describe('New Link Behavior with <a> child', () => {
     const msg =
       'Error: Invalid <Link> with <a> child. Please remove <a> or use <Link legacyBehavior>'
 
-    if ((global as any).isDev) {
+    if (next.isDev) {
       expect(next.cliOutput).toContain(msg)
       expect(await hasRedbox(browser)).toBe(true)
       expect(await getRedboxSource(browser)).toContain(msg)

--- a/test/e2e/next-font/basepath.test.ts
+++ b/test/e2e/next-font/basepath.test.ts
@@ -1,5 +1,5 @@
 import cheerio from 'cheerio'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDeploy } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { renderViaHTTP } from 'next-test-utils'
 import { join } from 'path'
@@ -11,7 +11,7 @@ const mockedGoogleFontResponses = require.resolve(
 describe('next/font/google basepath', () => {
   let next: NextInstance
 
-  if (next.isNextDeploy) {
+  if (isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }

--- a/test/e2e/next-font/basepath.test.ts
+++ b/test/e2e/next-font/basepath.test.ts
@@ -11,7 +11,7 @@ const mockedGoogleFontResponses = require.resolve(
 describe('next/font/google basepath', () => {
   let next: NextInstance
 
-  if (next.isDeploy) {
+  if (next.isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }

--- a/test/e2e/next-font/basepath.test.ts
+++ b/test/e2e/next-font/basepath.test.ts
@@ -11,7 +11,7 @@ const mockedGoogleFontResponses = require.resolve(
 describe('next/font/google basepath', () => {
   let next: NextInstance
 
-  if ((global as any).isNextDeploy) {
+  if (next.isDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }

--- a/test/e2e/next-font/google-fetch-error.test.ts
+++ b/test/e2e/next-font/google-fetch-error.test.ts
@@ -10,7 +10,7 @@ const mockedGoogleFontResponses = require.resolve(
 describe('next/font/google fetch error', () => {
   let next: NextInstance
 
-  if (next.isDeploy) {
+  if (next.isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }
@@ -28,7 +28,7 @@ describe('next/font/google fetch error', () => {
   })
   afterAll(() => next.destroy())
 
-  if (next.isDev) {
+  if (next.isNextDev) {
     it('should use a fallback font in dev', async () => {
       await next.start()
       const outputIndex = next.cliOutput.length

--- a/test/e2e/next-font/google-fetch-error.test.ts
+++ b/test/e2e/next-font/google-fetch-error.test.ts
@@ -1,4 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDeploy, isNextDev } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
@@ -10,7 +10,7 @@ const mockedGoogleFontResponses = require.resolve(
 describe('next/font/google fetch error', () => {
   let next: NextInstance
 
-  if (next.isNextDeploy) {
+  if (isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }
@@ -28,7 +28,7 @@ describe('next/font/google fetch error', () => {
   })
   afterAll(() => next.destroy())
 
-  if (next.isNextDev) {
+  if (isNextDev) {
     it('should use a fallback font in dev', async () => {
       await next.start()
       const outputIndex = next.cliOutput.length

--- a/test/e2e/next-font/google-fetch-error.test.ts
+++ b/test/e2e/next-font/google-fetch-error.test.ts
@@ -8,7 +8,6 @@ const mockedGoogleFontResponses = require.resolve(
 )
 
 describe('next/font/google fetch error', () => {
-  const isDev = next.isDev
   let next: NextInstance
 
   if (next.isDeploy) {
@@ -29,7 +28,7 @@ describe('next/font/google fetch error', () => {
   })
   afterAll(() => next.destroy())
 
-  if (isDev) {
+  if (next.isDev) {
     it('should use a fallback font in dev', async () => {
       await next.start()
       const outputIndex = next.cliOutput.length

--- a/test/e2e/next-font/google-fetch-error.test.ts
+++ b/test/e2e/next-font/google-fetch-error.test.ts
@@ -8,10 +8,10 @@ const mockedGoogleFontResponses = require.resolve(
 )
 
 describe('next/font/google fetch error', () => {
-  const isDev = (global as any).isNextDev
+  const isDev = next.isDev
   let next: NextInstance
 
-  if ((global as any).isNextDeploy) {
+  if (next.isDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }

--- a/test/e2e/next-font/index.test.ts
+++ b/test/e2e/next-font/index.test.ts
@@ -1,5 +1,5 @@
 import cheerio from 'cheerio'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDeploy, isNextDev } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { renderViaHTTP, shouldRunTurboDevTest } from 'next-test-utils'
 import { join } from 'path'
@@ -47,7 +47,7 @@ describe('next/font', () => {
       }
       let next: NextInstance
 
-      if (next.isNextDeploy) {
+      if (isNextDeploy) {
         it('should skip next deploy for now', () => {})
         return
       }
@@ -69,7 +69,7 @@ describe('next/font', () => {
       })
       afterAll(() => next.destroy())
 
-      if (next.isNextDev) {
+      if (isNextDev) {
         it('should use production cache control for fonts', async () => {
           const $ = await next.render$('/')
           const link = $('[rel="preload"][as="font"]').attr('href')

--- a/test/e2e/next-font/index.test.ts
+++ b/test/e2e/next-font/index.test.ts
@@ -47,7 +47,7 @@ describe('next/font', () => {
       }
       let next: NextInstance
 
-      if ((global as any).isNextDeploy) {
+      if (next.isDeploy) {
         it('should skip next deploy for now', () => {})
         return
       }
@@ -69,7 +69,7 @@ describe('next/font', () => {
       })
       afterAll(() => next.destroy())
 
-      if ((global as any).isNextDev) {
+      if (next.isDev) {
         it('should use production cache control for fonts', async () => {
           const $ = await next.render$('/')
           const link = $('[rel="preload"][as="font"]').attr('href')

--- a/test/e2e/next-font/index.test.ts
+++ b/test/e2e/next-font/index.test.ts
@@ -47,7 +47,7 @@ describe('next/font', () => {
       }
       let next: NextInstance
 
-      if (next.isDeploy) {
+      if (next.isNextDeploy) {
         it('should skip next deploy for now', () => {})
         return
       }
@@ -69,7 +69,7 @@ describe('next/font', () => {
       })
       afterAll(() => next.destroy())
 
-      if (next.isDev) {
+      if (next.isNextDev) {
         it('should use production cache control for fonts', async () => {
           const $ = await next.render$('/')
           const link = $('[rel="preload"][as="font"]').attr('href')

--- a/test/e2e/next-font/with-font-declarations-file.test.ts
+++ b/test/e2e/next-font/with-font-declarations-file.test.ts
@@ -8,12 +8,12 @@ const mockedGoogleFontResponses = require.resolve(
   './google-font-mocked-responses.js'
 )
 
-const isDev = (global as any).isNextDev
+const isDev = next.isDev
 
 describe('next/font/google with-font-declarations-file', () => {
   let next: NextInstance
 
-  if ((global as any).isNextDeploy) {
+  if (next.isDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }

--- a/test/e2e/next-font/with-font-declarations-file.test.ts
+++ b/test/e2e/next-font/with-font-declarations-file.test.ts
@@ -1,5 +1,5 @@
 import cheerio from 'cheerio'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDeploy, isNextDev } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { renderViaHTTP } from 'next-test-utils'
 import { join } from 'path'
@@ -11,7 +11,7 @@ const mockedGoogleFontResponses = require.resolve(
 describe('next/font/google with-font-declarations-file', () => {
   let next: NextInstance
 
-  if (next.isNextDeploy) {
+  if (isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }
@@ -46,7 +46,7 @@ describe('next/font/google with-font-declarations-file', () => {
     // Preconnect
     expect($('link[rel="preconnect"]').length).toBe(0)
 
-    if (next.isNextDev) {
+    if (isNextDev) {
       // In dev all fonts will be preloaded since it's before DCE
       expect($('link[as="font"]').length).toBe(4)
     } else {
@@ -80,7 +80,7 @@ describe('next/font/google with-font-declarations-file', () => {
     // Preconnect
     expect($('link[rel="preconnect"]').length).toBe(0)
 
-    if (next.isNextDev) {
+    if (isNextDev) {
       // In dev all fonts will be preloaded since it's before DCE
       expect($('link[as="font"]').length).toBe(4)
     } else {
@@ -114,7 +114,7 @@ describe('next/font/google with-font-declarations-file', () => {
     // Preconnect
     expect($('link[rel="preconnect"]').length).toBe(0)
 
-    if (next.isNextDev) {
+    if (isNextDev) {
       // In dev all fonts will be preloaded since it's before DCE
       expect($('link[as="font"]').length).toBe(4)
     } else {

--- a/test/e2e/next-font/with-font-declarations-file.test.ts
+++ b/test/e2e/next-font/with-font-declarations-file.test.ts
@@ -8,8 +8,6 @@ const mockedGoogleFontResponses = require.resolve(
   './google-font-mocked-responses.js'
 )
 
-const isDev = next.isDev
-
 describe('next/font/google with-font-declarations-file', () => {
   let next: NextInstance
 
@@ -48,7 +46,7 @@ describe('next/font/google with-font-declarations-file', () => {
     // Preconnect
     expect($('link[rel="preconnect"]').length).toBe(0)
 
-    if (isDev) {
+    if (next.isDev) {
       // In dev all fonts will be preloaded since it's before DCE
       expect($('link[as="font"]').length).toBe(4)
     } else {
@@ -82,7 +80,7 @@ describe('next/font/google with-font-declarations-file', () => {
     // Preconnect
     expect($('link[rel="preconnect"]').length).toBe(0)
 
-    if (isDev) {
+    if (next.isDev) {
       // In dev all fonts will be preloaded since it's before DCE
       expect($('link[as="font"]').length).toBe(4)
     } else {
@@ -116,7 +114,7 @@ describe('next/font/google with-font-declarations-file', () => {
     // Preconnect
     expect($('link[rel="preconnect"]').length).toBe(0)
 
-    if (isDev) {
+    if (next.isDev) {
       // In dev all fonts will be preloaded since it's before DCE
       expect($('link[as="font"]').length).toBe(4)
     } else {

--- a/test/e2e/next-font/with-font-declarations-file.test.ts
+++ b/test/e2e/next-font/with-font-declarations-file.test.ts
@@ -11,7 +11,7 @@ const mockedGoogleFontResponses = require.resolve(
 describe('next/font/google with-font-declarations-file', () => {
   let next: NextInstance
 
-  if (next.isDeploy) {
+  if (next.isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }
@@ -46,7 +46,7 @@ describe('next/font/google with-font-declarations-file', () => {
     // Preconnect
     expect($('link[rel="preconnect"]').length).toBe(0)
 
-    if (next.isDev) {
+    if (next.isNextDev) {
       // In dev all fonts will be preloaded since it's before DCE
       expect($('link[as="font"]').length).toBe(4)
     } else {
@@ -80,7 +80,7 @@ describe('next/font/google with-font-declarations-file', () => {
     // Preconnect
     expect($('link[rel="preconnect"]').length).toBe(0)
 
-    if (next.isDev) {
+    if (next.isNextDev) {
       // In dev all fonts will be preloaded since it's before DCE
       expect($('link[as="font"]').length).toBe(4)
     } else {
@@ -114,7 +114,7 @@ describe('next/font/google with-font-declarations-file', () => {
     // Preconnect
     expect($('link[rel="preconnect"]').length).toBe(0)
 
-    if (next.isDev) {
+    if (next.isNextDev) {
       // In dev all fonts will be preloaded since it's before DCE
       expect($('link[as="font"]').length).toBe(4)
     } else {

--- a/test/e2e/next-font/with-proxy.test.ts
+++ b/test/e2e/next-font/with-proxy.test.ts
@@ -9,7 +9,7 @@ describe('next/font/google with proxy', () => {
   let PROXY_PORT: number
   let SERVER_PORT: number
 
-  if (next.isDeploy) {
+  if (next.isNextDeploy) {
     it('should skip next deploy', () => {})
     return
   }

--- a/test/e2e/next-font/with-proxy.test.ts
+++ b/test/e2e/next-font/with-proxy.test.ts
@@ -9,7 +9,7 @@ describe('next/font/google with proxy', () => {
   let PROXY_PORT: number
   let SERVER_PORT: number
 
-  if ((global as any).isNextDeploy) {
+  if (next.isDeploy) {
     it('should skip next deploy', () => {})
     return
   }

--- a/test/e2e/next-font/with-proxy.test.ts
+++ b/test/e2e/next-font/with-proxy.test.ts
@@ -1,4 +1,4 @@
-import { FileRef, createNext, NextInstance } from 'e2e-utils'
+import { FileRef, createNext, NextInstance, isNextDeploy } from 'e2e-utils'
 import { findPort, renderViaHTTP, fetchViaHTTP } from 'next-test-utils'
 import { join } from 'path'
 import spawn from 'cross-spawn'
@@ -9,7 +9,7 @@ describe('next/font/google with proxy', () => {
   let PROXY_PORT: number
   let SERVER_PORT: number
 
-  if (next.isNextDeploy) {
+  if (isNextDeploy) {
     it('should skip next deploy', () => {})
     return
   }

--- a/test/e2e/next-font/without-preloaded-fonts.test.ts
+++ b/test/e2e/next-font/without-preloaded-fonts.test.ts
@@ -1,5 +1,5 @@
 import cheerio from 'cheerio'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDeploy } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { renderViaHTTP } from 'next-test-utils'
 import { join } from 'path'
@@ -11,7 +11,7 @@ const mockedGoogleFontResponses = require.resolve(
 describe('next/font/google without-preloaded-fonts without _app', () => {
   let next: NextInstance
 
-  if (next.isNextDeploy) {
+  if (isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }
@@ -62,7 +62,7 @@ describe('next/font/google without-preloaded-fonts without _app', () => {
 describe('next/font/google no preloads with _app', () => {
   let next: NextInstance
 
-  if (next.isNextDeploy) {
+  if (isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }

--- a/test/e2e/next-font/without-preloaded-fonts.test.ts
+++ b/test/e2e/next-font/without-preloaded-fonts.test.ts
@@ -11,7 +11,7 @@ const mockedGoogleFontResponses = require.resolve(
 describe('next/font/google without-preloaded-fonts without _app', () => {
   let next: NextInstance
 
-  if (next.isDeploy) {
+  if (next.isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }
@@ -62,7 +62,7 @@ describe('next/font/google without-preloaded-fonts without _app', () => {
 describe('next/font/google no preloads with _app', () => {
   let next: NextInstance
 
-  if (next.isDeploy) {
+  if (next.isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }

--- a/test/e2e/next-font/without-preloaded-fonts.test.ts
+++ b/test/e2e/next-font/without-preloaded-fonts.test.ts
@@ -11,7 +11,7 @@ const mockedGoogleFontResponses = require.resolve(
 describe('next/font/google without-preloaded-fonts without _app', () => {
   let next: NextInstance
 
-  if ((global as any).isNextDeploy) {
+  if (next.isDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }
@@ -62,7 +62,7 @@ describe('next/font/google without-preloaded-fonts without _app', () => {
 describe('next/font/google no preloads with _app', () => {
   let next: NextInstance
 
-  if ((global as any).isNextDeploy) {
+  if (next.isDeploy) {
     it('should skip next deploy for now', () => {})
     return
   }

--- a/test/e2e/no-eslint-warn-with-no-eslint-config/index.test.ts
+++ b/test/e2e/no-eslint-warn-with-no-eslint-config/index.test.ts
@@ -1,11 +1,11 @@
-import { createNext } from 'e2e-utils'
+import { createNext, isNextDeploy, isNextDev } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { renderViaHTTP } from 'next-test-utils'
 
 describe('no-eslint-warn-with-no-eslint-config', () => {
   let next: NextInstance
 
-  if (next.isNextDeploy) {
+  if (isNextDeploy) {
     it('should skip for deploy', () => {})
     return
   }
@@ -36,7 +36,7 @@ describe('no-eslint-warn-with-no-eslint-config', () => {
     expect(next.cliOutput).not.toBe('warn')
   })
 
-  if (!next.isNextDev) {
+  if (!isNextDev) {
     it('should warn with empty eslintrc', async () => {
       await next.stop()
       await next.patchFile('.eslintrc.json', '{}')

--- a/test/e2e/no-eslint-warn-with-no-eslint-config/index.test.ts
+++ b/test/e2e/no-eslint-warn-with-no-eslint-config/index.test.ts
@@ -5,7 +5,7 @@ import { renderViaHTTP } from 'next-test-utils'
 describe('no-eslint-warn-with-no-eslint-config', () => {
   let next: NextInstance
 
-  if (next.isDeploy) {
+  if (next.isNextDeploy) {
     it('should skip for deploy', () => {})
     return
   }
@@ -36,7 +36,7 @@ describe('no-eslint-warn-with-no-eslint-config', () => {
     expect(next.cliOutput).not.toBe('warn')
   })
 
-  if (!next.isDev) {
+  if (!next.isNextDev) {
     it('should warn with empty eslintrc', async () => {
       await next.stop()
       await next.patchFile('.eslintrc.json', '{}')

--- a/test/e2e/no-eslint-warn-with-no-eslint-config/index.test.ts
+++ b/test/e2e/no-eslint-warn-with-no-eslint-config/index.test.ts
@@ -5,7 +5,7 @@ import { renderViaHTTP } from 'next-test-utils'
 describe('no-eslint-warn-with-no-eslint-config', () => {
   let next: NextInstance
 
-  if ((global as any).isNextDeploy) {
+  if (next.isDeploy) {
     it('should skip for deploy', () => {})
     return
   }
@@ -36,7 +36,7 @@ describe('no-eslint-warn-with-no-eslint-config', () => {
     expect(next.cliOutput).not.toBe('warn')
   })
 
-  if (!(global as any).isNextDev) {
+  if (!next.isDev) {
     it('should warn with empty eslintrc', async () => {
       await next.stop()
       await next.patchFile('.eslintrc.json', '{}')

--- a/test/e2e/og-api/index.test.ts
+++ b/test/e2e/og-api/index.test.ts
@@ -46,7 +46,7 @@ describe('og-api', () => {
     expect(body.size).toBeGreaterThan(0)
   })
 
-  if (next.isStart) {
+  if (next.isNextStart) {
     it('should copy files correctly', async () => {
       expect(next.cliOutput).not.toContain('Failed to copy traced files')
 
@@ -63,7 +63,7 @@ describe('og-api', () => {
     })
   }
 
-  if (next.isDev) {
+  if (next.isNextDev) {
     it('should throw error when returning a response object in pages/api in node runtime', async () => {
       const res = await fetchViaHTTP(next.url, '/api/og-wrong-runtime')
       expect(res.status).toBe(500)

--- a/test/e2e/og-api/index.test.ts
+++ b/test/e2e/og-api/index.test.ts
@@ -1,4 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDev, isNextStart } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 import fs from 'fs-extra'
@@ -46,7 +46,7 @@ describe('og-api', () => {
     expect(body.size).toBeGreaterThan(0)
   })
 
-  if (next.isNextStart) {
+  if (isNextStart) {
     it('should copy files correctly', async () => {
       expect(next.cliOutput).not.toContain('Failed to copy traced files')
 
@@ -63,7 +63,7 @@ describe('og-api', () => {
     })
   }
 
-  if (next.isNextDev) {
+  if (isNextDev) {
     it('should throw error when returning a response object in pages/api in node runtime', async () => {
       const res = await fetchViaHTTP(next.url, '/api/og-wrong-runtime')
       expect(res.status).toBe(500)

--- a/test/e2e/og-api/index.test.ts
+++ b/test/e2e/og-api/index.test.ts
@@ -46,7 +46,7 @@ describe('og-api', () => {
     expect(body.size).toBeGreaterThan(0)
   })
 
-  if ((global as any).isNextStart) {
+  if (next.isStart) {
     it('should copy files correctly', async () => {
       expect(next.cliOutput).not.toContain('Failed to copy traced files')
 
@@ -63,7 +63,7 @@ describe('og-api', () => {
     })
   }
 
-  if ((global as any).isNextDev) {
+  if (next.isDev) {
     it('should throw error when returning a response object in pages/api in node runtime', async () => {
       const res = await fetchViaHTTP(next.url, '/api/og-wrong-runtime')
       expect(res.status).toBe(500)

--- a/test/e2e/opentelemetry/instrumentation-pages-app-only.test.ts
+++ b/test/e2e/opentelemetry/instrumentation-pages-app-only.test.ts
@@ -1,4 +1,4 @@
-import { nextTestSetup } from 'e2e-utils'
+import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
 for (const { app, src, pathname, text } of [
@@ -51,7 +51,7 @@ for (const { app, src, pathname, text } of [
           start: 'next start',
         },
       },
-      startCommand: `pnpm ${next.isDev ? 'dev' : 'start'}`,
+      startCommand: `pnpm ${isNextDev ? 'dev' : 'start'}`,
       buildCommand: `pnpm build`,
       dependencies: require('./package.json').dependencies,
     })

--- a/test/e2e/opentelemetry/instrumentation-pages-app-only.test.ts
+++ b/test/e2e/opentelemetry/instrumentation-pages-app-only.test.ts
@@ -51,7 +51,7 @@ for (const { app, src, pathname, text } of [
           start: 'next start',
         },
       },
-      startCommand: `pnpm ${(global as any).isNextDev ? 'dev' : 'start'}`,
+      startCommand: `pnpm ${next.isDev ? 'dev' : 'start'}`,
       buildCommand: `pnpm build`,
       dependencies: require('./package.json').dependencies,
     })

--- a/test/e2e/prerender-native-module.test.ts
+++ b/test/e2e/prerender-native-module.test.ts
@@ -61,7 +61,7 @@ describe('prerender native module', () => {
     })
   })
 
-  if (next.isStart) {
+  if (next.isNextStart) {
     it('should output traces', async () => {
       const checks = [
         {

--- a/test/e2e/prerender-native-module.test.ts
+++ b/test/e2e/prerender-native-module.test.ts
@@ -61,7 +61,7 @@ describe('prerender native module', () => {
     })
   })
 
-  if ((global as any).isNextStart) {
+  if (next.isStart) {
     it('should output traces', async () => {
       const checks = [
         {

--- a/test/e2e/prerender-native-module.test.ts
+++ b/test/e2e/prerender-native-module.test.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextStart } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import webdriver from 'next-webdriver'
 
@@ -61,7 +61,7 @@ describe('prerender native module', () => {
     })
   })
 
-  if (next.isNextStart) {
+  if (isNextStart) {
     it('should output traces', async () => {
       const checks = [
         {

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -3,7 +3,13 @@ import cookie from 'cookie'
 import cheerio from 'cheerio'
 import { join, sep } from 'path'
 import escapeRegex from 'escape-string-regexp'
-import { createNext, FileRef } from 'e2e-utils'
+import {
+  createNext,
+  FileRef,
+  isNextDeploy,
+  isNextDev,
+  isNextStart,
+} from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import {
   check,
@@ -753,7 +759,7 @@ describe('Prerender', () => {
       expect(value).toMatch(/Hi \[third\] \[fourth\]/)
     })
 
-    if (next.isNextStart) {
+    if (isNextStart) {
       // TODO: dev currently renders this page as blocking, meaning it shows the
       // server error instead of continuously retrying. Do we want to change this?
       it.skip('should reload page on failed data request, and retry', async () => {
@@ -967,7 +973,7 @@ describe('Prerender', () => {
       )
     })
 
-    if (next.isNextDev) {
+    if (isNextDev) {
       it('should show warning every time page with large amount of page data is returned', async () => {
         await renderViaHTTP(next.url, '/large-page-data-ssr')
         await check(
@@ -984,7 +990,7 @@ describe('Prerender', () => {
       })
     }
 
-    if (next.isNextStart) {
+    if (isNextStart) {
       it('should only show warning once per page when large amount of page data is returned', async () => {
         await renderViaHTTP(next.url, '/large-page-data-ssr')
         await check(
@@ -1000,7 +1006,7 @@ describe('Prerender', () => {
       })
     }
 
-    if (next.isNextDev) {
+    if (isNextDev) {
       it('should not show warning from url prop being returned', async () => {
         const urlPropPage = 'pages/url-prop.js'
         await next.patchFile(
@@ -1283,7 +1289,7 @@ describe('Prerender', () => {
         await check(() => getBrowserBodyText(browser), /hello /)
       })
 
-      if (next.isNextStart && !isDeploy) {
+      if (isNextStart && !isDeploy) {
         it('outputs dataRoutes in routes-manifest correctly', async () => {
           const { dataRoutes } = JSON.parse(
             await next.readFile('.next/routes-manifest.json')
@@ -2054,7 +2060,7 @@ describe('Prerender', () => {
       })
     }
 
-    if (next.isNextStart) {
+    if (isNextStart) {
       it('should of formatted build output correctly', () => {
         expect(next.cliOutput).toMatch(/○ \/normal/)
         expect(next.cliOutput).toMatch(/● \/blog\/\[post\]/)
@@ -2477,5 +2483,5 @@ describe('Prerender', () => {
       expect(next.cliOutput).not.toContain('argument entity must be string')
     })
   }
-  runTests(next.isNextDev, next.isNextDeploy)
+  runTests(isNextDev, isNextDeploy)
 })

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -753,7 +753,7 @@ describe('Prerender', () => {
       expect(value).toMatch(/Hi \[third\] \[fourth\]/)
     })
 
-    if (next.isStart) {
+    if (next.isNextStart) {
       // TODO: dev currently renders this page as blocking, meaning it shows the
       // server error instead of continuously retrying. Do we want to change this?
       it.skip('should reload page on failed data request, and retry', async () => {
@@ -967,7 +967,7 @@ describe('Prerender', () => {
       )
     })
 
-    if (next.isDev) {
+    if (next.isNextDev) {
       it('should show warning every time page with large amount of page data is returned', async () => {
         await renderViaHTTP(next.url, '/large-page-data-ssr')
         await check(
@@ -984,7 +984,7 @@ describe('Prerender', () => {
       })
     }
 
-    if (next.isStart) {
+    if (next.isNextStart) {
       it('should only show warning once per page when large amount of page data is returned', async () => {
         await renderViaHTTP(next.url, '/large-page-data-ssr')
         await check(
@@ -1000,7 +1000,7 @@ describe('Prerender', () => {
       })
     }
 
-    if (next.isDev) {
+    if (next.isNextDev) {
       it('should not show warning from url prop being returned', async () => {
         const urlPropPage = 'pages/url-prop.js'
         await next.patchFile(
@@ -1283,7 +1283,7 @@ describe('Prerender', () => {
         await check(() => getBrowserBodyText(browser), /hello /)
       })
 
-      if (next.isStart && !isDeploy) {
+      if (next.isNextStart && !isDeploy) {
         it('outputs dataRoutes in routes-manifest correctly', async () => {
           const { dataRoutes } = JSON.parse(
             await next.readFile('.next/routes-manifest.json')
@@ -2054,7 +2054,7 @@ describe('Prerender', () => {
       })
     }
 
-    if (next.isStart) {
+    if (next.isNextStart) {
       it('should of formatted build output correctly', () => {
         expect(next.cliOutput).toMatch(/○ \/normal/)
         expect(next.cliOutput).toMatch(/● \/blog\/\[post\]/)
@@ -2477,5 +2477,5 @@ describe('Prerender', () => {
       expect(next.cliOutput).not.toContain('argument entity must be string')
     })
   }
-  runTests(next.isDev, next.isDeploy)
+  runTests(next.isNextDev, next.isNextDeploy)
 })

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -753,7 +753,7 @@ describe('Prerender', () => {
       expect(value).toMatch(/Hi \[third\] \[fourth\]/)
     })
 
-    if ((global as any).isNextStart) {
+    if (next.isStart) {
       // TODO: dev currently renders this page as blocking, meaning it shows the
       // server error instead of continuously retrying. Do we want to change this?
       it.skip('should reload page on failed data request, and retry', async () => {
@@ -967,7 +967,7 @@ describe('Prerender', () => {
       )
     })
 
-    if ((global as any).isNextDev) {
+    if (next.isDev) {
       it('should show warning every time page with large amount of page data is returned', async () => {
         await renderViaHTTP(next.url, '/large-page-data-ssr')
         await check(
@@ -984,7 +984,7 @@ describe('Prerender', () => {
       })
     }
 
-    if ((global as any).isNextStart) {
+    if (next.isStart) {
       it('should only show warning once per page when large amount of page data is returned', async () => {
         await renderViaHTTP(next.url, '/large-page-data-ssr')
         await check(
@@ -1000,7 +1000,7 @@ describe('Prerender', () => {
       })
     }
 
-    if ((global as any).isNextDev) {
+    if (next.isDev) {
       it('should not show warning from url prop being returned', async () => {
         const urlPropPage = 'pages/url-prop.js'
         await next.patchFile(
@@ -1283,7 +1283,7 @@ describe('Prerender', () => {
         await check(() => getBrowserBodyText(browser), /hello /)
       })
 
-      if ((global as any).isNextStart && !isDeploy) {
+      if (next.isStart && !isDeploy) {
         it('outputs dataRoutes in routes-manifest correctly', async () => {
           const { dataRoutes } = JSON.parse(
             await next.readFile('.next/routes-manifest.json')
@@ -2054,7 +2054,7 @@ describe('Prerender', () => {
       })
     }
 
-    if ((global as any).isNextStart) {
+    if (next.isStart) {
       it('should of formatted build output correctly', () => {
         expect(next.cliOutput).toMatch(/○ \/normal/)
         expect(next.cliOutput).toMatch(/● \/blog\/\[post\]/)
@@ -2477,5 +2477,5 @@ describe('Prerender', () => {
       expect(next.cliOutput).not.toContain('argument entity must be string')
     })
   }
-  runTests((global as any).isNextDev, (global as any).isNextDeploy)
+  runTests(next.isDev, next.isDeploy)
 })

--- a/test/e2e/skip-trailing-slash-redirect/index.test.ts
+++ b/test/e2e/skip-trailing-slash-redirect/index.test.ts
@@ -222,7 +222,7 @@ describe('skip-trailing-slash-redirect', () => {
     expect(res.status).toBe(200)
     expect(await res.text()).toContain('Example Domain')
 
-    if (!next.isDeploy) {
+    if (!next.isNextDeploy) {
       await check(() => next.cliOutput, /missing-id rewrite/)
       expect(next.cliOutput).toContain('/_next/data/missing-id/hello.json')
     }
@@ -275,7 +275,7 @@ describe('skip-trailing-slash-redirect', () => {
     )
   })
 
-  if (next.isStart) {
+  if (next.isNextStart) {
     it('should not have trailing slash redirects in manifest', async () => {
       const routesManifest = JSON.parse(
         await next.readFile('.next/routes-manifest.json')

--- a/test/e2e/skip-trailing-slash-redirect/index.test.ts
+++ b/test/e2e/skip-trailing-slash-redirect/index.test.ts
@@ -222,7 +222,7 @@ describe('skip-trailing-slash-redirect', () => {
     expect(res.status).toBe(200)
     expect(await res.text()).toContain('Example Domain')
 
-    if (!(global as any).isNextDeploy) {
+    if (!next.isDeploy) {
       await check(() => next.cliOutput, /missing-id rewrite/)
       expect(next.cliOutput).toContain('/_next/data/missing-id/hello.json')
     }
@@ -275,7 +275,7 @@ describe('skip-trailing-slash-redirect', () => {
     )
   })
 
-  if ((global as any).isNextStart) {
+  if (next.isStart) {
     it('should not have trailing slash redirects in manifest', async () => {
       const routesManifest = JSON.parse(
         await next.readFile('.next/routes-manifest.json')

--- a/test/e2e/skip-trailing-slash-redirect/index.test.ts
+++ b/test/e2e/skip-trailing-slash-redirect/index.test.ts
@@ -1,4 +1,4 @@
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDeploy, isNextStart } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { check, fetchViaHTTP } from 'next-test-utils'
 import { join } from 'path'
@@ -222,7 +222,7 @@ describe('skip-trailing-slash-redirect', () => {
     expect(res.status).toBe(200)
     expect(await res.text()).toContain('Example Domain')
 
-    if (!next.isNextDeploy) {
+    if (!isNextDeploy) {
       await check(() => next.cliOutput, /missing-id rewrite/)
       expect(next.cliOutput).toContain('/_next/data/missing-id/hello.json')
     }
@@ -275,7 +275,7 @@ describe('skip-trailing-slash-redirect', () => {
     )
   })
 
-  if (next.isNextStart) {
+  if (isNextStart) {
     it('should not have trailing slash redirects in manifest', async () => {
       const routesManifest = JSON.parse(
         await next.readFile('.next/routes-manifest.json')

--- a/test/e2e/ssr-react-context/index.test.ts
+++ b/test/e2e/ssr-react-context/index.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import { renderViaHTTP, check } from 'next-test-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDev } from 'e2e-utils'
 
 describe('React Context', () => {
   let next: NextInstance
@@ -26,7 +26,7 @@ describe('React Context', () => {
     expect(html).toMatch(/Value: .*?12345/)
   })
 
-  if ((globalThis as any).isNextDev) {
+  if (isNextDev) {
     it('should render with context after change', async () => {
       const aboutAppPagePath = 'pages/_app.js'
       const originalContent = await next.readFile(aboutAppPagePath)

--- a/test/e2e/streaming-ssr/index.test.ts
+++ b/test/e2e/streaming-ssr/index.test.ts
@@ -10,7 +10,7 @@ import {
   renderViaHTTP,
 } from 'next-test-utils'
 
-const isNextProd = !(global as any).isNextDev && !(global as any).isNextDeploy
+const isNextProd = !next.isDev && !next.isDeploy
 
 createNextDescribe(
   'streaming SSR with custom next configs',
@@ -57,7 +57,7 @@ createNextDescribe(
       expect(html).toContain('マルチバイト'.repeat(28))
     })
 
-    if ((global as any).isNextDev) {
+    if (next.isDev) {
       it('should work with custom document', async () => {
         await next.patchFile(
           'pages/_document.js',

--- a/test/e2e/streaming-ssr/index.test.ts
+++ b/test/e2e/streaming-ssr/index.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'path'
-import { createNext, createNextDescribe } from 'e2e-utils'
+import { createNext, createNextDescribe, isNextStart } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import {
   check,
@@ -9,8 +9,6 @@ import {
   killApp,
   renderViaHTTP,
 } from 'next-test-utils'
-
-const isNextProd = !next.isDev && !next.isDeploy
 
 createNextDescribe(
   'streaming SSR with custom next configs',
@@ -86,7 +84,7 @@ createNextDescribe(
   }
 )
 
-if (isNextProd) {
+if (isNextStart) {
   describe('streaming SSR with custom server', () => {
     let next
     let server
@@ -126,7 +124,7 @@ if (isNextProd) {
     let next: NextInstance
 
     beforeAll(async () => {
-      if (isNextProd) {
+      if (isNextStart) {
         process.env.NEXT_PRIVATE_MINIMAL_MODE = '1'
       }
 
@@ -162,7 +160,7 @@ if (isNextProd) {
       })
     })
     afterAll(() => {
-      if (isNextProd) {
+      if (isNextStart) {
         delete process.env.NEXT_PRIVATE_MINIMAL_MODE
       }
       next.destroy()
@@ -178,7 +176,7 @@ if (isNextProd) {
       expect(html).toContain('streaming')
     })
 
-    if (isNextProd) {
+    if (isNextStart) {
       it('should have generated a static 404 page', async () => {
         expect(await next.readFile('.next/server/pages/404.html')).toBeTruthy()
 

--- a/test/e2e/streaming-ssr/index.test.ts
+++ b/test/e2e/streaming-ssr/index.test.ts
@@ -55,7 +55,7 @@ createNextDescribe(
       expect(html).toContain('マルチバイト'.repeat(28))
     })
 
-    if (next.isDev) {
+    if (next.isNextDev) {
       it('should work with custom document', async () => {
         await next.patchFile(
           'pages/_document.js',

--- a/test/e2e/streaming-ssr/index.test.ts
+++ b/test/e2e/streaming-ssr/index.test.ts
@@ -1,5 +1,10 @@
 import { join } from 'path'
-import { createNext, createNextDescribe, isNextStart } from 'e2e-utils'
+import {
+  createNext,
+  createNextDescribe,
+  isNextDev,
+  isNextStart,
+} from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import {
   check,
@@ -55,7 +60,7 @@ createNextDescribe(
       expect(html).toContain('マルチバイト'.repeat(28))
     })
 
-    if (next.isNextDev) {
+    if (isNextDev) {
       it('should work with custom document', async () => {
         await next.patchFile(
           'pages/_document.js',

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -37,7 +37,7 @@ describe('Switchable runtime', () => {
   let next: NextInstance
   let context
 
-  if ((global as any).isNextDeploy) {
+  if (next.isDeploy) {
     // TODO-APP: re-enable after Prerenders are handled on deploy
     it('should skip for deploy temporarily', () => {})
     return
@@ -60,7 +60,7 @@ describe('Switchable runtime', () => {
   })
   afterAll(() => next.destroy())
 
-  if ((global as any).isNextDev) {
+  if (next.isDev) {
     describe('Switchable runtime (dev)', () => {
       it('should not include edge api routes and edge ssr routes into dev middleware manifest', async () => {
         const res = await fetchViaHTTP(
@@ -180,7 +180,7 @@ describe('Switchable runtime', () => {
         text = await response.text()
         expect(text).toMatch(/Returned by Edge API Route .+\/api\/edge/)
 
-        if (!(global as any).isNextDeploy) {
+        if (!next.isDeploy) {
           const manifest = await readJson(
             join(context.appDir, '.next/server/middleware-manifest.json')
           )
@@ -614,7 +614,7 @@ describe('Switchable runtime', () => {
         text = await response.text()
         expect(text).toMatch(/Returned by Edge API Route .+\/api\/edge/)
 
-        if (!(global as any).isNextDeploy) {
+        if (!next.isDeploy) {
           const manifest = await readJson(
             join(context.appDir, '.next/server/middleware-manifest.json')
           )

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import webdriver from 'next-webdriver'
 import { join } from 'path'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDeploy, isNextDev } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { check, fetchViaHTTP, renderViaHTTP, waitFor } from 'next-test-utils'
 
@@ -37,7 +37,7 @@ describe('Switchable runtime', () => {
   let next: NextInstance
   let context
 
-  if (next.isNextDeploy) {
+  if (isNextDeploy) {
     // TODO-APP: re-enable after Prerenders are handled on deploy
     it('should skip for deploy temporarily', () => {})
     return
@@ -60,7 +60,7 @@ describe('Switchable runtime', () => {
   })
   afterAll(() => next.destroy())
 
-  if (next.isNextDev) {
+  if (isNextDev) {
     describe('Switchable runtime (dev)', () => {
       it('should not include edge api routes and edge ssr routes into dev middleware manifest', async () => {
         const res = await fetchViaHTTP(
@@ -180,7 +180,7 @@ describe('Switchable runtime', () => {
         text = await response.text()
         expect(text).toMatch(/Returned by Edge API Route .+\/api\/edge/)
 
-        if (!next.isNextDeploy) {
+        if (!isNextDeploy) {
           const manifest = await readJson(
             join(context.appDir, '.next/server/middleware-manifest.json')
           )
@@ -614,7 +614,7 @@ describe('Switchable runtime', () => {
         text = await response.text()
         expect(text).toMatch(/Returned by Edge API Route .+\/api\/edge/)
 
-        if (!next.isNextDeploy) {
+        if (!isNextDeploy) {
           const manifest = await readJson(
             join(context.appDir, '.next/server/middleware-manifest.json')
           )

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -37,7 +37,7 @@ describe('Switchable runtime', () => {
   let next: NextInstance
   let context
 
-  if (next.isDeploy) {
+  if (next.isNextDeploy) {
     // TODO-APP: re-enable after Prerenders are handled on deploy
     it('should skip for deploy temporarily', () => {})
     return
@@ -60,7 +60,7 @@ describe('Switchable runtime', () => {
   })
   afterAll(() => next.destroy())
 
-  if (next.isDev) {
+  if (next.isNextDev) {
     describe('Switchable runtime (dev)', () => {
       it('should not include edge api routes and edge ssr routes into dev middleware manifest', async () => {
         const res = await fetchViaHTTP(
@@ -180,7 +180,7 @@ describe('Switchable runtime', () => {
         text = await response.text()
         expect(text).toMatch(/Returned by Edge API Route .+\/api\/edge/)
 
-        if (!next.isDeploy) {
+        if (!next.isNextDeploy) {
           const manifest = await readJson(
             join(context.appDir, '.next/server/middleware-manifest.json')
           )
@@ -614,7 +614,7 @@ describe('Switchable runtime', () => {
         text = await response.text()
         expect(text).toMatch(/Returned by Edge API Route .+\/api\/edge/)
 
-        if (!next.isDeploy) {
+        if (!next.isNextDeploy) {
           const manifest = await readJson(
             join(context.appDir, '.next/server/middleware-manifest.json')
           )

--- a/test/e2e/testmode/testmode.test.ts
+++ b/test/e2e/testmode/testmode.test.ts
@@ -1,4 +1,4 @@
-import { createNextDescribe } from 'e2e-utils'
+import { createNextDescribe, isNextDev } from 'e2e-utils'
 import { createProxyServer } from 'next/experimental/testmode/proxy'
 
 createNextDescribe(
@@ -7,7 +7,7 @@ createNextDescribe(
     files: __dirname,
     skipDeployment: true,
     dependencies: require('./package.json').dependencies,
-    startCommand: next.isDev
+    startCommand: isNextDev
       ? 'yarn next dev --experimental-test-proxy'
       : 'yarn next start --experimental-test-proxy',
   },

--- a/test/e2e/testmode/testmode.test.ts
+++ b/test/e2e/testmode/testmode.test.ts
@@ -7,7 +7,7 @@ createNextDescribe(
     files: __dirname,
     skipDeployment: true,
     dependencies: require('./package.json').dependencies,
-    startCommand: (global as any).isNextDev
+    startCommand: next.isDev
       ? 'yarn next dev --experimental-test-proxy'
       : 'yarn next start --experimental-test-proxy',
   },

--- a/test/e2e/trailingslash-with-rewrite/index.test.ts
+++ b/test/e2e/trailingslash-with-rewrite/index.test.ts
@@ -6,7 +6,7 @@ import { fetchViaHTTP } from 'next-test-utils'
 describe('trailingSlash:true with rewrites and getStaticProps', () => {
   let next: NextInstance
 
-  if ((global as any).isNextDeploy) {
+  if (next.isDeploy) {
     it('should skip for deploy mode for now', () => {})
     return
   }

--- a/test/e2e/trailingslash-with-rewrite/index.test.ts
+++ b/test/e2e/trailingslash-with-rewrite/index.test.ts
@@ -1,12 +1,12 @@
 import { join } from 'path'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDeploy } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('trailingSlash:true with rewrites and getStaticProps', () => {
   let next: NextInstance
 
-  if (next.isNextDeploy) {
+  if (isNextDeploy) {
     it('should skip for deploy mode for now', () => {})
     return
   }

--- a/test/e2e/trailingslash-with-rewrite/index.test.ts
+++ b/test/e2e/trailingslash-with-rewrite/index.test.ts
@@ -6,7 +6,7 @@ import { fetchViaHTTP } from 'next-test-utils'
 describe('trailingSlash:true with rewrites and getStaticProps', () => {
   let next: NextInstance
 
-  if (next.isDeploy) {
+  if (next.isNextDeploy) {
     it('should skip for deploy mode for now', () => {})
     return
   }

--- a/test/e2e/transpile-packages/index.test.ts
+++ b/test/e2e/transpile-packages/index.test.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDeploy, isNextDev } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import webdriver from 'next-webdriver'
 import { shouldRunTurboDevTest } from '../../lib/next-test-utils'
@@ -7,7 +7,7 @@ import { shouldRunTurboDevTest } from '../../lib/next-test-utils'
 describe('transpile packages', () => {
   let next: NextInstance
 
-  if (next.isNextDeploy) {
+  if (isNextDeploy) {
     it('should skip for deploy mode for now', () => {})
     return
   }
@@ -28,13 +28,13 @@ describe('transpile packages', () => {
         },
       },
       installCommand: 'pnpm i',
-      startCommand: next.isNextDev ? 'pnpm dev' : 'pnpm start',
+      startCommand: isNextDev ? 'pnpm dev' : 'pnpm start',
       buildCommand: 'pnpm build',
     })
   })
   afterAll(() => next.destroy())
 
-  if (next.isNextDeploy) {
+  if (isNextDeploy) {
     it('should skip tests for next-deploy and react 17', () => {})
     return
   }

--- a/test/e2e/transpile-packages/index.test.ts
+++ b/test/e2e/transpile-packages/index.test.ts
@@ -7,7 +7,7 @@ import { shouldRunTurboDevTest } from '../../lib/next-test-utils'
 describe('transpile packages', () => {
   let next: NextInstance
 
-  if (next.isDeploy) {
+  if (next.isNextDeploy) {
     it('should skip for deploy mode for now', () => {})
     return
   }
@@ -28,13 +28,13 @@ describe('transpile packages', () => {
         },
       },
       installCommand: 'pnpm i',
-      startCommand: next.isDev ? 'pnpm dev' : 'pnpm start',
+      startCommand: next.isNextDev ? 'pnpm dev' : 'pnpm start',
       buildCommand: 'pnpm build',
     })
   })
   afterAll(() => next.destroy())
 
-  if (next.isDeploy) {
+  if (next.isNextDeploy) {
     it('should skip tests for next-deploy and react 17', () => {})
     return
   }

--- a/test/e2e/transpile-packages/index.test.ts
+++ b/test/e2e/transpile-packages/index.test.ts
@@ -34,8 +34,7 @@ describe('transpile packages', () => {
   })
   afterAll(() => next.destroy())
 
-  const { isNextDeploy } = global as any
-  if (isNextDeploy) {
+  if (next.isDeploy) {
     it('should skip tests for next-deploy and react 17', () => {})
     return
   }

--- a/test/e2e/transpile-packages/index.test.ts
+++ b/test/e2e/transpile-packages/index.test.ts
@@ -7,7 +7,7 @@ import { shouldRunTurboDevTest } from '../../lib/next-test-utils'
 describe('transpile packages', () => {
   let next: NextInstance
 
-  if ((global as any).isNextDeploy) {
+  if (next.isDeploy) {
     it('should skip for deploy mode for now', () => {})
     return
   }
@@ -28,7 +28,7 @@ describe('transpile packages', () => {
         },
       },
       installCommand: 'pnpm i',
-      startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
+      startCommand: next.isDev ? 'pnpm dev' : 'pnpm start',
       buildCommand: 'pnpm build',
     })
   })

--- a/test/e2e/type-module-interop/index.test.ts
+++ b/test/e2e/type-module-interop/index.test.ts
@@ -1,4 +1,4 @@
-import { createNext } from 'e2e-utils'
+import { createNext, isNextDeploy } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 import { hasRedbox, renderViaHTTP } from 'next-test-utils'
 import webdriver from 'next-webdriver'
@@ -69,7 +69,7 @@ describe('Type module interop', () => {
     })
 
     // can't modify build output after deploy
-    if (!next.isNextDeploy) {
+    if (!isNextDeploy) {
       const contents = await next.readFile('package.json')
       const pkg = JSON.parse(contents)
       await next.patchFile(

--- a/test/e2e/type-module-interop/index.test.ts
+++ b/test/e2e/type-module-interop/index.test.ts
@@ -69,7 +69,7 @@ describe('Type module interop', () => {
     })
 
     // can't modify build output after deploy
-    if (!next.isDeploy) {
+    if (!next.isNextDeploy) {
       const contents = await next.readFile('package.json')
       const pkg = JSON.parse(contents)
       await next.patchFile(

--- a/test/e2e/type-module-interop/index.test.ts
+++ b/test/e2e/type-module-interop/index.test.ts
@@ -69,7 +69,7 @@ describe('Type module interop', () => {
     })
 
     // can't modify build output after deploy
-    if (!(global as any).isNextDeploy) {
+    if (!next.isDeploy) {
       const contents = await next.readFile('package.json')
       const pkg = JSON.parse(contents)
       await next.patchFile(

--- a/test/e2e/yarn-pnp/test/utils.ts
+++ b/test/e2e/yarn-pnp/test/utils.ts
@@ -13,7 +13,7 @@ export function runTests(
 ) {
   const versionParts = process.versions.node.split('.').map((i) => Number(i))
 
-  if ((global as any).isNextDeploy) {
+  if (next.isDeploy) {
     it('should not run for next deploy', () => {})
     return
   }
@@ -51,9 +51,7 @@ export function runTests(
           )}`
         },
         buildCommand: `yarn next build --no-lint`,
-        startCommand: (global as any).isNextDev
-          ? `yarn next`
-          : `yarn next start`,
+        startCommand: next.isDev ? `yarn next` : `yarn next start`,
       })
     })
     afterAll(() => next?.destroy())

--- a/test/e2e/yarn-pnp/test/utils.ts
+++ b/test/e2e/yarn-pnp/test/utils.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra'
 import { join } from 'path'
 import { fetchViaHTTP } from 'next-test-utils'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, isNextDeploy } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 
 jest.setTimeout(2 * 60 * 1000)
@@ -13,7 +13,7 @@ export function runTests(
 ) {
   const versionParts = process.versions.node.split('.').map((i) => Number(i))
 
-  if (next.isDeploy) {
+  if (isNextDeploy) {
     it('should not run for next deploy', () => {})
     return
   }

--- a/test/e2e/yarn-pnp/test/utils.ts
+++ b/test/e2e/yarn-pnp/test/utils.ts
@@ -51,7 +51,7 @@ export function runTests(
           )}`
         },
         buildCommand: `yarn next build --no-lint`,
-        startCommand: next.isDev ? `yarn next` : `yarn next start`,
+        startCommand: next.isNextDev ? `yarn next` : `yarn next start`,
       })
     })
     afterAll(() => next?.destroy())

--- a/test/e2e/yarn-pnp/test/utils.ts
+++ b/test/e2e/yarn-pnp/test/utils.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra'
 import { join } from 'path'
 import { fetchViaHTTP } from 'next-test-utils'
-import { createNext, FileRef, isNextDeploy } from 'e2e-utils'
+import { createNext, FileRef, isNextDeploy, isNextDev } from 'e2e-utils'
 import { NextInstance } from 'test/lib/next-modes/base'
 
 jest.setTimeout(2 * 60 * 1000)
@@ -51,7 +51,7 @@ export function runTests(
           )}`
         },
         buildCommand: `yarn next build --no-lint`,
-        startCommand: next.isNextDev ? `yarn next` : `yarn next start`,
+        startCommand: isNextDev ? `yarn next` : `yarn next start`,
       })
     })
     afterAll(() => next?.destroy())

--- a/test/lib/e2e-utils.ts
+++ b/test/lib/e2e-utils.ts
@@ -274,21 +274,21 @@ export function nextTestSetup(
 
   return {
     get isNextDev() {
-      return next.isDev
+      return next.isNextDev
     },
     get isTurbopack(): boolean {
       return Boolean(
-        next.isDev &&
+        next.isNextDev &&
           !process.env.TEST_WASM &&
           (options.turbo ?? shouldRunTurboDevTest())
       )
     },
 
     get isNextDeploy() {
-      return next.isDeploy
+      return next.isNextDeploy
     },
     get isNextStart() {
-      return next.isStart
+      return next.isNextStart
     },
     get next() {
       return nextProxy

--- a/test/lib/e2e-utils.ts
+++ b/test/lib/e2e-utils.ts
@@ -82,13 +82,21 @@ if (testModeFromFile === 'e2e') {
   testMode = 'start'
 }
 
-if (testMode === 'dev') {
-  ;(global as any).isNextDev = true
-} else if (testMode === 'deploy') {
-  ;(global as any).isNextDeploy = true
-} else {
-  ;(global as any).isNextStart = true
-}
+/**
+ * Whether the test is running in dev mode.
+ * Based on `process.env.NEXT_TEST_MODE` and the test directory.
+ */
+export const isNextDev = testMode === 'dev'
+/**
+ * Whether the test is running in deploy mode.
+ * Based on `process.env.NEXT_TEST_MODE`.
+ */
+export const isNextDeploy = testMode === 'deploy'
+/**
+ * Whether the test is running in start mode.
+ * Default mode. `true` when both `isNextDev` and `isNextDeploy` are false.
+ */
+export const isNextStart = !isNextDev && !isNextDeploy
 
 if (!testMode) {
   throw new Error(
@@ -229,7 +237,7 @@ export function nextTestSetup(
 
   if (options.skipDeployment) {
     // When the environment is running for deployment tests.
-    if ((global as any).isNextDeploy) {
+    if (isNextDeploy) {
       // eslint-disable-next-line jest/no-focused-tests
       it.only('should skip next deploy', () => {})
       // No tests are run.
@@ -265,22 +273,22 @@ export function nextTestSetup(
   })
 
   return {
-    get isNextDev(): boolean {
-      return Boolean((global as any).isNextDev)
+    get isNextDev() {
+      return isNextDev
     },
     get isTurbopack(): boolean {
       return Boolean(
-        (global as any).isNextDev &&
+        isNextDev &&
           !process.env.TEST_WASM &&
           (options.turbo ?? shouldRunTurboDevTest())
       )
     },
 
-    get isNextDeploy(): boolean {
-      return Boolean((global as any).isNextDeploy)
+    get isNextDeploy() {
+      return isNextDeploy
     },
-    get isNextStart(): boolean {
-      return Boolean((global as any).isNextStart)
+    get isNextStart() {
+      return isNextStart
     },
     get next() {
       return nextProxy

--- a/test/lib/e2e-utils.ts
+++ b/test/lib/e2e-utils.ts
@@ -274,21 +274,21 @@ export function nextTestSetup(
 
   return {
     get isNextDev() {
-      return isNextDev
+      return next.isDev
     },
     get isTurbopack(): boolean {
       return Boolean(
-        isNextDev &&
+        next.isDev &&
           !process.env.TEST_WASM &&
           (options.turbo ?? shouldRunTurboDevTest())
       )
     },
 
     get isNextDeploy() {
-      return isNextDeploy
+      return next.isDeploy
     },
     get isNextStart() {
-      return isNextStart
+      return next.isStart
     },
     get next() {
       return nextProxy

--- a/test/lib/e2e-utils.ts
+++ b/test/lib/e2e-utils.ts
@@ -274,21 +274,21 @@ export function nextTestSetup(
 
   return {
     get isNextDev() {
-      return next.isNextDev
+      return isNextDev
     },
     get isTurbopack(): boolean {
       return Boolean(
-        next.isNextDev &&
+        isNextDev &&
           !process.env.TEST_WASM &&
           (options.turbo ?? shouldRunTurboDevTest())
       )
     },
 
     get isNextDeploy() {
-      return next.isNextDeploy
+      return isNextDeploy
     },
     get isNextStart() {
-      return next.isNextStart
+      return isNextStart
     },
     get next() {
       return nextProxy

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -72,17 +72,17 @@ export class NextInstance {
    * Whether the test is running in dev mode.
    * Based on `process.env.NEXT_TEST_MODE` and the test directory.
    */
-  public isDev = isNextDev
+  public isNextDev = isNextDev
   /**
    * Whether the test is running in deploy mode.
    * Based on `process.env.NEXT_TEST_MODE`.
    */
-  public isDeploy = isNextDeploy
+  public isNextDeploy = isNextDeploy
   /**
    * Whether the test is running in start mode.
    * Default mode. `true` when both `isNextDev` and `isNextDeploy` are false.
    */
-  public isStart = isNextStart
+  public isNextStart = isNextStart
 
   constructor(opts: NextInstanceOpts) {
     this.env = {}
@@ -90,7 +90,7 @@ export class NextInstance {
 
     require('console').log('packageJson??', this.packageJson)
 
-    if (!this.isDeploy) {
+    if (!this.isNextDeploy) {
       this.env = {
         ...this.env,
         // remove node_modules/.bin repo path from env
@@ -220,7 +220,7 @@ export class NextInstance {
             !this.dependencies &&
             !this.installCommand &&
             !this.packageJson &&
-            !this.isDeploy
+            !this.isNextDeploy
           ) {
             await fs.cp(process.env.NEXT_TEST_STARTER, this.testDir, {
               recursive: true,
@@ -259,7 +259,7 @@ export class NextInstance {
           )
         }
 
-        if (this.nextConfig || (this.isDeploy && !nextConfigFile)) {
+        if (this.nextConfig || (this.isNextDeploy && !nextConfigFile)) {
           const functions = []
           const exportDeclare =
             this.packageJson?.type === 'module'
@@ -293,7 +293,7 @@ export class NextInstance {
           )
         }
 
-        if (this.isDeploy) {
+        if (this.isNextDeploy) {
           const fileName = path.join(
             this.testDir,
             nextConfigFile || 'next.config.js'
@@ -462,7 +462,7 @@ export class NextInstance {
     // TODO: replace this with an event directly from WatchPack inside
     // router-server for better accuracy
     if (
-      this.isDev &&
+      this.isNextDev &&
       (filename.startsWith('app/') || filename.startsWith('pages/'))
     ) {
       require('console').log('fs dev delay', filename)

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import { existsSync, promises as fs } from 'fs'
 import treeKill from 'tree-kill'
 import type { NextConfig } from 'next'
-import { FileRef, isNextDeploy, isNextDev, isNextStart } from '../e2e-utils'
+import { FileRef, isNextDeploy, isNextDev } from '../e2e-utils'
 import { ChildProcess } from 'child_process'
 import { createNextInstall } from '../create-next-install'
 import { Span } from 'next/src/trace'
@@ -68,21 +68,6 @@ export class NextInstance {
   public env: Record<string, string>
   public forcedPort?: string
   public dirSuffix: string = ''
-  /**
-   * Whether the test is running in dev mode.
-   * Based on `process.env.NEXT_TEST_MODE` and the test directory.
-   */
-  public isNextDev = isNextDev
-  /**
-   * Whether the test is running in deploy mode.
-   * Based on `process.env.NEXT_TEST_MODE`.
-   */
-  public isNextDeploy = isNextDeploy
-  /**
-   * Whether the test is running in start mode.
-   * Default mode. `true` when both `isNextDev` and `isNextDeploy` are false.
-   */
-  public isNextStart = isNextStart
 
   constructor(opts: NextInstanceOpts) {
     this.env = {}
@@ -90,7 +75,7 @@ export class NextInstance {
 
     require('console').log('packageJson??', this.packageJson)
 
-    if (!this.isNextDeploy) {
+    if (!isNextDeploy) {
       this.env = {
         ...this.env,
         // remove node_modules/.bin repo path from env
@@ -220,7 +205,7 @@ export class NextInstance {
             !this.dependencies &&
             !this.installCommand &&
             !this.packageJson &&
-            !this.isNextDeploy
+            !isNextDeploy
           ) {
             await fs.cp(process.env.NEXT_TEST_STARTER, this.testDir, {
               recursive: true,
@@ -259,7 +244,7 @@ export class NextInstance {
           )
         }
 
-        if (this.nextConfig || (this.isNextDeploy && !nextConfigFile)) {
+        if (this.nextConfig || (isNextDeploy && !nextConfigFile)) {
           const functions = []
           const exportDeclare =
             this.packageJson?.type === 'module'
@@ -293,7 +278,7 @@ export class NextInstance {
           )
         }
 
-        if (this.isNextDeploy) {
+        if (isNextDeploy) {
           const fileName = path.join(
             this.testDir,
             nextConfigFile || 'next.config.js'
@@ -462,7 +447,7 @@ export class NextInstance {
     // TODO: replace this with an event directly from WatchPack inside
     // router-server for better accuracy
     if (
-      this.isNextDev &&
+      isNextDev &&
       (filename.startsWith('app/') || filename.startsWith('pages/'))
     ) {
       require('console').log('fs dev delay', filename)

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import { existsSync, promises as fs } from 'fs'
 import treeKill from 'tree-kill'
 import type { NextConfig } from 'next'
-import { FileRef } from '../e2e-utils'
+import { FileRef, isNextDeploy, isNextDev, isNextStart } from '../e2e-utils'
 import { ChildProcess } from 'child_process'
 import { createNextInstall } from '../create-next-install'
 import { Span } from 'next/src/trace'
@@ -68,6 +68,21 @@ export class NextInstance {
   public env: Record<string, string>
   public forcedPort?: string
   public dirSuffix: string = ''
+  /**
+   * Whether the test is running in dev mode.
+   * Based on `process.env.NEXT_TEST_MODE` and the test directory.
+   */
+  public isDev = isNextDev
+  /**
+   * Whether the test is running in deploy mode.
+   * Based on `process.env.NEXT_TEST_MODE`.
+   */
+  public isDeploy = isNextDeploy
+  /**
+   * Whether the test is running in start mode.
+   * Default mode. `true` when both `isNextDev` and `isNextDeploy` are false.
+   */
+  public isStart = isNextStart
 
   constructor(opts: NextInstanceOpts) {
     this.env = {}
@@ -75,7 +90,7 @@ export class NextInstance {
 
     require('console').log('packageJson??', this.packageJson)
 
-    if (!(global as any).isNextDeploy) {
+    if (!this.isDeploy) {
       this.env = {
         ...this.env,
         // remove node_modules/.bin repo path from env
@@ -205,7 +220,7 @@ export class NextInstance {
             !this.dependencies &&
             !this.installCommand &&
             !this.packageJson &&
-            !(global as any).isNextDeploy
+            !this.isDeploy
           ) {
             await fs.cp(process.env.NEXT_TEST_STARTER, this.testDir, {
               recursive: true,
@@ -244,10 +259,7 @@ export class NextInstance {
           )
         }
 
-        if (
-          this.nextConfig ||
-          ((global as any).isNextDeploy && !nextConfigFile)
-        ) {
+        if (this.nextConfig || (this.isDeploy && !nextConfigFile)) {
           const functions = []
           const exportDeclare =
             this.packageJson?.type === 'module'
@@ -281,7 +293,7 @@ export class NextInstance {
           )
         }
 
-        if ((global as any).isNextDeploy) {
+        if (this.isDeploy) {
           const fileName = path.join(
             this.testDir,
             nextConfigFile || 'next.config.js'
@@ -450,7 +462,7 @@ export class NextInstance {
     // TODO: replace this with an event directly from WatchPack inside
     // router-server for better accuracy
     if (
-      (global as any).isNextDev &&
+      this.isDev &&
       (filename.startsWith('app/') || filename.startsWith('pages/'))
     ) {
       require('console').log('fs dev delay', filename)


### PR DESCRIPTION
### What?

Getting rid of unsafe/verbose `global as any` usage in tests.

This PR focuses on the usage of `isNextDev`, `isNextDeploy` and `isNextStart` properties that were previously set on `global` here: https://github.com/vercel/next.js/pull/63217/files#diff-157a11a90bcd016137cddf000757ae627dad17c2eca7bf33ca6aef37a03f9b5fL85-L91

### Why?

Consistency/type safety. Less mental overhead while working with tests.

This PR also caught the following false-positive tests. Meaning they were passing before, but actually did not test anything. This is because they were run under the unsafe `(global as any).isDev` condition, which is a misspelling of `isNextDev`. See them for a detailed explanation:

- [`b2862dd` (#63217)](https://github.com/vercel/next.js/pull/63217/commits/b2862dd028971ace2c574b0135f9e211ab6aea33)
- [`78ede13` (#63217)](https://github.com/vercel/next.js/pull/63217/commits/78ede13ab0fe6bdb4f80a4e66f56090e913e10be)
### How?

Instead of unsafe/verbose `global as any`, we can use the re-exported properties from `e2e-utils`.

NOTE: To the reviewer. "Hide whitespace changes" will simplify the diff view for some tests.

Closes NEXT-2793