### PR TITLE
Ensure declaration reference published paths

### DIFF
--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -17,7 +17,6 @@
     "image-types/global.d.ts",
     "compat/*.d.ts",
     "legacy/*.d.ts",
-    "types/compiled.d.ts",
     "navigation-types/*.d.ts",
     "navigation-types/compat/*.d.ts",
     "experimental/**/*.d.ts"

--- a/packages/next/types/misc.d.ts
+++ b/packages/next/types/misc.d.ts
@@ -27,14 +27,9 @@ declare module 'next/dist/compiled/react-dom/server.browser'
 declare module 'next/dist/compiled/browserslist'
 
 declare module 'react-server-dom-webpack/client'
-declare module 'react-server-dom-webpack/server.edge'
 declare module 'react-server-dom-webpack/server.node'
 declare module 'react-server-dom-webpack/client.edge'
 
-declare module 'VAR_MODULE_GLOBAL_ERROR'
-declare module 'VAR_USERLAND'
-declare module 'VAR_MODULE_DOCUMENT'
-declare module 'VAR_MODULE_APP'
 
 declare module 'next/dist/compiled/@next/react-refresh-utils/dist/ReactRefreshWebpackPlugin' {
   import m from '@next/react-refresh-utils/ReactRefreshWebpackPlugin'


### PR DESCRIPTION
We currently emit declaration for files that reference unknown modules e.g. `export { default as GlobalError } from 'VAR_MODULE_GLOBAL_ERROR';` in `next/dist/build/templates/app-page.d.ts`. 

Since the referenced modules are declarated in `compiled.d.ts` which we do publish, I see no reason to not also let `next/dist/build/templates/app-page.d.ts` reference the appropriate ambient declaration file (`compiled.d.ts`). 

The alternative is marking the whole module as `@internal` but checking if every export truly never flows into a public module takes way more time.

This also unblocks the TypeScript 5.4 upgrade in https://github.com/vercel/next.js/pull/64043. TS 5.4 would emit a declaration referencing the appropriate ambient declaration but since `compiled.d.ts` is not part of the program but `misc.d.ts` is, the declaration would reference `misc.d.ts`(`/// <reference path="../../../types/misc.d.ts"`) which is not published and would cause TypeScript compilation to fail.



Closes NEXT-3104