### PR TITLE
fix(next-swc): always load wasm bindigns for unsupported platform

### DIFF
--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -227,8 +227,10 @@ export async function loadBindings(
         !!triple?.raw && knownDefaultWasmFallbackTriples.includes(triple.raw)
     )
     const isWebContainer = process.versions.webcontainer
+    // if the env is webcontainer or unsupportedPlatform, it can only load wasm
     const shouldLoadWasmFallbackFirst =
-      (!disableWasmFallback && unsupportedPlatform && useWasmBinary) ||
+      (!disableWasmFallback && useWasmBinary) ||
+      unsupportedPlatform ||
       isWebContainer
 
     if (!unsupportedPlatform && useWasmBinary) {


### PR DESCRIPTION
### What 

minor fix to load wasm fallback - if the platform is unsupported, load wasm always instead of checking `useWasmBinary` since there is no other native bindings we can load.

Closes PACK-2823