### PR TITLE
Move key generation to the earlier stage

### DIFF
--- a/packages/next/src/build/build-context.ts
+++ b/packages/next/src/build/build-context.ts
@@ -54,6 +54,7 @@ export const NextBuildContext: Partial<{
   // core fields
   dir: string
   buildId: string
+  encryptionKey: string
   config: NextConfigComplete
   appDir: string
   pagesDir: string

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -181,6 +181,7 @@ import { TurbopackManifestLoader } from '../server/dev/turbopack/manifest-loader
 import type { Entrypoints } from '../server/dev/turbopack/types'
 import { buildCustomRoute } from '../lib/build-custom-route'
 import { createProgress } from './progress'
+import { generateEncryptionKeyBase64 } from '../server/app-render/encryption-utils'
 
 interface ExperimentalBypassForInfo {
   experimentalBypassFor?: RouteHas[]
@@ -763,6 +764,11 @@ export default async function build(
         app: typeof appDir === 'string',
         pages: typeof pagesDir === 'string',
       }
+
+      // Generate a random encryption key for this build.
+      // This key is used to encrypt cross boundary values and can be used to generate hashes.
+      const encryptionKey = await generateEncryptionKeyBase64()
+      NextBuildContext.encryptionKey = encryptionKey
 
       const isSrcDir = path
         .relative(dir, pagesDir || appDir || '')
@@ -1395,7 +1401,11 @@ export default async function build(
 
         const currentEntryIssues: EntryIssuesMap = new Map()
 
-        const manifestLoader = new TurbopackManifestLoader({ buildId, distDir })
+        const manifestLoader = new TurbopackManifestLoader({
+          buildId,
+          distDir,
+          encryptionKey,
+        })
 
         // TODO: implement this
         const emptyRewritesObjToBeImplemented = {

--- a/packages/next/src/build/webpack-build/impl.ts
+++ b/packages/next/src/build/webpack-build/impl.ts
@@ -106,6 +106,7 @@ export async function webpackBuildImpl(
   const commonWebpackOptions = {
     isServer: false,
     buildId: NextBuildContext.buildId!,
+    encryptionKey: NextBuildContext.encryptionKey!,
     config: config,
     appDir: NextBuildContext.appDir!,
     pagesDir: NextBuildContext.pagesDir!,

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -300,6 +300,7 @@ export default async function getBaseWebpackConfig(
   dir: string,
   {
     buildId,
+    encryptionKey,
     config,
     compilerType,
     dev = false,
@@ -321,6 +322,7 @@ export default async function getBaseWebpackConfig(
     fetchCacheKeyPrefix,
   }: {
     buildId: string
+    encryptionKey: string
     config: NextConfigComplete
     compilerType: CompilerNameValues
     dev?: boolean
@@ -1867,6 +1869,7 @@ export default async function getBaseWebpackConfig(
               appDir,
               dev,
               isEdgeServer,
+              encryptionKey,
             })),
       hasAppDir &&
         !isClient &&

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -39,7 +39,6 @@ import {
 } from '../utils'
 import { normalizePathSep } from '../../../shared/lib/page-path/normalize-path-sep'
 import { getProxiedPluginState } from '../../build-context'
-import { generateEncryptionKeyBase64 } from '../../../server/app-render/encryption-utils'
 import { PAGE_TYPES } from '../../../lib/page-types'
 import { isWebpackServerOnlyLayer } from '../../utils'
 
@@ -47,6 +46,7 @@ interface Options {
   dev: boolean
   appDir: string
   isEdgeServer: boolean
+  encryptionKey: string
 }
 
 const PLUGIN_NAME = 'FlightClientEntryPlugin'
@@ -166,6 +166,7 @@ function deduplicateCSSImportsForEntry(mergedCSSimports: CssImports) {
 export class FlightClientEntryPlugin {
   dev: boolean
   appDir: string
+  encryptionKey: string
   isEdgeServer: boolean
   assetPrefix: string
 
@@ -174,6 +175,7 @@ export class FlightClientEntryPlugin {
     this.appDir = options.appDir
     this.isEdgeServer = options.isEdgeServer
     this.assetPrefix = !this.dev && !this.isEdgeServer ? '../' : ''
+    this.encryptionKey = options.encryptionKey
   }
 
   apply(compiler: webpack.Compiler) {
@@ -1000,9 +1002,7 @@ export class FlightClientEntryPlugin {
       {
         node: serverActions,
         edge: edgeServerActions,
-
-        // Assign encryption
-        encryptionKey: await generateEncryptionKeyBase64(this.dev),
+        encryptionKey: this.encryptionKey,
       },
       null,
       this.dev ? 2 : undefined

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -78,6 +78,7 @@ import {
   splitEntryKey,
 } from './turbopack/entry-key'
 import { FAST_REFRESH_RUNTIME_RELOAD } from './messages'
+import { generateEncryptionKeyBase64 } from '../app-render/encryption-utils'
 
 const wsServer = new ws.Server({ noServer: true })
 const isTestMode = !!(
@@ -160,7 +161,11 @@ export async function createHotReloaderTurbopack(
   const currentTopLevelIssues: TopLevelIssuesMap = new Map()
   const currentEntryIssues: EntryIssuesMap = new Map()
 
-  const manifestLoader = new TurbopackManifestLoader({ buildId, distDir })
+  const manifestLoader = new TurbopackManifestLoader({
+    buildId,
+    distDir,
+    encryptionKey: await generateEncryptionKeyBase64(),
+  })
 
   // Dev specific
   const changeSubscriptions: ChangeSubscriptions = new Map()

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -230,6 +230,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
   private hasPagesRouterEntrypoints: boolean
   private dir: string
   private buildId: string
+  private encryptionKey: string
   private interceptors: any[]
   private pagesDir?: string
   private distDir: string
@@ -271,6 +272,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       pagesDir,
       distDir,
       buildId,
+      encryptionKey,
       previewProps,
       rewrites,
       appDir,
@@ -280,6 +282,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       pagesDir?: string
       distDir: string
       buildId: string
+      encryptionKey: string
       previewProps: __ApiPreviewProps
       rewrites: CustomRoutes['rewrites']
       appDir?: string
@@ -290,6 +293,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
     this.hasAppRouterEntrypoints = false
     this.hasPagesRouterEntrypoints = false
     this.buildId = buildId
+    this.encryptionKey = encryptionKey
     this.dir = dir
     this.interceptors = []
     this.pagesDir = pagesDir
@@ -615,6 +619,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       const commonWebpackOptions = {
         dev: true,
         buildId: this.buildId,
+        encryptionKey: this.encryptionKey,
         config: this.config,
         pagesDir: this.pagesDir,
         rewrites: this.rewrites,
@@ -671,6 +676,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       compilerType: COMPILER_NAMES.client,
       config: this.config,
       buildId: this.buildId,
+      encryptionKey: this.encryptionKey,
       pagesDir: this.pagesDir,
       rewrites: {
         beforeFiles: [],

--- a/packages/next/src/server/dev/turbopack/manifest-loader.ts
+++ b/packages/next/src/server/dev/turbopack/manifest-loader.ts
@@ -7,7 +7,6 @@ import type { AppBuildManifest } from '../../../build/webpack/plugins/app-build-
 import type { PagesManifest } from '../../../build/webpack/plugins/pages-manifest-plugin'
 import { pathToRegexp } from 'next/dist/compiled/path-to-regexp'
 import type { ActionManifest } from '../../../build/webpack/plugins/flight-client-entry-plugin'
-import { generateEncryptionKeyBase64 } from '../../app-render/encryption-utils'
 import type { NextFontManifest } from '../../../build/webpack/plugins/next-font-manifest-plugin'
 import type { LoadableManifest } from '../../load-components'
 import {
@@ -86,13 +85,23 @@ export class TurbopackManifestLoader {
   private middlewareManifests: Map<EntryKey, TurbopackMiddlewareManifest> =
     new Map()
   private pagesManifests: Map<string, PagesManifest> = new Map()
+  private encryptionKey: string
 
   private readonly distDir: string
   private readonly buildId: string
 
-  constructor({ distDir, buildId }: { buildId: string; distDir: string }) {
+  constructor({
+    distDir,
+    buildId,
+    encryptionKey,
+  }: {
+    buildId: string
+    distDir: string
+    encryptionKey: string
+  }) {
     this.distDir = distDir
     this.buildId = buildId
+    this.encryptionKey = encryptionKey
   }
 
   delete(key: EntryKey) {
@@ -123,7 +132,7 @@ export class TurbopackManifestLoader {
     const manifest: ActionManifest = {
       node: {},
       edge: {},
-      encryptionKey: await generateEncryptionKeyBase64(true),
+      encryptionKey: this.encryptionKey,
     }
 
     function mergeActionIds(

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -75,6 +75,7 @@ import { PAGE_TYPES } from '../../../lib/page-types'
 import { createHotReloaderTurbopack } from '../../dev/hot-reloader-turbopack'
 import { getErrorSource } from '../../../shared/lib/error-source'
 import type { StackFrame } from 'next/dist/compiled/stacktrace-parser'
+import { generateEncryptionKeyBase64 } from '../../app-render/encryption-utils'
 
 export type SetupOpts = {
   renderServer: LazyRenderServerInstance
@@ -162,6 +163,7 @@ async function startWatcher(opts: SetupOpts) {
         distDir: distDir,
         config: opts.nextConfig,
         buildId: 'development',
+        encryptionKey: await generateEncryptionKeyBase64(),
         telemetry: opts.telemetry,
         rewrites: opts.fsChecker.rewrites,
         previewProps: opts.fsChecker.prerenderManifest.preview,


### PR DESCRIPTION
Currently, the encryption key for Server Actions is generated during the manifest creation. This PR moves it to be in the same position as the build ID generation, and we will later leverage that key for other use cases.

Closes NEXT-2959