### PR TITLE
fix(turbopack): Do not report hmr timing twice

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -243,13 +243,13 @@ export async function createHotReloaderTurbopack(
     }
     buildingIds.add(id)
     return function finishBuilding() {
-      hmrEventHappened = false
       if (buildingIds.size === 0) {
         return
       }
       readyIds.add(id)
       buildingIds.delete(id)
       if (buildingIds.size === 0) {
+        hmrEventHappened = false
         consoleStore.setState(
           {
             loading: false,

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -243,6 +243,7 @@ export async function createHotReloaderTurbopack(
     }
     buildingIds.add(id)
     return function finishBuilding() {
+      hmrEventHappened = false
       if (buildingIds.size === 0) {
         return
       }


### PR DESCRIPTION
### What?

Make turbopack not emit HMR timing report twice.

### Why?

We should not report HMR update twice.

### How?

Closes PACK-2581

