### PR TITLE
forward missing server actions to valid worker if one exists

### DIFF
--- a/packages/next/src/server/app-render/action-utils.ts
+++ b/packages/next/src/server/app-render/action-utils.ts
@@ -1,4 +1,7 @@
 import type { ActionManifest } from '../../build/webpack/plugins/flight-client-entry-plugin'
+import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
+import { pathHasPrefix } from '../../shared/lib/router/utils/path-has-prefix'
+import { removePathPrefix } from '../../shared/lib/router/utils/remove-path-prefix'
 
 // This function creates a Flight-acceptable server module map proxy from our
 // Server Reference Manifest similar to our client module map.
@@ -18,11 +21,57 @@ export function createServerModuleMap({
         return {
           id: serverActionsManifest[
             process.env.NEXT_RUNTIME === 'edge' ? 'edge' : 'node'
-          ][id].workers['app' + pageName],
+          ][id].workers[normalizeWorkerPageName(pageName)],
           name: id,
           chunks: [],
         }
       },
     }
   )
+}
+
+/**
+ * Checks if the requested action has a worker for the current page.
+ * If not, it returns the first worker that has a handler for the action.
+ */
+export function selectWorkerForForwarding(
+  actionId: string,
+  pageName: string,
+  serverActionsManifest: ActionManifest
+) {
+  const workers =
+    serverActionsManifest[
+      process.env.NEXT_RUNTIME === 'edge' ? 'edge' : 'node'
+    ][actionId]?.workers
+  const workerName = normalizeWorkerPageName(pageName)
+
+  // no workers, nothing to forward to
+  if (!workers) return
+
+  // if there is a worker for this page, no need to forward it.
+  if (workers[workerName]) {
+    return
+  }
+
+  // otherwise, grab the first worker that has a handler for this action id
+  return denormalizeWorkerPageName(Object.keys(workers)[0])
+}
+
+/**
+ * The flight entry loader keys actions by bundlePath.
+ * bundlePath corresponds with the relative path (including 'app') to the page entrypoint.
+ */
+function normalizeWorkerPageName(pageName: string) {
+  if (pathHasPrefix(pageName, 'app')) {
+    return pageName
+  }
+
+  return 'app' + pageName
+}
+
+/**
+ * Converts a bundlePath (relative path to the entrypoint) to a routable page name
+ */
+function denormalizeWorkerPageName(bundlePath: string) {
+  return normalizeAppPath(removePathPrefix(bundlePath, 'app'))
 }

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -512,6 +512,45 @@ createNextDescribe(
       ).toBe(true)
     })
 
