### PR TITLE
Fix pnpm support in Sanity example

### DIFF
--- a/examples/cms-sanity/package.json
+++ b/examples/cms-sanity/package.json
@@ -13,11 +13,12 @@
     "@sanity/assist": "^2.0.3",
     "@sanity/icons": "^2.11.2",
     "@sanity/image-url": "^1.0.2",
-    "@sanity/vision": "^3.32.0",
+    "@sanity/preview-url-secret": "^1.6.4",
+    "@sanity/vision": "^3.33.0",
     "@tailwindcss/typography": "^0.5.10",
-    "@types/node": "^20.11.26",
+    "@types/node": "^20.11.27",
     "@types/react": "^18.2.65",
-    "@types/react-dom": "^18.2.21",
+    "@types/react-dom": "^18.2.22",
     "@vercel/speed-insights": "^1.0.10",
     "autoprefixer": "^10.4.18",
     "date-fns": "^3.4.0",
@@ -27,7 +28,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rxjs": "^7.8.1",
-    "sanity": "^3.32.0",
+    "sanity": "^3.33.0",
     "sanity-plugin-asset-source-unsplash": "^2.0.1",
     "server-only": "^0.0.1",
     "styled-components": "^6.1.8",
@@ -35,6 +36,7 @@
     "typescript": "5.3.3"
   },
   "devDependencies": {
+    "@next/env": "latest",
     "eslint": "^8.57.0",
     "eslint-config-next": "latest"
   }


### PR DESCRIPTION
As `@sanity/preview-url-secret` wasn't declared as a dependency when doing:
```bash
pnpm install && pnpm build
```
It would fail to compile:
```bash
Linting and checking validity of types  .Failed to compile.

./app/api/draft/route.tsx:6:36
Type error: Cannot find module '@sanity/preview-url-secret' or its corresponding type declarations.

  4 |  */
  5 |
> 6 | import { validatePreviewUrl } from "@sanity/preview-url-secret";
    |                                    ^
  7 | import { draftMode } from "next/headers";
  8 | import { redirect } from "next/navigation";
  9 |
```