### PR TITLE
Fix the method prop case in Server Actions transform

### DIFF
--- a/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -741,8 +741,6 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                                     ids.into_iter().map(|id| (id.clone(), id.0.to_string())),
                                 );
 
-                                println!("ASTTTTT {:?}", var);
-
                                 for decl in &mut var.decls {
                                     if let Some(init) = &decl.init {
                                         if let Expr::Lit(_) = &**init {

--- a/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -572,6 +572,16 @@ impl<C: Comments> VisitMut for ServerActions<C> {
         }
     }
 
+    fn visit_mut_method_prop(&mut self, m: &mut MethodProp) {
+        let old_in_export_decl = self.in_export_decl;
+        let old_in_default_export_decl = self.in_default_export_decl;
+        self.in_export_decl = false;
+        self.in_default_export_decl = false;
+        m.visit_mut_children_with(self);
+        self.in_export_decl = old_in_export_decl;
+        self.in_default_export_decl = old_in_default_export_decl;
+    }
+
     fn visit_mut_arrow_expr(&mut self, a: &mut ArrowExpr) {
         // Arrow expressions need to be visited in prepass to determine if it's
         // an action function or not.
@@ -730,6 +740,8 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                                 self.exported_idents.extend(
                                     ids.into_iter().map(|id| (id.clone(), id.0.to_string())),
                                 );
+
+                                println!("ASTTTTT {:?}", var);
 
                                 for decl in &mut var.decls {
                                     if let Some(init) = &decl.init {

--- a/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -582,6 +582,16 @@ impl<C: Comments> VisitMut for ServerActions<C> {
         self.in_default_export_decl = old_in_default_export_decl;
     }
 
+    fn visit_mut_class_method(&mut self, m: &mut ClassMethod) {
+        let old_in_export_decl = self.in_export_decl;
+        let old_in_default_export_decl = self.in_default_export_decl;
+        self.in_export_decl = false;
+        self.in_default_export_decl = false;
+        m.visit_mut_children_with(self);
+        self.in_export_decl = old_in_export_decl;
+        self.in_default_export_decl = old_in_default_export_decl;
+    }
+
     fn visit_mut_arrow_expr(&mut self, a: &mut ArrowExpr) {
         // Arrow expressions need to be visited in prepass to determine if it's
         // an action function or not.

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/31/input.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/31/input.js
@@ -1,0 +1,9 @@
+'use server'
+
+export const action = {
+  async f(x) {
+    ;(() => {
+      console.log(x)
+    })()
+  },
+}.f

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/31/input.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/31/input.js
@@ -7,3 +7,11 @@ export const action = {
     })()
   },
 }.f
+
+export const action2 = new (class X {
+  async f(x) {
+    ;(() => {
+      console.log(x)
+    })()
+  }
+})().f

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/31/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/31/output.js
@@ -1,4 +1,4 @@
-/* __next_internal_action_entry_do_not_use__ {"f14702b5a021dd117f7ec7a3c838f397c2046d3b":"action"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+/* __next_internal_action_entry_do_not_use__ {"abf760c735ba66c4c26a2913864dd7e28fb88a91":"action2","f14702b5a021dd117f7ec7a3c838f397c2046d3b":"action"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export const action = {
     async f (x) {
@@ -8,8 +8,18 @@ export const action = {
         })();
     }
 }.f;
+export const action2 = new class X {
+    async f(x) {
+        ;
+        (()=>{
+            console.log(x);
+        })();
+    }
+}().f;
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
-    action
+    action,
+    action2
 ]);
 registerServerReference("f14702b5a021dd117f7ec7a3c838f397c2046d3b", action);
+registerServerReference("abf760c735ba66c4c26a2913864dd7e28fb88a91", action2);

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/31/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/31/output.js
@@ -1,0 +1,15 @@
+/* __next_internal_action_entry_do_not_use__ {"f14702b5a021dd117f7ec7a3c838f397c2046d3b":"action"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+export const action = {
+    async f (x) {
+        ;
+        (()=>{
+            console.log(x);
+        })();
+    }
+}.f;
+import { ensureServerEntryExports } from "private-next-rsc-action-validate";
+ensureServerEntryExports([
+    action
+]);
+registerServerReference("f14702b5a021dd117f7ec7a3c838f397c2046d3b", action);


### PR DESCRIPTION
This PR fixes the case where object method and class method prop functions are not considered as a new scope. Closes #63603.

Closes NEXT-3088