### PR TITLE
Turbopack: Allow client components to be imported in app routes

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -575,7 +575,7 @@ async fn insert_next_server_special_aliases(
         // the logic closely follows the one in createRSCAliases in webpack-config.ts
         ServerContextType::AppSSR { app_dir }
         | ServerContextType::AppRSC { app_dir, .. }
-        | ServerContextType::AppRoute { app_dir } => {
+        | ServerContextType::AppRoute { app_dir, .. } => {
             import_map.insert_exact_alias(
                 "styled-jsx",
                 request_to_import_mapping(get_next_package(app_dir), "styled-jsx"),

--- a/test/e2e/app-dir/app-routes-client-component/ClientComponent.tsx
+++ b/test/e2e/app-dir/app-routes-client-component/ClientComponent.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export function ClientComponent() {
+  return <div>ClientComponent</div>
+}

--- a/test/e2e/app-dir/app-routes-client-component/app-routes-client-component.test.ts
+++ b/test/e2e/app-dir/app-routes-client-component/app-routes-client-component.test.ts
@@ -1,0 +1,18 @@
+import { FileRef, nextTestSetup } from 'e2e-utils'
+import path from 'path'
+
+describe('referencing a client component in an app route', () => {
+  const { next } = nextTestSetup({
+    files: new FileRef(path.join(__dirname)),
+    dependencies: {
+      react: 'latest',
+      'react-dom': 'latest',
+    },
+  })
+
+  it('responds without error', async () => {
+    expect(JSON.parse(await next.render('/runtime'))).toEqual({
+      clientComponent: process.env.TURBOPACK ? 'function' : 'object',
+    })
+  })
+})

--- a/test/e2e/app-dir/app-routes-client-component/app-routes-client-component.test.ts
+++ b/test/e2e/app-dir/app-routes-client-component/app-routes-client-component.test.ts
@@ -12,6 +12,7 @@ describe('referencing a client component in an app route', () => {
 
   it('responds without error', async () => {
     expect(JSON.parse(await next.render('/runtime'))).toEqual({
+      // Turbopack's proxy components are functions
       clientComponent: process.env.TURBOPACK ? 'function' : 'object',
     })
   })

--- a/test/e2e/app-dir/app-routes-client-component/app/runtime/route.ts
+++ b/test/e2e/app-dir/app-routes-client-component/app/runtime/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+import { ClientComponent } from '../../ClientComponent'
+
+export function GET() {
+  return NextResponse.json({
+    clientComponent: typeof ClientComponent,
+  })
+}


### PR DESCRIPTION
Resolves #64412

This adds a client transition to the app route `ModuleAssetContext` and the corresponding transforms so that client components can be safely imported and referenced (as their proxies) in app routes.

Test Plan: Added an integration test


Closes PACK-2964