### PR TITLE
Ensure Webpack config shows a warning when using Turbopack

### DIFF
--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -93,8 +93,8 @@ export async function validateTurboNextConfig({
   let babelrc = await getBabelConfigFile(dir)
   if (babelrc) babelrc = path.basename(babelrc)
 
-  let hasWebpack = false
-  let hasTurbo = !!process.env.TURBOPACK
+  let hasWebpackConfig = false
+  let hasTurboConfig = false
 
   let unsupportedConfig: string[] = []
   let rawNextConfig: NextConfig = {}
@@ -154,10 +154,10 @@ export async function validateTurboNextConfig({
 
     for (const key of customKeys) {
       if (key.startsWith('webpack')) {
-        hasWebpack = true
+        hasWebpackConfig = true
       }
       if (key.startsWith('experimental.turbo')) {
-        hasTurbo = true
+        hasTurboConfig = true
       }
 
       let isUnsupported =
@@ -187,12 +187,12 @@ export async function validateTurboNextConfig({
     'https://nextjs.link/with-turbopack'
   )}\n`
 
-  if (hasWebpack && !hasTurbo) {
+  if (hasWebpackConfig && !hasTurboConfig) {
     Log.warn(
       `Webpack is configured while Turbopack is not, which may cause problems.`
     )
     Log.warn(
-      `See instructions if you need to configure Turbopack:\n  https://turbo.build/pack/docs/features/customizing-turbopack\n`
+      `See instructions if you need to configure Turbopack:\n  https://nextjs.org/docs/app/api-reference/next-config-js/turbo\n`
     )
   }
 


### PR DESCRIPTION
## What?

There was a logic error causing the warning to never show, the default should be `false` and turned to `true` when `experimental.turbo` is found.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-2957