### PR TITLE
Turbopack: refactor GlobalCssAsset to fix dynamic import of css

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "serde",
  "smallvec",
@@ -3219,7 +3219,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "serde",
@@ -7162,7 +7162,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7194,7 +7194,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7206,7 +7206,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7221,7 +7221,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7235,7 +7235,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7252,7 +7252,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7284,7 +7284,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "base16",
  "hex",
@@ -7296,7 +7296,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -7310,7 +7310,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7320,7 +7320,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "mimalloc",
 ]
@@ -7328,7 +7328,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7353,7 +7353,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7386,7 +7386,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7426,7 +7426,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7452,7 +7452,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "clap",
@@ -7471,7 +7471,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7502,7 +7502,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7530,7 +7530,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7567,7 +7567,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7605,7 +7605,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "serde",
  "serde_json",
@@ -7616,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7641,7 +7641,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7658,7 +7658,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7674,7 +7674,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7694,7 +7694,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "serde",
@@ -7709,7 +7709,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7724,7 +7724,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7762,7 +7762,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7786,7 +7786,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7808,7 +7808,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "serde",
@@ -7824,7 +7824,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7835,7 +7835,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -7851,7 +7851,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240404.2#583bb0934a2521b7549380f9c49b34565804b5b1"
+source = "git+https://github.com/vercel/turbo.git?branch=sokra/refactor-global-css#7c5e90077757769e72a9fbdf2691d56f21738527"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.90.24", features = [
 testing = { version = "0.35.21" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240404.2" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "sokra/refactor-global-css" } # last tag: "turbopack-240404.2"
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240404.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "sokra/refactor-global-css" } # last tag: "turbopack-240404.2"
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240404.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "sokra/refactor-global-css" } # last tag: "turbopack-240404.2"
 
 # General Deps
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -196,7 +196,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.4",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240329.2",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?7c5e90077757769e72a9fbdf2691d56f21738527",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1068,8 +1068,8 @@ importers:
         specifier: 0.26.4
         version: 0.26.4
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240329.2
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240329.2'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?7c5e90077757769e72a9fbdf2691d56f21738527
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?7c5e90077757769e72a9fbdf2691d56f21738527'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -25483,8 +25483,8 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240329.2':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240329.2}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?7c5e90077757769e72a9fbdf2691d56f21738527':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?7c5e90077757769e72a9fbdf2691d56f21738527}
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
### What?

testing for https://github.com/vercel/turbo/pull/7858

### Why?

### How?



Closes PACK-2865