### PR TITLE
Update middleware matcher docs to mention has matching

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/13-middleware.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/13-middleware.mdx
@@ -97,7 +97,7 @@ export const config = {
 }
 ```
 
-You can also ignore prefetches (from `next/link`) that don't need to go through the Middleware using the `missing` array:
+You can also ignore requests that don't need to go through the Middleware using the `missing` or `has` arrays or both combined:
 
 ```js filename="middleware.js"
 export const config = {
@@ -115,6 +115,20 @@ export const config = {
         { type: 'header', key: 'next-router-prefetch' },
         { type: 'header', key: 'purpose', value: 'prefetch' },
       ],
+    },
+
+    {
+      source: '/((?!api|_next/static|_next/image|favicon.ico).*)',
+      has: [
+        { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'purpose', value: 'prefetch' },
+      ],
+    },
+
+    {
+      source: '/((?!api|_next/static|_next/image|favicon.ico).*)',
+      has: [{ type: 'header', key: 'x-present' }],
+      missing: [{ type: 'header', key: 'x-missing', value: 'prefetch' }],
     },
   ],
 }

--- a/docs/02-app/01-building-your-application/01-routing/13-middleware.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/13-middleware.mdx
@@ -97,7 +97,7 @@ export const config = {
 }
 ```
 
-You can also ignore requests that don't need to go through the Middleware using the `missing` or `has` arrays or both combined:
+You can also bypass Middleware for certain requests by using the `missing` or `has` arrays, or a combination of both:
 
 ```js filename="middleware.js"
 export const config = {


### PR DESCRIPTION
Looks like we were only documenting the `missing` matcher use case although `has` is also supported and we weren't mentioning they can combined as well. 

x-ref: [slack thread](https://vercel.slack.com/archives/C06LDQYNPV0/p1710704436247789)

Closes NEXT-2883