### PR TITLE
chore(next): warn to use `--debug` if dynamic usage error exists

### DIFF
--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -210,7 +210,7 @@ function logDynamicUsageWarning({
   stack?: string
 }): void {
   if (!debugOutput) {
-    warn('Dynamic usage detected. Use `next build --debug` for details.')
+    warn('Dynamic usage error detected. Use `next build --debug` for details.')
     return
   }
 


### PR DESCRIPTION
cc @ztanner
Maybe you'd like to take a look at this!

### Why?

Issue #64146 is a **rare edge case** in which `app/not-found` is dynamic and `pages/404` is static.

This caused the transition from static to dynamic on the production render.

The error bubbled up but was lost during the build, resulting in the following production error, which seems hard to debug without access to Next.js sources.

```
 ⨯ [Error: An error occurred in the Server Components render.
The specific message is omitted in production builds to avoid leaking sensitive details.
A digest property is included on this error instance which may provide additional details
about the nature of the error.] {
  digest: 'DYNAMIC_SERVER_USAGE'
}
```

### How?

Warn to use `build --debug` to ensure the user notices dynamic usage errors that might cause production errors.

```
 Collecting page data ...
 Generating static pages (0/4) ...
 Generating static pages (1/4) 
⚠ Dynamic usage error detected. Use `next build --debug` for details.
 Generating static pages (2/4) 
 Generating static pages (3/4) 
⚠ Dynamic usage error detected. Use `next build --debug` for details.
✓ Generating static pages (4/4)
 Finalizing page optimization ...
 Collecting build traces ...
```

Which could properly give hints as:

```
⚠ Static generation failed due to dynamic usage on /, reason: headers
  at ...
```

### Concern

The recent approach to PPR and handling dynamic usage errors trying to reduce the logs on build, I hope this change is not considered spam.

Fixes #64146