### PR TITLE
test(turbopack): Add -Wl,--warn-unresolved-symbols to next-swc-napi on Linux

### DIFF
--- a/packages/next-swc/crates/napi/build.rs
+++ b/packages/next-swc/crates/napi/build.rs
@@ -8,6 +8,11 @@ fn main() {
 
     napi_build::setup();
 
+    // Resolve a potential linker issue for unit tests on linux
+    // https://github.com/napi-rs/napi-rs/issues/1782
+    #[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
+    println!("cargo:rustc-link-arg=-Wl,--warn-unresolved-symbols");
+
     #[cfg(not(target_arch = "wasm32"))]
     turbopack_binding::turbo::tasks_build::generate_register();
 }


### PR DESCRIPTION
I'm not sure why this issue is impacting me and seemingly not others, but on Debian 12 with the default linker options (gcc with ld) I get the following compilation error regarding unresolved symbols:

https://gist.github.com/bgw/92da94f46b0994514a144b8938aa2f6c

This flag downgrades that linker error to a warning (which cargo hides).

I've checked that this flag is supported by ld, gold, lld, and mold. I've also tried building with mold in addition to ld. I'm restricting the option to linux to avoid potentially breaking other platforms.

Tested by running:

```
cargo test -p next-swc-napi
```

Which now gives:

```
running 2 tests
test transform::test_deserialize_transform_regenerator ... ok
test transform::test_deser ... ok
```
