### PR TITLE
refactor: remove always truthy flag

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1815,7 +1815,6 @@ export default async function getBaseWebpackConfig(
           buildId,
           rewrites,
           isDevFallback,
-          exportRuntime: true,
           appDirEnabled: hasAppDir,
         }),
       new ProfilingPlugin({ runWebpackSpan, rootDir: dir }),

--- a/packages/next/src/build/webpack/plugins/build-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/build-manifest-plugin.ts
@@ -123,14 +123,12 @@ export default class BuildManifestPlugin {
   private buildId: string
   private rewrites: CustomRoutes['rewrites']
   private isDevFallback: boolean
-  private exportRuntime: boolean
   private appDirEnabled: boolean
 
   constructor(options: {
     buildId: string
     rewrites: CustomRoutes['rewrites']
     isDevFallback?: boolean
-    exportRuntime?: boolean
     appDirEnabled: boolean
   }) {
     this.buildId = options.buildId
@@ -144,7 +142,6 @@ export default class BuildManifestPlugin {
     this.rewrites.beforeFiles = options.rewrites.beforeFiles.map(processRoute)
     this.rewrites.afterFiles = options.rewrites.afterFiles.map(processRoute)
     this.rewrites.fallback = options.rewrites.fallback.map(processRoute)
-    this.exportRuntime = !!options.exportRuntime
   }
 
   createAssets(compiler: any, compilation: any, assets: any) {
@@ -258,12 +255,9 @@ export default class BuildManifestPlugin {
         JSON.stringify(assetMap, null, 2)
       )
 
-      if (this.exportRuntime) {
-        assets[`server/${MIDDLEWARE_BUILD_MANIFEST}.js`] =
-          new sources.RawSource(
-            `self.__BUILD_MANIFEST=${JSON.stringify(assetMap)}`
-          )
-      }
+      assets[`server/${MIDDLEWARE_BUILD_MANIFEST}.js`] = new sources.RawSource(
+        `self.__BUILD_MANIFEST=${JSON.stringify(assetMap)}`
+      )
 
       if (!this.isDevFallback) {
         const clientManifestPath = `${CLIENT_STATIC_FILES_PATH}/${this.buildId}/_buildManifest.js`


### PR DESCRIPTION
Remove the `this.exportRuntime` flag in build manifest plugin where it's always true

Closes NEXT-3118