### PR TITLE
hotfix(turbopack): Update with patch for postcss.config.js path resolution on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "serde",
  "smallvec",
@@ -3218,7 +3218,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "serde",
@@ -7174,7 +7174,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7205,7 +7205,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7217,7 +7217,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7231,7 +7231,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7245,7 +7245,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -7261,7 +7261,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7293,7 +7293,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "base16",
  "hex",
@@ -7305,7 +7305,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "proc-macro-error",
@@ -7318,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7328,7 +7328,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "mimalloc",
 ]
@@ -7336,7 +7336,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7361,7 +7361,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7391,7 +7391,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7431,7 +7431,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7454,7 +7454,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "clap",
@@ -7471,7 +7471,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7500,7 +7500,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7527,7 +7527,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7563,7 +7563,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7598,7 +7598,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "serde",
  "serde_json",
@@ -7609,7 +7609,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7633,7 +7633,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7649,7 +7649,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7665,7 +7665,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7684,7 +7684,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "serde",
@@ -7699,7 +7699,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7714,7 +7714,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7748,7 +7748,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7768,7 +7768,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7786,7 +7786,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "serde",
@@ -7802,7 +7802,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7813,7 +7813,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -7829,7 +7829,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240411.3#9d45eacc8bf80f52cd445d2926fabbf9fe7a535c"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.2#23826274b72195bb4e9cc24ddcea9b9932953887"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.90.30", features = [
 testing = { version = "0.35.22" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240411.3" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240417.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240411.3" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240417.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240411.3" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240417.2" }
 
 # General Deps
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -196,7 +196,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.4",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240411.3",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240417.2",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1068,8 +1068,8 @@ importers:
         specifier: 0.26.4
         version: 0.26.4
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240411.3
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240411.3'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240417.2
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240417.2'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -25483,8 +25483,8 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240411.3':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240411.3}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240417.2':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240417.2}
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
Not 100% sure I did this process right for a hotfix, but this new tag should be exactly the same as what's currently in the 14-2-1 branch, except with this one PR:

* https://github.com/vercel/turbo/pull/7995 <!-- Benjamin Woodruff - fix(turbopack-node) postcss.config.js path resolution on Windows  -->

Similar PR for the canary branch: #64686 (which contains other commits from the turbo main branch)

---

In turbo, I ran

```
git switch --detach turbopack-240411.3
git switch -c bgw/hotfix-turbopack-14-2-1
git cherry-pick e7a5c60a3b899d0c4293589c2844016da82442f7
git push origin HEAD
```

I then ran the GitHub action for the nightly release process for that new branch: https://github.com/vercel/turbo/actions/workflows/turbopack-nightly-release.yml (it seems like this just cuts a tag, I wonder for hotfixes if we should manually cut the tag so it's named differently)

In the nextpack repository:

```
pnpm next-link turbopack-240417.2
```