### PR TITLE
add tracing to server actions transform

### DIFF
--- a/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -34,6 +34,7 @@ pub struct Config {
 // Using BTreeMap to ensure the order of the actions is deterministic.
 pub type ActionsMap = BTreeMap<String, String>;
 
+#[tracing::instrument(level = tracing::Level::TRACE, skip_all)]
 pub fn server_actions<C: Comments>(
     file_name: &FileName,
     config: Config,


### PR DESCRIPTION
### What?

The transform seem to be quite inefficient regarding memory usage. Just leaving a trace here to allow inspecting performance and memory of it separately from the normal `parse` function.


Closes PACK-2855