### PR TITLE
chore(github-workflow): remove TODO comment

### DIFF
--- a/.github/workflows/turbopack-nextjs-build-integration-tests.yml
+++ b/.github/workflows/turbopack-nextjs-build-integration-tests.yml
@@ -96,7 +96,6 @@ jobs:
           path: |
             test/turbopack-test-junit-report
 
-  # TODO: Implement specifically running production tests only for Turbopack. Enabling this now enables running `test/integration` with development mode too.
   test-integration-production:
     name: Next.js integration test (Integration)
     needs: [setup_nextjs]


### PR DESCRIPTION
## Why?

This PR → https://github.com/vercel/next.js/pull/63679 was finishing the `TODO` comment, so we should be good to remove it.

Closes NEXT-2941