### PR TITLE
Ensure we dedupe fetch requests properly during page revalidate

### DIFF
--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -698,10 +698,11 @@ export function patchFetch({
             staticGenerationStore.pendingRevalidates[cacheKey]
 
           if (pendingRevalidate) {
-            return pendingRevalidate
+            const res: Response = await pendingRevalidate
+            return res.clone()
           }
           return (staticGenerationStore.pendingRevalidates[cacheKey] =
-            doOriginalFetch(false, cacheReasonOverride).finally(async () => {
+            doOriginalFetch(true, cacheReasonOverride).finally(async () => {
               staticGenerationStore.pendingRevalidates ??= {}
               delete staticGenerationStore.pendingRevalidates[cacheKey || '']
               await handleUnlock()

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -694,7 +694,7 @@ export function patchFetch({
             return pendingRevalidate
           }
           return (staticGenerationStore.pendingRevalidates[cacheKey] =
-            doOriginalFetch(false, cacheReasonOverride).catch(console.error))
+            doOriginalFetch(false, cacheReasonOverride).finally(handleUnlock))
         } else {
           return doOriginalFetch(false, cacheReasonOverride).finally(
             handleUnlock

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -689,7 +689,7 @@ export function patchFetch({
           if (hasNextConfig) delete init.next
         }
 
-        // if we are revalidating the whole page time or on-demand and
+        // if we are revalidating the whole page via time or on-demand and
         // the fetch cache entry is stale we should still de-dupe the
         // origin hit if it's a cache-able entry
         if (cacheKey) {

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -2289,6 +2289,7 @@ createNextDescribe(
 
         const layoutData = $('#layout-data').text()
         const pageData = $('#page-data').text()
+        const pageData2 = $('#page-data-2').text()
 
         const res2 = await fetchViaHTTP(
           next.url,
@@ -2300,6 +2301,8 @@ createNextDescribe(
 
         expect($2('#layout-data').text()).toBe(layoutData)
         expect($2('#page-data').text()).toBe(pageData)
+        expect($2('#page-data-2').text()).toBe(pageData2)
+        expect(pageData).toBe(pageData2)
         return 'success'
       }, 'success')
 

--- a/test/e2e/app-dir/app-static/app/variable-revalidate/revalidate-3/page.js
+++ b/test/e2e/app-dir/app-static/app/variable-revalidate/revalidate-3/page.js
@@ -1,18 +1,23 @@
-import { cache, use } from 'react'
-
-export default function Page() {
-  const getData = cache(() =>
-    fetch('https://next-data-api-endpoint.vercel.app/api/random?page', {
+export default async function Page() {
+  const data = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?page',
+    {
       next: { revalidate: 3 },
-    }).then((res) => res.text())
-  )
-  const dataPromise = getData()
-  const data = use(dataPromise)
+    }
+  ).then((res) => res.text())
+
+  const data2 = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?page',
+    {
+      next: { revalidate: 3 },
+    }
+  ).then((res) => res.text())
 
   return (
     <>
       <p id="page">/variable-revalidate/revalidate-3</p>
       <p id="page-data">revalidate 3: {data}</p>
+      <p id="page-data-2">revalidate 3: {data2}</p>
       <p id="now">{Date.now()}</p>
     </>
   )


### PR DESCRIPTION
When we are revalidating an entire page and a specific fetch cache entry is stale we refresh the data in the foreground so that the page cache doesn't contain the stale data. When this foreground fetch updating occurs we weren't de-duping the requests like we were when it was done in the background which could cause unexpected upstream requests. This copies over the deduping handling we have from the background handling to the foreground handling. 

x-ref: [slack thread](https://vercel.slack.com/archives/C03S8ED1DKM/p1711549750854149)

Closes NEXT-2966