### PR TITLE
build: Update turbopack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "serde",
  "smallvec",
@@ -3217,7 +3217,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "serde",
@@ -7159,7 +7159,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7191,7 +7191,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7203,7 +7203,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7218,7 +7218,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7232,7 +7232,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7249,7 +7249,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7281,7 +7281,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "base16",
  "hex",
@@ -7293,7 +7293,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7307,7 +7307,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7317,7 +7317,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "mimalloc",
 ]
@@ -7325,7 +7325,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7350,7 +7350,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7383,7 +7383,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7423,7 +7423,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7449,7 +7449,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "clap",
@@ -7468,7 +7468,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7499,7 +7499,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7527,7 +7527,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7564,7 +7564,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7602,7 +7602,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "serde",
  "serde_json",
@@ -7613,7 +7613,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7638,7 +7638,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7655,7 +7655,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7671,7 +7671,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7691,7 +7691,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "serde",
@@ -7706,7 +7706,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7721,7 +7721,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7759,7 +7759,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7783,7 +7783,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7805,7 +7805,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "serde",
@@ -7821,7 +7821,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7832,7 +7832,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -7848,7 +7848,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240312.5#70c36cbcce9db8870ebbf3faa20cc12fad6b6284"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "serde",
  "smallvec",
@@ -3217,7 +3217,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "serde",
@@ -7159,7 +7159,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7191,7 +7191,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7203,7 +7203,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7218,7 +7218,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7232,7 +7232,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7249,7 +7249,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7281,7 +7281,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "base16",
  "hex",
@@ -7293,7 +7293,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7307,7 +7307,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7317,7 +7317,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "mimalloc",
 ]
@@ -7325,7 +7325,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7350,7 +7350,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7383,7 +7383,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7423,7 +7423,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7449,7 +7449,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "clap",
@@ -7468,7 +7468,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7499,7 +7499,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7527,7 +7527,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7564,7 +7564,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7602,7 +7602,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "serde",
  "serde_json",
@@ -7613,7 +7613,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7638,7 +7638,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7655,7 +7655,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7671,7 +7671,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7691,7 +7691,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "serde",
@@ -7706,7 +7706,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7721,7 +7721,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7759,7 +7759,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7783,7 +7783,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7805,7 +7805,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "serde",
@@ -7821,7 +7821,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7832,7 +7832,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -7848,7 +7848,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/lcss-classname#f20b2438ed9cb75400e946bdd3fffb4d4a241517"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240313.3#20eabe84f03840f4f6c500e4a8629b1709149cd1"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.90.17", features = [
 testing = { version = "0.35.20" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240312.5" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/lcss-classname" } # last tag: "turbopack-240312.5"
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240312.5" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/lcss-classname" } # last tag: "turbopack-240312.5"
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240312.5" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/lcss-classname" } # last tag: "turbopack-240312.5"
 
 # General Deps
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.90.17", features = [
 testing = { version = "0.35.20" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/lcss-classname" } # last tag: "turbopack-240312.5"
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240313.3" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/lcss-classname" } # last tag: "turbopack-240312.5"
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240313.3" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/lcss-classname" } # last tag: "turbopack-240312.5"
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240313.3" }
 
 # General Deps
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -192,7 +192,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.4",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?f20b2438ed9cb75400e946bdd3fffb4d4a241517",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240313.3",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -192,7 +192,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.4",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240312.5",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?f20b2438ed9cb75400e946bdd3fffb4d4a241517",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1071,8 +1071,8 @@ importers:
         specifier: 0.26.4
         version: 0.26.4
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240312.5
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240312.5'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?f20b2438ed9cb75400e946bdd3fffb4d4a241517
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?f20b2438ed9cb75400e946bdd3fffb4d4a241517'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -25494,8 +25494,8 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240312.5':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240312.5}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?f20b2438ed9cb75400e946bdd3fffb4d4a241517':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?f20b2438ed9cb75400e946bdd3fffb4d4a241517}
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1071,8 +1071,8 @@ importers:
         specifier: 0.26.4
         version: 0.26.4
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?f20b2438ed9cb75400e946bdd3fffb4d4a241517
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?f20b2438ed9cb75400e946bdd3fffb4d4a241517'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240313.3
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240313.3'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -25494,8 +25494,8 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?f20b2438ed9cb75400e946bdd3fffb4d4a241517':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?f20b2438ed9cb75400e946bdd3fffb4d4a241517}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240313.3':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240313.3}
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/test/development/app-dir/experimental-lightningcss/experimental-lightningcss.test.ts
+++ b/test/development/app-dir/experimental-lightningcss/experimental-lightningcss.test.ts
@@ -12,7 +12,7 @@ describeVariants.each(['turbo'])('experimental-lightningcss', () => {
     expect($('p').text()).toBe('hello world')
     // swc_css does not include `-module` in the class name, while lightningcss does.
     expect($('p').attr('class')).toBe(
-      'search-keyword hlQ3RG__style-module__blue'
+      'search-keyword style-module__hlQ3RG__blue'
     )
   })
 })

