### PR TITLE
fix: call instrumentationHook earlier for prod server

### DIFF
--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -165,7 +165,6 @@ export default class NextNodeServer extends BaseServer {
   protected middlewareManifestPath: string
   private _serverDistDir: string | undefined
   private imageResponseCache?: ResponseCache
-  private prepareWasCalled = false
   protected renderWorkersPromises?: Promise<void>
   protected dynamicRoutes?: {
     match: import('../shared/lib/router/utils/route-matcher').RouteMatchFn

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -165,6 +165,7 @@ export default class NextNodeServer extends BaseServer {
   protected middlewareManifestPath: string
   private _serverDistDir: string | undefined
   private imageResponseCache?: ResponseCache
+  private prepareWasCalled = false
   protected renderWorkersPromises?: Promise<void>
   protected dynamicRoutes?: {
     match: import('../shared/lib/router/utils/route-matcher').RouteMatchFn
@@ -252,6 +253,16 @@ export default class NextNodeServer extends BaseServer {
     }
 
     this.middlewareManifestPath = join(this.serverDistDir, MIDDLEWARE_MANIFEST)
+
+    // This is just optimization to fire prepare as soon as possible. It will be
+    // properly awaited later. We add the catch here to ensure that it does not
+    // cause a unhandled promise rejection. The promise rejection will be
+    // handled later on via the `await` when the request handler is called.
+    if (!options.dev) {
+      this.prepare().catch((err) => {
+        console.error('Failed to prepare server', err)
+      })
+    }
   }
 
   protected async handleUpgrade(): Promise<void> {

--- a/test/e2e/instrumentation-hook/instrumentation-hook.test.ts
+++ b/test/e2e/instrumentation-hook/instrumentation-hook.test.ts
@@ -67,14 +67,12 @@ describe('Instrumentation Hook', () => {
 
   describeCase('with-node-api', ({ next }) => {
     it('with-node-api should run the instrumentation hook', async () => {
-      await next.render('/api')
       await check(() => next.cliOutput, /instrumentation hook on nodejs/)
     })
   })
 
   describeCase('with-node-page', ({ next }) => {
     it('with-node-page should run the instrumentation hook', async () => {
-      await next.render('/')
       await check(() => next.cliOutput, /instrumentation hook on nodejs/)
     })
   })


### PR DESCRIPTION

This ensures that the instrumentation hook for Node.js will run immediately during `next start` instead of waiting for the first request like does it `next dev`.

However, if there is a separate instrumentation hook for Edge, that will still be lazy evaluated and wait until the first request.

Fixes #59999 
Fixes NEXT-2738