### PR TITLE
refactor(test): expose test mode as re-exported variables

### DIFF
--- a/test/lib/e2e-utils.ts
+++ b/test/lib/e2e-utils.ts
@@ -90,6 +90,22 @@ if (testMode === 'dev') {
   ;(global as any).isNextStart = true
 }
 
+/**
+ * Whether the test is running in dev mode.
+ * Based on `process.env.NEXT_TEST_MODE` and the test directory.
+ */
+export const isNextDev = testMode === 'dev'
+/**
+ * Whether the test is running in deploy mode.
+ * Based on `process.env.NEXT_TEST_MODE`.
+ */
+export const isNextDeploy = testMode === 'deploy'
+/**
+ * Whether the test is running in start mode.
+ * Default mode. `true` when both `isNextDev` and `isNextDeploy` are false.
+ */
+export const isNextStart = !isNextDev && !isNextDeploy
+
 if (!testMode) {
   throw new Error(
     `No 'NEXT_TEST_MODE' set in environment, this is required for e2e-utils`


### PR DESCRIPTION
### What?

Getting rid of unsafe/verbose `global as any` usage in tests.

This PR focuses on the usage of `isNextDev`, `isNextDeploy` and `isNextStart` properties that were previously set on `global`.

### Why?

Consistency/type safety. Less mental overhead while working with tests.

This PR also caught the following false-positive tests. Meaning they were passing before, but actually did not test anything. This is because they were run under the unsafe `(global as any).isDev` condition, which is a misspelling of `isNextDev`. See them for a detailed explanation:

- [`b2862dd` (#63217)](https://github.com/vercel/next.js/pull/63217/commits/b2862dd028971ace2c574b0135f9e211ab6aea33)
- [`78ede13` (#63217)](https://github.com/vercel/next.js/pull/63217/commits/78ede13ab0fe6bdb4f80a4e66f56090e913e10be)
### How?

Instead of unsafe/verbose `global as any`, we can use the re-exported properties from `e2e-utils`.

NOTE: To the reviewer. "Hide whitespace changes" will simplify the diff view for some tests.

Closes NEXT-2793
Closes NEXT-2796
Supersedes #63217 