### PR TITLE
Ensure build-native is in needs properly

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -154,7 +154,7 @@ jobs:
 
   test-turbopack-dev:
     name: test turbopack dev
-    needs: ['changes', 'build-next']
+    needs: ['changes', 'build-next', 'build-native']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
 
     strategy:
@@ -169,7 +169,7 @@ jobs:
 
   test-turbopack-integration:
     name: test turbopack development integration
-    needs: ['changes', 'build-next']
+    needs: ['changes', 'build-next', 'build-native']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
 
     strategy:
@@ -185,7 +185,7 @@ jobs:
 
   test-turbopack-production:
     name: test turbopack production
-    needs: ['changes', 'build-next']
+    needs: ['changes', 'build-next', 'build-native']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
 
     strategy:
@@ -201,7 +201,7 @@ jobs:
 
   test-turbopack-production-integration:
     name: test turbopack production integration
-    needs: ['changes', 'build-next']
+    needs: ['changes', 'build-next', 'build-native']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
 
     strategy:


### PR DESCRIPTION
This ensures we don't un-necessarily re-run the `build-native` job across all CIs from cache misses while a build is pending. 



Closes NEXT-3080