### PR TITLE
perf(turbopack): Use `Arc<String>` instead of `String`

### DIFF
--- a/packages/next-swc/crates/napi/src/app_structure.rs
+++ b/packages/next-swc/crates/napi/src/app_structure.rs
@@ -27,8 +27,12 @@ use turbopack_binding::{
 use crate::register;
 
 #[turbo_tasks::function]
-async fn project_fs(project_dir: String, watching: bool) -> Result<Vc<Box<dyn FileSystem>>> {
-    let disk_fs = DiskFileSystem::new(PROJECT_FILESYSTEM_NAME.to_string(), project_dir, vec![]);
+async fn project_fs(project_dir: Arc<String>, watching: bool) -> Result<Vc<Box<dyn FileSystem>>> {
+    let disk_fs = DiskFileSystem::new(
+        PROJECT_FILESYSTEM_NAME.to_string().into(),
+        project_dir,
+        vec![],
+    );
     if watching {
         disk_fs.await?.start_watching_with_invalidation_reason()?;
     }
@@ -284,7 +288,7 @@ async fn prepare_loader_tree_for_js(
     add_meta(&mut meta.robots, project_path, global_metadata.robots).await?;
 
     Ok(LoaderTreeForJs {
-        segment: segment.clone(),
+        segment: segment.to_string(),
         parallel_routes,
         components,
         global_metadata: meta,
@@ -326,19 +330,24 @@ async fn prepare_entrypoints_for_js(
 
 #[turbo_tasks::function]
 async fn get_value(
-    root_dir: String,
-    project_dir: String,
-    page_extensions: Vec<String>,
+    root_dir: Arc<String>,
+    project_dir: Arc<String>,
+    page_extensions: Vec<Arc<String>>,
     watching: bool,
 ) -> Result<Vc<OptionEntrypointsForJs>> {
-    let page_extensions = Vc::cell(page_extensions);
+    let page_extensions = Vc::cell(
+        page_extensions
+            .iter()
+            .map(|v| (**v).clone())
+            .collect::<Vec<_>>(),
+    );
     let fs = project_fs(root_dir.clone(), watching);
-    let project_relative = project_dir.strip_prefix(&root_dir).unwrap();
+    let project_relative = project_dir.strip_prefix(&**root_dir).unwrap();
     let project_relative = project_relative
         .strip_prefix(MAIN_SEPARATOR)
         .unwrap_or(project_relative)
         .replace(MAIN_SEPARATOR, "/");
-    let project_path = fs.root().join(project_relative);
+    let project_path = fs.root().join(project_relative.into());
 
     let app_dir = find_app_dir(project_path);
 
@@ -379,9 +388,9 @@ pub fn stream_entrypoints(
         let page_extensions: Arc<Vec<String>> = page_extensions.clone();
         Box::pin(async move {
             if let Some(entrypoints) = &*get_value(
-                (*root_dir).clone(),
-                (*project_dir).clone(),
-                page_extensions.iter().map(|s| s.to_string()).collect(),
+                root_dir.clone(),
+                project_dir.clone(),
+                page_extensions.iter().cloned().map(Arc::new).collect(),
                 true,
             )
             .await?
@@ -411,9 +420,9 @@ pub async fn get_entrypoints(
     let result = turbo_tasks
         .run_once(async move {
             let value = if let Some(entrypoints) = &*get_value(
-                root_dir,
-                project_dir,
-                page_extensions.iter().map(|s| s.to_string()).collect(),
+                root_dir.into(),
+                project_dir.into(),
+                page_extensions.iter().cloned().map(Arc::new).collect(),
                 false,
             )
             .await?

--- a/packages/next-swc/crates/napi/src/app_structure.rs
+++ b/packages/next-swc/crates/napi/src/app_structure.rs
@@ -28,11 +28,7 @@ use crate::register;
 
 #[turbo_tasks::function]
 async fn project_fs(project_dir: String, watching: bool) -> Result<Vc<Box<dyn FileSystem>>> {
-    let disk_fs = DiskFileSystem::new(
-        PROJECT_FILESYSTEM_NAME.to_string(),
-        project_dir.to_string(),
-        vec![],
-    );
+    let disk_fs = DiskFileSystem::new(PROJECT_FILESYSTEM_NAME.to_string(), project_dir, vec![]);
     if watching {
         disk_fs.await?.start_watching_with_invalidation_reason()?;
     }

--- a/packages/next-swc/crates/napi/src/next_api/project.rs
+++ b/packages/next-swc/crates/napi/src/next_api/project.rs
@@ -186,15 +186,15 @@ pub struct NapiTurboEngineOptions {
 impl From<NapiProjectOptions> for ProjectOptions {
     fn from(val: NapiProjectOptions) -> Self {
         ProjectOptions {
-            root_path: val.root_path,
-            project_path: val.project_path,
+            root_path: val.root_path.into(),
+            project_path: val.project_path.into(),
             watch: val.watch,
-            next_config: val.next_config,
-            js_config: val.js_config,
+            next_config: val.next_config.into(),
+            js_config: val.js_config.into(),
             env: val
                 .env
                 .into_iter()
-                .map(|var| (var.name, var.value))
+                .map(|var| (var.name.into(), var.value.into()))
                 .collect(),
             define_env: val.define_env.into(),
             dev: val.dev,
@@ -208,14 +208,16 @@ impl From<NapiProjectOptions> for ProjectOptions {
 impl From<NapiPartialProjectOptions> for PartialProjectOptions {
     fn from(val: NapiPartialProjectOptions) -> Self {
         PartialProjectOptions {
-            root_path: val.root_path,
-            project_path: val.project_path,
+            root_path: val.root_path.map(Arc::new),
+            project_path: val.project_path.map(Arc::new),
             watch: val.watch,
-            next_config: val.next_config,
-            js_config: val.js_config,
-            env: val
-                .env
-                .map(|env| env.into_iter().map(|var| (var.name, var.value)).collect()),
+            next_config: val.next_config.map(Arc::new),
+            js_config: val.js_config.map(Arc::new),
+            env: val.env.map(|env| {
+                env.into_iter()
+                    .map(|var| (var.name.into(), var.value.into()))
+                    .collect()
+            }),
             define_env: val.define_env.map(|env| env.into()),
             dev: val.dev,
             encryption_key: val.encryption_key,
@@ -231,17 +233,17 @@ impl From<NapiDefineEnv> for DefineEnv {
             client: val
                 .client
                 .into_iter()
-                .map(|var| (var.name, var.value))
+                .map(|var| (var.name.into(), var.value.into()))
                 .collect(),
             edge: val
                 .edge
                 .into_iter()
-                .map(|var| (var.name, var.value))
+                .map(|var| (var.name.into(), var.value.into()))
                 .collect(),
             nodejs: val
                 .nodejs
                 .into_iter()
-                .map(|var| (var.name, var.value))
+                .map(|var| (var.name.into(), var.value.into()))
                 .collect(),
         }
     }
@@ -670,7 +672,7 @@ struct HmrUpdateWithIssues {
 #[turbo_tasks::function]
 async fn hmr_update(
     project: Vc<Project>,
-    identifier: String,
+    identifier: Arc<String>,
     state: Vc<VersionState>,
 ) -> Result<Vc<HmrUpdateWithIssues>> {
     let update_operation = project.hmr_update(identifier, state);
@@ -701,7 +703,7 @@ pub fn project_hmr_events(
             let outer_identifier = identifier.clone();
             let session = session.clone();
             move || {
-                let identifier = outer_identifier.clone();
+                let identifier = Arc::new(outer_identifier.clone());
                 let session = session.clone();
                 async move {
                     let project = project.project().resolve().await?;
@@ -992,24 +994,27 @@ pub async fn project_trace_source(
                 .container
                 .project()
                 .node_root()
-                .join(chunk_base.to_owned());
+                .join(chunk_base.to_owned().into());
 
             let client_path = project
                 .container
                 .project()
                 .client_relative_path()
-                .join(chunk_base.to_owned());
+                .join(chunk_base.to_owned().into());
 
             let mut map_result = project
                 .container
-                .get_source_map(server_path, module.clone())
+                .get_source_map(server_path, module.clone().map(Arc::new))
                 .await;
             if map_result.is_err() {
                 // If the chunk doesn't exist as a server chunk, try a client chunk.
                 // TODO: Properly tag all server chunks and use the `isServer` query param.
                 // Currently, this is inaccurate as it does not cover RSC server
                 // chunks.
-                map_result = project.container.get_source_map(client_path, module).await;
+                map_result = project
+                    .container
+                    .get_source_map(client_path, module.map(Arc::new))
+                    .await;
             }
             let map = map_result?.context("chunk/module is missing a sourcemap")?;
 
@@ -1079,7 +1084,7 @@ pub async fn project_get_source_for_asset(
                 .project_path()
                 .fs()
                 .root()
-                .join(file_path.to_string())
+                .join(file_path.to_string().into())
                 .read()
                 .await?;
 

--- a/packages/next-swc/crates/next-api/src/project.rs
+++ b/packages/next-swc/crates/next-api/src/project.rs
@@ -979,7 +979,7 @@ impl Project {
     #[turbo_tasks::function]
     async fn hmr_content(
         self: Vc<Self>,
-        identifier: String,
+        identifier: Arc<String>,
     ) -> Result<Vc<Box<dyn VersionedContent>>> {
         Ok(self
             .await?
@@ -988,7 +988,7 @@ impl Project {
     }
 
     #[turbo_tasks::function]
-    async fn hmr_version(self: Vc<Self>, identifier: String) -> Result<Vc<Box<dyn Version>>> {
+    async fn hmr_version(self: Vc<Self>, identifier: Arc<String>) -> Result<Vc<Box<dyn Version>>> {
         let content = self.hmr_content(identifier);
 
         Ok(content.version())
@@ -999,7 +999,7 @@ impl Project {
     #[turbo_tasks::function]
     pub async fn hmr_version_state(
         self: Vc<Self>,
-        identifier: String,
+        identifier: Arc<String>,
         session: TransientInstance<()>,
     ) -> Result<Vc<VersionState>> {
         let version = self.hmr_version(identifier);
@@ -1019,7 +1019,7 @@ impl Project {
     #[turbo_tasks::function]
     pub async fn hmr_update(
         self: Vc<Self>,
-        identifier: String,
+        identifier: Arc<String>,
         from: Vc<VersionState>,
     ) -> Result<Vc<Update>> {
         let from = from.get();

--- a/packages/next-swc/crates/next-api/src/server_actions.rs
+++ b/packages/next-swc/crates/next-api/src/server_actions.rs
@@ -76,7 +76,7 @@ pub(crate) async fn create_server_actions_manifest(
 #[turbo_tasks::function]
 async fn build_server_actions_loader(
     project_path: Vc<FileSystemPath>,
-    page_name: String,
+    page_name: Arc<String>,
     actions: Vc<AllActions>,
     asset_context: Vc<Box<dyn AssetContext>>,
 ) -> Result<Vc<Box<dyn EcmascriptChunkPlaceable>>> {
@@ -101,7 +101,8 @@ async fn build_server_actions_loader(
     }
     write!(contents, "}});")?;
 
-    let output_path = project_path.join(format!(".next-internal/server/app{page_name}/actions.js"));
+    let output_path =
+        project_path.join(format!(".next-internal/server/app{page_name}/actions.js").into());
     let file = File::from(contents.build());
     let source = VirtualSource::new(output_path, AssetContent::file(file.into()));
     let import_map = import_map.into_iter().map(|(k, v)| (v, k)).collect();
@@ -131,9 +132,8 @@ async fn build_manifest(
     loader_id: Vc<String>,
 ) -> Result<Vc<Box<dyn OutputAsset>>> {
     let manifest_path_prefix = page_name;
-    let manifest_path = node_root.join(format!(
-        "server/app{manifest_path_prefix}/server-reference-manifest.json",
-    ));
+    let manifest_path = node_root
+        .join(format!("server/app{manifest_path_prefix}/server-reference-manifest.json",).into());
     let mut manifest = ServerReferenceManifest {
         ..Default::default()
     };

--- a/packages/next-swc/crates/next-api/src/versioned_content_map.rs
+++ b/packages/next-swc/crates/next-api/src/versioned_content_map.rs
@@ -124,7 +124,7 @@ impl VersionedContentMap {
     pub async fn get_source_map(
         self: Vc<Self>,
         path: Vc<FileSystemPath>,
-        section: Option<String>,
+        section: Option<Arc<String>>,
     ) -> Result<Vc<OptionSourceMap>> {
         if let Some(generate_source_map) =
             Vc::try_resolve_sidecast::<Box<dyn GenerateSourceMap>>(self.get_asset(path)).await?

--- a/packages/next-swc/crates/next-core/src/app_structure.rs
+++ b/packages/next-swc/crates/next-core/src/app_structure.rs
@@ -704,7 +704,7 @@ fn directory_tree_to_entrypoints(
     directory_tree_to_entrypoints_internal(
         app_dir,
         global_metadata,
-        "".to_string(),
+        "".to_string().into(),
         directory_tree,
         AppPage::new(),
         root_layouts,
@@ -865,7 +865,7 @@ async fn directory_tree_to_loader_tree(
             "children".to_string(),
             LoaderTree {
                 page: app_page.clone(),
-                segment: "__PAGE__".to_string(),
+                segment: "__PAGE__".to_string().into(),
                 parallel_routes: IndexMap::new(),
                 components: Components {
                     page: Some(page),
@@ -879,7 +879,7 @@ async fn directory_tree_to_loader_tree(
         );
 
         if current_level_is_parallel_route {
-            tree.segment = "page$".to_string();
+            tree.segment = "page$".to_string().into();
         }
     }
 
@@ -902,7 +902,7 @@ async fn directory_tree_to_loader_tree(
         let subtree = *directory_tree_to_loader_tree(
             app_dir,
             global_metadata,
-            subdir_name.clone(),
+            subdir_name.clone().into(),
             *subdirectory,
             child_app_page.clone(),
             for_app_path.clone(),
@@ -967,7 +967,7 @@ async fn directory_tree_to_loader_tree(
     }
 
     if tree.parallel_routes.is_empty() {
-        tree.segment = "__DEFAULT__".to_string();
+        tree.segment = "__DEFAULT__".to_string().into();
         if let Some(default) = components.default {
             tree.components = Components {
                 default: Some(default),
@@ -978,8 +978,11 @@ async fn directory_tree_to_loader_tree(
             // default fallback component
             tree.components = Components {
                 default: Some(
-                    get_next_package(app_dir)
-                        .join("dist/client/components/parallel-route-default.js".to_string()),
+                    get_next_package(app_dir).join(
+                        "dist/client/components/parallel-route-default.js"
+                            .to_string()
+                            .into(),
+                    ),
                 ),
                 ..Default::default()
             }
@@ -992,7 +995,7 @@ async fn directory_tree_to_loader_tree(
             "children".to_string(),
             LoaderTree {
                 page: app_page.clone(),
-                segment: "__DEFAULT__".to_string(),
+                segment: "__DEFAULT__".to_string().into(),
                 parallel_routes: IndexMap::new(),
                 components: if let Some(default) = components.default {
                     Components {
@@ -1005,7 +1008,9 @@ async fn directory_tree_to_loader_tree(
                     Components {
                         default: Some(
                             get_next_package(app_dir).join(
-                                "dist/client/components/parallel-route-default.js".to_string(),
+                                "dist/client/components/parallel-route-default.js"
+                                    .to_string()
+                                    .into(),
                             ),
                         ),
                         ..Default::default()
@@ -1033,7 +1038,7 @@ async fn directory_tree_to_loader_tree(
 async fn directory_tree_to_entrypoints_internal(
     app_dir: Vc<FileSystemPath>,
     global_metadata: Vc<GlobalMetadata>,
-    directory_name: String,
+    directory_name: Arc<String>,
     directory_tree: Vc<DirectoryTree>,
     app_page: AppPage,
     root_layouts: Vc<Vec<Vc<FileSystemPath>>>,
@@ -1054,7 +1059,7 @@ async fn directory_tree_to_entrypoints_internal(
 async fn directory_tree_to_entrypoints_internal_untraced(
     app_dir: Vc<FileSystemPath>,
     global_metadata: Vc<GlobalMetadata>,
-    directory_name: String,
+    directory_name: Arc<String>,
     directory_tree: Vc<DirectoryTree>,
     app_page: AppPage,
     root_layouts: Vc<Vec<Vc<FileSystemPath>>>,
@@ -1163,14 +1168,14 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                 parallel_routes: indexmap! {
                     "children".to_string() => LoaderTree {
                         page: app_page.clone(),
-                        segment: "/_not-found".to_string(),
+                        segment: "/_not-found".to_string().into(),
                         parallel_routes: indexmap! {
                             "children".to_string() => LoaderTree {
                                 page: app_page.clone(),
-                                segment: "__PAGE__".to_string(),
+                                segment: "__PAGE__".to_string().into(),
                                 parallel_routes: IndexMap::new(),
                                 components: Components {
-                                    page: components.not_found.or_else(|| Some(get_next_package(app_dir).join("dist/client/components/not-found-error.js".to_string()))),
+                                    page: components.not_found.or_else(|| Some(get_next_package(app_dir).join("dist/client/components/not-found-error.js".to_string().into()))),
                                     ..Default::default()
                                 }.cell(),
                                 global_metadata

--- a/packages/next-swc/crates/next-core/src/embed_js.rs
+++ b/packages/next-swc/crates/next-core/src/embed_js.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use turbo_tasks::Vc;
 use turbopack_binding::{
     turbo::tasks_fs::{FileContent, FileSystem, FileSystemPath},
@@ -13,16 +15,16 @@ pub(crate) fn next_js_fs() -> Vc<Box<dyn FileSystem>> {
 }
 
 #[turbo_tasks::function]
-pub(crate) fn next_js_file(path: String) -> Vc<FileContent> {
+pub(crate) fn next_js_file(path: Arc<String>) -> Vc<FileContent> {
     next_js_fs().root().join(path).read()
 }
 
 #[turbo_tasks::function]
-pub(crate) fn next_js_file_path(path: String) -> Vc<FileSystemPath> {
+pub(crate) fn next_js_file_path(path: Arc<String>) -> Vc<FileSystemPath> {
     next_js_fs().root().join(path)
 }
 
 #[turbo_tasks::function]
-pub(crate) fn next_asset(path: String) -> Vc<Box<dyn Source>> {
+pub(crate) fn next_asset(path: Arc<String>) -> Vc<Box<dyn Source>> {
     Vc::upcast(FileSource::new(next_js_file_path(path)))
 }

--- a/packages/next-swc/crates/next-core/src/loader_tree.rs
+++ b/packages/next-swc/crates/next-core/src/loader_tree.rs
@@ -245,7 +245,7 @@ impl LoaderTreeBuilder {
                 let source = dynamic_image_metadata_source(
                     Vc::upcast(self.context),
                     *path,
-                    name.to_string(),
+                    name.to_string().into(),
                     app_page.clone(),
                 );
 

--- a/packages/next-swc/crates/next-core/src/next_app/app_page_entry.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/app_page_entry.rs
@@ -202,6 +202,6 @@ async fn wrap_edge_page(
         context,
         project_root,
         wrapped,
-        AppPath::from(page).to_string(),
+        AppPath::from(page).to_string().into(),
     ))
 }

--- a/packages/next-swc/crates/next-core/src/next_app/app_route_entry.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/app_route_entry.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::{bail, Result};
 use indexmap::indexmap;
 use turbo_tasks::{Value, ValueToString, Vc};
@@ -118,7 +120,7 @@ pub async fn get_app_route_entry(
             Vc::upcast(context),
             project_root,
             rsc_entry,
-            pathname.clone(),
+            pathname.clone().into(),
         );
     }
 
@@ -142,7 +144,7 @@ async fn wrap_edge_route(
     context: Vc<Box<dyn AssetContext>>,
     project_root: Vc<FileSystemPath>,
     entry: Vc<Box<dyn Module>>,
-    pathname: String,
+    pathname: Arc<String>,
 ) -> Result<Vc<Box<dyn Module>>> {
     const INNER: &str = "INNER_ROUTE_ENTRY";
 

--- a/packages/next-swc/crates/next-core/src/next_app/metadata/image.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/metadata/image.rs
@@ -57,7 +57,7 @@ pub async fn dynamic_image_metadata_source(
 
     let hash_query = format!("?{:x}", hash_file_content(path).await?);
 
-    let use_numeric_sizes = ty == "twitter" || ty == "openGraph";
+    let use_numeric_sizes = &**ty == "twitter" || &**ty == "openGraph";
     let sizes = if use_numeric_sizes {
         "data.width = size.width; data.height = size.height;"
     } else {
@@ -145,7 +145,9 @@ async fn collect_direct_exports(module: Vc<Box<dyn Module>>) -> Result<Vc<Vec<St
 
     if let EcmascriptExports::EsmExports(exports) = &*ecmascript_asset.get_exports().await? {
         let exports = &*exports.await?;
-        return Ok(Vc::cell(exports.exports.keys().cloned().collect()));
+        return Ok(Vc::cell(
+            exports.exports.keys().map(|v| &**v).cloned().collect(),
+        ));
     }
 
     Ok(Vc::cell(Vec::new()))

--- a/packages/next-swc/crates/next-core/src/next_app/metadata/image.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/metadata/image.rs
@@ -2,6 +2,8 @@
 //!
 //! See `next/src/build/webpack/loaders/next-metadata-image-loader`
 
+use std::sync::Arc;
+
 use anyhow::{bail, Result};
 use indoc::formatdoc;
 use turbo_tasks::{ValueToString, Vc};
@@ -46,7 +48,7 @@ async fn hash_file_content(path: Vc<FileSystemPath>) -> Result<u64> {
 pub async fn dynamic_image_metadata_source(
     asset_context: Vc<Box<dyn AssetContext>>,
     path: Vc<FileSystemPath>,
-    ty: String,
+    ty: Arc<String>,
     page: AppPage,
 ) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem().await?;
@@ -126,7 +128,7 @@ pub async fn dynamic_image_metadata_source(
 
     let file = File::from(code);
     let source = VirtualSource::new(
-        path.parent().join(format!("{stem}--metadata.js")),
+        path.parent().join(format!("{stem}--metadata.js").into()),
         AssetContent::file(file.into()),
     );
 

--- a/packages/next-swc/crates/next-core/src/next_app/metadata/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/metadata/mod.rs
@@ -339,7 +339,9 @@ pub fn normalize_metadata_route(mut page: AppPage) -> Result<AppPage> {
         ))?;
 
         if !is_static_route {
-            page.push(PageSegment::OptionalCatchAll("__metadata_id__".to_string()))?;
+            page.push(PageSegment::OptionalCatchAll(
+                "__metadata_id__".to_string().into(),
+            ))?;
         }
 
         page.push(PageSegment::PageType(PageType::Route))?;

--- a/packages/next-swc/crates/next-core/src/next_app/metadata/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/metadata/mod.rs
@@ -326,14 +326,17 @@ pub fn normalize_metadata_route(mut page: AppPage) -> Result<AppPage> {
 
         page.0.pop();
 
-        page.push(PageSegment::Static(format!(
-            "{}{}{}",
-            base_name,
-            suffix
-                .map(|suffix| format!("-{suffix}"))
-                .unwrap_or_default(),
-            ext.map(|ext| format!(".{ext}")).unwrap_or_default(),
-        )))?;
+        page.push(PageSegment::Static(
+            format!(
+                "{}{}{}",
+                base_name,
+                suffix
+                    .map(|suffix| format!("-{suffix}"))
+                    .unwrap_or_default(),
+                ext.map(|ext| format!(".{ext}")).unwrap_or_default(),
+            )
+            .into(),
+        ))?;
 
         if !is_static_route {
             page.push(PageSegment::OptionalCatchAll("__metadata_id__".to_string()))?;

--- a/packages/next-swc/crates/next-core/src/next_app/metadata/route.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/metadata/route.rs
@@ -218,7 +218,10 @@ async fn dynamic_site_map_route_source(
 
     let mut static_generation_code = "";
 
-    if mode.is_production() && page.contains(&PageSegment::Dynamic("[__metadata_id__]".to_string()))
+    if mode.is_production()
+        && page.contains(&PageSegment::Dynamic(
+            "[__metadata_id__]".to_string().into(),
+        ))
     {
         static_generation_code = indoc! {
             r#"
@@ -297,7 +300,7 @@ async fn dynamic_site_map_route_source(
 
     let file = File::from(code);
     let source = VirtualSource::new(
-        path.parent().join(format!("{stem}--route-entry.js")),
+        path.parent().join(format!("{stem}--route-entry.js").into()),
         AssetContent::file(file.into()),
     );
 
@@ -355,7 +358,7 @@ async fn dynamic_image_route_source(path: Vc<FileSystemPath>) -> Result<Vc<Box<d
 
     let file = File::from(code);
     let source = VirtualSource::new(
-        path.parent().join(format!("{stem}--route-entry.js")),
+        path.parent().join(format!("{stem}--route-entry.js").into()),
         AssetContent::file(file.into()),
     );
 

--- a/packages/next-swc/crates/next-core/src/next_app/metadata/route.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/metadata/route.rs
@@ -145,7 +145,7 @@ async fn static_route_source(
 
     let file = File::from(code);
     let source = VirtualSource::new(
-        path.parent().join(format!("{stem}--route-entry.js")),
+        path.parent().join(format!("{stem}--route-entry.js").into()),
         AssetContent::file(file.into()),
     );
 
@@ -197,7 +197,7 @@ async fn dynamic_text_route_source(path: Vc<FileSystemPath>) -> Result<Vc<Box<dy
 
     let file = File::from(code);
     let source = VirtualSource::new(
-        path.parent().join(format!("{stem}--route-entry.js")),
+        path.parent().join(format!("{stem}--route-entry.js").into()),
         AssetContent::file(file.into()),
     );
 

--- a/packages/next-swc/crates/next-core/src/next_app/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/mod.rs
@@ -10,6 +10,7 @@ use std::{
     cmp::Ordering,
     fmt::{Display, Formatter, Write},
     ops::Deref,
+    sync::Arc,
 };
 
 use anyhow::{bail, Result};
@@ -40,17 +41,17 @@ pub use crate::next_app::{
 )]
 pub enum PageSegment {
     /// e.g. `/dashboard`
-    Static(String),
+    Static(Arc<String>),
     /// e.g. `/[id]`
-    Dynamic(String),
+    Dynamic(Arc<String>),
     /// e.g. `/[...slug]`
-    CatchAll(String),
+    CatchAll(Arc<String>),
     /// e.g. `/[[...slug]]`
-    OptionalCatchAll(String),
+    OptionalCatchAll(Arc<String>),
     /// e.g. `/(shop)`
     Group(String),
     /// e.g. `/@auth`
-    Parallel(String),
+    Parallel(Arc<String>),
     /// The final page type appended. (e.g. `/dashboard/page`,
     /// `/api/hello/route`)
     PageType(PageType),

--- a/packages/next-swc/crates/next-core/src/next_app/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/mod.rs
@@ -68,32 +68,32 @@ impl PageSegment {
         }
 
         if let Some(s) = segment.strip_prefix('(').and_then(|s| s.strip_suffix(')')) {
-            return Ok(PageSegment::Group(s.to_string()));
+            return Ok(PageSegment::Group(s.to_string().into()));
         }
 
         if let Some(s) = segment.strip_prefix('@') {
-            return Ok(PageSegment::Parallel(s.to_string()));
+            return Ok(PageSegment::Parallel(s.to_string().into()));
         }
 
         if let Some(s) = segment
             .strip_prefix("[[...")
             .and_then(|s| s.strip_suffix("]]"))
         {
-            return Ok(PageSegment::OptionalCatchAll(s.to_string()));
+            return Ok(PageSegment::OptionalCatchAll(s.to_string().into()));
         }
 
         if let Some(s) = segment
             .strip_prefix("[...")
             .and_then(|s| s.strip_suffix(']'))
         {
-            return Ok(PageSegment::CatchAll(s.to_string()));
+            return Ok(PageSegment::CatchAll(s.to_string().into()));
         }
 
         if let Some(s) = segment.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
-            return Ok(PageSegment::Dynamic(s.to_string()));
+            return Ok(PageSegment::Dynamic(s.to_string().into()));
         }
 
-        Ok(PageSegment::Static(segment.to_string()))
+        Ok(PageSegment::Static(segment.to_string().into()))
     }
 }
 

--- a/packages/next-swc/crates/next-core/src/next_app/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/mod.rs
@@ -309,13 +309,13 @@ impl PartialOrd for AppPage {
 )]
 pub enum PathSegment {
     /// e.g. `/dashboard`
-    Static(String),
+    Static(Arc<String>),
     /// e.g. `/[id]`
-    Dynamic(String),
+    Dynamic(Arc<String>),
     /// e.g. `/[...slug]`
-    CatchAll(String),
+    CatchAll(Arc<String>),
     /// e.g. `/[[...slug]]`
-    OptionalCatchAll(String),
+    OptionalCatchAll(Arc<String>),
 }
 
 impl Display for PathSegment {

--- a/packages/next-swc/crates/next-core/src/next_build.rs
+++ b/packages/next-swc/crates/next-core/src/next_build.rs
@@ -15,7 +15,7 @@ pub async fn get_postcss_package_mapping(
         // Prefer the local installed version over the next.js version
         ImportMapping::PrimaryAlternative("postcss".to_string(), Some(project_path)).cell(),
         ImportMapping::PrimaryAlternative(
-            "postcss".to_string(),
+            "postcss".to_string().into(),
             Some(get_next_package(project_path)),
         )
         .cell(),
@@ -28,7 +28,7 @@ pub async fn get_external_next_compiled_package_mapping(
     package_name: Vc<String>,
 ) -> Result<Vc<ImportMapping>> {
     Ok(ImportMapping::Alternatives(vec![ImportMapping::External(
-        Some(format!("next/dist/compiled/{}", &*package_name.await?)),
+        Some(format!("next/dist/compiled/{}", &*package_name.await?).into()),
         ExternalType::CommonJs,
     )
     .into()])

--- a/packages/next-swc/crates/next-core/src/next_build.rs
+++ b/packages/next-swc/crates/next-core/src/next_build.rs
@@ -13,7 +13,7 @@ pub async fn get_postcss_package_mapping(
 ) -> Result<Vc<ImportMapping>> {
     Ok(ImportMapping::Alternatives(vec![
         // Prefer the local installed version over the next.js version
-        ImportMapping::PrimaryAlternative("postcss".to_string(), Some(project_path)).cell(),
+        ImportMapping::PrimaryAlternative("postcss".to_string().into(), Some(project_path)).cell(),
         ImportMapping::PrimaryAlternative(
             "postcss".to_string().into(),
             Some(get_next_package(project_path)),

--- a/packages/next-swc/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
+++ b/packages/next-swc/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
@@ -86,7 +86,7 @@ impl EcmascriptClientReferenceProxyModule {
             )?;
 
             for export_name in exports.exports.keys() {
-                if export_name == "default" {
+                if &**export_name == "default" {
                     writedoc!(
                         code,
                         r#"
@@ -143,7 +143,9 @@ impl EcmascriptClientReferenceProxyModule {
             AssetContent::file(File::from(code.source_code().clone()).into());
 
         let proxy_source = VirtualSource::new(
-            self.server_module_ident.path().join("proxy.js".to_string()),
+            self.server_module_ident
+                .path()
+                .join("proxy.js".to_string().into()),
             proxy_module_content,
         );
 

--- a/packages/next-swc/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
+++ b/packages/next-swc/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
@@ -58,10 +58,12 @@ impl Transition for NextEcmascriptClientReferenceTransition {
         let ident = source.ident().await?;
         let ident_path = ident.path.await?;
         let client_source = if ident_path.path.contains("next/dist/esm/") {
-            let path = ident
-                .path
-                .root()
-                .join(ident_path.path.replace("next/dist/esm/", "next/dist/"));
+            let path = ident.path.root().join(
+                ident_path
+                    .path
+                    .replace("next/dist/esm/", "next/dist/")
+                    .into(),
+            );
             Vc::upcast(FileSource::new_with_query(path, ident.query))
         } else {
             source

--- a/packages/next-swc/crates/next-core/src/next_edge/entry.rs
+++ b/packages/next-swc/crates/next-core/src/next_edge/entry.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::Result;
 use indexmap::indexmap;
 use indoc::formatdoc;
@@ -16,7 +18,7 @@ pub async fn wrap_edge_entry(
     context: Vc<Box<dyn AssetContext>>,
     project_root: Vc<FileSystemPath>,
     entry: Vc<Box<dyn Module>>,
-    pathname: String,
+    pathname: Arc<String>,
 ) -> Result<Vc<Box<dyn Module>>> {
     // The wrapped module could be an async module, we handle that with the proxy
     // here. The comma expression makes sure we don't call the function with the

--- a/packages/next-swc/crates/next-core/src/next_font/google/font_fallback.rs
+++ b/packages/next-swc/crates/next-core/src/next_font/google/font_fallback.rs
@@ -55,7 +55,7 @@ pub(super) async fn get_font_fallback(
         None => {
             let metrics_json = load_next_js_templateon(
                 context,
-                "dist/server/capsize-font-metrics.json".to_string(),
+                "dist/server/capsize-font-metrics.json".to_string().into(),
             )
             .await?;
             let fallback = lookup_fallback(

--- a/packages/next-swc/crates/next-core/src/next_font/google/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_font/google/mod.rs
@@ -386,7 +386,9 @@ impl ImportMappingReplacement for NextFontGoogleFontFileReplacer {
 async fn load_font_data(project_root: Vc<FileSystemPath>) -> Result<Vc<FontData>> {
     let data: FontData = load_next_js_templateon(
         project_root,
-        "dist/compiled/@next/font/dist/google/font-data.json".to_string(),
+        "dist/compiled/@next/font/dist/google/font-data.json"
+            .to_string()
+            .into(),
     )
     .await?;
 

--- a/packages/next-swc/crates/next-core/src/next_font/google/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_font/google/mod.rs
@@ -270,7 +270,7 @@ impl NextFontGoogleCssModuleReplacer {
 #[turbo_tasks::value_impl]
 impl ImportMappingReplacement for NextFontGoogleCssModuleReplacer {
     #[turbo_tasks::function]
-    fn replace(&self, _capture: String) -> Vc<ImportMapping> {
+    fn replace(&self, _capture: Arc<String>) -> Vc<ImportMapping> {
         ImportMapping::Ignore.into()
     }
 
@@ -322,7 +322,7 @@ impl NextFontGoogleFontFileReplacer {
 #[turbo_tasks::value_impl]
 impl ImportMappingReplacement for NextFontGoogleFontFileReplacer {
     #[turbo_tasks::function]
-    fn replace(&self, _capture: String) -> Vc<ImportMapping> {
+    fn replace(&self, _capture: Arc<String>) -> Vc<ImportMapping> {
         ImportMapping::Ignore.into()
     }
 
@@ -364,8 +364,8 @@ impl ImportMappingReplacement for NextFontGoogleFontFileReplacer {
             name.push_str(".p")
         }
 
-        let font_virtual_path = next_js_file_path("internal/font/google".to_string())
-            .join(format!("/{}.{}", name, ext));
+        let font_virtual_path = next_js_file_path("internal/font/google".to_string().into())
+            .join(format!("/{}.{}", name, ext).into());
 
         // doesn't seem ideal to download the font into a string, but probably doesn't
         // really matter either.
@@ -493,7 +493,7 @@ async fn get_stylesheet_url_from_options(
 
         let env = CommandLineProcessEnv::new();
         if let Some(url) = &*env
-            .read("TURBOPACK_TEST_ONLY_MOCK_SERVER".to_string())
+            .read("TURBOPACK_TEST_ONLY_MOCK_SERVER".to_string().into())
             .await?
         {
             css_url = Some(format!("{}/css2", url));
@@ -655,9 +655,13 @@ async fn get_mock_stylesheet(
         project_path: _,
         chunking_context,
     } = *execution_context.await?;
-    let context =
-        node_evaluate_asset_context(execution_context, None, None, "next_font".to_string());
-    let loader_path = mock_fs.root().join("loader.js".to_string());
+    let context = node_evaluate_asset_context(
+        execution_context,
+        None,
+        None,
+        "next_font".to_string().into(),
+    );
+    let loader_path = mock_fs.root().join("loader.js".to_string().into());
     let mocked_response_asset = context
         .process(
             Vc::upcast(VirtualSource::new(

--- a/packages/next-swc/crates/next-core/src/next_font/google/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_font/google/mod.rs
@@ -195,9 +195,9 @@ impl NextFontGoogleCssModuleReplacer {
     }
 
     #[turbo_tasks::function]
-    async fn import_map_result(&self, query: String) -> Result<Vc<ImportMapResult>> {
+    async fn import_map_result(&self, query: Arc<String>) -> Result<Vc<ImportMapResult>> {
         let request_hash = get_request_hash(&query).await?;
-        let query_vc = Vc::cell(query);
+        let query_vc = Vc::cell((*query).clone());
         let font_data = load_font_data(self.project_path);
         let options = font_options_from_query_map(query_vc, font_data);
         let stylesheet_url = get_stylesheet_url_from_options(options, font_data);

--- a/packages/next-swc/crates/next-core/src/next_font/google/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_font/google/mod.rs
@@ -295,7 +295,7 @@ impl ImportMappingReplacement for NextFontGoogleCssModuleReplacer {
             return Ok(ImportMapResult::NoEntry.into());
         };
 
-        Ok(self.import_map_result(query_vc.await?.to_string()))
+        Ok(self.import_map_result(query_vc.await?.to_string().into()))
     }
 }
 

--- a/packages/next-swc/crates/next-core/src/next_font/google/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_font/google/mod.rs
@@ -640,13 +640,14 @@ async fn get_mock_stylesheet(
 ) -> Result<Option<Vc<String>>> {
     let response_path = Path::new(&mocked_responses_path);
     let mock_fs = Vc::upcast::<Box<dyn FileSystem>>(DiskFileSystem::new(
-        "mock".to_string(),
+        "mock".to_string().into(),
         response_path
             .parent()
             .context("Must be valid path")?
             .to_str()
             .context("Must exist")?
-            .to_string(),
+            .to_string()
+            .into(),
         vec![],
     ));
 

--- a/packages/next-swc/crates/next-core/src/next_font/local/font_fallback.rs
+++ b/packages/next-swc/crates/next-core/src/next_font/local/font_fallback.rs
@@ -73,7 +73,10 @@ async fn get_font_adjustment(
 ) -> Result<FontAdjustment> {
     let options = &*options.await?;
     let main_descriptor = pick_font_for_fallback_generation(&options.fonts)?;
-    let font_file = &*context.join(main_descriptor.path.clone()).read().await?;
+    let font_file = &*context
+        .join(main_descriptor.path.clone().into())
+        .read()
+        .await?;
     let font_file_rope = match font_file {
         FileContent::NotFound => bail!(FontError::FontFileNotFound(main_descriptor.path.clone())),
         FileContent::Content(file) => file.content(),

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -1019,11 +1019,11 @@ fn insert_turbopack_dev_alias(import_map: &mut ImportMap) {
 /// Creates a direct import mapping to the result of resolving a request
 /// in a context.
 fn request_to_import_mapping(context_path: Vc<FileSystemPath>, request: &str) -> Vc<ImportMapping> {
-    ImportMapping::PrimaryAlternative(request.to_string(), Some(context_path)).cell()
+    ImportMapping::PrimaryAlternative(request.to_string().into(), Some(context_path)).cell()
 }
 
 /// Creates a direct import mapping to the result of resolving an external
 /// request.
 fn external_request_to_import_mapping(request: &str) -> Vc<ImportMapping> {
-    ImportMapping::External(Some(request.to_string()), ExternalType::CommonJs).into()
+    ImportMapping::External(Some(request.to_string().into()), ExternalType::CommonJs).into()
 }

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -948,13 +948,15 @@ fn export_value_to_import_mapping(
         None
     } else {
         Some(if result.len() == 1 {
-            ImportMapping::PrimaryAlternative(result[0].0.to_string(), Some(project_path)).cell()
+            ImportMapping::PrimaryAlternative(result[0].0.to_string().into(), Some(project_path))
+                .cell()
         } else {
             ImportMapping::Alternatives(
                 result
                     .iter()
                     .map(|(m, _)| {
-                        ImportMapping::PrimaryAlternative(m.to_string(), Some(project_path)).cell()
+                        ImportMapping::PrimaryAlternative(m.to_string().into(), Some(project_path))
+                            .cell()
                     })
                     .collect(),
             )

--- a/packages/next-swc/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/packages/next-swc/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -217,9 +217,10 @@ impl ClientReferenceManifest {
         // path still (same as webpack does)
         let normalized_manifest_entry = entry_name.replace("%5F", "_");
         Ok(Vc::upcast(VirtualOutputAsset::new(
-            node_root.join(format!(
-                "server/app{normalized_manifest_entry}_client-reference-manifest.js",
-            )),
+            node_root.join(
+                format!("server/app{normalized_manifest_entry}_client-reference-manifest.js",)
+                    .into(),
+            ),
             AssetContent::file(
                 File::from(formatdoc! {
                     r#"

--- a/packages/next-swc/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/packages/next-swc/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::Result;
 use indoc::formatdoc;
 use turbo_tasks::{TryJoinIterExt, ValueToString, Vc};
@@ -26,7 +28,7 @@ impl ClientReferenceManifest {
     pub async fn build_output(
         node_root: Vc<FileSystemPath>,
         client_relative_path: Vc<FileSystemPath>,
-        entry_name: String,
+        entry_name: Arc<String>,
         client_references: Vc<ClientReferenceGraphResult>,
         client_references_chunks: Vc<ClientReferencesChunks>,
         client_chunking_context: Vc<Box<dyn ChunkingContext>>,

--- a/packages/next-swc/crates/next-core/src/next_pages/page_entry.rs
+++ b/packages/next-swc/crates/next-core/src/next_pages/page_entry.rs
@@ -1,4 +1,4 @@
-use std::io::Write;
+use std::{io::Write, sync::Arc};
 
 use anyhow::{bail, Result};
 use indexmap::indexmap;
@@ -154,8 +154,8 @@ pub async fn create_page_ssr_entry_module(
                 ssr_module_context,
                 project_root,
                 ssr_module,
-                definition_page.clone(),
-                definition_pathname.clone(),
+                definition_page.clone().into(),
+                definition_pathname.clone().into(),
                 Value::new(reference_type),
                 pages_structure,
                 next_config,
@@ -165,7 +165,7 @@ pub async fn create_page_ssr_entry_module(
                 ssr_module_context,
                 project_root,
                 ssr_module,
-                definition_pathname.to_string(),
+                definition_pathname.to_string().into(),
             );
         }
     }
@@ -197,8 +197,8 @@ async fn wrap_edge_page(
     context: Vc<Box<dyn AssetContext>>,
     project_root: Vc<FileSystemPath>,
     entry: Vc<Box<dyn Module>>,
-    page: String,
-    pathname: String,
+    page: Arc<String>,
+    pathname: Arc<String>,
     reference_type: Value<ReferenceType>,
     pages_structure: Vc<PagesStructure>,
     next_config: Vc<NextConfig>,

--- a/packages/next-swc/crates/next-core/src/next_route_matcher/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_route_matcher/mod.rs
@@ -63,12 +63,12 @@ impl NextParamsMatcher {
 #[turbo_tasks::value_impl]
 impl RouteMatcher for NextParamsMatcher {
     #[turbo_tasks::function]
-    fn matches(&self, path: String) -> Vc<bool> {
+    fn matches(&self, path: Arc<String>) -> Vc<bool> {
         Vc::cell(self.matcher.matches(&path))
     }
 
     #[turbo_tasks::function]
-    fn params(&self, path: String) -> Vc<Params> {
+    fn params(&self, path: Arc<String>) -> Vc<Params> {
         Params::cell(self.matcher.params(&path))
     }
 }
@@ -100,12 +100,12 @@ impl NextPrefixSuffixParamsMatcher {
 #[turbo_tasks::value_impl]
 impl RouteMatcher for NextPrefixSuffixParamsMatcher {
     #[turbo_tasks::function]
-    fn matches(&self, path: String) -> Vc<bool> {
+    fn matches(&self, path: Arc<String>) -> Vc<bool> {
         Vc::cell(self.matcher.matches(&path))
     }
 
     #[turbo_tasks::function]
-    fn params(&self, path: String) -> Vc<Params> {
+    fn params(&self, path: Arc<String>) -> Vc<Params> {
         Params::cell(self.matcher.params(&path))
     }
 }

--- a/packages/next-swc/crates/next-core/src/next_route_matcher/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_route_matcher/mod.rs
@@ -86,7 +86,11 @@ impl NextPrefixSuffixParamsMatcher {
     /// Converts a filename within the server root into a regular expression
     /// with named capture groups for every dynamic segment.
     #[turbo_tasks::function]
-    pub async fn new(path: Vc<String>, prefix: String, suffix: String) -> Result<Vc<Self>> {
+    pub async fn new(
+        path: Vc<String>,
+        prefix: Arc<String>,
+        suffix: Arc<String>,
+    ) -> Result<Vc<Self>> {
         Ok(Self::cell(NextPrefixSuffixParamsMatcher {
             matcher: PrefixSuffixMatcher::new(
                 prefix.to_string(),
@@ -128,12 +132,12 @@ impl NextFallbackMatcher {
 #[turbo_tasks::value_impl]
 impl RouteMatcher for NextFallbackMatcher {
     #[turbo_tasks::function]
-    fn matches(&self, path: String) -> Vc<bool> {
+    fn matches(&self, path: Arc<String>) -> Vc<bool> {
         Vc::cell(self.matcher.matches(&path))
     }
 
     #[turbo_tasks::function]
-    fn params(&self, path: String) -> Vc<Params> {
+    fn params(&self, path: Arc<String>) -> Vc<Params> {
         Params::cell(self.matcher.params(&path))
     }
 }

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -820,8 +820,8 @@ pub async fn get_server_chunking_context_with_client_assets(
         project_path,
         node_root,
         client_root,
-        node_root.join("server/chunks/ssr".to_string()),
-        client_root.join("static/media".to_string()),
+        node_root.join("server/chunks/ssr".to_string().into()),
+        client_root.join("static/media".to_string().into()),
         environment,
         next_mode.runtime_type(),
     )
@@ -845,8 +845,8 @@ pub async fn get_server_chunking_context(
         project_path,
         node_root,
         node_root,
-        node_root.join("server/chunks".to_string()),
-        node_root.join("server/assets".to_string()),
+        node_root.join("server/chunks".to_string().into()),
+        node_root.join("server/assets".to_string().into()),
         environment,
         next_mode.runtime_type(),
     )

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -141,7 +141,7 @@ pub async fn get_server_resolve_options_context(
     // Always load these predefined packages as external.
     let mut external_packages: Vec<String> = load_next_js_templateon(
         project_path,
-        "dist/lib/server-external-packages.json".to_string(),
+        "dist/lib/server-external-packages.json".to_string().into(),
     )
     .await?;
 

--- a/packages/next-swc/crates/next-core/src/next_server/resolve.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/resolve.rs
@@ -354,7 +354,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                 // mark as external
                 Ok(ResolveResultOption::some(
                     ResolveResult::primary(ResolveResultItem::External(
-                        request_str,
+                        request_str.into(),
                         ExternalType::CommonJs,
                     ))
                     .cell(),
@@ -391,7 +391,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                     // mark as external
                     Ok(ResolveResultOption::some(
                         ResolveResult::primary(ResolveResultItem::External(
-                            request_str,
+                            request_str.into(),
                             if resolves_equal {
                                 ExternalType::CommonJs
                             } else {
@@ -406,7 +406,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                 // mark as external
                 Ok(ResolveResultOption::some(
                     ResolveResult::primary(ResolveResultItem::External(
-                        request_str,
+                        request_str.into(),
                         ExternalType::EcmaScriptModule,
                     ))
                     .cell(),

--- a/packages/next-swc/crates/next-core/src/next_server/resolve.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/resolve.rs
@@ -441,12 +441,9 @@ async fn packages_glob(packages: Vc<Vec<String>>) -> Result<Vc<OptionPackagesGlo
     if packages.is_empty() {
         return Ok(Vc::cell(None));
     }
-    let path_glob = Glob::new(format!("**/node_modules/{{{}}}/**", packages.join(",")));
-    let request_glob = Glob::new(format!(
-        "{{{},{}/**}}",
-        packages.join(","),
-        packages.join("/**,")
-    ));
+    let path_glob = Glob::new(format!("**/node_modules/{{{}}}/**", packages.join(",")).into());
+    let request_glob =
+        Glob::new(format!("{{{},{}/**}}", packages.join(","), packages.join("/**,")).into());
     Ok(Vc::cell(Some(PackagesGlobs {
         path_glob: path_glob.resolve().await?,
         request_glob: request_glob.resolve().await?,

--- a/packages/next-swc/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/packages/next-swc/crates/next-core/src/next_server_component/server_component_module.rs
@@ -96,7 +96,7 @@ impl EcmascriptChunkPlaceable for NextServerComponentModule {
     #[turbo_tasks::function]
     fn get_exports(&self) -> Vc<EcmascriptExports> {
         let exports = BTreeMap::from([(
-            "default".to_string(),
+            "default".to_string().into(),
             EsmExport::ImportedNamespace(Vc::upcast(NextServerComponentModuleReference::new(
                 Vc::upcast(self.module),
             ))),

--- a/packages/next-swc/crates/next-core/src/next_shared/resolve.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/resolve.rs
@@ -178,7 +178,11 @@ pub(crate) struct InvalidImportResolvePlugin {
 #[turbo_tasks::value_impl]
 impl InvalidImportResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(root: Vc<FileSystemPath>, invalid_import: String, message: Vec<String>) -> Vc<Self> {
+    pub fn new(
+        root: Vc<FileSystemPath>,
+        invalid_import: Arc<String>,
+        message: Vec<Arc<String>>,
+    ) -> Vc<Self> {
         InvalidImportResolvePlugin {
             root,
             invalid_import,

--- a/packages/next-swc/crates/next-core/src/next_shared/resolve.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/resolve.rs
@@ -85,7 +85,7 @@ impl AfterResolvePlugin for UnsupportedModulesResolvePlugin {
             if UNSUPPORTED_PACKAGES.contains(module.as_str()) {
                 UnsupportedModuleIssue {
                     file_path,
-                    package: module.into(),
+                    package: module.clone(),
                     package_path: None,
                 }
                 .cell()
@@ -96,7 +96,7 @@ impl AfterResolvePlugin for UnsupportedModulesResolvePlugin {
                 if UNSUPPORTED_PACKAGE_PATHS.contains(&(module, path)) {
                     UnsupportedModuleIssue {
                         file_path,
-                        package: module.into(),
+                        package: module.clone(),
                         package_path: Some(path.to_owned()),
                     }
                     .cell()

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
@@ -36,21 +36,21 @@ pub async fn get_next_pages_transforms_rule(
             ModuleRuleCondition::all(vec![
                 ModuleRuleCondition::ResourcePathInExactDirectory(pages_dir.await?),
                 ModuleRuleCondition::not(ModuleRuleCondition::ResourcePathInExactDirectory(
-                    pages_dir.join("api".to_string()).await?,
+                    pages_dir.join("api".to_string().into()).await?,
                 )),
                 ModuleRuleCondition::not(ModuleRuleCondition::any(vec![
                     // TODO(alexkirsz): Possibly ignore _app as well?
                     ModuleRuleCondition::ResourcePathEquals(
-                        pages_dir.join("_document.js".to_string()).await?,
+                        pages_dir.join("_document.js".to_string().into()).await?,
                     ),
                     ModuleRuleCondition::ResourcePathEquals(
-                        pages_dir.join("_document.jsx".to_string()).await?,
+                        pages_dir.join("_document.jsx".to_string().into()).await?,
                     ),
                     ModuleRuleCondition::ResourcePathEquals(
-                        pages_dir.join("_document.ts".to_string()).await?,
+                        pages_dir.join("_document.ts".to_string().into()).await?,
                     ),
                     ModuleRuleCondition::ResourcePathEquals(
-                        pages_dir.join("_document.tsx".to_string()).await?,
+                        pages_dir.join("_document.tsx".to_string().into()).await?,
                     ),
                 ])),
             ]),

--- a/packages/next-swc/crates/next-core/src/pages_structure.rs
+++ b/packages/next-swc/crates/next-core/src/pages_structure.rs
@@ -419,6 +419,6 @@ fn next_router_path_for_basename(
     if basename == "index" {
         next_router_path
     } else {
-        next_router_path.join(basename.to_string())
+        next_router_path.join(basename.to_string().into())
     }
 }

--- a/packages/next-swc/crates/next-core/src/util.rs
+++ b/packages/next-swc/crates/next-core/src/util.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::{bail, Context, Result};
 use indexmap::{IndexMap, IndexSet};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -803,12 +805,12 @@ pub fn virtual_next_js_template_path(
     file: String,
 ) -> Vc<FileSystemPath> {
     debug_assert!(!file.contains('/'));
-    get_next_package(project_path).join(format!("{NEXT_TEMPLATE_PATH}/{file}"))
+    get_next_package(project_path).join(format!("{NEXT_TEMPLATE_PATH}/{file}").into())
 }
 
 pub async fn load_next_js_templateon<T: DeserializeOwned>(
     project_path: Vc<FileSystemPath>,
-    path: String,
+    path: Arc<String>,
 ) -> Result<T> {
     let file_path = get_next_package(project_path).join(path.clone());
 

--- a/packages/next-swc/crates/next-core/src/util.rs
+++ b/packages/next-swc/crates/next-core/src/util.rs
@@ -593,7 +593,8 @@ pub async fn load_next_js_template(
                     import_request
                 },
             )
-            .context("path should not leave the fs")?,
+            .context("path should not leave the fs")?
+            .into(),
         };
 
         let relative = package_root_value


### PR DESCRIPTION
### What?

next.js counterpart for https://github.com/vercel/turbo/pull/7772

### Why?

Reduce memory allocations due to `String::clone()`.

### How?

Closes PACK-2776