### PR TITLE
feat: strip traceparent header from cachekey

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -385,14 +385,19 @@ export class IncrementalCache implements IncrementalCacheType {
       }
     }
 
+    const headers =
+      typeof (init.headers || {}).keys === 'function'
+        ? Object.fromEntries(init.headers as Headers)
+        : Object.assign(init.headers || {}, {})
+
+    if ('traceparent' in headers) delete headers['traceparent']
+
     const cacheString = JSON.stringify([
       MAIN_KEY_PREFIX,
       this.fetchCacheKeyPrefix || '',
       url,
       init.method,
-      typeof (init.headers || {}).keys === 'function'
-        ? Object.fromEntries(init.headers as Headers)
-        : init.headers,
+      headers,
       init.mode,
       init.redirect,
       init.credentials,


### PR DESCRIPTION
### What?
We strip the `traceparent` header from the cache-key.

### Why?
The traceparent header forms part of the W3C Trace Context standard, installed to track individual HTTP requests from start to end across multiple services. That means each individual HTTP request will have a unique traceparent value, reflecting its unique journey across servers and services.

If we include the traceparent header in the cache key, the uniqueness of the traceparent means the cache key would always be different even for requests that should yield the same response. This would cause the cache to always miss and re-process the request.

Effectively rendering fetch-cache useless.

