### PR TITLE
Fix optimizePackageImports docs for Pages Router

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/optimizePackageImports.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/optimizePackageImports.mdx
@@ -1,6 +1,6 @@
 ---
 title: optimizePackageImports
-description: API Reference for optmizedPackageImports Next.js Config Option
+description: API Reference for optimizePackageImports Next.js Config Option
 ---
 
 {/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}

--- a/docs/03-pages/02-api-reference/03-next-config-js/optimizePackageImports.mdx
+++ b/docs/03-pages/02-api-reference/03-next-config-js/optimizePackageImports.mdx
@@ -1,7 +1,7 @@
 ---
 title: optimizePackageImports
-description: API Reference for optmizedPackageImports Next.js Config Option
-source: app/api-reference/next-config-js/compress
+description: API Reference for optimizePackageImports Next.js Config Option
+source: app/api-reference/next-config-js/optimizePackageImports
 ---
 
 {/* DO NOT EDIT. The content of this doc is generated from the source above. To edit the content of this page, navigate to the source page in your editor. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}


### PR DESCRIPTION
The current documentation displays the docs for the `compress` option instead of the `optimizePackageImports` option.

https://nextjs.org/docs/pages/api-reference/next-config-js/optimizePackageImports