### PR TITLE
OTEL: use the current context when creating a root span

### DIFF
--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -248,7 +248,7 @@ class NextTracerImpl implements NextTracer {
     let isRootSpan = false
 
     if (!spanContext) {
-      spanContext = ROOT_CONTEXT
+      spanContext = context?.active() ?? ROOT_CONTEXT
       isRootSpan = true
     } else if (trace.getSpanContext(spanContext)?.isRemote) {
       isRootSpan = true

--- a/test/e2e/opentelemetry/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/opentelemetry.test.ts
@@ -200,6 +200,22 @@ createNextDescribe(
             ])
           })
 
+          it('should propagate custom context without span', async () => {
+            await next.fetch('/app/param/rsc-fetch', {
+              ...env.fetchInit,
+              headers: { ...env.fetchInit?.headers, 'x-custom': 'custom1' },
+            })
+
+            await expectTrace(getCollector(), [
+              {
+                name: 'GET /app/[param]/rsc-fetch',
+                attributes: {
+                  custom: 'custom1',
+                },
+              },
+            ])
+          })
+
           it('should handle RSC with fetch on edge', async () => {
             await next.fetch('/app/param/rsc-fetch/edge', env.fetchInit)
 


### PR DESCRIPTION
Fixes: https://github.com/vercel/next.js/issues/63783