### PR TITLE
Add job to test flakiness of added/changed tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -256,6 +256,18 @@ jobs:
 
     secrets: inherit
 
+  test-new-tests:
+    name: Test new tests for flakes
+    needs: ['changes', 'build-native', 'build-next']
+    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+
+    uses: ./.github/workflows/build_reusable.yml
+    with:
+      afterBuild: node scripts/test-new-tests.mjs
+      stepName: 'test-new-tests'
+
+    secrets: inherit
+
   test-dev:
     name: test dev
     needs: ['changes', 'build-native', 'build-next']
@@ -332,8 +344,6 @@ jobs:
     needs: ['changes', 'build-native', 'build-next']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
 
-    strategy:
-      fail-fast: false
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: 18.17.0

--- a/run-tests.js
+++ b/run-tests.js
@@ -20,6 +20,7 @@ let argv = require('yargs/yargs')(process.argv.slice(2))
   .string('test-pattern')
   .boolean('timings')
   .boolean('write-timings')
+  .number('retries')
   .boolean('debug')
   .string('g')
   .alias('g', 'group')
@@ -185,8 +186,6 @@ async function getTestTimings() {
 }
 
 async function main() {
-  let numRetries = DEFAULT_NUM_RETRIES
-
   // Ensure we have the arguments awaited from yargs.
   argv = await argv
 
@@ -198,8 +197,9 @@ async function main() {
     group: argv.group ?? false,
     testPattern: argv.testPattern ?? false,
     type: argv.type ?? false,
+    retries: argv.retries ?? DEFAULT_NUM_RETRIES,
   }
-
+  let numRetries = options.retries
   const hideOutput = !options.debug
 
   let filterTestsBy

--- a/scripts/test-new-tests.mjs
+++ b/scripts/test-new-tests.mjs
@@ -61,7 +61,6 @@ async function main() {
     `\ngit diff:\n${changesResult.stderr}\n${changesResult.stdout}`
   )
   const changedFiles = changesResult.stdout.split('\n')
-  console.log('detected tests:', changedFiles)
 
   // run each test 3 times in each test mode (if E2E) with no-retrying
   // and if any fail it's flakey
@@ -87,6 +86,18 @@ async function main() {
       }
     }
   }
+
+  console.log(
+    'Detected tests:',
+    JSON.stringify(
+      {
+        devTests,
+        prodTests,
+      },
+      null,
+      2
+    )
+  )
 
   if (prodTests.length === 0 && devTests.length === 0) {
     console.log(`No added/changed tests detected`)

--- a/scripts/test-new-tests.mjs
+++ b/scripts/test-new-tests.mjs
@@ -80,9 +80,9 @@ async function main() {
         devTests.push(file)
         prodTests.push(file)
       } else if (file.startsWith('test/prod')) {
-        devTests.push(file)
-      } else if (file.startsWith('test/development')) {
         prodTests.push(file)
+      } else if (file.startsWith('test/development')) {
+        devTests.push(file)
       }
     }
   }
@@ -107,7 +107,7 @@ async function main() {
   const RUN_TESTS_ARGS = ['run-tests.js', '-c', '1', '--retries', '0']
 
   async function invokeRunTests({ mode, testFiles }) {
-    await execa('node', [...RUN_TESTS_ARGS, ...devTests], {
+    await execa('node', [...RUN_TESTS_ARGS, ...testFiles], {
       ...EXECA_OPTS_STDIO,
       env: {
         ...process.env,

--- a/test/e2e/app-dir/mdx/mdx.test.ts
+++ b/test/e2e/app-dir/mdx/mdx.test.ts
@@ -1,7 +1,5 @@
 import { createNextDescribe } from 'e2e-utils'
 
-// test change
-
 for (const type of [
   'with-mdx-rs',
   // only mdx-rs should work with turbopack

--- a/test/e2e/app-dir/mdx/mdx.test.ts
+++ b/test/e2e/app-dir/mdx/mdx.test.ts
@@ -1,5 +1,7 @@
 import { createNextDescribe } from 'e2e-utils'
 
+// test change
+
 for (const type of [
   'with-mdx-rs',
   // only mdx-rs should work with turbopack


### PR DESCRIPTION
To help detect when newly added/changed assertions are flakey this adds a job to our build and test workflow to re-run them 3 times. If the changed test is an E2E test it will re-run in both development and production mode to ensure it's not flakey specifically in one of those modes.

Test run with changed test can be seen here https://github.com/vercel/next.js/actions/runs/8511797725/job/23312158523?pr=63943

Closes NEXT-2973