### PR TITLE
skip HEAD request in server action redirect

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -209,8 +209,8 @@ async function createRedirectRenderResult(
     // }
 
     try {
-      const headResponse = await fetch(fetchUrl, {
-        method: 'HEAD',
+      const response = await fetch(fetchUrl, {
+        method: 'GET',
         headers: forwardedHeaders,
         next: {
           // @ts-ignore
@@ -218,26 +218,19 @@ async function createRedirectRenderResult(
         },
       })
 
-      if (
-        headResponse.headers.get('content-type') === RSC_CONTENT_TYPE_HEADER
-      ) {
-        const response = await fetch(fetchUrl, {
-          method: 'GET',
-          headers: forwardedHeaders,
-          next: {
-            // @ts-ignore
-            internal: 1,
-          },
-        })
-        // copy the headers from the redirect response to the response we're sending
-        for (const [key, value] of response.headers) {
-          if (!actionsForbiddenHeaders.includes(key)) {
-            res.setHeader(key, value)
-          }
-        }
-
-        return new FlightRenderResult(response.body!)
+      if (response.headers.get('content-type') !== RSC_CONTENT_TYPE_HEADER) {
+        throw new Error(
+          'Redirected to a page that provided an invalid RSC response. This can happen when navigating to a route handled by the Pages Router. Falling back to a full page navigation.'
+        )
       }
+      // copy the headers from the redirect response to the response we're sending
+      for (const [key, value] of response.headers) {
+        if (!actionsForbiddenHeaders.includes(key)) {
+          res.setHeader(key, value)
+        }
+      }
+
+      return new FlightRenderResult(response.body!)
     } catch (err) {
       // we couldn't stream the redirect response, so we'll just do a normal redirect
       console.error(`failed to get redirect response`, err)

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -227,6 +227,9 @@ async function createRedirectRenderResult(
         }
 
         return new FlightRenderResult(response.body!)
+      } else {
+        // Since we aren't consuming the response body, we cancel it to avoid memory leaks
+        response.body?.cancel()
       }
     } catch (err) {
       // we couldn't stream the redirect response, so we'll just do a normal redirect

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -218,19 +218,16 @@ async function createRedirectRenderResult(
         },
       })
 
-      if (response.headers.get('content-type') !== RSC_CONTENT_TYPE_HEADER) {
-        throw new Error(
-          'Redirected to a page that provided an invalid RSC response. This can happen when navigating to a route handled by the Pages Router. Falling back to a full page navigation.'
-        )
-      }
-      // copy the headers from the redirect response to the response we're sending
-      for (const [key, value] of response.headers) {
-        if (!actionsForbiddenHeaders.includes(key)) {
-          res.setHeader(key, value)
+      if (response.headers.get('content-type') === RSC_CONTENT_TYPE_HEADER) {
+        // copy the headers from the redirect response to the response we're sending
+        for (const [key, value] of response.headers) {
+          if (!actionsForbiddenHeaders.includes(key)) {
+            res.setHeader(key, value)
+          }
         }
-      }
 
-      return new FlightRenderResult(response.body!)
+        return new FlightRenderResult(response.body!)
+      }
     } catch (err) {
       // we couldn't stream the redirect response, so we'll just do a normal redirect
       console.error(`failed to get redirect response`, err)

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -774,9 +774,6 @@ createNextDescribe(
         await retry(async () => {
           expect(await browser.url()).toBe(`${next.url}/pages-dir`)
           expect(mpaTriggered).toBe(true)
-          expect(next.cliOutput).toContain(
-            'Redirected to a page that provided an invalid RSC response'
-          )
         })
 
         expect(await browser.elementByCss('body').text()).toContain(

--- a/test/e2e/app-dir/actions/app/client/page.js
+++ b/test/e2e/app-dir/actions/app/client/page.js
@@ -86,6 +86,14 @@ export default function Counter() {
           redirect internal with domain
         </button>
       </form>
+      <form>
+        <button
+          id="redirect-pages"
+          formAction={() => redirectAction('/pages-dir')}
+        >
+          redirect to a pages route
+        </button>
+      </form>
       <form action={getHeaders}>
         <button type="submit" id="get-header">
           submit

--- a/test/e2e/app-dir/actions/pages/pages-dir.tsx
+++ b/test/e2e/app-dir/actions/pages/pages-dir.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Hello from a pages route</div>
+}


### PR DESCRIPTION
When a server action performs a redirect, we currently initiate a `HEAD` request to the targeted URL to verify if it has a proper RSC response. If it does, it then invokes a GET and streams the response. This leads to an extra request to the server which can be costly and poor for performance. If the `GET` returns an invalid RSC response, we'll discard the response. The client router will also see the invalid response which will signal that it needs to perform an MPA navigation to the targeted URL. 

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2956