### PR TITLE
Tweak flakey on-demand revalidate test

### DIFF
--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -2133,7 +2133,6 @@ describe('Prerender', () => {
 
     if (!isDev) {
       it('should handle on-demand revalidate for fallback: blocking', async () => {
-        const beforeRevalidate = Date.now()
         const res = await fetchViaHTTP(
           next.url,
           '/blocking-fallback/test-manual-1'


### PR DESCRIPTION
This test flakes due to cache writing race so this uses retry instead to avoid this. 

x-ref: https://github.com/vercel/next.js/actions/runs/8512132584/job/23313143810?pr=63921

Closes NEXT-2974