### PR TITLE
feat(third-parties): minify google script

### DIFF
--- a/packages/third-parties/src/google/ga.tsx
+++ b/packages/third-parties/src/google/ga.tsx
@@ -38,12 +38,7 @@ export function GoogleAnalytics(props: GAParams) {
       <Script
         id="_next-ga-init"
         dangerouslySetInnerHTML={{
-          __html: `
-          window['${dataLayerName}'] = window['${dataLayerName}'] || [];
-          function gtag(){window['${dataLayerName}'].push(arguments);}
-          gtag('js', new Date());
-
-          gtag('config', '${gaId}');`,
+          __html: `window['${dataLayerName}']=window['${dataLayerName}']||[];function gtag(){window['${dataLayerName}'].push(arguments);}gtag('js',new Date());gtag('config','${gaId}');`,
         }}
       />
       <Script

--- a/packages/third-parties/src/google/gtm.tsx
+++ b/packages/third-parties/src/google/gtm.tsx
@@ -36,12 +36,9 @@ export function GoogleTagManager(props: GTMParams) {
       <Script
         id="_next-gtm-init"
         dangerouslySetInnerHTML={{
-          __html: `
-      (function(w,l){
-        w[l]=w[l]||[];
-        w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});
-        ${dataLayer ? `w[l].push(${JSON.stringify(dataLayer)})` : ''}
-      })(window,'${dataLayerName}');`,
+          __html: `(function(w,l){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});${
+            dataLayer ? `w[l].push(${JSON.stringify(dataLayer)})` : ''
+          }})(window,'${dataLayerName}');`,
         }}
       />
       <Script


### PR DESCRIPTION
I found unminified code in _app.tsx's output.

We should minify these scripts manually as it's using `dangerouslySetInnerHTML`

<img width="586" alt="image" src="https://github.com/vercel/next.js/assets/5862369/b3e516d7-1167-49e2-a443-cc71875284b2">
