### PR TITLE
Add note about data cache not applying middleware

### DIFF
--- a/docs/02-app/01-building-your-application/04-caching/index.mdx
+++ b/docs/02-app/01-building-your-application/04-caching/index.mdx
@@ -224,7 +224,7 @@ Alternatively, you can also use the [Route Segment Config options](#segment-conf
 export const dynamic = 'force-dynamic'
 ```
 
-> **Note**: data cache is only available in pages/routes but not middleware currently so any fetches done inside of your middleware will be uncached by default.
+> **Note**: Data Cache is currently only available in pages/routes, not middleware. Any fetches done inside of your middleware will be uncached by default.
 
 > **Vercel Data Cache**
 >

--- a/docs/02-app/01-building-your-application/04-caching/index.mdx
+++ b/docs/02-app/01-building-your-application/04-caching/index.mdx
@@ -224,6 +224,8 @@ Alternatively, you can also use the [Route Segment Config options](#segment-conf
 export const dynamic = 'force-dynamic'
 ```
 
+> **Note**: data cache is only available in pages/routes but not middleware currently so any fetches done inside of your middleware will be uncached by default.
+
 > **Vercel Data Cache**
 >
 > If your Next.js application is deployed to Vercel, we recommend reading the [Vercel Data Cache](https://vercel.com/docs/infrastructure/data-cache) documentation for a better understanding of Vercel specific features.


### PR DESCRIPTION
It isn't obvious that data cache doesn't apply in middleware the same as it does pages/routes in app router so this adds an explicit note in our docs to flag this. 

x-ref: [slack thread](https://vercel.slack.com/archives/C0676QZBWKS/p1711663041319019?thread_ts=1711543518.787019&cid=C0676QZBWKS)

Closes NEXT-2962