### PR TITLE
Rename encryption key generation code

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -884,10 +884,7 @@ async fn insert_next_shared_aliases(
     );
     import_map.insert_exact_alias(
         "private-next-rsc-action-encryption",
-        request_to_import_mapping(
-            project_path,
-            "next/dist/server/app-render/action-encryption",
-        ),
+        request_to_import_mapping(project_path, "next/dist/server/app-render/encryption"),
     );
 
     insert_turbopack_dev_alias(import_map);

--- a/packages/next/src/build/create-compiler-aliases.ts
+++ b/packages/next/src/build/create-compiler-aliases.ts
@@ -150,8 +150,7 @@ export function createWebpackAliases({
     [RSC_ACTION_PROXY_ALIAS]:
       'next/dist/build/webpack/loaders/next-flight-loader/server-reference',
 
-    [RSC_ACTION_ENCRYPTION_ALIAS]:
-      'next/dist/server/app-render/action-encryption',
+    [RSC_ACTION_ENCRYPTION_ALIAS]: 'next/dist/server/app-render/encryption',
 
     ...(isClient || isEdgeServer
       ? {

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -11,7 +11,7 @@ import type { BuildManifest } from '../../server/get-page-files'
 import type { RequestData } from '../../server/web/types'
 import type { NextConfigComplete } from '../../server/config-shared'
 import { PAGE_TYPES } from '../../lib/page-types'
-import { setReferenceManifestsSingleton } from '../../server/app-render/action-encryption-utils'
+import { setReferenceManifestsSingleton } from '../../server/app-render/encryption-utils'
 import { createServerModuleMap } from '../../server/app-render/action-utils'
 
 declare const incrementalCacheHandler: any

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -39,7 +39,7 @@ import {
 } from '../utils'
 import { normalizePathSep } from '../../../shared/lib/page-path/normalize-path-sep'
 import { getProxiedPluginState } from '../../build-context'
-import { generateRandomActionKeyRaw } from '../../../server/app-render/action-encryption-utils'
+import { generateEncryptionKeyBase64 } from '../../../server/app-render/encryption-utils'
 import { PAGE_TYPES } from '../../../lib/page-types'
 import { isWebpackServerOnlyLayer } from '../../utils'
 
@@ -1002,7 +1002,7 @@ export class FlightClientEntryPlugin {
         edge: edgeServerActions,
 
         // Assign encryption
-        encryptionKey: await generateRandomActionKeyRaw(this.dev),
+        encryptionKey: await generateEncryptionKeyBase64(this.dev),
       },
       null,
       this.dev ? 2 : undefined

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -79,7 +79,7 @@ import { makeGetServerInsertedHTML } from './make-get-server-inserted-html'
 import { walkTreeWithFlightRouterState } from './walk-tree-with-flight-router-state'
 import { createComponentTree } from './create-component-tree'
 import { getAssetQueryString } from './get-asset-query-string'
-import { setReferenceManifestsSingleton } from './action-encryption-utils'
+import { setReferenceManifestsSingleton } from './encryption-utils'
 import {
   createStaticRenderer,
   getDynamicDataPostponedState,

--- a/packages/next/src/server/app-render/encryption.ts
+++ b/packages/next/src/server/app-render/encryption.ts
@@ -21,7 +21,7 @@ import {
   getClientReferenceManifestSingleton,
   getServerModuleMap,
   stringToUint8Array,
-} from './action-encryption-utils'
+} from './encryption-utils'
 
 const textEncoder = new TextEncoder()
 const textDecoder = new TextDecoder()

--- a/packages/next/src/server/dev/turbopack/manifest-loader.ts
+++ b/packages/next/src/server/dev/turbopack/manifest-loader.ts
@@ -7,7 +7,7 @@ import type { AppBuildManifest } from '../../../build/webpack/plugins/app-build-
 import type { PagesManifest } from '../../../build/webpack/plugins/pages-manifest-plugin'
 import { pathToRegexp } from 'next/dist/compiled/path-to-regexp'
 import type { ActionManifest } from '../../../build/webpack/plugins/flight-client-entry-plugin'
-import { generateRandomActionKeyRaw } from '../../app-render/action-encryption-utils'
+import { generateEncryptionKeyBase64 } from '../../app-render/encryption-utils'
 import type { NextFontManifest } from '../../../build/webpack/plugins/next-font-manifest-plugin'
 import type { LoadableManifest } from '../../load-components'
 import {
@@ -123,7 +123,7 @@ export class TurbopackManifestLoader {
     const manifest: ActionManifest = {
       node: {},
       edge: {},
-      encryptionKey: await generateRandomActionKeyRaw(true),
+      encryptionKey: await generateEncryptionKeyBase64(true),
     }
 
     function mergeActionIds(

--- a/packages/next/src/server/load-components.ts
+++ b/packages/next/src/server/load-components.ts
@@ -28,7 +28,7 @@ import { getTracer } from './lib/trace/tracer'
 import { LoadComponentsSpan } from './lib/trace/constants'
 import { evalManifest, loadManifest } from './load-manifest'
 import { wait } from '../lib/wait'
-import { setReferenceManifestsSingleton } from './app-render/action-encryption-utils'
+import { setReferenceManifestsSingleton } from './app-render/encryption-utils'
 import { createServerModuleMap } from './app-render/action-utils'
 
 export type ManifestItem = {


### PR DESCRIPTION
This PR renames the API to be not specifically related to Server Actions, as in the future it might be used by other things. It also adds the `__next_encryption_key_generation_promise` variable to avoid double-generating of the key when it's called concurrently (e.g. by the node server and edge server compilers).

Closes NEXT-2938