### PR TITLE
chore: externalize undici for bundling

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/serverComponentsExternalPackages.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/serverComponentsExternalPackages.mdx
@@ -68,6 +68,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `ts-node`
 - `typescript`
 - `vscode-oniguruma`
+- `undici`
 - `webpack`
 - `websocket`
 - `zeromq`

--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -46,6 +46,7 @@
   "tailwindcss",
   "ts-node",
   "typescript",
+  "undici",
   "vscode-oniguruma",
   "webpack",
   "websocket",

--- a/test/e2e/app-dir/app-external/app-external.test.ts
+++ b/test/e2e/app-dir/app-external/app-external.test.ts
@@ -21,6 +21,7 @@ createNextDescribe(
     files: __dirname,
     dependencies: {
       swr: 'latest',
+      undici: 'latest',
     },
     packageJson: {
       scripts: {

--- a/test/e2e/app-dir/app-external/app/undici/page.js
+++ b/test/e2e/app-dir/app-external/app/undici/page.js
@@ -1,0 +1,8 @@
+import { request } from 'undici'
+
+export default async function Page() {
+  const { statusCode } = await request('https://example.com')
+  return <div>status: {statusCode}</div>
+}
+
+export const dynamic = 'force-dynamic'


### PR DESCRIPTION
Currently acornjs has an issue with compiling undici, add undici externalize, once it's resolved we can remove the externalization for it

```
You may need an additional loader to handle the result of these loaders.
|       // 5. If object is not a default iterator object for interface,
|       //    then throw a TypeError.
>       if (typeof this !== 'object' || this === null || !(#target in this)) {
|         throw new TypeError(
|           `'next' called on an object that does not implement interface ${name} Iterator.`

Import trace for requested module:
../../../../node_modules/.pnpm/undici@6.12.0/node_modules/undici/lib/web/fetch/util.js
../../../../node_modules/.pnpm/undici@6.12.0/node_modules/undici/lib/web/fetch/headers.js
../../../../node_modules/.pnpm/undici@6.12.0/node_modules/undici/index.js
./app/undici/page.js
```

Closes NEXT-3030