### PR TITLE
Fix: css in next/dynamic component in edge runtime

### DIFF
--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -244,7 +244,13 @@ export async function adapter(
           )
       )
     }
-    return params.handler(request, event)
+    return RequestAsyncStorageWrapper.wrap(
+      requestAsyncStorage,
+      {
+        req: request,
+      },
+      () => params.handler(request, event)
+    )
   })
 
   // check if response is a Response object

--- a/packages/next/src/shared/lib/lazy-dynamic/preload-css.tsx
+++ b/packages/next/src/shared/lib/lazy-dynamic/preload-css.tsx
@@ -5,10 +5,10 @@ export function PreloadCss({ moduleIds }: { moduleIds: string[] | undefined }) {
   if (typeof window !== 'undefined') {
     return null
   }
-  const {
-    getExpectedRequestStore,
-  } = require('../../../client/components/request-async-storage.external')
-  const requestStore = getExpectedRequestStore()
+  const getExpectedRequestStore: typeof import('../../../client/components/request-async-storage.external').getExpectedRequestStore =
+    require('../../../client/components/request-async-storage.external').getExpectedRequestStore
+
+  const requestStore = getExpectedRequestStore('next/dynamic css')
 
   const allFiles = []
 

--- a/test/e2e/app-dir/dynamic-css/app/ssr/edge/page.js
+++ b/test/e2e/app-dir/dynamic-css/app/ssr/edge/page.js
@@ -1,0 +1,3 @@
+export { default } from '../page'
+
+export const runtime = 'edge'

--- a/test/e2e/app-dir/dynamic-css/app/ssr/page.js
+++ b/test/e2e/app-dir/dynamic-css/app/ssr/page.js
@@ -9,3 +9,4 @@ export default function Page() {
 }
 
 export const dynamic = 'force-dynamic'
+export const runtime = 'edge'

--- a/test/e2e/app-dir/dynamic-css/app/ssr/page.js
+++ b/test/e2e/app-dir/dynamic-css/app/ssr/page.js
@@ -9,4 +9,3 @@ export default function Page() {
 }
 
 export const dynamic = 'force-dynamic'
-export const runtime = 'edge'

--- a/test/e2e/app-dir/dynamic-css/index.test.ts
+++ b/test/e2e/app-dir/dynamic-css/index.test.ts
@@ -31,7 +31,7 @@ createNextDescribe(
       })
     })
 
-    it('should only apply corresponding css for page loaded that /ssr', async () => {
+    it('should only apply corresponding css for page loaded in edge runtime', async () => {
       const browser = await next.browser('/ssr/edge')
       await retry(async () => {
         expect(

--- a/test/e2e/app-dir/dynamic-css/index.test.ts
+++ b/test/e2e/app-dir/dynamic-css/index.test.ts
@@ -31,6 +31,23 @@ createNextDescribe(
       })
     })
 
+    it('should only apply corresponding css for page loaded that /ssr', async () => {
+      const browser = await next.browser('/ssr/edge')
+      await retry(async () => {
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('.text')).color`
+          )
+        ).toBe('rgb(255, 0, 0)')
+        // Default border width, which is not effected by bar.css that is not loaded in /ssr
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.querySelector('.text')).borderWidth`
+          )
+        ).toBe('0px')
+      })
+    })
+
     it('should only apply corresponding css for page loaded that /another', async () => {
       const browser = await next.browser('/another')
       await retry(async () => {


### PR DESCRIPTION
### What

Wrap async local storage for all edge runtime routes in adapter 

Basically fixed the case reported in [this tweet](https://x.com/keegandonley/status/1778538456458854880)

### Why

We're relying on the ALS for dynamic css preloading but we didn't wrap the ALS for request handlers for edge. So if you have CSS imports in `next/dynamic` in edge runtime it would break.

Closes NEXT-3085