### PR TITLE
chore(next/font): update @capsizecss/metrics package

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -140,7 +140,7 @@
     "@babel/runtime": "7.22.5",
     "@babel/traverse": "7.22.5",
     "@babel/types": "7.22.5",
-    "@capsizecss/metrics": "2.2.0",
+    "@capsizecss/metrics": "3.0.0",
     "@edge-runtime/cookies": "4.1.1",
     "@edge-runtime/ponyfill": "2.4.2",
     "@edge-runtime/primitives": "4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -900,8 +900,8 @@ importers:
         specifier: 7.22.5
         version: 7.22.5
       '@capsizecss/metrics':
-        specifier: 2.2.0
-        version: 2.2.0
+        specifier: 3.0.0
+        version: 3.0.0
       '@edge-runtime/cookies':
         specifier: 4.1.1
         version: 4.1.1
@@ -3385,8 +3385,8 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@capsizecss/metrics@2.2.0:
-    resolution: {integrity: sha512-DkFIser1KbGxWyG2hhQQeCit72TnOQDx5pr9bkA7+XlIy7qv+4lYtslH3bidVxm2qkY2guAgypSIPYuQQuk70A==}
+  /@capsizecss/metrics@3.0.0:
+    resolution: {integrity: sha512-GTOIvDhuZKBDLeLPaA4mgwuKVwm2eaKR6Oaa76reaSkWTa5GCSe6W+DWPKEUJqjJyxsvkOYpC8reQ8njk90t5w==}
     dev: true
 
   /@csstools/postcss-color-function@1.1.0(postcss@8.4.31):


### PR DESCRIPTION
## Why?

Having the latest `@capsizecss/metrics` package allows us to have the latest font fallbacks when using [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts).

- x-ref: https://github.com/vercel/next.js/issues/47115#issuecomment-2051755660
- x-ref: https://github.com/vercel/next.js/issues/47115#issuecomment-2055079526
- https://github.com/seek-oss/capsize/releases/tag/%40capsizecss%2Fmetrics%403.0.0

Closes NEXT-3123