### PR TITLE
fix revalidation/refresh behavior with parallel routes

### DIFF
--- a/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.ts
+++ b/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.ts
@@ -4,6 +4,7 @@ import type {
 } from '../../../server/app-render/types'
 import { DEFAULT_SEGMENT_KEY } from '../../../shared/lib/segment'
 import { matchSegment } from '../match-segments'
+import { addRefreshMarkerToActiveParallelSegments } from './refetch-inactive-parallel-segments'
 
 /**
  * Deep merge of the two router states. Parallel route keys are preserved if the patch doesn't have them.
@@ -138,6 +139,8 @@ export function applyRouterStatePatchToTree(
   if (isRootLayout) {
     tree[4] = true
   }
+
+  addRefreshMarkerToActiveParallelSegments(tree, href)
 
   return tree
 }

--- a/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.ts
+++ b/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.ts
@@ -140,7 +140,7 @@ export function applyRouterStatePatchToTree(
     tree[4] = true
   }
 
-  addRefreshMarkerToActiveParallelSegments(tree, href)
+  addRefreshMarkerToActiveParallelSegments(tree, pathname)
 
   return tree
 }

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -11,6 +11,7 @@ import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-
 import { extractPathFromFlightRouterState } from './compute-changed-path'
 import { createPrefetchCacheEntryForInitialLoad } from './prefetch-cache-utils'
 import { PrefetchKind, type PrefetchCacheEntry } from './router-reducer-types'
+import { addRefreshMarkerToActiveParallelSegments } from './refetch-inactive-parallel-segments'
 
 export interface InitialRouterStateParameters {
   buildId: string
@@ -48,6 +49,16 @@ export function createInitialRouterState({
     loading: initialSeedData[3],
   }
 
+  const canonicalUrl =
+    // location.href is read as the initial value for canonicalUrl in the browser
+    // This is safe to do as canonicalUrl can't be rendered, it's only used to control the history updates in the useEffect further down in this file.
+    location
+      ? // window.location does not have the same type as URL but has all the fields createHrefFromUrl needs.
+        createHrefFromUrl(location)
+      : initialCanonicalUrl
+
+  addRefreshMarkerToActiveParallelSegments(initialTree, canonicalUrl)
+
   const prefetchCache = new Map<string, PrefetchCacheEntry>()
 
   // When the cache hasn't been seeded yet we fill the cache with the head.
@@ -79,13 +90,7 @@ export function createInitialRouterState({
       hashFragment: null,
       segmentPaths: [],
     },
-    canonicalUrl:
-      // location.href is read as the initial value for canonicalUrl in the browser
-      // This is safe to do as canonicalUrl can't be rendered, it's only used to control the history updates in the useEffect further down in this file.
-      location
-        ? // window.location does not have the same type as URL but has all the fields createHrefFromUrl needs.
-          createHrefFromUrl(location)
-        : initialCanonicalUrl,
+    canonicalUrl,
     nextUrl:
       // the || operator is intentional, the pathname can be an empty string
       (extractPathFromFlightRouterState(initialTree) || location?.pathname) ??

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -49,15 +49,7 @@ export function createInitialRouterState({
     loading: initialSeedData[3],
   }
 
-  const canonicalUrl =
-    // location.href is read as the initial value for canonicalUrl in the browser
-    // This is safe to do as canonicalUrl can't be rendered, it's only used to control the history updates in the useEffect further down in this file.
-    location
-      ? // window.location does not have the same type as URL but has all the fields createHrefFromUrl needs.
-        createHrefFromUrl(location)
-      : initialCanonicalUrl
-
-  addRefreshMarkerToActiveParallelSegments(initialTree, canonicalUrl)
+  addRefreshMarkerToActiveParallelSegments(initialTree, initialCanonicalUrl)
 
   const prefetchCache = new Map<string, PrefetchCacheEntry>()
 
@@ -90,7 +82,13 @@ export function createInitialRouterState({
       hashFragment: null,
       segmentPaths: [],
     },
-    canonicalUrl,
+    canonicalUrl:
+      // location.href is read as the initial value for canonicalUrl in the browser
+      // This is safe to do as canonicalUrl can't be rendered, it's only used to control the history updates in the useEffect further down in this file.
+      location
+        ? // window.location does not have the same type as URL but has all the fields createHrefFromUrl needs.
+          createHrefFromUrl(location)
+        : initialCanonicalUrl,
     nextUrl:
       // the || operator is intentional, the pathname can be an empty string
       (extractPathFromFlightRouterState(initialTree) || location?.pathname) ??

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -119,10 +119,9 @@ export function refreshReducer(
 
         await refreshInactiveParallelSegments({
           state,
-          newTree,
-          newCache: cache,
+          updatedTree: newTree,
+          updatedCache: cache,
           includeNextUrl,
-          clearExistingCache: true,
         })
 
         mutable.cache = cache

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -261,10 +261,9 @@ export function serverActionReducer(
 
           await refreshInactiveParallelSegments({
             state,
-            newTree,
-            newCache: cache,
+            updatedTree: newTree,
+            updatedCache: cache,
             includeNextUrl: Boolean(nextUrl),
-            clearExistingCache: !redirectLocation,
           })
 
           mutable.cache = cache

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -39,6 +39,7 @@ import { fillLazyItemsTillLeafWithHead } from '../fill-lazy-items-till-leaf-with
 import { createEmptyCacheNode } from '../../app-router'
 import { hasInterceptionRouteInCurrentTree } from './has-interception-route-in-current-tree'
 import { handleSegmentMismatch } from '../handle-segment-mismatch'
+import { refreshInactiveParallelSegments } from '../refetch-inactive-parallel-segments'
 
 type FetchServerActionResult = {
   redirectLocation: URL | undefined
@@ -53,16 +54,10 @@ type FetchServerActionResult = {
 
 async function fetchServerAction(
   state: ReadonlyReducerState,
+  nextUrl: ReadonlyReducerState['nextUrl'],
   { actionId, actionArgs }: ServerActionAction
 ): Promise<FetchServerActionResult> {
   const body = await encodeReply(actionArgs)
-
-  // only pass along the `nextUrl` param (used for interception routes) if the current route was intercepted.
-  // If the route has been intercepted, the action should be as well.
-  // Otherwise the server action might be intercepted with the wrong action id
-  // (ie, one that corresponds with the intercepted route)
-  const includeNextUrl =
-    state.nextUrl && hasInterceptionRouteInCurrentTree(state.tree)
 
   const res = await fetch('', {
     method: 'POST',
@@ -75,9 +70,9 @@ async function fetchServerAction(
             'x-deployment-id': process.env.NEXT_DEPLOYMENT_ID,
           }
         : {}),
-      ...(includeNextUrl
+      ...(nextUrl
         ? {
-            [NEXT_URL]: state.nextUrl,
+            [NEXT_URL]: nextUrl,
           }
         : {}),
     },
@@ -162,10 +157,24 @@ export function serverActionReducer(
   let currentTree = state.tree
 
   mutable.preserveCustomHistoryState = false
-  mutable.inFlightServerAction = fetchServerAction(state, action)
+
+  // only pass along the `nextUrl` param (used for interception routes) if the current route was intercepted.
+  // If the route has been intercepted, the action should be as well.
+  // Otherwise the server action might be intercepted with the wrong action id
+  // (ie, one that corresponds with the intercepted route)
+  const nextUrl =
+    state.nextUrl && hasInterceptionRouteInCurrentTree(state.tree)
+      ? state.nextUrl
+      : null
+
+  mutable.inFlightServerAction = fetchServerAction(state, nextUrl, action)
 
   return mutable.inFlightServerAction.then(
-    ({ actionResult, actionFlightData: flightData, redirectLocation }) => {
+    async ({
+      actionResult,
+      actionFlightData: flightData,
+      redirectLocation,
+    }) => {
       // Make sure the redirection is a push instead of a replace.
       // Issue: https://github.com/vercel/next.js/issues/53911
       if (redirectLocation) {
@@ -249,6 +258,15 @@ export function serverActionReducer(
             cacheNodeSeedData,
             head
           )
+
+          await refreshInactiveParallelSegments({
+            state,
+            newTree,
+            newCache: cache,
+            includeNextUrl: Boolean(nextUrl),
+            clearExistingCache: !redirectLocation,
+          })
+
           mutable.cache = cache
           mutable.prefetchCache = new Map()
         }

--- a/packages/next/src/client/components/router-reducer/refetch-inactive-parallel-segments.ts
+++ b/packages/next/src/client/components/router-reducer/refetch-inactive-parallel-segments.ts
@@ -1,0 +1,89 @@
+import type { FlightRouterState } from '../../../server/app-render/types'
+import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
+import type { AppRouterState } from './router-reducer-types'
+import { createEmptyCacheNode } from '../app-router'
+import { applyFlightData } from './apply-flight-data'
+import { fetchServerResponse } from './fetch-server-response'
+import { PAGE_SEGMENT_KEY } from '../../../shared/lib/segment'
+
+/**
+ * Refreshes inactive segments that are still in the current FlightRouterState.
+ * A segment is considered "inactive" when the server response indicates it didn't match to a page component.
+ * This happens during a soft-navigation, where the server will want to patch in the segment
+ * with the "default" component, but we explicitly ignore the server in this case
+ * and keep the existing state for that segment. New data for inactive segments are inherently
+ * not part of the server response when we patch the tree, because they were associated with a response
+ * from an earlier navigation/request. For each segment, once it becomes "active", we encode the URL that provided
+ * the data for it. This function traverses parallel routes looking for these markers so that it can re-fetch
+ * and patch the new data into the tree.
+ */
+export async function refreshInactiveParallelSegments({
+  state,
+  newTree,
+  newCache,
+  includeNextUrl,
+  clearExistingCache,
+}: {
+  state: AppRouterState
+  newTree: FlightRouterState
+  newCache: CacheNode
+  includeNextUrl: boolean
+  clearExistingCache: boolean
+}) {
+  const [, parallelRoutes, refetchUrl, refetchMarker] = newTree
+
+  if (
+    refetchUrl &&
+    refetchUrl !== state.canonicalUrl &&
+    refetchMarker === 'refetch'
+  ) {
+    const fetchResponse = await fetchServerResponse(
+      new URL(refetchUrl, location.origin),
+      [newTree[0], newTree[1], newTree[2], 'refetch'],
+      includeNextUrl ? state.nextUrl : null,
+      state.buildId
+    )
+
+    const newFlightData = fetchResponse[0]
+    if (typeof newFlightData !== 'string') {
+      for (const flightDataPath2 of newFlightData) {
+        const existingCache = clearExistingCache
+          ? createEmptyCacheNode()
+          : state.cache
+
+        applyFlightData(existingCache, newCache, flightDataPath2)
+      }
+    }
+  }
+
+  for (const key in parallelRoutes) {
+    await refreshInactiveParallelSegments({
+      state,
+      newTree: parallelRoutes[key],
+      newCache,
+      includeNextUrl,
+      clearExistingCache,
+    })
+  }
+}
+
+/**
+ * Walks the current parallel segments to determine if they are "active".
+ * An active parallel route will have a `__PAGE__` segment in the FlightRouterState.
+ * As opposed to a `__DEFAULT__` segment, which means there was no match for that parallel route.
+ * We add a special marker here so that we know how to refresh its data when the router is revalidated.
+ */
+export function addRefreshMarkerToActiveParallelSegments(
+  tree: FlightRouterState,
+  canonicalUrl: string
+) {
+  const [segment, parallelRoutes, , refetchMarker] = tree
+  if (segment === PAGE_SEGMENT_KEY && refetchMarker !== 'refetch') {
+    tree[2] = canonicalUrl
+    tree[3] = 'refetch'
+  }
+
+  for (const key in parallelRoutes) {
+    addRefreshMarkerToActiveParallelSegments(parallelRoutes[key], canonicalUrl)
+  }
+}

