### PR TITLE
chore(cli): fix the order `--experimental-debug-memory-usage` so it's alphabetical

### DIFF
--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -106,9 +106,9 @@ program
   )
   .option('-d, --debug', 'Enables a more verbose build output.')
 
-  .option('--profile', 'Enables production profiling for React.')
   .option('--no-lint', 'Disables linting.')
   .option('--no-mangling', 'Disables mangling.')
+  .option('--profile', 'Enables production profiling for React.')
   .option('--experimental-app-only', 'Builds only App Router routes.')
   .addOption(new Option('--experimental-turbo').hideHelp())
   .addOption(

--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -105,10 +105,7 @@ program
     )}`
   )
   .option('-d, --debug', 'Enables a more verbose build output.')
-  .option(
-    '--experimental-debug-memory-usage',
-    'Enables memory profiling features to debug memory consumption.'
-  )
+
   .option('--profile', 'Enables production profiling for React.')
   .option('--no-lint', 'Disables linting.')
   .option('--no-mangling', 'Disables mangling.')
@@ -121,6 +118,10 @@ program
     )
       .choices(['compile', 'generate'])
       .default('default')
+  )
+  .option(
+    '--experimental-debug-memory-usage',
+    'Enables memory profiling features to debug memory consumption.'
   )
   .action((directory, options) =>
     // ensure process exits after build completes so open handles/connections


### PR DESCRIPTION
## Why?

This fixes the ordering of `--experimental-debug-memory-usage` so the help output for experimental options are alphabetical/ordered properly (grouped at the end).

- Related https://github.com/vercel/next.js/pull/63869

Closes NEXT-3054