### PR TITLE
chore: add polyfill for structuredClone api

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-unwanted-polyfillio.ts
+++ b/packages/eslint-plugin-next/src/rules/no-unwanted-polyfillio.ts
@@ -14,6 +14,7 @@ const NEXT_POLYFILLED_FEATURES = [
   'Array.prototype.includes',
   'Array.of',
   'Function.prototype.name',
+  'structuredClone',
   'fetch',
   'Map',
   'Number.EPSILON',

--- a/packages/next-polyfill-nomodule/package.json
+++ b/packages/next-polyfill-nomodule/package.json
@@ -14,7 +14,7 @@
     "prepublishOnly": "cd ../../ && turbo run build"
   },
   "devDependencies": {
-    "core-js": "3.6.5",
+    "core-js": "3.36.0",
     "microbundle": "0.15.0",
     "object-assign": "4.1.1",
     "whatwg-fetch": "3.0.0"

--- a/packages/next-polyfill-nomodule/src/index.js
+++ b/packages/next-polyfill-nomodule/src/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
-// Keep in sync with eslint no-unwanted-polyfillio rule: https://github.com/vercel/next.js/blob/master/packages/eslint-plugin-next/lib/rules/no-unwanted-polyfillio.js
+// Keep in sync with eslint no-unwanted-polyfillio rule: https://github.com/vercel/next.js/blob/master/packages/eslint-plugin-next/src/rules/no-unwanted-polyfillio.ts
 import 'core-js/actual/structured-clone'
 import 'core-js/features/array/at'
 import 'core-js/features/array/copy-within'

--- a/packages/next-polyfill-nomodule/src/index.js
+++ b/packages/next-polyfill-nomodule/src/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 // Keep in sync with eslint no-unwanted-polyfillio rule: https://github.com/vercel/next.js/blob/master/packages/eslint-plugin-next/lib/rules/no-unwanted-polyfillio.js
+import 'core-js/actual/structured-clone'
 import 'core-js/features/array/at'
 import 'core-js/features/array/copy-within'
 import 'core-js/features/array/fill'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1512,8 +1512,8 @@ importers:
   packages/next-polyfill-nomodule:
     devDependencies:
       core-js:
-        specifier: 3.6.5
-        version: 3.6.5
+        specifier: 3.36.0
+        version: 3.36.0
       microbundle:
         specifier: 0.15.0
         version: 0.15.0
@@ -9893,6 +9893,11 @@ packages:
     resolution: {integrity: sha512-nriW1nuJjUgvkEjIot1Spwakz52V9YkYHZAQG6A1eCgC8AA1p0zngrQEP9R0+V6hji5XilWKG1Bd0YRppmGimA==}
     dependencies:
       browserslist: 4.22.2
+
+  /core-js@3.36.0:
+    resolution: {integrity: sha512-mt7+TUBbTFg5+GngsAxeKBTl5/VS0guFeJacYge9OmHb+m058UwwIm41SE9T4Den7ClatV57B6TYTuJ0CX1MAw==}
+    requiresBuild: true
+    dev: true
 
   /core-js@3.6.5:
     resolution: {integrity: sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==}


### PR DESCRIPTION
In our application we notice a lot of people run into errors because they don’t have the global `structuredClone` API in their browser. This PR solves this by polyfilling this API using the official `core-js` polyfill.

References:
- https://caniuse.com/?search=structuredClone
- https://developer.mozilla.org/en-US/docs/Web/API/structuredClone