### PR TITLE
tweak test for Azure

### DIFF
--- a/test/integration/create-next-app/index.test.ts
+++ b/test/integration/create-next-app/index.test.ts
@@ -31,6 +31,9 @@ describe('create-next-app', () => {
   })
 
   it('should not create if the target directory is not writable', async () => {
+    const expectedErrorMessage =
+      /you do not have write permissions for this folder|EPERM: operation not permitted/
+
     await useTempDir(async (cwd) => {
       const projectName = 'dir-not-writable'
 
@@ -45,6 +48,7 @@ describe('create-next-app', () => {
         )
         return
       }
+
       const res = await run(
         [
           projectName,
@@ -61,10 +65,12 @@ describe('create-next-app', () => {
         }
       )
 
-      expect(res.stderr).toMatch(
-        /you do not have write permissions for this folder/
-      )
+      expect(res.stderr).toMatch(expectedErrorMessage)
       expect(res.exitCode).toBe(1)
-    }, 0o500)
+    }, 0o500).catch((err) => {
+      if (!expectedErrorMessage.test(err.message)) {
+        throw err
+      }
+    })
   })
 })


### PR DESCRIPTION
Looks like the `useTempDir` function throws when running in Windows rather than piping the message to stderr. This makes the test resilient to both cases. 

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-3095