### PR TITLE
Update 13-debugging.mdx

### DIFF
--- a/docs/03-pages/01-building-your-application/06-configuring/13-debugging.mdx
+++ b/docs/03-pages/01-building-your-application/06-configuring/13-debugging.mdx
@@ -32,20 +32,16 @@ Create a file named `.vscode/launch.json` at the root of your project with the f
       "type": "node",
       "request": "launch",
       "program": "${workspaceFolder}/node_modules/.bin/next",
-      "runtimeArgs": [
-          "--inspect"
-      ],
-      "skipFiles": [
-          "<node_internals>/**"
-      ],
+      "runtimeArgs": ["--inspect"],
+      "skipFiles": ["<node_internals>/**"],
       "serverReadyAction": {
-          "action": "debugWithEdge",
-          "killOnServerStop": true,
-          "webRoot": "${workspaceFolder}",
-          "pattern": "- Local:.+(https?://.+)",
-          "uriFormat": "%s"
+        "action": "debugWithEdge",
+        "killOnServerStop": true,
+        "pattern": "- Local:.+(https?://.+)",
+        "uriFormat": "%s",
+        "webRoot": "${workspaceFolder}"
       }
-  }
+    }
   ]
 }
 ```

--- a/docs/03-pages/01-building-your-application/06-configuring/13-debugging.mdx
+++ b/docs/03-pages/01-building-your-application/06-configuring/13-debugging.mdx
@@ -29,15 +29,23 @@ Create a file named `.vscode/launch.json` at the root of your project with the f
     },
     {
       "name": "Next.js: debug full stack",
-      "type": "node-terminal",
+      "type": "node",
       "request": "launch",
-      "command": "npm run dev",
+      "program": "${workspaceFolder}/node_modules/.bin/next",
+      "runtimeArgs": [
+          "--inspect"
+      ],
+      "skipFiles": [
+          "<node_internals>/**"
+      ],
       "serverReadyAction": {
-        "pattern": "- Local:.+(https?://.+)",
-        "uriFormat": "%s",
-        "action": "debugWithChrome"
+          "action": "debugWithEdge",
+          "killOnServerStop": true,
+          "webRoot": "${workspaceFolder}",
+          "pattern": "- Local:.+(https?://.+)",
+          "uriFormat": "%s"
       }
-    }
+  }
   ]
 }
 ```


### PR DESCRIPTION
This doc is outdated as mentioned as this issue has been going on for years now where people are unable to debug/set breakpoints in VSCode due to some mismatch of port/process configuration b/w VSC, Next/Node or Browser(Chrome Dev tools).

Regardless, I found the fix on https://github.com/vercel/next.js/issues/47561#issuecomment-1549241442 and it works like a charm. 

Kindly update your docs accordingly. Thanks.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
