### PR TITLE
Use local AMP validator to reduce test flakiness

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -39,3 +39,4 @@ packages/next-bundle-analyzer/index.d.ts
 examples/with-typescript-graphql/lib/gql/
 test/development/basic/hmr/components/parse-error.js
 packages/next-swc/docs/assets/**/*
+test/lib/amp-validator-wasm.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -40,3 +40,4 @@ examples/with-typescript-graphql/lib/gql/
 test/development/basic/hmr/components/parse-error.js
 packages/next-swc/docs/assets/**/*
 test/lib/amp-validator-wasm.js
+test/production/pages-dir/production/fixture/amp-validator-wasm.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -37,3 +37,4 @@ bench/nested-deps/components/**/*
 
 **/convex/_generated/**
 **/.tina/__generated__/**
+test/lib/amp-validator-wasm.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -38,3 +38,4 @@ bench/nested-deps/components/**/*
 **/convex/_generated/**
 **/.tina/__generated__/**
 test/lib/amp-validator-wasm.js
+test/production/pages-dir/production/fixture/amp-validator-wasm.js

--- a/.prettierignore_staged
+++ b/.prettierignore_staged
@@ -14,3 +14,4 @@ pnpm-lock.yaml
 .github/actions/*/index.mjs
 **/convex/_generated/**
 test/lib/amp-validator-wasm.js
+test/production/pages-dir/production/fixture/amp-validator-wasm.js

--- a/.prettierignore_staged
+++ b/.prettierignore_staged
@@ -13,3 +13,4 @@ pnpm-lock.yaml
 .github/actions/needs-triage/index.js
 .github/actions/*/index.mjs
 **/convex/_generated/**
+test/lib/amp-validator-wasm.js

--- a/test/integration/amp-export-validation/next.config.js
+++ b/test/integration/amp-export-validation/next.config.js
@@ -1,4 +1,9 @@
 module.exports = {
   output: 'export',
+  experimental: {
+    amp: {
+      validator: require.resolve('../../lib/amp-validator-wasm.js'),
+    },
+  },
   // exportPathMap
 }

--- a/test/integration/amphtml-custom-optimizer/next.config.js
+++ b/test/integration/amphtml-custom-optimizer/next.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   experimental: {
     amp: {
+      validator: require.resolve('../../lib/amp-validator-wasm.js'),
       optimizer: {
         ampRuntimeVersion: '001515617716922',
         rtv: true,

--- a/test/integration/amphtml-custom-validator/next.config.js
+++ b/test/integration/amphtml-custom-validator/next.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   experimental: {
     amp: {
-      validator: 'https://cdn.ampproject.org/v0/validator_wasm.js',
+      validator: require.resolve('../../lib/amp-validator-wasm.js'),
     },
   },
 }

--- a/test/integration/amphtml-fragment-style/next.config.js
+++ b/test/integration/amphtml-fragment-style/next.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  experimental: {
+    amp: {
+      validator: require.resolve('../../lib/amp-validator-wasm.js'),
+    },
+  },
+}

--- a/test/integration/amphtml-ssg/next.config.js
+++ b/test/integration/amphtml-ssg/next.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  experimental: {
+    amp: {
+      validator: require.resolve('../../lib/amp-validator-wasm.js'),
+    },
+  },
+}

--- a/test/integration/amphtml/next.config.js
+++ b/test/integration/amphtml/next.config.js
@@ -6,5 +6,10 @@ module.exports = {
   amp: {
     canonicalBase: 'http://localhost:1234',
   },
+  experimental: {
+    amp: {
+      validator: require.resolve('../../lib/amp-validator-wasm.js'),
+    },
+  },
   // edit here
 }

--- a/test/integration/async-modules/next.config.js
+++ b/test/integration/async-modules/next.config.js
@@ -4,4 +4,9 @@ module.exports = {
     config.experiments.topLevelAwait = true
     return config
   },
+  experimental: {
+    amp: {
+      validator: require.resolve('../../lib/amp-validator-wasm.js'),
+    },
+  },
 }

--- a/test/integration/auto-export-query-error/next.config.js
+++ b/test/integration/auto-export-query-error/next.config.js
@@ -7,4 +7,9 @@ module.exports = {
       '/ssr': { page: '/ssr', query: { another: 'one' } },
     }
   },
+  experimental: {
+    amp: {
+      validator: require.resolve('../../lib/amp-validator-wasm.js'),
+    },
+  },
 }

--- a/test/integration/build-output/fixtures/with-amp/next.config.js
+++ b/test/integration/build-output/fixtures/with-amp/next.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   experimental: {
     amp: {
-      validator: require.resolve('../../lib/amp-validator-wasm.js'),
+      validator: require.resolve('../../../../lib/amp-validator-wasm.js'),
     },
   },
 }

--- a/test/integration/build-output/fixtures/with-amp/next.config.js
+++ b/test/integration/build-output/fixtures/with-amp/next.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  experimental: {
+    amp: {
+      validator: require.resolve('../../lib/amp-validator-wasm.js'),
+    },
+  },
+}

--- a/test/integration/export-default-map/next.config.js
+++ b/test/integration/export-default-map/next.config.js
@@ -1,3 +1,8 @@
 module.exports = {
   output: 'export',
+  experimental: {
+    amp: {
+      validator: require.resolve('../../lib/amp-validator-wasm.js'),
+    },
+  },
 }

--- a/test/integration/font-optimization/fixtures/with-google/next.config.js
+++ b/test/integration/font-optimization/fixtures/with-google/next.config.js
@@ -1,1 +1,8 @@
-module.exports = { cleanDistDir: false }
+module.exports = {
+  cleanDistDir: false,
+  experimental: {
+    amp: {
+      validator: require.resolve('../../lib/amp-validator-wasm.js'),
+    },
+  },
+}

--- a/test/integration/font-optimization/fixtures/with-google/next.config.js
+++ b/test/integration/font-optimization/fixtures/with-google/next.config.js
@@ -2,7 +2,7 @@ module.exports = {
   cleanDistDir: false,
   experimental: {
     amp: {
-      validator: require.resolve('../../lib/amp-validator-wasm.js'),
+      validator: require.resolve('../../../../lib/amp-validator-wasm.js'),
     },
   },
 }

--- a/test/integration/font-optimization/fixtures/with-typekit/next.config.js
+++ b/test/integration/font-optimization/fixtures/with-typekit/next.config.js
@@ -1,3 +1,8 @@
 module.exports = {
   cleanDistDir: false,
+  experimental: {
+    amp: {
+      validator: require.resolve('../../lib/amp-validator-wasm.js'),
+    },
+  },
 }

--- a/test/integration/font-optimization/fixtures/with-typekit/next.config.js
+++ b/test/integration/font-optimization/fixtures/with-typekit/next.config.js
@@ -2,7 +2,7 @@ module.exports = {
   cleanDistDir: false,
   experimental: {
     amp: {
-      validator: require.resolve('../../lib/amp-validator-wasm.js'),
+      validator: require.resolve('../../../../lib/amp-validator-wasm.js'),
     },
   },
 }

--- a/test/integration/i18n-support-base-path/next.config.js
+++ b/test/integration/i18n-support-base-path/next.config.js
@@ -1,5 +1,10 @@
 module.exports = {
   basePath: '/docs',
+  experimental: {
+    amp: {
+      validator: require.resolve('../../lib/amp-validator-wasm.js'),
+    },
+  },
   i18n: {
     // localeDetection: false,
     locales: [

--- a/test/integration/i18n-support/next.config.js
+++ b/test/integration/i18n-support/next.config.js
@@ -1,6 +1,11 @@
 module.exports = {
   // basePath: '/docs',
   // trailingSlash: true,
+  experimental: {
+    amp: {
+      validator: require.resolve('../../lib/amp-validator-wasm.js'),
+    },
+  },
   i18n: {
     // localeDetection: false,
     locales: [

--- a/test/integration/page-config/next.config.js
+++ b/test/integration/page-config/next.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  experimental: {
+    amp: {
+      validator: require.resolve('../../lib/amp-validator-wasm.js'),
+    },
+  },
+}

--- a/test/lib/amp-readme.md
+++ b/test/lib/amp-readme.md
@@ -1,0 +1,1 @@
+The `amp-validator-wasm.js` is used instead of the CDN as it isn't super reliable and causes test flakiness.

--- a/test/production/pages-dir/production/fixture/next.config.js
+++ b/test/production/pages-dir/production/fixture/next.config.js
@@ -2,6 +2,11 @@
 setInterval(() => {}, 250)
 
 module.exports = {
+  experimental: {
+    amp: {
+      validator: require.resolve('../../lib/amp-validator-wasm.js'),
+    },
+  },
   onDemandEntries: {
     // Make sure entries are not getting disposed.
     maxInactiveAge: 1000 * 60 * 60,

--- a/test/production/pages-dir/production/fixture/next.config.js
+++ b/test/production/pages-dir/production/fixture/next.config.js
@@ -4,7 +4,7 @@ setInterval(() => {}, 250)
 module.exports = {
   experimental: {
     amp: {
-      validator: require.resolve('../../lib/amp-validator-wasm.js'),
+      validator: require.resolve('./amp-validator-wasm.js'),
     },
   },
   onDemandEntries: {


### PR DESCRIPTION
We've seen test flakiness from the upstream AMP resource being unavailable so this pulls that resource to the repo and uses that instead. 

x-ref: [slack thread](https://vercel.slack.com/archives/C04KC8A53T7/p1711643629072819)

Closes NEXT-2961