### PR TITLE
Ensure test-firefox-safari is required for tests passing

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -424,6 +424,7 @@ jobs:
         'test-dev',
         'test-prod',
         'test-integration',
+        'test-firefox-safari',
         'test-ppr-dev',
         'test-ppr-prod',
         'test-ppr-integration',


### PR DESCRIPTION
This can currently fail and still pass our final tests pass check which it shouldn't

x-ref: https://github.com/vercel/next.js/pull/63726

Closes NEXT-2939