### PR TITLE
fix(turbopack): loosen warning log guards

### DIFF
--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -67,7 +67,7 @@ export function printNonFatalIssue(issue: Issue) {
   // Currently only warnings will be printed, excluding if the error source
   // is coming from foreign (node_modules) codes.
   if (issue.severity === 'warning') {
-    if (!issue.filePath.match(/\[project\].+\/node_modules\//g)) {
+    if (!issue.filePath.match(/^(?:.*[\\/])?node_modules(?:[\\/].*)?$/)) {
       Log.warn(formatIssue(issue))
     }
   }


### PR DESCRIPTION
### What

issue's filepath can be outside of turbopack root (`[project]/..`). Loosening check to include any node_modules path.


Closes PACK-2876