### PR TITLE
hotfix(next):`next lint` installs `eslint@9` which includes breaking changes

### DIFF
--- a/packages/next/src/lib/eslint/runLintCheck.ts
+++ b/packages/next/src/lib/eslint/runLintCheck.ts
@@ -369,8 +369,16 @@ export async function runLintCheck(
         } else {
           // Check if necessary deps installed, and install any that are missing
           deps = await hasNecessaryDependencies(baseDir, requiredPackages)
-          if (deps.missing.length > 0)
+          if (deps.missing.length > 0) {
+            deps.missing.forEach(({ pkg }) => {
+              if (pkg === 'eslint') {
+                // eslint v9 has breaking changes, so lock to 8 until dependency plugins fully support v9.
+                pkg = 'eslint@^8'
+              }
+            })
+
             await installDependencies(baseDir, deps.missing, true)
+          }
 
           // Write default ESLint config.
           // Check for /pages and src/pages is to make sure this happens in Next.js folder

--- a/packages/next/src/lib/eslint/runLintCheck.ts
+++ b/packages/next/src/lib/eslint/runLintCheck.ts
@@ -370,10 +370,10 @@ export async function runLintCheck(
           // Check if necessary deps installed, and install any that are missing
           deps = await hasNecessaryDependencies(baseDir, requiredPackages)
           if (deps.missing.length > 0) {
-            deps.missing.forEach(({ pkg }) => {
-              if (pkg === 'eslint') {
+            deps.missing.forEach((dep) => {
+              if (dep.pkg === 'eslint') {
                 // eslint v9 has breaking changes, so lock to 8 until dependency plugins fully support v9.
-                pkg = 'eslint@^8'
+                dep.pkg = 'eslint@^8'
               }
             })
 


### PR DESCRIPTION
This is a hotfix since it breaks `next lint`, I'll start to implement eslint v9 for canary.

x-ref: #64114
x-ref: [eslint v9 release](https://github.com/eslint/eslint/releases/tag/v9.0.0)
Fixes #64136