### PR TITLE
improve turborepo caching

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -275,6 +275,9 @@ jobs:
           cache-provider: 'turbo'
           shared-key: build-${{ matrix.settings.target }}-${{ hashFiles('.cargo/config.toml') }}
 
+      - name: Clear native build
+        run: rm -rf packages/next-swc/native
+
       # we only need custom caching for docker builds
       # as they are on an older Node.js version and have
       # issues with turbo caching

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -11,7 +11,7 @@
     "build-native-no-plugin-woa-release": "napi build --platform -p next-swc-napi --cargo-cwd ../../ --cargo-name next_swc_napi --release --cargo-flags=--no-default-features --features image-webp,tracing/release_max_level_info --js false native",
     "build-native-wasi": "npx --package=@napi-rs/cli@3.0.0-alpha.45 napi build --platform --target wasm32-wasip1-threads -p next-swc-napi --cwd ../../ --output-dir packages/next-swc/native",
     "build-wasm": "wasm-pack build crates/wasm --scope=next",
-    "cache-build-native": "[ ! -d native ] && echo $(ls native)",
+    "cache-build-native": "[ -d native ] && echo $(ls native)",
     "rust-check-fmt": "cd ../..; cargo fmt -- --check",
     "rust-check-clippy": "cargo clippy --workspace --all-targets -- -D warnings -A deprecated",
     "rust-check-napi-rustls": "cargo check -p next-swc-napi",

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -11,7 +11,7 @@
     "build-native-no-plugin-woa-release": "napi build --platform -p next-swc-napi --cargo-cwd ../../ --cargo-name next_swc_napi --release --cargo-flags=--no-default-features --features image-webp,tracing/release_max_level_info --js false native",
     "build-native-wasi": "npx --package=@napi-rs/cli@3.0.0-alpha.45 napi build --platform --target wasm32-wasip1-threads -p next-swc-napi --cwd ../../ --output-dir packages/next-swc/native",
     "build-wasm": "wasm-pack build crates/wasm --scope=next",
-    "cache-build-native": "echo $(ls native)",
+    "cache-build-native": "[ ! -d native ] && echo $(ls native)",
     "rust-check-fmt": "cd ../..; cargo fmt -- --check",
     "rust-check-clippy": "cargo clippy --workspace --all-targets -- -D warnings -A deprecated",
     "rust-check-napi-rustls": "cargo check -p next-swc-napi",

--- a/scripts/pull-turbo-cache.js
+++ b/scripts/pull-turbo-cache.js
@@ -42,6 +42,7 @@ const { spawn } = require('child_process')
 
   // pull cache if it was available
   if (task.cache.local || task.cache.remote) {
+    console.log('Cache Status', task.taskId, task.hash, task.cache)
     await new Promise((resolve, reject) => {
       const child = spawn(
         '/bin/bash',


### PR DESCRIPTION
### What?

There is a race condition in the `pull-build-cache` script. When the remote cache entry was removed between the dry run and the real run, it will run the command and caches whatever is in the native folder.

Seems like there are some very old leftover files there which lead to an broken publish.

This changes the command to fail when there are no files and empties the folder before running the script. This should lead to pull-build-cache to failing instead.

Closes PACK-2957
Fixes #64468