### PR TITLE
docs(cli): re-order profile to match help output

### DIFF
--- a/docs/02-app/02-api-reference/08-next-cli.mdx
+++ b/docs/02-app/02-api-reference/08-next-cli.mdx
@@ -191,16 +191,6 @@ Options:
   -h, --help                        Displays this message.
 ```
 
-### Profiling
-
-You can enable production profiling for React with the `--profile` flag in `next build`.
-
-```bash filename="Terminal"
-next build --profile
-```
-
-After that, you can use the profiler in the same way as you would in development.
-
 ### Debug
 
 You can enable more verbose build output with the `--debug` flag in `next build`.
@@ -228,6 +218,16 @@ next build --no-mangling
 ```
 
 > **Good to know**: This may affect performance and should only be used for debugging purposes.
+
+### Profiling
+
+You can enable production profiling for React with the `--profile` flag in `next build`.
+
+```bash filename="Terminal"
+next build --profile
+```
+
+After that, you can use the profiler in the same way as you would in development.
 
 ## Production
 


### PR DESCRIPTION
## Why?

Forgot to add this change in here → https://github.com/vercel/next.js/pull/64264.

Closes NEXT-3055