### PR TITLE
add additional handling to prevent double redirects in streaming context

### DIFF
--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -460,7 +460,7 @@ createNextDescribe(
 
         it.each([
           '/redirect/servercomponent',
-          'redirect/redirect-with-loading',
+          '/redirect/redirect-with-loading',
         ])('should only trigger the redirect once (%s)', async (path) => {
           const browser = await next.browser(path)
           const initialTimestamp = await browser
@@ -497,6 +497,17 @@ createNextDescribe(
             }
             // If it's our "forcing continue" error, do nothing. This means we succeeded.
           }
+        })
+
+        it('should handle the streaming redirect when JavaScript is disabled', async () => {
+          const browser = await next.browser(
+            '/redirect/redirect-with-loading',
+            { disableJavaScript: true }
+          )
+
+          await browser.waitForElementByCss('#timestamp')
+
+          expect(await browser.url()).toBe(next.url + '/redirect/result')
         })
       })
 


### PR DESCRIPTION
In #63786, handling was added to the client side router to abort the SPA navigation if a `meta http-equiv="refresh"` tag was inserted into the DOM.

However, this doesn't consider the case where the `meta` tag is inserted after (or at the same time) as the client side handling of the redirect. This could lead to the client handling the nav, followed by the meta tag being inserted into the DOM, which would then trigger an MPA navigation. To the end-user this would look like the page they were redirected to got reloaded.

Once the meta tag is inserted into the DOM, we can't tell the browser to abort the request. This updates the server inserted HTML to inject a script tag that checks if hydration has already occurred before inserting the meta tag. If it has been, this is a no-op, as the client-side router will handle the redirect instead. This also adds the previous meta tag behavior inside of a `noscript` tag as a fallback for cases where JavaScript isn't supported.

### Test Plan
Since this is inherently flaky based on the order that the streaming operations happen in, I couldn't think of a good test beyond the one that was added in #63786. However, when testing locally, I added an artificial delay to flushing the server inserted HTML and it correctly aborted inserting the meta tag if the client already handled it.

I also added a test to verify that the meta redirect is working properly when JavaScript is disabled -- wasn't sure if that was covered elsewhere already, but seemed like a good one to add. 

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-3070