### PR TITLE
fext(next-core): inherit root layout segment config for the routes

### DIFF
--- a/packages/next-swc/crates/next-api/src/app.rs
+++ b/packages/next-swc/crates/next-api/src/app.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use indexmap::IndexSet;
 use next_core::{
     all_assets_from_entries,
+    app_segment_config::NextSegmentConfig,
     app_structure::{
         get_entrypoints, Entrypoint as AppEntrypoint, Entrypoints as AppEntrypoints, LoaderTree,
         MetadataItem,
@@ -30,6 +31,7 @@ use next_core::{
         get_server_module_options_context, get_server_resolve_options_context,
         get_server_runtime_entries, ServerContextType,
     },
+    parse_segment_config_from_source,
     util::NextRuntime,
 };
 use serde::{Deserialize, Serialize};
@@ -522,11 +524,15 @@ pub fn app_entry_point_to_route(
                 })
                 .collect(),
         ),
-        AppEntrypoint::AppRoute { page, path } => Route::AppRoute {
+        AppEntrypoint::AppRoute {
+            page,
+            path,
+            root_layouts,
+        } => Route::AppRoute {
             original_name: page.to_string(),
             endpoint: Vc::upcast(
                 AppEndpoint {
-                    ty: AppEndpointType::Route { path },
+                    ty: AppEndpointType::Route { path, root_layouts },
                     app_project,
                     page,
                 }
@@ -562,6 +568,7 @@ enum AppEndpointType {
     },
     Route {
         path: Vc<FileSystemPath>,
+        root_layouts: Vc<Vec<Vc<FileSystemPath>>>,
     },
     Metadata {
         metadata: MetadataItem,
@@ -590,15 +597,34 @@ impl AppEndpoint {
     }
 
     #[turbo_tasks::function]
-    fn app_route_entry(&self, path: Vc<FileSystemPath>) -> Vc<AppEntry> {
-        get_app_route_entry(
+    async fn app_route_entry(
+        &self,
+        path: Vc<FileSystemPath>,
+        root_layouts: Vc<Vec<Vc<FileSystemPath>>>,
+    ) -> Result<Vc<AppEntry>> {
+        let root_layouts = root_layouts.await?;
+        let config = if root_layouts.is_empty() {
+            None
+        } else {
+            let mut config = NextSegmentConfig::default();
+
+            for layout in root_layouts.iter().rev() {
+                let source = Vc::upcast(FileSource::new(*layout));
+                let layout_config = parse_segment_config_from_source(source);
+                config.apply_parent_config(&*layout_config.await?);
+            }
+
+            Some(config.cell())
+        };
+
+        Ok(get_app_route_entry(
             self.app_project.route_module_context(),
             self.app_project.edge_route_module_context(),
             Vc::upcast(FileSource::new(path)),
             self.page.clone(),
             self.app_project.project().project_path(),
-            None,
-        )
+            config,
+        ))
     }
 
     #[turbo_tasks::function]
@@ -631,7 +657,9 @@ impl AppEndpoint {
             // NOTE(alexkirsz) For routes, technically, a lot of the following code is not needed,
             // as we know we won't have any client references. However, for now, for simplicity's
             // sake, we just do the same thing as for pages.
-            AppEndpointType::Route { path } => (self.app_route_entry(path), false, false),
+            AppEndpointType::Route { path, root_layouts } => {
+                (self.app_route_entry(path, root_layouts), false, false)
+            }
             AppEndpointType::Metadata { metadata } => {
                 (self.app_metadata_entry(metadata), false, false)
             }

--- a/packages/next-swc/crates/next-core/src/app_segment_config.rs
+++ b/packages/next-swc/crates/next-core/src/app_segment_config.rs
@@ -63,8 +63,8 @@ pub enum NextRevalidate {
     },
 }
 
-#[turbo_tasks::value]
-#[derive(Debug, Default)]
+#[turbo_tasks::value(into = "shared")]
+#[derive(Debug, Default, Clone)]
 pub struct NextSegmentConfig {
     pub dynamic: Option<NextSegmentDynamic>,
     pub dynamic_params: Option<bool>,
@@ -443,6 +443,7 @@ pub async fn parse_segment_config_from_loader_tree(
     for tree in parallel_configs {
         config.apply_parallel_config(&tree)?;
     }
+
     for component in [components.page, components.default, components.layout]
         .into_iter()
         .flatten()

--- a/packages/next-swc/crates/next-core/src/app_segment_config.rs
+++ b/packages/next-swc/crates/next-core/src/app_segment_config.rs
@@ -349,11 +349,10 @@ fn parse_config_value(
                 JsValue::Constant(ConstantValue::Str(str)) if str.as_str() == "force-cache" => {
                     config.revalidate = Some(NextRevalidate::ForceCache);
                 }
-                _ => invalid_config(
-                    "`revalidate` needs to be static false, static 'force-cache' or a static \
-                     positive integer",
-                    &value,
-                ),
+                _ => {
+                    //noop; revalidate validation occurs in runtime at
+                    //https://github.com/vercel/next.js/blob/cd46c221d2b7f796f963d2b81eea1e405023db23/packages/next/src/server/lib/patch-fetch.ts#L20
+                }
             }
         }
         "fetchCache" => {

--- a/packages/next-swc/crates/next-core/src/lib.rs
+++ b/packages/next-swc/crates/next-core/src/lib.rs
@@ -6,7 +6,7 @@
 #![feature(arbitrary_self_types)]
 #![feature(iter_intersperse)]
 
-mod app_segment_config;
+pub mod app_segment_config;
 pub mod app_structure;
 mod babel;
 mod bootstrap;

--- a/packages/next-swc/crates/next-core/src/next_app/app_route_entry.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/app_route_entry.rs
@@ -39,8 +39,15 @@ pub async fn get_app_route_entry(
     project_root: Vc<FileSystemPath>,
     original_segment_config: Option<Vc<NextSegmentConfig>>,
 ) -> Result<Vc<AppEntry>> {
-    let config =
-        original_segment_config.unwrap_or_else(|| parse_segment_config_from_source(source));
+    let segment_from_source = parse_segment_config_from_source(source);
+    let config = if let Some(original_segment_config) = original_segment_config {
+        let mut segment_config = (*segment_from_source.await?).clone();
+        segment_config.apply_parent_config(&*original_segment_config.await?);
+        segment_config.into()
+    } else {
+        segment_from_source
+    };
+
     let is_edge = matches!(config.await?.runtime, Some(NextRuntime::Edge));
     let context = if is_edge {
         edge_context

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -3367,12 +3367,11 @@
       "app dir - draft mode in nodejs runtime should not perform full page navigation on router.refresh()",
       "app dir - draft mode in nodejs runtime should read other cookies when draft mode enabled",
       "app dir - draft mode in nodejs runtime should use initial rand when draft mode is disabled on /index",
-      "app dir - draft mode in nodejs runtime should use initial rand when draft mode is disabled on /with-cookies"
-    ],
-    "failed": [
+      "app dir - draft mode in nodejs runtime should use initial rand when draft mode is disabled on /with-cookies",
       "app dir - draft mode in edge runtime should genenerate rand when draft mode enabled",
       "app dir - draft mode in edge runtime should read other cookies when draft mode enabled"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
### What

Supports root segment config inherit from layout. Currently route segment config only runs agasint own source, so individual route segment config works but if the config is set in layout level it is being ignored. PR introduces root segment and pass into each route if tree level have a corresponding layout.

Closes PACK-2839