### PR TITLE
fix logic error in parallel route catch-all normalization

### DIFF
--- a/packages/next/src/build/normalize-catchall-routes.test.ts
+++ b/packages/next/src/build/normalize-catchall-routes.test.ts
@@ -100,7 +100,8 @@ describe('normalizeCatchallRoutes', () => {
     })
   })
 
-  it('should only match optional catch-all paths to the "index" of a segment', () => {
+  // TODO-APP: Enable this test once support for optional catch-all slots is added.
+  it.skip('should only match optional catch-all paths to the "index" of a segment', () => {
     const appPaths = {
       '/': ['/page'],
       '/[[...catchAll]]': ['/@slot/[[...catchAll]]/page'],

--- a/packages/next/src/build/normalize-catchall-routes.ts
+++ b/packages/next/src/build/normalize-catchall-routes.ts
@@ -41,12 +41,10 @@ export function normalizeCatchAllRoutes(
         // check if the appPath could match the catch-all
         appPath.startsWith(normalizedCatchAllRouteBasePath) &&
         // check if there's not already a slot value that could match the catch-all
-        !appPaths[appPath].some((path) =>
-          hasMatchedSlots(path, catchAllRoute)
-        ) &&
-        // check if appPath is a catch-all OR is not more specific than the catch-all
-        (isCatchAllRoute(appPath) || !isMoreSpecific(appPath, catchAllRoute))
+        !appPaths[appPath].some((path) => hasMatchedSlots(path, catchAllRoute))
       ) {
+        // optional catch-all routes are not currently supported, but leaving this logic in place
+        // for when they are eventually supported.
         if (isOptionalCatchAll(catchAllRoute)) {
           // optional catch-all routes should match both the root segment and any segment after it
           // for example, `/[[...slug]]` should match `/` and `/foo` and `/foo/bar`
@@ -90,7 +88,8 @@ function isMatchableSlot(segment: string): boolean {
 const catchAllRouteRegex = /\[?\[\.\.\./
 
 function isCatchAllRoute(pathname: string): boolean {
-  return isOptionalCatchAll(pathname) || isCatchAll(pathname)
+  // Optional catch-all slots are not currently supported, and as such they are not considered when checking for match compatability.
+  return !isOptionalCatchAll(pathname) && isCatchAll(pathname)
 }
 
 function isOptionalCatchAll(pathname: string): boolean {
@@ -99,11 +98,4 @@ function isOptionalCatchAll(pathname: string): boolean {
 
 function isCatchAll(pathname: string): boolean {
   return pathname.includes('[...')
-}
-
-// test to see if a path is more specific than a catch-all route
-function isMoreSpecific(pathname: string, catchAllRoute: string): boolean {
-  const pathnameDepth = pathname.split('/').length
-  const catchAllRouteDepth = catchAllRoute.split('/').length - 1
-  return pathnameDepth > catchAllRouteDepth
 }

--- a/test/e2e/app-dir/parallel-routes-catchall-specificity/app/@modal/(...)comments/[productId]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall-specificity/app/@modal/(...)comments/[productId]/page.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Modal</h1>
+      <ul>
+        <li>
+          <Link href="/u/foobar/l">Profile Link</Link>
+        </li>
+        <li>
+          <Link href="/trending">Trending Link</Link>
+        </li>
+      </ul>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-catchall-specificity/app/@modal/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall-specificity/app/@modal/[...catchAll]/page.tsx
@@ -1,0 +1,3 @@
+export default function CatchAll() {
+  return null
+}

--- a/test/e2e/app-dir/parallel-routes-catchall-specificity/app/@modal/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall-specificity/app/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/parallel-routes-catchall-specificity/app/@modal/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall-specificity/app/@modal/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return null
+}

--- a/test/e2e/app-dir/parallel-routes-catchall-specificity/app/comments/[productId]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall-specificity/app/comments/[productId]/page.tsx
@@ -1,0 +1,7 @@
+export default function Page({
+  params: { productId },
+}: {
+  params: { productId: string }
+}) {
+  return <h1>{productId}</h1>
+}

--- a/test/e2e/app-dir/parallel-routes-catchall-specificity/app/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall-specificity/app/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/parallel-routes-catchall-specificity/app/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall-specificity/app/layout.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from 'react'
+
+const RootLayout = ({
+  children,
+  modal,
+}: {
+  children: ReactNode
+  modal: ReactNode
+}) => {
+  return (
+    <html lang="en">
+      <body>
+        {children}
+        {modal}
+      </body>
+    </html>
+  )
+}
+
+export default RootLayout

--- a/test/e2e/app-dir/parallel-routes-catchall-specificity/app/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall-specificity/app/page.tsx
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <Link href="/comments/some-text">Open Modal</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-catchall-specificity/app/trending/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall-specificity/app/trending/page.tsx
@@ -1,0 +1,3 @@
+export default function TrendingPage() {
+  return <h1>Trending</h1>
+}

--- a/test/e2e/app-dir/parallel-routes-catchall-specificity/app/u/[userName]/l/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall-specificity/app/u/[userName]/l/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Profile</h1>
+}

--- a/test/e2e/app-dir/parallel-routes-catchall-specificity/next.config.js
+++ b/test/e2e/app-dir/parallel-routes-catchall-specificity/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/parallel-routes-catchall-specificity/parallel-routes-catchall-specificity.test.ts
+++ b/test/e2e/app-dir/parallel-routes-catchall-specificity/parallel-routes-catchall-specificity.test.ts
@@ -1,0 +1,34 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('parallel-routes-catchall-specificity', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should match the catch-all route when navigating from a page with a similar path depth as the previously matched slot', async () => {
+    const browser = await next.browser('/')
+
+    await browser.elementByCss('[href="/comments/some-text"]').click()
+
+    await browser.waitForElementByCss('h1')
+
+    // we're matching @modal/(...comments)/[productId]
+    expect(await browser.elementByCss('h1').text()).toBe('Modal')
+
+    await browser.elementByCss('[href="/u/foobar/l"]').click()
+
+    // we're now matching @modal/[...catchAll]
+    await retry(async () => {
+      expect(await browser.elementByCss('h1').text()).toBe('Profile')
+    })
+
+    await browser.back()
+
+    await browser.elementByCss('[href="/trending"]').click()
+
+    await retry(async () => {
+      expect(await browser.elementByCss('h1').text()).toBe('Trending')
+    })
+  })
+})

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -2219,6 +2219,15 @@
       "flakey": [],
       "runtimeError": false
     },
+    "test/e2e/app-dir/parallel-routes-catchall-specificity/parallel-routes-catchall-specificity.test.ts": {
+      "passed": [],
+      "failed": [
+        "parallel-routes-catchall-specificity should match the catch-all route when navigating from a page with a similar path depth as the previously matched slot"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
     "test/e2e/app-dir/parallel-routes-catchall/parallel-routes-catchall.test.ts": {
       "passed": [
         "parallel-routes-catchall should match correctly when defining an explicit page & slot",


### PR DESCRIPTION
### What & Why
There was some code added in the catch-all route normalization that doesn't seem to make sense -- it was checking if the provided `appPath` depth was larger than the catch-all route depth, prior to inserting it. But it was comparing depths in an inconsistent way (`.length` vs `.length - 1`), and the catch all path was also considering the `@slot` and `/page` suffix as part of the path depth.  

This means that if you had a `@modal/[...catchAll]` slot, it wouldn't be considered for a page like `/foo/bar/baz`, because `/foo/bar/baz` (depth: 4 with the current logic) and `/@modal/[...catchAll]/page` (depth: 3 with the current logic) signaled that the `/foo/bar/baz` route was "more specific" and shouldn't match the catch-all.

I think this was most likely added to resolve a bug where we were inserting optional catch-all (`[[...catchAll]]`) routes into parallel slots. However, optional catch-all routes are currently unsupported with parallel routes, so this feature didn't work properly and the partial support introduced a bug for regular catch-all routes. 

### How
This removes the confusing workaround and skips optional catch-all segments in this handling. Separately, we can add support for optional catch-all parallel routes, but doing so will require quite a bit more changes & also similar handling in Turbopack. Namely, if have a top-level optional catch-all, in both the Turbopack & current Webpack implementation, that top-level catch-all wouldn't be matched. And if you tried to have an optional catch-all slot, in both implementations, the app would error with: 
> You cannot define a route with the same specificity as a optional catch-all route ("/" and "/[[...catchAll]]")

because our route normalization logic does not treat slots specificity differently than pages. 

**Note**: This keeps the test that was added when this logic was first introduced in #60776 to ensure that the case this was originally added for still passes. 

Fixes #62948
Closes NEXT-2728
