### PR TITLE
Fix ServerAction rejection reason

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -269,7 +269,7 @@ export function serverActionReducer(
     },
     (e: any) => {
       // When the server action is rejected we don't update the state and instead call the reject handler of the promise.
-      reject(e.reason)
+      reject(e)
 
       return state
     }

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -39,6 +39,23 @@ createNextDescribe(
       await check(() => browser.elementById('count').text(), '3')
     })
 
+    it('should report errors with bad inputs correctly', async () => {
+      const browser = await next.browser('/error-handling', {
+        pushErrorAsConsoleLog: true,
+      })
+
+      await browser.elementByCss('#submit').click()
+
+      const logs = await browser.log()
+      expect(
+        logs.some((log) =>
+          log.message.includes(
+            'Only plain objects, and a few built-ins, can be passed to Server Actions. Classes or null prototypes are not supported.'
+          )
+        )
+      ).toBe(true)
+    })
+
     it('should support headers and cookies', async () => {
       const browser = await next.browser('/header')
 

--- a/test/e2e/app-dir/actions/app/error-handling/actions.js
+++ b/test/e2e/app-dir/actions/app/error-handling/actions.js
@@ -1,0 +1,5 @@
+'use server'
+
+export async function action() {
+  return 'action result'
+}

--- a/test/e2e/app-dir/actions/app/error-handling/page.js
+++ b/test/e2e/app-dir/actions/app/error-handling/page.js
@@ -1,0 +1,25 @@
+'use client'
+
+import { action } from './actions'
+
+export default function Page() {
+  return (
+    <main>
+      <p>
+        This button will call a server action and pass something unserializable
+        like a class instance. We expect this action to error with a reasonable
+        message explaning what happened
+      </p>
+      <button
+        id="submit"
+        onClick={async () => {
+          await action(new Foo())
+        }}
+      >
+        Submit
+      </button>
+    </main>
+  )
+}
+
+class Foo {}


### PR DESCRIPTION
Recently the serverActionReducer was updated to no longer use React's thenable type to carry resolution/rejection information. However the rejection reason was not updated so now when a server action fails we were rejecting with `undefined` rather than the rejected reason. This change updates the reject to use the rejection value.


Closes NEXT-2943