--- a/packages/next/src/client/components/router-reducer/refetch-inactive-parallel-segments.ts
+++ b/packages/next/src/client/components/router-reducer/refetch-inactive-parallel-segments.ts
@@ -43,7 +43,7 @@ async function refreshInactiveParallelSegmentsImpl({
   if (
     refetchPathname &&
     refetchPathname !== location.pathname &&
-    refetchMarker === 'refetch' &&
+    refetchMarker === 'refresh' &&
     // it's possible for the tree to contain multiple segments that contain data at the same URL
     // we keep track of them so we can dedupe the requests
     !fetchedSegments.has(refetchPathname)
@@ -104,9 +104,9 @@ export function addRefreshMarkerToActiveParallelSegments(
   pathname: string
 ) {
   const [segment, parallelRoutes, , refetchMarker] = tree
-  if (segment === PAGE_SEGMENT_KEY && refetchMarker !== 'refetch') {
+  if (segment === PAGE_SEGMENT_KEY && refetchMarker !== 'refresh') {
     tree[2] = pathname
-    tree[3] = 'refetch'
+    tree[3] = 'refresh'
   }
 
   for (const key in parallelRoutes) {

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -38,7 +38,7 @@ export const flightRouterStateSchema: s.Describe<any> = s.tuple([
     s.lazy(() => flightRouterStateSchema)
   ),
   s.optional(s.nullable(s.string())),
-  s.optional(s.nullable(s.literal('refetch'))),
+  s.optional(s.nullable(s.union([s.literal('refetch'), s.literal('refresh')]))),
   s.optional(s.boolean()),
 ])
 
@@ -49,7 +49,13 @@ export type FlightRouterState = [
   segment: Segment,
   parallelRoutes: { [parallelRouterKey: string]: FlightRouterState },
   url?: string | null,
-  refresh?: 'refetch' | null,
+  /*
+  /* "refresh" and "refetch", despite being similarly named, have different semantics.
+   * - "refetch" is a server indicator which informs where rendering should start from.
+   * - "refresh" is a client router indicator that it should re-fetch the data from the server for the current segment.
+   *   It uses the "url" property above to determine where to fetch from.
+   */
+  refresh?: 'refetch' | 'refresh' | null,
   isRootLayout?: boolean
 ]
 

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/@interception/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/@interception/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return null
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/layout.tsx
@@ -11,6 +11,9 @@ export default function Root({
 }) {
   return (
     <html>
+      <head>
+        <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+      </head>
       <body>
         {children}
         {dialog}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/nested-revalidate/@drawer/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/nested-revalidate/@drawer/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/nested-revalidate/@drawer/drawer/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/nested-revalidate/@drawer/drawer/page.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { revalidateAction } from '../../@modal/modal/action'
+
+export default function Page() {
+  const router = useRouter()
+
+  const handleRevalidateSubmit = async () => {
+    const result = await revalidateAction()
+    if (result.success) {
+      close()
+    }
+  }
+
+  const close = () => {
+    router.back()
+  }
+
+  return (
+    <div className="w-1/3 fixed right-0 top-0 bottom-0 h-screen shadow-2xl bg-gray-50 p-10">
+      <h2 id="drawer">Drawer</h2>
+      <p id="drawer-now">{Date.now()}</p>
+
+      <button
+        type="button"
+        id="drawer-close-button"
+        onClick={() => close()}
+        className="bg-gray-100 border p-2 rounded"
+      >
+        close
+      </button>
+      <p className="mt-4">Drawer</p>
+      <div className="mt-4 flex flex-col gap-2">
+        <Link
+          href="/nested-revalidate/modal"
+          className="bg-sky-600 text-white p-2 rounded"
+        >
+          Open modal
+        </Link>
+        <form action={handleRevalidateSubmit}>
+          <button
+            type="submit"
+            className="bg-sky-600 text-white p-2 rounded"
+            id="drawer-submit-button"
+          >
+            Revalidate submit
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/nested-revalidate/@modal/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/nested-revalidate/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/nested-revalidate/@modal/modal/action.ts
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/nested-revalidate/@modal/modal/action.ts
@@ -1,0 +1,11 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+
+export async function revalidateAction() {
+  console.log('revalidate action')
+  revalidatePath('/')
+  return {
+    success: true,
+  }
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/nested-revalidate/@modal/modal/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/nested-revalidate/@modal/modal/page.tsx
@@ -1,0 +1,43 @@
+'use client'
+import { useRouter } from 'next/navigation'
+import { revalidateAction } from './action'
+
+export default function Page() {
+  const router = useRouter()
+
+  const handleRevalidateSubmit = async () => {
+    const result = await revalidateAction()
+    if (result.success) {
+      close()
+    }
+  }
+
+  const close = () => {
+    router.back()
+  }
+
+  return (
+    <div className="z-10 fixed w-96 p-5 top-20 left-0 right-0 m-auto rounded shadow-2xl bg-gray-50 border-2">
+      <div className="flex justify-between">
+        <h2 id="modal">Modal</h2>
+        <button
+          type="button"
+          id="modal-close-button"
+          onClick={() => close()}
+          className="bg-gray-100 border p-2 rounded"
+        >
+          close
+        </button>
+      </div>
+      <form action={handleRevalidateSubmit}>
+        <button
+          type="submit"
+          className="bg-sky-600 text-white p-2 rounded"
+          id="modal-submit-button"
+        >
+          Revalidate Submit
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/nested-revalidate/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/nested-revalidate/layout.tsx
@@ -1,0 +1,19 @@
+export const dynamic = 'force-dynamic'
+
+export default function Layout({
+  children,
+  modal,
+  drawer,
+}: {
+  children: React.ReactNode
+  modal: React.ReactNode
+  drawer: React.ReactNode
+}) {
+  return (
+    <div>
+      <div>{children}</div>
+      <div>{modal}</div>
+      <div>{drawer}</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/nested-revalidate/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/nested-revalidate/page.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <div className="text-center h-screen flex flex-col gap-4 justify-center w-60 mx-auto">
+      <p>Nested parallel routes demo.</p>
+      <p id="page-now">Date.now {Date.now()}</p>
+      <div className="flex flex-col gap-2">
+        <Link
+          href="/nested-revalidate/drawer"
+          className="bg-sky-600 text-white p-2 rounded"
+        >
+          Open Drawer
+        </Link>
+        <Link
+          href="/nested-revalidate/modal"
+          className="bg-sky-600 text-white p-2 rounded"
+        >
+          Open Modal
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/refreshing/@modal/(.)login/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/refreshing/@modal/(.)login/page.tsx
@@ -1,0 +1,19 @@
+import { Button } from '../../buttonRefresh'
+
+const getRandom = async () => Math.random()
+
+export default async function Page() {
+  const someProp = await getRandom()
+
+  return (
+    <dialog open>
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <div>
+          <span>Modal Page</span>
+          <span id="modal-random">{someProp}</span>
+        </div>
+        <Button />
+      </div>
+    </dialog>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/refreshing/@modal/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/refreshing/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/refreshing/buttonRefresh.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/refreshing/buttonRefresh.tsx
@@ -1,0 +1,16 @@
+'use client'
+import { useRouter } from 'next/navigation'
+
+export function Button() {
+  const router = useRouter()
+
+  return (
+    <button
+      id="refresh-button"
+      style={{ color: 'red', padding: '10px' }}
+      onClick={() => router.refresh()}
+    >
+      Refresh
+    </button>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/refreshing/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/refreshing/layout.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link'
+
+export const dynamic = 'force-dynamic'
+
+export default function Layout({
+  children,
+  modal,
+}: {
+  children: React.ReactNode
+  modal: React.ReactNode
+}) {
+  return (
+    <div>
+      <div>{children}</div>
+      <div>{modal}</div>
+      <Link href="/refreshing/other">Go to Other Page</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/refreshing/login/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/refreshing/login/page.tsx
@@ -1,0 +1,11 @@
+import { Button } from '../buttonRefresh'
+
+export default function Page() {
+  return (
+    <>
+      <span>Login Page</span>
+      <Button />
+      Random Number: <span id="login-page-random">{Math.random()}</span>
+    </>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/refreshing/other/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/refreshing/other/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <div>
+      <div>Other Page</div>
+      <div id="other-page-random">{Math.random()}</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/refreshing/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/refreshing/page.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <main>
+      <Link href="/refreshing/login">
+        <button>Login button</button>
+      </Link>
+      <div>
+        Random # from Root Page: <span id="random-number">{Math.random()}</span>
+      </div>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts
+++ b/test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts
@@ -7,7 +7,7 @@ createNextDescribe(
     files: __dirname,
   },
   ({ next }) => {
-    it.skip('should submit the action and revalidate the page data', async () => {
+    it('should submit the action and revalidate the page data', async () => {
       const browser = await next.browser('/')
       await check(() => browser.hasElementByCssSelector('#create-entry'), false)
 
@@ -41,7 +41,7 @@ createNextDescribe(
       await check(() => browser.elementByCss('body').text(), /Current Data/)
     })
 
-    it.skip('should handle router.refresh() when called in a slot', async () => {
+    it('should handle router.refresh() when called in a slot', async () => {
       const browser = await next.browser('/')
       await check(
         () => browser.hasElementByCssSelector('#refresh-router'),
@@ -69,7 +69,7 @@ createNextDescribe(
       await check(() => browser.elementByCss('body').text(), /Current Data/)
     })
 
-    it.skip('should handle a redirect action when called in a slot', async () => {
+    it('should handle a redirect action when called in a slot', async () => {
       const browser = await next.browser('/')
       await check(() => browser.hasElementByCssSelector('#redirect'), false)
       await browser.elementByCss("[href='/redirect-modal']").click()
@@ -155,6 +155,89 @@ createNextDescribe(
 
         // confirm the paramsare still present
         expect(await browser.elementById('params').text()).toBe('foobar')
+      })
+    })
+
+    describe('router.refresh', () => {
+      it('should correctly refresh data for the intercepted route and previously active page slot', async () => {
+        const browser = await next.browser('/refreshing')
+        const initialRandomNumber = await browser.elementById('random-number')
+
+        await browser.elementByCss("[href='/refreshing/login']").click()
+
+        // interception modal should be visible
+        const initialModalRandomNumber = await browser
+          .elementById('modal-random')
+          .text()
+
+        // trigger a refresh
+        await browser.elementById('refresh-button').click()
+
+        await retry(async () => {
+          const newRandomNumber = await browser
+            .elementById('random-number')
+            .text()
+          const newModalRandomNumber = await browser
+            .elementById('modal-random')
+            .text()
+          expect(initialRandomNumber).not.toBe(newRandomNumber)
+          expect(initialModalRandomNumber).not.toBe(newModalRandomNumber)
+        })
+
+        // reload the page, triggering which will remove the interception route and show the full page
+        await browser.refresh()
+
+        const initialLoginPageRandomNumber = await browser
+          .elementById('login-page-random')
+          .text()
+
+        // trigger a refresh
+        await browser.elementById('refresh-button').click()
+
+        await retry(async () => {
+          const newLoginPageRandomNumber = await browser
+            .elementById('login-page-random')
+            .text()
+
+          expect(newLoginPageRandomNumber).not.toBe(
+            initialLoginPageRandomNumber
+          )
+        })
+      })
+
+      it('should correctly refresh data for previously intercepted modal and active page slot', async () => {
+        const browser = await next.browser('/refreshing')
+
+        await browser.elementByCss("[href='/refreshing/login']").click()
+
+        // interception modal should be visible
+        const initialModalRandomNumber = await browser
+          .elementById('modal-random')
+          .text()
+
+        await browser.elementByCss("[href='/refreshing/other']").click()
+        // data for the /other page should be visible
+
+        const initialOtherPageRandomNumber = await browser
+          .elementById('other-page-random')
+          .text()
+
+        // trigger a refresh
+        await browser.elementById('refresh-button').click()
+
+        await retry(async () => {
+          const newModalRandomNumber = await browser
+            .elementById('modal-random')
+            .text()
+
+          const newOtherPageRandomNumber = await browser
+            .elementById('other-page-random')
+            .text()
+          expect(initialModalRandomNumber).not.toBe(newModalRandomNumber)
+          expect(initialOtherPageRandomNumber).not.toBe(
+            newOtherPageRandomNumber
+          )
+        })
       })
     })
   }

--- a/test/ppr-tests-manifest.json
+++ b/test/ppr-tests-manifest.json
@@ -48,6 +48,11 @@
         "app dir - navigation bots should block rendering for bots and return 404 status"
       ]
     },
+    "test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts": {
+      "failed": [
+        "parallel-routes-revalidation router.refresh should correctly refresh data for previously intercepted modal and active page slot"
+      ]
+    },
     "test/e2e/app-dir/app-static/app-static-custom-handler.test.ts": {
       "failed": [
         "app-dir static/dynamic handling should output debug info for static bailouts",

--- a/test/ppr-tests-manifest.json
+++ b/test/ppr-tests-manifest.json
@@ -48,11 +48,6 @@
         "app dir - navigation bots should block rendering for bots and return 404 status"
       ]
     },
-    "test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts": {
-      "failed": [
-        "parallel-routes-revalidation router.refresh should correctly refresh data for previously intercepted modal and active page slot"
-      ]
-    },
     "test/e2e/app-dir/app-static/app-static-custom-handler.test.ts": {
       "failed": [
         "app-dir static/dynamic handling should output debug info for static bailouts",

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -2251,7 +2251,10 @@
       "failed": [
         "parallel-routes-revalidation should handle a redirect action when called in a slot",
         "parallel-routes-revalidation should handle router.refresh() when called in a slot",
-        "parallel-routes-revalidation should not trigger full page when calling router.refresh() on an intercepted route"
+        "parallel-routes-revalidation should not trigger full page when calling router.refresh() on an intercepted route",
+        "parallel-routes-revalidation router.refresh should correctly refresh data for the intercepted route and previously active page slot",
+        "parallel-routes-revalidation router.refresh should correctly refresh data for previously intercepted modal and active page slot",
+        "parallel-routes-revalidation server action revalidation handles refreshing when multiple parallel slots are active"
       ],
       "pending": [],
       "flakey": [],


### PR DESCRIPTION
### What
When a parallel segment in the current router tree is no longer "active" during a soft navigation (ie, no longer matches a page component on the particular route), it remains on-screen until the page is refreshed, at which point it would switch to rendering the `default.tsx` component. However, when revalidating the router cache via `router.refresh`, or when a server action finishes & refreshes the router cache, this would trigger the "hard refresh" behavior. This would have the unintended consequence of a 404 being triggered (which is the default behavior of `default.tsx`) or inactive segments disappearing unexpectedly.

### Why
When the router cache is refreshed, it currently fetches new data for the page by fetching from the current URL the user is on. This means that the server will never respond with the data it needs if the segment wasn't "activated" via the URL we're fetching from, as it came from someplace else. Instead, the server will give us data for the `default.tsx` component, which we don't want to render when doing a soft refresh. 

### How
This updates the `FlightRouterState` to encode information about the URL that caused the segment to become  active. That way, when some sort of revalidation event takes place, we can both refresh the data for the current URL (existing handling), and recursively refetch segment data for anything that was still present in the tree but requires fetching from a different URL. We patch this new data into the tree before committing the final `CacheNode` to the router. 

**Note**: I re-used the existing `refresh` and `url` arguments in `FlightRouterState` to avoid introducing more options to this data structure that is already a bit tricky to work with. Initially I was going to re-use `"refetch"` as-is, which seemed to work ok, but I'm worried about potential implications of this considering they have different semantics. In an abundance of caution, I added a new marker type ("`refresh`", alternative suggestions welcome).

This has some trade-offs: namely, if there are a lot of different segments that are in this stale state that require data from different URLs, the refresh is going to be blocked while we fetch all of these segments. Having to do a separate round-trip for each of these segments could be expensive. In an ideal world, we'd be able to enumerate the segments we'd want to refetch and where they came from, so it could be handled in a single round-trip. There are some ideas on how to improve per-segment fetching which are out of scope of this PR. However, due to the implicit contract that `middleware.ts` creates with URLs, we still need to identify these resources by URLs.

Fixes #60815
Fixes #60950
Fixes #51711
Fixes #51714
Fixes #58715
Fixes #60948
Fixes #62213
Fixes #61341

Closes NEXT-1845
Closes NEXT-2030
