### PR TITLE
perf(image-optimizer): optimize content-type detect

### DIFF
--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -117,40 +117,57 @@ async function writeToCacheDir(
  * https://en.wikipedia.org/wiki/List_of_file_signatures
  */
 export function detectContentType(buffer: Buffer) {
-  if ([0xff, 0xd8, 0xff].every((b, i) => buffer[i] === b)) {
-    return JPEG
+  switch (buffer[0]) {
+    case 0xff:
+      if ([0xff, 0xd8, 0xff].every((b, i) => buffer[i] === b)) {
+        return JPEG
+      }
+      return null
+    case 0x89:
+      if (
+        [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a].every(
+          (b, i) => buffer[i] === b
+        )
+      ) {
+        return PNG
+      }
+      return null
+    case 0x47:
+      if ([0x47, 0x49, 0x46, 0x38].every((b, i) => buffer[i] === b)) {
+        return GIF
+      }
+      return null
+    case 0x52: {
+      if (
+        [0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50].every(
+          (b, i) => !b || buffer[i] === b
+        )
+      ) {
+        return WEBP
+      }
+      return null
+    }
+    case 0x3c:
+      if ([0x3c, 0x3f, 0x78, 0x6d, 0x6c].every((b, i) => buffer[i] === b)) {
+        return SVG
+      }
+      return null
+    case 0x00: {
+      if (
+        [0, 0, 0, 0, 0x66, 0x74, 0x79, 0x70, 0x61, 0x76, 0x69, 0x66].every(
+          (b, i) => !b || buffer[i] === b
+        )
+      ) {
+        return AVIF
+      }
+      if ([0x00, 0x00, 0x01, 0x00].every((b, i) => buffer[i] === b)) {
+        return ICO
+      }
+      return null
+    }
+    default:
+      return null
   }
-  if (
-    [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a].every(
-      (b, i) => buffer[i] === b
-    )
-  ) {
-    return PNG
-  }
-  if ([0x47, 0x49, 0x46, 0x38].every((b, i) => buffer[i] === b)) {
-    return GIF
-  }
-  if (
-    [0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50].every(
-      (b, i) => !b || buffer[i] === b
-    )
-  ) {
-    return WEBP
-  }
-  if ([0x3c, 0x3f, 0x78, 0x6d, 0x6c].every((b, i) => buffer[i] === b)) {
-    return SVG
-  }
-  if (
-    [0, 0, 0, 0, 0x66, 0x74, 0x79, 0x70, 0x61, 0x76, 0x69, 0x66].every(
-      (b, i) => !b || buffer[i] === b
-    )
-  ) {
-    return AVIF
-  }
-  if ([0x00, 0x00, 0x01, 0x00].every((b, i) => buffer[i] === b)) {
-    return ICO
-  }
-  return null
 }
 
 export class ImageOptimizerCache {


### PR DESCRIPTION
Previously, the `detectContentType` function could invocate `Array.prototype.every` over the initial few bytes of the buffer multiple times before determining its content type. In the worst-case scenario, if a non-image file was inadvertently passed to the `imageOptimizer` function, the first few bytes would be invoked by `Array.prototype.every` up to seven times before `detectContentType` acknowledges that it's not a known image type.

This PR fixes the issue by adding an additional check for the first byte. With this change, `Array.prototype.every` will only be invoked at a maximum of two times (as both AVIF and ICO share the same initial byte `0x00`).