### PR TITLE
Fix missing CNA tests env variable

### DIFF
--- a/test/integration/create-next-app/utils.ts
+++ b/test/integration/create-next-app/utils.ts
@@ -27,7 +27,11 @@ export const run = (
     // tests with options.reject false are expected to exit(1) so don't inherit
     stdio: options.reject === false ? 'pipe' : 'inherit',
     ...options,
-    env: { ...process.env, ...options.env },
+    env: {
+      ...process.env,
+      ...options.env,
+      NEXT_PRIVATE_TEST_VERSION: 'canary',
+    },
   })
 
 export const command = (cmd: string, args: string[]) =>


### PR DESCRIPTION
This re-adds a missing env variable that was dropped in https://github.com/vercel/next.js/pull/63921/files that is needed to ensure we can properly run the tests even when a new canary is being published. 

x-ref: https://github.com/vercel/next.js/actions/runs/8562770063/job/23467092059
x-ref: https://github.com/vercel/next.js/actions/runs/8562770063/job/23467097300

Closes NEXT-3009