### PR TITLE
feat(error-overlay): handle script under html hydration error

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
@@ -231,7 +231,8 @@ export function Errors({
     ? warningTemplate
         .replace('%s', serverContent)
         .replace('%s', clientContent)
-        .replace('%s', '') // remove the last %s for stack
+        .replace('%s', '') // remove the %s for stack
+        .replace(/%s$/, '') // If there's still a %s at the end, remove it
         .replace(/^Warning: /, '')
     : null
 
@@ -269,16 +270,18 @@ export function Errors({
             >
               {error.name}: <HotlinkedText text={error.message} />
             </p>
-            {hydrationWarning && activeError.componentStackFrames && (
+            {hydrationWarning && (
               <>
                 <p id="nextjs__container_errors__extra">{hydrationWarning}</p>
-                <PseudoHtmlDiff
-                  className="nextjs__container_errors__extra_code"
-                  hydrationMismatchType={hydrationErrorType}
-                  componentStackFrames={activeError.componentStackFrames}
-                  firstContent={serverContent}
-                  secondContent={clientContent}
-                />
+                {activeError.componentStackFrames?.length ? (
+                  <PseudoHtmlDiff
+                    className="nextjs__container_errors__extra_code"
+                    hydrationMismatchType={hydrationErrorType}
+                    componentStackFrames={activeError.componentStackFrames}
+                    firstContent={serverContent}
+                    secondContent={clientContent}
+                  />
+                ) : null}
               </>
             )}
             {isServerError ? (

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/hydration-error-info.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/hydration-error-info.ts
@@ -32,7 +32,11 @@ export const hydrationErrorState: HydrationErrorState = {}
 
 // https://github.com/facebook/react/blob/main/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js used as a reference
 const htmlTagsWarnings = new Set([
+  'Warning: Cannot render a sync or defer <script> outside the main document without knowing its order. Try adding async="" or moving it into the root <head> tag.%s',
+  'Warning: In HTML, %s cannot be a child of <%s>.%s\nThis will cause a hydration error.%s',
   'Warning: In HTML, %s cannot be a descendant of <%s>.\nThis will cause a hydration error.%s',
+  'Warning: In HTML, text nodes cannot be a child of <%s>.\nThis will cause a hydration error.',
+  "Warning: In HTML, whitespace text nodes cannot be a child of <%s>. Make sure you don't have any extra whitespace between tags on each line of your source code.\nThis will cause a hydration error.",
   'Warning: Expected server HTML to contain a matching <%s> in <%s>.%s',
   'Warning: Did not expect server HTML to contain a <%s> in <%s>.%s',
 ])


### PR DESCRIPTION
script tag cannot be placed under html directly, users reported a case in #51242 that having `<Script>` under html will cause hydration error, this will display the React hydration error related warning of bad usage for it.

You will see this warning in dev overlay instead of displaying nothing
```
In HTML, <script> cannot be a child of <html>.
This will cause a hydration error.
```

Added two other react warnings detection patterns  as well
* `Warning: In HTML, text nodes cannot be a child of <%s>.\nThis will cause a hydration error.',`
* `Warning: In HTML, whitespace text nodes cann...`

But tested they're not generating hydration errors, only warnings in console, so we don't need to have tests for them.

Closes NEXT-2835