### PR TITLE
Turbopack: fix allocation inefficiency

### DIFF
--- a/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -424,7 +424,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
     fn visit_mut_fn_expr(&mut self, f: &mut FnExpr) {
         let is_action_fn = self.get_action_info(f.function.body.as_mut(), true);
 
-        let current_declared_idents = self.declared_idents.clone();
+        let declared_idents_until = self.declared_idents.len();
         let current_names = take(&mut self.names);
 
         // Visit children
@@ -475,7 +475,10 @@ impl<C: Comments> VisitMut for ServerActions<C> {
 
             // Collect all the identifiers defined inside the closure and used
             // in the action function. With deduplication.
-            retain_names_from_declared_idents(&mut child_names, &current_declared_idents);
+            retain_names_from_declared_idents(
+                &mut child_names,
+                &self.declared_idents[..declared_idents_until],
+            );
 
             let maybe_new_expr =
                 self.maybe_hoist_and_create_proxy(child_names, Some(&mut f.function), None);

--- a/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -583,9 +583,8 @@ impl<C: Comments> VisitMut for ServerActions<C> {
             true,
         );
 
-        let current_declared_idents = self.declared_idents.clone();
-        let current_names = self.names.clone();
-        self.names = vec![];
+        let declared_idents_until = self.declared_idents.len();
+        let current_names = take(&mut self.names);
 
         {
             // Visit children
@@ -629,7 +628,10 @@ impl<C: Comments> VisitMut for ServerActions<C> {
 
         // Collect all the identifiers defined inside the closure and used
         // in the action function. With deduplication.
-        retain_names_from_declared_idents(&mut child_names, &current_declared_idents);
+        retain_names_from_declared_idents(
+            &mut child_names,
+            &self.declared_idents[..declared_idents_until],
+        );
 
         let maybe_new_expr = self.maybe_hoist_and_create_proxy(child_names, None, Some(a));
         self.rewrite_expr_to_proxy_expr = maybe_new_expr;

--- a/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::BTreeMap,
     convert::{TryFrom, TryInto},
+    mem::take,
 };
 
 use hex::encode as hex_encode;
@@ -424,8 +425,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
         let is_action_fn = self.get_action_info(f.function.body.as_mut(), true);
 
         let current_declared_idents = self.declared_idents.clone();
-        let current_names = self.names.clone();
-        self.names = vec![];
+        let current_names = take(&mut self.names);
 
         // Visit children
         {

--- a/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -507,8 +507,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
         let is_action_fn = self.get_action_info(f.function.body.as_mut(), true);
 
         let current_declared_idents = self.declared_idents.clone();
-        let current_names = self.names.clone();
-        self.names = vec![];
+        let current_names = take(&mut self.names);
 
         {
             // Visit children


### PR DESCRIPTION
### What?

- remove unnecessary clones

### Why?

### How?


Closes PACK-2847