### PR TITLE
fix the command to install nextjs using bun

### DIFF
--- a/docs/02-app/02-api-reference/06-create-next-app.mdx
+++ b/docs/02-app/02-api-reference/06-create-next-app.mdx
@@ -26,7 +26,7 @@ pnpm create next-app
 ```
 
 ```bash filename="Terminal"
-bunx create-next-app
+bunx create next-app
 ```
 
 You will then be asked the following prompts:


### PR DESCRIPTION
the correct installation command for nextjs using bun is  " bunx create next-app " not bunx create-next-app

I've changed it to correct command.