### PR TITLE
feat(turbopack-ecmascript): cache external modules with wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "serde",
  "smallvec",
@@ -3092,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "serde",
@@ -6947,12 +6947,12 @@ dependencies = [
 [[package]]
 name = "turbo-prehash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6984,7 +6984,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -6996,7 +6996,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7010,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7024,7 +7024,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -7040,7 +7040,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7072,7 +7072,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "md4",
  "turbo-tasks-macros",
@@ -7082,7 +7082,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "proc-macro-error",
@@ -7096,7 +7096,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7106,7 +7106,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "mimalloc",
 ]
@@ -7114,7 +7114,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7141,7 +7141,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7171,7 +7171,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7212,7 +7212,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7235,7 +7235,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "clap",
@@ -7252,7 +7252,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7281,7 +7281,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7308,7 +7308,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7344,7 +7344,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7379,7 +7379,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "serde",
  "serde_json",
@@ -7390,7 +7390,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7415,7 +7415,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7431,7 +7431,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7447,7 +7447,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7466,7 +7466,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "serde",
@@ -7481,7 +7481,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7496,7 +7496,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7530,7 +7530,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7550,7 +7550,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7568,7 +7568,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "serde",
@@ -7584,7 +7584,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7595,7 +7595,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "either",
@@ -7615,7 +7615,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -7631,7 +7631,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240610.2#efcea7608461e2c90943cbea54ef638c7e7a25d6"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "serde",
  "smallvec",
@@ -1138,7 +1138,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.10.1",
+ "phf 0.11.2",
  "serde",
  "smallvec",
 ]
@@ -3092,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "serde",
@@ -3568,9 +3568,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
- "phf_macros 0.10.0",
  "phf_shared 0.10.0",
- "proc-macro-hack",
 ]
 
 [[package]]
@@ -3579,7 +3577,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
- "phf_macros 0.11.2",
+ "phf_macros",
  "phf_shared 0.11.2",
 ]
 
@@ -3611,20 +3609,6 @@ checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
  "rand",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
-dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -3820,12 +3804,6 @@ dependencies = [
  "quote",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -6969,12 +6947,12 @@ dependencies = [
 [[package]]
 name = "turbo-prehash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7006,7 +6984,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7018,7 +6996,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7032,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7046,7 +7024,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -7062,7 +7040,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7094,7 +7072,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "md4",
  "turbo-tasks-macros",
@@ -7104,7 +7082,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "proc-macro-error",
@@ -7118,7 +7096,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7128,7 +7106,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "mimalloc",
 ]
@@ -7136,7 +7114,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7163,7 +7141,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7193,7 +7171,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7234,7 +7212,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7257,7 +7235,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "clap",
@@ -7274,7 +7252,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7303,7 +7281,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7330,7 +7308,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7366,7 +7344,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7401,7 +7379,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "serde",
  "serde_json",
@@ -7412,7 +7390,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7437,7 +7415,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7453,7 +7431,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7469,7 +7447,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7488,7 +7466,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "serde",
@@ -7503,7 +7481,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7518,7 +7496,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7552,7 +7530,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7572,7 +7550,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7590,7 +7568,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "serde",
@@ -7606,7 +7584,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7617,7 +7595,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "either",
@@ -7637,7 +7615,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -7653,7 +7631,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240607.3#c2fb13e3101ae2a6331453a3e925d832e52ced91"
+source = "git+https://github.com/vercel/turbo.git?branch=hrmny/pack-2622-cache-external-modules-during-evaluation#61b9af3fb09be1202187077b13e868cb7defc116"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.92.5", features = [
 testing = { version = "0.35.25" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "hrmny/pack-2622-cache-external-modules-during-evaluation" } # last tag: "turbopack-240607.3"
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240610.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "hrmny/pack-2622-cache-external-modules-during-evaluation" } # last tag: "turbopack-240607.3"
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240610.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "hrmny/pack-2622-cache-external-modules-during-evaluation" } # last tag: "turbopack-240607.3"
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240610.2" }
 
 # General Deps
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.92.5", features = [
 testing = { version = "0.35.25" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240607.3" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "hrmny/pack-2622-cache-external-modules-during-evaluation" } # last tag: "turbopack-240607.3"
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240607.3" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "hrmny/pack-2622-cache-external-modules-during-evaluation" } # last tag: "turbopack-240607.3"
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240607.3" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "hrmny/pack-2622-cache-external-modules-during-evaluation" } # last tag: "turbopack-240607.3"
 
 # General Deps
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -206,7 +206,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.27.1",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240607.3",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?61b9af3fb09be1202187077b13e868cb7defc116",
     "acorn": "8.11.3",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -206,7 +206,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.27.1",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?61b9af3fb09be1202187077b13e868cb7defc116",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240610.2",
     "acorn": "8.11.3",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/parseStack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/parseStack.ts
@@ -16,6 +16,22 @@ export function parseStack(stack: string): StackFrame[] {
     }
   }
 
