### PR TITLE
Parallelize dev/start flake detection

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -256,14 +256,26 @@ jobs:
 
     secrets: inherit
 
-  test-new-tests:
-    name: Test new tests for flakes
+  test-new-tests-dev:
+    name: Test new tests for flakes (dev)
     needs: ['changes', 'build-native', 'build-next']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: node scripts/test-new-tests.mjs
+      afterBuild: node scripts/test-new-tests.mjs --dev-mode
+      stepName: 'test-new-tests'
+
+    secrets: inherit
+
+  test-new-tests-start:
+    name: Test new tests for flakes (prod)
+    needs: ['changes', 'build-native', 'build-next']
+    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+
+    uses: ./.github/workflows/build_reusable.yml
+    with:
+      afterBuild: node scripts/test-new-tests.mjs --prod-mode
       stepName: 'test-new-tests'
 
     secrets: inherit

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -264,7 +264,7 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: node scripts/test-new-tests.mjs --dev-mode
-      stepName: 'test-new-tests'
+      stepName: 'test-new-tests-dev'
 
     secrets: inherit
 
@@ -276,7 +276,7 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: node scripts/test-new-tests.mjs --prod-mode
-      stepName: 'test-new-tests'
+      stepName: 'test-new-tests-start'
 
     secrets: inherit
 

--- a/scripts/test-new-tests.mjs
+++ b/scripts/test-new-tests.mjs
@@ -112,7 +112,7 @@ async function main() {
   const RUN_TESTS_ARGS = ['run-tests.js', '-c', '1', '--retries', '0']
 
   for (let i = 0; i < 3; i++) {
-    console.log(`\n\nRun ${i + 1} for production tests`)
+    console.log(`\n\nRun ${i + 1} for ${testMode} tests`)
     await execa('node', [...RUN_TESTS_ARGS, ...currentTests], {
       ...EXECA_OPTS_STDIO,
       env: {


### PR DESCRIPTION
Since we're re-running tests a few times and in both modes this can take a while ([related run](https://github.com/vercel/next.js/actions/runs/8514892757/job/23321431099?pr=56995)), so this parallelizes by separating dev/prod into separate jobs. 

Closes NEXT-2975