### PR TITLE
test: Use the correct chunk path for testing

### DIFF
--- a/test/integration/script-loader/test/index.test.js
+++ b/test/integration/script-loader/test/index.test.js
@@ -106,6 +106,7 @@ const runTests = (isDev) => {
     const html = await renderViaHTTP(appPort, '/page1')
     const $ = cheerio.load(html)
 
+    console.log('html', html)
     function test(id) {
       const script = $(`#${id}`)
 
@@ -114,9 +115,18 @@ const runTests = (isDev) => {
       expect(script.attr('data-nscript')).toBeDefined()
 
       // Script is inserted before NextScripts
-      expect(
-        $(`#${id} ~ script[src^="/_next/static/chunks/main"]`).length
-      ).toBeGreaterThan(0)
+      if (process.env.TURBOPACK) {
+        // Turbopack generates different script names
+        expect(
+          $(
+            `#${id} ~ script[src^="/_next/static/chunks/%5Broot%20of%20the%20server%5D__"]`
+          ).length
+        ).toBeGreaterThan(0)
+      } else {
+        expect(
+          $(`#${id} ~ script[src^="/_next/static/chunks/main"]`).length
+        ).toBeGreaterThan(0)
+      }
     }
 
     test('scriptBeforeInteractive')
@@ -135,9 +145,18 @@ const runTests = (isDev) => {
       expect(script.attr('data-nscript')).toBeDefined()
 
       // Script is inserted before NextScripts
-      expect(
-        $(`#${id} ~ script[src^="/_next/static/chunks/main"]`).length
-      ).toBeGreaterThan(0)
+      if (process.env.TURBOPACK) {
+        // Turbopack generates different script names
+        expect(
+          $(
+            `#${id} ~ script[src^="/_next/static/chunks/%5Broot%20of%20the%20server%5D__"]`
+          ).length
+        ).toBeGreaterThan(0)
+      } else {
+        expect(
+          $(`#${id} ~ script[src^="/_next/static/chunks/main"]`).length
+        ).toBeGreaterThan(0)
+      }
     }
 
     test('scriptBeforePageRenderOld')

--- a/test/integration/script-loader/test/index.test.js
+++ b/test/integration/script-loader/test/index.test.js
@@ -106,7 +106,6 @@ const runTests = (isDev) => {
     const html = await renderViaHTTP(appPort, '/page1')
     const $ = cheerio.load(html)
 
-    console.log('html', html)
     function test(id) {
       const script = $(`#${id}`)
 

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -15388,12 +15388,11 @@
       "Next.js Script - Primary Strategies - Strict Mode priority beforeInteractive on navigate",
       "Next.js Script - Primary Strategies - Strict Mode priority beforeInteractive with inline script",
       "Next.js Script - Primary Strategies - Strict Mode priority beforeInteractive with inline script should execute",
-      "Next.js Script - Primary Strategies - Strict Mode priority lazyOnload"
-    ],
-    "failed": [
+      "Next.js Script - Primary Strategies - Strict Mode priority lazyOnload",
       "Next.js Script - Primary Strategies - Strict Mode priority beforeInteractive",
       "Next.js Script - Primary Strategies - Strict Mode priority beforeInteractive - older version"
     ],
+    "failed": [],
     "pending": [
       "Next.js Script - Primary Strategies - Production Mode production mode Does not duplicate inline scripts",
       "Next.js Script - Primary Strategies - Production Mode production mode Error message is shown if Partytown is not installed locally",


### PR DESCRIPTION
### What?

Match on `/_next/static/chunks/%5Broot%20of%20the%20server%5D__` instead of `/_next/static/chunks/main` while testing.

### Why?

Turbopack does not use `/_next/static/chunks/main` as the name of the chunk

### How?



Closes PACK-2874