### PR TITLE
Add `@appsignal/nodejs` to the external packages list

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/serverComponentsExternalPackages.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/serverComponentsExternalPackages.mdx
@@ -20,6 +20,7 @@ module.exports = nextConfig
 
 Next.js includes a [short list of popular packages](https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/server-external-packages.json) that currently are working on compatibility and automatically opt-ed out:
 
+- `@appsignal/nodejs`
 - `@aws-sdk/client-s3`
 - `@aws-sdk/s3-presigned-post`
 - `@blockfrost/blockfrost-js`

--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -1,4 +1,5 @@
 [
+  "@appsignal/nodejs",
   "@aws-sdk/client-s3",
   "@aws-sdk/s3-presigned-post",
   "@blockfrost/blockfrost-js",


### PR DESCRIPTION
The `@appsignal/nodejs` instrumentation package fails to load in Next.js 14 due to Webpack failing to bundle its Node.js native extension. Adding it to the server components external packages list fixes this issue.

Part of https://github.com/appsignal/appsignal-nodejs/issues/1014.