### PR TITLE
Turbopack: Fail when `next/font` is used in `_document`

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_font/google/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_font/google/mod.rs
@@ -45,7 +45,8 @@ use self::{
 use super::{
     font_fallback::FontFallback,
     util::{
-        get_request_hash, get_request_id, get_scoped_font_family, FontCssProperties, FontFamilyType,
+        can_use_next_font, get_request_hash, get_request_id, get_scoped_font_family,
+        FontCssProperties, FontFamilyType,
     },
 };
 use crate::{
@@ -163,7 +164,12 @@ impl ImportMappingReplacement for NextFontGoogleReplacer {
             return Ok(ImportMapResult::NoEntry.into());
         };
 
-        Ok(self.import_map_result(query.await?.to_string()))
+        let this = &*self.await?;
+        if can_use_next_font(this.project_path, *query).await? {
+            Ok(self.import_map_result(query.await?.to_string()))
+        } else {
+            Ok(ImportMapResult::NoEntry.into())
+        }
     }
 }
 

--- a/packages/next-swc/crates/next-core/src/next_font/local/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_font/local/mod.rs
@@ -24,7 +24,10 @@ use self::{
     stylesheet::build_stylesheet,
     util::build_font_family_string,
 };
-use super::{font_fallback::FontFallbacks, util::FontCssProperties};
+use super::{
+    font_fallback::FontFallbacks,
+    util::{can_use_next_font, FontCssProperties},
+};
 use crate::{
     next_app::metadata::split_extension,
     next_font::{
@@ -134,7 +137,12 @@ impl ImportMappingReplacement for NextFontLocalReplacer {
             return Ok(ImportMapResult::NoEntry.into());
         };
 
-        Ok(self.import_map_result(context, query_vc.await?.to_string()))
+        let this = &*self.await?;
+        if can_use_next_font(this.project_path, *query_vc).await? {
+            Ok(self.import_map_result(context, query_vc.await?.to_string()))
+        } else {
+            Ok(ImportMapResult::NoEntry.into())
+        }
     }
 }
 

--- a/test/development/next-font/font-loader-in-document-error.test.ts
+++ b/test/development/next-font/font-loader-in-document-error.test.ts
@@ -19,10 +19,19 @@ describe('font-loader-in-document-error', () => {
   test('next/font inside _document', async () => {
     const browser = await webdriver(next.url, '/')
     expect(await hasRedbox(browser)).toBeTrue()
-    expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
-      "pages/_document.js
-      \`next/font\` error:
-      Cannot be used within pages/_document.js."
-    `)
+    if (process.env.TURBOPACK) {
+      // TODO: Turbopack doesn't include pages/
+      expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
+        "./_document.js
+        next/font: error:
+        Cannot be used within _document.js"
+      `)
+    } else {
+      expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
+              "pages/_document.js
+              \`next/font\` error:
+              Cannot be used within pages/_document.js."
+          `)
+    }
   })
 })


### PR DESCRIPTION
Test Plan: https://github.com/vercel/next.js/blob/d01a6219610ec90f632c67b53670377870a6e3f5/test/development/next-font/font-loader-in-document-error.test.ts#L19


Closes PACK-2858