### PR TITLE
fix(next/server): do not preconnect to self origin

### DIFF
--- a/packages/next/src/server/app-render/get-layer-assets.tsx
+++ b/packages/next/src/server/app-render/get-layer-assets.tsx
@@ -64,11 +64,9 @@ export function getLayerAssets({
           ctx.componentMod.preconnect(url.origin, 'anonymous', ctx.nonce)
         })
       } catch (error) {
-        // assetPrefix must not be a fully qualified domain name. We assume
-        // we should preconnect to same origin instead
-        preloadCallbacks.push(() => {
-          ctx.componentMod.preconnect('/', 'anonymous', ctx.nonce)
-        })
+        // assetPrefix must not be a fully qualified domain name.
+        // If it's not, it means it's in the same origin and
+        // the browser has already connected to it.
       }
     }
   }


### PR DESCRIPTION
## For Contributors

### Fixing a bug

Avoid unnecessary preconnect.
I see a strange preconnect in `<head/>`

```html
<link rel="preconnect" href="/" crossorigin=""/>
```

It's unnecessary because according to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preconnect), 

> Preconnecting speeds up future loads from a given origin by preemptively performing part or all of the handshake (DNS+TCP for HTTP, and DNS+TCP+TLS for HTTPS origins).

Since we're connecting to the same origin, the browser has already established the connection with server. (Same domain, same IP, same server). There's no need to preconnect to the same server.

