### PR TITLE
use pathToFileUrl to make esm import()s work with absolute windows paths

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,7 @@ stages:
             condition: eq(variables['isDocsOnly'], 'No')
 
           - script: |
-              node run-tests.js -c 1 test/production/pages-dir/production/test/index.test.ts test/integration/css-client-nav/test/index.test.js test/integration/rewrites-has-condition/test/index.test.js
+              node run-tests.js -c 1 test/production/pages-dir/production/test/index.test.ts test/integration/css-client-nav/test/index.test.js test/integration/rewrites-has-condition/test/index.test.js test/integration/create-next-app/examples.test.ts test/integration/create-next-app/index.test.ts test/integration/create-next-app/package-manager/npm.test.ts test/integration/create-next-app/package-manager/pnpm.test.ts test/integration/create-next-app/package-manager/yarn.test.ts test/integration/create-next-app/prompts.test.ts test/integration/create-next-app/templates/app.test.ts test/integration/create-next-app/templates/pages.test.ts
             condition: eq(variables['isDocsOnly'], 'No')
             displayName: 'Run tests'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,8 +69,9 @@ stages:
           - script: npx playwright@1.35.1 install chromium
             condition: eq(variables['isDocsOnly'], 'No')
 
+          # Test critical app router and CNA tests to cover basic usage cases with windows
           - script: |
-              node run-tests.js -c 1 test/production/pages-dir/production/test/index.test.ts test/integration/css-client-nav/test/index.test.js test/integration/rewrites-has-condition/test/index.test.js test/integration/create-next-app/examples.test.ts test/integration/create-next-app/index.test.ts test/integration/create-next-app/package-manager/npm.test.ts test/integration/create-next-app/package-manager/pnpm.test.ts test/integration/create-next-app/package-manager/yarn.test.ts test/integration/create-next-app/prompts.test.ts test/integration/create-next-app/templates/app.test.ts test/integration/create-next-app/templates/pages.test.ts
+              node run-tests.js -c 1 test/production/pages-dir/production/test/index.test.ts test/integration/css-client-nav/test/index.test.js test/integration/rewrites-has-condition/test/index.test.js test/integration/create-next-app/examples.test.ts test/integration/create-next-app/index.test.ts test/integration/create-next-app/package-manager/pnpm.test.ts
             condition: eq(variables['isDocsOnly'], 'No')
             displayName: 'Run tests'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,7 @@ stages:
             condition: eq(variables['isDocsOnly'], 'No')
 
           - script: |
-              node run-tests.js -c 1 test/production/pages-dir/production/test/index.test.ts test/integration/css-client-nav/test/index.test.js test/integration/rewrites-has-condition/test/index.test.js test/integration/create-next-app/examples.test.ts test/integration/create-next-app/index.test.ts test/integration/create-next-app/package-manager/npm.test.ts test/integration/create-next-app/package-manager/pnpm.test.ts test/integration/create-next-app/package-manager/yarn.test.ts test/integration/create-next-app/prompts.test.ts test/integration/create-next-app/templates/app.test.ts test/integration/create-next-app/templates/pages.test.ts
+              node run-tests.js -c 1 test/production/pages-dir/production/test/index.test.ts test/integration/css-client-nav/test/index.test.js test/integration/rewrites-has-condition/test/index.test.js test/integration/create-next-app/examples.test.ts test/integration/create-next-app/index.test.ts test/integration/create-next-app/package-manager/npm.test.ts test/integration/create-next-app/package-manager/pnpm.test.ts test/integration/create-next-app/package-manager/yarn.test.ts test/integration/create-next-app/prompts.test.ts test/integration/create-next-app/templates/app.test.ts test/integration/create-next-app/templates/pages.test.ts packages/next/src/lib/find-config.test.ts
             condition: eq(variables['isDocsOnly'], 'No')
             displayName: 'Run tests'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,7 @@ stages:
             condition: eq(variables['isDocsOnly'], 'No')
 
           - script: |
