### PR TITLE
Use correct protocol and hostname for internal redirections in Server Actions

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -182,12 +182,13 @@ async function createRedirectRenderResult(
     const proto =
       staticGenerationStore.incrementalCache?.requestProtocol || 'https'
 
-    // For standalone or the serverful mode, use the internal hostname directly
-    // other than the headers from the request.
-    const host = process.env.__NEXT_PRIVATE_HOST || originalHost.value
+    // For standalone or the serverful mode, use the internal origin directly
+    // other than the host headers from the request.
+    const origin =
+      process.env.__NEXT_PRIVATE_ORIGIN || `${proto}://${originalHost.value}`
 
     const fetchUrl = new URL(
-      `${proto}://${host}${basePath}${parsedRedirectUrl.pathname}${parsedRedirectUrl.search}`
+      `${origin}${basePath}${parsedRedirectUrl.pathname}${parsedRedirectUrl.search}`
     )
 
     if (staticGenerationStore.revalidatedTags) {

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -246,7 +246,7 @@ export async function startServer(
 
       // expose the main port to render workers
       process.env.PORT = port + ''
-      process.env.__NEXT_PRIVATE_HOST = `${actualHostname}:${port}`
+      process.env.__NEXT_PRIVATE_ORIGIN = appUrl
 
       // Only load env and config in dev to for logging purposes
       let envInfo: string[] | undefined


### PR DESCRIPTION
Currently, we always fallback to https as the protocol for redirection requests inside Server Actions even for the local server host, which can be `0.0.0.0` and result in SSL errors.

Closes #63114, partially resolves https://github.com/vercel/next.js/issues/62903#issuecomment-1984179180.

Closes NEXT-2829