### PR TITLE
Rework experimental preload entries handling

### DIFF
--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -236,7 +236,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
     experimental: z
       .strictObject({
         appDocumentPreloading: z.boolean().optional(),
-        allServerChunksPreloading: z.boolean().optional(),
+        preloadEntriesOnStart: z.boolean().optional(),
         adjustFontFallbacks: z.boolean().optional(),
         adjustFontFallbacksWithSizeAdjust: z.boolean().optional(),
         allowedRevalidateHeaderKeys: z.array(z.string()).optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -184,7 +184,7 @@ export interface ExperimentalConfig {
   linkNoTouchStart?: boolean
   caseSensitiveRoutes?: boolean
   appDocumentPreloading?: boolean
-  allServerChunksPreloading?: boolean
+  preloadEntriesOnStart?: boolean
   strictNextHead?: boolean
   clientRouterFilter?: boolean
   clientRouterFilterRedirects?: boolean
@@ -882,7 +882,7 @@ export const defaultConfig: NextConfig = {
     linkNoTouchStart: false,
     caseSensitiveRoutes: false,
     appDocumentPreloading: undefined,
-    allServerChunksPreloading: undefined,
+    preloadEntriesOnStart: undefined,
     clientRouterFilter: true,
     clientRouterFilterRedirects: false,
     fetchCacheKeyPrefix: '',

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -228,31 +228,8 @@ export default class NextNodeServer extends BaseServer {
       }).catch(() => {})
     }
 
-    if (
-      !options.dev &&
-      this.nextConfig.experimental.allServerChunksPreloading
-    ) {
-      const appPathsManifest = this.getAppPathsManifest()
-      const pagesManifest = this.getPagesManifest()
-
-      for (const page of Object.keys(pagesManifest || {})) {
-        loadComponents({ distDir: this.distDir, page, isAppPath: false }).catch(
-          () => {}
-        )
-      }
-
-      for (const page of Object.keys(appPathsManifest || {})) {
-        loadComponents({ distDir: this.distDir, page, isAppPath: true })
-          .then(({ ComponentMod }) => {
-            const webpackRequire = ComponentMod.__next_app__.require
-            if (webpackRequire?.m) {
-              for (const id of Object.keys(webpackRequire.m)) {
-                webpackRequire(id)
-              }
-            }
-          })
-          .catch(() => {})
-      }
+    if (!options.dev && this.nextConfig.experimental.preloadEntriesOnStart) {
+      this.unstable_preloadEntries()
     }
 
     if (!options.dev) {
@@ -292,6 +269,32 @@ export default class NextNodeServer extends BaseServer {
       this.prepare().catch((err) => {
         console.error('Failed to prepare server', err)
       })
+    }
+  }
+
+  public async unstable_preloadEntries(): Promise<void> {
+    const appPathsManifest = this.getAppPathsManifest()
+    const pagesManifest = this.getPagesManifest()
+
+    for (const page of Object.keys(pagesManifest || {})) {
+      await loadComponents({
+        distDir: this.distDir,
+        page,
+        isAppPath: false,
+      }).catch(() => {})
+    }
+
+    for (const page of Object.keys(appPathsManifest || {})) {
+      await loadComponents({ distDir: this.distDir, page, isAppPath: true })
+        .then(async ({ ComponentMod }) => {
+          const webpackRequire = ComponentMod.__next_app__.require
+          if (webpackRequire?.m) {
+            for (const id of Object.keys(webpackRequire.m)) {
+              await webpackRequire(id)
+            }
+          }
+        })
+        .catch(() => {})
     }
   }
 


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/64084 this refactors it a bit and renames the flag. 

Closes NEXT-3018