### PR TITLE
Add job to test flakiness of added/changed tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -256,6 +256,21 @@ jobs:
 
     secrets: inherit
 
+  test-new-test:
+    name: Test new tests for flakes
+    needs: ['changes', 'build-native', 'build-next']
+    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+
+    strategy:
+      fail-fast: false
+
+    uses: ./.github/workflows/build_reusable.yml
+
+    with:
+      afterBuild: node scripts/test-new-tests.mjs
+
+    secrets: inherit
+
   test-dev:
     name: test dev
     needs: ['changes', 'build-native', 'build-next']

--- a/run-tests.js
+++ b/run-tests.js
@@ -20,6 +20,7 @@ let argv = require('yargs/yargs')(process.argv.slice(2))
   .string('test-pattern')
   .boolean('timings')
   .boolean('write-timings')
+  .number('retries')
   .boolean('debug')
   .string('g')
   .alias('g', 'group')
@@ -185,8 +186,6 @@ async function getTestTimings() {
 }
 
 async function main() {
-  let numRetries = DEFAULT_NUM_RETRIES
-
   // Ensure we have the arguments awaited from yargs.
   argv = await argv
 
@@ -198,8 +197,9 @@ async function main() {
     group: argv.group ?? false,
     testPattern: argv.testPattern ?? false,
     type: argv.type ?? false,
+    retries: argv.retries ?? DEFAULT_NUM_RETRIES,
   }
-
+  let numRetries = options.retries
   const hideOutput = !options.debug
 
   let filterTestsBy


### PR DESCRIPTION
To help detect when newly added/changed assertions are flakey this adds a job to our build and test workflow to re-run them 3 times. If the changed test is an E2E test it will re-run in both development and production mode to ensure it's not flakey specifically in one of those modes. 

Closes NEXT-2972