+    it.each(['node', 'edge'])(
+      'should forward action request to a worker that contains the action handler (%s)',
+      async (runtime) => {
+        const cliOutputIndex = next.cliOutput.length
+        const browser = await next.browser(`/delayed-action/${runtime}`)
+
+        // confirm there's no data yet
+        expect(await browser.elementById('delayed-action-result').text()).toBe(
+          ''
+        )
+
+        // Trigger the delayed action. This will sleep for a few seconds before dispatching the server action handler
+        await browser.elementById('run-action').click()
+
+        // navigate away from the page
+        await browser
+          .elementByCss(`[href='/delayed-action/${runtime}/other']`)
+          .click()
+          .waitForElementByCss('#other-page')
+
+        await retry(async () => {
+          expect(
+            await browser.elementById('delayed-action-result').text()
+          ).toMatch(
+            // matches a Math.random() string
+            /0\.\d+/
+          )
+        })
+
+        // make sure that we still are rendering other-page content
+        expect(await browser.hasElementByCssSelector('#other-page')).toBe(true)
+
+        // make sure we didn't get any errors in the console
+        expect(next.cliOutput.slice(cliOutputIndex)).not.toContain(
+          'Failed to find Server Action'
+        )
+      }
+    )
+
     if (isNextStart) {
       it('should not expose action content in sourcemaps', async () => {
         const sourcemap = (

--- a/test/e2e/app-dir/actions/app/delayed-action/actions.ts
+++ b/test/e2e/app-dir/actions/app/delayed-action/actions.ts
@@ -1,0 +1,8 @@
+'use server'
+import { revalidatePath } from 'next/cache'
+
+export const action = async () => {
+  console.log('revalidating')
+  revalidatePath('/delayed-action', 'page')
+  return Math.random()
+}

--- a/test/e2e/app-dir/actions/app/delayed-action/button.tsx
+++ b/test/e2e/app-dir/actions/app/delayed-action/button.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { useContext } from 'react'
+import { action } from './actions'
+import { DataContext } from './context'
+
+export function Button() {
+  const { setData } = useContext(DataContext)
+  const handleClick = async () => {
+    await new Promise((res) => setTimeout(res, 1000))
+
+    const result = await action()
+
+    setData(result)
+  }
+  return (
+    <button onClick={handleClick} id="run-action">
+      Run Action
+    </button>
+  )
+}

--- a/test/e2e/app-dir/actions/app/delayed-action/context.tsx
+++ b/test/e2e/app-dir/actions/app/delayed-action/context.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+
+export const DataContext = React.createContext<{
+  data: number | null
+  setData: (number: number) => void
+}>({ data: null, setData: () => {} })

--- a/test/e2e/app-dir/actions/app/delayed-action/edge/layout.tsx
+++ b/test/e2e/app-dir/actions/app/delayed-action/edge/layout.tsx
@@ -1,0 +1,1 @@
+export { default } from '../layout-edge'

--- a/test/e2e/app-dir/actions/app/delayed-action/edge/other/page.tsx
+++ b/test/e2e/app-dir/actions/app/delayed-action/edge/other/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../other-page'

--- a/test/e2e/app-dir/actions/app/delayed-action/edge/page.tsx
+++ b/test/e2e/app-dir/actions/app/delayed-action/edge/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+import { Button } from '../button'
+
+export default function Page() {
+  return (
+    <>
+      <div>
+        <Link href="/delayed-action/edge/other">Navigate to Other Page</Link>
+      </div>
+      <div>
+        <Button />
+      </div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/actions/app/delayed-action/layout-edge.tsx
+++ b/test/e2e/app-dir/actions/app/delayed-action/layout-edge.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+export const runtime = 'edge'
+
+import { useState } from 'react'
+import { DataContext } from './context'
+
+export default function Layout({ children }) {
+  const [data, setData] = useState<number | null>(null)
+
+  return (
+    <DataContext.Provider value={{ data, setData }}>
+      <div>{children}</div>
+      <div id="delayed-action-result">{data}</div>
+    </DataContext.Provider>
+  )
+}

--- a/test/e2e/app-dir/actions/app/delayed-action/layout-node.tsx
+++ b/test/e2e/app-dir/actions/app/delayed-action/layout-node.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { useState } from 'react'
+import { DataContext } from './context'
+
+export default function Layout({ children }) {
+  const [data, setData] = useState<number | null>(null)
+
+  return (
+    <DataContext.Provider value={{ data, setData }}>
+      <div>{children}</div>
+      <div id="delayed-action-result">{data}</div>
+    </DataContext.Provider>
+  )
+}

--- a/test/e2e/app-dir/actions/app/delayed-action/node/layout.tsx
+++ b/test/e2e/app-dir/actions/app/delayed-action/node/layout.tsx
@@ -1,0 +1,1 @@
+export { default } from '../layout-node'

--- a/test/e2e/app-dir/actions/app/delayed-action/node/other/page.tsx
+++ b/test/e2e/app-dir/actions/app/delayed-action/node/other/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../other-page'

--- a/test/e2e/app-dir/actions/app/delayed-action/node/page.tsx
+++ b/test/e2e/app-dir/actions/app/delayed-action/node/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+import { Button } from '../button'
+
+export default function Page() {
+  return (
+    <>
+      <div>
+        <Link href="/delayed-action/node/other">Navigate to Other Page</Link>
+      </div>
+      <div>
+        <Button />
+      </div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/actions/app/delayed-action/other-page.tsx
+++ b/test/e2e/app-dir/actions/app/delayed-action/other-page.tsx
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default function Other() {
+  return (
+    <div id="other-page">
+      Hello from Other Page <Link href="/delayed-action">Back</Link>
+    </div>
+  )
+}


### PR DESCRIPTION
### What
When submitting a server action on a page that doesn't import the action handler, a "Failed to find server action" error is thrown, even if there's a valid handler for it elsewhere.

### Why
Workers for a particular server action ID are keyed by their page entrypoints, and the client router invokes the current page when triggering a server action, since it assumes it's available on the current page. If an action is invoked after the router has moved away from a page that can handle the action, then the action wouldn't run and an error would be thrown in the server console.

### How
We try to find a valid worker to forward the action to, if one exists. Otherwise it'll fallback to the usual error handling. This also adds a header to opt out of rendering the flight tree, as if the action calls a `revalidate` API, then it'll return a React tree corresponding with the wrong page. 

Fixes #61918
Fixes #63915

Closes NEXT-2489
