### PR TITLE
fix(log): tweak coloring

### DIFF
--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1124,9 +1124,9 @@ export default class NextNodeServer extends BaseServer {
           const color = statusColor(res.statusCode)
           const method = req.method || 'GET'
           writeStdoutLine(
-            `${color(method)} ${color(req.url ?? '')} ${
-              res.statusCode
-            } in ${reqDuration}ms`
+            `${method} ${req.url ?? ''} ${color(
+              (res.statusCode ?? 200).toString()
+            )} in ${reqDuration}ms`
           )
 
           if (fetchMetrics.length && enabledVerboseLogging) {


### PR DESCRIPTION
### What/Why?
Tweak the log output colors to make it less visually distracting.

Before/After:

![image](https://github.com/vercel/next.js/assets/18369201/f0330914-bbb9-4358-9df0-7f3efe0966d0)

![image](https://github.com/vercel/next.js/assets/18369201/df913ea5-d6d1-459c-942e-25f039659d91)

### How?

Coloring the status code instead of the method and URL, since the color is correlated to the status code anyway.

Closes NEXT-3011