### PR TITLE
fix(logs): filter logs with URLs containing _rsc=

### DIFF
--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1132,13 +1132,13 @@ export default class NextNodeServer extends BaseServer {
           'originalResponse' in _res ? _res.originalResponse : _res
 
         const reqStart = Date.now()
+        // We don't log for non-route requests,
+        // need to be accessed before and outside of `reqCallback`.
+        const isRouteRequest = getRequestMeta(req).match
+        const isRSC = isRSCRequestCheck(req)
 
         const reqCallback = () => {
-          // we don't log for non-route requests
-          const isRouteRequest = getRequestMeta(req).match
-          const isRSC = isRSCRequestCheck(req)
-          const hasRSCParam = req.url?.includes('_rsc=')
-          if (!isRouteRequest || isRSC || hasRSCParam) return
+          if (!isRouteRequest || isRSC) return
 
           const reqEnd = Date.now()
           const fetchMetrics = normalizedReq.fetchMetrics || []

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -107,6 +107,7 @@ import { interopDefault } from '../lib/interop-default'
 import { formatDynamicImportPath } from '../lib/format-dynamic-import-path'
 import type { NextFontManifest } from '../build/webpack/plugins/next-font-manifest-plugin'
 import { isInterceptionRouteRewrite } from '../lib/generate-interception-routes-rewrites'
+import { parseRelativeUrl } from '../shared/lib/router/utils/parse-relative-url'
 
 export * from './base-server'
 
@@ -1138,7 +1139,13 @@ export default class NextNodeServer extends BaseServer {
         const isRSC = isRSCRequestCheck(req)
 
         const reqCallback = () => {
-          if (!isRouteRequest || isRSC) return
+          // we don't log for non-route requests
+          const isRSC = isRSCRequestCheck(req)
+          const isRouteRequest = getRequestMeta(req).match
+          const { query } = parseRelativeUrl(req.url || '')
+          // TODO: rsc headers are stripped from the request rn, so we need to check the query.
+          // Once we figured out how to strip the flight headers properly, we can remove this check.
+          if (!isRouteRequest || isRSC || query['_rsc']) return
 
           const reqEnd = Date.now()
           const fetchMetrics = normalizedReq.fetchMetrics || []

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1133,10 +1133,6 @@ export default class NextNodeServer extends BaseServer {
           'originalResponse' in _res ? _res.originalResponse : _res
 
         const reqStart = Date.now()
-        // We don't log for non-route requests,
-        // need to be accessed before and outside of `reqCallback`.
-        const isRouteRequest = getRequestMeta(req).match
-        const isRSC = isRSCRequestCheck(req)
 
         const reqCallback = () => {
           // we don't log for non-route requests

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1137,7 +1137,8 @@ export default class NextNodeServer extends BaseServer {
           // we don't log for non-route requests
           const isRouteRequest = getRequestMeta(req).match
           const isRSC = isRSCRequestCheck(req)
-          if (!isRouteRequest || isRSC) return
+          const hasRSCParam = req.url?.includes('_rsc=')
+          if (!isRouteRequest || isRSC || hasRSCParam) return
 
           const reqEnd = Date.now()
           const fetchMetrics = normalizedReq.fetchMetrics || []


### PR DESCRIPTION
`reqCallback` is called when response is ended where the flight headers are stripped, we should do it earlier otherwise it might still get the `isRSC` condition false that will log the url with `_rsc` query

[Slack thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1712795639336399)

Closes NEXT-3078