### PR TITLE
chore: Update pnpm v8.15.14 to v8.15.7

### DIFF
--- a/.github/actions/next-integration-stat/package.json
+++ b/.github/actions/next-integration-stat/package.json
@@ -22,7 +22,7 @@
   },
   "engines": {
     "node": ">=18.17.0",
-    "pnpm": "8.15.4"
+    "pnpm": "8.15.7"
   },
-  "packageManager": "pnpm@8.15.4"
+  "packageManager": "pnpm@8.15.7"
 }

--- a/.github/actions/next-stats-action/package.json
+++ b/.github/actions/next-stats-action/package.json
@@ -19,7 +19,7 @@
   },
   "engines": {
     "node": ">=18.17.0",
-    "pnpm": "8.15.4"
+    "pnpm": "8.15.7"
   },
-  "packageManager": "pnpm@8.15.4"
+  "packageManager": "pnpm@8.15.7"
 }

--- a/.github/actions/upload-turboyet-data/package.json
+++ b/.github/actions/upload-turboyet-data/package.json
@@ -13,7 +13,7 @@
   },
   "engines": {
     "node": ">=18.17.0",
-    "pnpm": "8.15.4"
+    "pnpm": "8.15.7"
   },
-  "packageManager": "pnpm@8.15.4"
+  "packageManager": "pnpm@8.15.7"
 }

--- a/package.json
+++ b/package.json
@@ -256,7 +256,7 @@
   },
   "engines": {
     "node": ">=18.17.0",
-    "pnpm": "8.15.4"
+    "pnpm": "8.15.7"
   },
-  "packageManager": "pnpm@8.15.4"
+  "packageManager": "pnpm@8.15.7"
 }

--- a/test/.stats-app/package.json
+++ b/test/.stats-app/package.json
@@ -9,7 +9,7 @@
   },
   "engines": {
     "node": ">=18.17.0",
-    "pnpm": "8.15.4"
+    "pnpm": "8.15.7"
   },
-  "packageManager": "pnpm@8.15.4"
+  "packageManager": "pnpm@8.15.7"
 }


### PR DESCRIPTION

Here are the release notes for pnpm versions v8.15.2 through v8.15.7,

- [v8.15.2 Release Notes](https://github.com/pnpm/pnpm/releases/tag/v8.15.2)
- [v8.15.3 Release Notes](https://github.com/pnpm/pnpm/releases/tag/v8.15.3)
- [v8.15.4 Release Notes](https://github.com/pnpm/pnpm/releases/tag/v8.15.4)
- [v8.15.5 Release Notes](https://github.com/pnpm/pnpm/releases/tag/v8.15.5)
- [v8.15.6 Release Notes](https://github.com/pnpm/pnpm/releases/tag/v8.15.6)
- [v8.15.7 Release Notes](https://github.com/pnpm/pnpm/releases/tag/v8.15.7)
