### PR TITLE
Fix client boundary inheritance for barrel optimization

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-barrel-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-barrel-loader.ts
@@ -186,7 +186,7 @@ async function getBarrelMapping(
       ? JSON.parse(matchedDirectives[3])
       : []
     // "use client" in barrel files has to be transferred to the target file.
-    isClientEntry = directiveList.includes('use client')
+    const hasClientDirective = directiveList.includes('use client')
 
     let exportList = JSON.parse(matches[3].slice(1, -1)) as [
       string,
@@ -219,11 +219,14 @@ async function getBarrelMapping(
           const targetMatches = await getMatches(
             targetPath,
             true,
-            isClientEntry
+            hasClientDirective
           )
+
           if (targetMatches) {
             // Merge the export list
             exportList = exportList.concat(targetMatches.exportList)
+            // Inherit the client boundary from the target matched file
+            isClientEntry = isClientEntry || targetMatches.isClientEntry
           }
         })
       )

--- a/packages/next/src/build/webpack/loaders/next-barrel-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-barrel-loader.ts
@@ -186,7 +186,7 @@ async function getBarrelMapping(
       ? JSON.parse(matchedDirectives[3])
       : []
     // "use client" in barrel files has to be transferred to the target file.
-    const hasClientDirective = directiveList.includes('use client')
+    isClientEntry = directiveList.includes('use client')
 
     let exportList = JSON.parse(matches[3].slice(1, -1)) as [
       string,
@@ -219,7 +219,7 @@ async function getBarrelMapping(
           const targetMatches = await getMatches(
             targetPath,
             true,
-            hasClientDirective
+            isClientEntry
           )
 
           if (targetMatches) {

--- a/test/development/basic/barrel-optimization/barrel-optimization-mui.test.ts
+++ b/test/development/basic/barrel-optimization/barrel-optimization-mui.test.ts
@@ -14,7 +14,7 @@ import { hasRedbox } from 'next-test-utils'
         files: join(__dirname, 'fixture'),
 
         dependencies: {
-          '@mui/material': '5.15.4',
+          '@mui/material': '5.15.15',
           '@emotion/react': '11.11.1',
           '@emotion/styled': '11.11.0',
         },

--- a/test/production/app-dir/barrel-optimization/basic/app/layout.js
+++ b/test/production/app-dir/barrel-optimization/basic/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/barrel-optimization/basic/app/page.js
+++ b/test/production/app-dir/barrel-optimization/basic/app/page.js
@@ -1,0 +1,9 @@
+import { ClientDefault } from 'my-lib'
+
+export default function Home() {
+  return (
+    <div id="client-mod">
+      <ClientDefault />
+    </div>
+  )
+}

--- a/test/production/app-dir/barrel-optimization/basic/index.test.ts
+++ b/test/production/app-dir/barrel-optimization/basic/index.test.ts
@@ -5,21 +5,15 @@ import { createNextDescribe } from 'e2e-utils'
   'Skipped in Turbopack',
   () => {
     createNextDescribe(
-      'app-dir - optimizePackageImports - mui',
+      'app-dir - optimizePackageImports - basic',
       {
         files: __dirname,
-
-        dependencies: {
-          '@mui/material': '5.15.15',
-          '@emotion/react': '11.11.1',
-          '@emotion/styled': '11.11.0',
-        },
       },
       ({ next }) => {
         it('should build successfully', async () => {
           // Ensure that MUI is working
           const $ = await next.render$('/')
-          expect(await $('#typography').text()).toContain('typography')
+          expect(await $('#client-mod').text()).toContain('client:default')
         })
       }
     )

--- a/test/production/app-dir/barrel-optimization/basic/index.test.ts
+++ b/test/production/app-dir/barrel-optimization/basic/index.test.ts
@@ -1,21 +1,17 @@
 import { createNextDescribe } from 'e2e-utils'
 
-// Skipped in Turbopack, will be added later.
-;(process.env.TURBOPACK ? describe.skip : describe)(
-  'Skipped in Turbopack',
-  () => {
-    createNextDescribe(
-      'app-dir - optimizePackageImports - basic',
-      {
-        files: __dirname,
-      },
-      ({ next }) => {
-        it('should build successfully', async () => {
-          // Ensure that MUI is working
-          const $ = await next.render$('/')
-          expect(await $('#client-mod').text()).toContain('client:default')
-        })
-      }
-    )
-  }
-)
+describe('Skipped in Turbopack', () => {
+  createNextDescribe(
+    'app-dir - optimizePackageImports - basic',
+    {
+      files: __dirname,
+    },
+    ({ next }) => {
+      it('should build successfully', async () => {
+        // Ensure that MUI is working
+        const $ = await next.render$('/')
+        expect(await $('#client-mod').text()).toContain('client:default')
+      })
+    }
+  )
+})

--- a/test/production/app-dir/barrel-optimization/basic/next.config.js
+++ b/test/production/app-dir/barrel-optimization/basic/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    optimizePackageImports: ['my-lib'],
+  },
+}

--- a/test/production/app-dir/barrel-optimization/basic/node_modules/my-lib/client/client-module.js
+++ b/test/production/app-dir/barrel-optimization/basic/node_modules/my-lib/client/client-module.js
@@ -1,0 +1,9 @@
+'use client'
+
+export default function ClientDefault() {
+  return 'client:default'
+}
+
+export function ClientFoo() {
+  return 'client:foo'
+}

--- a/test/production/app-dir/barrel-optimization/basic/node_modules/my-lib/client/index.js
+++ b/test/production/app-dir/barrel-optimization/basic/node_modules/my-lib/client/index.js
@@ -1,0 +1,4 @@
+'use client'
+
+export { default } from './client-module'
+export * from './client-module'

--- a/test/production/app-dir/barrel-optimization/basic/node_modules/my-lib/index.js
+++ b/test/production/app-dir/barrel-optimization/basic/node_modules/my-lib/index.js
@@ -1,0 +1,2 @@
+export { default as ClientDefault } from './client'
+export * from './client'

--- a/test/production/app-dir/barrel-optimization/basic/node_modules/my-lib/package.json
+++ b/test/production/app-dir/barrel-optimization/basic/node_modules/my-lib/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "my-lib",
+  "type": "module",
+  "exports": "./index.js"
+}

--- a/test/production/app-dir/barrel-optimization/mui/app/layout.js
+++ b/test/production/app-dir/barrel-optimization/mui/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/barrel-optimization/mui/app/page.js
+++ b/test/production/app-dir/barrel-optimization/mui/app/page.js
@@ -1,0 +1,11 @@
+import { Typography } from '@mui/material'
+
+export default function Home() {
+  return (
+    <div id="typography">
+      <Typography id="typography" variant="h1">
+        typography
+      </Typography>
+    </div>
+  )
+}

--- a/test/production/app-dir/barrel-optimization/mui/index.test.ts
+++ b/test/production/app-dir/barrel-optimization/mui/index.test.ts
@@ -1,0 +1,27 @@
+import { createNextDescribe } from 'e2e-utils'
+
+// Skipped in Turbopack, will be added later.
+;(process.env.TURBOPACK ? describe.skip : describe)(
+  'Skipped in Turbopack',
+  () => {
+    createNextDescribe(
+      'optimizePackageImports - mui',
+      {
+        files: __dirname,
+
+        dependencies: {
+          '@mui/material': '5.15.15',
+          '@emotion/react': '11.11.1',
+          '@emotion/styled': '11.11.0',
+        },
+      },
+      ({ next }) => {
+        it('should build successfully', async () => {
+          // Ensure that MUI is working
+          const $ = await next.render$('/mui')
+          expect(await $('#typography').text()).toContain('typography')
+        })
+      }
+    )
+  }
+)

--- a/test/production/app-dir/barrel-optimization/mui/index.test.ts
+++ b/test/production/app-dir/barrel-optimization/mui/index.test.ts
@@ -18,7 +18,7 @@ import { createNextDescribe } from 'e2e-utils'
       ({ next }) => {
         it('should build successfully', async () => {
           // Ensure that MUI is working
-          const $ = await next.render$('/mui')
+          const $ = await next.render$('/')
           expect(await $('#typography').text()).toContain('typography')
         })
       }

--- a/test/production/app-dir/barrel-optimization/mui/index.test.ts
+++ b/test/production/app-dir/barrel-optimization/mui/index.test.ts
@@ -1,27 +1,23 @@
 import { createNextDescribe } from 'e2e-utils'
 
-// Skipped in Turbopack, will be added later.
-;(process.env.TURBOPACK ? describe.skip : describe)(
-  'Skipped in Turbopack',
-  () => {
-    createNextDescribe(
-      'app-dir - optimizePackageImports - mui',
-      {
-        files: __dirname,
+describe('Skipped in Turbopack', () => {
+  createNextDescribe(
+    'app-dir - optimizePackageImports - mui',
+    {
+      files: __dirname,
 
-        dependencies: {
-          '@mui/material': '5.15.15',
-          '@emotion/react': '11.11.1',
-          '@emotion/styled': '11.11.0',
-        },
+      dependencies: {
+        '@mui/material': '5.15.15',
+        '@emotion/react': '11.11.1',
+        '@emotion/styled': '11.11.0',
       },
-      ({ next }) => {
-        it('should build successfully', async () => {
-          // Ensure that MUI is working
-          const $ = await next.render$('/')
-          expect(await $('#typography').text()).toContain('typography')
-        })
-      }
-    )
-  }
-)
+    },
+    ({ next }) => {
+      it('should build successfully', async () => {
+        // Ensure that MUI is working
+        const $ = await next.render$('/')
+        expect(await $('#typography').text()).toContain('typography')
+      })
+    }
+  )
+})


### PR DESCRIPTION
### What

Inherit the client boudaries from the found matched target in load barrel

### Why
The root cause with the barrel transform, we missed the client boundary directive during the transform.
Since the new version of mui's case looks like this:

Import path
page.js (server module) -> `<module>/index.js` (shared module) -> `<module/subpath>/index.js` (client module) -> `<module/subpath/sub-module.js> (client module)

After our transform, we lost the `"use client"` which causes the mismatch of the transform:

In `rsc` layer: the file pointing to the sub module entry (`<module/subpath>/index.js`), but without the client boundary.


Fixes #64369 
Closes NEXT-3101