### PR TITLE
chore: tweak unhelpful comment weight

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -35,3 +35,4 @@ jobs:
           reproduction-link-section: '### Link to the code that reproduces this issue(.*)### To Reproduce'
           reproduction-invalid-label: 'invalid link'
           reproduction-issue-labels: 'template: bug,'
+          comment-unhelpful-weight: 0.5


### PR DESCRIPTION
### What?

Make sure that more unhelpful comments get minimized by default so issue threads are easier to read.

### Why?

https://github.com/vercel/next.js/issues/64465

### How?

Using https://github.com/balazsorban44/nissuer#handle-unhelpful-comments

NOTE: This has the potential to hide comments that _might_ be useful, but currently it looks like it is too permissive.

Closes NEXT-3107