### PR TITLE
prevent router markers from leaking

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -401,9 +401,14 @@ async function createTreeCodeFromPath(
         ? parallelSegment[0]
         : parallelSegment
 
+      // normalize the parallel segment key to remove any special markers that we inserted in the
+      // earlier logic (such as children$ and page$). These should never appear in the loader tree, and
+      // should instead be the corresponding segment keys (ie `__PAGE__`) or the `children` parallel route.
       parallelSegmentKey =
         parallelSegmentKey === PARALLEL_CHILDREN_SEGMENT
           ? 'children'
+          : parallelSegmentKey === PAGE_SEGMENT
+          ? PAGE_SEGMENT_KEY
           : parallelSegmentKey
 
       const normalizedParallelKey = normalizeParallelKey(parallelKey)

--- a/packages/next/src/client/components/router-reducer/compute-changed-path.ts
+++ b/packages/next/src/client/components/router-reducer/compute-changed-path.ts
@@ -16,6 +16,10 @@ const removeLeadingSlash = (segment: string): string => {
 
 const segmentToPathname = (segment: Segment): string => {
   if (typeof segment === 'string') {
+    // 'children' is not a valid path -- it's technically a parallel route that corresponds with the current segment's page
+    // if we don't skip it, then the computed pathname might be something like `/children` which doesn't make sense.
+    if (segment === 'children') return ''
+
     return segment
   }
 
@@ -50,7 +54,7 @@ export function extractPathFromFlightRouterState(
 
   if (segment.startsWith(PAGE_SEGMENT_KEY)) return ''
 
-  const segments = [segment]
+  const segments = [segmentToPathname(segment)]
   const parallelRoutes = flightRouterState[1] ?? {}
 
   const childrenPath = parallelRoutes.children


### PR DESCRIPTION
While looking into bugfixes related to router refreshing (the other PRs in this stack), I noticed there were situations where the `Next-URL` header would include `/children`, or where `page$` would be present in LoaderTree for a segment.

This updates a few spots to prevent these markers from leaking into places they shouldn't, and shouldn't have any behavioral changes. 

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2902