### PR TITLE
fix(turbopack): Remove error overlay when `pages/_app` is fixed

### DIFF
--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -867,6 +867,11 @@ export async function handlePagesErrorRoute({
 
     const writtenEndpoint = await entrypoints.global.app.writeToDisk()
     hooks?.handleWrittenEndpoint(key, writtenEndpoint)
+    hooks?.subscribeToChanges(key, false, entrypoints.global.app, () => {
+      // There's a special case for this in `../client/page-bootstrap.ts`.
+      // https://github.com/vercel/next.js/blob/08d7a7e5189a835f5dcb82af026174e587575c0e/packages/next/src/client/page-bootstrap.ts#L69-L71
+      return { event: HMR_ACTIONS_SENT_TO_BROWSER.CLIENT_CHANGES }
+    })
     processIssues(currentEntryIssues, key, writtenEndpoint)
   }
   await manifestLoader.loadBuildManifest('_app')

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -1203,15 +1203,13 @@
     "passed": [
       "ReactRefreshLogBox turbo Module not found",
       "ReactRefreshLogBox turbo Module not found (empty import trace)",
-      "ReactRefreshLogBox turbo Node.js builtins"
-    ],
-    "failed": [
+      "ReactRefreshLogBox turbo Node.js builtins",
       "ReactRefreshLogBox turbo Module not found (missing global CSS)"
     ],
+    "failed": [],
     "pending": [
       "ReactRefreshLogBox default Module not found",
       "ReactRefreshLogBox default Module not found (empty import trace)",
-      "ReactRefreshLogBox default Module not found (missing global CSS)",
       "ReactRefreshLogBox default Node.js builtins"
     ],
     "flakey": [],


### PR DESCRIPTION
### What?

Apply same patch as https://github.com/vercel/next.js/pull/62983 for `pages/_app.js`

### Why?

To make turbopack match behavior of webpack mode, and make the test passs

### How?

Closes PACK-2407