### PR TITLE
Turbopack HMR: use own snapshot in error-recovery

### DIFF
--- a/test/development/acceptance/__snapshots__/error-recovery.test.ts.snap
+++ b/test/development/acceptance/__snapshots__/error-recovery.test.ts.snap
@@ -11,3 +11,15 @@ exports[`ReactRefreshLogBox default syntax > runtime error 1`] = `
   7 | export default function FunctionNamed() {
   8 |   return <div />"
 `;
+
+exports[`ReactRefreshLogBox turbo syntax > runtime error 1`] = `
+"index.js (5:9) @ eval
+
+  3 | setInterval(() => {
+  4 |   i++
+> 5 |   throw Error('no ' + i)
+    |         ^
+  6 | }, 1000)
+  7 | export default function FunctionNamed() {
+  8 |   return <div />"
+`;

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -434,50 +434,81 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 1000))
     expect(await session.hasRedbox()).toBe(true)
-    expect(next.normalizeTestDirContent(await session.getRedboxSource()))
-      .toMatchInlineSnapshot(`
-      "./index.js
-      Error: 
-        x Expected '}', got '<eof>'
-         ,-[TEST_DIR/index.js:4:1]
-       4 |   i++
-       5 |   throw Error('no ' + i)
-       6 | }, 1000)
-       7 | export default function FunctionNamed() {
-         :                                         ^
-         \`----
+    let redboxSource = next.normalizeTestDirContent(
+      await session.getRedboxSource()
+    )
 
-      Caused by:
-          Syntax Error
+    if (isTurbopack) {
+      // TODO: Remove this branching once import traces are implemented in Turbopack
+      expect(redboxSource).toMatchInlineSnapshot(`
+        "./index.js:7:41
+        Parsing ecmascript source code failed
+          5 |   throw Error('no ' + i)
+          6 | }, 1000)
+        > 7 | export default function FunctionNamed() {
+            |                                         ^
 
-      Import trace for requested module:
-      ./index.js
-      ./pages/index.js"
-    `)
+        Expected '}', got '<eof>'"
+      `)
+    } else {
+      expect(redboxSource).toMatchInlineSnapshot(`
+              "./index.js
+              Error: 
+                x Expected '}', got '<eof>'
+                 ,-[TEST_DIR/index.js:4:1]
+               4 |   i++
+               5 |   throw Error('no ' + i)
+               6 | }, 1000)
+               7 | export default function FunctionNamed() {
+                 :                                         ^
+                 \`----
+
+              Caused by:
+                  Syntax Error
+
+              Import trace for requested module:
+              ./index.js
+              ./pages/index.js"
+          `)
+    }
 
     // Test that runtime error does not take over:
     await new Promise((resolve) => setTimeout(resolve, 2000))
     expect(await session.hasRedbox()).toBe(true)
-    expect(next.normalizeTestDirContent(await session.getRedboxSource()))
-      .toMatchInlineSnapshot(`
-      "./index.js
-      Error: 
-        x Expected '}', got '<eof>'
-         ,-[TEST_DIR/index.js:4:1]
-       4 |   i++
-       5 |   throw Error('no ' + i)
-       6 | }, 1000)
-       7 | export default function FunctionNamed() {
-         :                                         ^
-         \`----
+    redboxSource = next.normalizeTestDirContent(await session.getRedboxSource())
+    if (isTurbopack) {
+      // TODO: Remove this branching once import traces are implemented in Turbopack
+      expect(redboxSource).toMatchInlineSnapshot(`
+        "./index.js:7:41
+        Parsing ecmascript source code failed
+          5 |   throw Error('no ' + i)
+          6 | }, 1000)
+        > 7 | export default function FunctionNamed() {
+            |                                         ^
 
-      Caused by:
-          Syntax Error
+        Expected '}', got '<eof>'"
+      `)
+    } else {
+      expect(redboxSource).toMatchInlineSnapshot(`
+              "./index.js
+              Error: 
+                x Expected '}', got '<eof>'
+                 ,-[TEST_DIR/index.js:4:1]
+               4 |   i++
+               5 |   throw Error('no ' + i)
+               6 | }, 1000)
+               7 | export default function FunctionNamed() {
+                 :                                         ^
+                 \`----
 
-      Import trace for requested module:
-      ./index.js
-      ./pages/index.js"
-    `)
+              Caused by:
+                  Syntax Error
+
+              Import trace for requested module:
+              ./index.js
+              ./pages/index.js"
+          `)
+    }
 
     await cleanup()
   })


### PR DESCRIPTION
This records dedicated snapshots for Turbopack for the remaining tests in `test/development/acceptance/error-recovery.test.ts`. The only remaining difference was the lack of Import trace information.

Test Plan: `TURBOPACK=1 pnpm test-dev test/development/acceptance/error-recovery.test.ts`


Closes PACK-2761