### PR TITLE
the argument might be written with underscores

### DIFF
--- a/packages/next/src/server/lib/utils.ts
+++ b/packages/next/src/server/lib/utils.ts
@@ -62,7 +62,7 @@ export function checkNodeDebugType() {
 
 export function getMaxOldSpaceSize() {
   const maxOldSpaceSize = process.env.NODE_OPTIONS?.match(
-    /--max-old-space-size=(\d+)/
+    /--max[-_]old[-_]space[-_]size=(\d+)/
   )?.[1]
 
   return maxOldSpaceSize ? parseInt(maxOldSpaceSize, 10) : undefined


### PR DESCRIPTION
### What?

You can pass `--max_old_space_size=` with underscores instead of dashes which wasn't handled yet. 

### Why?

### How?



Closes PACK-2817