### PR TITLE
chore(metadata): only render png content type for og images

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
@@ -98,7 +98,7 @@ async function nextMetadataImageLoader(
       function getImageMetadata(imageMetadata, idParam) {
         const data = {
           alt: imageMetadata.alt,
-          type: imageMetadata.contentType || 'image/png',
+          type: 'image/png',
           url: imageUrl + (idParam ? ('/' + idParam) : '') + ${JSON.stringify(
             hashQuery
           )},


### PR DESCRIPTION
Since `@vercel/og` only supports `image/png`, we always mark the content-type as `image/png`

Closes NEXT-3029