### PR TITLE
Fix instant loading states after invalidating prefetch cache

### DIFF
--- a/packages/next/src/client/components/router-reducer/clear-cache-node-data-for-segment-path.test.tsx
+++ b/packages/next/src/client/components/router-reducer/clear-cache-node-data-for-segment-path.test.tsx
@@ -1,18 +1,9 @@
 import React from 'react'
-import type { FetchServerResponseResult } from './fetch-server-response'
-import { fillCacheWithDataProperty } from './fill-cache-with-data-property'
+import { clearCacheNodeDataForSegmentPath } from './clear-cache-node-data-for-segment-path'
 import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
 
-describe('fillCacheWithDataProperty', () => {
-  it('should add data property', () => {
-    const fetchServerResponseMock: jest.Mock<
-      Promise<FetchServerResponseResult>
-    > = jest.fn(() =>
-      Promise.resolve([
-        /* TODO-APP: replace with actual FlightData */ '',
-        undefined,
-      ])
-    )
+describe('clearCacheNodeDataForSegmentPath', () => {
+  it('should clear the data property', () => {
     const pathname = '/dashboard/settings'
     const segments = pathname.split('/')
 
@@ -80,9 +71,7 @@ describe('fillCacheWithDataProperty', () => {
       ]),
     }
 
-    fillCacheWithDataProperty(cache, existingCache, flightSegmentPath, () =>
-      fetchServerResponseMock()
-    )
+    clearCacheNodeDataForSegmentPath(cache, existingCache, flightSegmentPath)
 
     expect(cache).toMatchInlineSnapshot(`
       {
@@ -121,7 +110,7 @@ describe('fillCacheWithDataProperty', () => {
             },
             "dashboard" => {
               "head": null,
-              "lazyData": Promise {},
+              "lazyData": null,
               "lazyDataResolved": false,
               "loading": null,
               "parallelRoutes": Map {},

--- a/packages/next/src/client/components/router-reducer/clear-cache-node-data-for-segment-path.ts
+++ b/packages/next/src/client/components/router-reducer/clear-cache-node-data-for-segment-path.ts
@@ -1,16 +1,14 @@
-import type { FetchServerResponseResult } from './fetch-server-response'
 import type { FlightSegmentPath } from '../../../server/app-render/types'
 import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
 import { createRouterCacheKey } from './create-router-cache-key'
 
 /**
- * Kick off fetch based on the common layout between two routes. Fill cache with data property holding the in-progress fetch.
+ * This will clear the CacheNode data for a particular segment path. This will cause a lazy-fetch in layout router to fill in new data.
  */
-export function fillCacheWithDataProperty(
+export function clearCacheNodeDataForSegmentPath(
   newCache: CacheNode,
   existingCache: CacheNode,
-  flightSegmentPath: FlightSegmentPath,
-  fetchResponse: () => Promise<FetchServerResponseResult>
+  flightSegmentPath: FlightSegmentPath
 ): void {
   const isLastEntry = flightSegmentPath.length <= 2
 
@@ -38,7 +36,7 @@ export function fillCacheWithDataProperty(
       childCacheNode === existingChildCacheNode
     ) {
       childSegmentMap.set(cacheKey, {
-        lazyData: fetchResponse(),
+        lazyData: null,
         rsc: null,
         prefetchRsc: null,
         head: null,
@@ -55,7 +53,7 @@ export function fillCacheWithDataProperty(
     // Start fetch in the place where the existing cache doesn't have the data yet.
     if (!childCacheNode) {
       childSegmentMap.set(cacheKey, {
-        lazyData: fetchResponse(),
+        lazyData: null,
         rsc: null,
         prefetchRsc: null,
         head: null,
@@ -82,10 +80,9 @@ export function fillCacheWithDataProperty(
     childSegmentMap.set(cacheKey, childCacheNode)
   }
 
-  return fillCacheWithDataProperty(
+  return clearCacheNodeDataForSegmentPath(
     childCacheNode,
     existingChildCacheNode,
-    flightSegmentPath.slice(2),
-    fetchResponse
+    flightSegmentPath.slice(2)
   )
 }

--- a/packages/next/src/client/components/router-reducer/prefetch-cache-utils.ts
+++ b/packages/next/src/client/components/router-reducer/prefetch-cache-utils.ts
@@ -79,12 +79,7 @@ export function getOrCreatePrefetchCacheEntry({
       existingCacheEntry.kind !== PrefetchKind.FULL &&
       kind === PrefetchKind.FULL
 
-    // If the cache entry isn't reusable, rather than returning it, we want to create a new entry.
-    const hasReusablePrefetch =
-      existingCacheEntry.status === PrefetchCacheEntryStatus.reusable ||
-      existingCacheEntry.status === PrefetchCacheEntryStatus.fresh
-
-    if (switchedToFullPrefetch || !hasReusablePrefetch) {
+    if (switchedToFullPrefetch) {
       return createLazyPrefetchEntry({
         tree,
         url,

--- a/test/e2e/app-dir/app-client-cache/client-cache.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.test.ts
@@ -373,9 +373,7 @@ createNextDescribe(
           expect(newNumber).toBe(initialNumber)
         })
 
-        // TODO: Rather than reusing parts of a stale prefetch cache entry to make this work,
-        // we should be able to copy over the existing loading from a previous cache node on navigation.
-        it.skip('should refetch below the fold after 30 seconds', async () => {
+        it('should refetch below the fold after 30 seconds', async () => {
           const randomLoadingNumber = await browser
             .elementByCss('[href="/1?timeout=1000"]')
             .click()

--- a/test/ppr-tests-manifest.json
+++ b/test/ppr-tests-manifest.json
@@ -12,7 +12,6 @@
     "test/e2e/app-dir/app-client-cache/client-cache.test.ts": {
       "failed": [
         "app dir client cache semantics prefetch={undefined} - default should re-use the full cache for only 30 seconds",
-        "app dir client cache semantics prefetch={undefined} - default should refetch below the fold after 30 seconds",
         "app dir client cache semantics prefetch={undefined} - default should renew the 30s cache once the data is revalidated",
         "app dir client cache semantics prefetch={undefined} - default should refetch the full page after 5 mins"
       ]


### PR DESCRIPTION
In #61573, I updated the navigation reducer to request a new prefetch entry if it's stale. But this has the unintended consequence of making instant loading states effectively useless after 30s (when the prefetch would have expired). Blocking navigation and then rendering the loading state isn't ideal - if we have some loading data in a cache node, we should re-use it.

Now that #62346 stores loading data in the `CacheNode`, we can copy over `loading` during a navigation.

This PR repurposes `fillCacheWithDataProperty` which wasn't being used anywhere, to instead be a utility we can use to programmatically trigger a lazy fetch on a particular segment path by nulling out it's data while copying over other properties. We could have used the existing util as-is, but ideally we only have a single spot where lazy fetching can happen, which currently is in `LayoutRouter`.

When a stale prefetch entry is detected, rather than applying the data to the tree, this PR will copy over the `loading` nodes and will "delete" the data so it can be refetched.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2806