### PR TITLE
fix(turbopack): emit loadable manifest for app

### DIFF
--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -443,6 +443,7 @@ export async function handleRouteType({
       await manifestLoader.loadBuildManifest(page, 'app')
       await manifestLoader.loadAppPathsManifest(page)
       await manifestLoader.loadActionManifest(page)
+      await manifestLoader.loadLoadableManifest(page, 'app')
       await manifestLoader.loadFontManifest(page, 'app')
       await manifestLoader.writeManifests({
         rewrites,


### PR DESCRIPTION
### What

Seems we only emit loadable manifest for the pages so far, adding quick fix for app.

Closes PACK-2902