### PR TITLE
docs: add link to Next.js Learn repo in issue template switcher

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,6 @@ contact_links:
   - name: Feature request
     url: https://github.com/vercel/next.js/discussions/new?category=ideas
     about: Feature requests should be opened as discussions
+  - name: Next.js Learn course
+    url: https://github.com/vercel/next-learn/issues/new
+    about: Next.js Lean course-related issues should be reported in their respective repository


### PR DESCRIPTION
### What?

Add a link to the Next.js Learn course repository

### Why?

Sometimes issues like https://github.com/vercel/next-learn/issues/633, https://github.com/vercel/next-learn/issues/634 end up in the Next.js repo, which should track Next.js bugs and documentation issues only. There is a separate team maintaining the Learn course already, so we should transfer related issues there.



Closes NEXT-2976