### PR TITLE
Exclude changes that already landed in canary when finding changed tests

### DIFF
--- a/scripts/get-changed-tests.mjs
+++ b/scripts/get-changed-tests.mjs
@@ -50,6 +50,11 @@ export default async function getChangedTests() {
   if (process.env.GITHUB_ACTIONS === 'true') {
     // GH Actions run on the merge commit so HEAD~1:
     // 1. includes all changes in the PR
+    //    e.g. in
+    //    A-B-C-main - F
+    //     \          /
+    //      D-E-branch
+    //    GH actions for `branch` runs on F, so a diff for HEAD~1 includes the diff of D and E combined
     // 2. Includes all changes of the commit for pushes
     diffRevision = 'HEAD~1'
   } else {

--- a/scripts/get-changed-tests.mjs
+++ b/scripts/get-changed-tests.mjs
@@ -47,8 +47,11 @@ export default async function getChangedTests() {
   }
 
   let diffRevision
-  if (process.env.GITHUB_ACTIONS === 'true') {
-    // GH Actions run on the merge commit so HEAD~1:
+  if (
+    process.env.GITHUB_ACTIONS === 'true' &&
+    process.env.GITHUB_EVENT_NAME === 'pull_request'
+  ) {
+    // GH Actions for `pull_request` run on the merge commit so HEAD~1:
     // 1. includes all changes in the PR
     //    e.g. in
     //    A-B-C-main - F

--- a/scripts/get-changed-tests.mjs
+++ b/scripts/get-changed-tests.mjs
@@ -46,16 +46,34 @@ export default async function getChangedTests() {
     return { devTests: [], prodTests: [] }
   }
 
-  try {
-    await execa('git remote set-branches --add origin canary', EXECA_OPTS_STDIO)
-    await execa('git fetch origin canary --depth=20', EXECA_OPTS_STDIO)
-  } catch (err) {
-    console.error(await execa('git remote -v', EXECA_OPTS_STDIO))
-    console.error(`Failed to fetch origin/canary`, err)
+  let diffRevision
+  if (process.env.GITHUB_ACTIONS === 'true') {
+    // GH Actions run on the merge commit so HEAD~1:
+    // 1. includes all changes in the PR
+    // 2. Includes all changes of the commit for pushes
+    diffRevision = 'HEAD~1'
+  } else {
+    try {
+      await execa(
+        'git remote set-branches --add origin canary',
+        EXECA_OPTS_STDIO
+      )
+      await execa('git fetch origin canary --depth=20', EXECA_OPTS_STDIO)
+    } catch (err) {
+      console.error(await execa('git remote -v', EXECA_OPTS_STDIO))
+      console.error(`Failed to fetch origin/canary`, err)
+    }
+    // TODO: We should diff against the merge base with origin/canary not directly against origin/canary.
+    // A --- B ---- origin/canary
+    //  \
+    //   \-- C ---- HEAD
+    // `git diff origin/canary` includes B and C
+    // But we should only include C.
+    diffRevision = 'origin/canary'
   }
 
   const changesResult = await execa(
-    `git diff origin/canary --name-only`,
+    `git diff ${diffRevision} --name-only`,
     EXECA_OPTS
   ).catch((err) => {
     console.error(err)


### PR DESCRIPTION
Since GitHub Workflows run on the merge commit instead of branch head on `pull_request` events<sup>1</sup>, we don't need to diff against (the merge base with) `origin/canary` and can shortcut to `HEAD~1` which would also works for push events where you'd just want the diff for that commit.

Notice how on https://github.com/vercel/next.js/actions/runs/8601913701/job/23573401816?pr=64117 we included changes that weren't on my branch but landed between the CI job starting and `git diff origin/canary` running:

```

git diff:

Cargo.lock
examples/with-apollo/README.md
examples/with-apollo/components/App.js
examples/with-apollo/components/ErrorMessage.js
examples/with-apollo/components/Header.js
examples/with-apollo/components/InfoBox.js
examples/with-apollo/components/PostList.js
examples/with-apollo/components/PostUpvoter.js
examples/with-apollo/components/Submit.js
examples/with-apollo/lib/apolloClient.js
examples/with-apollo/next.config.mjs
examples/with-apollo/package.json
examples/with-apollo/pages/_app.js
examples/with-apollo/pages/about.js
examples/with-apollo/pages/client-only.js
examples/with-apollo/pages/index.js
examples/with-apollo/pages/ssr.js
examples/with-apollo/src/app/favicon.ico
examples/with-apollo/src/app/globals.css
examples/with-apollo/src/app/layout.tsx
examples/with-apollo/src/app/page.tsx
examples/with-apollo/src/client-components/apollo-client-provider.tsx
examples/with-apollo/src/client-components/index.ts
examples/with-apollo/src/client-components/repo-list.tsx
examples/with-apollo/tsconfig.json
examples/with-graphql-hooks/README.md
examples/with-graphql-hooks/components/app.js
examples/with-graphql-hooks/components/error-message.js
examples/with-graphql-hooks/components/header.js
examples/with-graphql-hooks/components/post-list.js
examples/with-graphql-hooks/components/post-upvoter.js
examples/with-graphql-hooks/components/submit.js
examples/with-graphql-hooks/lib/graphql-client.js
examples/with-graphql-hooks/lib/graphql-request.js
examples/with-graphql-hooks/next.config.mjs
examples/with-graphql-hooks/package.json
examples/with-graphql-hooks/pages/_app.js
examples/with-graphql-hooks/pages/about.js
examples/with-graphql-hooks/pages/index.js
examples/with-graphql-hooks/src/app/favicon.ico
examples/with-graphql-hooks/src/app/globals.css
examples/with-graphql-hooks/src/app/layout.tsx
examples/with-graphql-hooks/src/app/page.tsx
examples/with-graphql-hooks/src/client-components/client-context-provider.tsx
examples/with-graphql-hooks/src/client-components/index.ts
examples/with-graphql-hooks/src/client-components/repo-list.tsx
examples/with-graphql-hooks/styles.css
examples/with-graphql-hooks/tsconfig.json
```

## Test plan

- [x] CI run on this PR only detects `scripts/test-new-tests.mjs` in changed files: https://github.com/vercel/next.js/actions/runs/8605588371/job/23582195980?pr=64218#step:27:30
- [x] cherry-picked onto https://github.com/vercel/next.js/pull/64117 and verified the changed tests are still recognized: https://github.com/vercel/next.js/actions/runs/8605523039/job/23581990844?pr=64117#step:27:30

Closes NEXT-3038

## Sources

<sup>1</sup>
> Last merge commit on the GITHUB_REF branch

-- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request