### PR TITLE
Rename variable in documentation example

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/cookies.mdx
+++ b/docs/02-app/02-api-reference/04-functions/cookies.mdx
@@ -52,8 +52,8 @@ A method that takes a cookie name and returns a `boolean` based on if the cookie
 import { cookies } from 'next/headers'
 
 export default function Page() {
-  const cookiesList = cookies()
-  const hasCookie = cookiesList.has('theme')
+  const cookieStore = cookies()
+  const hasCookie = cookieStore.has('theme')
   return '...'
 }
 ```


### PR DESCRIPTION
Rename variable `cookieList` to `cookieStore` in [documentation example](https://nextjs.org/docs/app/api-reference/functions/cookies#cookieshasname) to be aligned with every other example in the same page ([here](https://github.com/KonkenBonken/next.js/blob/51b878f5a30c01c8fa3ba7a227becea951909c99/docs/02-app/02-api-reference/04-functions/cookies.mdx#L23) and [here](https://github.com/KonkenBonken/next.js/blob/51b878f5a30c01c8fa3ba7a227becea951909c99/docs/02-app/02-api-reference/04-functions/cookies.mdx#L37) compared to [here](https://github.com/KonkenBonken/next.js/blob/51b878f5a30c01c8fa3ba7a227becea951909c99/docs/02-app/02-api-reference/04-functions/cookies.mdx#L55))
I see no deliberate reason the [third example](https://github.com/KonkenBonken/next.js/blob/51b878f5a30c01c8fa3ba7a227becea951909c99/docs/02-app/02-api-reference/04-functions/cookies.mdx#L51-L59) should differ from the rest.