### PR TITLE
fix(route-handlers): make sure preflight has CORS headers

### DIFF
--- a/packages/next/src/server/future/route-modules/app-route/helpers/auto-implement-methods.ts
+++ b/packages/next/src/server/future/route-modules/app-route/helpers/auto-implement-methods.ts
@@ -35,7 +35,7 @@ export function autoImplementMethods(
     if (method === 'HEAD') {
       // If the userland module doesn't implement the GET method, then
       // we're done.
-      if (!handlers.GET) break
+      if (!handlers.GET) continue
 
       // Implement the HEAD method by calling the GET method.
       methods.HEAD = handlers.GET

--- a/packages/next/src/server/future/route-modules/app-route/helpers/auto-implement-methods.ts
+++ b/packages/next/src/server/future/route-modules/app-route/helpers/auto-implement-methods.ts
@@ -34,7 +34,7 @@ export function autoImplementMethods(
     // exists).
     if (method === 'HEAD') {
       // If the userland module doesn't implement the GET method, then
-      // we can continue to checking the OPTION method below.
+      // we can continue to check the OPTION method below.
       if (!handlers.GET) continue
 
       // Implement the HEAD method by calling the GET method.

--- a/packages/next/src/server/future/route-modules/app-route/helpers/auto-implement-methods.ts
+++ b/packages/next/src/server/future/route-modules/app-route/helpers/auto-implement-methods.ts
@@ -32,7 +32,7 @@ export function autoImplementMethods(
     // If the userland module doesn't implement the HEAD method, then
     // we'll automatically implement it by calling the GET method (if it
     // exists).
-    if (method === 'HEAD') {
+    if (method === 'HEAD' && handles.GET) {
       // If the userland module doesn't implement the GET method, then
       // we can continue to check the OPTION method below.
       if (!handlers.GET) continue

--- a/packages/next/src/server/future/route-modules/app-route/helpers/auto-implement-methods.ts
+++ b/packages/next/src/server/future/route-modules/app-route/helpers/auto-implement-methods.ts
@@ -33,10 +33,6 @@ export function autoImplementMethods(
     // we'll automatically implement it by calling the GET method (if it
     // exists).
     if (method === 'HEAD' && handles.GET) {
-      // If the userland module doesn't implement the GET method, then
-      // we can continue to check the OPTION method below.
-      if (!handlers.GET) continue
-
       // Implement the HEAD method by calling the GET method.
       methods.HEAD = handlers.GET
 

--- a/packages/next/src/server/future/route-modules/app-route/helpers/auto-implement-methods.ts
+++ b/packages/next/src/server/future/route-modules/app-route/helpers/auto-implement-methods.ts
@@ -32,7 +32,7 @@ export function autoImplementMethods(
     // If the userland module doesn't implement the HEAD method, then
     // we'll automatically implement it by calling the GET method (if it
     // exists).
-    if (method === 'HEAD' && handlers.GET) {
+    if (method === 'HEAD' && implemented.has('GET')) {
       // Implement the HEAD method by calling the GET method.
       methods.HEAD = handlers.GET
 

--- a/packages/next/src/server/future/route-modules/app-route/helpers/auto-implement-methods.ts
+++ b/packages/next/src/server/future/route-modules/app-route/helpers/auto-implement-methods.ts
@@ -34,7 +34,7 @@ export function autoImplementMethods(
     // exists).
     if (method === 'HEAD') {
       // If the userland module doesn't implement the GET method, then
-      // we're done.
+      // we can continue to checking the OPTION method below.
       if (!handlers.GET) continue
 
       // Implement the HEAD method by calling the GET method.

--- a/packages/next/src/server/future/route-modules/app-route/helpers/auto-implement-methods.ts
+++ b/packages/next/src/server/future/route-modules/app-route/helpers/auto-implement-methods.ts
@@ -32,13 +32,14 @@ export function autoImplementMethods(
     // If the userland module doesn't implement the HEAD method, then
     // we'll automatically implement it by calling the GET method (if it
     // exists).
-    if (method === 'HEAD' && handlers.GET) {
-      // Implement the HEAD method by calling the GET method.
-      methods.HEAD = handlers.GET
+    if (method === 'HEAD') {
+      if (handlers.GET) {
+        // Implement the HEAD method by calling the GET method.
+        methods.HEAD = handlers.GET
 
-      // Mark it as implemented.
-      implemented.add('HEAD')
-
+        // Mark it as implemented.
+        implemented.add('HEAD')
+      }
       continue
     }
 

--- a/packages/next/src/server/future/route-modules/app-route/helpers/auto-implement-methods.ts
+++ b/packages/next/src/server/future/route-modules/app-route/helpers/auto-implement-methods.ts
@@ -32,7 +32,7 @@ export function autoImplementMethods(
     // If the userland module doesn't implement the HEAD method, then
     // we'll automatically implement it by calling the GET method (if it
     // exists).
-    if (method === 'HEAD' && implemented.has('GET')) {
+    if (method === 'HEAD' && handlers.GET) {
       // Implement the HEAD method by calling the GET method.
       methods.HEAD = handlers.GET
 

--- a/packages/next/src/server/future/route-modules/app-route/helpers/auto-implement-methods.ts
+++ b/packages/next/src/server/future/route-modules/app-route/helpers/auto-implement-methods.ts
@@ -32,7 +32,7 @@ export function autoImplementMethods(
     // If the userland module doesn't implement the HEAD method, then
     // we'll automatically implement it by calling the GET method (if it
     // exists).
-    if (method === 'HEAD' && handles.GET) {
+    if (method === 'HEAD' && handlers.GET) {
       // Implement the HEAD method by calling the GET method.
       methods.HEAD = handlers.GET
 

--- a/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
@@ -557,9 +557,7 @@ createNextDescribe(
         expect(res.status).toEqual(204)
         expect(await res.text()).toBeEmpty()
 
-        expect(res.headers.get('allow')).toEqual(
-          'DELETE, GET, HEAD, OPTIONS, POST'
-        )
+        expect(res.headers.get('allow')).toEqual('OPTIONS, POST')
       })
     })
 

--- a/test/e2e/app-dir/app-routes/app/methods/options/route.ts
+++ b/test/e2e/app-dir/app-routes/app/methods/options/route.ts
@@ -1,3 +1,3 @@
 // This route exports GET, POST, and DELETE. The test verifies that this route
 // will handle the OPTIONS request.
-export { GET, POST, DELETE } from '../../../handlers/hello'
+export { POST } from '../../../handlers/hello'

--- a/test/e2e/app-dir/app-routes/app/methods/options/route.ts
+++ b/test/e2e/app-dir/app-routes/app/methods/options/route.ts
@@ -1,3 +1,3 @@
-// This route exports GET, POST, and DELETE. The test verifies that this route
+// This route exports  POST. The test verifies that this route
 // will handle the OPTIONS request.
 export { POST } from '../../../handlers/hello'


### PR DESCRIPTION
## Why?

When we just have a POST route handler, it seems CORs is not working properly. This is because we break out of the loop here https://github.com/vercel/next.js/blob/768a92b15bd72002df0f9f893d78e094a8e3165f/packages/next/src/server/future/route-modules/app-route/helpers/auto-implement-methods.ts#L38 when a `GET` isn't present before we add the correct headers and status to the preflight `OPTION`.

- Closes https://github.com/vercel/next.js/issues/57999

Closes NEXT-2813