### PR TITLE
[PPR] Added generateMetadata tests

### DIFF
--- a/test/e2e/app-dir/ppr-full/app/metadata/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/metadata/page.jsx
@@ -7,10 +7,7 @@ export const revalidate = 60
 export async function generateMetadata() {
   unstable_noStore()
 
-  return {
-    title: 'Metadata',
-    description: 'This is the metadata page.',
-  }
+  return { title: 'Metadata' }
 }
 
 export default function MetadataPage() {

--- a/test/e2e/app-dir/ppr-full/app/metadata/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/metadata/page.jsx
@@ -1,0 +1,22 @@
+import { Suspense } from 'react'
+import { Dynamic } from '../../components/dynamic'
+import { unstable_noStore } from 'next/cache'
+
+export const revalidate = 60
+
+export async function generateMetadata() {
+  unstable_noStore()
+
+  return {
+    title: 'Metadata',
+    description: 'This is the metadata page.',
+  }
+}
+
+export default function MetadataPage() {
+  return (
+    <Suspense fallback={<Dynamic pathname="/metadata" fallback />}>
+      <Dynamic pathname="/metadata" />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/ppr-full/components/dynamic.jsx
+++ b/test/e2e/app-dir/ppr-full/components/dynamic.jsx
@@ -1,7 +1,7 @@
 import React, { use } from 'react'
 import * as next from 'next/headers'
 
-export const Dynamic = ({ pathname, fallback }) => {
+export const Dynamic = ({ pathname, fallback = null }) => {
   if (fallback) {
     return <div>Dynamic Loading...</div>
   }

--- a/test/e2e/app-dir/ppr-full/components/links.jsx
+++ b/test/e2e/app-dir/ppr-full/components/links.jsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import Link from 'next/link'
 
-const links = [
+export const links = [
   { href: '/', tag: 'pre-generated' },
+  { href: '/metadata', tag: 'pre-generated' },
   { href: '/nested/a', tag: 'pre-generated' },
   { href: '/nested/b', tag: 'on-demand' },
   { href: '/nested/c', tag: 'on-demand' },

--- a/test/e2e/app-dir/ppr-full/ppr-full.test.ts
+++ b/test/e2e/app-dir/ppr-full/ppr-full.test.ts
@@ -94,6 +94,19 @@ createNextDescribe(
       })
     })
 
+    describe('Metadata', () => {
+      it('should set the right metadata when generateMetadata uses dynamic APIs', async () => {
+        const browser = await next.browser('/metadata')
+
+        try {
+          const title = await browser.elementByCss('title').text()
+          expect(title).toEqual('Metadata')
+        } finally {
+          await browser.close()
+        }
+      })
+    })
+
     describe('HTML Response', () => {
       describe.each(pages)(
         'for $pathname',
@@ -107,12 +120,6 @@ createNextDescribe(
           })
 
           it('should allow navigations to and from a pages/ page', async () => {
-            // Ensure that the links array is updated with the URL of the target
-            // page, otherwise this test won't do anything correct.
-            expect(links).toContainEqual(
-              expect.objectContaining({ href: pathname })
-            )
-
             const browser = await next.browser(pathname)
 
             try {

--- a/test/e2e/app-dir/ppr-full/ppr-full.test.ts
+++ b/test/e2e/app-dir/ppr-full/ppr-full.test.ts
@@ -1,4 +1,5 @@
 import { createNextDescribe } from 'e2e-utils'
+import { links } from './components/links'
 
 async function measure(stream: NodeJS.ReadableStream) {
   let streamFirstChunk = 0
@@ -54,6 +55,7 @@ const pages: Page[] = [
   { pathname: '/nested/a', dynamic: true, revalidate: 60 },
   { pathname: '/nested/b', dynamic: true, revalidate: 60 },
   { pathname: '/nested/c', dynamic: true, revalidate: 60 },
+  { pathname: '/metadata', dynamic: true, revalidate: 60 },
   { pathname: '/on-demand/a', dynamic: true },
   { pathname: '/on-demand/b', dynamic: true },
   { pathname: '/on-demand/c', dynamic: true },
@@ -82,11 +84,21 @@ createNextDescribe(
     files: __dirname,
   },
   ({ next, isNextDev, isNextDeploy }) => {
+    describe('Test Setup', () => {
+      it('has all the test pathnames listed in the links component', () => {
+        for (const { pathname } of pages) {
+          expect(links).toContainEqual(
+            expect.objectContaining({ href: pathname })
+          )
+        }
+      })
+    })
+
     describe('HTML Response', () => {
       describe.each(pages)(
         'for $pathname',
         ({ pathname, dynamic, revalidate, emptyStaticPart }) => {
-          beforeEach(async () => {
+          beforeAll(async () => {
             // Hit the page once to populate the cache.
             const res = await next.fetch(pathname)
 
@@ -95,6 +107,12 @@ createNextDescribe(
           })
 
           it('should allow navigations to and from a pages/ page', async () => {
+            // Ensure that the links array is updated with the URL of the target
+            // page, otherwise this test won't do anything correct.
+            expect(links).toContainEqual(
+              expect.objectContaining({ href: pathname })
+            )
+
             const browser = await next.browser(pathname)
 
             try {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

This adds a missing test case for a page which accesses dynamic API's within `generateMetadata`. It also adds a test case to verify that any of the URL's being tested can succeed based on the components link components (it relies on finding a link to click in the browser).

Closes NEXT-3004