### PR TITLE
Require turbopack build jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -461,6 +461,8 @@ jobs:
         'test-turbopack-integration',
         'test-new-tests-dev',
         'test-new-tests-start',
+        'test-turbopack-production',
+        'test-turbopack-production-integration',
       ]
 
     if: always()


### PR DESCRIPTION
These should be required for the workflow to be considered passing so that we don't accidentally forget to update the manifests

Closes NEXT-3122