### PR TITLE
feat(turbopack): Print error message for `next/font` fetching failure

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_font/google/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_font/google/mod.rs
@@ -237,7 +237,13 @@ impl NextFontGoogleCssModuleReplacer {
                 .await?
                 .clone_value(),
             ),
-            None => None,
+            None => {
+                println!(
+                    "Failed to download `{}` from Google Fonts. Using fallback font instead.",
+                    options.await?.font_family
+                );
+                None
+            }
         };
 
         let css_asset = VirtualSource::new(

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -6507,10 +6507,10 @@
     "runtimeError": false
   },
   "test/e2e/next-font/google-fetch-error.test.ts": {
-    "passed": [],
-    "failed": [
+    "passed": [
       "next/font/google fetch error should use a fallback font in dev"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
### What?

Print an error message to stdout if stylesheet fetching fails.

### Why?

To align behavior with the default mode. This PR fixes one integration test case.

### How?



Closes PACK-2896