### PR TITLE
Add alias for react-dom react-server condition

### DIFF
--- a/packages/next/src/build/create-compiler-aliases.ts
+++ b/packages/next/src/build/create-compiler-aliases.ts
@@ -296,6 +296,9 @@ export function createRSCAliases(
       alias[
         'react$'
       ] = `next/dist/compiled/react${bundledReactChannel}/react.react-server`
+      alias[
+        'react-dom$'
+      ] = `next/dist/compiled/react-dom${bundledReactChannel}/react-dom.react-server`
     }
     // Use server rendering stub for RSC and SSR
     // x-ref: https://github.com/facebook/react/pull/25436

--- a/packages/next/src/server/future/route-modules/app-page/vendored/rsc/entrypoints.ts
+++ b/packages/next/src/server/future/route-modules/app-page/vendored/rsc/entrypoints.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import * as ReactDOM from 'react-dom/server-rendering-stub'
+import * as ReactDOM from 'react-dom'
 import * as ReactJsxDevRuntime from 'react/jsx-dev-runtime'
 import * as ReactJsxRuntime from 'react/jsx-runtime'
 

--- a/packages/next/src/server/future/route-modules/app-page/vendored/rsc/entrypoints.ts
+++ b/packages/next/src/server/future/route-modules/app-page/vendored/rsc/entrypoints.ts
@@ -67,6 +67,14 @@ if (process.env.TURBOPACK) {
   }
 }
 
+if (ReactDOM.version === undefined) {
+  // FIXME: ReactDOM's 'react-server' entrypoint is missing `.version`,
+  // which makes our tests fail when it's used, so this is an ugly workaround
+  // (but should be safe because these are always kept in sync anyway)
+  // @ts-expect-error
+  ReactDOM.version = React.version
+}
+
 export {
   React,
   ReactJsxDevRuntime,

--- a/packages/next/webpack.config.js
+++ b/packages/next/webpack.config.js
@@ -238,6 +238,12 @@ module.exports = ({ dev, turbo, bundleType, experimental }) => {
               'next/dist/compiled/react$': `next/dist/compiled/react${
                 experimental ? '-experimental' : ''
               }/react.react-server`,
+              'react-dom$': `next/dist/compiled/react-dom${
+                experimental ? '-experimental' : ''
+              }/react-dom.react-server`,
+              'next/dist/compiled/react-dom$': `next/dist/compiled/react-dom${
+                experimental ? '-experimental' : ''
+              }/react-dom.react-server`,
             },
           },
           layer: 'react-server',

--- a/packages/next/webpack.config.js
+++ b/packages/next/webpack.config.js
@@ -253,6 +253,12 @@ module.exports = ({ dev, turbo, bundleType, experimental }) => {
               'next/dist/compiled/react$': `next/dist/compiled/react${
                 experimental ? '-experimental' : ''
               }/react.react-server`,
+              'react-dom$': `next/dist/compiled/react-dom${
+                experimental ? '-experimental' : ''
+              }/react-dom.react-server`,
+              'next/dist/compiled/react-dom$': `next/dist/compiled/react-dom${
+                experimental ? '-experimental' : ''
+              }/react-dom.react-server`,
             },
           },
         },


### PR DESCRIPTION
`react-dom` also contains a `react-server` condition that need to be picked up in RSC bundle layer, like what we did for react. This will ensures the server runtime smaller and you don't accidentally use the client apis on server side.


Closes NEXT-2898