### PR TITLE
ensure seeded prefetch entry is renewed after expiry

### DIFF
--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
@@ -115,7 +115,7 @@ describe('createInitialRouterState', () => {
             data: expect.any(Promise),
             prefetchTime: expect.any(Number),
             kind: PrefetchKind.AUTO,
-            lastUsedTime: null,
+            lastUsedTime: expect.any(Number),
             treeAtTimeOfPrefetch: initialTree,
             status: PrefetchCacheEntryStatus.fresh,
           },

--- a/packages/next/src/client/components/router-reducer/prefetch-cache-utils.ts
+++ b/packages/next/src/client/components/router-reducer/prefetch-cache-utils.ts
@@ -168,7 +168,7 @@ export function createPrefetchCacheEntryForInitialLoad({
     data: Promise.resolve(data),
     kind,
     prefetchTime: Date.now(),
-    lastUsedTime: null,
+    lastUsedTime: Date.now(),
     key: prefetchCacheKey,
     status: PrefetchCacheEntryStatus.fresh,
   }

--- a/test/e2e/app-dir/app-client-cache/client-cache.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.test.ts
@@ -390,6 +390,7 @@ createNextDescribe(
           ).toBeTrue()
         })
       })
+
       it('should seed the prefetch cache with the fetched page data', async () => {
         const browser = (await next.browser(
           '/1',
@@ -407,6 +408,25 @@ createNextDescribe(
 
         // The number should be the same as we've seeded it in the prefetch cache when we loaded the full page
         expect(newNumber).toBe(initialNumber)
+      })
+
+      it('should renew the initial seeded data after expiration time', async () => {
+        const browser = (await next.browser(
+          '/without-loading/1',
+          browserConfigWithFixedTime
+        )) as BrowserInterface
+
+        const initialNumber = await browser.elementById('random-number').text()
+
+        // Expire the cache
+        await browser.eval(fastForwardTo, 30 * 1000)
+        await browser.elementByCss('[href="/without-loading"]').click()
+        await browser.elementByCss('[href="/without-loading/1"]').click()
+
+        const newNumber = await browser.elementById('random-number').text()
+
+        // The number should be different, as the seeded data has expired after 30s
+        expect(newNumber).not.toBe(initialNumber)
       })
     }
   }


### PR DESCRIPTION
When we seed the prefetch cache with an entry for the loaded page, we should also mark `lastUsedTime` to be the current time. Otherwise, if the prefetch entry has technically expired, it'll incorrectly be considered "reusable" because the `lastUsedTime` will be set to when it's first routed to client-side. 

x-ref: https://github.com/vercel/next.js/discussions/54075#discussioncomment-9031149
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-3025