-              node run-tests.js -c 1 test/production/pages-dir/production/test/index.test.ts test/integration/css-client-nav/test/index.test.js test/integration/rewrites-has-condition/test/index.test.js test/integration/create-next-app/examples.test.ts test/integration/create-next-app/index.test.ts test/integration/create-next-app/package-manager/npm.test.ts test/integration/create-next-app/package-manager/pnpm.test.ts test/integration/create-next-app/package-manager/yarn.test.ts test/integration/create-next-app/prompts.test.ts test/integration/create-next-app/templates/app.test.ts test/integration/create-next-app/templates/pages.test.ts packages/next/src/lib/find-config.test.ts
+              node run-tests.js -c 1 test/production/pages-dir/production/test/index.test.ts test/integration/css-client-nav/test/index.test.js test/integration/rewrites-has-condition/test/index.test.js test/integration/create-next-app/examples.test.ts test/integration/create-next-app/index.test.ts test/integration/create-next-app/package-manager/npm.test.ts test/integration/create-next-app/package-manager/pnpm.test.ts test/integration/create-next-app/package-manager/yarn.test.ts test/integration/create-next-app/prompts.test.ts test/integration/create-next-app/templates/app.test.ts test/integration/create-next-app/templates/pages.test.ts
             condition: eq(variables['isDocsOnly'], 'No')
             displayName: 'Run tests'
 

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1220,7 +1220,7 @@ async function loadWasm(importPath = '') {
         // the import path must be exact when not in node_modules
         pkgPath = path.join(importPath, pkg, 'wasm.js')
       }
-      let bindings = await import(pkgPath)
+      let bindings = await import(pathToFileURL(pkgPath).toString())
       if (pkg === '@next/swc-wasm-web') {
         bindings = await bindings.default()
       }

--- a/packages/next/src/lib/find-config.test.ts
+++ b/packages/next/src/lib/find-config.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { findConfig } from './find-config'
 
 // Jest does not support `import('file://something')` (file: imports) yet.
-describe.skip('findConfig()', () => {
+describe('findConfig()', () => {
   const exampleConfig = {
     basePath: '/docs',
   }

--- a/packages/next/src/lib/find-config.test.ts
+++ b/packages/next/src/lib/find-config.test.ts
@@ -3,7 +3,8 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { findConfig } from './find-config'
 
-describe('findConfig()', () => {
+// Jest does not support `import('file://something')` (file: imports) yet.
+describe.skip('findConfig()', () => {
   const exampleConfig = {
     basePath: '/docs',
   }

--- a/packages/next/src/lib/find-config.ts
+++ b/packages/next/src/lib/find-config.ts
@@ -1,6 +1,7 @@
 import findUp from 'next/dist/compiled/find-up'
 import { readFile } from 'fs/promises'
 import JSON5 from 'next/dist/compiled/json5'
+import { pathToFileURL } from 'url'
 
 type RecursivePartial<T> = {
   [P in keyof T]?: RecursivePartial<T[P]>
@@ -66,9 +67,15 @@ export async function findConfig<T>(
 
   if (filePath) {
     if (filePath.endsWith('.js')) {
-      return isESM ? (await import(filePath)).default : require(filePath)
+      if (isESM) {
+        const fileUrl = pathToFileURL(filePath).toString()
+        return (await import(fileUrl)).default
+      } else {
+        return require(filePath)
+      }
     } else if (filePath.endsWith('.mjs')) {
-      return (await import(filePath)).default
+      const fileUrl = pathToFileURL(filePath).toString()
+      return (await import(fileUrl)).default
     } else if (filePath.endsWith('.cjs')) {
       return require(filePath)
     }

--- a/packages/next/src/lib/find-config.ts
+++ b/packages/next/src/lib/find-config.ts
@@ -66,7 +66,9 @@ export async function findConfig<T>(
   const filePath = await findConfigPath(directory, key)
 
   const esmImport = (path: string) => {
-    if (process.platform === 'win32') {
+    // Skip mapping to absolute url with pathToFileURL on windows if it's jest
+    // https://github.com/nodejs/node/issues/31710#issuecomment-587345749
+    if (process.platform === 'win32' && !process.env.JEST_WORKER_ID) {
       // on windows import("C:\\path\\to\\file") is not valid, so we need to
       // use file:// URLs
       return import(pathToFileURL(path).toString())

--- a/packages/next/src/lib/find-config.ts
+++ b/packages/next/src/lib/find-config.ts
@@ -2,7 +2,6 @@ import findUp from 'next/dist/compiled/find-up'
 import { readFile } from 'fs/promises'
 import JSON5 from 'next/dist/compiled/json5'
 import { pathToFileURL } from 'url'
-import { isAbsolute } from 'path'
 
 type RecursivePartial<T> = {
   [P in keyof T]?: RecursivePartial<T[P]>


### PR DESCRIPTION
### What?

Fixes #64371
Fixes #63359


Closes PACK-2946