### PR TITLE
chore(docs): update wrong route in staleTimes.mdx

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/staleTimes.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/staleTimes.mdx
@@ -36,7 +36,7 @@ The `static` and `dynamic` properties correspond with the time period (in second
 >
 > - [Loading boundaries](/docs/app/api-reference/file-conventions/loading) are considered reusable for the `static` period defined in this configuration.
 > - This doesn't disable [partial rendering support](/docs/app/building-your-application/routing/linking-and-navigating#4-partial-rendering), **meaning shared layouts won't automatically be refetched every navigation, only the new segment data.**
-> - This doesn't change [back/forward caching](/app/building-your-application/caching#router-cache) behavior to prevent layout shift & to prevent losing the browser scroll position.
+> - This doesn't change [back/forward caching](/docs/app/building-your-application/caching#router-cache) behavior to prevent layout shift & to prevent losing the browser scroll position.
 > - The different properties of this config refer to variable levels of "liveness" and are unrelated to whether the segment itself is opting into static or dynamic rendering. In other words, the current `static` default of 5 minutes suggests that data feels static by virtue of it being revalidated infrequently.
 
 You can learn more about the Client Router Cache [here](/docs/app/building-your-application/caching#router-cache).


### PR DESCRIPTION
This fixes a wrong route in the [staleTimes](https://nextjs.org/docs/app/api-reference/next-config-js/staleTimes) doc

