### PR TITLE
chore: fix stale issue closing GH Action

### DIFF
--- a/.github/workflows/issue_stale.yml
+++ b/.github/workflows/issue_stale.yml
@@ -15,7 +15,7 @@ jobs:
         name: 'Close stale issues with no reproduction'
         with:
           repo-token: ${{ secrets.STALE_TOKEN }}
-          only-labels: 'please add a complete reproduction,please simplify reproduction'
+          any-of-labels: 'please add a complete reproduction,please simplify reproduction'
           close-issue-message: 'This issue has been automatically closed because it received no activity for a month and had no reproduction to investigate. If you think it was closed by accident, please leave a comment. If you are running into a similar issue, please open a new issue with a reproduction. Thank you.'
           days-before-issue-close: 1
           days-before-issue-stale: 30
@@ -28,7 +28,7 @@ jobs:
         name: 'Close issues not verified on canary'
         with:
           repo-token: ${{ secrets.STALE_TOKEN }}
-          only-labels: 'please verify canary'
+          any-of-labels: 'please verify canary'
           close-issue-message: "This issue has been automatically closed because it wasn't verified against next@canary. If you think it was closed by accident, please leave a comment. If you are running into a similar issue, please open a new issue with a reproduction. Thank you."
           days-before-issue-close: 1
           days-before-issue-stale: 30


### PR DESCRIPTION
### What?

We were not closing some issues even after the defined stale time. Example: https://github.com/vercel/next.js/issues/57601#issuecomment-1893878000

### Why?

https://github.com/actions/stale#only-labels this config wants all labels to be present.

### How?

We need to use https://github.com/actions/stale#any-of-labels instead.

Closes NEXT-2879
[Slack thread](https://vercel.slack.com/archives/C04LGE5SYEB/p1710944041440829)