### PR TITLE
Apply client bailout for usePathname during static generation

### DIFF
--- a/packages/next/src/client/components/error-boundary.tsx
+++ b/packages/next/src/client/components/error-boundary.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import React from 'react'
-import { usePathname } from './navigation'
+import React, { useContext } from 'react'
 import { isNextRouterError } from './is-next-router-error'
+import { PathnameContext } from '../../shared/lib/hooks-client-context.shared-runtime'
 
 const styles = {
   error: {
@@ -172,7 +172,7 @@ export function ErrorBoundary({
   errorScripts,
   children,
 }: ErrorBoundaryProps & { children: React.ReactNode }): JSX.Element {
-  const pathname = usePathname()
+  const pathname = useContext(PathnameContext) as string
   if (errorComponent) {
     return (
       <ErrorBoundaryHandler

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -79,6 +79,17 @@ function useSearchParams(): ReadonlyURLSearchParams {
  * Read more: [Next.js Docs: `usePathname`](https://nextjs.org/docs/app/api-reference/functions/use-pathname)
  */
 function usePathname(): string {
+  // Same as with useSearchParams(), we should bail to client
+  // rendering during static generation so that we don't
+  // include the wrong URL pathname value during initial render
+  if (typeof window === 'undefined') {
+    // AsyncLocalStorage should not be included in the client bundle.
+    const { bailoutToClientRendering } =
+      require('./bailout-to-client-rendering') as typeof import('./bailout-to-client-rendering')
+    // TODO-APP: handle dynamic = 'force-static' here and on the client
+    bailoutToClientRendering('usePathname()')
+  }
+
   // In the case where this is `null`, the compat types added in `next-env.d.ts`
   // will add a new overload that changes the return type to include `null`.
   return useContext(PathnameContext) as string

--- a/packages/next/src/client/components/not-found-boundary.tsx
+++ b/packages/next/src/client/components/not-found-boundary.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import React, { useContext } from 'react'
-import { usePathname } from './navigation'
 import { isNotFoundError } from './not-found'
 import { warnOnce } from '../../shared/lib/utils/warn-once'
 import { MissingSlotContext } from '../../shared/lib/app-router-context.shared-runtime'
+import { PathnameContext } from '../../shared/lib/hooks-client-context.shared-runtime'
 
 interface NotFoundBoundaryProps {
   notFound?: React.ReactNode
@@ -114,7 +114,7 @@ export function NotFoundBoundary({
   asNotFound,
   children,
 }: NotFoundBoundaryProps) {
-  const pathname = usePathname()
+  const pathname = useContext(PathnameContext) as string
   const missingSlots = useContext(MissingSlotContext)
   return notFound ? (
     <NotFoundErrorBoundary

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1410,8 +1410,12 @@ export const renderToHTMLOrFlight: AppPageRender = (
   query,
   renderOpts
 ) => {
-  // TODO: this includes query string, should it?
-  const pathname = validateURL(req.url)
+  // This should include query as well as that is parsed
+  // from this value further down in app-router via new URL
+  // TODO: should we normalize/stub this value for the static
+  // generation case so that revalidate doesn't accidentally
+  // "leak" a request URL to rendering
+  const urlPathname = validateURL(req.url)
 
   return RequestAsyncStorageWrapper.wrap(
     renderOpts.ComponentMod.requestAsyncStorage,
@@ -1420,7 +1424,7 @@ export const renderToHTMLOrFlight: AppPageRender = (
       StaticGenerationAsyncStorageWrapper.wrap(
         renderOpts.ComponentMod.staticGenerationAsyncStorage,
         {
-          urlPathname: pathname,
+          urlPathname,
           renderOpts,
           postpone: React.unstable_postpone,
         },

--- a/test/e2e/app-dir/app-basepath/app/use-pathname-another/page.js
+++ b/test/e2e/app-dir/app-basepath/app/use-pathname-another/page.js
@@ -1,3 +1,12 @@
 'use client'
 
-export { ReadPathName as default } from '../../components/read-path-name'
+import { Suspense } from 'react'
+import { ReadPathName } from '../../components/read-path-name'
+
+export default function Page() {
+  return (
+    <Suspense>
+      <ReadPathName />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/app-basepath/app/use-pathname/page.js
+++ b/test/e2e/app-dir/app-basepath/app/use-pathname/page.js
@@ -1,3 +1,12 @@
 'use client'
 
-export { ReadPathName as default } from '../../components/read-path-name'
+import { Suspense } from 'react'
+import { ReadPathName } from '../../components/read-path-name'
+
+export default function Page() {
+  return (
+    <Suspense>
+      <ReadPathName />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/app-static/app/pathname-component.tsx
+++ b/test/e2e/app-dir/app-static/app/pathname-component.tsx
@@ -1,14 +1,13 @@
 'use client'
+
 import { usePathname } from 'next/navigation'
 import { Suspense } from 'react'
 
-export const dynamicParams = false
-
 function Pathname() {
-  return <p id="pathname">{usePathname()}</p>
+  return <p>pathname: {usePathname()}</p>
 }
 
-export default function Page() {
+export function ShowPathname() {
   return (
     <Suspense fallback={null}>
       <Pathname />

--- a/test/e2e/app-dir/app-static/app/rewritten-isr-3/page.tsx
+++ b/test/e2e/app-dir/app-static/app/rewritten-isr-3/page.tsx
@@ -1,0 +1,13 @@
+import { ShowPathname } from '../pathname-component'
+
+export const revalidate = 3
+
+export default function Page() {
+  console.log('rendering /rewritten-isr-3')
+  return (
+    <>
+      <p>/rewritten-isr-3</p>
+      <ShowPathname />
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-static/app/rewritten-isr-false/page.tsx
+++ b/test/e2e/app-dir/app-static/app/rewritten-isr-false/page.tsx
@@ -1,0 +1,13 @@
+import { ShowPathname } from '../pathname-component'
+
+export const revalidate = false
+
+export default function Page() {
+  console.log('rendering /rewritten-isr-false')
+  return (
+    <>
+      <p>/rewritten-isr-false</p>
+      <ShowPathname />
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-static/middleware.ts
+++ b/test/e2e/app-dir/app-static/middleware.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export default function middleware(req: NextRequest) {
+  if (req.nextUrl.pathname === '/rewrite-me-isr-false') {
+    req.nextUrl.pathname = '/rewritten-isr-false'
+    return NextResponse.rewrite(req.nextUrl)
+  }
+
+  if (req.nextUrl.pathname === '/rewrite-me-isr-3') {
+    req.nextUrl.pathname = '/rewritten-isr-3'
+    return NextResponse.rewrite(req.nextUrl)
+  }
+}

--- a/test/e2e/app-dir/app/app/dynamic-client/[category]/[id]/page.js
+++ b/test/e2e/app-dir/app/app/dynamic-client/[category]/[id]/page.js
@@ -2,14 +2,13 @@
 
 import { useSearchParams } from 'next/navigation'
 
-export default function IdPage({ children, params }) {
+export default function IdPage({ params }) {
   return (
     <>
       <p>
         Id Page. Params:{' '}
         <span id="id-page-params">{JSON.stringify(params)}</span>
       </p>
-      {children}
 
       <p id="search-params">
         {JSON.stringify(Object.fromEntries(useSearchParams()))}

--- a/test/e2e/app-dir/app/app/dynamic/[category]/[id]/page.js
+++ b/test/e2e/app-dir/app/app/dynamic/[category]/[id]/page.js
@@ -1,11 +1,10 @@
-export default function IdPage({ children, params, searchParams }) {
+export default function IdPage({ params, searchParams }) {
   return (
     <>
       <p>
         Id Page. Params:{' '}
         <span id="id-page-params">{JSON.stringify(params)}</span>
       </p>
-      {children}
 
       <p id="search-params">{JSON.stringify(searchParams)}</p>
     </>

--- a/test/e2e/app-dir/ppr/components/state.jsx
+++ b/test/e2e/app-dir/ppr/components/state.jsx
@@ -1,8 +1,12 @@
 'use client'
 
 import { usePathname } from 'next/navigation'
-import React from 'react'
+import { Suspense } from 'react'
 import { useCallback } from 'react'
+
+function Pathname() {
+  return <pre>pathname: {usePathname()}</pre>
+}
 
 export function Login({ signedIn = false, fallback }) {
   const onClick = useCallback(async () => {
@@ -20,11 +24,12 @@ export function Login({ signedIn = false, fallback }) {
 
     window.location.reload()
   }, [signedIn])
-  const pathname = usePathname()
 
   return (
     <>
-      <pre>pathname: {pathname}</pre>
+      <Suspense fallback={null}>
+        <Pathname />
+      </Suspense>
       <button
         id="login"
         className="bg-gray-400 hover:bg-gray-500 px-4 py-2 text-white rounded-md"


### PR DESCRIPTION
Currently when reading `usePathname()` during static generation or revalidation, the original request URL can leak through unexpectedly. This can cause issues when a rewrite is occurring as `usePathname()` should be the actual URL requested in the users browser but during static generation/ISR the URL is normalized to the destination URL to avoid redundant cache entries per-URL. 

To avoid this issue, this applies the same handling we do for `useSearchParams()` with static generation to bail to client rendering and wrapping usage in a `Suspense` boundary. 

x-ref: [slack thread](https://vercel.slack.com/archives/C04DUD7EB1B/p1710979289519679)

Closes NEXT-2886