### PR TITLE
fix(next-lint): update option --report-unused-disable-directives to --report-unused-disable-directives-severity

### DIFF
--- a/docs/02-app/02-api-reference/08-next-cli.mdx
+++ b/docs/02-app/02-api-reference/08-next-cli.mdx
@@ -357,48 +357,46 @@ The output should look like this:
 ```bash filename="Terminal"
 Usage: next lint [directory] [options]
 
-Runs ESLint for all files in the `/src`, `/app`, `/pages`, `/components`, and `/lib`
-directories. It also provides a guided setup to install any required dependencies if ESLint
-is not already configured in your application.
+Runs ESLint for all files in the `/src`, `/app`, `/pages`, `/components`, and `/lib` directories. It also
+provides a guided setup to install any required dependencies if ESLint is not already configured in your
+application.
 
 Arguments:
-  [directory]                            A base directory on which to lint the application.
-                                         If no directory is provided, the current
-                                         directory will be used.
+  [directory]                                         A base directory on which to lint the application.
+                                                      If no directory is provided, the current directory
+                                                      will be used.
 
 Options:
-  -d, --dir, <dirs...>                   Include directory, or directories, to run ESLint.
-  --file, <files...>                     Include file, or files, to run ESLint.
-  --ext, [exts...]                       Specify JavaScript file extensions. (default:
-                                         [".js", ".mjs", ".cjs", ".jsx", ".ts", ".mts", ".cts", ".ts
-x"])
-  -c, --config, <config>                 Uses this configuration file, overriding all other
-                                         configuration options.
-  --resolve-plugins-relative-to, <rprt>  Specify a directory where plugins should be
-                                         resolved from.
-  --strict                               Creates a `.eslintrc.json` file using the Next.js
-                                         strict configuration.
-  --rulesdir, <rulesdir...>              Uses additional rules from this directory(s).
-  --fix                                  Automatically fix linting issues.
-  --fix-type <fixType>                   Specify the types of fixes to apply (e.g., problem,
-                                         suggestion, layout).
-  --ignore-path <path>                   Specify a file to ignore.
-  --no-ignore <path>                     Disables the `--ignore-path` option.
-  --quiet                                Reports errors only.
-  --max-warnings [maxWarnings]           Specify the number of warnings before triggering a
-                                         non-zero exit code. (default: -1)
-  -o, --output-file, <outputFile>        Specify a file to write report to.
-  -f, --format, <format>                 Uses a specifc output format.
-  --no-inline-config                     Prevents comments from changing config or rules.
-  --report-unused-disable-directives     Adds reprted errors for unused eslint-disable
-                                         directives.
-  --no-cache                             Disables caching.
-  --cache-location, <cacheLocation>      Specify a location for cache.
-  --cache-strategy, [cacheStrategy]      Specify a strategy to use for detecting changed
-                                         files in the cache. (default: "metadata")
-  --error-on-unmatched-pattern           Reports errors when any file patterns are
-                                         unmatched.
-  -h, --help                             Displays this message.
+  -d, --dir, <dirs...>                                Include directory, or directories, to run ESLint.
+  --file, <files...>                                  Include file, or files, to run ESLint.
+  --ext, [exts...]                                    Specify JavaScript file extensions. (default:
+                                                      [".js", ".mjs", ".cjs", ".jsx", ".ts", ".mts", ".cts", ".tsx"])
+  -c, --config, <config>                              Uses this configuration file, overriding all other
+                                                      configuration options.
+  --resolve-plugins-relative-to, <rprt>               Specify a directory where plugins should be resolved
+                                                      from.
+  --strict                                            Creates a `.eslintrc.json` file using the Next.js
+                                                      strict configuration.
+  --rulesdir, <rulesdir...>                           Uses additional rules from this directory(s).
+  --fix                                               Automatically fix linting issues.
+  --fix-type <fixType>                                Specify the types of fixes to apply (e.g., problem,
+                                                      suggestion, layout).
+  --ignore-path <path>                                Specify a file to ignore.
+  --no-ignore <path>                                  Disables the `--ignore-path` option.
+  --quiet                                             Reports errors only.
+  --max-warnings [maxWarnings]                        Specify the number of warnings before triggering a
+                                                      non-zero exit code. (default: -1)
+  -o, --output-file, <outputFile>                     Specify a file to write report to.
+  -f, --format, <format>                              Uses a specifc output format.
+  --no-inline-config                                  Prevents comments from changing config or rules.
+  --report-unused-disable-directives-severity <level> Specify severity level for unused eslint-disable
+                                                      directives. (choices: "error", "off", "warn")
+  --no-cache                                          Disables caching.
+  --cache-location, <cacheLocation>                   Specify a location for cache.
+  --cache-strategy, [cacheStrategy]                   Specify a strategy to use for detecting changed files
+                                                      in the cache. (default: "metadata")
+  --error-on-unmatched-pattern                        Reports errors when any file patterns are unmatched.
+  -h, --help                                          Displays this message.
 ```
 
 If you have other directories that you would like to lint, you can specify them using the `--dir` flag:

