### PR TITLE
fix double redirect when using a loading boundary

### DIFF
--- a/packages/next/src/client/components/router-reducer/is-navigating-to-new-root-layout.test.ts
+++ b/packages/next/src/client/components/router-reducer/is-navigating-to-new-root-layout.test.ts
@@ -1,7 +1,7 @@
 import type { FlightRouterState } from '../../../server/app-render/types'
 import { isNavigatingToNewRootLayout } from './is-navigating-to-new-root-layout'
 
-describe('shouldHardNavigate', () => {
+describe('isNavigatingToNewRootLayout', () => {
   it('should return false if there is no new root layout', () => {
     const getInitialRouterStateTree = (): FlightRouterState => [
       '',

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -150,6 +150,12 @@ function navigateReducer_noPPR(
         return handleExternalUrl(state, mutable, flightData, pendingPush)
       }
 
+      // Handles case where `<meta http-equiv="refresh">` tag is present,
+      // which will trigger an MPA navigation.
+      if (document.getElementById('__next-page-redirect')) {
+        return handleExternalUrl(state, mutable, href, pendingPush)
+      }
+
       let currentTree = state.tree
       const currentCache = state.cache
       let scrollableSegments: FlightSegmentPath[] = []
@@ -316,6 +322,12 @@ function navigateReducer_PPR(
       // Handle case when navigating to page in `pages` from `app`
       if (typeof flightData === 'string') {
         return handleExternalUrl(state, mutable, flightData, pendingPush)
+      }
+
+      // Handles case where `<meta http-equiv="refresh">` tag is present,
+      // which will trigger an MPA navigation.
+      if (document.getElementById('__next-page-redirect')) {
+        return handleExternalUrl(state, mutable, href, pendingPush)
       }
 
       let currentTree = state.tree

--- a/packages/next/src/server/app-render/make-get-server-inserted-html.tsx
+++ b/packages/next/src/server/app-render/make-get-server-inserted-html.tsx
@@ -50,6 +50,7 @@ export function makeGetServerInsertedHTML({
         if (redirectUrl) {
           errorMetaTags.push(
             <meta
+              id="__next-page-redirect"
               httpEquiv="refresh"
               content={`${isPermanent ? 0 : 1};url=${redirectUrl}`}
               key={error.digest}

--- a/test/e2e/app-dir/navigation/app/redirect/redirect-with-loading/loading.tsx
+++ b/test/e2e/app-dir/navigation/app/redirect/redirect-with-loading/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div id="loading">Loading...</div>
+}

--- a/test/e2e/app-dir/navigation/app/redirect/redirect-with-loading/page.tsx
+++ b/test/e2e/app-dir/navigation/app/redirect/redirect-with-loading/page.tsx
@@ -1,0 +1,8 @@
+import { redirect } from 'next/navigation'
+
+export default async function Page() {
+  // fake delay 1s to trigger loading state
+  await new Promise((res) => setTimeout(res, 1000))
+
+  redirect('/redirect/result')
+}

--- a/test/e2e/app-dir/navigation/app/redirect/result/page.js
+++ b/test/e2e/app-dir/navigation/app/redirect/result/page.js
@@ -1,3 +1,8 @@
 export default function Page() {
-  return <h1 id="result-page">Result Page</h1>
+  return (
+    <div>
+      <h1 id="result-page">Result Page</h1>
+      <div id="timestamp">{Date.now()}</div>
+    </div>
+  )
 }


### PR DESCRIPTION
### What & Why
When an RSC triggers `navigate` after the shell has already been sent to the client, a meta tag is inserted to signal to the browser it needs to perform an MPA navigation. This is primarily used for bot user agents, since we wouldn't have been able to provide a proper redirect status code (since it occurred after the initial response was sent).

However, the router would trigger a SPA navigation, while the `<meta>` tag lagged to perform an MPA navigation, resulting in 2 navigations to the same URL.

### How
When the client side code attempts to handle the redirect, we treat it like an MPA navigation. This will suspend in render and trigger a `location.push`/`location.replace` to the targeted URL. As a result, only one of these navigation events will win.

Fixes #59800
Fixes #62463
FIxes #57257

Closes NEXT-2952
Closes NEXT-2719
