### PR TITLE
Update flakey prerender fallback test

### DIFF
--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -846,7 +846,9 @@ describe('Prerender', () => {
     })
 
     it('should handle fallback only page correctly HTML', async () => {
-      const browser = await webdriver(next.url, '/fallback-only/first%2Fpost')
+      const browser = await webdriver(next.url, '/fallback-only/first%2Fpost', {
+        waitHydration: false,
+      })
 
       const text = await browser.elementByCss('p').text()
       expect(text).toContain('hi fallback')


### PR DESCRIPTION
This test could flake as it's racing the fallback data loading and the initial assertion checking the initial fallback text so this skips waiting for hydration to allow checking fallback text faster. 

x-ref: https://github.com/vercel/next.js/actions/runs/8529790447/job/23366315476?pr=64000

Closes NEXT-2985