### PR TITLE
test: pin eslint version to 8 in test to avoid breaking changes

### DIFF
--- a/test/e2e/new-link-behavior/material-ui.test.ts
+++ b/test/e2e/new-link-behavior/material-ui.test.ts
@@ -26,7 +26,7 @@ describe('New Link Behavior with material-ui', () => {
         'prop-types': 'latest',
         react: 'latest',
         'react-dom': 'latest',
-        eslint: 'latest',
+        eslint: '8',
         'eslint-config-next': 'latest',
       },
     })

--- a/test/e2e/new-link-behavior/material-ui.test.ts
+++ b/test/e2e/new-link-behavior/material-ui.test.ts
@@ -26,7 +26,8 @@ describe('New Link Behavior with material-ui', () => {
         'prop-types': 'latest',
         react: 'latest',
         'react-dom': 'latest',
-        eslint: '8',
+        // Use minimum peer dep version instead of v9 of eslint to avoid breaking changes
+        eslint: '8.56.0',
         'eslint-config-next': 'latest',
       },
     })

--- a/test/production/eslint-plugin-deps/index.test.ts
+++ b/test/production/eslint-plugin-deps/index.test.ts
@@ -95,7 +95,8 @@ describe('eslint plugin deps', () => {
         '@types/node': 'latest',
         '@types/react': 'latest',
         '@types/react-dom': 'latest',
-        eslint: '8',
+        // Use minimum peer dep version instead of v9 of eslint to avoid breaking changes
+        eslint: '8.56.0',
         'eslint-config-next': 'latest',
         typescript: 'latest',
       },

--- a/test/production/eslint-plugin-deps/index.test.ts
+++ b/test/production/eslint-plugin-deps/index.test.ts
@@ -95,7 +95,7 @@ describe('eslint plugin deps', () => {
         '@types/node': 'latest',
         '@types/react': 'latest',
         '@types/react-dom': 'latest',
-        eslint: 'latest',
+        eslint: '8',
         'eslint-config-next': 'latest',
         typescript: 'latest',
       },


### PR DESCRIPTION
x-ref: https://github.com/vercel/next.js/actions/runs/8598454715/job/23559349141?pr=64110

Follow up for #64141

Closes NEXT-3028