### PR TITLE
Turbopack webpack loaders can't load a page with `getServerSideProps` if `app` folder exist

### DIFF
--- a/test/e2e/app-dir/webpack-loader-getServerSideProps/app/layout.tsx
+++ b/test/e2e/app-dir/webpack-loader-getServerSideProps/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/webpack-loader-getServerSideProps/app/page.tsx
+++ b/test/e2e/app-dir/webpack-loader-getServerSideProps/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'App page'
+}

--- a/test/e2e/app-dir/webpack-loader-getServerSideProps/next.config.js
+++ b/test/e2e/app-dir/webpack-loader-getServerSideProps/next.config.js
@@ -1,0 +1,16 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    turbo: {
+      rules: {
+        './pages/index.tsx': {
+          loaders: [require.resolve('./test-file-loader.js')],
+        },
+      },
+    },
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/webpack-loader-getServerSideProps/pages/index.tsx
+++ b/test/e2e/app-dir/webpack-loader-getServerSideProps/pages/index.tsx
@@ -1,0 +1,1 @@
+// this file will be loaded by test-file-loader

--- a/test/e2e/app-dir/webpack-loader-getServerSideProps/test-file-loader.js
+++ b/test/e2e/app-dir/webpack-loader-getServerSideProps/test-file-loader.js
@@ -1,0 +1,12 @@
+module.exports = function () {
+  const options = this.getOptions()
+  return `
+  export default function Page({}) {
+    return 'RENDERED_BY_LOADER'
+  }
+  export const getServerSideProps = async () => {
+    return {
+      props: {}
+    }
+  }`
+}

--- a/test/e2e/app-dir/webpack-loader-getServerSideProps/webpack-loader-pages.test.ts
+++ b/test/e2e/app-dir/webpack-loader-getServerSideProps/webpack-loader-pages.test.ts
@@ -1,0 +1,24 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('webpack-loader-conditions', () => {
+  const { next, isTurbopack } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (!isTurbopack) {
+    it('should only run the test in turbopack', () => {})
+    return
+  }
+
+  it('should render correctly on server site', async () => {
+    const res = await next.fetch('/')
+    const html = (await res.text()).replaceAll(/<!-- -->/g, '')
+    expect(html).toContain(`MAGIC_NUMBER`)
+  })
+
+  it('should render correctly on client side', async () => {
+    const browser = await next.browser('/')
+    const text = await browser.elementByCss('body').text()
+    expect(text).toContain(`MAGIC_NUMBER`)
+  })
+})


### PR DESCRIPTION
### Fixing a bug

Added a failing test, when a loader returns code for a page with `getServerSideProps` in a loader Next.js will show the error 

```
"getServerSideProps" is not supported in app/. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching
```

Notice that if you don't have an app folder everything will work correctly

