### PR TITLE
fix(error-overlay): matching html tag with brackets in hydration error

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/component-stack-pseudo-html.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/component-stack-pseudo-html.tsx
@@ -73,7 +73,10 @@ export function PseudoHtmlDiff({
   const [isHtmlCollapsed, toggleCollapseHtml] = useState(shouldCollapse)
 
   const htmlComponents = useMemo(() => {
-    const tagNames = isHtmlTagsWarning ? [firstContent, secondContent] : []
+    const tagNames = isHtmlTagsWarning
+      ? // tags could have < or > in the name, so we always remove them to match
+        [firstContent.replace(/<|>/g, ''), secondContent.replace(/<|>/g, '')]
+      : []
     const nestedHtmlStack: React.ReactNode[] = []
     let lastText = ''
 

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
@@ -216,6 +216,6 @@ export const styles = css`
     font-size: 0;
   }
   [data-nextjs-container-errors-pseudo-html--tag-adjacent='false'] {
-    color: var(--color-accents-3);
+    color: var(--color-accents-1);
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/hydration-error-info.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/hydration-error-info.ts
@@ -19,8 +19,7 @@ export const getHydrationWarningType = (
 const isHtmlTagsWarning = (msg: NullableText) =>
   Boolean(msg && htmlTagsWarnings.has(msg))
 
-const isTextMismatchWarning = (msg: NullableText) =>
-  Boolean(msg && textMismatchWarning === msg)
+const isTextMismatchWarning = (msg: NullableText) => textMismatchWarning === msg
 const isTextInTagsMismatchWarning = (msg: NullableText) =>
   Boolean(msg && textAndTagsMismatchWarnings.has(msg))
 

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/hydration-error-info.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/hydration-error-info.ts
@@ -20,9 +20,9 @@ const isHtmlTagsWarning = (msg: NullableText) =>
   Boolean(msg && htmlTagsWarnings.has(msg))
 
 const isTextMismatchWarning = (msg: NullableText) =>
-  Boolean(msg && textMismatchWarnings.has(msg))
+  Boolean(msg && textMismatchWarning === msg)
 const isTextInTagsMismatchWarning = (msg: NullableText) =>
-  Boolean(msg && textInTagsMismatchWarnings.has(msg))
+  Boolean(msg && textAndTagsMismatchWarnings.has(msg))
 
 const isKnownHydrationWarning = (msg: NullableText) =>
   isHtmlTagsWarning(msg) ||
@@ -37,13 +37,12 @@ const htmlTagsWarnings = new Set([
   'Warning: Expected server HTML to contain a matching <%s> in <%s>.%s',
   'Warning: Did not expect server HTML to contain a <%s> in <%s>.%s',
 ])
-const textInTagsMismatchWarnings = new Set([
+const textAndTagsMismatchWarnings = new Set([
   'Warning: Expected server HTML to contain a matching text node for "%s" in <%s>.%s',
   'Warning: Did not expect server HTML to contain the text node "%s" in <%s>.%s',
 ])
-const textMismatchWarnings = new Set([
-  'Warning: Text content did not match. Server: "%s" Client: "%s"%s',
-])
+const textMismatchWarning =
+  'Warning: Text content did not match. Server: "%s" Client: "%s"%s'
 
 /**
  * Patch console.error to capture hydration errors.

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -349,7 +349,7 @@ describe('Error overlay for hydration errors', () => {
     await cleanup()
   })
 
-  it('should only show one hydration error when bad nesting happened', async () => {
+  it('should only show one hydration error when bad nesting happened - p under p', async () => {
     const { cleanup, session, browser } = await sandbox(
       next,
       new Map([
@@ -406,6 +406,69 @@ describe('Error overlay for hydration errors', () => {
           ^^^
             <p>
             ^^^"
+      `)
+    }
+
+    await cleanup()
+  })
+
+  it('should only show one hydration error when bad nesting happened - div under p', async () => {
+    const { cleanup, session, browser } = await sandbox(
+      next,
+      new Map([
+        [
+          'app/page.js',
+          outdent`
+            'use client'
+
+            export default function Page() {
+              return (
+                <p>
+                  <div>Nested div under p tag</div>
+                </p>
+              )
+            }
+          `,
+        ],
+      ])
+    )
+
+    await session.waitForAndOpenRuntimeError()
+    expect(await session.hasRedbox()).toBe(true)
+
+    const totalErrorCount = await browser
+      .elementByCss('[data-nextjs-dialog-header-total-count]')
+      .text()
+    expect(totalErrorCount).toBe('1')
+
+    const description = await session.getRedboxDescription()
+    expect(description).toContain(
+      'Error: Hydration failed because the initial UI does not match what was rendered on the server.'
+    )
+    const warning = await session.getRedboxDescriptionWarning()
+    expect(warning).toContain(
+      'In HTML, <div> cannot be a descendant of <p>.\nThis will cause a hydration error.'
+    )
+
+    const pseudoHtml = await session.getRedboxComponentStack()
+
+    // Turbopack currently has longer component stack trace
+    if (isTurbopack) {
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+        "...
+          <Page>
+            <p>
+            ^^^
+              <div>
+              ^^^^^"
+      `)
+    } else {
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+        "<Page>
+          <p>
+          ^^^
+            <div>
+            ^^^^^"
       `)
     }
 


### PR DESCRIPTION
### What

* The tags extracted from hydration errors could be "<div>" and "p", we need to stripe the brackets "<>" for matching the tag name from component stack
* Change the dimmed text color to lighter so you can see it better in light mode

#### After vs Before

<img width="450" src="https://github.com/vercel/next.js/assets/4800338/6caed5ac-c073-41cc-a699-eb29f3785d59">

<img width="450" src="https://github.com/vercel/next.js/assets/4800338/926aa80f-2a49-4362-b77e-16b819955b0a">


Closes NEXT-2828