### PR TITLE
perf: improve next server static performance

### DIFF
--- a/packages/next/src/server/serve-static.ts
+++ b/packages/next/src/server/serve-static.ts
@@ -27,22 +27,12 @@ export function serveStatic(
   })
 }
 
-export function getContentType(extWithoutDot: string): string | null {
-  const { mime } = send
-  if ('getType' in mime) {
-    // 2.0
-    return mime.getType(extWithoutDot)
-  }
-  // 1.0
-  return (mime as any).lookup(extWithoutDot)
-}
+export const getContentType: (extWithoutDot: string) => string | null =
+  'getType' in send.mime
+    ? (extWithoutDot: string) => send.mime.getType(extWithoutDot)
+    : (extWithoutDot: string) => (send.mime as any).lookup(extWithoutDot)
 
-export function getExtension(contentType: string): string | null {
-  const { mime } = send
-  if ('getExtension' in mime) {
-    // 2.0
-    return mime.getExtension(contentType)
-  }
-  // 1.0
-  return (mime as any).extension(contentType)
-}
+export const getExtension: (contentType: string) => string | null =
+  'getExtension' in send.mime
+    ? (contentType: string) => send.mime.getExtension(contentType)
+    : (contentType: string) => (send.mime as any).extension(contentType)


### PR DESCRIPTION
Previously, the `serve-static` utility function in Next.js would determine which codepath to use based on the version of `mime` **for every incoming request**. The PR changes so that the codepath **will be determined in advance**, thereby reducing the overhead.