### PR TITLE
chore(next/font): update @capsizecss/metrics package to the latest

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -136,7 +136,7 @@
     "@babel/runtime": "7.22.5",
     "@babel/traverse": "7.22.5",
     "@babel/types": "7.22.5",
-    "@capsizecss/metrics": "2.1.1",
+    "@capsizecss/metrics": "2.2.0",
     "@edge-runtime/cookies": "4.1.0",
     "@edge-runtime/ponyfill": "2.4.2",
     "@edge-runtime/primitives": "4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -903,8 +903,8 @@ importers:
         specifier: 7.22.5
         version: 7.22.5
       '@capsizecss/metrics':
-        specifier: 2.1.1
-        version: 2.1.1
+        specifier: 2.2.0
+        version: 2.2.0
       '@edge-runtime/cookies':
         specifier: 4.1.0
         version: 4.1.0
@@ -3399,8 +3399,8 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@capsizecss/metrics@2.1.1:
-    resolution: {integrity: sha512-c+anvlfk5+EYO8tnf9a6bmKQpniw+Nd7ZyiQpA9lRBCwM93zDZEGiTO5w04xVckj7fpPsiYuzNUS78AKMShnIw==}
+  /@capsizecss/metrics@2.2.0:
+    resolution: {integrity: sha512-DkFIser1KbGxWyG2hhQQeCit72TnOQDx5pr9bkA7+XlIy7qv+4lYtslH3bidVxm2qkY2guAgypSIPYuQQuk70A==}
     dev: true
 
   /@csstools/postcss-color-function@1.1.0(postcss@8.4.31):


### PR DESCRIPTION
## Why?

- https://github.com/seek-oss/capsize/releases/tag/%40capsizecss%2Fmetrics%402.2.0
- Related → https://github.com/vercel/next.js/pull/62896

Closes NEXT-2854