### PR TITLE
test: switch order of tests to avoid flakniess

### DIFF
--- a/test/e2e/app-dir/app-basepath/index.test.ts
+++ b/test/e2e/app-dir/app-basepath/index.test.ts
@@ -59,8 +59,9 @@ createNextDescribe(
     it('should handle redirect in dynamic in suspense boundary routes with basePath', async () => {
       const browser = await next.browser('/base/dynamic/source')
       await retry(async () => {
-        expect(await browser.url()).toBe(`${next.url}/base/dynamic/dest`)
+        // Check content is loaded first to avoid flakiness
         expect(await browser.elementByCss('p').text()).toBe(`id:dest`)
+        expect(await browser.url()).toBe(`${next.url}/base/dynamic/dest`)
       })
     })
   }


### PR DESCRIPTION
x-ref: https://github.com/vercel/next.js/actions/runs/8344655954/job/22838765632?pr=63476

We saw the playwright execution was broken while accessing url in turbopack tests. Switching the order to check the content first solve the problem

Closes NEXT-2867