### PR TITLE
Improve rendering performance

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2983,12 +2983,13 @@ export default async function build(
                 if (i18n) {
                   if (additionalSsgFile) return
 
+                  const localeExt = page === '/' ? path.extname(file) : ''
+                  const relativeDestNoPages = relativeDest.slice(
+                    'pages/'.length
+                  )
+
                   for (const locale of i18n.locales) {
                     const curPath = `/${locale}${page === '/' ? '' : page}`
-                    const localeExt = page === '/' ? path.extname(file) : ''
-                    const relativeDestNoPages = relativeDest.slice(
-                      'pages/'.length
-                    )
 
                     if (isSsg && ssgNotFoundPaths.includes(curPath)) {
                       continue

--- a/packages/next/src/server/app-render/make-get-server-inserted-html.tsx
+++ b/packages/next/src/server/app-render/make-get-server-inserted-html.tsx
@@ -60,6 +60,18 @@ export function makeGetServerInsertedHTML({
       }
     }
 
+    const serverInsertedHTML = renderServerInsertedHTML()
+
+    // Skip React rendering if we know the content is empty.
+    if (
+      !hasUnflushedPolyfills &&
+      errorMetaTags.length === 0 &&
+      Array.isArray(serverInsertedHTML) &&
+      serverInsertedHTML.length === 0
+    ) {
+      return ''
+    }
+
     const stream = await renderToReadableStream(
       <>
         {
@@ -69,16 +81,21 @@ export function makeGetServerInsertedHTML({
               return <script key={polyfill.src} {...polyfill} />
             })
         }
-        {renderServerInsertedHTML()}
+        {serverInsertedHTML}
         {errorMetaTags}
-      </>
+      </>,
+      {
+        // Larger chunk because this isn't sent over the network.
+        // Let's set it to 1MB.
+        progressiveChunkSize: 1024 * 1024,
+      }
     )
 
     hasUnflushedPolyfills = false
 
-    // Wait for the stream to be ready.
-    await stream.allReady
-
+    // There's no need to wait for the stream to be ready
+    // e.g. calling `await stream.allReady` because `streamToString` will
+    // wait and decode the stream progressively with better parallelism.
     return streamToString(stream)
   }
 }


### PR DESCRIPTION
This PR improves the server rendering performance a bit, especially for the App Router. It has mainly 2 changes.

A rough benchmark test with a 300kB Lorem Ipsum page, SSR is about 18% faster.

### Improve `getServerInsertedHTML`

- Avoid an extra `renderToReadableStream` if we already know the content will be empty
- Avoid `await stream.allReady` for better parallelism with `streamToString()`
- Increase the `progressiveChunkSize`

### Improve `createHeadInsertionTransformStream`

- Only do chunk splitting and enqueuing if the inserted string is not empty