### PR TITLE
fix(log): skip logging non-route requests

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -35,7 +35,7 @@ import type { NodeNextRequest, NodeNextResponse } from './base-http/node'
 import type { WebNextRequest, WebNextResponse } from './base-http/web'
 import type { PagesAPIRouteMatch } from './future/route-matches/pages-api-route-match'
 import type { AppRouteRouteHandlerContext } from './future/route-modules/app-route/module'
-import type { Server as HTTPServer } from 'http'
+import type { Server as HTTPServer, IncomingMessage } from 'http'
 import type { MiddlewareMatcher } from '../build/analysis/get-page-static-info'
 import type { TLSSocket } from 'tls'
 import type { PathnameNormalizer } from './future/normalizers/request/pathname-normalizer'
@@ -3489,7 +3489,9 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   }
 }
 
-function isRSCRequestCheck(req: BaseNextRequest): boolean {
+export function isRSCRequestCheck(
+  req: IncomingMessage | BaseNextRequest
+): boolean {
   return (
     req.headers[RSC_HEADER.toLowerCase()] === '1' ||
     Boolean(getRequestMeta(req, 'isRSCRequest'))

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -62,7 +62,7 @@ import type {
   RouteHandler,
   NextEnabledDirectories,
 } from './base-server'
-import BaseServer, { NoFallbackError } from './base-server'
+import BaseServer, { NoFallbackError, isRSCRequestCheck } from './base-server'
 import { getMaybePagePath, getPagePath, requireFontManifest } from './require'
 import { denormalizePagePath } from '../shared/lib/page-path/denormalize-page-path'
 import { normalizePagePath } from '../shared/lib/page-path/normalize-page-path'
@@ -1105,7 +1105,9 @@ export default class NextNodeServer extends BaseServer {
 
         const reqCallback = () => {
           // we don't log for non-route requests
-          if (!getRequestMeta(req, 'match')?.definition.kind) return
+          const isRouteRequest = getRequestMeta(req).match
+          const isRSC = isRSCRequestCheck(req)
+          if (!isRouteRequest || isRSC) return
 
           const reqEnd = Date.now()
           const fetchMetrics = normalizedReq.fetchMetrics || []

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1097,9 +1097,7 @@ export default class NextNodeServer extends BaseServer {
       if (this.renderOpts.dev) {
         const { blue, green, yellow, red, gray, white } =
           require('../lib/picocolors') as typeof import('../lib/picocolors')
-        const _req = req as NodeNextRequest | IncomingMessage
         const _res = res as NodeNextResponse | ServerResponse
-        const origReq = 'originalRequest' in _req ? _req.originalRequest : _req
         const origRes =
           'originalResponse' in _res ? _res.originalResponse : _res
 

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1106,15 +1106,9 @@ export default class NextNodeServer extends BaseServer {
         const reqStart = Date.now()
 
         const reqCallback = () => {
-          // if we already logged in a render worker
-          // don't log again in the router worker.
-          // we also don't log for middleware alone
-          if (
-            (normalizedReq as any).didInvokePath ||
-            origReq.headers['x-middleware-invoke']
-          ) {
-            return
-          }
+          // we don't log for non-route requests
+          if (!getRequestMeta(req, 'match')?.definition.kind) return
+
           const reqEnd = Date.now()
           const fetchMetrics = normalizedReq.fetchMetrics || []
           const reqDuration = reqEnd - reqStart

--- a/test/e2e/app-dir/logging/app/link/page.js
+++ b/test/e2e/app-dir/logging/app/link/page.js
@@ -1,0 +1,5 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return <Link href="/foo">Trigger RSC request</Link>
+}

--- a/test/e2e/app-dir/logging/fetch-logging.test.ts
+++ b/test/e2e/app-dir/logging/fetch-logging.test.ts
@@ -154,6 +154,17 @@ describe('app-dir - logging', () => {
             expect(output).toContain('Cache skipped reason: (cache: no-store)')
           })
         })
+
+        it('should exlucde Middleware invoked and _rsc requests', async () => {
+          const outputIndex = next.cliOutput.length
+          await next.fetch('/')
+          const browser = await next.browser('/link')
+          await browser.elementByCss('a').click()
+          await browser.waitForElementByCss('h2')
+          const logs = stripAnsi(next.cliOutput.slice(outputIndex))
+          expect(logs).not.toContain('GET /_next/static')
+          expect(logs).not.toContain('GET /foo?_rsc')
+        })
       }
     } else {
       // No fetches logging enabled

--- a/test/e2e/app-dir/logging/middleware.js
+++ b/test/e2e/app-dir/logging/middleware.js
@@ -1,0 +1,2 @@
+// used to test that if Middleware is present, non-route requests are still not logged
+export function middleware() {}


### PR DESCRIPTION
### What?

We should only log route requests and related `fetch` calls.

<details>
<summary><b>Before/After:</b></summary>
<div><img src="https://github.com/vercel/next.js/assets/18369201/b29d3048-b266-4320-ac4c-71c62e87f5a6" width="48%"/><img src="https://github.com/vercel/next.js/assets/18369201/73e1b2ab-def8-42be-80b3-66f54ed50d87" width="48%"/></div>
</details>



### Why?

#62946 introduced logging some request information by default, but it is too verbose, logging even requests that are unlikely useful to the user (ie.: _rsc, static asset requests when Middleware is present, etc.)

### How?

We have some meta information on requests so we can identify if a request belongs to a route so we can terminate logging early.

Closes NEXT-2977, closes NEXT-2954