### PR TITLE
Fix abort condition for requests

### DIFF
--- a/packages/next/src/server/web/spec-extension/adapters/next-request.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/next-request.ts
@@ -96,7 +96,6 @@ export class NextRequestAdapter {
     }
 
     return new NextRequest(url, {
-      body,
       method: request.method,
       headers: fromNodeOutgoingHttpHeaders(request.headers),
       // @ts-expect-error - see https://github.com/whatwg/fetch/pull/1457
@@ -105,6 +104,14 @@ export class NextRequestAdapter {
       // geo
       // ip
       // nextConfig
+
+      // body can not be passed if request was aborted
+      // or we get a Request body was disturbed error
+      ...(signal.aborted
+        ? {}
+        : {
+            body,
+          }),
     })
   }
 
@@ -116,7 +123,6 @@ export class NextRequestAdapter {
     }
 
     return new NextRequest(request.url, {
-      body,
       method: request.method,
       headers: fromNodeOutgoingHttpHeaders(request.headers),
       // @ts-expect-error - see https://github.com/whatwg/fetch/pull/1457
@@ -125,6 +131,14 @@ export class NextRequestAdapter {
       // geo
       // ip
       // nextConfig
+
+      // body can not be passed if request was aborted
+      // or we get a Request body was disturbed error
+      ...(request.request.signal.aborted
+        ? {}
+        : {
+            body,
+          }),
     })
   }
 }


### PR DESCRIPTION
This ensures we don't attempt passing a closed body to a Request/Response object when a request is aborted as this triggers the disturbed/locked error condition. 

<details>

<summary>Example error</summary>

```sh
TypeError: Response body object should not be disturbed or locked
        at extractBody (node:internal/deps/undici/undici:4507:17)
        at new Request (node:internal/deps/undici/undici:5487:48)
        at new NextRequest (/private/var/folders/cw/z0v1fby13ll4ytx_j3t8hhqh0000gn/T/next-install-d72b2dfb54a1417294505ab189942a38fd6bc139c24b9a8089fc3248568ff902/node_modules/.pnpm/file+..+next-repo-aef41a0c8a591889bcb0dc2e751aa71aa1c2e78c82d9e9b2fe3515c3d40f6c03+packages+n_wd7e7pnjmf2re4cc3l4tp6yzqe/node_modules/next/dist/server/web/spec-extension/request.js:33:14)
        at NextRequestAdapter.fromNodeNextRequest (/private/var/folders/cw/z0v1fby13ll4ytx_j3t8hhqh0000gn/T/next-install-d72b2dfb54a1417294505ab189942a38fd6bc139c24b9a8089fc3248568ff902/node_modules/.pnpm/file+..+next-repo-aef41a0c8a591889bcb0dc2e751aa71aa1c2e78c82d9e9b2fe3515c3d40f6c03+packages+n_wd7e7pnjmf2re4cc3l4tp6yzqe/node_modules/next/dist/server/web/spec-extension/adapters/next-request.js:94:16)
        at NextRequestAdapter.fromBaseNextRequest (/private/var/folders/cw/z0v1fby13ll4ytx_j3t8hhqh0000gn/T/next-install-d72b2dfb54a1417294505ab189942a38fd6bc139c24b9a8089fc3248568ff902/node_modules/.pnpm/file+..+next-repo-aef41a0c8a591889bcb0dc2e751aa71aa1c2e78c82d9e9b2fe3515c3d40f6c03+packages+n_wd7e7pnjmf2re4cc3l4tp6yzqe/node_modules/next/dist/server/web/spec-extension/adapters/next-request.js:70:35)
        at doRender (/private/var/folders/cw/z0v1fby13ll4ytx_j3t8hhqh0000gn/T/next-install-d72b2dfb54a1417294505ab189942a38fd6bc139c24b9a8089fc3248568ff902/node_modules/.pnpm/file+..+next-repo-aef41a0c8a591889bcb0dc2e751aa71aa1c2e78c82d9e9b2fe3515c3d40f6c03+packages+n_wd7e7pnjmf2re4cc3l4tp6yzqe/node_modules/next/dist/server/base-server.js:1365:73)
```

</details>

Fixes: https://github.com/vercel/next.js/issues/63481

Closes NEXT-2984
Closes NEXT-2904