### PR TITLE
Skip worker test in Turbopack

### DIFF
--- a/test/e2e/app-dir/app-external/app-external.test.ts
+++ b/test/e2e/app-dir/app-external/app-external.test.ts
@@ -149,19 +149,26 @@ createNextDescribe(
         )
       ).toMatch(/^__myFont_.{6}, __myFont_Fallback_.{6}$/)
     })
-
-    it('should not apply swc optimizer transform for external packages in browser layer in web worker', async () => {
-      const browser = await next.browser('/browser')
-      expect(await browser.elementByCss('#worker-state').text()).toBe('default')
-
-      await browser.elementByCss('button').click()
-
-      await retry(async () => {
+    // TODO: This test depends on `new Worker` which is not supported in Turbopack yet.
+    ;(process.env.TURBOPACK ? it.skip : it)(
+      'should not apply swc optimizer transform for external packages in browser layer in web worker',
+      async () => {
+        const browser = await next.browser('/browser')
+        // eslint-disable-next-line jest/no-standalone-expect
         expect(await browser.elementByCss('#worker-state').text()).toBe(
-          'worker.js:browser-module/other'
+          'default'
         )
-      })
-    })
+
+        await browser.elementByCss('button').click()
+
+        await retry(async () => {
+          // eslint-disable-next-line jest/no-standalone-expect
+          expect(await browser.elementByCss('#worker-state').text()).toBe(
+            'worker.js:browser-module/other'
+          )
+        })
+      }
+    )
 
     describe('react in external esm packages', () => {
       it('should use the same react in client app', async () => {


### PR DESCRIPTION
## What?

`new Worker()` is not supported yet in Turbopack. Support for it will be added after stable.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2831