### PR TITLE
Add Next.js version to process title

### DIFF
--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -91,7 +91,7 @@ export async function startServer(
   } = serverOptions
   let { port } = serverOptions
 
-  process.title = 'next-server'
+  process.title = `next-server (v${process.env.__NEXT_VERSION})`
   let handlersReady = () => {}
   let handlersError = () => {}
 


### PR DESCRIPTION
Makes debugging a little easier by showing the Next.js version in the process title as well. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1711401562557429?thread_ts=1711400819.248569&cid=C03KAR5DCKC)

Closes NEXT-2924