### PR TITLE
Fix edge-can-use-wasm-files test for Turbopack

### DIFF
--- a/test/e2e/edge-can-use-wasm-files/index.test.ts
+++ b/test/e2e/edge-can-use-wasm-files/index.test.ts
@@ -106,15 +106,29 @@ describe('middleware can use wasm files', () => {
         '.next/server/middleware-manifest.json'
       )
       const manifest = await fs.readJSON(manifestPath)
-      expect(manifest.middleware['/']).toMatchObject({
-        wasm: [
-          {
-            filePath:
-              'server/edge-chunks/wasm_58ccff8b2b94b5dac6ef8957082ecd8f6d34186d.wasm',
-            name: 'wasm_58ccff8b2b94b5dac6ef8957082ecd8f6d34186d',
-          },
-        ],
-      })
+      if (process.env.TURBOPACK) {
+        expect(manifest.middleware['/'].wasm).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              filePath: expect.stringMatching(
+                /^server\/edge\/chunks\/ssr\/.*\.wasm$/
+              ),
+              name: expect.stringMatching(/^wasm_/),
+            }),
+          ])
+        )
+      } else {
+        expect(manifest.middleware['/'].wasm).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              filePath: expect.stringMatching(
+                /^server\/edge-chunks\/wasm_.*\.wasm$/
+              ),
+              name: expect.stringMatching(/^wasm_/),
+            }),
+          ])
+        )
+      }
     })
   }
 })

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -5417,12 +5417,11 @@
     "passed": [
       "edge api endpoints can use wasm files uses the wasm file",
       "middleware can use wasm files can be called twice",
+      "middleware can use wasm files lists the necessary wasm bindings in the manifest",
       "middleware can use wasm files uses the wasm file",
       "middleware can use wasm files with the experimental modes on uses the wasm file"
     ],
-    "failed": [
-      "middleware can use wasm files lists the necessary wasm bindings in the manifest"
-    ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
## What?

Test fix for Turbopack, the paths are slightly different. Fixes 1 test.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2888