### PR TITLE
Add typechecking test for all entrypoints

### DIFF
--- a/test/production/typescript-basic/typechecking.test.ts
+++ b/test/production/typescript-basic/typechecking.test.ts
@@ -1,0 +1,28 @@
+import * as childProcess from 'child_process'
+import path from 'path'
+import { FileRef, nextTestSetup } from 'e2e-utils'
+
+describe('typechecking', () => {
+  const { next } = nextTestSetup({
+    files: new FileRef(path.join(__dirname, 'typechecking')),
+    skipStart: true,
+  })
+
+  it('should typecheck', async () => {
+    const { status, stdout } = childProcess.spawnSync(
+      'pnpm',
+      ['tsc', '--project', 'tsconfig.json', '--skipLibCheck', 'false'],
+      {
+        cwd: next.testDir,
+        encoding: 'utf-8',
+      }
+    )
+
+    if (status !== 0) {
+      // Piped output is incomplete and the format barely useable.
+      // Printing it as a last resort in case it's not reproducible locally.
+      // Best to NEXT_TEST_SKIP_CLEANUP=1 this test and run the command in the app localy.
+      throw new Error('Typecheck failed: \n' + stdout)
+    }
+  })
+})

--- a/test/production/typescript-basic/typechecking/.gitignore
+++ b/test/production/typescript-basic/typechecking/.gitignore
@@ -1,0 +1,1 @@
+!next-env.d.ts

--- a/test/production/typescript-basic/typechecking/index.ts
+++ b/test/production/typescript-basic/typechecking/index.ts
@@ -1,0 +1,25 @@
+import 'next/amp'
+import 'next/app'
+// FIXME
+// import 'next/babel';
+import 'next/cache'
+import 'next/client'
+import 'next/config'
+import 'next/constants'
+import 'next/document'
+import 'next/dynamic'
+import 'next/error'
+import 'next/head'
+import 'next/headers'
+import 'next/image'
+import 'next'
+// TODO @jest/types is an undeclared peer dependecy
+// import 'next/jest';
+import 'next/link'
+import 'next/navigation'
+import 'next/og'
+import 'next/router'
+import 'next/script'
+import 'next/server'
+// FIXME
+// import 'next/web-vitals';

--- a/test/production/typescript-basic/typechecking/next-env.d.ts
+++ b/test/production/typescript-basic/typechecking/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/test/production/typescript-basic/typechecking/next.config.js
+++ b/test/production/typescript-basic/typechecking/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/production/typescript-basic/typechecking/tsconfig.json
+++ b/test/production/typescript-basic/typechecking/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": false,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Couldn't find existing tests for checking that all entrypoints have working types. 3 entrypoints currently don't typecheck with `skipLibCheck`:

- `next/jest`: Just need to declare an explicit peer dependency on `@jest/types` and install that to validate
- `next/babel`: References `next/dist/compiled/babel/core` which re-exports via `misc.d.ts` from `babel/core`. Since misc.d.ts is not published, installing `@babel/core` wouldn't be sufficient. Need to check how to fix.
- `next/web-vitals`: Unclear how to fix. Tracking in https://github.com/vercel/next.js/issues/59903

The main point here was to write a regression test before we land https://github.com/vercel/next.js/pull/64043 which needs more `@internal` annotations.

Closes NEXT-3105