### PR TITLE
fix: avoid metadata viewport warning during manually merging metadata

### DIFF
--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -256,9 +256,10 @@ function mergeMetadata({
 
       default: {
         if (
-          key === 'viewport' ||
-          key === 'themeColor' ||
-          key === 'colorScheme'
+          (key === 'viewport' ||
+            key === 'themeColor' ||
+            key === 'colorScheme') &&
+          source[key] != null
         ) {
           buildState.warnings.add(
             `Unsupported metadata ${key} is configured in metadata export in ${metadataContext.pathname}. Please move it to viewport export instead.\nRead more: https://nextjs.org/docs/app/api-reference/functions/generate-viewport`

--- a/test/e2e/app-dir/metadata-warnings/app/merge/page.js
+++ b/test/e2e/app-dir/metadata-warnings/app/merge/page.js
@@ -1,0 +1,11 @@
+export default function Page() {
+  return 'merge'
+}
+
+export async function generateMetadata(props, parentResolvingMetadata) {
+  const parentMetadata = await parentResolvingMetadata
+
+  return {
+    ...parentMetadata,
+  }
+}

--- a/test/e2e/app-dir/metadata-warnings/index.test.ts
+++ b/test/e2e/app-dir/metadata-warnings/index.test.ts
@@ -1,5 +1,4 @@
 import { createNextDescribe } from 'e2e-utils'
-import { fetchViaHTTP } from 'next-test-utils'
 
 const METADATA_BASE_WARN_STRING =
   'metadataBase property in metadata export is not set for resolving social open graph or twitter images,'
@@ -20,7 +19,7 @@ createNextDescribe(
     if (isNextDev) {
       it('should not warn metadataBase is missing if there is only absolute url', async () => {
         const logStartPosition = next.cliOutput.length
-        await fetchViaHTTP(next.url, '/absolute-url-og')
+        await next.fetch('/absolute-url-og')
         const output = getCliOutput(logStartPosition)
         expect(output).not.toInclude(METADATA_BASE_WARN_STRING)
       })
@@ -28,7 +27,7 @@ createNextDescribe(
 
     it('should fallback to localhost if metadataBase is missing for absolute urls resolving', async () => {
       const logStartPosition = next.cliOutput.length
-      await fetchViaHTTP(next.url, '/og-image-convention')
+      await next.fetch('/og-image-convention')
       const output = getCliOutput(logStartPosition)
       expect(output).toInclude(METADATA_BASE_WARN_STRING)
       expect(output).toMatch(/using "http:\/\/localhost:\d+/)
@@ -39,7 +38,7 @@ createNextDescribe(
 
     it('should warn for unsupported metadata properties', async () => {
       const logStartPosition = next.cliOutput.length
-      await fetchViaHTTP(next.url, '/unsupported-metadata')
+      await next.fetch('/unsupported-metadata')
       const output = getCliOutput(logStartPosition)
       expect(output).toInclude(
         'Unsupported metadata themeColor is configured in metadata export in /unsupported-metadata. Please move it to viewport'
@@ -47,6 +46,15 @@ createNextDescribe(
       expect(output).toInclude(
         'Read more: https://nextjs.org/docs/app/api-reference/functions/generate-viewport'
       )
+    })
+
+    it('should not warn for viewport properties during manually merging metadata', async () => {
+      const outputLength = next.cliOutput.length
+      await next.fetch('/merge')
+      // Should not log the unsupported metadata viewport warning in the output
+      // during merging the metadata, if the value is still nullable.
+      const output = next.cliOutput.slice(outputLength)
+      expect(output).not.toContain('Unsupported metadata viewport')
     })
   }
 )


### PR DESCRIPTION
We're incorrectly showing warnings for `viewport` if you manually merge metadata.
Found this while fixing #63843 

Closes NEXT-2964