### PR TITLE
fix: default relative canonical url should not contain search

### DIFF
--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -58,7 +58,8 @@ export function createMetadataComponents({
   ) => ParsedUrlQuery
 }): [React.ComponentType, React.ComponentType] {
   const metadataContext = {
-    pathname,
+    // Make sure the pathname without query string
+    pathname: pathname.split('?')[0],
     trailingSlash,
   }
 

--- a/test/e2e/app-dir/metadata/app/alternates/page.tsx
+++ b/test/e2e/app-dir/metadata/app/alternates/page.tsx
@@ -1,5 +1,5 @@
 export default function Page() {
-  return 'alternate'
+  return <p id="alternates">alternate</p>
 }
 
 export async function generateMetadata(props, parentResolvingMetadata) {

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -352,6 +352,23 @@ createNextDescribe(
         })
       })
 
+      it('should not contain query in canonical url after client navigation', async () => {
+        const browser = await next.browser('/')
+        await browser.waitForElementByCss('p#index')
+        await browser.eval(`next.router.push('/alternates')`)
+        // wait for /alternates page is loaded
+        await browser.waitForElementByCss('p#alternates')
+
+        const matchDom = createDomMatcher(browser)
+        await matchDom('link', 'rel="canonical"', {
+          href: 'https://example.com/alternates',
+        })
+        await matchDom('link', 'title="js title"', {
+          type: 'application/rss+xml',
+          href: 'https://example.com/blog/js.rss',
+        })
+      })
+
       it('should support robots tags', async () => {
         const $ = await next.render$('/robots')
         const matchMultiDom = createMultiHtmlMatcher($)


### PR DESCRIPTION
### What

Strip the search query for the `urlPathname` passed down to metadata handling. 

### Why
This is because the `urlPathname` from `staticGenerationStore` contains query, so it will contain `?rsc` query for client navigation, which lead to the relative path canonical url (e.g. `./`) will have the search query along with it. This PR is to remove that and make sure always uses pathname.

Reported by @pacocoursey 

Closes NEXT-2963