### PR TITLE
test(turbopack): Update a test to work with turbopack

### DIFF
--- a/test/integration/edge-runtime-module-errors/test/module-imports.test.js
+++ b/test/integration/edge-runtime-module-errors/test/module-imports.test.js
@@ -211,7 +211,7 @@ describe('Edge runtime code with imports', () => {
 
     beforeEach(() => init(importStatement))
 
-    it.only('throws not-found module error in dev at runtime and highlights the faulty line', async () => {
+    it('throws not-found module error in dev at runtime and highlights the faulty line', async () => {
       context.app = await launchApp(context.appDir, context.appPort, appOption)
       const res = await fetchViaHTTP(context.appPort, url)
       expect(res.status).toBe(500)

--- a/test/integration/edge-runtime-module-errors/test/module-imports.test.js
+++ b/test/integration/edge-runtime-module-errors/test/module-imports.test.js
@@ -183,9 +183,7 @@ describe('Edge runtime code with imports', () => {
       init(importStatement) {
         context.api.write(`
           export default async function handler(request) {
-            if (process.env === 'production') {
-              new (${importStatement})()
-            }
+            new (${importStatement})()
             return Response.json({ ok: true })
           }
 
@@ -201,9 +199,7 @@ describe('Edge runtime code with imports', () => {
           import { NextResponse } from 'next/server'
 
           export async function middleware(request) {
-            if (process.env === 'production') {
-              new (${importStatement})()
-            }
+            new (${importStatement})()
             return NextResponse.next()
           }
         `)
@@ -215,7 +211,7 @@ describe('Edge runtime code with imports', () => {
 
     beforeEach(() => init(importStatement))
 
-    it('throws not-found module error in dev at runtime and highlights the faulty line', async () => {
+    it.only('throws not-found module error in dev at runtime and highlights the faulty line', async () => {
       context.app = await launchApp(context.appDir, context.appPort, appOption)
       const res = await fetchViaHTTP(context.appPort, url)
       expect(res.status).toBe(500)

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -9653,7 +9653,7 @@
       "Edge runtime code with imports Middleware importing unused node.js module does not throw in dev at runtime",
       "Edge runtime code with imports Middleware statically importing node.js module throws unsupported module error in dev at runtime and highlights the faulty line",
       "Edge runtime code with imports Edge API importing unused 3rd party module throws not-found module error in dev at runtime and highlights the faulty line",
-      "Edge runtime code with imports Middleware importing unused 3rd party module throws not-found module error in dev at runtime and highlights the faulty line"
+      "Edge runtime code with imports Edge API importing unused 3rd party module throws not-found module error in dev at runtime and highlights the faulty line"
     ],
     "failed": [],
     "pending": [


### PR DESCRIPTION
### What?

Turbopack does not evaluate `await import` because the condition in the if statement is false.

<img width="1840" alt="image" src="https://github.com/vercel/next.js/assets/29931815/ddbf3217-a10a-4c85-ac60-280f2998931d">

### Why?

For 100%.

### How?



Closes PACK-2898