### PR TITLE
Update generate-viewport.mdx

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/generate-viewport.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-viewport.mdx
@@ -118,7 +118,7 @@ export const viewport = {
 
 ### `width`, `initialScale`, `maximumScale` and `userScalable`
 
-> **Good to know**: The `viewport` meta tag is automatically set with the following default values. Usually, manual configuration is unnecessary as the default is sufficient. However, the information is provided for completeness.
+> **Good to know**: The `viewport` meta tag is automatically set, and manual configuration is usually unnecessary as the default is sufficient. However, the information is provided for completeness.
 
 ```tsx filename="layout.tsx | page.tsx" switcher
 import type { Viewport } from 'next'


### PR DESCRIPTION
Updates inaccurate wording that says the following example contains the default configuration. I did this rather than update the example because the [default configuration](https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/default-metadata.tsx#L9) does not set all values, so it seems useful that the example documents all of them.

(By the way, the configuration in the example violates accessibility standards by setting `userScalable: false` and `maximumScale: 1`, which is what caught my eye in the first place. Glad to find out that it wasn't the actual default)