### PR TITLE
Third libraries custom src url gtm

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/12-third-party-libraries.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/12-third-party-libraries.mdx
@@ -181,6 +181,7 @@ docs](https://developers.google.com/tag-platform/tag-manager/datalayer).
 | `dataLayerName` | Optional | Name of the data layer. Defaults to `dataLayer`.                                |
 | `auth`          | Optional | Value of authentication parameter (`gtm_auth`) for environment snippets.        |
 | `preview`       | Optional | Value of preview parameter (`gtm_preview`) for environment snippets.            |
+| `srcUrl`        | Optional | Custom src url for your GTM server.                                             |
 
 ### Google Analytics
 

--- a/packages/third-parties/src/google/gtm.tsx
+++ b/packages/third-parties/src/google/gtm.tsx
@@ -8,7 +8,14 @@ import type { GTMParams } from '../types/google'
 let currDataLayerName: string | undefined = undefined
 
 export function GoogleTagManager(props: GTMParams) {
-  const { gtmId, dataLayerName = 'dataLayer', auth, preview, dataLayer } = props
+  const {
+    gtmId,
+    dataLayerName = 'dataLayer',
+    auth,
+    preview,
+    dataLayer,
+    srcUrl = 'https://www.googletagmanager.com/gtm.js',
+  } = props
 
   if (currDataLayerName === undefined) {
     currDataLayerName = dataLayerName
@@ -47,7 +54,7 @@ export function GoogleTagManager(props: GTMParams) {
       <Script
         id="_next-gtm"
         data-ntpc="GTM"
-        src={`https://www.googletagmanager.com/gtm.js?id=${gtmId}${gtmLayer}${gtmAuth}${gtmPreview}`}
+        src={`${srcUrl}?id=${gtmId}${gtmLayer}${gtmAuth}${gtmPreview}`}
       />
     </>
   )

--- a/packages/third-parties/src/types/google.ts
+++ b/packages/third-parties/src/types/google.ts
@@ -11,6 +11,7 @@ export type GTMParams = {
   dataLayerName?: string
   auth?: string
   preview?: string
+  srcUrl?: string
 }
 
 export type GAParams = {


### PR DESCRIPTION
Added custom src url to GTM in third parties lib

GTM can have custom domain, so we have to be able to set it: https://developers.google.com/tag-platform/tag-manager/server-side/custom-domain?option=same-origin

Its nessesary especially in EU so that you dont send these events directly to third parties, but to your own server first.