--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -264,9 +264,11 @@ program
     '--no-inline-config',
     'Prevents comments from changing config or rules.'
   )
-  .option(
-    '--report-unused-disable-directives',
-    'Adds reported errors for unused eslint-disable directives.'
+  .addOption(
+    new Option(
+      '--report-unused-disable-directives-severity <level>',
+      'Specify severity level for unused eslint-disable directives.'
+    ).choices(['error', 'off', 'warn'])
   )
   .option('--no-cache', 'Disables caching.')
   .option('--cache-location, <cacheLocation>', 'Specify a location for cache.')

--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -265,7 +265,7 @@ program
     'Prevents comments from changing config or rules.'
   )
   .option(
-    '--report-unused-disable-directives',
+    '--report-unused-disable-directives <type>',
     'Adds reported errors for unused eslint-disable directives.'
   )
   .option('--no-cache', 'Disables caching.')

--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -265,7 +265,7 @@ program
     'Prevents comments from changing config or rules.'
   )
   .option(
-    '--report-unused-disable-directives <type>',
+    '--report-unused-disable-directives',
     'Adds reported errors for unused eslint-disable directives.'
   )
   .option('--no-cache', 'Disables caching.')

--- a/packages/next/src/cli/next-lint.ts
+++ b/packages/next/src/cli/next-lint.ts
@@ -34,7 +34,7 @@ type NextLintOptions = {
   maxWarnings: number
   outputFile?: string
   quiet?: boolean
-  reportUnusedDisableDirectives: string
+  reportUnusedDisableDirectives: 'error' | 'off' | 'warn'
   resolvePluginsRelativeTo?: string
   rulesdir?: string
   strict?: boolean

--- a/packages/next/src/cli/next-lint.ts
+++ b/packages/next/src/cli/next-lint.ts
@@ -34,7 +34,7 @@ type NextLintOptions = {
   maxWarnings: number
   outputFile?: string
   quiet?: boolean
-  reportUnusedDisableDirectives: 'error' | 'off' | 'warn'
+  reportUnusedDisableDirectivesSeverity: 'error' | 'off' | 'warn'
   resolvePluginsRelativeTo?: string
   rulesdir?: string
   strict?: boolean
@@ -53,7 +53,8 @@ const eslintOptions = (
   ignorePath: options.ignorePath || null,
   ignore: options.ignore,
   allowInlineConfig: options.inlineConfig,
-  reportUnusedDisableDirectives: options.reportUnusedDisableDirectives || null,
+  reportUnusedDisableDirectives:
+    options.reportUnusedDisableDirectivesSeverity || null,
   cache: options.cache,
   cacheLocation: options.cacheLocation || defaultCacheLocation,
   cacheStrategy: options.cacheStrategy,

--- a/test/integration/eslint/test/next-lint.test.js
+++ b/test/integration/eslint/test/next-lint.test.js
@@ -4,7 +4,7 @@ import os from 'os'
 import { join } from 'path'
 
 import findUp from 'next/dist/compiled/find-up'
-import { File, nextBuild, nextLint } from 'next-test-utils'
+import { nextLint } from 'next-test-utils'
 
 const dirFirstTimeSetup = join(__dirname, '../first-time-setup')
 const dirCustomConfig = join(__dirname, '../custom-config')
@@ -21,17 +21,9 @@ const dirIgnoreDuringBuilds = join(__dirname, '../ignore-during-builds')
 const dirBaseDirectories = join(__dirname, '../base-directories')
 const dirCustomDirectories = join(__dirname, '../custom-directories')
 const dirConfigInPackageJson = join(__dirname, '../config-in-package-json')
-const dirInvalidOlderEslintVersion = join(
-  __dirname,
-  '../invalid-eslint-version'
-)
 const dirMaxWarnings = join(__dirname, '../max-warnings')
 const dirEmptyDirectory = join(__dirname, '../empty-directory')
-const dirEslintIgnore = join(__dirname, '../eslint-ignore')
-const dirNoEslintPlugin = join(__dirname, '../no-eslint-plugin')
 const dirNoConfig = join(__dirname, '../no-config')
-const dirEslintCache = join(__dirname, '../eslint-cache')
-const dirEslintCacheCustomDir = join(__dirname, '../eslint-cache-custom-dir')
 const dirFileLinting = join(__dirname, '../file-linting')
 const mjsCjsLinting = join(__dirname, '../mjs-cjs-linting')
 const dirTypescript = join(__dirname, '../with-typescript')
@@ -209,6 +201,42 @@ describe('Next Lint', () => {
     expect(output).toContain(
       'Error: Comments inside children section of tag should be placed inside braces'
     )
+  })
+
+  test.only('verify options name and type with auto-generated help output', async () => {
+    const options = [
+      '-d, --dir, <dirs...>',
+      '--file, <files...>',
+      '--ext, [exts...]',
+      '-c, --config, <config>',
+      '--resolve-plugins-relative-to, <rprt>',
+      '--strict',
+      '--rulesdir, <rulesdir...>',
+      '--fix',
+      '--fix-type <fixType>',
+      '--ignore-path <path>',
+      '--no-ignore',
+      '--quiet',
+      '--max-warnings [maxWarnings]',
+      '-o, --output-file, <outputFile>',
+      '-f, --format, <format>',
+      '--no-inline-config',
+      '--report-unused-disable-directives',
+      '--no-cache',
+      '--cache-location, <cacheLocation>',
+      '--cache-strategy, [cacheStrategy]',
+      '--error-on-unmatched-pattern',
+    ]
+    const { stdout, stderr } = await nextLint(dirNoConfig, ['-h'], {
+      stdout: true,
+      stderr: true,
+    })
+
+    const output = stdout + stderr
+
+    for (let option of options) {
+      expect(output).toContain(option)
+    }
   })
 
   test('base directories are linted by default', async () => {

--- a/test/integration/eslint/test/next-lint.test.js
+++ b/test/integration/eslint/test/next-lint.test.js
@@ -221,7 +221,7 @@ describe('Next Lint', () => {
       '-o, --output-file, <outputFile>',
       '-f, --format, <format>',
       '--no-inline-config',
-      '--report-unused-disable-directives',
+      '--report-unused-disable-directives-severity <level>',
       '--no-cache',
       '--cache-location, <cacheLocation>',
       '--cache-strategy, [cacheStrategy]',

--- a/test/integration/eslint/test/next-lint.test.js
+++ b/test/integration/eslint/test/next-lint.test.js
@@ -203,7 +203,7 @@ describe('Next Lint', () => {
     )
   })
 
-  test.only('verify options name and type with auto-generated help output', async () => {
+  test('verify options name and type with auto-generated help output', async () => {
     const options = [
       '-d, --dir, <dirs...>',
       '--file, <files...>',


### PR DESCRIPTION
## Why?

The Option name and type has been incorrect for `--report-unused-disable-directives` (it's likely that https://github.com/vercel/next.js/pull/61877 exposed this.

For correctness, we have updated the name to `--report-unsed-disable-directives-severity` → https://eslint.org/docs/v8.x/use/command-line-interface#--report-unused-disable-directives-severity.

- Fixes https://github.com/vercel/next.js/issues/64402