### PR TITLE
fix(turbopack): throws api issues

### DIFF
--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -195,6 +195,9 @@ export function processIssues(
 
     if (issue.severity !== 'warning') {
       relevantIssues.add(formatted)
+      if (isWellKnownError(issue)) {
+        Log.error(formatted)
+      }
     }
   }
 
@@ -406,7 +409,7 @@ export async function handleRouteType({
         pageEntrypoints: entrypoints.page,
       })
 
-      processIssues(currentEntryIssues, key, writtenEndpoint)
+      processIssues(currentEntryIssues, key, writtenEndpoint, true)
 
       break
     }

--- a/test/integration/edge-runtime-module-errors/test/utils.js
+++ b/test/integration/edge-runtime-module-errors/test/utils.js
@@ -73,10 +73,12 @@ export function expectModuleNotFoundProdError(
 ) {
   const moduleNotSupportedMessage = getUnsupportedModule(moduleName)
   expect(stripAnsi(output)).not.toContain(moduleNotSupportedMessage)
-  const moduleNotFoundMessage = process.env.TURBOPACK
-    ? `Error: Cannot find module '${moduleName}'`
-    : getModuleNotFound(moduleName)
-  expect(stripAnsi(output)).toContain(moduleNotFoundMessage)
+  const moduleNotFoundMessages = [
+    expect.stringContaining(`Error: Cannot find module '${moduleName}'`),
+    expect.stringContaining(getModuleNotFound(moduleName)),
+  ]
+
+  expect(moduleNotFoundMessages).toContainEqual(stripAnsi(output))
 }
 
 export function expectModuleNotFoundDevError(

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -9651,12 +9651,11 @@
       "Edge runtime code with imports Edge API statically importing node.js module throws unsupported module error in dev at runtime and highlights the faulty line",
       "Edge runtime code with imports Middleware dynamically importing 3rd party module throws not-found module error in dev at runtime and highlights the faulty line",
       "Edge runtime code with imports Middleware importing unused node.js module does not throw in dev at runtime",
-      "Edge runtime code with imports Middleware statically importing node.js module throws unsupported module error in dev at runtime and highlights the faulty line"
-    ],
-    "failed": [
+      "Edge runtime code with imports Middleware statically importing node.js module throws unsupported module error in dev at runtime and highlights the faulty line",
       "Edge runtime code with imports Edge API importing unused 3rd party module throws not-found module error in dev at runtime and highlights the faulty line",
       "Edge runtime code with imports Middleware importing unused 3rd party module throws not-found module error in dev at runtime and highlights the faulty line"
     ],
+    "failed": [],
     "pending": [
       "Edge runtime code with imports Edge API dynamically importing 3rd party module production mode does not build and reports module not found error",
       "Edge runtime code with imports Edge API importing unused 3rd party module production mode does not build and reports module not found error",


### PR DESCRIPTION
### What

Correctly raises error for the /api, unlike other places we were suppressing it.

Closes PACK-2900