### PR TITLE
Fix DynamicServerError not being thrown in fetch

### DIFF
--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -668,6 +668,7 @@ function createPatchedFetcher(
             const err = new DynamicServerError(dynamicUsageReason)
             staticGenerationStore.dynamicUsageErr = err
             staticGenerationStore.dynamicUsageDescription = dynamicUsageReason
+            throw err
           }
 
           const hasNextConfig = 'next' in init
@@ -695,6 +696,7 @@ function createPatchedFetcher(
               const err = new DynamicServerError(dynamicUsageReason)
               staticGenerationStore.dynamicUsageErr = err
               staticGenerationStore.dynamicUsageDescription = dynamicUsageReason
+              throw err
             }
 
             if (!staticGenerationStore.forceStatic || next.revalidate !== 0) {

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -703,6 +703,8 @@ createNextDescribe(
             "force-dynamic-no-prerender/[id]/page_client-reference-manifest.js",
             "force-dynamic-prerender/[slug]/page.js",
             "force-dynamic-prerender/[slug]/page_client-reference-manifest.js",
+            "force-no-store-bailout/page.js",
+            "force-no-store-bailout/page_client-reference-manifest.js",
             "force-no-store/page.js",
             "force-no-store/page_client-reference-manifest.js",
             "force-static-fetch-no-store.html",

--- a/test/e2e/app-dir/app-static/app/force-no-store-bailout/page.js
+++ b/test/e2e/app-dir/app-static/app/force-no-store-bailout/page.js
@@ -1,0 +1,16 @@
+export const fetchCache = 'force-no-store'
+
+export default async function Page() {
+  // this should not be invoked during build as
+  // no-store should have it bail out
+  await fetch('https://non-existent', {
+    cache: 'no-store',
+  })
+
+  return (
+    <>
+      <p id="page">/force-no-store-bailout</p>
+      <p id="now">{Date.now()}</p>
+    </>
+  )
+}


### PR DESCRIPTION
This ensures we properly skip calling a fetch during build-time that has `cache: 'no-store'` as it should only be called during runtime instead. 

Fixes: https://github.com/vercel/next.js/issues/64462

Closes NEXT-3114