### PR TITLE
Use proper response type in revalidateTag docs

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/revalidateTag.mdx
+++ b/docs/02-app/02-api-reference/04-functions/revalidateTag.mdx
@@ -57,22 +57,23 @@ export default async function submit() {
 ### Route Handler
 
 ```ts filename="app/api/revalidate/route.ts" switcher
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { revalidateTag } from 'next/cache'
 
 export async function GET(request: NextRequest) {
   const tag = request.nextUrl.searchParams.get('tag')
   revalidateTag(tag)
-  return Response.json({ revalidated: true, now: Date.now() })
+  return NextResponse.json({ revalidated: true, now: Date.now() })
 }
 ```
 
 ```js filename="app/api/revalidate/route.js" switcher
+import { NextResponse } from 'next/server'
 import { revalidateTag } from 'next/cache'
 
 export async function GET(request) {
   const tag = request.nextUrl.searchParams.get('tag')
   revalidateTag(tag)
-  return Response.json({ revalidated: true, now: Date.now() })
+  return NextResponse.json({ revalidated: true, now: Date.now() })
 }
 ```


### PR DESCRIPTION
Using Response type causes build to fail as `.json()` is not available in Response. Use NextResponse instead

