### PR TITLE
Enhance types for Node and Edge environments

### DIFF
--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -18,6 +18,7 @@ import {
 import { hasNextSupport } from '../../telemetry/ci-info'
 import { lazyRenderAppPage } from '../../server/future/route-modules/app-page/module.render'
 import { isBailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
+import { NodeNextRequest, NodeNextResponse } from '../../server/base-http/node'
 
 export const enum ExportedAppPageFiles {
   HTML = 'HTML',
@@ -50,8 +51,8 @@ export async function exportAppPage(
 
   try {
     const result = await lazyRenderAppPage(
-      req,
-      res,
+      new NodeNextRequest(req),
+      new NodeNextResponse(res),
       pathname,
       query,
       renderOpts

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -195,7 +195,7 @@ async function createForwardedActionResponse(
       process.env.NEXT_RUNTIME !== 'edge' &&
       isNodeNextRequest(req)
     ) {
-      body = req.body
+      body = req.stream()
     } else {
       throw new Error('Invariant: Unknown request type.')
     }
@@ -203,7 +203,6 @@ async function createForwardedActionResponse(
     // Forward the request to the new worker
     const response = await fetch(fetchUrl, {
       method: 'POST',
-      // @ts-expect-error - undici supports AsyncIterable in Node.js (not part of the Fetch API spec yet)
       body,
       duplex: 'half',
       headers: forwardedHeaders,
@@ -641,8 +640,7 @@ export async function handleAction({
               method: 'POST',
               // @ts-expect-error
               headers: { 'Content-Type': contentType },
-              // @ts-expect-error - undici supports AsyncIterable in Node.js (not part of the Fetch API spec yet)
-              body: req.body,
+              body: req.stream(),
               duplex: 'half',
             })
             const formData = await fakeRequest.formData()

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -1,14 +1,9 @@
-import type {
-  IncomingHttpHeaders,
-  IncomingMessage,
-  OutgoingHttpHeaders,
-  ServerResponse,
-} from 'http'
-import type { WebNextRequest } from '../base-http/web'
+import type { IncomingHttpHeaders, OutgoingHttpHeaders } from 'http'
 import type { SizeLimit } from '../../../types'
 import type { RequestStore } from '../../client/components/request-async-storage.external'
 import type { AppRenderContext, GenerateFlight } from './app-render'
 import type { AppPageModule } from '../../server/future/route-modules/app-page/module'
+import type { BaseNextRequest, BaseNextResponse } from '../base-http'
 
 import {
   RSC_HEADER,
@@ -43,6 +38,7 @@ import { RequestCookies, ResponseCookies } from '../web/spec-extension/cookies'
 import { HeadersAdapter } from '../web/spec-extension/adapters/headers'
 import { fromNodeOutgoingHttpHeaders } from '../web/utils'
 import { selectWorkerForForwarding } from './action-utils'
+import { isNodeNextRequest, isWebNextRequest } from '../base-http/helpers'
 
 function formDataFromSearchQueryString(query: string) {
   const searchParams = new URLSearchParams(query)
@@ -66,8 +62,8 @@ function nodeHeadersToRecord(
 }
 
 function getForwardedHeaders(
-  req: IncomingMessage,
-  res: ServerResponse
+  req: BaseNextRequest,
+  res: BaseNextResponse
 ): Headers {
   // Get request headers and cookies
   const requestHeaders = req.headers
@@ -108,7 +104,7 @@ function getForwardedHeaders(
 }
 
 async function addRevalidationHeader(
-  res: ServerResponse,
+  res: BaseNextResponse,
   {
     staticGenerationStore,
     requestStore,
@@ -151,8 +147,8 @@ async function addRevalidationHeader(
  * Forwards a server action request to a separate worker. Used when the requested action is not available in the current worker.
  */
 async function createForwardedActionResponse(
-  req: IncomingMessage,
-  res: ServerResponse,
+  req: BaseNextRequest,
+  res: BaseNextResponse,
   host: Host,
   workerPathname: string,
   basePath: string,
@@ -181,35 +177,34 @@ async function createForwardedActionResponse(
   const fetchUrl = new URL(`${origin}${basePath}${workerPathname}`)
 
   try {
-    let readableStream: ReadableStream<Uint8Array> | undefined
-    if (process.env.NEXT_RUNTIME === 'edge') {
-      const webRequest = req as unknown as WebNextRequest
-      if (!webRequest.body) {
-        throw new Error('invariant: Missing request body.')
+    let body: BodyInit | AsyncIterable<any> | undefined
+    if (
+      // The type check here ensures that `req` is correctly typed, and the
+      // environment variable check provides dead code elimination.
+      process.env.NEXT_RUNTIME === 'edge' &&
+      isWebNextRequest(req)
+    ) {
+      if (!req.body) {
+        throw new Error('Invariant: missing request body.')
       }
 
-      readableStream = webRequest.body
+      body = req.body
+    } else if (
+      // The type check here ensures that `req` is correctly typed, and the
+      // environment variable check provides dead code elimination.
+      process.env.NEXT_RUNTIME !== 'edge' &&
+      isNodeNextRequest(req)
+    ) {
+      body = req.body
     } else {
-      // Convert the Node.js readable stream to a Web Stream.
-      readableStream = new ReadableStream({
-        start(controller) {
-          req.on('data', (chunk) => {
-            controller.enqueue(new Uint8Array(chunk))
-          })
-          req.on('end', () => {
-            controller.close()
-          })
-          req.on('error', (err) => {
-            controller.error(err)
-          })
-        },
-      })
+      throw new Error('Invariant: Unknown request type.')
     }
 
     // Forward the request to the new worker
     const response = await fetch(fetchUrl, {
       method: 'POST',
-      body: readableStream,
+      // @ts-expect-error - undici supports AsyncIterable in Node.js (not part of the Fetch API spec yet)
+      body,
       duplex: 'half',
       headers: forwardedHeaders,
       next: {
@@ -238,8 +233,8 @@ async function createForwardedActionResponse(
 }
 
 async function createRedirectRenderResult(
-  req: IncomingMessage,
-  res: ServerResponse,
+  req: BaseNextRequest,
+  res: BaseNextResponse,
   originalHost: Host,
   redirectUrl: string,
   basePath: string,
@@ -370,8 +365,8 @@ export async function handleAction({
   serverActions,
   ctx,
 }: {
-  req: IncomingMessage
-  res: ServerResponse
+  req: BaseNextRequest
+  res: BaseNextResponse
   ComponentMod: AppPageModule
   serverModuleMap: ServerModuleMap
   generateFlight: GenerateFlight
@@ -550,18 +545,22 @@ export async function handleAction({
 
   try {
     await actionAsyncStorage.run({ isAction: true }, async () => {
-      if (process.env.NEXT_RUNTIME === 'edge') {
+      if (
+        // The type check here ensures that `req` is correctly typed, and the
+        // environment variable check provides dead code elimination.
+        process.env.NEXT_RUNTIME === 'edge' &&
+        isWebNextRequest(req)
+      ) {
         // Use react-server-dom-webpack/server.edge
         const { decodeReply, decodeAction, decodeFormState } = ComponentMod
 
-        const webRequest = req as unknown as WebNextRequest
-        if (!webRequest.body) {
+        if (!req.body) {
           throw new Error('invariant: Missing request body.')
         }
 
         if (isMultipartAction) {
           // TODO-APP: Add streaming support
-          const formData = await webRequest.request.formData()
+          const formData = await req.request.formData()
           if (isFetchAction) {
             bound = await decodeReply(formData, serverModuleMap)
           } else {
@@ -590,7 +589,7 @@ export async function handleAction({
 
           let actionData = ''
 
-          const reader = webRequest.body.getReader()
+          const reader = req.body.getReader()
           while (true) {
             const { done, value } = await reader.read()
             if (done) {
@@ -607,7 +606,12 @@ export async function handleAction({
             bound = await decodeReply(actionData, serverModuleMap)
           }
         }
-      } else {
+      } else if (
+        // The type check here ensures that `req` is correctly typed, and the
+        // environment variable check provides dead code elimination.
+        process.env.NEXT_RUNTIME !== 'edge' &&
+        isNodeNextRequest(req)
+      ) {
         // Use react-server-dom-webpack/server.node which supports streaming
         const {
           decodeReply,
@@ -627,32 +631,18 @@ export async function handleAction({
               headers: req.headers,
               limits: { fieldSize: limit },
             })
-            req.pipe(bb)
+            req.body.pipe(bb)
 
             bound = await decodeReplyFromBusboy(bb, serverModuleMap)
           } else {
-            // Convert the Node.js readable stream to a Web Stream.
-            const readableStream = new ReadableStream({
-              start(controller) {
-                req.on('data', (chunk) => {
-                  controller.enqueue(new Uint8Array(chunk))
-                })
-                req.on('end', () => {
-                  controller.close()
-                })
-                req.on('error', (err) => {
-                  controller.error(err)
-                })
-              },
-            })
-
             // React doesn't yet publish a busboy version of decodeAction
             // so we polyfill the parsing of FormData.
             const fakeRequest = new Request('http://localhost', {
               method: 'POST',
               // @ts-expect-error
               headers: { 'Content-Type': contentType },
-              body: readableStream,
+              // @ts-expect-error - undici supports AsyncIterable in Node.js (not part of the Fetch API spec yet)
+              body: req.body,
               duplex: 'half',
             })
             const formData = await fakeRequest.formData()
@@ -681,7 +671,7 @@ export async function handleAction({
 
           const chunks = []
 
-          for await (const chunk of req) {
+          for await (const chunk of req.body) {
             chunks.push(Buffer.from(chunk))
           }
 
@@ -706,6 +696,8 @@ To configure the body size limit for Server Actions, see: https://nextjs.org/doc
             bound = await decodeReply(actionData, serverModuleMap)
           }
         }
+      } else {
+        throw new Error('Invariant: Unknown request type.')
       }
 
       // actions.js

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1,4 +1,3 @@
-import type { IncomingMessage, ServerResponse } from 'http'
 import type {
   ActionResult,
   DynamicParamTypesShort,
@@ -16,6 +15,8 @@ import type { LoaderTree } from '../lib/app-dir-module'
 import type { AppPageModule } from '../future/route-modules/app-page/module'
 import type { ClientReferenceManifest } from '../../build/webpack/plugins/flight-manifest-plugin'
 import type { Revalidate } from '../lib/revalidate'
+import type { DeepReadonly } from '../../shared/lib/deep-readonly'
+import type { BaseNextRequest, BaseNextResponse } from '../base-http'
 
 import React from 'react'
 
@@ -107,7 +108,7 @@ import {
   wrapClientComponentLoader,
 } from '../client-component-renderer-logger'
 import { createServerModuleMap } from './action-utils'
-import type { DeepReadonly } from '../../shared/lib/deep-readonly'
+import { isNodeNextRequest } from '../base-http/helpers'
 
 export type GetDynamicParamFromSegment = (
   // [slug] / [[slug]] / [...slug]
@@ -143,7 +144,7 @@ export type AppRenderContext = AppRenderBaseContext & {
   flightDataRendererErrorHandler: ErrorHandler
   serverComponentsErrorHandler: ErrorHandler
   isNotFoundPath: boolean
-  res: ServerResponse
+  res: BaseNextResponse
 }
 
 function createNotFoundLoaderTree(loaderTree: LoaderTree): LoaderTree {
@@ -458,9 +459,10 @@ async function ReactServerApp({ tree, ctx, asNotFound }: ReactServerAppProps) {
         couldBeIntercepted={couldBeIntercepted}
         initialHead={
           <>
-            {ctx.res.statusCode > 400 && (
-              <meta name="robots" content="noindex" />
-            )}
+            {typeof ctx.res.statusCode === 'number' &&
+              ctx.res.statusCode > 400 && (
+                <meta name="robots" content="noindex" />
+              )}
             {/* Adding requestId as react key to make metadata remount for each render */}
             <MetadataTree key={ctx.requestId} />
           </>
@@ -514,7 +516,9 @@ async function ReactServerError({
     <>
       {/* Adding requestId as react key to make metadata remount for each render */}
       <MetadataTree key={requestId} />
-      {res.statusCode >= 400 && <meta name="robots" content="noindex" />}
+      {typeof res.statusCode === 'number' && res.statusCode >= 400 && (
+        <meta name="robots" content="noindex" />
+      )}
       {process.env.NODE_ENV === 'development' && (
         <meta name="next-error" content="not-found" />
       )}
@@ -581,8 +585,8 @@ function ReactServerEntrypoint<T>({
 export type BinaryStreamOf<T> = ReadableStream<Uint8Array>
 
 async function renderToHTMLOrFlightImpl(
-  req: IncomingMessage,
-  res: ServerResponse,
+  req: BaseNextRequest,
+  res: BaseNextResponse,
   pagePath: string,
   query: NextParsedUrlQuery,
   renderOpts: RenderOpts,
@@ -620,8 +624,13 @@ async function renderToHTMLOrFlightImpl(
     globalThis.__next_chunk_load__ = instrumented.loadChunk
   }
 
-  if (typeof req.on === 'function') {
-    req.on('end', () => {
+  if (
+    // The type check here ensures that `req` is correctly typed, and the
+    // environment variable check provides dead code elimination.
+    process.env.NEXT_RUNTIME !== 'edge' &&
+    isNodeNextRequest(req)
+  ) {
+    req.originalRequest.on('end', () => {
       if ('performance' in globalThis) {
         const metrics = getClientComponentLoaderMetrics({ reset: true })
         if (metrics) {
@@ -1413,8 +1422,8 @@ async function renderToHTMLOrFlightImpl(
 }
 
 export type AppPageRender = (
-  req: IncomingMessage,
-  res: ServerResponse,
+  req: BaseNextRequest,
+  res: BaseNextResponse,
   pagePath: string,
   query: NextParsedUrlQuery,
   renderOpts: RenderOpts

--- a/packages/next/src/server/base-http/helpers.ts
+++ b/packages/next/src/server/base-http/helpers.ts
@@ -1,0 +1,49 @@
+import type { BaseNextRequest, BaseNextResponse } from './'
+import type { NodeNextRequest, NodeNextResponse } from './node'
+import type { WebNextRequest, WebNextResponse } from './web'
+
+/**
+ * This file provides some helpers that should be used in conjunction with
+ * explicit environment checks. When combined with the environment checks, it
+ * will ensure that the correct typings are used as well as enable code
+ * elimination.
+ */
+
+/**
+ * Type guard to determine if a request is a WebNextRequest. This does not
+ * actually check the type of the request, but rather the runtime environment.
+ * It's expected that when the runtime environment is the edge runtime, that any
+ * base request is a WebNextRequest.
+ */
+export const isWebNextRequest = (req: BaseNextRequest): req is WebNextRequest =>
+  process.env.NEXT_RUNTIME === 'edge'
+
+/**
+ * Type guard to determine if a response is a WebNextResponse. This does not
+ * actually check the type of the response, but rather the runtime environment.
+ * It's expected that when the runtime environment is the edge runtime, that any
+ * base response is a WebNextResponse.
+ */
+export const isWebNextResponse = (
+  res: BaseNextResponse
+): res is WebNextResponse => process.env.NEXT_RUNTIME === 'edge'
+
+/**
+ * Type guard to determine if a request is a NodeNextRequest. This does not
+ * actually check the type of the request, but rather the runtime environment.
+ * It's expected that when the runtime environment is the node runtime, that any
+ * base request is a NodeNextRequest.
+ */
+export const isNodeNextRequest = (
+  req: BaseNextRequest
+): req is NodeNextRequest => process.env.NEXT_RUNTIME !== 'edge'
+
+/**
+ * Type guard to determine if a response is a NodeNextResponse. This does not
+ * actually check the type of the response, but rather the runtime environment.
+ * It's expected that when the runtime environment is the node runtime, that any
+ * base response is a NodeNextResponse.
+ */
+export const isNodeNextResponse = (
+  res: BaseNextResponse
+): res is NodeNextResponse => process.env.NEXT_RUNTIME !== 'edge'

--- a/packages/next/src/server/base-http/index.ts
+++ b/packages/next/src/server/base-http/index.ts
@@ -81,7 +81,7 @@ export abstract class BaseNextResponse<Destination = any> {
 
   // Utils implemented using the abstract methods above
 
-  redirect(destination: string, statusCode: number) {
+  public redirect(destination: string, statusCode: number) {
     this.setHeader('Location', destination)
     this.statusCode = statusCode
 
@@ -90,6 +90,7 @@ export abstract class BaseNextResponse<Destination = any> {
     if (statusCode === RedirectStatusCode.PermanentRedirect) {
       this.setHeader('Refresh', `0;url=${destination}`)
     }
+
     return this
   }
 }

--- a/packages/next/src/server/base-http/node.ts
+++ b/packages/next/src/server/base-http/node.ts
@@ -18,9 +18,13 @@ type Req = IncomingMessage & {
 
 export class NodeNextRequest extends BaseNextRequest<Readable> {
   public headers = this._req.headers
-  public fetchMetrics?: FetchMetric[] = this._req?.fetchMetrics;
+  public fetchMetrics: FetchMetric[] | undefined = this._req?.fetchMetrics;
 
   [NEXT_REQUEST_META]: RequestMeta = this._req[NEXT_REQUEST_META] || {}
+
+  constructor(private _req: Req) {
+    super(_req.method!.toUpperCase(), _req.url!, _req)
+  }
 
   get originalRequest() {
     // Need to mimic these changes to the original req object for places where we use it:
@@ -33,10 +37,6 @@ export class NodeNextRequest extends BaseNextRequest<Readable> {
 
   set originalRequest(value: Req) {
     this._req = value
-  }
-
-  constructor(private _req: Req) {
-    super(_req.method!.toUpperCase(), _req.url!, _req)
   }
 }
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -153,8 +153,8 @@ export interface MiddlewareRoutingItem {
 }
 
 export type RouteHandler<
-  ServerRequest extends BaseNextRequest,
-  ServerResponse extends BaseNextResponse
+  ServerRequest extends BaseNextRequest = BaseNextRequest,
+  ServerResponse extends BaseNextResponse = BaseNextResponse
 > = (
   req: ServerRequest,
   res: ServerResponse,
@@ -241,8 +241,10 @@ type BaseRenderOpts = RenderOpts & {
  * be the base Node.js request and response types.
  */
 export interface BaseRequestHandler<
-  ServerRequest extends BaseNextRequest | IncomingMessage,
-  ServerResponse extends BaseNextResponse | HTTPServerResponse
+  ServerRequest extends BaseNextRequest | IncomingMessage = BaseNextRequest,
+  ServerResponse extends
+    | BaseNextResponse
+    | HTTPServerResponse = BaseNextResponse
 > {
   (
     req: ServerRequest,
@@ -252,8 +254,8 @@ export interface BaseRequestHandler<
 }
 
 export type RequestContext<
-  ServerRequest extends BaseNextRequest,
-  ServerResponse extends BaseNextResponse
+  ServerRequest extends BaseNextRequest = BaseNextRequest,
+  ServerResponse extends BaseNextResponse = BaseNextResponse
 > = {
   req: ServerRequest
   res: ServerResponse

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -31,11 +31,13 @@ import type {
 import type { ClientReferenceManifest } from '../build/webpack/plugins/flight-manifest-plugin'
 import type { NextFontManifest } from '../build/webpack/plugins/next-font-manifest-plugin'
 import type { AppPageRouteModule } from './future/route-modules/app-page/module'
-import type { NodeNextRequest, NodeNextResponse } from './base-http/node'
-import type { WebNextRequest, WebNextResponse } from './base-http/web'
 import type { PagesAPIRouteMatch } from './future/route-matches/pages-api-route-match'
 import type { AppRouteRouteHandlerContext } from './future/route-modules/app-route/module'
-import type { Server as HTTPServer, IncomingMessage } from 'http'
+import type {
+  Server as HTTPServer,
+  IncomingMessage,
+  ServerResponse as HTTPServerResponse,
+} from 'http'
 import type { MiddlewareMatcher } from '../build/analysis/get-page-static-info'
 import type { TLSSocket } from 'tls'
 import type { PathnameNormalizer } from './future/normalizers/request/pathname-normalizer'
@@ -136,6 +138,8 @@ import { getIsServerAction } from './lib/server-action-request-meta'
 import { isInterceptionRouteAppPath } from './future/helpers/interception-routes'
 import { toRoute } from './lib/to-route'
 import type { DeepReadonly } from '../shared/lib/deep-readonly'
+import { isNodeNextRequest, isNodeNextResponse } from './base-http/helpers'
+import { patchSetHeaderWithCookieSupport } from './lib/patch-set-header'
 
 export type FindComponentsResult = {
   components: LoadComponentsReturnType
@@ -148,9 +152,12 @@ export interface MiddlewareRoutingItem {
   matchers?: MiddlewareMatcher[]
 }
 
-export type RouteHandler = (
-  req: BaseNextRequest,
-  res: BaseNextResponse,
+export type RouteHandler<
+  ServerRequest extends BaseNextRequest,
+  ServerResponse extends BaseNextResponse
+> = (
+  req: ServerRequest,
+  res: ServerResponse,
   parsedUrl: NextUrlWithParsedQuery
 ) => PromiseLike<boolean> | boolean
 
@@ -227,17 +234,29 @@ type BaseRenderOpts = RenderOpts & {
   previewProps: __ApiPreviewProps
 }
 
-export interface BaseRequestHandler {
+/**
+ * The public interface for rendering with the server programmatically. This
+ * would typically only allow the base request or response to extend it, but
+ * because this can be programmatically accessed, we assume that it could also
+ * be the base Node.js request and response types.
+ */
+export interface BaseRequestHandler<
+  ServerRequest extends BaseNextRequest | IncomingMessage,
+  ServerResponse extends BaseNextResponse | HTTPServerResponse
+> {
   (
-    req: BaseNextRequest,
-    res: BaseNextResponse,
+    req: ServerRequest,
+    res: ServerResponse,
     parsedUrl?: NextUrlWithParsedQuery | undefined
   ): Promise<void> | void
 }
 
-export type RequestContext = {
-  req: BaseNextRequest
-  res: BaseNextResponse
+export type RequestContext<
+  ServerRequest extends BaseNextRequest,
+  ServerResponse extends BaseNextResponse
+> = {
+  req: ServerRequest
+  res: ServerResponse
   pathname: string
   query: NextParsedUrlQuery
   renderOpts: RenderOpts
@@ -269,7 +288,11 @@ export type NextEnabledDirectories = {
   readonly app: boolean
 }
 
-export default abstract class Server<ServerOptions extends Options = Options> {
+export default abstract class Server<
+  ServerOptions extends Options = Options,
+  ServerRequest extends BaseNextRequest = BaseNextRequest,
+  ServerResponse extends BaseNextResponse = BaseNextResponse
+> {
   public readonly hostname?: string
   public readonly fetchHostname?: string
   public readonly port?: number
@@ -321,15 +344,15 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     | DeepReadonly<NextFontManifest>
     | undefined
   protected abstract attachRequestMeta(
-    req: BaseNextRequest,
+    req: ServerRequest,
     parsedUrl: NextUrlWithParsedQuery
   ): void
   protected abstract getFallback(page: string): Promise<string>
   protected abstract hasPage(pathname: string): Promise<boolean>
 
   protected abstract sendRenderResult(
-    req: BaseNextRequest,
-    res: BaseNextResponse,
+    req: ServerRequest,
+    res: ServerResponse,
     options: {
       result: RenderResult
       type: 'html' | 'json' | 'rsc'
@@ -341,15 +364,15 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   ): Promise<void>
 
   protected abstract runApi(
-    req: BaseNextRequest,
-    res: BaseNextResponse,
+    req: ServerRequest,
+    res: ServerResponse,
     query: ParsedUrlQuery,
     match: PagesAPIRouteMatch
   ): Promise<boolean>
 
   protected abstract renderHTML(
-    req: BaseNextRequest,
-    res: BaseNextResponse,
+    req: ServerRequest,
+    res: ServerResponse,
     pathname: string,
     query: NextParsedUrlQuery,
     renderOpts: LoadedRenderOpts
@@ -557,7 +580,11 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     return this.matchers.reload()
   }
 
-  private handleRSCRequest: RouteHandler = (req, _res, parsedUrl) => {
+  private handleRSCRequest: RouteHandler<ServerRequest, ServerResponse> = (
+    req,
+    _res,
+    parsedUrl
+  ) => {
     if (!parsedUrl.pathname) return false
 
     if (this.normalizers.prefetchRSC?.match(parsedUrl.pathname)) {
@@ -606,102 +633,114 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     return false
   }
 
-  private handleNextDataRequest: RouteHandler = async (req, res, parsedUrl) => {
-    const middleware = this.getMiddleware()
-    const params = matchNextDataPathname(parsedUrl.pathname)
+  private handleNextDataRequest: RouteHandler<ServerRequest, ServerResponse> =
+    async (req, res, parsedUrl) => {
+      const middleware = this.getMiddleware()
+      const params = matchNextDataPathname(parsedUrl.pathname)
 
-    // ignore for non-next data URLs
-    if (!params || !params.path) {
-      return false
-    }
-
-    if (params.path[0] !== this.buildId) {
-      // Ignore if its a middleware request when we aren't on edge.
-      if (
-        process.env.NEXT_RUNTIME !== 'edge' &&
-        req.headers['x-middleware-invoke']
-      ) {
+      // ignore for non-next data URLs
+      if (!params || !params.path) {
         return false
       }
 
-      // Make sure to 404 if the buildId isn't correct
-      await this.render404(req, res, parsedUrl)
-      return true
-    }
+      if (params.path[0] !== this.buildId) {
+        // Ignore if its a middleware request when we aren't on edge.
+        if (
+          process.env.NEXT_RUNTIME !== 'edge' &&
+          req.headers['x-middleware-invoke']
+        ) {
+          return false
+        }
 
-    // remove buildId from URL
-    params.path.shift()
-
-    const lastParam = params.path[params.path.length - 1]
-
-    // show 404 if it doesn't end with .json
-    if (typeof lastParam !== 'string' || !lastParam.endsWith('.json')) {
-      await this.render404(req, res, parsedUrl)
-      return true
-    }
-
-    // re-create page's pathname
-    let pathname = `/${params.path.join('/')}`
-    pathname = getRouteFromAssetPath(pathname, '.json')
-
-    // ensure trailing slash is normalized per config
-    if (middleware) {
-      if (this.nextConfig.trailingSlash && !pathname.endsWith('/')) {
-        pathname += '/'
-      }
-      if (
-        !this.nextConfig.trailingSlash &&
-        pathname.length > 1 &&
-        pathname.endsWith('/')
-      ) {
-        pathname = pathname.substring(0, pathname.length - 1)
-      }
-    }
-
-    if (this.i18nProvider) {
-      // Remove the port from the hostname if present.
-      const hostname = req?.headers.host?.split(':', 1)[0].toLowerCase()
-
-      const domainLocale = this.i18nProvider.detectDomainLocale(hostname)
-      const defaultLocale =
-        domainLocale?.defaultLocale ?? this.i18nProvider.config.defaultLocale
-
-      const localePathResult = this.i18nProvider.analyze(pathname)
-
-      // If the locale is detected from the path, we need to remove it
-      // from the pathname.
-      if (localePathResult.detectedLocale) {
-        pathname = localePathResult.pathname
-      }
-
-      // Update the query with the detected locale and default locale.
-      parsedUrl.query.__nextLocale = localePathResult.detectedLocale
-      parsedUrl.query.__nextDefaultLocale = defaultLocale
-
-      // If the locale is not detected from the path, we need to mark that
-      // it was not inferred from default.
-      if (!localePathResult.detectedLocale) {
-        delete parsedUrl.query.__nextInferredLocaleFromDefault
-      }
-
-      // If no locale was detected and we don't have middleware, we need
-      // to render a 404 page.
-      if (!localePathResult.detectedLocale && !middleware) {
-        parsedUrl.query.__nextLocale = defaultLocale
+        // Make sure to 404 if the buildId isn't correct
         await this.render404(req, res, parsedUrl)
         return true
       }
+
+      // remove buildId from URL
+      params.path.shift()
+
+      const lastParam = params.path[params.path.length - 1]
+
+      // show 404 if it doesn't end with .json
+      if (typeof lastParam !== 'string' || !lastParam.endsWith('.json')) {
+        await this.render404(req, res, parsedUrl)
+        return true
+      }
+
+      // re-create page's pathname
+      let pathname = `/${params.path.join('/')}`
+      pathname = getRouteFromAssetPath(pathname, '.json')
+
+      // ensure trailing slash is normalized per config
+      if (middleware) {
+        if (this.nextConfig.trailingSlash && !pathname.endsWith('/')) {
+          pathname += '/'
+        }
+        if (
+          !this.nextConfig.trailingSlash &&
+          pathname.length > 1 &&
+          pathname.endsWith('/')
+        ) {
+          pathname = pathname.substring(0, pathname.length - 1)
+        }
+      }
+
+      if (this.i18nProvider) {
+        // Remove the port from the hostname if present.
+        const hostname = req?.headers.host?.split(':', 1)[0].toLowerCase()
+
+        const domainLocale = this.i18nProvider.detectDomainLocale(hostname)
+        const defaultLocale =
+          domainLocale?.defaultLocale ?? this.i18nProvider.config.defaultLocale
+
+        const localePathResult = this.i18nProvider.analyze(pathname)
+
+        // If the locale is detected from the path, we need to remove it
+        // from the pathname.
+        if (localePathResult.detectedLocale) {
+          pathname = localePathResult.pathname
+        }
+
+        // Update the query with the detected locale and default locale.
+        parsedUrl.query.__nextLocale = localePathResult.detectedLocale
+        parsedUrl.query.__nextDefaultLocale = defaultLocale
+
+        // If the locale is not detected from the path, we need to mark that
+        // it was not inferred from default.
+        if (!localePathResult.detectedLocale) {
+          delete parsedUrl.query.__nextInferredLocaleFromDefault
+        }
+
+        // If no locale was detected and we don't have middleware, we need
+        // to render a 404 page.
+        if (!localePathResult.detectedLocale && !middleware) {
+          parsedUrl.query.__nextLocale = defaultLocale
+          await this.render404(req, res, parsedUrl)
+          return true
+        }
+      }
+
+      parsedUrl.pathname = pathname
+      parsedUrl.query.__nextDataReq = '1'
+
+      return false
     }
 
-    parsedUrl.pathname = pathname
-    parsedUrl.query.__nextDataReq = '1'
+  protected handleNextImageRequest: RouteHandler<
+    ServerRequest,
+    ServerResponse
+  > = () => false
 
-    return false
-  }
+  protected handleCatchallRenderRequest: RouteHandler<
+    ServerRequest,
+    ServerResponse
+  > = () => false
 
-  protected handleNextImageRequest: RouteHandler = () => false
-  protected handleCatchallRenderRequest: RouteHandler = () => false
-  protected handleCatchallMiddlewareRequest: RouteHandler = () => false
+  protected handleCatchallMiddlewareRequest: RouteHandler<
+    ServerRequest,
+    ServerResponse
+  > = () => false
 
   protected getRouteMatchers(): RouteMatcherManager {
     // Create a new manifest loader that get's the manifests from the server.
@@ -757,8 +796,8 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   }
 
   public async handleRequest(
-    req: BaseNextRequest,
-    res: BaseNextResponse,
+    req: ServerRequest,
+    res: ServerResponse,
     parsedUrl?: NextUrlWithParsedQuery
   ): Promise<void> {
     await this.prepare()
@@ -816,8 +855,8 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   }
 
   private async handleRequestImpl(
-    req: BaseNextRequest,
-    res: BaseNextResponse,
+    req: ServerRequest,
+    res: ServerResponse,
     parsedUrl?: NextUrlWithParsedQuery
   ): Promise<void> {
     try {
@@ -826,38 +865,10 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
       // ensure cookies set in middleware are merged and
       // not overridden by API routes/getServerSideProps
-      const _res = (res as any).originalResponse || res
-      const origSetHeader = _res.setHeader.bind(_res)
-
-      _res.setHeader = (name: string, val: string | string[]) => {
-        // When renders /_error after page is failed,
-        // it could attempt to set headers after headers
-        if (_res.headersSent) {
-          return
-        }
-        if (name.toLowerCase() === 'set-cookie') {
-          const middlewareValue = getRequestMeta(req, 'middlewareCookie')
-
-          if (
-            !middlewareValue ||
-            !Array.isArray(val) ||
-            !val.every((item, idx) => item === middlewareValue[idx])
-          ) {
-            val = [
-              // TODO: (wyattjoh) find out why this is called multiple times resulting in duplicate cookies being added
-              ...new Set([
-                ...(middlewareValue || []),
-                ...(typeof val === 'string'
-                  ? [val]
-                  : Array.isArray(val)
-                  ? val
-                  : []),
-              ]),
-            ]
-          }
-        }
-        return origSetHeader(name, val)
-      }
+      patchSetHeaderWithCookieSupport(
+        req,
+        isNodeNextResponse(res) ? res.originalResponse : res
+      )
 
       const urlParts = (req.url || '').split('?', 1)
       const urlNoQuery = urlParts[0]
@@ -892,7 +903,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         )
       }
 
-      const { originalRequest } = req as NodeNextRequest
+      const { originalRequest = null } = isNodeNextRequest(req) ? req : {}
       const xForwardedProto = originalRequest?.headers['x-forwarded-proto']
       const isHttps = xForwardedProto
         ? xForwardedProto === 'https'
@@ -905,7 +916,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
         ? '443'
         : '80'
       req.headers['x-forwarded-proto'] ??= isHttps ? 'https' : 'http'
-      req.headers['x-forwarded-for'] ??= originalRequest.socket?.remoteAddress
+      req.headers['x-forwarded-for'] ??= originalRequest?.socket?.remoteAddress
 
       // This should be done before any normalization of the pathname happens as
       // it captures the initial URL.
@@ -1423,7 +1434,10 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     return pathname
   }
 
-  private normalizeAndAttachMetadata: RouteHandler = async (req, res, url) => {
+  private normalizeAndAttachMetadata: RouteHandler<
+    ServerRequest,
+    ServerResponse
+  > = async (req, res, url) => {
     let finished = await this.handleNextImageRequest(req, res, url)
     if (finished) return true
 
@@ -1438,7 +1452,9 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   /**
    * @internal - this method is internal to Next.js and should not be used directly by end-users
    */
-  public getRequestHandlerWithMetadata(meta: RequestMeta): BaseRequestHandler {
+  public getRequestHandlerWithMetadata(
+    meta: RequestMeta
+  ): BaseRequestHandler<ServerRequest, ServerResponse> {
     const handler = this.getRequestHandler()
     return (req, res, parsedUrl) => {
       setRequestMeta(req, meta)
@@ -1446,12 +1462,15 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     }
   }
 
-  public getRequestHandler(): BaseRequestHandler {
+  public getRequestHandler(): BaseRequestHandler<
+    ServerRequest,
+    ServerResponse
+  > {
     return this.handleRequest.bind(this)
   }
 
   protected abstract handleUpgrade(
-    req: BaseNextRequest,
+    req: ServerRequest,
     socket: any,
     head?: any
   ): Promise<void>
@@ -1496,8 +1515,8 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   }
 
   protected async run(
-    req: BaseNextRequest,
-    res: BaseNextResponse,
+    req: ServerRequest,
+    res: ServerResponse,
     parsedUrl: UrlWithParsedQuery
   ): Promise<void> {
     return getTracer().trace(BaseServerSpan.run, async () =>
@@ -1506,16 +1525,21 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   }
 
   private async runImpl(
-    req: BaseNextRequest,
-    res: BaseNextResponse,
+    req: ServerRequest,
+    res: ServerResponse,
     parsedUrl: UrlWithParsedQuery
   ): Promise<void> {
     await this.handleCatchallRenderRequest(req, res, parsedUrl)
   }
 
   private async pipe(
-    fn: (ctx: RequestContext) => Promise<ResponsePayload | null>,
-    partialContext: Omit<RequestContext, 'renderOpts'>
+    fn: (
+      ctx: RequestContext<ServerRequest, ServerResponse>
+    ) => Promise<ResponsePayload | null>,
+    partialContext: Omit<
+      RequestContext<ServerRequest, ServerResponse>,
+      'renderOpts'
+    >
   ): Promise<void> {
     return getTracer().trace(BaseServerSpan.pipe, async () =>
       this.pipeImpl(fn, partialContext)
@@ -1523,11 +1547,16 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   }
 
   private async pipeImpl(
-    fn: (ctx: RequestContext) => Promise<ResponsePayload | null>,
-    partialContext: Omit<RequestContext, 'renderOpts'>
+    fn: (
+      ctx: RequestContext<ServerRequest, ServerResponse>
+    ) => Promise<ResponsePayload | null>,
+    partialContext: Omit<
+      RequestContext<ServerRequest, ServerResponse>,
+      'renderOpts'
+    >
   ): Promise<void> {
     const isBotRequest = isBot(partialContext.req.headers['user-agent'] || '')
-    const ctx: RequestContext = {
+    const ctx: RequestContext<ServerRequest, ServerResponse> = {
       ...partialContext,
       renderOpts: {
         ...this.renderOpts,
@@ -1565,10 +1594,15 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   }
 
   private async getStaticHTML(
-    fn: (ctx: RequestContext) => Promise<ResponsePayload | null>,
-    partialContext: Omit<RequestContext, 'renderOpts'>
+    fn: (
+      ctx: RequestContext<ServerRequest, ServerResponse>
+    ) => Promise<ResponsePayload | null>,
+    partialContext: Omit<
+      RequestContext<ServerRequest, ServerResponse>,
+      'renderOpts'
+    >
   ): Promise<string | null> {
-    const ctx: RequestContext = {
+    const ctx: RequestContext<ServerRequest, ServerResponse> = {
       ...partialContext,
       renderOpts: {
         ...this.renderOpts,
@@ -1583,8 +1617,8 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   }
 
   public async render(
-    req: BaseNextRequest,
-    res: BaseNextResponse,
+    req: ServerRequest,
+    res: ServerResponse,
     pathname: string,
     query: NextParsedUrlQuery = {},
     parsedUrl?: NextUrlWithParsedQuery,
@@ -1596,8 +1630,8 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   }
 
   private async renderImpl(
-    req: BaseNextRequest,
-    res: BaseNextResponse,
+    req: ServerRequest,
+    res: ServerResponse,
     pathname: string,
     query: NextParsedUrlQuery = {},
     parsedUrl?: NextUrlWithParsedQuery,
@@ -1674,7 +1708,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   }
 
   private async renderToResponseWithComponents(
-    requestContext: RequestContext,
+    requestContext: RequestContext<ServerRequest, ServerResponse>,
     findComponentsResult: FindComponentsResult
   ): Promise<ResponsePayload | null> {
     return getTracer().trace(
@@ -1687,7 +1721,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     )
   }
 
-  protected stripInternalHeaders(req: BaseNextRequest): void {
+  protected stripInternalHeaders(req: ServerRequest): void {
     // Skip stripping internal headers in test mode while the header stripping
     // has been explicitly disabled. This allows tests to verify internal
     // routing behavior.
@@ -1701,11 +1735,14 @@ export default abstract class Server<ServerOptions extends Options = Options> {
     // Strip the internal headers from both the request and the original
     // request.
     stripInternalHeaders(req.headers)
+
     if (
-      'originalRequest' in req &&
-      'headers' in (req as NodeNextRequest).originalRequest
+      // The type check here ensures that `req` is correctly typed, and the
+      // environment variable check provides dead code elimination.
+      process.env.NEXT_RUNTIME !== 'edge' &&
+      isNodeNextRequest(req)
     ) {
-      stripInternalHeaders((req as NodeNextRequest).originalRequest.headers)
+      stripInternalHeaders(req.originalRequest.headers)
     }
   }
 
@@ -1719,8 +1756,8 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   }
 
   protected setVaryHeader(
-    req: BaseNextRequest,
-    res: BaseNextResponse,
+    req: ServerRequest,
+    res: ServerResponse,
     isAppPath: boolean,
     resolvedPathname: string
   ): void {
@@ -1748,7 +1785,12 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   }
 
   private async renderToResponseWithComponentsImpl(
-    { req, res, pathname, renderOpts: opts }: RequestContext,
+    {
+      req,
+      res,
+      pathname,
+      renderOpts: opts,
+    }: RequestContext<ServerRequest, ServerResponse>,
     { components, query }: FindComponentsResult
   ): Promise<ResponsePayload | null> {
     if (pathname === UNDERSCORE_NOT_FOUND_ROUTE) {
@@ -2244,6 +2286,18 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
       if (routeModule) {
         if (isAppRouteRouteModule(routeModule)) {
+          if (
+            // The type check here ensures that `req` is correctly typed, and the
+            // environment variable check provides dead code elimination.
+            process.env.NEXT_RUNTIME === 'edge' ||
+            !isNodeNextRequest(req) ||
+            !isNodeNextResponse(res)
+          ) {
+            throw new Error(
+              'Invariant: App Route Route Modules cannot be used in the edge runtime'
+            )
+          }
+
           const context: AppRouteRouteHandlerContext = {
             params: opts.params,
             prerenderManifest,
@@ -2258,9 +2312,9 @@ export default abstract class Server<ServerOptions extends Options = Options> {
           }
 
           try {
-            const request = NextRequestAdapter.fromBaseNextRequest(
+            const request = NextRequestAdapter.fromNodeNextRequest(
               req,
-              signalFromNodeResponse((res as NodeNextResponse).originalResponse)
+              signalFromNodeResponse(res.originalResponse)
             )
 
             const response = await routeModule.handle(request, context)
@@ -2273,7 +2327,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
             // If the request is for a static response, we can cache it so long
             // as it's not edge.
-            if (isSSG && process.env.NEXT_RUNTIME !== 'edge') {
+            if (isSSG) {
               const blob = await response.blob()
 
               // Copy the headers from the response.
@@ -2326,12 +2380,21 @@ export default abstract class Server<ServerOptions extends Options = Options> {
           renderOpts.clientReferenceManifest =
             components.clientReferenceManifest
 
+          const request = isNodeNextRequest(req) ? req.originalRequest : req
+          const response = isNodeNextResponse(res) ? res.originalResponse : res
+
           // Call the built-in render method on the module.
           result = await routeModule.render(
-            (req as NodeNextRequest).originalRequest ?? (req as WebNextRequest),
-            (res as NodeNextResponse).originalResponse ??
-              (res as WebNextResponse),
-            { page: pathname, params: opts.params, query, renderOpts }
+            // TODO: fix this type
+            // @ts-expect-error - preexisting accepted this
+            request,
+            response,
+            {
+              page: pathname,
+              params: opts.params,
+              query,
+              renderOpts,
+            }
           )
         } else if (isAppPageRouteModule(routeModule)) {
           const module = components.routeModule as AppPageRouteModule
@@ -2342,17 +2405,12 @@ export default abstract class Server<ServerOptions extends Options = Options> {
           renderOpts.nextFontManifest = this.nextFontManifest
 
           // Call the built-in render method on the module.
-          result = await module.render(
-            (req as NodeNextRequest).originalRequest ?? (req as WebNextRequest),
-            (res as NodeNextResponse).originalResponse ??
-              (res as WebNextResponse),
-            {
-              page: is404Page ? '/404' : pathname,
-              params: opts.params,
-              query,
-              renderOpts,
-            }
-          )
+          result = await module.render(req, res, {
+            page: is404Page ? '/404' : pathname,
+            params: opts.params,
+            query,
+            renderOpts,
+          })
         } else {
           throw new Error('Invariant: Unknown route module type')
         }
@@ -2987,7 +3045,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   }
 
   protected async renderPageComponent(
-    ctx: RequestContext,
+    ctx: RequestContext<ServerRequest, ServerResponse>,
     bubbleNoFallback: boolean
   ) {
     const { query, pathname } = ctx
@@ -3027,7 +3085,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   }
 
   private async renderToResponse(
-    ctx: RequestContext
+    ctx: RequestContext<ServerRequest, ServerResponse>
   ): Promise<ResponsePayload | null> {
     return getTracer().trace(
       BaseServerSpan.renderToResponse,
@@ -3050,7 +3108,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   protected abstract getRoutesManifest(): NormalizedRouteManifest | undefined
 
   private async renderToResponseImpl(
-    ctx: RequestContext
+    ctx: RequestContext<ServerRequest, ServerResponse>
   ): Promise<ResponsePayload | null> {
     const { res, query, pathname } = ctx
     let page = pathname
@@ -3181,8 +3239,8 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   }
 
   public async renderToHTML(
-    req: BaseNextRequest,
-    res: BaseNextResponse,
+    req: ServerRequest,
+    res: ServerResponse,
     pathname: string,
     query: ParsedUrlQuery = {}
   ): Promise<string | null> {
@@ -3192,8 +3250,8 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   }
 
   private async renderToHTMLImpl(
-    req: BaseNextRequest,
-    res: BaseNextResponse,
+    req: ServerRequest,
+    res: ServerResponse,
     pathname: string,
     query: ParsedUrlQuery = {}
   ): Promise<string | null> {
@@ -3207,8 +3265,8 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
   public async renderError(
     err: Error | null,
-    req: BaseNextRequest,
-    res: BaseNextResponse,
+    req: ServerRequest,
+    res: ServerResponse,
     pathname: string,
     query: NextParsedUrlQuery = {},
     setHeaders = true
@@ -3220,8 +3278,8 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
   private async renderErrorImpl(
     err: Error | null,
-    req: BaseNextRequest,
-    res: BaseNextResponse,
+    req: ServerRequest,
+    res: ServerResponse,
     pathname: string,
     query: NextParsedUrlQuery = {},
     setHeaders = true
@@ -3252,7 +3310,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   })
 
   private async renderErrorToResponse(
-    ctx: RequestContext,
+    ctx: RequestContext<ServerRequest, ServerResponse>,
     err: Error | null
   ): Promise<ResponsePayload | null> {
     return getTracer().trace(BaseServerSpan.renderErrorToResponse, async () => {
@@ -3261,7 +3319,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   }
 
   protected async renderErrorToResponseImpl(
-    ctx: RequestContext,
+    ctx: RequestContext<ServerRequest, ServerResponse>,
     err: Error | null
   ): Promise<ResponsePayload | null> {
     // Short-circuit favicon.ico in development to avoid compiling 404 page when the app has no favicon.ico.
@@ -3460,8 +3518,8 @@ export default abstract class Server<ServerOptions extends Options = Options> {
 
   public async renderErrorToHTML(
     err: Error | null,
-    req: BaseNextRequest,
-    res: BaseNextResponse,
+    req: ServerRequest,
+    res: ServerResponse,
     pathname: string,
     query: ParsedUrlQuery = {}
   ): Promise<string | null> {
@@ -3474,8 +3532,8 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   }
 
   public async render404(
-    req: BaseNextRequest,
-    res: BaseNextResponse,
+    req: ServerRequest,
+    res: ServerResponse,
     parsedUrl?: Pick<NextUrlWithParsedQuery, 'pathname' | 'query'>,
     setHeaders = true
   ): Promise<void> {
@@ -3491,9 +3549,7 @@ export default abstract class Server<ServerOptions extends Options = Options> {
   }
 }
 
-export function isRSCRequestCheck(
-  req: IncomingMessage | BaseNextRequest
-): boolean {
+export function isRSCRequestCheck(req: BaseNextRequest): boolean {
   return (
     req.headers[RSC_HEADER.toLowerCase()] === '1' ||
     Boolean(getRequestMeta(req, 'isRSCRequest'))

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -5,7 +5,6 @@ import type { Params } from '../../shared/lib/router/utils/route-matcher'
 import type { ParsedUrl } from '../../shared/lib/router/utils/parse-url'
 import type { ParsedUrlQuery } from 'querystring'
 import type { UrlWithParsedQuery } from 'url'
-import type { BaseNextRequest, BaseNextResponse } from '../base-http'
 import type { FallbackMode, MiddlewareRoutingItem } from '../base-server'
 import type { FunctionComponent } from 'react'
 import type { RouteDefinition } from '../future/route-definitions/route-definition'
@@ -362,8 +361,8 @@ export default class DevServer extends Server {
   }
 
   async runMiddleware(params: {
-    request: BaseNextRequest
-    response: BaseNextResponse
+    request: NodeNextRequest
+    response: NodeNextResponse
     parsedUrl: ParsedUrl
     parsed: UrlWithParsedQuery
     middlewareList: MiddlewareRoutingItem[]
@@ -421,8 +420,8 @@ export default class DevServer extends Server {
   }
 
   async runEdgeFunction(params: {
-    req: BaseNextRequest
-    res: BaseNextResponse
+    req: NodeNextRequest
+    res: NodeNextResponse
     query: ParsedUrlQuery
     params: Params | undefined
     page: string
@@ -451,8 +450,8 @@ export default class DevServer extends Server {
   }
 
   public async handleRequest(
-    req: BaseNextRequest,
-    res: BaseNextResponse,
+    req: NodeNextRequest,
+    res: NodeNextResponse,
     parsedUrl?: NextUrlWithParsedQuery
   ): Promise<void> {
     const span = trace('handle-request', undefined, { url: req.url })

--- a/packages/next/src/server/future/route-modules/app-page/module.ts
+++ b/packages/next/src/server/future/route-modules/app-page/module.ts
@@ -1,4 +1,3 @@
-import type { IncomingMessage, ServerResponse } from 'http'
 import type { AppPageRouteDefinition } from '../../route-definitions/app-page-route-definition'
 import type RenderResult from '../../../render-result'
 import type { RenderOpts } from '../../../app-render/types'
@@ -12,6 +11,7 @@ import {
   type RouteModuleHandleContext,
 } from '../route-module'
 import * as vendoredContexts from './vendored/contexts/entrypoints'
+import type { BaseNextRequest, BaseNextResponse } from '../../../base-http'
 
 let vendoredReactRSC
 let vendoredReactSSR
@@ -52,8 +52,8 @@ export class AppPageRouteModule extends RouteModule<
   AppPageUserlandModule
 > {
   public render(
-    req: IncomingMessage,
-    res: ServerResponse,
+    req: BaseNextRequest,
+    res: BaseNextResponse,
     context: AppPageRouteHandlerContext
   ): Promise<RenderResult> {
     return renderToHTMLOrFlight(

--- a/packages/next/src/server/lib/patch-set-header.ts
+++ b/packages/next/src/server/lib/patch-set-header.ts
@@ -1,0 +1,53 @@
+import { getRequestMeta, type NextIncomingMessage } from '../request-meta'
+
+type PatchableResponse = {
+  setHeader(key: string, value: string | string[]): PatchableResponse
+}
+
+/**
+ * Ensure cookies set in middleware are merged and not overridden by API
+ * routes/getServerSideProps.
+ *
+ * @param req Incoming request
+ * @param res Outgoing response
+ */
+export function patchSetHeaderWithCookieSupport(
+  req: NextIncomingMessage,
+  res: PatchableResponse
+) {
+  const setHeader = res.setHeader.bind(res)
+  res.setHeader = (
+    name: string,
+    value: string | string[]
+  ): PatchableResponse => {
+    // When renders /_error after page is failed, it could attempt to set
+    // headers after headers.
+    if ('headersSent' in res && res.headersSent) {
+      return res
+    }
+
+    if (name.toLowerCase() === 'set-cookie') {
+      const middlewareValue = getRequestMeta(req, 'middlewareCookie')
+
+      if (
+        !middlewareValue ||
+        !Array.isArray(value) ||
+        !value.every((item, idx) => item === middlewareValue[idx])
+      ) {
+        value = [
+          // TODO: (wyattjoh) find out why this is called multiple times resulting in duplicate cookies being added
+          ...new Set([
+            ...(middlewareValue || []),
+            ...(typeof value === 'string'
+              ? [value]
+              : Array.isArray(value)
+              ? value
+              : []),
+          ]),
+        ]
+      }
+    }
+
+    return setHeader(name, value)
+  }
+}

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -12,11 +12,7 @@ import type { MiddlewareManifest } from '../build/webpack/plugins/middleware-plu
 import type RenderResult from './render-result'
 import type { FetchEventResult } from './web/types'
 import type { PrerenderManifest } from '../build'
-import type {
-  BaseNextRequest,
-  BaseNextResponse,
-  FetchMetric,
-} from './base-http'
+import type { FetchMetric } from './base-http'
 import type { PagesManifest } from '../build/webpack/plugins/pages-manifest-plugin'
 import type { NextParsedUrlQuery, NextUrlWithParsedQuery } from './request-meta'
 import type { Params } from '../shared/lib/router/utils/route-matcher'
@@ -61,6 +57,7 @@ import type {
   LoadedRenderOpts,
   RouteHandler,
   NextEnabledDirectories,
+  BaseRequestHandler,
 } from './base-server'
 import BaseServer, { NoFallbackError, isRSCRequestCheck } from './base-server'
 import { getMaybePagePath, getPagePath, requireFontManifest } from './require'
@@ -133,13 +130,12 @@ function formatRequestUrl(url: string, maxLength: number | undefined) {
     : url
 }
 
-export interface NodeRequestHandler {
-  (
-    req: IncomingMessage | BaseNextRequest,
-    res: ServerResponse | BaseNextResponse,
-    parsedUrl?: NextUrlWithParsedQuery | undefined
-  ): Promise<void> | void
-}
+export type NodeRequestHandler = BaseRequestHandler<
+  IncomingMessage | NodeNextRequest,
+  ServerResponse | NodeNextResponse
+>
+
+type NodeRouteHandler = RouteHandler<NodeNextRequest, NodeNextResponse>
 
 const MiddlewareMatcherCache = new WeakMap<
   MiddlewareManifest['middleware'][string],
@@ -165,7 +161,11 @@ function getMiddlewareMatcher(
   return matcher
 }
 
-export default class NextNodeServer extends BaseServer {
+export default class NextNodeServer extends BaseServer<
+  Options,
+  NodeNextRequest,
+  NodeNextResponse
+> {
   protected middlewareManifestPath: string
   private _serverDistDir: string | undefined
   private imageResponseCache?: ResponseCache
@@ -485,8 +485,8 @@ export default class NextNodeServer extends BaseServer {
   }
 
   protected async runApi(
-    req: BaseNextRequest | NodeNextRequest,
-    res: BaseNextResponse | NodeNextResponse,
+    req: NodeNextRequest,
+    res: NodeNextResponse,
     query: ParsedUrlQuery,
     match: PagesAPIRouteMatch
   ): Promise<boolean> {
@@ -520,23 +520,19 @@ export default class NextNodeServer extends BaseServer {
     delete query.__nextDefaultLocale
     delete query.__nextInferredLocaleFromDefault
 
-    await module.render(
-      (req as NodeNextRequest).originalRequest,
-      (res as NodeNextResponse).originalResponse,
-      {
-        previewProps: this.renderOpts.previewProps,
-        revalidate: this.revalidate.bind(this),
-        trustHostHeader: this.nextConfig.experimental.trustHostHeader,
-        allowedRevalidateHeaderKeys:
-          this.nextConfig.experimental.allowedRevalidateHeaderKeys,
-        hostname: this.fetchHostname,
-        minimalMode: this.minimalMode,
-        dev: this.renderOpts.dev === true,
-        query,
-        params: match.params,
-        page: match.definition.pathname,
-      }
-    )
+    await module.render(req.originalRequest, res.originalResponse, {
+      previewProps: this.renderOpts.previewProps,
+      revalidate: this.revalidate.bind(this),
+      trustHostHeader: this.nextConfig.experimental.trustHostHeader,
+      allowedRevalidateHeaderKeys:
+        this.nextConfig.experimental.allowedRevalidateHeaderKeys,
+      hostname: this.fetchHostname,
+      minimalMode: this.minimalMode,
+      dev: this.renderOpts.dev === true,
+      query,
+      params: match.params,
+      page: match.definition.pathname,
+    })
 
     return true
   }
@@ -572,13 +568,7 @@ export default class NextNodeServer extends BaseServer {
       renderOpts.nextFontManifest = this.nextFontManifest
 
       if (this.enabledDirectories.app && renderOpts.isAppPath) {
-        return lazyRenderAppPage(
-          req.originalRequest,
-          res.originalResponse,
-          pathname,
-          query,
-          renderOpts
-        )
+        return lazyRenderAppPage(req, res, pathname, query, renderOpts)
       }
 
       // TODO: re-enable this once we've refactored to use implicit matches
@@ -653,7 +643,7 @@ export default class NextNodeServer extends BaseServer {
   }
 
   protected async renderPageComponent(
-    ctx: RequestContext,
+    ctx: RequestContext<NodeNextRequest, NodeNextResponse>,
     bubbleNoFallback: boolean
   ) {
     const edgeFunctionsPages = this.getEdgeFunctionsPages() || []
@@ -815,7 +805,7 @@ export default class NextNodeServer extends BaseServer {
     )
   }
 
-  protected handleNextImageRequest: RouteHandler = async (
+  protected handleNextImageRequest: NodeRouteHandler = async (
     req,
     res,
     parsedUrl
@@ -856,7 +846,7 @@ export default class NextNodeServer extends BaseServer {
       }
 
       const paramsResult = ImageOptimizerCache.validateParams(
-        (req as NodeNextRequest).originalRequest,
+        req.originalRequest,
         parsedUrl.query,
         this.nextConfig,
         !!this.renderOpts.dev
@@ -877,8 +867,8 @@ export default class NextNodeServer extends BaseServer {
           cacheKey,
           async () => {
             const { buffer, contentType, maxAge } = await this.imageOptimizer(
-              req as NodeNextRequest,
-              res as NodeNextResponse,
+              req,
+              res,
               paramsResult
             )
             const etag = getHash([buffer])
@@ -905,8 +895,8 @@ export default class NextNodeServer extends BaseServer {
         }
 
         sendResponse(
-          (req as NodeNextRequest).originalRequest,
-          (res as NodeNextResponse).originalResponse,
+          req.originalRequest,
+          res.originalResponse,
           paramsResult.href,
           cacheEntry.value.extension,
           cacheEntry.value.buffer,
@@ -928,7 +918,7 @@ export default class NextNodeServer extends BaseServer {
     }
   }
 
-  protected handleCatchallRenderRequest: RouteHandler = async (
+  protected handleCatchallRenderRequest: NodeRouteHandler = async (
     req,
     res,
     parsedUrl
@@ -1060,8 +1050,8 @@ export default class NextNodeServer extends BaseServer {
    * @param pathname path of request
    */
   protected async handleApiRequest(
-    req: BaseNextRequest,
-    res: BaseNextResponse,
+    req: NodeNextRequest,
+    res: NodeNextResponse,
     query: ParsedUrlQuery,
     match: PagesAPIRouteMatch
   ): Promise<boolean> {
@@ -1080,19 +1070,15 @@ export default class NextNodeServer extends BaseServer {
   }
 
   private normalizeReq(
-    req: BaseNextRequest | IncomingMessage
-  ): BaseNextRequest {
-    return !(req instanceof NodeNextRequest)
-      ? new NodeNextRequest(req as IncomingMessage)
-      : req
+    req: NodeNextRequest | IncomingMessage
+  ): NodeNextRequest {
+    return !(req instanceof NodeNextRequest) ? new NodeNextRequest(req) : req
   }
 
   private normalizeRes(
-    res: BaseNextResponse | ServerResponse
-  ): BaseNextResponse {
-    return !(res instanceof NodeNextResponse)
-      ? new NodeNextResponse(res as ServerResponse)
-      : res
+    res: NodeNextResponse | ServerResponse
+  ): NodeNextResponse {
+    return !(res instanceof NodeNextResponse) ? new NodeNextResponse(res) : res
   }
 
   public getRequestHandler(): NodeRequestHandler {
@@ -1127,16 +1113,15 @@ export default class NextNodeServer extends BaseServer {
       if (this.renderOpts.dev) {
         const { blue, green, yellow, red, gray, white } =
           require('../lib/picocolors') as typeof import('../lib/picocolors')
-        const _res = res as NodeNextResponse | ServerResponse
-        const origRes =
-          'originalResponse' in _res ? _res.originalResponse : _res
+
+        const { originalResponse } = normalizedRes
 
         const reqStart = Date.now()
 
         const reqCallback = () => {
           // we don't log for non-route requests
           const isRouteRequest = getRequestMeta(req).match
-          const isRSC = isRSCRequestCheck(req)
+          const isRSC = isRSCRequestCheck(normalizedReq)
           if (!isRouteRequest || isRSC) return
 
           const reqEnd = Date.now()
@@ -1245,9 +1230,9 @@ export default class NextNodeServer extends BaseServer {
               }
             }
           }
-          origRes.off('close', reqCallback)
+          originalResponse.off('close', reqCallback)
         }
-        origRes.on('close', reqCallback)
+        originalResponse.on('close', reqCallback)
       }
       return handler(normalizedReq, normalizedRes, parsedUrl)
     }
@@ -1283,8 +1268,8 @@ export default class NextNodeServer extends BaseServer {
   }
 
   public async render(
-    req: BaseNextRequest | IncomingMessage,
-    res: BaseNextResponse | ServerResponse,
+    req: NodeNextRequest | IncomingMessage,
+    res: NodeNextResponse | ServerResponse,
     pathname: string,
     query?: NextParsedUrlQuery,
     parsedUrl?: NextUrlWithParsedQuery,
@@ -1301,8 +1286,8 @@ export default class NextNodeServer extends BaseServer {
   }
 
   public async renderToHTML(
-    req: BaseNextRequest | IncomingMessage,
-    res: BaseNextResponse | ServerResponse,
+    req: NodeNextRequest | IncomingMessage,
+    res: NodeNextResponse | ServerResponse,
     pathname: string,
     query?: ParsedUrlQuery
   ): Promise<string | null> {
@@ -1315,7 +1300,7 @@ export default class NextNodeServer extends BaseServer {
   }
 
   protected async renderErrorToResponseImpl(
-    ctx: RequestContext,
+    ctx: RequestContext<NodeNextRequest, NodeNextResponse>,
     err: Error | null
   ) {
     const { req, res, query } = ctx
@@ -1334,8 +1319,8 @@ export default class NextNodeServer extends BaseServer {
         this.getEdgeFunctionsPages().includes(UNDERSCORE_NOT_FOUND_ROUTE_ENTRY)
       ) {
         await this.runEdgeFunction({
-          req: req as BaseNextRequest,
-          res: res as BaseNextResponse,
+          req,
+          res,
           query: query || {},
           params: {},
           page: UNDERSCORE_NOT_FOUND_ROUTE_ENTRY,
@@ -1349,8 +1334,8 @@ export default class NextNodeServer extends BaseServer {
 
   public async renderError(
     err: Error | null,
-    req: BaseNextRequest | IncomingMessage,
-    res: BaseNextResponse | ServerResponse,
+    req: NodeNextRequest | IncomingMessage,
+    res: NodeNextResponse | ServerResponse,
     pathname: string,
     query?: NextParsedUrlQuery,
     setHeaders?: boolean
@@ -1367,8 +1352,8 @@ export default class NextNodeServer extends BaseServer {
 
   public async renderErrorToHTML(
     err: Error | null,
-    req: BaseNextRequest | IncomingMessage,
-    res: BaseNextResponse | ServerResponse,
+    req: NodeNextRequest | IncomingMessage,
+    res: NodeNextResponse | ServerResponse,
     pathname: string,
     query?: ParsedUrlQuery
   ): Promise<string | null> {
@@ -1382,8 +1367,8 @@ export default class NextNodeServer extends BaseServer {
   }
 
   public async render404(
-    req: BaseNextRequest | IncomingMessage,
-    res: BaseNextResponse | ServerResponse,
+    req: NodeNextRequest | IncomingMessage,
+    res: NodeNextResponse | ServerResponse,
     parsedUrl?: NextUrlWithParsedQuery,
     setHeaders?: boolean
   ): Promise<void> {
@@ -1510,8 +1495,8 @@ export default class NextNodeServer extends BaseServer {
    * and errors with rich traces.
    */
   protected async runMiddleware(params: {
-    request: BaseNextRequest
-    response: BaseNextResponse
+    request: NodeNextRequest
+    response: NodeNextResponse
     parsedUrl: ParsedUrl
     parsed: UrlWithParsedQuery
     onWarning?: (warning: Error) => void
@@ -1596,9 +1581,7 @@ export default class NextNodeServer extends BaseServer {
         url: url,
         page,
         body: getRequestMeta(params.request, 'clonableBody'),
-        signal: signalFromNodeResponse(
-          (params.response as NodeNextResponse).originalResponse
-        ),
+        signal: signalFromNodeResponse(params.response.originalResponse),
       },
       useCache: true,
       onWarning: params.onWarning,
@@ -1634,10 +1617,10 @@ export default class NextNodeServer extends BaseServer {
     return result
   }
 
-  protected handleCatchallMiddlewareRequest: RouteHandler = async (
-    req: BaseNextRequest,
-    res: BaseNextResponse,
-    parsed: NextUrlWithParsedQuery
+  protected handleCatchallMiddlewareRequest: NodeRouteHandler = async (
+    req,
+    res,
+    parsed
   ) => {
     const isMiddlewareInvoke = req.headers['x-middleware-invoke']
 
@@ -1705,7 +1688,7 @@ export default class NextNodeServer extends BaseServer {
         }
         res.statusCode = result.response.status
 
-        const { originalResponse } = res as NodeNextResponse
+        const { originalResponse } = res
         if (result.response.body) {
           await pipeToNodeResponse(result.response.body, originalResponse)
         } else {
@@ -1798,7 +1781,7 @@ export default class NextNodeServer extends BaseServer {
   }
 
   protected attachRequestMeta(
-    req: BaseNextRequest,
+    req: NodeNextRequest,
     parsedUrl: NextUrlWithParsedQuery,
     isUpgradeReq?: boolean
   ) {
@@ -1820,13 +1803,13 @@ export default class NextNodeServer extends BaseServer {
     addRequestMeta(req, 'initProtocol', protocol)
 
     if (!isUpgradeReq) {
-      addRequestMeta(req, 'clonableBody', getCloneableBody(req.body))
+      addRequestMeta(req, 'clonableBody', getCloneableBody(req.originalRequest))
     }
   }
 
   protected async runEdgeFunction(params: {
-    req: BaseNextRequest | NodeNextRequest
-    res: BaseNextResponse | NodeNextResponse
+    req: NodeNextRequest
+    res: NodeNextResponse
     query: ParsedUrlQuery
     params: Params | undefined
     page: string
@@ -1903,9 +1886,7 @@ export default class NextNodeServer extends BaseServer {
           ...(params.params && { params: params.params }),
         },
         body: getRequestMeta(params.req, 'clonableBody'),
-        signal: signalFromNodeResponse(
-          (params.res as NodeNextResponse).originalResponse
-        ),
+        signal: signalFromNodeResponse(params.res.originalResponse),
       },
       useCache: true,
       onError: params.onError,
@@ -1938,11 +1919,11 @@ export default class NextNodeServer extends BaseServer {
       }
     })
 
-    const nodeResStream = (params.res as NodeNextResponse).originalResponse
+    const { originalResponse } = params.res
     if (result.response.body) {
-      await pipeToNodeResponse(result.response.body, nodeResStream)
+      await pipeToNodeResponse(result.response.body, originalResponse)
     } else {
-      nodeResStream.end()
+      originalResponse.end()
     }
 
     return result

--- a/packages/next/src/server/web-server.ts
+++ b/packages/next/src/server/web-server.ts
@@ -54,7 +54,13 @@ interface WebServerOptions extends Options {
   }
 }
 
-export default class NextWebServer extends BaseServer<WebServerOptions> {
+type WebRouteHandler = RouteHandler<WebNextRequest, WebNextResponse>
+
+export default class NextWebServer extends BaseServer<
+  WebServerOptions,
+  WebNextRequest,
+  WebNextResponse
+> {
   constructor(options: WebServerOptions) {
     super(options)
 
@@ -152,7 +158,7 @@ export default class NextWebServer extends BaseServer<WebServerOptions> {
     return this.serverOptions.webServerConfig.extendRenderOpts.nextFontManifest
   }
 
-  protected handleCatchallRenderRequest: RouteHandler = async (
+  protected handleCatchallRenderRequest: WebRouteHandler = async (
     req,
     res,
     parsedUrl


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

This enhances the typings in the `BaseServer`, `NextNodeServer`, and `NextWebServer` to simplify types for request and responses across the entire server. Rather than relying on manual environment checks only as the source with error-prone type casts, this adds basic guards (albeit naive) that assert the typings depending on the runtime environment variables. This greatly enhances the typings used across the servers as the servers no longer use the `as` keyword when working with these request and response types.

This is a precursor to future planned work to further split the different rendering runtimes to assist with code elimination and framework organization.

### Why?

As a step to utilizing these more unified types, the `app-render.tsx` (App Pages rendering pipeline) has been modified to instead accept the abstract `BaseNextRequest` and `BaseNextResponse` types. This is a precursor to future work to split the streaming behaviour based on the runtime environment (ie, in Node.js, we can utilize the native streams instead of web streams, which offer significant performance gains).

### How?

The server types were modified to be generic, allowing the three server implementations to have their types flow safely between the different methods. This enables us to only reference the `NodeNextRequest` within the `NextNodeServer`, and the `WebNextRequest` within the `NextWebServer` for example.

🎥 [Loom Video](https://www.loom.com/share/76af2225cf0246d0b4f609ab3e35fff9?sid=c948a919-ac9e-4571-8a75-bd9d0a0776e2)

Closes NEXT-3102