### PR TITLE
Fix interception/detail routes being triggered by router refreshes

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/fast-refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/fast-refresh-reducer.ts
@@ -14,6 +14,7 @@ import { applyFlightData } from '../apply-flight-data'
 import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
 import { createEmptyCacheNode } from '../../app-router'
 import { handleSegmentMismatch } from '../handle-segment-mismatch'
+import { hasInterceptionRouteInCurrentTree } from './has-interception-route-in-current-tree'
 
 // A version of refresh reducer that keeps the cache around instead of wiping all of it.
 function fastRefreshReducerImpl(
@@ -27,12 +28,16 @@ function fastRefreshReducerImpl(
   mutable.preserveCustomHistoryState = false
 
   const cache: CacheNode = createEmptyCacheNode()
+  // If the current tree was intercepted, the nextUrl should be included in the request.
+  // This is to ensure that the refresh request doesn't get intercepted, accidentally triggering the interception route.
+  const includeNextUrl = hasInterceptionRouteInCurrentTree(state.tree)
+
   // TODO-APP: verify that `href` is not an external url.
   // Fetch data from the root of the tree.
   cache.lazyData = fetchServerResponse(
     new URL(href, origin),
     [state.tree[0], state.tree[1], state.tree[2], 'refetch'],
-    state.nextUrl,
+    includeNextUrl ? state.nextUrl : null,
     state.buildId
   )
 

--- a/packages/next/src/client/components/router-reducer/reducers/has-interception-route-in-current-tree.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/has-interception-route-in-current-tree.ts
@@ -1,0 +1,28 @@
+import type { FlightRouterState } from '../../../../server/app-render/types'
+import { isInterceptionRouteAppPath } from '../../../../server/future/helpers/interception-routes'
+
+export function hasInterceptionRouteInCurrentTree([
+  segment,
+  parallelRoutes,
+]: FlightRouterState): boolean {
+  // If we have a dynamic segment, it's marked as an interception route by the presence of the `i` suffix.
+  if (Array.isArray(segment) && (segment[2] === 'di' || segment[2] === 'ci')) {
+    return true
+  }
+
+  // If segment is not an array, apply the existing string-based check
+  if (typeof segment === 'string' && isInterceptionRouteAppPath(segment)) {
+    return true
+  }
+
+  // Iterate through parallelRoutes if they exist
+  if (parallelRoutes) {
+    for (const key in parallelRoutes) {
+      if (hasInterceptionRouteInCurrentTree(parallelRoutes[key])) {
+        return true
+      }
+    }
+  }
+
+  return false
+}

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -14,6 +14,7 @@ import type { CacheNode } from '../../../../shared/lib/app-router-context.shared
 import { fillLazyItemsTillLeafWithHead } from '../fill-lazy-items-till-leaf-with-head'
 import { createEmptyCacheNode } from '../../app-router'
 import { handleSegmentMismatch } from '../handle-segment-mismatch'
+import { hasInterceptionRouteInCurrentTree } from './has-interception-route-in-current-tree'
 
 export function refreshReducer(
   state: ReadonlyReducerState,
@@ -28,12 +29,17 @@ export function refreshReducer(
   mutable.preserveCustomHistoryState = false
 
   const cache: CacheNode = createEmptyCacheNode()
+
+  // If the current tree was intercepted, the nextUrl should be included in the request.
+  // This is to ensure that the refresh request doesn't get intercepted, accidentally triggering the interception route.
+  const includeNextUrl = hasInterceptionRouteInCurrentTree(state.tree)
+
   // TODO-APP: verify that `href` is not an external url.
   // Fetch data from the root of the tree.
   cache.lazyData = fetchServerResponse(
     new URL(href, origin),
     [currentTree[0], currentTree[1], currentTree[2], 'refetch'],
-    state.nextUrl,
+    includeNextUrl ? state.nextUrl : null,
     state.buildId
   )
 

--- a/packages/next/src/server/app-render/get-segment-param.tsx
+++ b/packages/next/src/server/app-render/get-segment-param.tsx
@@ -20,6 +20,8 @@ export function getSegmentParam(segment: string): {
 
   if (segment.startsWith('[[...') && segment.endsWith(']]')) {
     return {
+      // TODO-APP: Optional catchall does not currently work with parallel routes,
+      // so for now aren't handling a potential interception marker.
       type: 'optional-catchall',
       param: segment.slice(5, -2),
     }
@@ -27,14 +29,14 @@ export function getSegmentParam(segment: string): {
 
   if (segment.startsWith('[...') && segment.endsWith(']')) {
     return {
-      type: 'catchall',
+      type: interceptionMarker ? 'catchall-intercepted' : 'catchall',
       param: segment.slice(4, -1),
     }
   }
 
   if (segment.startsWith('[') && segment.endsWith(']')) {
     return {
-      type: 'dynamic',
+      type: interceptionMarker ? 'dynamic-intercepted' : 'dynamic',
       param: segment.slice(1, -1),
     }
   }

--- a/packages/next/src/server/app-render/get-short-dynamic-param-type.tsx
+++ b/packages/next/src/server/app-render/get-short-dynamic-param-type.tsx
@@ -5,8 +5,10 @@ export const dynamicParamTypes: Record<
   DynamicParamTypesShort
 > = {
   catchall: 'c',
+  'catchall-intercepted': 'ci',
   'optional-catchall': 'oc',
   dynamic: 'd',
+  'dynamic-intercepted': 'di',
 }
 
 /**

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -10,9 +10,14 @@ import type { LoadingModuleData } from '../../shared/lib/app-router-context.shar
 
 import s from 'next/dist/compiled/superstruct'
 
-export type DynamicParamTypes = 'catchall' | 'optional-catchall' | 'dynamic'
+export type DynamicParamTypes =
+  | 'catchall'
+  | 'catchall-intercepted'
+  | 'optional-catchall'
+  | 'dynamic'
+  | 'dynamic-intercepted'
 
-const dynamicParamTypesSchema = s.enums(['c', 'oc', 'd'])
+const dynamicParamTypesSchema = s.enums(['c', 'ci', 'oc', 'd', 'di'])
 
 export type DynamicParamTypesShort = s.Infer<typeof dynamicParamTypesSchema>
 

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -82,10 +82,12 @@ function convertDynamicParamTypeToSyntax(
 ) {
   switch (dynamicParamTypeShort) {
     case 'c':
+    case 'ci':
       return `[...${param}]`
     case 'oc':
       return `[[...${param}]]`
     case 'd':
+    case 'di':
       return `[${param}]`
     default:
       throw new Error('Unknown dynamic param type')

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/@interception/(.)detail-page/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/@interception/(.)detail-page/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <div>
+      <h2 id="detail-title">Detail Page (Intercepted)</h2>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/catchall/@interception2/(.)[...dynamic]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/catchall/@interception2/(.)[...dynamic]/page.tsx
@@ -1,0 +1,16 @@
+'use client'
+import { useRouter } from 'next/navigation'
+
+export default function Page({ params }: { params: { dynamic: string } }) {
+  const router = useRouter()
+  return (
+    <div>
+      <h2 id="detail-title">Detail Page (Intercepted)</h2>
+      <p id="params">{params.dynamic}</p>
+      <span suppressHydrationWarning id="random-number">
+        {Math.random()}
+      </span>
+      <button onClick={() => router.refresh()}>Refresh</button>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/catchall/@interception2/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/catchall/@interception2/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/catchall/[...dynamic]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/catchall/[...dynamic]/page.tsx
@@ -1,0 +1,16 @@
+'use client'
+import { useRouter } from 'next/navigation'
+
+export default function Page({ params }: { params: { dynamic: string } }) {
+  const router = useRouter()
+  return (
+    <div>
+      <h2 id="detail-title">Detail Page (Non-Intercepted)</h2>
+      <p id="params">{params.dynamic}</p>
+      <span suppressHydrationWarning id="random-number">
+        {Math.random()}
+      </span>
+      <button onClick={() => router.refresh()}>Refresh</button>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/catchall/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/catchall/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/catchall/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/catchall/layout.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+export default function Layout({
+  children,
+  interception2,
+}: {
+  children: React.ReactNode
+  interception2: React.ReactNode
+}) {
+  return (
+    <div>
+      {children}
+      {interception2}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/catchall/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/catchall/page.tsx
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <Link href="/catchall/foobar">Dynamic Catchall Interception</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/detail-page/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/detail-page/page.tsx
@@ -1,0 +1,15 @@
+'use client'
+import { useRouter } from 'next/navigation'
+
+export default function Page() {
+  const router = useRouter()
+  return (
+    <div>
+      <h2 id="detail-title">Detail Page (Non-Intercepted)</h2>
+      <span suppressHydrationWarning id="random-number">
+        {Math.random()}
+      </span>
+      <button onClick={() => router.refresh()}>Refresh</button>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/dynamic/@interception2/(.)[dynamic]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/dynamic/@interception2/(.)[dynamic]/page.tsx
@@ -1,0 +1,16 @@
+'use client'
+import { useRouter } from 'next/navigation'
+
+export default function Page({ params }: { params: { dynamic: string } }) {
+  const router = useRouter()
+  return (
+    <div>
+      <h2 id="detail-title">Detail Page (Intercepted)</h2>
+      <p id="params">{params.dynamic}</p>
+      <span suppressHydrationWarning id="random-number">
+        {Math.random()}
+      </span>
+      <button onClick={() => router.refresh()}>Refresh</button>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/dynamic/@interception2/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/dynamic/@interception2/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/dynamic/[dynamic]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/dynamic/[dynamic]/page.tsx
@@ -1,0 +1,16 @@
+'use client'
+import { useRouter } from 'next/navigation'
+
+export default function Page({ params }: { params: { dynamic: string } }) {
+  const router = useRouter()
+  return (
+    <div>
+      <h2 id="detail-title">Detail Page (Non-Intercepted)</h2>
+      <p id="params">{params.dynamic}</p>
+      <span suppressHydrationWarning id="random-number">
+        {Math.random()}
+      </span>
+      <button onClick={() => router.refresh()}>Refresh</button>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/dynamic/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/dynamic/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/dynamic/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/dynamic/layout.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+export default function Layout({
+  children,
+  interception2,
+}: {
+  children: React.ReactNode
+  interception2: React.ReactNode
+}) {
+  return (
+    <div>
+      {children}
+      {interception2}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/dynamic/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/dynamic/page.tsx
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <Link href="/dynamic/foobar">Dynamic Interception</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/page.tsx
@@ -12,6 +12,7 @@ export default async function Home() {
       <Link href="/revalidate-modal">Open Revalidate Modal</Link>
       <Link href="/refresh-modal">Open Refresh Modal</Link>
       <Link href="/redirect-modal">Open Redirect Modal</Link>
+      <Link href="/detail-page">Intercepted Detail Page</Link>
       <div id="random-number">{randomNumber}</div>
       <div>
         <h1>Current Data</h1>

--- a/test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts
+++ b/test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts
@@ -1,5 +1,5 @@
 import { createNextDescribe } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { check, retry } from 'next-test-utils'
 
 createNextDescribe(
   'parallel-routes-revalidation',
@@ -79,5 +79,89 @@ createNextDescribe(
       await check(() => browser.hasElementByCssSelector('#redirect'), false)
       await check(() => browser.elementByCss('body').text(), /Current Data/)
     })
+
+    it.each([
+      { path: '/detail-page' },
+      { path: '/dynamic/foobar', param: 'foobar' },
+      { path: '/catchall/foobar', param: 'foobar' },
+    ])(
+      'should not trigger interception when calling router.refresh() on an intercepted route ($path)',
+      async (route) => {
+        const browser = await next.browser(route.path)
+
+        // directly loaded the detail page, so it should not be intercepted.
+        expect(await browser.elementById('detail-title').text()).toBe(
+          'Detail Page (Non-Intercepted)'
+        )
+        const randomNumber = (await browser.elementById('random-number')).text()
+
+        // confirm that if the route contained a dynamic parameter, that it's reflected in the UI
+        if (route.param) {
+          expect(await browser.elementById('params').text()).toBe(route.param)
+        }
+
+        // click the refresh button
+        await browser.elementByCss('button').click()
+
+        await retry(async () => {
+          // confirm that the page is still not intercepted after
+          expect(await browser.elementById('detail-title').text()).toBe(
+            'Detail Page (Non-Intercepted)'
+          )
+
+          const newRandomNumber = await browser
+            .elementById('random-number')
+            .text()
+
+          // but we should have received a new random number, indicating the non-intercepted page was refreshed
+          expect(randomNumber).not.toBe(newRandomNumber)
+
+          // confirm the params (if previously present) are still present
+          if (route.param) {
+            expect(await browser.elementById('params').text()).toBe(route.param)
+          }
+        })
+      }
+    )
+
+    it.each([{ path: '/dynamic', param: 'foobar' }])(
+      'should not trigger full page when calling router.refresh() on an intercepted route ($path)',
+      async (route) => {
+        const browser = await next.browser(route.path)
+        await browser.elementByCss('a').click()
+
+        // we soft-navigated to the route, so it should be intercepted
+        expect(await browser.elementById('detail-title').text()).toBe(
+          'Detail Page (Intercepted)'
+        )
+        const randomNumber = (await browser.elementById('random-number')).text()
+
+        // if the route contained a dynamic parameter, confirm that it's reflected in the UI
+        if (route.param) {
+          expect(await browser.elementById('params').text()).toBe(route.param)
+        }
+
+        // click the refresh button
+        await browser.elementByCss('button').click()
+
+        await retry(async () => {
+          // confirm that the page is still intercepted
+          expect(await browser.elementById('detail-title').text()).toBe(
+            'Detail Page (Intercepted)'
+          )
+          const newRandomNumber = await browser
+            .elementById('random-number')
+            .text()
+
+          // confirm that the intercepted page was refreshed
+          expect(randomNumber).not.toBe(newRandomNumber)
+
+          // confirm the params (if previously present) are still present
+          if (route.param) {
+            expect(await browser.elementById('params').text()).toBe(route.param)
+          }
+        })
+      }
+    )
   }
 )


### PR DESCRIPTION
### What
Actions that revalidate the router state by kicking off a refetch (such as `router.refresh()` or dev fast refresh) would incorrectly trigger an interception route if one matched the current URL, or in the case of already being on an intercepted route, would trigger the full detail page instead.

### Why
Interception rewrites use the `nextUrl` header to determine if the requested path should be rewritten to a different path. We currently forward that header indiscriminately, which means that if you were on a non-intercepted route and called `router.refresh()`, the UI would change to the intercepted content instead (since it would treat it the same as a soft-navigation).

### How
This updates various reducers to only forward the `nextUrl` header if there's an interception route present in the tree. If there is, we want to refresh its data, rather than the data for the underlying page. The reverse is also true: if we were on the "full" page, and triggered a `router.refresh()`, we won't forward `nextUrl` meaning it won't fetch the interception data. 

In order to determine if an interception route is present in the tree, I had to add a new segment type for dynamic interception routes, as by the time they reach the client they are stripped of their interception marker.

**Note: There are a series of bugs related to `router.refresh` with parallel/interception routes, such as the previous page/slot content disappearing when triggering a refresh. This does not address all of those cases, but I'm working through them!**

Fixes #60844
Fixes #62470
Closes NEXT-2737
