### PR TITLE
Ensure unstable_cache bypasses for draft mode

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1980,7 +1980,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     let previewData: PreviewData
     let isPreviewMode = false
 
-    if (hasServerProps || isSSG) {
+    if (hasServerProps || isSSG || isAppPath) {
       // For the edge runtime, we don't support preview mode in SSG.
       if (process.env.NEXT_RUNTIME !== 'edge') {
         const { tryGetPreviewData } =

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -161,7 +161,8 @@ export function unstable_cache<T extends Callback>(
         // we should bypass cache similar to fetches
         store.fetchCache !== 'force-no-store' &&
         !store.isOnDemandRevalidate &&
-        !incrementalCache.isOnDemandRevalidate
+        !incrementalCache.isOnDemandRevalidate &&
+        !store.isDraftMode
       ) {
         // We attempt to get the current cache entry from the incremental cache.
         const cacheEntry = await incrementalCache.get(cacheKey, {

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -3147,6 +3147,27 @@ createNextDescribe(
         expect(data).toEqual(data2)
       })
 
+      it('should bypass cache in draft mode', async () => {
+        const draftRes = await next.fetch('/api/draft-mode?status=enable')
+        const setCookie = draftRes.headers.get('set-cookie')
+        const cookieHeader = { Cookie: setCookie?.split(';', 1)[0] }
+
+        expect(cookieHeader.Cookie).toBeTruthy()
+
+        const res = await next.fetch('/unstable-cache/dynamic', {
+          headers: cookieHeader,
+        })
+        const html = await res.text()
+        const data = cheerio.load(html)('#cached-data').text()
+        const res2 = await next.fetch('/unstable-cache/dynamic', {
+          headers: cookieHeader,
+        })
+        const html2 = await res2.text()
+        const data2 = cheerio.load(html2)('#cached-data').text()
+
+        expect(data).not.toEqual(data2)
+      })
+
       it('should not error when retrieving the value undefined', async () => {
         const res = await next.fetch('/unstable-cache/dynamic-undefined')
         const html = await res.text()


### PR DESCRIPTION
Currently we aren't detecting the draft mode case properly in `unstable_cache` so the cache is unexpectedly being leveraged. This ensures we bypass the cache for `unstable_cache` in draft mode the same way we do for the fetch cache handling. 

Fixes: https://github.com/vercel/next.js/issues/60445

Closes NEXT-2987