### PR TITLE
fix(next-core): carry over original segment config to metadata route

### DIFF
--- a/packages/next-swc/crates/next-api/src/app.rs
+++ b/packages/next-swc/crates/next-api/src/app.rs
@@ -495,6 +495,7 @@ impl AppEndpoint {
             Vc::upcast(FileSource::new(path)),
             self.page.clone(),
             self.app_project.project().project_path(),
+            None,
         )
     }
 

--- a/packages/next-swc/crates/next-core/src/next_app/app_favicon_entry.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/app_favicon_entry.rs
@@ -89,5 +89,6 @@ pub async fn get_app_route_favicon_entry(
         // TODO(alexkirsz) Get this from the metadata?
         AppPage(vec![PageSegment::Static("/favicon.ico".to_string())]),
         project_root,
+        None,
     ))
 }

--- a/packages/next-swc/crates/next-core/src/next_app/metadata/route.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/metadata/route.rs
@@ -9,7 +9,10 @@ use turbo_tasks::{ValueToString, Vc};
 use turbopack_binding::{
     turbo::tasks_fs::{File, FileContent, FileSystemPath},
     turbopack::{
-        core::{asset::AssetContent, source::Source, virtual_source::VirtualSource},
+        core::{
+            asset::AssetContent, file_source::FileSource, source::Source,
+            virtual_source::VirtualSource,
+        },
         ecmascript::utils::StringifyJs,
         turbopack::ModuleAssetContext,
     },
@@ -20,6 +23,7 @@ use crate::{
     app_structure::MetadataItem,
     mode::NextMode,
     next_app::{app_entry::AppEntry, app_route_entry::get_app_route_entry, AppPage, PageSegment},
+    parse_segment_config_from_source,
 };
 
 /// Computes the route source for a Next.js metadata file.
@@ -55,12 +59,22 @@ pub fn get_app_metadata_route_entry(
     mode: NextMode,
     metadata: MetadataItem,
 ) -> Vc<AppEntry> {
+    // Read original source's segment config before replacing source into
+    // dynamic|static metadata route handler.
+    let original_path = match metadata {
+        MetadataItem::Static { path } | MetadataItem::Dynamic { path } => path,
+    };
+
+    let source = Vc::upcast(FileSource::new(original_path));
+    let config = parse_segment_config_from_source(source);
+
     get_app_route_entry(
         nodejs_context,
         edge_context,
         get_app_metadata_route_source(page.clone(), mode, metadata),
         page,
         project_root,
+        Some(config),
     )
 }
 

--- a/test/turbopack-tests-manifest.json
+++ b/test/turbopack-tests-manifest.json
@@ -3774,11 +3774,10 @@
       "app dir - metadata dynamic routes social image routes should support params as argument in dynamic routes",
       "app dir - metadata dynamic routes text routes should handle robots.[ext] dynamic routes",
       "app dir - metadata dynamic routes text routes should handle sitemap.[ext] dynamic routes",
-      "app dir - metadata dynamic routes text routes should not throw if client components are imported but not used"
-    ],
-    "failed": [
+      "app dir - metadata dynamic routes text routes should not throw if client components are imported but not used",
       "app dir - metadata dynamic routes social image routes should handle custom fonts in both edge and nodejs runtime"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
### What

Fixes to honor metadata route's segment config - turbopack replaces it into route handler, then parsed segment config so original segment config was ignored always.

Closes PACK-2762