### PR TITLE
Turbopack HMR: Reload when recovering from server-side errors

### DIFF
--- a/packages/next/src/client/page-bootstrap.ts
+++ b/packages/next/src/client/page-bootstrap.ts
@@ -82,6 +82,11 @@ export function pageBootrap(assetPrefix: string) {
             break
           }
           case HMR_ACTIONS_SENT_TO_BROWSER.SERVER_ONLY_CHANGES: {
+            if (RuntimeErrorHandler.hadRuntimeError) {
+              console.warn(REACT_REFRESH_FULL_RELOAD_FROM_ERROR)
+              performFullReload(null)
+            }
+
             const { pages } = payload
 
             // Make sure to reload when the dev-overlay is showing for an


### PR DESCRIPTION
Test Plan: `TURBOPACK=1 pnpm test-dev test/development/basic/gssp-ssr-change-reloading/test/index.test.ts


Closes PACK-2767