### PR TITLE
Turbopack: Fail when module type is unhandled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "serde",
  "smallvec",
@@ -3217,7 +3217,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "serde",
@@ -7160,7 +7160,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7192,7 +7192,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7204,7 +7204,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7219,7 +7219,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7233,7 +7233,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7250,7 +7250,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7282,7 +7282,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "base16",
  "hex",
@@ -7294,7 +7294,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7308,7 +7308,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7318,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "mimalloc",
 ]
@@ -7326,7 +7326,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7351,7 +7351,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7384,7 +7384,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7424,7 +7424,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7450,7 +7450,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "clap",
@@ -7469,7 +7469,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7500,7 +7500,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7528,7 +7528,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7565,7 +7565,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7603,7 +7603,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "serde",
  "serde_json",
@@ -7614,7 +7614,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7639,7 +7639,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7656,7 +7656,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7672,7 +7672,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7692,7 +7692,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "serde",
@@ -7707,7 +7707,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7722,7 +7722,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7760,7 +7760,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7784,7 +7784,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7806,7 +7806,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "serde",
@@ -7822,7 +7822,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7833,7 +7833,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -7849,7 +7849,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240320.2#8a311c10a5adb45f65bf886a2f1aab1e7398d039"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "serde",
  "smallvec",
@@ -3217,7 +3217,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "serde",
@@ -7160,7 +7160,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7192,7 +7192,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7204,7 +7204,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7219,7 +7219,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7233,7 +7233,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7250,7 +7250,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7282,7 +7282,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "base16",
  "hex",
@@ -7294,7 +7294,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7308,7 +7308,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7318,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "mimalloc",
 ]
@@ -7326,7 +7326,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7351,7 +7351,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7384,7 +7384,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7424,7 +7424,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7450,7 +7450,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "clap",
@@ -7469,7 +7469,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7500,7 +7500,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7528,7 +7528,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7565,7 +7565,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7603,7 +7603,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "serde",
  "serde_json",
@@ -7614,7 +7614,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7639,7 +7639,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7656,7 +7656,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7672,7 +7672,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7692,7 +7692,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "serde",
@@ -7707,7 +7707,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7722,7 +7722,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7760,7 +7760,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7784,7 +7784,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7806,7 +7806,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "serde",
@@ -7822,7 +7822,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7833,7 +7833,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -7849,7 +7849,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240319.2#0f31686269839f10966ae1f60eb71f822f29303a"
+source = "git+https://github.com/vercel/turbo.git?branch=wbinnssmith/module-type-issue#dd62d91665622d340e094301c942b171c941dc9a"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.90.22", features = [
 testing = { version = "0.35.20" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "wbinnssmith/module-type-issue" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240320.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "wbinnssmith/module-type-issue" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240320.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "wbinnssmith/module-type-issue" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240320.2" }
 
 # General Deps
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.90.22", features = [
 testing = { version = "0.35.20" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240319.2" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "wbinnssmith/module-type-issue" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240319.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "wbinnssmith/module-type-issue" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240319.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "wbinnssmith/module-type-issue" }
 
 # General Deps
 

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -51,7 +51,10 @@ export function isWellKnownError(issue: Issue): boolean {
   const { title } = issue
   const formattedTitle = renderStyledStringToErrorAnsi(title)
   // TODO: add more well known errors
-  if (formattedTitle.includes('Module not found')) {
+  if (
+    formattedTitle.includes('Module not found') ||
+    formattedTitle.includes('Unknown module type')
+  ) {
     return true
   }
 

--- a/test/development/basic/hmr.test.ts
+++ b/test/development/basic/hmr.test.ts
@@ -877,7 +877,17 @@ describe.each([[''], ['/docs']])(
 
           expect(await hasRedbox(browser)).toBe(true)
           expect(await getRedboxHeader(browser)).toMatch('Failed to compile')
-          expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
+
+          if (process.env.TURBOPACK) {
+            expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
+              "./components/parse-error.xyz
+              Unknown module type
+              This module doesn't have an associated type. Use a known file extension, or register a loader for it.
+
+              Read more: https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders"
+            `)
+          } else {
+            expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
                       "./components/parse-error.xyz
                       Module parse failed: Unexpected token (3:0)
                       You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
@@ -891,7 +901,7 @@ describe.each([[''], ['/docs']])(
                       ./components/parse-error.xyz
                       ./pages/hmr/about8.js"
                   `)
-
+          }
           await next.patchFile(aboutPage, aboutContent)
 
           await check(


### PR DESCRIPTION
This causes Turbopack to fail and communicate when a file with an unhandled or unregistered extension is built.

Test Plan: `TURBOPACK=1 pnpm test-dev test/development/basic/hmr.test.ts`


Closes PACK-2803