### PR TITLE
Documentation change for with-docker-compose

### DIFF
--- a/examples/with-docker-compose/README.md
+++ b/examples/with-docker-compose/README.md
@@ -88,6 +88,8 @@ docker compose -f docker-compose.prod-without-multistage.yml build
 docker compose -f docker-compose.prod-without-multistage.yml up -d
 ```
 
+[For self-hosted using this image with next/image needs sharp.](https://nextjs.org/docs/messages/sharp-missing-in-production)
+
 Open [http://localhost:3000](http://localhost:3000).
 
 ## Useful commands


### PR DESCRIPTION
### Improving Documentation
Hello i faced with the problem that in examples (with-docker-compose) production image if you are self hosting needs sharp if you also use next/image so instead of directly changing the prod.Dockerfile i changed the documentation and added it there.
thank you, next

Solves #64362 