### PR TITLE
fix: skip checking rewrites with an empty has array in isInterceptionRouteRewrite

### DIFF
--- a/packages/next/src/lib/generate-interception-routes-rewrites.ts
+++ b/packages/next/src/lib/generate-interception-routes-rewrites.ts
@@ -89,5 +89,5 @@ export function generateInterceptionRoutesRewrites(
 
 export function isInterceptionRouteRewrite(route: Rewrite) {
   // When we generate interception rewrites in the above implementation, we always do so with only a single `has` condition.
-  return route.has?.[0].key === NEXT_URL
+  return route.has?.[0]?.key === NEXT_URL
 }

--- a/test/e2e/app-dir/app/next.config.js
+++ b/test/e2e/app-dir/app/next.config.js
@@ -8,6 +8,14 @@ module.exports = {
   // output: 'standalone',
   rewrites: async () => {
     return {
+      beforeFiles: [
+        {
+          source: '/before-files-rewrite-with-empty-arrays',
+          destination: '/',
+          has: [],
+          missing: [],
+        },
+      ],
       afterFiles: [
         {
           source: '/rewritten-to-dashboard',
@@ -22,6 +30,20 @@ module.exports = {
           source: '/search-params-prop-server-rewrite',
           destination:
             '/search-params-prop/server?first=value&second=other%20value&third',
+        },
+        {
+          source: '/after-files-rewrite-with-empty-arrays',
+          destination: '/',
+          has: [],
+          missing: [],
+        },
+      ],
+      fallback: [
+        {
+          source: '/fallback-rewrite-with-empty-arrays',
+          destination: '/',
+          has: [],
+          missing: [],
         },
       ],
     }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Fixes #63871

-->

### What?

Adds safe traversal to rewrite `has` items in a certain new (`isInterceptionRouteRewrite()` added in the v14.2.0 canaries) check to the rewrite routes.

### Why?

The new check assumed that all `has` arrays had at least one item, when previously Next.js accepted rewrites with empty `has`. Adding safe traversal doesn't negatively impact the check, as the check only needs rewrites with the first item.

Fixes #63871
