### PR TITLE
fix router revalidation behavior for dynamic interception routes

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -133,7 +133,7 @@ export type AppRenderContext = AppRenderBaseContext & {
   isPrefetch: boolean
   requestTimestamp: number
   appUsingSizeAdjustment: boolean
-  providedFlightRouterState?: FlightRouterState
+  flightRouterState?: FlightRouterState
   requestId: string
   defaultRevalidate: Revalidate
   pagePath: string
@@ -158,7 +158,7 @@ function createNotFoundLoaderTree(loaderTree: LoaderTree): LoaderTree {
  * so we need to read it from the router state.
  */
 function findDynamicParamFromRouterState(
-  providedFlightRouterState: FlightRouterState | undefined,
+  flightRouterState: FlightRouterState | undefined,
   segment: string
 ): {
   param: string
@@ -166,11 +166,11 @@ function findDynamicParamFromRouterState(
   treeSegment: Segment
   type: DynamicParamTypesShort
 } | null {
-  if (!providedFlightRouterState) {
+  if (!flightRouterState) {
     return null
   }
 
-  const treeSegment = providedFlightRouterState[0]
+  const treeSegment = flightRouterState[0]
 
   if (canSegmentBeOverridden(segment, treeSegment)) {
     if (!Array.isArray(treeSegment) || Array.isArray(segment)) {
@@ -185,9 +185,7 @@ function findDynamicParamFromRouterState(
     }
   }
 
-  for (const parallelRouterState of Object.values(
-    providedFlightRouterState[1]
-  )) {
+  for (const parallelRouterState of Object.values(flightRouterState[1])) {
     const maybeDynamicParam = findDynamicParamFromRouterState(
       parallelRouterState,
       segment
@@ -207,7 +205,7 @@ export type CreateSegmentPath = (child: FlightSegmentPath) => FlightSegmentPath
  */
 function makeGetDynamicParamFromSegment(
   params: { [key: string]: any },
-  providedFlightRouterState: FlightRouterState | undefined
+  flightRouterState: FlightRouterState | undefined
 ): GetDynamicParamFromSegment {
   return function getDynamicParamFromSegment(
     // [slug] / [[slug]] / [...slug]
@@ -245,7 +243,7 @@ function makeGetDynamicParamFromSegment(
           treeSegment: [key, '', type],
         }
       }
-      return findDynamicParamFromRouterState(providedFlightRouterState, segment)
+      return findDynamicParamFromRouterState(flightRouterState, segment)
     }
 
     const type = getShortDynamicParamType(segmentParam.type)
@@ -285,7 +283,7 @@ async function generateFlight(
     staticGenerationStore: { urlPathname },
     query,
     requestId,
-    providedFlightRouterState,
+    flightRouterState,
   } = ctx
 
   if (!options?.skipFlight) {
@@ -304,7 +302,7 @@ async function generateFlight(
         createSegmentPath: (child) => child,
         loaderTreeToFilter: loaderTree,
         parentParams: {},
-        flightRouterState: providedFlightRouterState,
+        flightRouterState,
         isFirst: true,
         // For flight, render metadata inside leaf page
         rscPayloadHead: (
@@ -787,7 +785,7 @@ async function renderToHTMLOrFlightImpl(
     isPrefetch: isPrefetchRSCRequest,
     requestTimestamp,
     appUsingSizeAdjustment,
-    providedFlightRouterState: shouldProvideFlightRouterState
+    flightRouterState: shouldProvideFlightRouterState
       ? parsedFlightRouterState
       : undefined,
     requestId,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -752,11 +752,9 @@ async function renderToHTMLOrFlightImpl(
       // extract dynamic params.
       isInterceptionRouteAppPath(pagePath))
 
-  let providedFlightRouterState = shouldProvideFlightRouterState
-    ? parseAndValidateFlightRouterState(
-        req.headers[NEXT_ROUTER_STATE_TREE.toLowerCase()]
-      )
-    : undefined
+  const parsedFlightRouterState = parseAndValidateFlightRouterState(
+    req.headers[NEXT_ROUTER_STATE_TREE.toLowerCase()]
+  )
 
   /**
    * The metadata items array created in next-app-loader with all relevant information
@@ -777,7 +775,9 @@ async function renderToHTMLOrFlightImpl(
 
   const getDynamicParamFromSegment = makeGetDynamicParamFromSegment(
     params,
-    providedFlightRouterState
+    // `FlightRouterState` is unconditionally provided here because this method uses it
+    // to extract dynamic params as a fallback if they're not present in the path.
+    parsedFlightRouterState
   )
 
   const ctx: AppRenderContext = {
@@ -787,7 +787,9 @@ async function renderToHTMLOrFlightImpl(
     isPrefetch: isPrefetchRSCRequest,
     requestTimestamp,
     appUsingSizeAdjustment,
-    providedFlightRouterState,
+    providedFlightRouterState: shouldProvideFlightRouterState
+      ? parsedFlightRouterState
+      : undefined,
     requestId,
     defaultRevalidate: false,
     pagePath,

--- a/test/e2e/app-dir/dynamic-interception-route-revalidate/app/[locale]/@modal/(.)photos/[id]/layout.tsx
+++ b/test/e2e/app-dir/dynamic-interception-route-revalidate/app/[locale]/@modal/(.)photos/[id]/layout.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { ReactNode } from 'react'
+
+export default function Layout({ children }: { children: ReactNode }) {
+  const pathname = usePathname()
+  return <>{pathname.endsWith('view') ? children : null}</>
+}

--- a/test/e2e/app-dir/dynamic-interception-route-revalidate/app/[locale]/@modal/(.)photos/[id]/view/page.tsx
+++ b/test/e2e/app-dir/dynamic-interception-route-revalidate/app/[locale]/@modal/(.)photos/[id]/view/page.tsx
@@ -1,0 +1,10 @@
+import Modal from '../../../../modal'
+
+export default function Page({ params }: { params: { id: string } }) {
+  return (
+    <div>
+      <h1 id="intercepted-page">Intercepted Page</h1>
+      <Modal photoId={params.id} />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/dynamic-interception-route-revalidate/app/[locale]/@modal/default.tsx
+++ b/test/e2e/app-dir/dynamic-interception-route-revalidate/app/[locale]/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/dynamic-interception-route-revalidate/app/[locale]/actions.ts
+++ b/test/e2e/app-dir/dynamic-interception-route-revalidate/app/[locale]/actions.ts
@@ -1,0 +1,10 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+
+export async function doAction() {
+  revalidatePath('/en/photos/1/view')
+  // sleep 1s
+  await new Promise((resolve) => setTimeout(resolve, 1000))
+  return Math.random()
+}

--- a/test/e2e/app-dir/dynamic-interception-route-revalidate/app/[locale]/layout.tsx
+++ b/test/e2e/app-dir/dynamic-interception-route-revalidate/app/[locale]/layout.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export default function Root({
+  children,
+  modal,
+}: {
+  children: React.ReactNode
+  modal: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>
+        {children}
+        {modal}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/dynamic-interception-route-revalidate/app/[locale]/modal.tsx
+++ b/test/e2e/app-dir/dynamic-interception-route-revalidate/app/[locale]/modal.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { useState } from 'react'
+import { doAction } from './actions'
+
+export default function Modal({ photoId }: { photoId: string }) {
+  const [loading, setLoading] = useState(false)
+  const [result, setResult] = useState<number>()
+
+  async function handleClick() {
+    setLoading(true)
+    const result = await doAction()
+    setLoading(false)
+    setResult(result)
+  }
+
+  return (
+    <>
+      <h2>Photo Id: {photoId}</h2>
+
+      <button onClick={handleClick}>Revalidate</button>
+      {loading && <div id="loading">Loading...</div>}
+      {result && <div id="result">Result: {result}</div>}
+    </>
+  )
+}

--- a/test/e2e/app-dir/dynamic-interception-route-revalidate/app/[locale]/page.tsx
+++ b/test/e2e/app-dir/dynamic-interception-route-revalidate/app/[locale]/page.tsx
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default async function Home() {
+  return (
+    <div>
+      Root Page <Link href="/en/photos/1/view">To Photo</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/dynamic-interception-route-revalidate/app/[locale]/photos/[id]/view/page.tsx
+++ b/test/e2e/app-dir/dynamic-interception-route-revalidate/app/[locale]/photos/[id]/view/page.tsx
@@ -1,0 +1,16 @@
+import Modal from '../../../modal'
+
+export default function PhotoPage({
+  params: { id },
+}: {
+  params: { id: string }
+}) {
+  return (
+    <div className="container mx-auto my-10">
+      <div className="w-1/2 mx-auto border border-gray-700">
+        <h1 id="full-page">Full Page</h1>
+        <Modal photoId={id} />
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/dynamic-interception-route-revalidate/dynamic-interception-route-revalidate.test.ts
+++ b/test/e2e/app-dir/dynamic-interception-route-revalidate/dynamic-interception-route-revalidate.test.ts
@@ -1,0 +1,45 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('dynamic-interception-route-revalidate', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should refresh the dynamic intercepted route when the interception route is revalidated', async () => {
+    const browser = await next.browser('/en')
+
+    // trigger the interception
+    await browser.elementByCss("[href='/en/photos/1/view']").click()
+
+    // verify we're on the intercepted page
+    await browser.waitForElementByCss('#intercepted-page')
+
+    expect(await browser.elementByCss('h2').text()).toBe('Photo Id: 1')
+
+    // trigger the revalidate
+    await browser.elementByCss('button').click()
+
+    // make sure the loading state fired
+    await browser.waitForElementByCss('#loading')
+
+    // verify that we get a result from the server action
+    await retry(async () => {
+      const result = await browser.elementByCss('#result').text()
+      expect(result).toMatch(/^Result: 0(\.\d+)?$/)
+    })
+
+    // make sure we're still on the intercepted page
+    expect(await browser.hasElementByCssSelector('#intercepted-page')).toBe(
+      true
+    )
+
+    // refresh the page to get the full (non-intercepted) page
+    await browser.refresh()
+
+    expect(await browser.hasElementByCssSelector('#intercepted-page')).toBe(
+      false
+    )
+    expect(await browser.hasElementByCssSelector('#full-page')).toBe(true)
+  })
+})

--- a/test/e2e/app-dir/dynamic-interception-route-revalidate/next.config.js
+++ b/test/e2e/app-dir/dynamic-interception-route-revalidate/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -1382,6 +1382,15 @@
       "flakey": [],
       "runtimeError": false
     },
+    "test/e2e/app-dir/dynamic-interception-route-revalidate/dynamic-interception-route-revalidate.test.ts": {
+      "passed": [],
+      "failed": [
+        "dynamic-interception-route-revalidate should refresh the dynamic intercepted route when the interception route is revalidated"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
     "test/e2e/app-dir/dynamic-requests/dynamic-requests.test.ts": {
       "passed": [
         "dynamic-requests should not error for dynamic requests in pages",


### PR DESCRIPTION
### What
When calling `revalidatePath` or `revalidateTag` in a server action for an intercepted route with dynamic segments, the page would do a full browser refresh.

### Why
When constructing rewrites for interception routes, the route params leading up to the interception route are "voided" with a `__NEXT_EMPTY_PARAM__` demarcation. When it comes time to look up the values for these dynamic segments, since the params aren't going to be part of the URL, they get matched via `FlightRouterState` ([ref](https://github.com/vercel/next.js/blob/d67d658ce7396c4b6be1b724be5f45763d5a1803/packages/next/src/server/app-render/app-render.tsx#L153-L201)). 

The `shouldProvideFlightRouterState` variable only passes it through for RSC requests; however, since the server action will perform the action & return the flight data in a single pass, that means the updated tree from the server action isn't going to receive the `FlightRouterState` when constructing the new tree. This means the old tree will have a `["locale", "en", "d"]` segment, and the new tree from the server action will have `"[locale]"`. When the router detects this kind of segment mismatch, it assumes the user navigated to a new root layout, and triggers an MPA navigation. 

### How
This unconditionally provides the `FlightRouterState` to `makeGetDynamicParamFromSegment` so that it can properly extract dynamic params for interception routes. We currently enforce interception routes to be dynamic due to this `FlightRouterState` dependency.

Fixes #59796
Closes NEXT-2079
