### PR TITLE
make CacheNode properties non-optional

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -182,6 +182,8 @@ export function createEmptyCacheNode(): CacheNode {
     lazyData: null,
     rsc: null,
     prefetchRsc: null,
+    head: null,
+    prefetchHead: null,
     parallelRoutes: new Map(),
     lazyDataResolved: false,
   }

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -354,6 +354,7 @@ function InnerLayoutRouter({
       rsc: null,
       prefetchRsc: null,
       head: null,
+      prefetchHead: null,
       parallelRoutes: new Map(),
       lazyDataResolved: false,
     }

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
@@ -58,6 +58,7 @@ describe('createInitialRouterState', () => {
       lazyData: null,
       rsc: children,
       prefetchRsc: null,
+      lazyDataResolved: false,
       parallelRoutes: new Map([
         [
           'children',
@@ -77,6 +78,7 @@ describe('createInitialRouterState', () => {
                           prefetchRsc: null,
                           parallelRoutes: new Map(),
                           head: <title>Test</title>,
+                          lazyDataResolved: false,
                         },
                       ],
                     ]),
@@ -85,6 +87,7 @@ describe('createInitialRouterState', () => {
                 lazyData: null,
                 rsc: null,
                 prefetchRsc: null,
+                lazyDataResolved: false,
               },
             ],
           ]),

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
@@ -58,6 +58,8 @@ describe('createInitialRouterState', () => {
       lazyData: null,
       rsc: children,
       prefetchRsc: null,
+      head: null,
+      prefetchHead: null,
       lazyDataResolved: false,
       parallelRoutes: new Map([
         [
@@ -78,6 +80,7 @@ describe('createInitialRouterState', () => {
                           prefetchRsc: null,
                           parallelRoutes: new Map(),
                           head: <title>Test</title>,
+                          prefetchHead: null,
                           lazyDataResolved: false,
                         },
                       ],
@@ -87,6 +90,8 @@ describe('createInitialRouterState', () => {
                 lazyData: null,
                 rsc: null,
                 prefetchRsc: null,
+                head: null,
+                prefetchHead: null,
                 lazyDataResolved: false,
               },
             ],

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -42,6 +42,7 @@ export function createInitialRouterState({
     prefetchRsc: null,
     // The cache gets seeded during the first render. `initialParallelRoutes` ensures the cache from the first render is there during the second render.
     parallelRoutes: isServer ? new Map() : initialParallelRoutes,
+    lazyDataResolved: false,
   }
 
   const prefetchCache = new Map<string, PrefetchCacheEntry>()

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -40,6 +40,8 @@ export function createInitialRouterState({
     lazyData: null,
     rsc: rsc,
     prefetchRsc: null,
+    head: null,
+    prefetchHead: null,
     // The cache gets seeded during the first render. `initialParallelRoutes` ensures the cache from the first render is there during the second render.
     parallelRoutes: isServer ? new Map() : initialParallelRoutes,
     lazyDataResolved: false,

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-data-property.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-data-property.test.tsx
@@ -25,6 +25,8 @@ describe('fillCacheWithDataProperty', () => {
       lazyData: null,
       rsc: null,
       prefetchRsc: null,
+      head: null,
+      prefetchHead: null,
       parallelRoutes: new Map(),
       lazyDataResolved: false,
     }
@@ -32,6 +34,8 @@ describe('fillCacheWithDataProperty', () => {
       lazyData: null,
       rsc: <>Root layout</>,
       prefetchRsc: null,
+      head: null,
+      prefetchHead: null,
       lazyDataResolved: false,
       parallelRoutes: new Map([
         [
@@ -44,6 +48,8 @@ describe('fillCacheWithDataProperty', () => {
                 rsc: <>Linking</>,
                 prefetchRsc: null,
                 lazyDataResolved: false,
+                head: null,
+                prefetchHead: null,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -54,6 +60,8 @@ describe('fillCacheWithDataProperty', () => {
                           lazyData: null,
                           rsc: <>Page</>,
                           prefetchRsc: null,
+                          head: null,
+                          prefetchHead: null,
                           parallelRoutes: new Map(),
                           lazyDataResolved: false,
                         },
@@ -74,19 +82,23 @@ describe('fillCacheWithDataProperty', () => {
 
     expect(cache).toMatchInlineSnapshot(`
       {
+        "head": null,
         "lazyData": null,
         "lazyDataResolved": false,
         "parallelRoutes": Map {
           "children" => Map {
             "linking" => {
+              "head": null,
               "lazyData": null,
               "lazyDataResolved": false,
               "parallelRoutes": Map {
                 "children" => Map {
                   "" => {
+                    "head": null,
                     "lazyData": null,
                     "lazyDataResolved": false,
                     "parallelRoutes": Map {},
+                    "prefetchHead": null,
                     "prefetchRsc": null,
                     "rsc": <React.Fragment>
                       Page
@@ -94,20 +106,24 @@ describe('fillCacheWithDataProperty', () => {
                   },
                 },
               },
+              "prefetchHead": null,
               "prefetchRsc": null,
               "rsc": <React.Fragment>
                 Linking
               </React.Fragment>,
             },
             "dashboard" => {
+              "head": null,
               "lazyData": Promise {},
               "lazyDataResolved": false,
               "parallelRoutes": Map {},
+              "prefetchHead": null,
               "prefetchRsc": null,
               "rsc": null,
             },
           },
         },
+        "prefetchHead": null,
         "prefetchRsc": null,
         "rsc": null,
       }

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-data-property.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-data-property.test.tsx
@@ -26,11 +26,13 @@ describe('fillCacheWithDataProperty', () => {
       rsc: null,
       prefetchRsc: null,
       parallelRoutes: new Map(),
+      lazyDataResolved: false,
     }
     const existingCache: CacheNode = {
       lazyData: null,
       rsc: <>Root layout</>,
       prefetchRsc: null,
+      lazyDataResolved: false,
       parallelRoutes: new Map([
         [
           'children',
@@ -41,6 +43,7 @@ describe('fillCacheWithDataProperty', () => {
                 lazyData: null,
                 rsc: <>Linking</>,
                 prefetchRsc: null,
+                lazyDataResolved: false,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -52,6 +55,7 @@ describe('fillCacheWithDataProperty', () => {
                           rsc: <>Page</>,
                           prefetchRsc: null,
                           parallelRoutes: new Map(),
+                          lazyDataResolved: false,
                         },
                       ],
                     ]),
@@ -71,14 +75,17 @@ describe('fillCacheWithDataProperty', () => {
     expect(cache).toMatchInlineSnapshot(`
       {
         "lazyData": null,
+        "lazyDataResolved": false,
         "parallelRoutes": Map {
           "children" => Map {
             "linking" => {
               "lazyData": null,
+              "lazyDataResolved": false,
               "parallelRoutes": Map {
                 "children" => Map {
                   "" => {
                     "lazyData": null,
+                    "lazyDataResolved": false,
                     "parallelRoutes": Map {},
                     "prefetchRsc": null,
                     "rsc": <React.Fragment>
@@ -94,6 +101,7 @@ describe('fillCacheWithDataProperty', () => {
             },
             "dashboard" => {
               "lazyData": Promise {},
+              "lazyDataResolved": false,
               "parallelRoutes": Map {},
               "prefetchRsc": null,
               "rsc": null,

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-data-property.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-data-property.ts
@@ -41,6 +41,8 @@ export function fillCacheWithDataProperty(
         lazyData: fetchResponse(),
         rsc: null,
         prefetchRsc: null,
+        head: null,
+        prefetchHead: null,
         parallelRoutes: new Map(),
         lazyDataResolved: false,
       })
@@ -55,6 +57,8 @@ export function fillCacheWithDataProperty(
         lazyData: fetchResponse(),
         rsc: null,
         prefetchRsc: null,
+        head: null,
+        prefetchHead: null,
         parallelRoutes: new Map(),
         lazyDataResolved: false,
       })
@@ -67,7 +71,10 @@ export function fillCacheWithDataProperty(
       lazyData: childCacheNode.lazyData,
       rsc: childCacheNode.rsc,
       prefetchRsc: childCacheNode.prefetchRsc,
+      head: childCacheNode.head,
+      prefetchHead: childCacheNode.prefetchHead,
       parallelRoutes: new Map(childCacheNode.parallelRoutes),
+      lazyDataResolved: childCacheNode.lazyDataResolved,
     } as CacheNode
     childSegmentMap.set(cacheKey, childCacheNode)
   }

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-data-property.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-data-property.ts
@@ -42,6 +42,7 @@ export function fillCacheWithDataProperty(
         rsc: null,
         prefetchRsc: null,
         parallelRoutes: new Map(),
+        lazyDataResolved: false,
       })
     }
     return
@@ -55,6 +56,7 @@ export function fillCacheWithDataProperty(
         rsc: null,
         prefetchRsc: null,
         parallelRoutes: new Map(),
+        lazyDataResolved: false,
       })
     }
     return

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
@@ -30,6 +30,8 @@ describe('fillCacheWithNewSubtreeData', () => {
       lazyData: null,
       rsc: null,
       prefetchRsc: null,
+      head: null,
+      prefetchHead: null,
       parallelRoutes: new Map(),
       lazyDataResolved: false,
     }
@@ -37,6 +39,8 @@ describe('fillCacheWithNewSubtreeData', () => {
       lazyData: null,
       rsc: <>Root layout</>,
       prefetchRsc: null,
+      head: null,
+      prefetchHead: null,
       lazyDataResolved: false,
       parallelRoutes: new Map([
         [
@@ -48,6 +52,8 @@ describe('fillCacheWithNewSubtreeData', () => {
                 lazyData: null,
                 rsc: <>Linking</>,
                 prefetchRsc: null,
+                head: null,
+                prefetchHead: null,
                 lazyDataResolved: false,
                 parallelRoutes: new Map([
                   [
@@ -59,6 +65,8 @@ describe('fillCacheWithNewSubtreeData', () => {
                           lazyData: null,
                           rsc: <>Page</>,
                           prefetchRsc: null,
+                          head: null,
+                          prefetchHead: null,
                           lazyDataResolved: false,
                           parallelRoutes: new Map(),
                         },
@@ -88,6 +96,8 @@ describe('fillCacheWithNewSubtreeData', () => {
       lazyData: null,
       rsc: null,
       prefetchRsc: null,
+      head: null,
+      prefetchHead: null,
       lazyDataResolved: false,
       parallelRoutes: new Map([
         [
@@ -99,6 +109,8 @@ describe('fillCacheWithNewSubtreeData', () => {
                 lazyData: null,
                 rsc: <>Linking</>,
                 prefetchRsc: null,
+                head: null,
+                prefetchHead: null,
                 lazyDataResolved: false,
                 parallelRoutes: new Map([
                   [
@@ -111,6 +123,8 @@ describe('fillCacheWithNewSubtreeData', () => {
                           lazyData: null,
                           rsc: <>Page</>,
                           prefetchRsc: null,
+                          head: null,
+                          prefetchHead: null,
                           lazyDataResolved: false,
                           parallelRoutes: new Map(),
                         },
@@ -120,6 +134,8 @@ describe('fillCacheWithNewSubtreeData', () => {
                         {
                           lazyData: null,
                           lazyDataResolved: false,
+                          head: null,
+                          prefetchHead: null,
                           parallelRoutes: new Map([
                             [
                               'children',
@@ -131,6 +147,7 @@ describe('fillCacheWithNewSubtreeData', () => {
                                     rsc: null,
                                     prefetchRsc: null,
                                     parallelRoutes: new Map(),
+                                    prefetchHead: null,
                                     head: (
                                       <>
                                         <title>Head Injected!</title>

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
@@ -31,11 +31,13 @@ describe('fillCacheWithNewSubtreeData', () => {
       rsc: null,
       prefetchRsc: null,
       parallelRoutes: new Map(),
+      lazyDataResolved: false,
     }
     const existingCache: CacheNode = {
       lazyData: null,
       rsc: <>Root layout</>,
       prefetchRsc: null,
+      lazyDataResolved: false,
       parallelRoutes: new Map([
         [
           'children',
@@ -46,6 +48,7 @@ describe('fillCacheWithNewSubtreeData', () => {
                 lazyData: null,
                 rsc: <>Linking</>,
                 prefetchRsc: null,
+                lazyDataResolved: false,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -56,6 +59,7 @@ describe('fillCacheWithNewSubtreeData', () => {
                           lazyData: null,
                           rsc: <>Page</>,
                           prefetchRsc: null,
+                          lazyDataResolved: false,
                           parallelRoutes: new Map(),
                         },
                       ],
@@ -84,6 +88,7 @@ describe('fillCacheWithNewSubtreeData', () => {
       lazyData: null,
       rsc: null,
       prefetchRsc: null,
+      lazyDataResolved: false,
       parallelRoutes: new Map([
         [
           'children',
@@ -94,6 +99,7 @@ describe('fillCacheWithNewSubtreeData', () => {
                 lazyData: null,
                 rsc: <>Linking</>,
                 prefetchRsc: null,
+                lazyDataResolved: false,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -105,6 +111,7 @@ describe('fillCacheWithNewSubtreeData', () => {
                           lazyData: null,
                           rsc: <>Page</>,
                           prefetchRsc: null,
+                          lazyDataResolved: false,
                           parallelRoutes: new Map(),
                         },
                       ],
@@ -112,6 +119,7 @@ describe('fillCacheWithNewSubtreeData', () => {
                         'about',
                         {
                           lazyData: null,
+                          lazyDataResolved: false,
                           parallelRoutes: new Map([
                             [
                               'children',

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
@@ -56,6 +56,7 @@ export function fillCacheWithNewSubTreeData(
         parallelRoutes: existingChildCacheNode
           ? new Map(existingChildCacheNode.parallelRoutes)
           : new Map(),
+        lazyDataResolved: false,
       }
 
       if (existingChildCacheNode) {
@@ -92,6 +93,7 @@ export function fillCacheWithNewSubTreeData(
       rsc: childCacheNode.rsc,
       prefetchRsc: childCacheNode.prefetchRsc,
       parallelRoutes: new Map(childCacheNode.parallelRoutes),
+      lazyDataResolved: false,
     } as CacheNode
     childSegmentMap.set(cacheKey, childCacheNode)
   }

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
@@ -52,6 +52,8 @@ export function fillCacheWithNewSubTreeData(
         lazyData: null,
         rsc,
         prefetchRsc: null,
+        head: null,
+        prefetchHead: null,
         // Ensure segments other than the one we got data for are preserved.
         parallelRoutes: existingChildCacheNode
           ? new Map(existingChildCacheNode.parallelRoutes)
@@ -92,6 +94,8 @@ export function fillCacheWithNewSubTreeData(
       lazyData: childCacheNode.lazyData,
       rsc: childCacheNode.rsc,
       prefetchRsc: childCacheNode.prefetchRsc,
+      head: childCacheNode.head,
+      prefetchHead: childCacheNode.prefetchHead,
       parallelRoutes: new Map(childCacheNode.parallelRoutes),
       lazyDataResolved: false,
     } as CacheNode

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
@@ -39,6 +39,8 @@ describe('fillLazyItemsTillLeafWithHead', () => {
       lazyData: null,
       rsc: null,
       prefetchRsc: null,
+      head: null,
+      prefetchHead: null,
       parallelRoutes: new Map(),
       lazyDataResolved: false,
     }
@@ -46,6 +48,8 @@ describe('fillLazyItemsTillLeafWithHead', () => {
       lazyData: null,
       rsc: <>Root layout</>,
       prefetchRsc: null,
+      head: null,
+      prefetchHead: null,
       lazyDataResolved: false,
       parallelRoutes: new Map([
         [
@@ -57,6 +61,8 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                 lazyData: null,
                 rsc: <>Linking</>,
                 prefetchRsc: null,
+                head: null,
+                prefetchHead: null,
                 lazyDataResolved: false,
                 parallelRoutes: new Map([
                   [
@@ -68,6 +74,8 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                           lazyData: null,
                           rsc: <>Page</>,
                           prefetchRsc: null,
+                          head: null,
+                          prefetchHead: null,
                           lazyDataResolved: false,
                           parallelRoutes: new Map(),
                         },
@@ -103,6 +111,8 @@ describe('fillLazyItemsTillLeafWithHead', () => {
       lazyData: null,
       rsc: null,
       prefetchRsc: null,
+      head: null,
+      prefetchHead: null,
       lazyDataResolved: false,
       parallelRoutes: new Map([
         [
@@ -114,6 +124,8 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                 lazyData: null,
                 rsc: null,
                 prefetchRsc: null,
+                head: null,
+                prefetchHead: null,
                 lazyDataResolved: false,
                 parallelRoutes: new Map([
                   [
@@ -134,6 +146,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                                     lazyData: null,
                                     rsc: null,
                                     prefetchRsc: null,
+                                    prefetchHead: null,
                                     parallelRoutes: new Map(),
                                     lazyDataResolved: false,
                                     head: (
@@ -148,6 +161,8 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                           ]),
                           rsc: null,
                           prefetchRsc: null,
+                          head: null,
+                          prefetchHead: null,
                         },
                       ],
                       [
@@ -156,6 +171,8 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                           lazyData: null,
                           rsc: <>Page</>,
                           prefetchRsc: null,
+                          head: null,
+                          prefetchHead: null,
                           parallelRoutes: new Map(),
                           lazyDataResolved: false,
                         },

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
@@ -40,11 +40,13 @@ describe('fillLazyItemsTillLeafWithHead', () => {
       rsc: null,
       prefetchRsc: null,
       parallelRoutes: new Map(),
+      lazyDataResolved: false,
     }
     const existingCache: CacheNode = {
       lazyData: null,
       rsc: <>Root layout</>,
       prefetchRsc: null,
+      lazyDataResolved: false,
       parallelRoutes: new Map([
         [
           'children',
@@ -55,6 +57,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                 lazyData: null,
                 rsc: <>Linking</>,
                 prefetchRsc: null,
+                lazyDataResolved: false,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -65,6 +68,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                           lazyData: null,
                           rsc: <>Page</>,
                           prefetchRsc: null,
+                          lazyDataResolved: false,
                           parallelRoutes: new Map(),
                         },
                       ],
@@ -99,6 +103,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
       lazyData: null,
       rsc: null,
       prefetchRsc: null,
+      lazyDataResolved: false,
       parallelRoutes: new Map([
         [
           'children',
@@ -109,6 +114,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                 lazyData: null,
                 rsc: null,
                 prefetchRsc: null,
+                lazyDataResolved: false,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -117,6 +123,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                         'about',
                         {
                           lazyData: null,
+                          lazyDataResolved: false,
                           parallelRoutes: new Map([
                             [
                               'children',
@@ -128,6 +135,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                                     rsc: null,
                                     prefetchRsc: null,
                                     parallelRoutes: new Map(),
+                                    lazyDataResolved: false,
                                     head: (
                                       <>
                                         <title>About page!</title>
@@ -149,6 +157,7 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                           rsc: <>Page</>,
                           prefetchRsc: null,
                           parallelRoutes: new Map(),
+                          lazyDataResolved: false,
                         },
                       ],
                     ]),

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
@@ -66,6 +66,7 @@ export function fillLazyItemsTillLeafWithHead(
             // old behavior — no PPR value.
             prefetchRsc: null,
             parallelRoutes: new Map(existingCacheNode?.parallelRoutes),
+            lazyDataResolved: false,
           }
         } else if (hasReusablePrefetch && existingCacheNode) {
           // No new data was sent from the server, but the existing cache node
@@ -87,6 +88,7 @@ export function fillLazyItemsTillLeafWithHead(
             rsc: null,
             prefetchRsc: null,
             parallelRoutes: new Map(existingCacheNode?.parallelRoutes),
+            lazyDataResolved: false,
           }
         }
 
@@ -116,6 +118,7 @@ export function fillLazyItemsTillLeafWithHead(
         rsc: seedNode,
         prefetchRsc: null,
         parallelRoutes: new Map(),
+        lazyDataResolved: false,
       }
     } else {
       // No data available for this node. This will trigger a lazy fetch
@@ -125,6 +128,7 @@ export function fillLazyItemsTillLeafWithHead(
         rsc: null,
         prefetchRsc: null,
         parallelRoutes: new Map(),
+        lazyDataResolved: false,
       }
     }
 

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
@@ -65,6 +65,8 @@ export function fillLazyItemsTillLeafWithHead(
             // `prefetchRsc`. As an incremental step, we'll just de-opt to the
             // old behavior — no PPR value.
             prefetchRsc: null,
+            head: null,
+            prefetchHead: null,
             parallelRoutes: new Map(existingCacheNode?.parallelRoutes),
             lazyDataResolved: false,
           }
@@ -78,7 +80,10 @@ export function fillLazyItemsTillLeafWithHead(
             // just cloning the existing cache node, we might as well keep the
             // PPR value, if it exists.
             prefetchRsc: existingCacheNode.prefetchRsc,
+            head: existingCacheNode.head,
+            prefetchHead: existingCacheNode.prefetchHead,
             parallelRoutes: new Map(existingCacheNode.parallelRoutes),
+            lazyDataResolved: existingCacheNode.lazyDataResolved,
           } as CacheNode
         } else {
           // No data available for this node. This will trigger a lazy fetch
@@ -87,6 +92,8 @@ export function fillLazyItemsTillLeafWithHead(
             lazyData: null,
             rsc: null,
             prefetchRsc: null,
+            head: null,
+            prefetchHead: null,
             parallelRoutes: new Map(existingCacheNode?.parallelRoutes),
             lazyDataResolved: false,
           }
@@ -117,6 +124,8 @@ export function fillLazyItemsTillLeafWithHead(
         lazyData: null,
         rsc: seedNode,
         prefetchRsc: null,
+        head: null,
+        prefetchHead: null,
         parallelRoutes: new Map(),
         lazyDataResolved: false,
       }
@@ -127,6 +136,8 @@ export function fillLazyItemsTillLeafWithHead(
         lazyData: null,
         rsc: null,
         prefetchRsc: null,
+        head: null,
+        prefetchHead: null,
         parallelRoutes: new Map(),
         lazyDataResolved: false,
       }

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
@@ -31,6 +31,8 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
       lazyData: null,
       rsc: null,
       prefetchRsc: null,
+      head: null,
+      prefetchHead: null,
       parallelRoutes: new Map(),
       lazyDataResolved: false,
     }
@@ -38,6 +40,8 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
       lazyData: null,
       rsc: <>Root layout</>,
       prefetchRsc: null,
+      head: null,
+      prefetchHead: null,
       lazyDataResolved: false,
       parallelRoutes: new Map([
         [
@@ -49,6 +53,8 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
                 lazyData: null,
                 rsc: <>Linking</>,
                 prefetchRsc: null,
+                head: null,
+                prefetchHead: null,
                 lazyDataResolved: false,
                 parallelRoutes: new Map([
                   [
@@ -60,6 +66,8 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
                           lazyData: null,
                           rsc: <>Page</>,
                           prefetchRsc: null,
+                          head: null,
+                          prefetchHead: null,
                           lazyDataResolved: false,
                           parallelRoutes: new Map(),
                         },
@@ -100,6 +108,8 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
     const expectedCache: CacheNode = {
       lazyData: null,
       lazyDataResolved: false,
+      head: null,
+      prefetchHead: null,
       parallelRoutes: new Map([
         [
           'children',
@@ -109,6 +119,8 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
               {
                 lazyData: null,
                 lazyDataResolved: false,
+                head: null,
+                prefetchHead: null,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -120,6 +132,8 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
                           parallelRoutes: new Map(),
                           rsc: <React.Fragment>Page</React.Fragment>,
                           prefetchRsc: null,
+                          head: null,
+                          prefetchHead: null,
                           lazyDataResolved: false,
                         },
                       ],

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
@@ -32,11 +32,13 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
       rsc: null,
       prefetchRsc: null,
       parallelRoutes: new Map(),
+      lazyDataResolved: false,
     }
     const existingCache: CacheNode = {
       lazyData: null,
       rsc: <>Root layout</>,
       prefetchRsc: null,
+      lazyDataResolved: false,
       parallelRoutes: new Map([
         [
           'children',
@@ -47,6 +49,7 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
                 lazyData: null,
                 rsc: <>Linking</>,
                 prefetchRsc: null,
+                lazyDataResolved: false,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -57,6 +60,7 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
                           lazyData: null,
                           rsc: <>Page</>,
                           prefetchRsc: null,
+                          lazyDataResolved: false,
                           parallelRoutes: new Map(),
                         },
                       ],
@@ -95,6 +99,7 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
 
     const expectedCache: CacheNode = {
       lazyData: null,
+      lazyDataResolved: false,
       parallelRoutes: new Map([
         [
           'children',
@@ -103,6 +108,7 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
               'linking',
               {
                 lazyData: null,
+                lazyDataResolved: false,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -114,6 +120,7 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
                           parallelRoutes: new Map(),
                           rsc: <React.Fragment>Page</React.Fragment>,
                           prefetchRsc: null,
+                          lazyDataResolved: false,
                         },
                       ],
                     ]),

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.ts
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.ts
@@ -51,6 +51,7 @@ export function invalidateCacheBelowFlightSegmentPath(
       rsc: childCacheNode.rsc,
       prefetchRsc: childCacheNode.prefetchRsc,
       parallelRoutes: new Map(childCacheNode.parallelRoutes),
+      lazyDataResolved: false,
     } as CacheNode
     childSegmentMap.set(cacheKey, childCacheNode)
   }

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.ts
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.ts
@@ -50,8 +50,10 @@ export function invalidateCacheBelowFlightSegmentPath(
       lazyData: childCacheNode.lazyData,
       rsc: childCacheNode.rsc,
       prefetchRsc: childCacheNode.prefetchRsc,
+      head: childCacheNode.head,
+      prefetchHead: childCacheNode.prefetchHead,
       parallelRoutes: new Map(childCacheNode.parallelRoutes),
-      lazyDataResolved: false,
+      lazyDataResolved: childCacheNode.lazyDataResolved,
     } as CacheNode
     childSegmentMap.set(cacheKey, childCacheNode)
   }

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.test.tsx
@@ -10,11 +10,13 @@ describe('invalidateCacheByRouterState', () => {
       rsc: null,
       prefetchRsc: null,
       parallelRoutes: new Map(),
+      lazyDataResolved: false,
     }
     const existingCache: CacheNode = {
       lazyData: null,
       rsc: <>Root layout</>,
       prefetchRsc: null,
+      lazyDataResolved: false,
       parallelRoutes: new Map([
         [
           'children',
@@ -25,6 +27,7 @@ describe('invalidateCacheByRouterState', () => {
                 lazyData: null,
                 rsc: <>Linking</>,
                 prefetchRsc: null,
+                lazyDataResolved: false,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -35,6 +38,7 @@ describe('invalidateCacheByRouterState', () => {
                           lazyData: null,
                           rsc: <>Page</>,
                           prefetchRsc: null,
+                          lazyDataResolved: false,
                           parallelRoutes: new Map(),
                         },
                       ],
@@ -74,6 +78,7 @@ describe('invalidateCacheByRouterState', () => {
       lazyData: null,
       rsc: null,
       prefetchRsc: null,
+      lazyDataResolved: false,
       parallelRoutes: new Map([['children', new Map()]]),
     }
 

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.test.tsx
@@ -9,6 +9,8 @@ describe('invalidateCacheByRouterState', () => {
       lazyData: null,
       rsc: null,
       prefetchRsc: null,
+      head: null,
+      prefetchHead: null,
       parallelRoutes: new Map(),
       lazyDataResolved: false,
     }
@@ -16,6 +18,8 @@ describe('invalidateCacheByRouterState', () => {
       lazyData: null,
       rsc: <>Root layout</>,
       prefetchRsc: null,
+      head: null,
+      prefetchHead: null,
       lazyDataResolved: false,
       parallelRoutes: new Map([
         [
@@ -27,6 +31,8 @@ describe('invalidateCacheByRouterState', () => {
                 lazyData: null,
                 rsc: <>Linking</>,
                 prefetchRsc: null,
+                head: null,
+                prefetchHead: null,
                 lazyDataResolved: false,
                 parallelRoutes: new Map([
                   [
@@ -38,6 +44,8 @@ describe('invalidateCacheByRouterState', () => {
                           lazyData: null,
                           rsc: <>Page</>,
                           prefetchRsc: null,
+                          head: null,
+                          prefetchHead: null,
                           lazyDataResolved: false,
                           parallelRoutes: new Map(),
                         },
@@ -78,6 +86,8 @@ describe('invalidateCacheByRouterState', () => {
       lazyData: null,
       rsc: null,
       prefetchRsc: null,
+      head: null,
+      prefetchHead: null,
       lazyDataResolved: false,
       parallelRoutes: new Map([['children', new Map()]]),
     }

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -236,6 +236,7 @@ export function updateCacheNodeOnNavigation(
 
     // Everything is cloned except for the children, which we computed above.
     parallelRoutes: prefetchParallelRoutes,
+    lazyDataResolved: false,
   }
 
   return {
@@ -523,6 +524,7 @@ function createPendingCacheNode(
     // response is received from the server.
     rsc: createDeferredRsc(),
     head: isLeafSegment ? createDeferredRsc() : null,
+    lazyDataResolved: false,
   }
 }
 
@@ -763,6 +765,7 @@ export function updateCacheNodeOnPopstateRestoration(
 
     // These are the cloned children we computed above
     parallelRoutes: newParallelRoutes,
+    lazyDataResolved: false,
   }
 }
 

--- a/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx
@@ -29,6 +29,7 @@ describe('findHeadInCache', () => {
       lazyData: null,
       rsc: null,
       prefetchRsc: null,
+      lazyDataResolved: false,
       parallelRoutes: new Map([
         [
           'children',
@@ -39,6 +40,7 @@ describe('findHeadInCache', () => {
                 lazyData: null,
                 rsc: null,
                 prefetchRsc: null,
+                lazyDataResolved: false,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -47,6 +49,7 @@ describe('findHeadInCache', () => {
                         'about',
                         {
                           lazyData: null,
+                          lazyDataResolved: false,
                           parallelRoutes: new Map([
                             [
                               'children',
@@ -57,6 +60,7 @@ describe('findHeadInCache', () => {
                                     lazyData: null,
                                     rsc: null,
                                     prefetchRsc: null,
+                                    lazyDataResolved: false,
                                     parallelRoutes: new Map(),
                                     head: (
                                       <>

--- a/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx
@@ -29,6 +29,8 @@ describe('findHeadInCache', () => {
       lazyData: null,
       rsc: null,
       prefetchRsc: null,
+      head: null,
+      prefetchHead: null,
       lazyDataResolved: false,
       parallelRoutes: new Map([
         [
@@ -40,6 +42,8 @@ describe('findHeadInCache', () => {
                 lazyData: null,
                 rsc: null,
                 prefetchRsc: null,
+                head: null,
+                prefetchHead: null,
                 lazyDataResolved: false,
                 parallelRoutes: new Map([
                   [
@@ -50,6 +54,8 @@ describe('findHeadInCache', () => {
                         {
                           lazyData: null,
                           lazyDataResolved: false,
+                          head: null,
+                          prefetchHead: null,
                           parallelRoutes: new Map([
                             [
                               'children',
@@ -60,6 +66,7 @@ describe('findHeadInCache', () => {
                                     lazyData: null,
                                     rsc: null,
                                     prefetchRsc: null,
+                                    prefetchHead: null,
                                     lazyDataResolved: false,
                                     parallelRoutes: new Map(),
                                     head: (

--- a/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
@@ -51,12 +51,8 @@ export type LazyCacheNode = {
    */
   lazyData: Promise<FetchServerResponseResult> | null
 
-  // TODO: We should make both of these non-optional. Most of the places that
-  // clone the Cache Nodes do not preserve this field. In practice this ends up
-  // working out because we only clone nodes when we're receiving a new head,
-  // anyway. But it's fragile. It also breaks monomorphization.
-  prefetchHead?: React.ReactNode
-  head?: React.ReactNode
+  prefetchHead: React.ReactNode
+  head: React.ReactNode
   /**
    * Child parallel routes.
    */
@@ -99,8 +95,8 @@ export type ReadyCacheNode = {
    * There should never be a lazy data request in this case.
    */
   lazyData: null
-  prefetchHead?: React.ReactNode
-  head?: React.ReactNode
+  prefetchHead: React.ReactNode
+  head: React.ReactNode
   parallelRoutes: Map<string, ChildSegmentMap>
 }
 

--- a/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
@@ -21,7 +21,7 @@ export type LazyCacheNode = {
    * Whether the lazy cache node data promise has been resolved.
    * This value is only true after we've called `use` on the promise (and applied the data to the tree).
    */
-  lazyDataResolved?: boolean
+  lazyDataResolved: boolean
   /**
    * When rsc is null, this is a lazily-initialized cache node.
    *
@@ -68,7 +68,7 @@ export type ReadyCacheNode = {
    * Whether the lazy cache node data promise has been resolved.
    * This value is only true after we've called `use` on the promise (and applied the data to the tree).
    */
-  lazyDataResolved?: boolean
+  lazyDataResolved: boolean
   /**
    * When rsc is not null, it represents the RSC data for the
    * corresponding segment.


### PR DESCRIPTION
No behavior changes in this PR -- this is a refactor to remove the optional types on `CacheNode` to be more explicit when we aren't copying over a value and to help with monomorphization. There's still work to be done to ensure consistent property order, which will come in a separate PR. 

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2794