### PR TITLE
style(dev-overlay): refine the error message header styling

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/components/hot-linked-text/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/components/hot-linked-text/index.tsx
@@ -10,15 +10,19 @@ const splitRegexp = new RegExp(`(${MAGIC_IDENTIFIER_REGEX.source}|\\s+)`)
 
 export const HotlinkedText: React.FC<{
   text: string
+  matcher?: (text: string) => boolean
 }> = function HotlinkedText(props) {
-  const { text } = props
+  const { text, matcher } = props
 
   const wordsAndWhitespaces = text.split(splitRegexp)
 
   return (
     <>
       {wordsAndWhitespaces.map((word, index) => {
-        if (linkRegex.test(word)) {
+        if (
+          linkRegex.test(word) &&
+          (typeof matcher === 'function' ? matcher(word) : true)
+        ) {
           const link = linkRegex.exec(word)!
           return (
             <React.Fragment key={`link-${index}`}>

--- a/packages/next/src/client/components/react-dev-overlay/internal/components/hot-linked-text/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/components/hot-linked-text/index.tsx
@@ -19,14 +19,16 @@ export const HotlinkedText: React.FC<{
   return (
     <>
       {wordsAndWhitespaces.map((word, index) => {
-        if (
-          linkRegex.test(word) &&
-          (typeof matcher === 'function' ? matcher(word) : true)
-        ) {
+        if (linkRegex.test(word)) {
           const link = linkRegex.exec(word)!
+          const href = link[0]
+          // If link matcher is present but the link doesn't match, don't turn it into a link
+          if (typeof matcher === 'function' && !matcher(href)) {
+            return word
+          }
           return (
             <React.Fragment key={`link-${index}`}>
-              <a href={link[0]} target="_blank" rel="noreferrer noopener">
+              <a href={href} target="_blank" rel="noreferrer noopener">
                 {word}
               </a>
             </React.Fragment>

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/BuildError.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/BuildError.tsx
@@ -64,8 +64,6 @@ export const styles = css`
   .nextjs-container-errors-header p {
     font-size: var(--size-font-small);
     line-height: var(--size-font-big);
-    margin: 0;
-    margin-top: var(--size-gap);
     white-space: pre-wrap;
   }
   .nextjs-container-errors-body footer {

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/BuildError.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/BuildError.tsx
@@ -27,11 +27,17 @@ export const BuildError: React.FC<BuildErrorProps> = function BuildError({
         onClose={noop}
       >
         <DialogContent>
-          <DialogHeader className="nextjs-container-build-error-header">
-            <h4 id="nextjs__container_build_error_label">Failed to compile</h4>
+          <DialogHeader className="nextjs-container-errors-header">
+            <h1 id="nextjs__container_errors_label">{'Build Error'}</h1>
+            <p
+              id="nextjs__container_errors_desc"
+              className="nextjs__container_errors_desc"
+            >
+              Failed to compile
+            </p>
             {versionInfo ? <VersionStalenessInfo {...versionInfo} /> : null}
           </DialogHeader>
-          <DialogBody className="nextjs-container-build-error-body">
+          <DialogBody className="nextjs-container-errors-body">
             <Terminal content={message} />
             <footer>
               <p id="nextjs__container_build_error_desc">
@@ -49,24 +55,27 @@ export const BuildError: React.FC<BuildErrorProps> = function BuildError({
 }
 
 export const styles = css`
-  .nextjs-container-build-error-header {
-    display: flex;
-    align-items: center;
+  .nextjs-container-errors-header > h1 {
+    font-size: var(--size-font-big);
+    line-height: var(--size-font-bigger);
+    font-weight: bold;
+    margin: var(--size-gap-double) 0;
   }
-  .nextjs-container-build-error-header > h4 {
-    line-height: 1.5;
+  .nextjs-container-errors-header p {
+    font-size: var(--size-font-small);
+    line-height: var(--size-font-big);
     margin: 0;
-    padding: 0;
+    margin-top: var(--size-gap);
+    white-space: pre-wrap;
   }
-
-  .nextjs-container-build-error-body footer {
+  .nextjs-container-errors-body footer {
     margin-top: var(--size-gap);
   }
-  .nextjs-container-build-error-body footer p {
+  .nextjs-container-errors-body footer p {
     margin: 0;
   }
 
-  .nextjs-container-build-error-body small {
+  .nextjs-container-errors-body small {
     color: var(--color-font);
   }
 `

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/BuildError.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/BuildError.tsx
@@ -22,8 +22,8 @@ export const BuildError: React.FC<BuildErrorProps> = function BuildError({
     <Overlay fixed>
       <Dialog
         type="error"
-        aria-labelledby="nextjs__container_build_error_label"
-        aria-describedby="nextjs__container_build_error_desc"
+        aria-labelledby="nextjs__container_error_label"
+        aria-describedby="nextjs__container_error_desc"
         onClose={noop}
       >
         <DialogContent>

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
@@ -317,7 +317,8 @@ export const styles = css`
     font-size: var(--size-font-big);
     line-height: var(--size-font-bigger);
     font-weight: bold;
-    margin: var(--size-gap-double) 0;
+    margin: calc(var(--size-gap-double) * 1.5) 0;
+    color: var(--color-title-h1);
   }
   .nextjs-container-errors-header small {
     font-size: var(--size-font-small);
@@ -330,8 +331,6 @@ export const styles = css`
   .nextjs-container-errors-header p {
     font-size: var(--size-font-small);
     line-height: var(--size-font-big);
-    margin: 0;
-    margin-top: var(--size-gap);
     white-space: pre-wrap;
   }
   .nextjs__container_errors_desc {
@@ -346,8 +345,7 @@ export const styles = css`
   p.nextjs__container_errors__notes {
     margin: var(--size-gap-double) auto;
     color: var(--color-stack-headline);
-    font-family: var(--font-stack-sans);
-    font-weight: bold;
+    font-weight: 600;
     font-size: 15px;
   }
   .nextjs-container-errors-header > div > small {
@@ -362,6 +360,7 @@ export const styles = css`
     margin-top: calc(var(--size-gap-double) + var(--size-gap));
   }
   .nextjs-container-errors-body > h2 {
+    color: var(--color-title-color);
     margin-bottom: var(--size-gap);
     font-size: var(--size-font-big);
   }

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
@@ -320,10 +320,10 @@ export const styles = css`
     margin-left: var(--size-gap-double);
   }
   .nextjs-container-errors-header small > span {
-    font-family: var(--font-stack-sans);
+    font-family: var(--font-stack-monospace);
   }
   .nextjs-container-errors-header p {
-    font-family: var(--font-stack-sans);
+    font-family: var(--font-stack-monospace);
     font-size: var(--size-font-small);
     line-height: var(--size-font-big);
     margin: 0;
@@ -334,19 +334,20 @@ export const styles = css`
     padding-left: var(--size-gap);
     border-left: 4px solid var(--color-accents-1);
     margin-top: var(--size-gap);
-    font-weight: 500;
+    font-weight: bold;
     color: var(--color-stack-subline);
   }
   .nextjs__container_errors__extra {
     margin: var(--size-gap-half) 0;
     color: var(--color-stack-headline);
-    font-weight: 500;
+    font-weight: bold;
   }
   .nextjs-container-errors-header > div > small {
     margin: 0;
     margin-top: var(--size-gap-half);
   }
   .nextjs-container-errors-header > p > a {
+    color: inherit;
     font-weight: bold;
   }
   .nextjs-container-errors-body > h2:not(:first-child) {

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
@@ -344,7 +344,7 @@ export const styles = css`
   }
   p.nextjs__container_errors__notes {
     margin: var(--size-gap-double) auto;
-    color: var(--color-stack-headline);
+    color: var(--color-stack-notes);
     font-weight: 600;
     font-size: 15px;
   }

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
@@ -44,6 +44,10 @@ type ReadyErrorEvent = ReadyRuntimeError
 
 type DisplayState = 'minimized' | 'fullscreen' | 'hidden'
 
+function isNextjsLink(text: string): boolean {
+  return text.startsWith('https://nextjs.org')
+}
+
 function getErrorSignature(ev: SupportedErrorEvent): string {
   const { event } = ev
   switch (event.type) {
@@ -268,19 +272,20 @@ export function Errors({
               id="nextjs__container_errors_desc"
               className="nextjs__container_errors_desc"
             >
-              {error.name}: <HotlinkedText text={error.message} />
+              {error.name}:{' '}
+              <HotlinkedText text={error.message} matcher={isNextjsLink} />
             </p>
             {hydrationWarning && (
               <>
                 <p
-                  id="nextjs__container_errors__extra"
-                  className="nextjs__container_errors__extra"
+                  id="nextjs__container_errors__notes"
+                  className="nextjs__container_errors__notes"
                 >
                   {hydrationWarning}
                 </p>
                 {activeError.componentStackFrames?.length ? (
                   <PseudoHtmlDiff
-                    className="nextjs__container_errors__extra_code"
+                    className="nextjs__container_errors__component-stack"
                     hydrationMismatchType={hydrationErrorType}
                     componentStackFrames={activeError.componentStackFrames}
                     firstContent={serverContent}
@@ -323,7 +328,6 @@ export const styles = css`
     font-family: var(--font-stack-monospace);
   }
   .nextjs-container-errors-header p {
-    font-family: var(--font-stack-monospace);
     font-size: var(--size-font-small);
     line-height: var(--size-font-big);
     margin: 0;
@@ -331,16 +335,20 @@ export const styles = css`
     white-space: pre-wrap;
   }
   .nextjs__container_errors_desc {
-    padding-left: var(--size-gap);
-    border-left: 4px solid var(--color-accents-1);
+    font-family: var(--font-stack-monospace);
+    padding: var(--size-gap) var(--size-gap-double);
+    border-left: 2px solid var(--color-text-color-red-1);
     margin-top: var(--size-gap);
     font-weight: bold;
-    color: var(--color-stack-subline);
+    color: var(--color-text-color-red-1);
+    background-color: var(--color-text-background-red-1);
   }
-  .nextjs__container_errors__extra {
-    margin: var(--size-gap-half) 0;
+  p.nextjs__container_errors__notes {
+    margin: var(--size-gap-double) auto;
     color: var(--color-stack-headline);
+    font-family: var(--font-stack-sans);
     font-weight: bold;
+    font-size: 15px;
   }
   .nextjs-container-errors-header > div > small {
     margin: 0;
@@ -357,8 +365,7 @@ export const styles = css`
     margin-bottom: var(--size-gap);
     font-size: var(--size-font-big);
   }
-  .nextjs__container_errors__extra_code {
-    margin-top: var(--size-gap);
+  .nextjs__container_errors__component-stack {
     padding: 12px 32px;
     color: var(--color-ansi-fg);
     background: var(--color-ansi-bg);

--- a/packages/next/src/client/components/react-dev-overlay/internal/styles/Base.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/styles/Base.tsx
@@ -21,6 +21,7 @@ export function Base() {
           --color-font: #757575;
           --color-backdrop: rgba(17, 17, 17, 0.2);
 
+          --color-title-color: #1f1f1f;
           --color-stack-h6: #222;
           --color-stack-headline: #666;
           --color-stack-subline: #999;
@@ -64,6 +65,7 @@ export function Base() {
             --color-font: white;
             --color-backdrop: rgb(44, 44, 46);
 
+            --color-title-color: #fafafa;
             --color-stack-h6: rgb(200, 200, 204);
             --color-stack-headline: rgb(99, 99, 102);
             --color-stack-subline: rgb(121, 121, 121);

--- a/packages/next/src/client/components/react-dev-overlay/internal/styles/Base.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/styles/Base.tsx
@@ -29,9 +29,12 @@ export function Base() {
           --color-accents-2: #222222;
           --color-accents-3: #404040;
 
+          --color-text-color-red-1: #ff5555;
+          --color-text-background-red-1: #fff7f7;
+
           --font-stack-monospace: 'SFMono-Regular', Consolas, 'Liberation Mono',
             Menlo, Courier, monospace;
-          --font-stack-sans: -apple-system, BlinkMacSystemFont, sans-serif;
+          --font-stack-sans: -apple-system, 'Source Sans Pro', sans-serif;
 
           --color-ansi-selection: rgba(95, 126, 151, 0.48);
           --color-ansi-bg: #111111;

--- a/packages/next/src/client/components/react-dev-overlay/internal/styles/Base.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/styles/Base.tsx
@@ -25,6 +25,7 @@ export function Base() {
           --color-stack-h6: #222;
           --color-stack-headline: #666;
           --color-stack-subline: #999;
+          --color-stack-notes: #777;
 
           --color-accents-1: #808080;
           --color-accents-2: #222222;
@@ -68,6 +69,7 @@ export function Base() {
             --color-title-color: #fafafa;
             --color-stack-h6: rgb(200, 200, 204);
             --color-stack-headline: rgb(99, 99, 102);
+            --color-stack-notes: #a9a9a9;
             --color-stack-subline: rgb(121, 121, 121);
 
             --color-accents-3: rgb(118, 118, 118);

--- a/packages/next/src/client/components/react-dev-overlay/internal/styles/Base.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/styles/Base.tsx
@@ -30,7 +30,7 @@ export function Base() {
           --color-accents-3: #404040;
 
           --color-text-color-red-1: #ff5555;
-          --color-text-background-red-1: #fff7f7;
+          --color-text-background-red-1: #fff9f9;
 
           --font-stack-monospace: 'SFMono-Regular', Consolas, 'Liberation Mono',
             Menlo, Courier, monospace;
@@ -69,6 +69,8 @@ export function Base() {
             --color-stack-subline: rgb(121, 121, 121);
 
             --color-accents-3: rgb(118, 118, 118);
+
+            --color-text-background-red-1: #2a1e1e;
           }
         }
 

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -390,7 +390,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
 
         export default function Index() {
           const boom = useCallback(() => {
-            throw new Error('end http://nextjs.org')
+            throw new Error('end https://nextjs.org')
           }, [])
           return (
             <main>

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -435,7 +435,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
 
         export default function Index() {
           const boom = useCallback(() => {
-            throw new Error('http://nextjs.org start')
+            throw new Error('https://nextjs.org start')
           }, [])
           return (
             <main>
@@ -480,7 +480,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
 
         export default function Index() {
           const boom = useCallback(() => {
-            throw new Error('middle http://nextjs.org end')
+            throw new Error('middle https://nextjs.org end')
           }, [])
           return (
             <main>
@@ -525,7 +525,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
 
         export default function Index() {
           const boom = useCallback(() => {
-            throw new Error('multiple http://nextjs.org links http://example.com')
+            throw new Error('multiple https://nextjs.org links http://example.com')
           }, [])
           return (
             <main>
@@ -541,8 +541,9 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
 
     const header4 = await session.getRedboxDescription()
     expect(header4).toMatchInlineSnapshot(
-      `"Error: multiple http://nextjs.org links http://example.com"`
+      `"Error: multiple https://nextjs.org links http://example.com"`
     )
+    // Do not highlight example.com but do highlight nextjs.org
     expect(
       await session.evaluate(
         () =>
@@ -551,7 +552,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
             .shadowRoot.querySelectorAll('#nextjs__container_errors_desc a')
             .length
       )
-    ).toBe(2)
+    ).toBe(1)
     expect(
       await session.evaluate(
         () =>

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -576,7 +576,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
               ) as any
           ).href
       )
-    ).toMatchSnapshot()
+    ).toBe(null)
 
     await cleanup()
   })

--- a/test/development/acceptance-app/__snapshots__/ReactRefreshLogBox.test.ts.snap
+++ b/test/development/acceptance-app/__snapshots__/ReactRefreshLogBox.test.ts.snap
@@ -74,8 +74,6 @@ exports[`ReactRefreshLogBox app default logbox: anchors links in error messages 
 
 exports[`ReactRefreshLogBox app default logbox: anchors links in error messages 8`] = `"https://nextjs.org/"`;
 
-exports[`ReactRefreshLogBox app default logbox: anchors links in error messages 9`] = `"http://example.com/"`;
-
 exports[`ReactRefreshLogBox app default module init error not shown 1`] = `
 "index.js (3:7) @ eval
 
@@ -167,8 +165,6 @@ exports[`ReactRefreshLogBox app turbo logbox: anchors links in error messages 5`
 exports[`ReactRefreshLogBox app turbo logbox: anchors links in error messages 6`] = `"https://nextjs.org/"`;
 
 exports[`ReactRefreshLogBox app turbo logbox: anchors links in error messages 8`] = `"https://nextjs.org/"`;
-
-exports[`ReactRefreshLogBox app turbo logbox: anchors links in error messages 9`] = `"http://example.com/"`;
 
 exports[`ReactRefreshLogBox app turbo module init error not shown 1`] = `
 "index.js (3:7) @ <unknown>

--- a/test/development/acceptance-app/__snapshots__/ReactRefreshLogBox.test.ts.snap
+++ b/test/development/acceptance-app/__snapshots__/ReactRefreshLogBox.test.ts.snap
@@ -60,19 +60,19 @@ Syntax error: Selector "button" is not pure (pure selectors must contain at leas
     | ^"
 `;
 
-exports[`ReactRefreshLogBox app default logbox: anchors links in error messages 1`] = `"Error: end http://nextjs.org"`;
+exports[`ReactRefreshLogBox app default logbox: anchors links in error messages 1`] = `"Error: end https://nextjs.org"`;
 
-exports[`ReactRefreshLogBox app default logbox: anchors links in error messages 2`] = `"http://nextjs.org/"`;
+exports[`ReactRefreshLogBox app default logbox: anchors links in error messages 2`] = `"https://nextjs.org/"`;
 
-exports[`ReactRefreshLogBox app default logbox: anchors links in error messages 3`] = `"Error: http://nextjs.org start"`;
+exports[`ReactRefreshLogBox app default logbox: anchors links in error messages 3`] = `"Error: https://nextjs.org start"`;
 
-exports[`ReactRefreshLogBox app default logbox: anchors links in error messages 4`] = `"http://nextjs.org/"`;
+exports[`ReactRefreshLogBox app default logbox: anchors links in error messages 4`] = `"https://nextjs.org/"`;
 
-exports[`ReactRefreshLogBox app default logbox: anchors links in error messages 5`] = `"Error: middle http://nextjs.org end"`;
+exports[`ReactRefreshLogBox app default logbox: anchors links in error messages 5`] = `"Error: middle https://nextjs.org end"`;
 
-exports[`ReactRefreshLogBox app default logbox: anchors links in error messages 6`] = `"http://nextjs.org/"`;
+exports[`ReactRefreshLogBox app default logbox: anchors links in error messages 6`] = `"https://nextjs.org/"`;
 
-exports[`ReactRefreshLogBox app default logbox: anchors links in error messages 8`] = `"http://nextjs.org/"`;
+exports[`ReactRefreshLogBox app default logbox: anchors links in error messages 8`] = `"https://nextjs.org/"`;
 
 exports[`ReactRefreshLogBox app default logbox: anchors links in error messages 9`] = `"http://example.com/"`;
 
@@ -154,19 +154,19 @@ Parsing css source code failed
 Selector is not pure (pure selectors must contain at least one local class or id), (lightningcss, Selector(button, specificity = 0x1))"
 `;
 
-exports[`ReactRefreshLogBox app turbo logbox: anchors links in error messages 1`] = `"Error: end http://nextjs.org"`;
+exports[`ReactRefreshLogBox app turbo logbox: anchors links in error messages 1`] = `"Error: end https://nextjs.org"`;
 
-exports[`ReactRefreshLogBox app turbo logbox: anchors links in error messages 2`] = `"http://nextjs.org/"`;
+exports[`ReactRefreshLogBox app turbo logbox: anchors links in error messages 2`] = `"https://nextjs.org/"`;
 
-exports[`ReactRefreshLogBox app turbo logbox: anchors links in error messages 3`] = `"Error: http://nextjs.org start"`;
+exports[`ReactRefreshLogBox app turbo logbox: anchors links in error messages 3`] = `"Error: https://nextjs.org start"`;
 
-exports[`ReactRefreshLogBox app turbo logbox: anchors links in error messages 4`] = `"http://nextjs.org/"`;
+exports[`ReactRefreshLogBox app turbo logbox: anchors links in error messages 4`] = `"https://nextjs.org/"`;
 
-exports[`ReactRefreshLogBox app turbo logbox: anchors links in error messages 5`] = `"Error: middle http://nextjs.org end"`;
+exports[`ReactRefreshLogBox app turbo logbox: anchors links in error messages 5`] = `"Error: middle https://nextjs.org end"`;
 
-exports[`ReactRefreshLogBox app turbo logbox: anchors links in error messages 6`] = `"http://nextjs.org/"`;
+exports[`ReactRefreshLogBox app turbo logbox: anchors links in error messages 6`] = `"https://nextjs.org/"`;
 
-exports[`ReactRefreshLogBox app turbo logbox: anchors links in error messages 8`] = `"http://nextjs.org/"`;
+exports[`ReactRefreshLogBox app turbo logbox: anchors links in error messages 8`] = `"https://nextjs.org/"`;
 
 exports[`ReactRefreshLogBox app turbo logbox: anchors links in error messages 9`] = `"http://example.com/"`;
 

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -382,7 +382,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
         export default function Index() {
           const boom = useCallback(() => {
-            throw new Error('end http://nextjs.org')
+            throw new Error('end https://nextjs.org')
           }, [])
           return (
             <main>
@@ -428,7 +428,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
         export default function Index() {
           const boom = useCallback(() => {
-            throw new Error('http://nextjs.org start')
+            throw new Error('https://nextjs.org start')
           }, [])
           return (
             <main>
@@ -474,7 +474,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
         export default function Index() {
           const boom = useCallback(() => {
-            throw new Error('middle http://nextjs.org end')
+            throw new Error('middle https://nextjs.org end')
           }, [])
           return (
             <main>
@@ -520,7 +520,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
         export default function Index() {
           const boom = useCallback(() => {
-            throw new Error('multiple http://nextjs.org links http://example.com')
+            throw new Error('multiple https://nextjs.org links http://example.com')
           }, [])
           return (
             <main>
@@ -537,8 +537,9 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
     const header4 = await session.getRedboxDescription()
     expect(header4).toMatchInlineSnapshot(
-      `"Error: multiple http://nextjs.org links http://example.com"`
+      `"Error: multiple https://nextjs.org links http://example.com"`
     )
+    // Do not highlight the http://example.com link
     expect(
       await session.evaluate(
         () =>
@@ -547,7 +548,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
             .shadowRoot.querySelectorAll('#nextjs__container_errors_desc a')
             .length
       )
-    ).toBe(2)
+    ).toBe(1)
     expect(
       await session.evaluate(
         () =>
@@ -580,7 +581,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
         export default function Index() {
           const boom = useCallback(() => {
-            throw new Error('multiple http://nextjs.org links (http://example.com)')
+            throw new Error('multiple https://nextjs.org links (http://example.com)')
           }, [])
           return (
             <main>
@@ -597,7 +598,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
 
     const header5 = await session.getRedboxDescription()
     expect(header5).toMatchInlineSnapshot(
-      `"Error: multiple http://nextjs.org links (http://example.com)"`
+      `"Error: multiple https://nextjs.org links (http://example.com)"`
     )
     expect(
       await session.evaluate(
@@ -607,7 +608,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
             .shadowRoot.querySelectorAll('#nextjs__container_errors_desc a')
             .length
       )
-    ).toBe(2)
+    ).toBe(1)
     expect(
       await session.evaluate(
         () =>

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -572,7 +572,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
               ) as any
           ).href
       )
-    ).toMatchSnapshot()
+    ).toBe(null)
 
     await session.patch(
       'index.js',
@@ -600,6 +600,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     expect(header5).toMatchInlineSnapshot(
       `"Error: multiple https://nextjs.org links (http://example.com)"`
     )
+    // Do not highlight the http://example.com link
     expect(
       await session.evaluate(
         () =>
@@ -632,7 +633,7 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
               ) as any
           ).href
       )
-    ).toMatchSnapshot()
+    ).toBe(null)
 
     await cleanup()
   })

--- a/test/development/acceptance/__snapshots__/ReactRefreshLogBox.test.ts.snap
+++ b/test/development/acceptance/__snapshots__/ReactRefreshLogBox.test.ts.snap
@@ -26,23 +26,23 @@ Syntax error: Selector "button" is not pure (pure selectors must contain at leas
     | ^"
 `;
 
-exports[`ReactRefreshLogBox default logbox: anchors links in error messages 1`] = `"Error: end http://nextjs.org"`;
+exports[`ReactRefreshLogBox default logbox: anchors links in error messages 1`] = `"Error: end https://nextjs.org"`;
 
-exports[`ReactRefreshLogBox default logbox: anchors links in error messages 2`] = `"http://nextjs.org/"`;
+exports[`ReactRefreshLogBox default logbox: anchors links in error messages 2`] = `"https://nextjs.org/"`;
 
-exports[`ReactRefreshLogBox default logbox: anchors links in error messages 3`] = `"Error: http://nextjs.org start"`;
+exports[`ReactRefreshLogBox default logbox: anchors links in error messages 3`] = `"Error: https://nextjs.org start"`;
 
-exports[`ReactRefreshLogBox default logbox: anchors links in error messages 4`] = `"http://nextjs.org/"`;
+exports[`ReactRefreshLogBox default logbox: anchors links in error messages 4`] = `"https://nextjs.org/"`;
 
-exports[`ReactRefreshLogBox default logbox: anchors links in error messages 5`] = `"Error: middle http://nextjs.org end"`;
+exports[`ReactRefreshLogBox default logbox: anchors links in error messages 5`] = `"Error: middle https://nextjs.org end"`;
 
-exports[`ReactRefreshLogBox default logbox: anchors links in error messages 6`] = `"http://nextjs.org/"`;
+exports[`ReactRefreshLogBox default logbox: anchors links in error messages 6`] = `"https://nextjs.org/"`;
 
-exports[`ReactRefreshLogBox default logbox: anchors links in error messages 8`] = `"http://nextjs.org/"`;
+exports[`ReactRefreshLogBox default logbox: anchors links in error messages 8`] = `"https://nextjs.org/"`;
 
 exports[`ReactRefreshLogBox default logbox: anchors links in error messages 9`] = `"http://example.com/"`;
 
-exports[`ReactRefreshLogBox default logbox: anchors links in error messages 11`] = `"http://nextjs.org/"`;
+exports[`ReactRefreshLogBox default logbox: anchors links in error messages 11`] = `"https://nextjs.org/"`;
 
 exports[`ReactRefreshLogBox default logbox: anchors links in error messages 12`] = `"http://example.com/"`;
 
@@ -94,23 +94,23 @@ Parsing css source code failed
 Selector is not pure (pure selectors must contain at least one local class or id), (lightningcss, Selector(button, specificity = 0x1))"
 `;
 
-exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 1`] = `"Error: end http://nextjs.org"`;
+exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 1`] = `"Error: end https://nextjs.org"`;
 
-exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 2`] = `"http://nextjs.org/"`;
+exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 2`] = `"https://nextjs.org/"`;
 
-exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 3`] = `"Error: http://nextjs.org start"`;
+exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 3`] = `"Error: https://nextjs.org start"`;
 
-exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 4`] = `"http://nextjs.org/"`;
+exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 4`] = `"https://nextjs.org/"`;
 
-exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 5`] = `"Error: middle http://nextjs.org end"`;
+exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 5`] = `"Error: middle https://nextjs.org end"`;
 
-exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 6`] = `"http://nextjs.org/"`;
+exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 6`] = `"https://nextjs.org/"`;
 
-exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 8`] = `"http://nextjs.org/"`;
+exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 8`] = `"https://nextjs.org/"`;
 
 exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 9`] = `"http://example.com/"`;
 
-exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 11`] = `"http://nextjs.org/"`;
+exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 11`] = `"https://nextjs.org/"`;
 
 exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 12`] = `"http://example.com/"`;
 

--- a/test/development/acceptance/__snapshots__/ReactRefreshLogBox.test.ts.snap
+++ b/test/development/acceptance/__snapshots__/ReactRefreshLogBox.test.ts.snap
@@ -40,9 +40,7 @@ exports[`ReactRefreshLogBox default logbox: anchors links in error messages 6`] 
 
 exports[`ReactRefreshLogBox default logbox: anchors links in error messages 8`] = `"https://nextjs.org/"`;
 
-exports[`ReactRefreshLogBox default logbox: anchors links in error messages 9`] = `"http://example.com/"`;
-
-exports[`ReactRefreshLogBox default logbox: anchors links in error messages 11`] = `"https://nextjs.org/"`;
+exports[`ReactRefreshLogBox default logbox: anchors links in error messages 10`] = `"https://nextjs.org/"`;
 
 exports[`ReactRefreshLogBox default module init error not shown 1`] = `
 "index.js (3:7) @ eval

--- a/test/development/acceptance/__snapshots__/ReactRefreshLogBox.test.ts.snap
+++ b/test/development/acceptance/__snapshots__/ReactRefreshLogBox.test.ts.snap
@@ -44,8 +44,6 @@ exports[`ReactRefreshLogBox default logbox: anchors links in error messages 9`] 
 
 exports[`ReactRefreshLogBox default logbox: anchors links in error messages 11`] = `"https://nextjs.org/"`;
 
-exports[`ReactRefreshLogBox default logbox: anchors links in error messages 12`] = `"http://example.com/"`;
-
 exports[`ReactRefreshLogBox default module init error not shown 1`] = `
 "index.js (3:7) @ eval
 
@@ -108,11 +106,7 @@ exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 6`] = 
 
 exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 8`] = `"https://nextjs.org/"`;
 
-exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 9`] = `"http://example.com/"`;
-
 exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 11`] = `"https://nextjs.org/"`;
-
-exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 12`] = `"http://example.com/"`;
 
 exports[`ReactRefreshLogBox turbo module init error not shown 1`] = `
 "index.js (3:7) @ <unknown>

--- a/test/development/acceptance/__snapshots__/ReactRefreshLogBox.test.ts.snap
+++ b/test/development/acceptance/__snapshots__/ReactRefreshLogBox.test.ts.snap
@@ -104,7 +104,7 @@ exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 6`] = 
 
 exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 8`] = `"https://nextjs.org/"`;
 
-exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 11`] = `"https://nextjs.org/"`;
+exports[`ReactRefreshLogBox turbo logbox: anchors links in error messages 10`] = `"https://nextjs.org/"`;
 
 exports[`ReactRefreshLogBox turbo module init error not shown 1`] = `
 "index.js (3:7) @ <unknown>

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -269,9 +269,7 @@ createNextDescribe(
         const browser = await next.browser('/')
         expect(await hasRedbox(browser)).toBe(true)
         expect(
-          await browser
-            .elementByCss('#nextjs__container_build_error_label')
-            .text()
+          await browser.elementByCss('#nextjs__container_errors_label').text()
         ).toEqual('Failed to compile')
         await next.patchFile('middleware.js', `export default function () {}`)
         await hasRedbox(browser)

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -269,7 +269,7 @@ createNextDescribe(
         const browser = await next.browser('/')
         expect(await hasRedbox(browser)).toBe(true)
         expect(
-          await browser.elementByCss('#nextjs__container_errors_label').text()
+          await browser.elementByCss('#nextjs__container_errors_desc').text()
         ).toEqual('Failed to compile')
         await next.patchFile('middleware.js', `export default function () {}`)
         await hasRedbox(browser)

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -858,7 +858,7 @@ export async function getRedboxDescriptionWarning(browser: BrowserInterface) {
           )
         const root = portal.shadowRoot
         const text = root.querySelector(
-          '#nextjs__container_errors__extra'
+          '#nextjs__container_errors__notes'
         )?.innerText
         return text
       }),

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -753,7 +753,7 @@ export async function hasRedbox(browser: BrowserInterface): Promise<boolean> {
         .call(document.querySelectorAll('nextjs-portal'))
         .find((p) =>
           p.shadowRoot.querySelector(
-            '#nextjs__container_errors_label, #nextjs__container_build_error_label, #nextjs__container_root_layout_error_label'
+            '#nextjs__container_errors_label, #nextjs__container_errors_label'
           )
         )
     )
@@ -811,7 +811,7 @@ export async function getRedboxSource(browser: BrowserInterface) {
           .call(document.querySelectorAll('nextjs-portal'))
           .find((p) =>
             p.shadowRoot.querySelector(
-              '#nextjs__container_errors_label, #nextjs__container_build_error_label, #nextjs__container_root_layout_error_label'
+              '#nextjs__container_errors_label, #nextjs__container_errors_label'
             )
           )
         const root = portal.shadowRoot


### PR DESCRIPTION
### What

Polish the UX based on the feedbacks from @sambecker 

* Fix the font that still use mono
* Align the color, to use red for the warnings
* Give the title to build error
* Only highlight the nextjs doc url as link

### After vs Before

#### Runtime Error


<img width="335" alt="image" src="https://github.com/vercel/next.js/assets/4800338/64f2f692-1eae-41db-9287-046aff9ba112">
<img width="335" alt="image" src="https://github.com/vercel/next.js/assets/4800338/2d4bad15-745e-4083-ba57-8968c0f321c2">

#### Build Error

<img width="335" alt="image" src="https://github.com/vercel/next.js/assets/4800338/ecfc3883-4522-40c6-b042-6d85e7ea970e">
<img width="335" alt="image" src="https://github.com/vercel/next.js/assets/4800338/bbf37ec5-b639-4b95-a87f-9911182e431c">



Closes NEXT-2958