### PR TITLE
test: fix azure test for CNA

### DIFF
--- a/test/integration/create-next-app/index.test.ts
+++ b/test/integration/create-next-app/index.test.ts
@@ -62,7 +62,7 @@ describe('create-next-app', () => {
       )
 
       expect(res.stderr).toMatch(
-        /you do not have write permissions for this folder/
+        /you do not have write permissions for this folder|operation not permitted/
       )
       expect(res.exitCode).toBe(1)
     }, 0o500)


### PR DESCRIPTION
The fs write error message are different on azure

x-ref: https://dev.azure.com/nextjs/next.js/_build/results?buildId=84876&view=logs&j=14d0eb3f-bc66-5450-3353-28256327ad6c&t=7e988112-57f9-5e14-1c8c-05f6c2b0ea47

Closes NEXT-3091