### PR TITLE
Revert "Fix: css in next/dynamic component in edge runtime"

### DIFF
--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -244,13 +244,7 @@ export async function adapter(
           )
       )
     }
-    return RequestAsyncStorageWrapper.wrap(
-      requestAsyncStorage,
-      {
-        req: request,
-      },
-      () => params.handler(request, event)
-    )
+    return params.handler(request, event)
   })
 
   // check if response is a Response object

--- a/packages/next/src/shared/lib/lazy-dynamic/preload-css.tsx
+++ b/packages/next/src/shared/lib/lazy-dynamic/preload-css.tsx
@@ -5,10 +5,10 @@ export function PreloadCss({ moduleIds }: { moduleIds: string[] | undefined }) {
   if (typeof window !== 'undefined') {
     return null
   }
-  const getExpectedRequestStore: typeof import('../../../client/components/request-async-storage.external').getExpectedRequestStore =
-    require('../../../client/components/request-async-storage.external').getExpectedRequestStore
-
-  const requestStore = getExpectedRequestStore('next/dynamic css')
+  const {
+    getExpectedRequestStore,
+  } = require('../../../client/components/request-async-storage.external')
+  const requestStore = getExpectedRequestStore()
 
   const allFiles = []
 

--- a/test/e2e/app-dir/dynamic-css/app/ssr/edge/page.js
+++ b/test/e2e/app-dir/dynamic-css/app/ssr/edge/page.js
@@ -1,3 +1,0 @@
-export { default } from '../page'
-
-export const runtime = 'edge'

--- a/test/e2e/app-dir/dynamic-css/index.test.ts
+++ b/test/e2e/app-dir/dynamic-css/index.test.ts
@@ -31,23 +31,6 @@ createNextDescribe(
       })
     })
 
-    it('should only apply corresponding css for page loaded in edge runtime', async () => {
-      const browser = await next.browser('/ssr/edge')
-      await retry(async () => {
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('.text')).color`
-          )
-        ).toBe('rgb(255, 0, 0)')
-        // Default border width, which is not effected by bar.css that is not loaded in /ssr
-        expect(
-          await browser.eval(
-            `window.getComputedStyle(document.querySelector('.text')).borderWidth`
-          )
-        ).toBe('0px')
-      })
-    })
-
     it('should only apply corresponding css for page loaded that /another', async () => {
       const browser = await next.browser('/another')
       await retry(async () => {


### PR DESCRIPTION
The fix is not correct, we already have request ALS wrapping the request in app-render, shouldn't get another one for edge adapter. This is actually a bundler bug

Reverts vercel/next.js#64382

Closes NEXT-3097