### PR TITLE
Fix missing PagesOnly in 05-mdx

### DIFF
--- a/docs/02-app/01-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/05-mdx.mdx
@@ -539,6 +539,8 @@ export default function MDXPage({ children }) {
 }
 ```
 
+</PagesOnly >
+
 ## Frontmatter
 
 Frontmatter is a YAML like key/value pairing that can be used to store data about a page. `@next/mdx` does **not** support frontmatter by default, though there are many solutions for adding frontmatter to your MDX content, such as:


### PR DESCRIPTION
Looks like we have a syntax error in https://github.com/vercel/next.js/pull/63568 from missing closing `</PagessOnly>` tag. 

```sh
b383-75ab3d452c93.mdx:0:0: ERROR: [plugin: @mdx-js/esbuild] Expected a closing tag for `</PagesOnly>` (503:1-503:12)
```

x-ref: https://github.com/vercel/next.js/pull/63568

Closes NEXT-3111