### PR TITLE
fix: add css content-type to head links

### DIFF
--- a/packages/next/src/pages/_document.tsx
+++ b/packages/next/src/pages/_document.tsx
@@ -472,6 +472,7 @@ export class Head extends React.Component<HeadProps> {
           key={file}
           nonce={this.props.nonce}
           rel="stylesheet"
+          type="text/css"
           href={`${assetPrefix}/_next/${encodeURI(file)}${assetQueryString}`}
           crossOrigin={this.props.crossOrigin || crossOrigin}
           data-n-g={isUnmanagedFile ? undefined : isSharedFile ? '' : undefined}

--- a/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
+++ b/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
@@ -43,6 +43,7 @@ export async function createComponentStylesAndScripts({
         return (
           <link
             rel="stylesheet"
+            type="text/css"
             href={fullHref}
             // @ts-ignore
             precedence={precedence}

--- a/packages/next/src/server/app-render/get-layer-assets.tsx
+++ b/packages/next/src/server/app-render/get-layer-assets.tsx
@@ -83,6 +83,7 @@ export function getLayerAssets({
         return (
           <link
             rel="stylesheet"
+            type="text/css"
             href={fullHref}
             // @ts-ignore
             precedence={precedence}

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -257,7 +257,7 @@ export class WrappedBuildError extends Error {
 }
 
 type ResponsePayload = {
-  type: 'html' | 'json' | 'rsc'
+  type: 'html' | 'json' | 'rsc' | 'css'
   body: RenderResult
   revalidate?: Revalidate
 }
@@ -328,7 +328,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     res: BaseNextResponse,
     options: {
       result: RenderResult
-      type: 'html' | 'json' | 'rsc'
+      type: 'html' | 'json' | 'rsc' | 'css'
       generateEtags: boolean
       poweredByHeader: boolean
       revalidate?: Revalidate

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -431,7 +431,7 @@ export default class NextNodeServer extends BaseServer {
     res: NodeNextResponse,
     options: {
       result: RenderResult
-      type: 'html' | 'json'
+      type: 'html' | 'json' | 'css'
       generateEtags: boolean
       poweredByHeader: boolean
       revalidate: Revalidate | undefined

--- a/packages/next/src/server/send-payload.ts
+++ b/packages/next/src/server/send-payload.ts
@@ -45,7 +45,7 @@ export async function sendRenderResult({
   req: IncomingMessage
   res: ServerResponse
   result: RenderResult
-  type: 'html' | 'json' | 'rsc'
+  type: 'html' | 'json' | 'rsc' | 'css'
   generateEtags: boolean
   poweredByHeader: boolean
   revalidate: Revalidate | undefined
@@ -120,16 +120,26 @@ export async function sendRenderResult({
   }
 
   if (!res.getHeader('Content-Type')) {
-    res.setHeader(
-      'Content-Type',
-      result.contentType
-        ? result.contentType
-        : type === 'rsc'
-        ? RSC_CONTENT_TYPE_HEADER
-        : type === 'json'
-        ? 'application/json'
-        : 'text/html; charset=utf-8'
-    )
+    let contentType = result.contentType
+
+    if (!contentType) {
+      switch (type) {
+        case 'rsc':
+          contentType = RSC_CONTENT_TYPE_HEADER
+          break
+        case 'json':
+          contentType = 'application/json'
+          break
+        case 'css':
+          contentType = 'text/css'
+          break
+        case 'html':
+        default:
+          contentType = 'text/html; charset=utf-8'
+      }
+    }
+
+    res.setHeader('Content-Type', contentType)
   }
 
   if (payload) {

--- a/packages/next/src/server/web-server.ts
+++ b/packages/next/src/server/web-server.ts
@@ -263,7 +263,7 @@ export default class NextWebServer extends BaseServer<WebServerOptions> {
     res: WebNextResponse,
     options: {
       result: RenderResult
-      type: 'html' | 'json'
+      type: 'html' | 'json' | 'css'
       generateEtags: boolean
       poweredByHeader: boolean
       revalidate: Revalidate | undefined
@@ -279,14 +279,24 @@ export default class NextWebServer extends BaseServer<WebServerOptions> {
     }
 
     if (!res.getHeader('Content-Type')) {
-      res.setHeader(
-        'Content-Type',
-        options.result.contentType
-          ? options.result.contentType
-          : options.type === 'json'
-          ? 'application/json'
-          : 'text/html; charset=utf-8'
-      )
+      let contentType = options.result.contentType
+
+      if (!contentType) {
+        switch (options.type) {
+          case 'json':
+            contentType = 'application/json'
+            break
+          case 'css':
+            contentType = 'text/css'
+            break
+          case 'html':
+          default:
+            contentType = 'text/html; charset=utf-8'
+            break
+        }
+      }
+
+      res.setHeader('Content-Type', contentType)
     }
 
     let promise: Promise<void> | undefined


### PR DESCRIPTION
Add Content-Type "text/css" to fetching stylesheets

When an assetPrefix is set in the next config, the stylesheets fail as the server response with a Content-Type: "text/html".
<img width="1016" alt="Screenshot 2024-03-22 at 17 50 57" src="https://github.com/vercel/next.js/assets/11695769/a9a7a29e-d3a1-4e87-823c-fb024fa831ff">
