### PR TITLE
update turbopack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "serde",
  "smallvec",
@@ -3094,7 +3094,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "serde",
@@ -6920,7 +6920,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6951,7 +6951,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -6963,7 +6963,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6977,7 +6977,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -6991,7 +6991,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -7007,7 +7007,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7039,7 +7039,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "base16",
  "hex",
@@ -7051,7 +7051,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "proc-macro-error",
@@ -7064,7 +7064,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7074,7 +7074,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "mimalloc",
 ]
@@ -7082,7 +7082,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7107,7 +7107,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7137,7 +7137,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7177,7 +7177,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7200,7 +7200,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "clap",
@@ -7217,7 +7217,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7246,7 +7246,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7273,7 +7273,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7309,7 +7309,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7344,7 +7344,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "serde",
  "serde_json",
@@ -7355,7 +7355,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7379,7 +7379,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7395,7 +7395,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7411,7 +7411,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7430,7 +7430,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "serde",
@@ -7445,7 +7445,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7460,7 +7460,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7494,7 +7494,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7514,7 +7514,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7532,7 +7532,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "serde",
@@ -7548,7 +7548,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7559,7 +7559,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -7575,7 +7575,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240416.1#c8fd56653ae3be19a158319e931422f1203d6cfa"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.90.30", features = [
 testing = { version = "0.35.22" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240416.1" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240417.1" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240416.1" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240417.1" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240416.1" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240417.1" }
 
 # General Deps
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -197,7 +197,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.4",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240416.1",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240417.1",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1068,8 +1068,8 @@ importers:
         specifier: 0.26.4
         version: 0.26.4
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240416.1
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240416.1'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240417.1
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240417.1'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -25544,8 +25544,8 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240416.1':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240416.1}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240417.1':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240417.1}
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
* https://github.com/vercel/turbo/pull/7995 <!-- Benjamin Woodruff - fix(turbopack-node) postcss.config.js path resolution on Windows  -->

(plus unrelated turborepo + CI changes)

This PR should not be cherrypicked into the 14-2-1 branch. Instead https://github.com/vercel/next.js/pull/64677 should be merged into that branch, as that PR contains only the one above Windows commit.