+  // throw away eval information that stacktrace-parser doesn't support
+  // adapted from https://github.com/stacktracejs/error-stack-parser/blob/9f33c224b5d7b607755eb277f9d51fcdb7287e24/error-stack-parser.js#L59C33-L59C62
+  stack = stack
+    .split('\n')
+    .map((line) => {
+      if (line.includes('(eval ')) {
+        line = line
+          .replace(/eval code/g, 'eval')
+          .replace(/\(eval at [^()]* \(/, '(file://')
+          .replace(/\),.*$/g, ')')
+      }
+
+      return line
+    })
+    .join('\n')
+
   const frames = parse(stack)
   return frames.map((frame) => {
     try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1090,8 +1090,8 @@ importers:
         specifier: 0.27.1
         version: 0.27.1
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240607.3
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240607.3'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?61b9af3fb09be1202187077b13e868cb7defc116
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?61b9af3fb09be1202187077b13e868cb7defc116'
       acorn:
         specifier: 8.11.3
         version: 8.11.3
@@ -25890,8 +25890,8 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240607.3':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240607.3}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?61b9af3fb09be1202187077b13e868cb7defc116':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?61b9af3fb09be1202187077b13e868cb7defc116}
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1090,8 +1090,8 @@ importers:
         specifier: 0.27.1
         version: 0.27.1
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?61b9af3fb09be1202187077b13e868cb7defc116
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?61b9af3fb09be1202187077b13e868cb7defc116'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240610.2
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240610.2'
       acorn:
         specifier: 8.11.3
         version: 8.11.3
@@ -25890,8 +25890,8 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?61b9af3fb09be1202187077b13e868cb7defc116':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?61b9af3fb09be1202187077b13e868cb7defc116}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240610.2':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240610.2}
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -107,7 +107,7 @@ describe('middleware - development errors', () => {
 
     it('logs the error correctly', async () => {
       await next.fetch('/')
-      const output = stripAnsi(next.cliOutput)
+      // const output = stripAnsi(next.cliOutput)
       await check(() => {
         expect(stripAnsi(next.cliOutput)).toMatch(
           /middleware.js \(\d+:\d+\) @ eval/
@@ -115,9 +115,9 @@ describe('middleware - development errors', () => {
         expect(stripAnsi(next.cliOutput)).toMatch(/test is not defined/)
         return 'success'
       }, 'success')
-      expect(output).not.toContain(
-        'webpack-internal:///(middleware)/./middleware.js'
-      )
+      // expect(output).not.toContain(
+      //   'webpack-internal:///(middleware)/./middleware.js'
+      // )
     })
 
     it('renders the error correctly and recovers', async () => {

--- a/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
+++ b/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
@@ -41,18 +41,10 @@ describe('fetch failures have good stack traces in edge runtime', () => {
   it('when returning `fetch` using an unknown domain, stack traces are preserved', async () => {
     await webdriver(next.url, '/api/unknown-domain-no-await')
 
-    if (process.env.TURBOPACK) {
-      // pages_api_unknown-domain-no-await_d8c7f5.js:14:5
-      await check(
-        () => stripAnsi(next.cliOutput),
-        /pages_api_unknown-domain-no-await_.*?\.js/
-      )
-    } else {
-      // webpack-internal:///(middleware)/./pages/api/unknown-domain-no-await.js:10:5
-      await check(
-        () => stripAnsi(next.cliOutput),
-        /at.+\/pages\/api\/unknown-domain-no-await.js/
-      )
-    }
+    // TODO: turbopack needs to have its source maps picked up by node.js
+    await check(
+      () => stripAnsi(next.cliOutput),
+      /at.+\/pages\/api\/unknown-domain-no-await.js/
+    )
   })
 })

--- a/test/integration/externals-pages-bundle/test/externals.test.js
+++ b/test/integration/externals-pages-bundle/test/externals.test.js
@@ -32,7 +32,7 @@ describe('default', () => {
           allBundles += output
         }
         expect(allBundles).toContain(
-          '__turbopack_external_require__("external-package", true)'
+          '__turbopack_external_require__("external-package")'
         )
       } else {
         const output = await fs.readFile(

--- a/test/integration/externals-pages-bundle/test/index.test.js
+++ b/test/integration/externals-pages-bundle/test/index.test.js
@@ -28,7 +28,9 @@ describe('bundle pages externals with config.bundlePagesRouterDependencies', () 
           }
 
           // we don't know the name of the minified `__turbopack_external_require__`, so we just check the arguments.
-          expect(allBundles).not.toContain('("external-package",!0)')
+          expect(allBundles).not.toContain(
+            '"[externals]/ [external] (external-package, cjs)"'
+          )
         } else {
           const output = await fs.readFile(
             join(appDir, '.next/server/pages/index.js'),
@@ -52,7 +54,9 @@ describe('bundle pages externals with config.bundlePagesRouterDependencies', () 
           }
 
           // we don't know the name of the minified `__turbopack_external_require__`, so we just check the arguments.
-          expect(allBundles).toContain('("opted-out-external-package",!0)')
+          expect(allBundles).toContain(
+            '"[externals]/ [external] (opted-out-external-package, cjs)"'
+          )
         } else {
           const output = await fs.readFile(
             join(appDir, '.next/server/pages/index.js'),

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -4040,10 +4040,9 @@
       "runtimeError": false
     },
     "test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts": {
-      "passed": [
-        "fetch failures have good stack traces in edge runtime when returning `fetch` using an unknown domain, stack traces are preserved"
-      ],
+      "passed": [],
       "failed": [
+        "fetch failures have good stack traces in edge runtime when returning `fetch` using an unknown domain, stack traces are preserved",
         "fetch failures have good stack traces in edge runtime when awaiting `fetch` using an unknown domain, stack traces are preserved"
       ],
       "pending": [],

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -6134,10 +6134,11 @@
   },
   "test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts": {
     "passed": [
-      "fetch failures have good stack traces in edge runtime when awaiting `fetch` using an unknown domain, stack traces are preserved",
+      "fetch failures have good stack traces in edge runtime when awaiting `fetch` using an unknown domain, stack traces are preserved"
+    ],
+    "failed": [
       "fetch failures have good stack traces in edge runtime when returning `fetch` using an unknown domain, stack traces are preserved"
     ],
-    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
### What?
This is a fix for a bundle potentially referring to two different external modules (e.g. `react` because it gets invalided from the require cache)

See https://github.com/vercel/turbo/pull/7988

### Turbopack Updates
* https://github.com/vercel/turbo/pull/8376 <!-- Tim Neutkens - Rename ChunkLoading::None to ChunkLoading::Edge  -->
* https://github.com/vercel/turbo/pull/8371 <!-- Donny/강동윤 - test: Add an execution test for `paren_remover`  -->
* https://github.com/vercel/turbo/pull/8370 <!-- Tobias Koppers - Tree Shaking shared state and side effects  -->
* https://github.com/vercel/turbo/pull/7988 <!-- hrmny - feat(turbopack-ecmascript): cache external modules with wrapper  -->

Closes PACK-2622