--- a/test/development/app-dir/experimental-lightningcss/experimental-lightningcss.test.ts
+++ b/test/development/app-dir/experimental-lightningcss/experimental-lightningcss.test.ts
@@ -12,7 +12,7 @@ describeVariants.each(['turbo'])('experimental-lightningcss', () => {
     expect($('p').text()).toBe('hello world')
     // swc_css does not include `-module` in the class name, while lightningcss does.
     expect($('p').attr('class')).toBe(
-      'search-keyword blue__style-module__hlQ3RG'
+      'search-keyword hlQ3RG__style-module__blue'
     )
   })
 })

--- a/test/e2e/app-dir/next-font/next-font.test.ts
+++ b/test/e2e/app-dir/next-font/next-font.test.ts
@@ -47,10 +47,10 @@ describe('app dir - next/font', () => {
               // layout
               expect(JSON.parse($('#root-layout').text())).toEqual({
                 className: expect.stringMatching(
-                  process.env.TURBOPACK ? /^className_.*/ : /^__className_.*/
+                  process.env.TURBOPACK ? /.*_className$/ : /^__className_.*/
                 ),
                 variable: expect.stringMatching(
-                  process.env.TURBOPACK ? /^variable_.*/ : /^__variable_.*/
+                  process.env.TURBOPACK ? /.*_variable$/ : /^__variable_.*/
                 ),
                 style: {
                   fontFamily: expect.stringMatching(
@@ -61,10 +61,10 @@ describe('app dir - next/font', () => {
               // page
               expect(JSON.parse($('#root-page').text())).toEqual({
                 className: expect.stringMatching(
-                  process.env.TURBOPACK ? /^className_.*/ : /^__className_.*/
+                  process.env.TURBOPACK ? /.*_className$/ : /^__className_.*/
                 ),
                 variable: expect.stringMatching(
-                  process.env.TURBOPACK ? /^variable_.*/ : /^__variable_.*/
+                  process.env.TURBOPACK ? /.*_variable$/ : /^__variable_.*/
                 ),
                 style: {
                   fontFamily: expect.stringMatching(
@@ -75,7 +75,7 @@ describe('app dir - next/font', () => {
               // Comp
               expect(JSON.parse($('#root-comp').text())).toEqual({
                 className: expect.stringMatching(
-                  process.env.TURBOPACK ? /^className_.*/ : /^__className_.*/
+                  process.env.TURBOPACK ? /.*_className$/ : /^__className_.*/
                 ),
                 style: {
                   fontFamily: expect.stringMatching(
@@ -93,10 +93,10 @@ describe('app dir - next/font', () => {
               // root layout
               expect(JSON.parse($('#root-layout').text())).toEqual({
                 className: expect.stringMatching(
-                  process.env.TURBOPACK ? /^className_.*/ : /^__className_.*/
+                  process.env.TURBOPACK ? /.*_className$/ : /^__className_.*/
                 ),
                 variable: expect.stringMatching(
-                  process.env.TURBOPACK ? /^variable_.*/ : /^__variable_.*/
+                  process.env.TURBOPACK ? /.*_variable$/ : /^__variable_.*/
                 ),
                 style: {
                   fontFamily: expect.stringMatching(
@@ -108,7 +108,7 @@ describe('app dir - next/font', () => {
               // layout
               expect(JSON.parse($('#client-layout').text())).toEqual({
                 className: expect.stringMatching(
-                  process.env.TURBOPACK ? /^className_.*/ : /^__className_.*/
+                  process.env.TURBOPACK ? /.*_className$/ : /^__className_.*/
                 ),
                 style: {
                   fontFamily: expect.stringMatching(
@@ -120,7 +120,7 @@ describe('app dir - next/font', () => {
               // page
               expect(JSON.parse($('#client-page').text())).toEqual({
                 className: expect.stringMatching(
-                  process.env.TURBOPACK ? /^className_.*/ : /^__className_.*/
+                  process.env.TURBOPACK ? /.*_className$/ : /^__className_.*/
                 ),
                 style: {
                   fontFamily: expect.stringMatching(
@@ -132,7 +132,7 @@ describe('app dir - next/font', () => {
               // Comp
               expect(JSON.parse($('#client-comp').text())).toEqual({
                 className: expect.stringMatching(
-                  process.env.TURBOPACK ? /^className_.*/ : /^__className_.*/
+                  process.env.TURBOPACK ? /.*_className$/ : /^__className_.*/
                 ),
                 style: {
                   fontFamily: expect.stringMatching(
@@ -146,7 +146,7 @@ describe('app dir - next/font', () => {
               const $ = await next.render$('/third-party')
               expect(JSON.parse($('#third-party-page').text())).toEqual({
                 className: expect.stringMatching(
-                  process.env.TURBOPACK ? /^className_.*/ : /^__className_.*/
+                  process.env.TURBOPACK ? /.*_className$/ : /^__className_.*/
                 ),
                 style: {
                   fontFamily: expect.stringMatching(
@@ -154,7 +154,7 @@ describe('app dir - next/font', () => {
                   ),
                 },
                 variable: expect.stringMatching(
-                  process.env.TURBOPACK ? /^variable_.*/ : /^__variable_.*/
+                  process.env.TURBOPACK ? /.*_variable$/ : /^__variable_.*/
                 ),
               })
             })

--- a/test/e2e/next-font/index.test.ts
+++ b/test/e2e/next-font/index.test.ts
@@ -12,7 +12,7 @@ const mockedGoogleFontResponses = require.resolve(
 function getClassNameRegex(className: string): RegExp {
   // Turbopack uses a different format for its css modules than webpack-based Next.js
   return shouldRunTurboDevTest()
-    ? new RegExp(`^.{6}__.*__${className}$`) // e.g. `ks7jmG__nabla_abb2401d-module__className`
+    ? new RegExp(`^.*__.{6}__${className}$`) // e.g. `ks7jmG__nabla_abb2401d-module__className`
     : new RegExp(`^__${className}_.{6}$`) // e.g. `__className_a8cc56`
 }
 

--- a/test/e2e/next-font/index.test.ts
+++ b/test/e2e/next-font/index.test.ts
@@ -12,7 +12,7 @@ const mockedGoogleFontResponses = require.resolve(
 function getClassNameRegex(className: string): RegExp {
   // Turbopack uses a different format for its css modules than webpack-based Next.js
   return shouldRunTurboDevTest()
-    ? new RegExp(`^${className}__.*__.{6}$`) // e.g. `className__nabla_abb2401d-module__ks7jmG`
+    ? new RegExp(`^.{6}__.*__${className}$`) // e.g. `ks7jmG__nabla_abb2401d-module__className`
     : new RegExp(`^__${className}_.{6}$`) // e.g. `__className_a8cc56`
 }
 


### PR DESCRIPTION
# Turbopack

* https://github.com/vercel/turbo/pull/7719 <!-- Tobias Koppers - accept css files outside of the project as virtual assets  -->
* https://github.com/vercel/turbo/pull/7661 <!-- Tobias Koppers - more efficient node.js process startup  -->
* https://github.com/vercel/turbo/pull/7720 <!-- Tobias Koppers - generate correct async module handling for side effects optimization  -->
* https://github.com/vercel/turbo/pull/7718 <!-- Donny/강동윤 - fix(turbopack): Fix CSS Modules class name for lightningcss mode  -->

### What?

Update tests to make CSS Modules of `lightningcss` work with CSS grids.

### Why?

`lightningcss` enforces the class name to end with `[local]`.

See: https://lightningcss.dev/css-modules.html#css-grid


### How?

Closes PACK-2731

