### PR TITLE
test: Use the correct matcher pattern for stack traces

### DIFF
--- a/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
+++ b/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
@@ -37,7 +37,6 @@ createNextDescribe(
 
     it('when returning `fetch` using an unknown domain, stack traces are preserved', async () => {
       await webdriver(next.url, '/api/unknown-domain-no-await')
-      console.log('cliOutput', next.cliOutput)
 
       if (process.env.TURBOPACK) {
         // pages_api_unknown-domain-no-await_d8c7f5.js:14:5

--- a/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
+++ b/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
@@ -37,10 +37,21 @@ createNextDescribe(
 
     it('when returning `fetch` using an unknown domain, stack traces are preserved', async () => {
       await webdriver(next.url, '/api/unknown-domain-no-await')
-      await check(
-        () => stripAnsi(next.cliOutput),
-        /at.+\/pages\/api\/unknown-domain-no-await.js/
-      )
+      console.log('cliOutput', next.cliOutput)
+
+      if (process.env.TURBOPACK_DEV) {
+        // pages_api_unknown-domain-no-await_d8c7f5.js:14:5
+        await check(
+          () => stripAnsi(next.cliOutput),
+          /pages_api_unknown-domain-no-await_.*?\.js/
+        )
+      } else {
+        // webpack-internal:///(middleware)/./pages/api/unknown-domain-no-await.js:10:5
+        await check(
+          () => stripAnsi(next.cliOutput),
+          /at.+\/pages\/api\/unknown-domain-no-await.js/
+        )
+      }
     })
   }
 )

--- a/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
+++ b/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
@@ -39,7 +39,7 @@ createNextDescribe(
       await webdriver(next.url, '/api/unknown-domain-no-await')
       console.log('cliOutput', next.cliOutput)
 
-      if (process.env.TURBOPACK_DEV) {
+      if (process.env.TURBOPACK) {
         // pages_api_unknown-domain-no-await_d8c7f5.js:14:5
         await check(
           () => stripAnsi(next.cliOutput),

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -5567,11 +5567,10 @@
   },
   "test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts": {
     "passed": [
-      "fetch failures have good stack traces in edge runtime when awaiting `fetch` using an unknown domain, stack traces are preserved"
-    ],
-    "failed": [
+      "fetch failures have good stack traces in edge runtime when awaiting `fetch` using an unknown domain, stack traces are preserved",
       "fetch failures have good stack traces in edge runtime when returning `fetch` using an unknown domain, stack traces are preserved"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
### What?

Match on `pages_api_unknown-domain-no-await_.*?\.js/` instead of `/at.+\/pages\/api\/unknown-domain-no-await.js/`

### Why?

Turbopack generates a different chunk path for js files. This PR fixes one integration test case.

### How?



Closes PACK-2883