### PR TITLE
ensure null loading boundaries still render a Suspense boundary

### DIFF
--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -468,16 +468,20 @@ function InnerLayoutRouter({
  */
 function LoadingBoundary({
   children,
+  hasLoading,
   loading,
   loadingStyles,
   loadingScripts,
 }: {
   children: React.ReactNode
+  hasLoading: boolean
   loading?: React.ReactNode
   loadingStyles?: React.ReactNode
   loadingScripts?: React.ReactNode
 }): JSX.Element {
-  if (loading) {
+  // We have an explicit prop for checking if `loading` is provided, to disambiguate between a loading
+  // component that returns `null` / `undefined`, vs not having a loading component at all.
+  if (hasLoading) {
     return (
       <Suspense
         fallback={
@@ -581,6 +585,7 @@ export default function OuterLayoutRouter({
                   errorScripts={errorScripts}
                 >
                   <LoadingBoundary
+                    hasLoading={Boolean(loading)}
                     loading={loading?.[0]}
                     loadingStyles={loading?.[1]}
                     loadingScripts={loading?.[2]}

--- a/test/e2e/app-dir/app-client-cache/app/layout.js
+++ b/test/e2e/app-dir/app-client-cache/app/layout.js
@@ -2,7 +2,10 @@ export default function Root({ children }) {
   return (
     <html>
       <head></head>
-      <body>{children}</body>
+      <body>
+        <div id="root-layout">Root Layout</div>
+        <div>{children}</div>
+      </body>
     </html>
   )
 }

--- a/test/e2e/app-dir/app-client-cache/app/null-loading/loading.js
+++ b/test/e2e/app-dir/app-client-cache/app/null-loading/loading.js
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return null
+}

--- a/test/e2e/app-dir/app-client-cache/app/null-loading/page.js
+++ b/test/e2e/app-dir/app-client-cache/app/null-loading/page.js
@@ -1,0 +1,15 @@
+export const dynamic = 'force-dynamic'
+
+export default async function Page() {
+  const randomNumber = await new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(Math.random())
+    }, 1000)
+  })
+
+  return (
+    <div>
+      Page Data! <div id="random-number">{randomNumber}</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-client-cache/app/page.js
+++ b/test/e2e/app-dir/app-client-cache/app/page.js
@@ -20,6 +20,9 @@ export default function HomePage() {
           To Random Number - prefetch: auto, slow
         </Link>
       </div>
+      <div>
+        <Link href="/null-loading">To Null Loading - prefetch: auto</Link>
+      </div>
     </>
   )
 }

--- a/test/e2e/app-dir/app-client-cache/client-cache.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.test.ts
@@ -434,6 +434,26 @@ createNextDescribe(
 
           expect(newNumber).not.toBe(randomNumber)
         })
+
+        it('should respect a loading boundary that returns `null`', async () => {
+          await browser.elementByCss('[href="/null-loading"]').click()
+
+          // the page content should disappear immediately
+          expect(
+            await browser.hasElementByCssSelector('[href="/null-loading"]')
+          ).toBeFalse()
+
+          // the root layout should still be visible
+          expect(
+            await browser.hasElementByCssSelector('#root-layout')
+          ).toBeTrue()
+
+          // the dynamic content should eventually appear
+          await browser.waitForElementByCss('#random-number')
+          expect(
+            await browser.hasElementByCssSelector('#random-number')
+          ).toBeTrue()
+        })
       })
 
       it('should seed the prefetch cache with the fetched page data', async () => {


### PR DESCRIPTION
This ensures that even if a `loading.js` returns `null`, that we still render a `Suspense` boundary, as it's perfectly valid to have an empty fallback. 

This was accidentally lost in #62346 -- this brings back the `hasLoading` prop which will check the loading module itself (rather than the `ReactNode`) for truthiness, and I've added a test to avoid another regression.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2936