### PR TITLE
refactor: next-flight-client-module-loader return conditions

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-flight-client-module-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-client-module-loader.ts
@@ -1,24 +1,25 @@
+import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import { getRSCModuleInformation } from '../../analysis/get-page-static-info'
 import { getModuleBuildInfo } from './get-module-build-info'
 
-export default function transformSource(
-  this: any,
-  source: string,
-  sourceMap: any
-) {
-  // Avoid buffer to be consumed
-  if (typeof source !== 'string') {
-    throw new Error('Expected source to have been transformed to a string.')
-  }
+const flightClientModuleLoader: webpack.LoaderDefinitionFunction =
+  function transformSource(this, source: string, sourceMap: any) {
+    // Avoid buffer to be consumed
+    if (typeof source !== 'string') {
+      throw new Error('Expected source to have been transformed to a string.')
+    }
 
-  // Assign the RSC meta information to buildInfo.
-  const buildInfo = getModuleBuildInfo(this._module)
-  buildInfo.rsc = getRSCModuleInformation(source, false)
+    if (!this._module) {
+      return source
+    }
+    // Assign the RSC meta information to buildInfo.
+    const buildInfo = getModuleBuildInfo(this._module)
+    buildInfo.rsc = getRSCModuleInformation(source, false)
 
-  // This is a server action entry module in the client layer. We need to attach
-  // noop exports of `callServer` wrappers for each action.
-  if (buildInfo.rsc.actions) {
-    source = `
+    // This is a server action entry module in the client layer. We need to attach
+    // noop exports of `callServer` wrappers for each action.
+    if (buildInfo.rsc.actions) {
+      return `
 import { callServer } from 'next/dist/client/app-call-server'
 
 function __build_action__(action, args) {
@@ -27,7 +28,9 @@ function __build_action__(action, args) {
 
 ${source}
 `
+    }
+
+    return this.callback(null, source, sourceMap)
   }
 
-  return this.callback(null, source, sourceMap)
-}
+export default flightClientModuleLoader


### PR DESCRIPTION
* Early return if the `this._module` doesn't exist, aligning with the type
* If the source is changed, we should return the changed source otherwise the indexes in source map will be wrong unless the modified code is appended to the source code, but in this loader it's a different case

Closes NEXT-3075