### PR TITLE
Stop using `baseUrl` in root tsconfig

### DIFF
--- a/test/development/api-cors-with-rewrite/index.test.ts
+++ b/test/development/api-cors-with-rewrite/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('Rewritten API Requests should pass OPTIONS requests to the api function', () => {

--- a/test/development/app-dir/strict-mode-enabled-by-default/strict-mode-enabled-by-default.test.ts
+++ b/test/development/app-dir/strict-mode-enabled-by-default/strict-mode-enabled-by-default.test.ts
@@ -1,4 +1,4 @@
-import { type BrowserInterface } from 'test/lib/browsers/base'
+import { type BrowserInterface } from 'next-webdriver'
 import { createNextDescribe } from 'e2e-utils'
 import { check } from 'next-test-utils'
 

--- a/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
+++ b/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
@@ -4,7 +4,7 @@ import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
 import { check, getRedboxHeader, hasRedbox } from 'next-test-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 
 const installCheckVisible = (browser) => {
   return browser.eval(`(function() {

--- a/test/development/basic/hmr.test.ts
+++ b/test/development/basic/hmr.test.ts
@@ -13,7 +13,7 @@ import {
   waitFor,
 } from 'next-test-utils'
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { outdent } from 'outdent'
 
 describe.each([[''], ['/docs']])(

--- a/test/development/basic/legacy-decorators.test.ts
+++ b/test/development/basic/legacy-decorators.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
 describe('Legacy decorators SWC option', () => {

--- a/test/development/basic/misc.test.ts
+++ b/test/development/basic/misc.test.ts
@@ -2,7 +2,7 @@ import url from 'url'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 
 describe.each([[''], ['/docs']])(

--- a/test/development/basic/next-dynamic.test.ts
+++ b/test/development/basic/next-dynamic.test.ts
@@ -3,7 +3,7 @@ import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
 import { renderViaHTTP, check, hasRedbox } from 'next-test-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 
 const customDocumentGipFiles = {
   'pages/_document.js': `

--- a/test/development/basic/project-directory-rename.test.ts
+++ b/test/development/basic/project-directory-rename.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra'
 import webdriver from 'next-webdriver'
 import { check, findPort, hasRedbox } from 'next-test-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { createNext } from 'e2e-utils'
 import stripAnsi from 'strip-ansi'
 

--- a/test/development/basic/styled-components-disabled.test.ts
+++ b/test/development/basic/styled-components-disabled.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { check, fetchViaHTTP } from 'next-test-utils'
 
 // TODO: Somehow the warning doesn't show up with Turbopack, even though the transform is not enabled.

--- a/test/development/basic/tailwind-jit.test.ts
+++ b/test/development/basic/tailwind-jit.test.ts
@@ -1,8 +1,7 @@
 import { join } from 'path'
-import webdriver from 'next-webdriver'
+import webdriver, { BrowserInterface } from 'next-webdriver'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import { check, shouldRunTurboDevTest } from 'next-test-utils'
-import { BrowserInterface } from 'test/lib/browsers/base'
 
 // [TODO]: It is unclear why turbopack takes longer to run this test
 // remove once it's fixed

--- a/test/development/client-dev-overlay/index.test.ts
+++ b/test/development/client-dev-overlay/index.test.ts
@@ -1,6 +1,6 @@
 import { createNext, FileRef } from 'e2e-utils'
 import webdriver from 'next-webdriver'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { join } from 'path'
 import { BrowserInterface } from 'test/lib/browsers/base'
 import { check } from 'next-test-utils'

--- a/test/development/client-dev-overlay/index.test.ts
+++ b/test/development/client-dev-overlay/index.test.ts
@@ -1,8 +1,7 @@
 import { createNext, FileRef } from 'e2e-utils'
-import webdriver from 'next-webdriver'
+import webdriver, { BrowserInterface } from 'next-webdriver'
 import { NextInstance } from 'e2e-utils'
 import { join } from 'path'
-import { BrowserInterface } from 'test/lib/browsers/base'
 import { check } from 'next-test-utils'
 
 describe('client-dev-overlay', () => {

--- a/test/development/correct-tsconfig-defaults/index.test.ts
+++ b/test/development/correct-tsconfig-defaults/index.test.ts
@@ -1,6 +1,6 @@
 import { createNext } from 'e2e-utils'
 import { check } from 'next-test-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 
 describe('correct tsconfig.json defaults', () => {
   let next: NextInstance

--- a/test/development/dotenv-default-expansion/index.test.ts
+++ b/test/development/dotenv-default-expansion/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 
 describe('Dotenv default expansion', () => {

--- a/test/development/gssp-notfound/index.test.ts
+++ b/test/development/gssp-notfound/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 

--- a/test/development/jsconfig-path-reloading/index.test.ts
+++ b/test/development/jsconfig-path-reloading/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import {
   check,
   hasRedbox,

--- a/test/development/next-font/build-errors.test.ts
+++ b/test/development/next-font/build-errors.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { getRedboxSource, hasRedbox } from 'next-test-utils'

--- a/test/development/next-font/font-loader-in-document-error.test.ts
+++ b/test/development/next-font/font-loader-in-document-error.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { getRedboxSource, hasRedbox } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'

--- a/test/development/project-directory-with-styled-jsx-suffix/index.test.ts
+++ b/test/development/project-directory-with-styled-jsx-suffix/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 describe('project directory with styled-jsx suffix', () => {

--- a/test/development/tsconfig-path-reloading/index.test.ts
+++ b/test/development/tsconfig-path-reloading/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import {
   check,
   hasRedbox,

--- a/test/development/typescript-auto-install/index.test.ts
+++ b/test/development/typescript-auto-install/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { check, renderViaHTTP } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import stripAnsi from 'strip-ansi'

--- a/test/development/webpack-issuer-deprecation-warning/index.test.ts
+++ b/test/development/webpack-issuer-deprecation-warning/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 // Skip on Turbopack because it's not supported

--- a/test/e2e/404-page-router/index.test.ts
+++ b/test/e2e/404-page-router/index.test.ts
@@ -1,9 +1,8 @@
 import path from 'path'
 import fs from 'fs-extra'
 import webdriver from 'next-webdriver'
-import { createNext, FileRef } from 'e2e-utils'
+import { createNext, FileRef, type NextInstance } from 'e2e-utils'
 import { check } from 'next-test-utils'
-import { type NextInstance } from 'test/lib/next-modes/base'
 
 const pathnames = {
   '/404': ['/not/a/real/page?with=query', '/not/a/real/page'],

--- a/test/e2e/app-dir/app-a11y/index.test.ts
+++ b/test/e2e/app-dir/app-a11y/index.test.ts
@@ -1,6 +1,6 @@
 import { createNextDescribe } from 'e2e-utils'
 import { check } from 'next-test-utils'
-import type { BrowserInterface } from 'test/lib/browsers/base'
+import type { BrowserInterface } from 'next-webdriver'
 
 createNextDescribe(
   'app a11y features',

--- a/test/e2e/app-dir/app-client-cache/client-cache.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.test.ts
@@ -1,6 +1,6 @@
 import { createNextDescribe } from 'e2e-utils'
 import { check } from 'next-test-utils'
-import { BrowserInterface } from 'test/lib/browsers/base'
+import { BrowserInterface } from 'next-webdriver'
 import {
   browserConfigWithFixedTime,
   createRequestsListener,

--- a/test/e2e/app-dir/app-client-cache/test-utils.ts
+++ b/test/e2e/app-dir/app-client-cache/test-utils.ts
@@ -1,4 +1,4 @@
-import { BrowserInterface } from 'test/lib/browsers/base'
+import { BrowserInterface } from 'next-webdriver'
 import type { Request } from 'playwright'
 
 export const getPathname = (url: string) => {

--- a/test/e2e/app-dir/app/useReportWebVitals.test.ts
+++ b/test/e2e/app-dir/app/useReportWebVitals.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
 describe('useReportWebVitals hook', () => {

--- a/test/e2e/app-dir/app/vercel-speed-insights.test.ts
+++ b/test/e2e/app-dir/app/vercel-speed-insights.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
 describe('vercel speed insights', () => {

--- a/test/e2e/app-dir/create-root-layout/create-root-layout.test.ts
+++ b/test/e2e/app-dir/create-root-layout/create-root-layout.test.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 ;(process.env.TURBOPACK ? describe.skip : describe)(

--- a/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
+++ b/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 
 describe('navigation between pages and app dir', () => {

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -1,4 +1,4 @@
-import type { BrowserInterface } from 'test/lib/browsers/base'
+import type { BrowserInterface } from 'next-webdriver'
 import { createNextDescribe } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import fs from 'fs/promises'

--- a/test/e2e/app-dir/use-selected-layout-segment-s/use-selected-layout-segment-s.test.ts
+++ b/test/e2e/app-dir/use-selected-layout-segment-s/use-selected-layout-segment-s.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 import { check } from 'next-test-utils'
 

--- a/test/e2e/basepath-trailing-slash.test.ts
+++ b/test/e2e/basepath-trailing-slash.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { hasRedbox } from 'next-test-utils'
 
 describe('basePath + trailingSlash', () => {

--- a/test/e2e/basepath.test.ts
+++ b/test/e2e/basepath.test.ts
@@ -4,7 +4,7 @@ import assert from 'assert'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import {
   check,
   fetchViaHTTP,

--- a/test/e2e/browserslist-extends/index.test.ts
+++ b/test/e2e/browserslist-extends/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 describe('browserslist-extends', () => {

--- a/test/e2e/browserslist/browserslist.test.ts
+++ b/test/e2e/browserslist/browserslist.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP, fetchViaHTTP } from 'next-test-utils'
 import path from 'path'
 import cheerio from 'cheerio'

--- a/test/e2e/browserslist/default-target.test.ts
+++ b/test/e2e/browserslist/default-target.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP, fetchViaHTTP } from 'next-test-utils'
 import path from 'path'
 import cheerio from 'cheerio'

--- a/test/e2e/config-promise-export/async-function.test.ts
+++ b/test/e2e/config-promise-export/async-function.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 describe('async export', () => {

--- a/test/e2e/config-promise-export/promise.test.ts
+++ b/test/e2e/config-promise-export/promise.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 describe('promise export', () => {

--- a/test/e2e/edge-api-endpoints-can-receive-body/index.test.ts
+++ b/test/e2e/edge-api-endpoints-can-receive-body/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 import path from 'path'
 

--- a/test/e2e/edge-async-local-storage/index.test.ts
+++ b/test/e2e/edge-async-local-storage/index.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable jest/valid-expect-in-promise */
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('edge api can use async local storage', () => {

--- a/test/e2e/edge-can-read-request-body/index.test.ts
+++ b/test/e2e/edge-can-read-request-body/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 import path from 'path'
 import type { Response } from 'node-fetch'

--- a/test/e2e/edge-can-use-wasm-files/index.test.ts
+++ b/test/e2e/edge-can-use-wasm-files/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 import path from 'path'
 import fs from 'fs-extra'

--- a/test/e2e/edge-compiler-can-import-blob-assets/index.test.ts
+++ b/test/e2e/edge-compiler-can-import-blob-assets/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 import path from 'path'
 import { promises as fs } from 'fs'

--- a/test/e2e/edge-compiler-module-exports-preference/index.test.ts
+++ b/test/e2e/edge-compiler-module-exports-preference/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { fetchViaHTTP, shouldRunTurboDevTest } from 'next-test-utils'
 
 describe('Edge compiler module exports preference', () => {

--- a/test/e2e/edge-configurable-runtime/index.test.ts
+++ b/test/e2e/edge-configurable-runtime/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { fetchViaHTTP, File, nextBuild } from 'next-test-utils'
 import { join } from 'path'
 import stripAnsi from 'strip-ansi'

--- a/test/e2e/getserversideprops/test/index.test.ts
+++ b/test/e2e/getserversideprops/test/index.test.ts
@@ -14,7 +14,7 @@ import {
 } from 'next-test-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 
 const appDir = join(__dirname, '../app')
 

--- a/test/e2e/handle-non-hoisted-swc-helpers/index.test.ts
+++ b/test/e2e/handle-non-hoisted-swc-helpers/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 describe('handle-non-hoisted-swc-helpers', () => {

--- a/test/e2e/i18n-api-support/index.test.ts
+++ b/test/e2e/i18n-api-support/index.test.ts
@@ -1,6 +1,6 @@
 import { createNext } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 
 describe('i18n API support', () => {
   let next: NextInstance

--- a/test/e2e/i18n-data-fetching-redirect/index.test.ts
+++ b/test/e2e/i18n-data-fetching-redirect/index.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 

--- a/test/e2e/i18n-ignore-redirect-source-locale/redirects-with-basepath.test.ts
+++ b/test/e2e/i18n-ignore-redirect-source-locale/redirects-with-basepath.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'

--- a/test/e2e/i18n-ignore-redirect-source-locale/redirects.test.ts
+++ b/test/e2e/i18n-ignore-redirect-source-locale/redirects.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'

--- a/test/e2e/i18n-ignore-rewrite-source-locale/rewrites-with-basepath.test.ts
+++ b/test/e2e/i18n-ignore-rewrite-source-locale/rewrites-with-basepath.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 import path from 'path'
 import fs from 'fs-extra'

--- a/test/e2e/i18n-ignore-rewrite-source-locale/rewrites.test.ts
+++ b/test/e2e/i18n-ignore-rewrite-source-locale/rewrites.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 import path from 'path'
 import fs from 'fs-extra'

--- a/test/e2e/ignore-invalid-popstateevent/with-i18n.test.ts
+++ b/test/e2e/ignore-invalid-popstateevent/with-i18n.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { check, waitFor } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 

--- a/test/e2e/ignore-invalid-popstateevent/with-i18n.test.ts
+++ b/test/e2e/ignore-invalid-popstateevent/with-i18n.test.ts
@@ -2,10 +2,9 @@ import { join } from 'path'
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
 import { check, waitFor } from 'next-test-utils'
-import webdriver from 'next-webdriver'
+import webdriver, { BrowserInterface } from 'next-webdriver'
 
 import type { HistoryState } from '../../../packages/next/src/shared/lib/router/router'
-import { BrowserInterface } from 'test/lib/browsers/base'
 
 const emitPopsStateEvent = (browser: BrowserInterface, state: HistoryState) =>
   browser.eval(

--- a/test/e2e/ignore-invalid-popstateevent/without-i18n.test.ts
+++ b/test/e2e/ignore-invalid-popstateevent/without-i18n.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { check, waitFor } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 

--- a/test/e2e/ignore-invalid-popstateevent/without-i18n.test.ts
+++ b/test/e2e/ignore-invalid-popstateevent/without-i18n.test.ts
@@ -2,10 +2,9 @@ import { join } from 'path'
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
 import { check, waitFor } from 'next-test-utils'
-import webdriver from 'next-webdriver'
+import webdriver, { BrowserInterface } from 'next-webdriver'
 
 import type { HistoryState } from '../../../packages/next/src/shared/lib/router/router'
-import { BrowserInterface } from 'test/lib/browsers/base'
 
 const emitPopsStateEvent = (browser: BrowserInterface, state: HistoryState) =>
   browser.eval(

--- a/test/e2e/link-with-api-rewrite/index.test.ts
+++ b/test/e2e/link-with-api-rewrite/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'

--- a/test/e2e/manual-client-base-path/index.test.ts
+++ b/test/e2e/manual-client-base-path/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import httpProxy from 'http-proxy'
 import { join } from 'path'
 import http from 'http'

--- a/test/e2e/middleware-base-path/test/index.test.ts
+++ b/test/e2e/middleware-base-path/test/index.test.ts
@@ -4,7 +4,7 @@ import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
 import { fetchViaHTTP } from 'next-test-utils'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 
 describe('Middleware base tests', () => {
   let next: NextInstance

--- a/test/e2e/middleware-custom-matchers-basepath/test/index.test.ts
+++ b/test/e2e/middleware-custom-matchers-basepath/test/index.test.ts
@@ -5,7 +5,7 @@ import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { fetchViaHTTP } from 'next-test-utils'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 
 const itif = (condition: boolean) => (condition ? it : it.skip)
 

--- a/test/e2e/middleware-custom-matchers-i18n/test/index.test.ts
+++ b/test/e2e/middleware-custom-matchers-i18n/test/index.test.ts
@@ -5,7 +5,7 @@ import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { fetchViaHTTP } from 'next-test-utils'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 
 const itif = (condition: boolean) => (condition ? it : it.skip)
 

--- a/test/e2e/middleware-custom-matchers/test/index.test.ts
+++ b/test/e2e/middleware-custom-matchers/test/index.test.ts
@@ -4,7 +4,7 @@ import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { fetchViaHTTP } from 'next-test-utils'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 
 const itif = (condition: boolean) => (condition ? it : it.skip)
 

--- a/test/e2e/middleware-dynamic-basepath-matcher/test/index.test.ts
+++ b/test/e2e/middleware-dynamic-basepath-matcher/test/index.test.ts
@@ -5,7 +5,7 @@ import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { check, fetchViaHTTP } from 'next-test-utils'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 
 const itif = (condition: boolean) => (condition ? it : it.skip)
 

--- a/test/e2e/middleware-fetches-with-any-http-method/index.test.ts
+++ b/test/e2e/middleware-fetches-with-any-http-method/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('Middleware fetches with any HTTP method', () => {

--- a/test/e2e/middleware-fetches-with-body/index.test.ts
+++ b/test/e2e/middleware-fetches-with-body/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('Middleware fetches with body', () => {

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -3,7 +3,7 @@
 import fs from 'fs-extra'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import {
   check,
   fetchViaHTTP,

--- a/test/e2e/middleware-matcher/index.test.ts
+++ b/test/e2e/middleware-matcher/index.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable jest/no-identical-title */
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { check, fetchViaHTTP } from 'next-test-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'

--- a/test/e2e/middleware-redirects/test/index.test.ts
+++ b/test/e2e/middleware-redirects/test/index.test.ts
@@ -4,7 +4,7 @@ import { join } from 'path'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
 import { check, fetchViaHTTP } from 'next-test-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { createNext, FileRef } from 'e2e-utils'
 
 describe('Middleware Redirect', () => {

--- a/test/e2e/middleware-request-header-overrides/test/index.test.ts
+++ b/test/e2e/middleware-request-header-overrides/test/index.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 import { join } from 'path'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 import { createNext, FileRef } from 'e2e-utils'
 import cheerio from 'cheerio'

--- a/test/e2e/middleware-responses/test/index.test.ts
+++ b/test/e2e/middleware-responses/test/index.test.ts
@@ -2,7 +2,7 @@
 
 import { join } from 'path'
 import { fetchViaHTTP } from 'next-test-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { createNext, FileRef } from 'e2e-utils'
 
 describe('Middleware Responses', () => {

--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -3,7 +3,7 @@
 import { join } from 'path'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { check, fetchViaHTTP, retry } from 'next-test-utils'
 import { createNext, FileRef } from 'e2e-utils'
 import escapeStringRegexp from 'escape-string-regexp'

--- a/test/e2e/middleware-shallow-link/index.test.ts
+++ b/test/e2e/middleware-shallow-link/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
 import { check } from 'next-test-utils'

--- a/test/e2e/middleware-trailing-slash/test/index.test.ts
+++ b/test/e2e/middleware-trailing-slash/test/index.test.ts
@@ -4,7 +4,7 @@ import fs from 'fs-extra'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { check, fetchViaHTTP, waitFor } from 'next-test-utils'
 
 describe('Middleware Runtime trailing slash', () => {

--- a/test/e2e/new-link-behavior/child-a-tag-error.test.ts
+++ b/test/e2e/new-link-behavior/child-a-tag-error.test.ts
@@ -1,6 +1,6 @@
 import { createNext, FileRef, isNextDev } from 'e2e-utils'
 import { getRedboxDescription, hasRedbox } from 'next-test-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 import path from 'path'
 

--- a/test/e2e/new-link-behavior/index.test.ts
+++ b/test/e2e/new-link-behavior/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import cheerio from 'cheerio'

--- a/test/e2e/new-link-behavior/material-ui.test.ts
+++ b/test/e2e/new-link-behavior/material-ui.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 import path from 'path'
 

--- a/test/e2e/new-link-behavior/stitches.test.ts
+++ b/test/e2e/new-link-behavior/stitches.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 import path from 'path'
 

--- a/test/e2e/new-link-behavior/typescript.test.ts
+++ b/test/e2e/new-link-behavior/typescript.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 import cheerio from 'cheerio'
 import path from 'path'

--- a/test/e2e/next-font/basepath.test.ts
+++ b/test/e2e/next-font/basepath.test.ts
@@ -1,6 +1,6 @@
 import cheerio from 'cheerio'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 import { join } from 'path'
 

--- a/test/e2e/next-font/google-fetch-error.test.ts
+++ b/test/e2e/next-font/google-fetch-error.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 

--- a/test/e2e/next-font/index.test.ts
+++ b/test/e2e/next-font/index.test.ts
@@ -1,6 +1,6 @@
 import cheerio from 'cheerio'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP, shouldRunTurboDevTest } from 'next-test-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'

--- a/test/e2e/next-font/with-font-declarations-file.test.ts
+++ b/test/e2e/next-font/with-font-declarations-file.test.ts
@@ -1,6 +1,6 @@
 import cheerio from 'cheerio'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 import { join } from 'path'
 

--- a/test/e2e/next-font/without-preloaded-fonts.test.ts
+++ b/test/e2e/next-font/without-preloaded-fonts.test.ts
@@ -1,6 +1,6 @@
 import cheerio from 'cheerio'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 import { join } from 'path'
 

--- a/test/e2e/next-head/index.test.ts
+++ b/test/e2e/next-head/index.test.ts
@@ -2,7 +2,7 @@ import { createNext, FileRef } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { join } from 'path'
 
 describe('next/head', () => {

--- a/test/e2e/next-image-forward-ref/index.test.ts
+++ b/test/e2e/next-image-forward-ref/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
 import path from 'path'
 import webdriver from 'next-webdriver'

--- a/test/e2e/next-script/index.test.ts
+++ b/test/e2e/next-script/index.test.ts
@@ -1,6 +1,6 @@
 import webdriver from 'next-webdriver'
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { BrowserInterface } from 'test/lib/browsers/base'
 import { check } from 'next-test-utils'
 

--- a/test/e2e/next-script/index.test.ts
+++ b/test/e2e/next-script/index.test.ts
@@ -1,7 +1,6 @@
-import webdriver from 'next-webdriver'
+import webdriver, { BrowserInterface } from 'next-webdriver'
 import { createNext } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { BrowserInterface } from 'test/lib/browsers/base'
 import { check } from 'next-test-utils'
 
 describe('beforeInteractive in document Head', () => {

--- a/test/e2e/no-eslint-warn-with-no-eslint-config/index.test.ts
+++ b/test/e2e/no-eslint-warn-with-no-eslint-config/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 describe('no-eslint-warn-with-no-eslint-config', () => {

--- a/test/e2e/nonce-head-manager/index.test.ts
+++ b/test/e2e/nonce-head-manager/index.test.ts
@@ -1,7 +1,7 @@
 import { createNext, FileRef } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import webdriver from 'next-webdriver'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { join } from 'path'
 
 describe('nonce head manager', () => {

--- a/test/e2e/og-api/index.test.ts
+++ b/test/e2e/og-api/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 import fs from 'fs-extra'
 import { join } from 'path'

--- a/test/e2e/postcss-config-cjs/index.test.ts
+++ b/test/e2e/postcss-config-cjs/index.test.ts
@@ -1,6 +1,6 @@
 import { createNext, FileRef } from 'e2e-utils'
 import { join } from 'path'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 
 describe('postcss-config-cjs', () => {

--- a/test/e2e/prerender-crawler.test.ts
+++ b/test/e2e/prerender-crawler.test.ts
@@ -1,6 +1,6 @@
 import { createNext } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 
 describe('Prerender crawler handling', () => {
   let next: NextInstance

--- a/test/e2e/prerender-native-module.test.ts
+++ b/test/e2e/prerender-native-module.test.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 
 describe('prerender native module', () => {

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -4,7 +4,7 @@ import cheerio from 'cheerio'
 import { join, sep } from 'path'
 import escapeRegex from 'escape-string-regexp'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import {
   check,
   fetchViaHTTP,

--- a/test/e2e/proxy-request-with-middleware/test/index.test.ts
+++ b/test/e2e/proxy-request-with-middleware/test/index.test.ts
@@ -2,7 +2,7 @@
 
 import { join } from 'path'
 import { fetchViaHTTP } from 'next-test-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { createNext, FileRef } from 'e2e-utils'
 
 describe('Requests not effected when middleware used', () => {

--- a/test/e2e/reload-scroll-backforward-restoration/index.test.ts
+++ b/test/e2e/reload-scroll-backforward-restoration/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'

--- a/test/e2e/skip-trailing-slash-redirect/index.test.ts
+++ b/test/e2e/skip-trailing-slash-redirect/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { check, fetchViaHTTP } from 'next-test-utils'
 import { join } from 'path'
 import cheerio from 'cheerio'

--- a/test/e2e/ssr-react-context/index.test.ts
+++ b/test/e2e/ssr-react-context/index.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path'
 import { renderViaHTTP, check } from 'next-test-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { createNext, FileRef } from 'e2e-utils'
 
 describe('React Context', () => {

--- a/test/e2e/streaming-ssr/index.test.ts
+++ b/test/e2e/streaming-ssr/index.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path'
 import { createNext, createNextDescribe } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import {
   check,
   fetchViaHTTP,

--- a/test/e2e/swc-warnings/index.test.ts
+++ b/test/e2e/swc-warnings/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 // Tests Babel, not needed for Turbopack

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { check, fetchViaHTTP, renderViaHTTP, waitFor } from 'next-test-utils'
 
 function splitLines(text) {

--- a/test/e2e/trailingslash-with-rewrite/index.test.ts
+++ b/test/e2e/trailingslash-with-rewrite/index.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('trailingSlash:true with rewrites and getStaticProps', () => {

--- a/test/e2e/transpile-packages/index.test.ts
+++ b/test/e2e/transpile-packages/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 import { shouldRunTurboDevTest } from '../../lib/next-test-utils'
 

--- a/test/e2e/type-module-interop/index.test.ts
+++ b/test/e2e/type-module-interop/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { hasRedbox, renderViaHTTP } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import cheerio from 'cheerio'

--- a/test/e2e/undici-fetch/index.test.ts
+++ b/test/e2e/undici-fetch/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('undici fetch', () => {

--- a/test/e2e/yarn-pnp/test/utils.ts
+++ b/test/e2e/yarn-pnp/test/utils.ts
@@ -2,7 +2,7 @@ import fs from 'fs-extra'
 import { join } from 'path'
 import { fetchViaHTTP } from 'next-test-utils'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 
 jest.setTimeout(2 * 60 * 1000)
 

--- a/test/production/app-dir-edge-runtime-with-wasm/index.test.ts
+++ b/test/production/app-dir-edge-runtime-with-wasm/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 const files = {

--- a/test/production/app-dir-hide-suppressed-error-during-next-export/index.test.ts
+++ b/test/production/app-dir-hide-suppressed-error-during-next-export/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { join } from 'path'
 
 describe('app-dir-hide-suppressed-error-during-next-export', () => {

--- a/test/production/app-dir-prefetch-non-iso-url/index.test.ts
+++ b/test/production/app-dir-prefetch-non-iso-url/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { join } from 'path'
 import { BrowserInterface } from '../../lib/browsers/base'
 import webdriver from 'next-webdriver'

--- a/test/production/app-dir-prevent-304-caching/index.test.ts
+++ b/test/production/app-dir-prevent-304-caching/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { join } from 'path'
 import { fetchViaHTTP, waitFor } from 'next-test-utils'
 

--- a/test/production/custom-error-500/index.test.ts
+++ b/test/production/custom-error-500/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { check, renderViaHTTP } from 'next-test-utils'
 
 describe('custom-error-500', () => {

--- a/test/production/dependencies-can-use-env-vars-in-middlewares/index.test.ts
+++ b/test/production/dependencies-can-use-env-vars-in-middlewares/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('dependencies can use env vars in middlewares', () => {

--- a/test/production/disable-fallback-polyfills/index.test.ts
+++ b/test/production/disable-fallback-polyfills/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 
 describe('Disable fallback polyfills', () => {
   let next: NextInstance

--- a/test/production/edge-config-validations/index.test.ts
+++ b/test/production/edge-config-validations/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 
 describe('Edge config validations', () => {
   let next: NextInstance

--- a/test/production/edge-runtime-is-addressable/index.test.ts
+++ b/test/production/edge-runtime-is-addressable/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 import fs from 'fs-extra'
 import path from 'path'

--- a/test/production/emit-decorator-metadata/index.test.ts
+++ b/test/production/emit-decorator-metadata/index.test.ts
@@ -1,8 +1,7 @@
 import { join } from 'path'
-import webdriver from 'next-webdriver'
+import webdriver, { BrowserInterface } from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { BrowserInterface } from 'test/lib/browsers/base'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('emitDecoratorMetadata SWC option', () => {

--- a/test/production/emit-decorator-metadata/index.test.ts
+++ b/test/production/emit-decorator-metadata/index.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { BrowserInterface } from 'test/lib/browsers/base'
 import { fetchViaHTTP } from 'next-test-utils'
 

--- a/test/production/enoent-during-require/index.test.ts
+++ b/test/production/enoent-during-require/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { check, renderViaHTTP } from 'next-test-utils'
 
 describe('ENOENT during require', () => {

--- a/test/production/escheck-output/index.test.ts
+++ b/test/production/escheck-output/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 
 describe('ES Check .next output', () => {
   let next: NextInstance

--- a/test/production/eslint-plugin-deps/index.test.ts
+++ b/test/production/eslint-plugin-deps/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 describe('eslint plugin deps', () => {

--- a/test/production/fallback-export-error/index.test.ts
+++ b/test/production/fallback-export-error/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { join } from 'path'
 
 describe('fallback export error', () => {

--- a/test/production/fatal-render-errror/index.test.ts
+++ b/test/production/fatal-render-errror/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { check, renderViaHTTP, waitFor } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'

--- a/test/production/generate-middleware-source-maps/index.test.ts
+++ b/test/production/generate-middleware-source-maps/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import fs from 'fs-extra'
 import path from 'path'
 

--- a/test/production/jest/index.test.ts
+++ b/test/production/jest/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 describe('next/jest', () => {

--- a/test/production/jest/new-link-behavior.test.ts
+++ b/test/production/jest/new-link-behavior.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 
 describe('next/jest newLinkBehavior', () => {
   let next: NextInstance

--- a/test/production/jest/next-image-preload/next-image-preload.test.ts
+++ b/test/production/jest/next-image-preload/next-image-preload.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import path from 'path'
 import execa from 'execa'
 

--- a/test/production/jest/relay/relay-jest.test.ts
+++ b/test/production/jest/relay/relay-jest.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import path from 'path'
 
 const appDir = path.join(__dirname, 'app')

--- a/test/production/jest/remove-react-properties/remove-react-properties-jest.test.ts
+++ b/test/production/jest/remove-react-properties/remove-react-properties-jest.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 import path from 'path'
 

--- a/test/production/jest/transpile-packages.test.ts
+++ b/test/production/jest/transpile-packages.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 describe('next/jest', () => {
   let next: NextInstance

--- a/test/production/next-font/babel-unsupported.test.ts
+++ b/test/production/next-font/babel-unsupported.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { join } from 'path'
 
 describe('@next/fon babel unsupported', () => {

--- a/test/production/next-font/telemetry-old.test.ts
+++ b/test/production/next-font/telemetry-old.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { findAllTelemetryEvents } from 'next-test-utils'
 import { join } from 'path'
 

--- a/test/production/next-font/telemetry.test.ts
+++ b/test/production/next-font/telemetry.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { findAllTelemetryEvents } from 'next-test-utils'
 import { join } from 'path'
 

--- a/test/production/pnpm-support/index.test.ts
+++ b/test/production/pnpm-support/index.test.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import fs from 'fs-extra'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import {
   findPort,
   initNextServerScript,

--- a/test/production/postcss-plugin-config-as-string/index.test.ts
+++ b/test/production/postcss-plugin-config-as-string/index.test.ts
@@ -1,6 +1,6 @@
 import { createNext } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 
 describe('PostCSS plugin config as string', () => {
   let next: NextInstance

--- a/test/production/prerender-prefetch/index.test.ts
+++ b/test/production/prerender-prefetch/index.test.ts
@@ -1,4 +1,4 @@
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { createNext, FileRef } from 'e2e-utils'
 import {
   check,

--- a/test/production/reading-request-body-in-middleware/index.test.ts
+++ b/test/production/reading-request-body-in-middleware/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('reading request body in middleware', () => {

--- a/test/production/standalone-mode/optimizecss/index.test.ts
+++ b/test/production/standalone-mode/optimizecss/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 describe('standalone mode and optimizeCss', () => {

--- a/test/production/standalone-mode/required-server-files/required-server-files-app.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-app.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs-extra'
 import { join } from 'path'
 import cheerio from 'cheerio'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import {
   fetchViaHTTP,
   findPort,

--- a/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs-extra'
 import cheerio from 'cheerio'
 import { join } from 'path'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import {
   check,
   fetchViaHTTP,

--- a/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs-extra'
 import { join } from 'path'
 import cheerio from 'cheerio'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import {
   fetchViaHTTP,
   findPort,

--- a/test/production/standalone-mode/required-server-files/required-server-files.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files.test.ts
@@ -4,7 +4,7 @@ import cheerio from 'cheerio'
 import { join } from 'path'
 import { nanoid } from 'nanoid'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import {
   check,
   fetchViaHTTP,

--- a/test/production/standalone-mode/response-cache/index.test.ts
+++ b/test/production/standalone-mode/response-cache/index.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs-extra'
 import { join } from 'path'
 import cheerio from 'cheerio'
 import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import {
   killApp,
   findPort,

--- a/test/production/standalone-mode/type-module/index.test.ts
+++ b/test/production/standalone-mode/type-module/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 import { join } from 'path'
 import fs from 'fs-extra'
 import {

--- a/test/production/typescript-basic/index.test.ts
+++ b/test/production/typescript-basic/index.test.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import { createNext, FileRef } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'
 
 describe('TypeScript basic', () => {
   let next: NextInstance

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,8 +17,7 @@
       "next-webdriver": ["./test/lib/next-webdriver"],
       "e2e-utils": ["./test/lib/e2e-utils"],
       "test-data-service/*": ["./test/lib/test-data-service/*"],
-      "test-log": ["./test/lib/test-log"],
-      "test/*": ["./test/*"]
+      "test-log": ["./test/lib/test-log"]
     }
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,16 +9,16 @@
     "target": "ESNext",
     "esModuleInterop": true,
     "moduleResolution": "node",
-    "baseUrl": ".",
     "types": ["react", "jest", "node", "trusted-types", "jest-extended"],
     "paths": {
-      "development-sandbox": ["test/lib/development-sandbox"],
-      "next-test-utils": ["test/lib/next-test-utils"],
-      "amp-test-utils": ["test/lib/amp-test-utils"],
-      "next-webdriver": ["test/lib/next-webdriver"],
-      "e2e-utils": ["test/lib/e2e-utils"],
-      "test-data-service/*": ["test/lib/test-data-service/*"],
-      "test-log": ["test/lib/test-log"]
+      "development-sandbox": ["./test/lib/development-sandbox"],
+      "next-test-utils": ["./test/lib/next-test-utils"],
+      "amp-test-utils": ["./test/lib/amp-test-utils"],
+      "next-webdriver": ["./test/lib/next-webdriver"],
+      "e2e-utils": ["./test/lib/e2e-utils"],
+      "test-data-service/*": ["./test/lib/test-data-service/*"],
+      "test-log": ["./test/lib/test-log"],
+      "test/*": ["./test/*"]
     }
   }
 }


### PR DESCRIPTION
`baseUrl` is not supposed to be used for catch-all resolutions. It's not recommended outside of AMD modules: https://www.typescriptlang.org/tsconfig#baseUrl.

https://github.com/microsoft/TypeScript/issues/54743 has some more context.
`baseUrl` is not so bad if used in projects where the emit doesn't matter (such is the case for the root tsconfig.json) but I want to avoid having people c&p this option around since it's especially bad for packages that do emit declarations and where we ship those declarations to NPM.

It also allowed importing from just any test which is probably not what we want. The main use case was importing utils which already had corresponding exports in public modules:
```diff
-import { NextInstance } from 'test/lib/next-modes/base'
+import { NextInstance } from 'e2e-utils'

-import { BrowserInterface } from 'test/lib/browsers/base'
+import { BrowserInterface } from 'next-webdriver'
```


## Test plan

- `pnpm build && pnpm tsc -p tsconfig.json --noEmit`

Closes NEXT-3017