### PR TITLE
Fix experimental/testmode by removing console.log

### DIFF
--- a/packages/next/src/experimental/testmode/playwright/step.ts
+++ b/packages/next/src/experimental/testmode/playwright/step.ts
@@ -39,7 +39,6 @@ export async function step<T>(
   let result: Awaited<T>
   let reportedError: any
   try {
-    console.log(props.title, props)
     await test.step(props.title, async () => {
       result = await handler(({ error }) => {
         reportedError = error


### PR DESCRIPTION
This pr removes a console.log that is making testmode tests very noisy.

This relates to an upstream feature request: https://github.com/microsoft/playwright/issues/27059

Closes NEXT-3139