### PR TITLE
feat(turbopack): emit well known error into cli

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -61,6 +61,7 @@ import {
   type StartBuilding,
   processTopLevelIssues,
   type TopLevelIssuesMap,
+  isWellKnownError,
 } from './turbopack-utils'
 import {
   propagateServerField,
@@ -666,9 +667,14 @@ export async function createHotReloaderTurbopack(
         currentEntryIssues.get(pagesEntryKey)
       if (thisEntryIssues !== undefined && thisEntryIssues.size > 0) {
         // If there is an error related to the requesting page we display it instead of the first error
-        return [...topLevelIssues, ...thisEntryIssues.values()].map(
-          (issue) => new Error(formatIssue(issue))
-        )
+        return [...topLevelIssues, ...thisEntryIssues.values()].map((issue) => {
+          const formattedIssue = formatIssue(issue)
+          if (isWellKnownError(issue)) {
+            Log.error(formattedIssue)
+          }
+
+          return new Error(formattedIssue)
+        })
       }
 
       // Otherwise, return all errors across pages

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -43,6 +43,21 @@ export async function getTurbopackJsConfig(
 
 class ModuleBuildError extends Error {}
 
+/**
+ * Thin stopgap workaround layer to mimic existing wellknown-errors-plugin in webpack's build
+ * to emit certain type of errors into cli.
+ */
+export function isWellKnownError(issue: Issue): boolean {
+  const { title } = issue
+  const formattedTitle = renderStyledStringToErrorAnsi(title)
+  // TODO: add more well known errors
+  if (formattedTitle.includes('Module not found')) {
+    return true
+  }
+
+  return false
+}
+
 export function formatIssue(issue: Issue) {
   const { filePath, title, description, source } = issue
   let { documentationLink } = issue

--- a/test/integration/jsconfig-baseurl/test/index.test.js
+++ b/test/integration/jsconfig-baseurl/test/index.test.js
@@ -48,21 +48,24 @@ describe('jsconfig.json baseurl', () => {
       const basicPage = join(appDir, 'pages/hello.js')
       const contents = await fs.readFile(basicPage, 'utf8')
 
-      await fs.writeFile(
-        basicPage,
-        contents.replace('components/world', 'components/worldd')
-      )
-      await renderViaHTTP(appPort, '/hello')
+      try {
+        await fs.writeFile(
+          basicPage,
+          contents.replace('components/world', 'components/worldd')
+        )
 
-      const found = await check(
-        () => stripAnsi(output),
-        process.env.TURBOPACK
-          ? /unable to resolve module "components\/worldd"/
-          : /Module not found: Can't resolve 'components\/worldd'/,
-        false
-      )
-      await fs.writeFile(basicPage, contents)
-      expect(found).toBe(true)
+        const found = await check(
+          async () => {
+            await renderViaHTTP(appPort, '/hello')
+            return stripAnsi(output)
+          },
+          /Module not found: Can't resolve 'components\/worldd'/,
+          false
+        )
+        expect(found).toBe(true)
+      } finally {
+        await fs.writeFile(basicPage, contents)
+      }
     })
   })
 

--- a/test/integration/jsconfig-paths/test/index.test.js
+++ b/test/integration/jsconfig-paths/test/index.test.js
@@ -68,15 +68,14 @@ function runTests() {
 
       try {
         await fs.writeFile(basicPage, contents.replace('@c/world', '@c/worldd'))
-        await renderViaHTTP(appPort, '/basic-alias')
 
         const found = await check(
-          () => stripAnsi(output),
-          process.env.TURBOPACK
-            ? /unable to resolve module "@c\/worldd"/
-            : /Module not found: Can't resolve '@c\/worldd'/,
-          false,
-          10
+          async () => {
+            await renderViaHTTP(appPort, '/basic-alias')
+            return stripAnsi(output)
+          },
+          /Module not found: Can't resolve '@c\/worldd'/,
+          false
         )
         expect(found).toBe(true)
       } finally {

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -13180,10 +13180,11 @@
     "runtimeError": false
   },
   "test/integration/jsconfig-baseurl/test/index.test.js": {
-    "passed": ["jsconfig.json baseurl default behavior should render the page"],
-    "failed": [
+    "passed": [
+      "jsconfig.json baseurl default behavior should render the page",
       "jsconfig.json baseurl default behavior should have correct module not found error"
     ],
+    "failed": [],
     "pending": [
       "jsconfig.json baseurl should build production mode should trace correctly"
     ],
@@ -13218,12 +13219,11 @@
       "jsconfig paths without baseurl default behavior should alias components",
       "jsconfig paths without baseurl default behavior should resolve a single matching alias",
       "jsconfig paths without baseurl default behavior should resolve the first item in the array first",
-      "jsconfig paths without baseurl default behavior should resolve the second item as fallback"
-    ],
-    "failed": [
+      "jsconfig paths without baseurl default behavior should resolve the second item as fallback",
       "jsconfig paths default behavior should have correct module not found error",
       "jsconfig paths without baseurl default behavior should have correct module not found error"
     ],
+    "failed": [],
     "pending": [
       "jsconfig paths should build production mode should trace correctly",
       "jsconfig paths without baseurl should build production mode should trace correctly"


### PR DESCRIPTION
### What

This is stopgap substitution to webpack's wellknownerrorsplugin. When webpack compilation hits known errors kind it emits compilation errors into cli (and dev overlay both) while turbopack currently only emits into error overlay. PR simply detects if given issue is well known, and then logs into std. 

Probably a long term there should be proper wiring instead; but for now this allows to make few things work out of the box.

Closes PACK-2727