### PR TITLE
docs: Suggest a blobless clone instead of a shallow clone

### DIFF
--- a/contributing/core/developing.md
+++ b/contributing/core/developing.md
@@ -10,7 +10,7 @@ To develop locally:
 1. Install the [GitHub CLI](https://github.com/cli/cli#installation).
 1. Clone the Next.js repository (download only recent commits for faster clone):
    ```
-   gh repo clone vercel/next.js -- --depth=3000 --branch canary --single-branch
+   gh repo clone vercel/next.js -- --filter=blob:none --branch canary --single-branch
    ```
 1. Create a new branch:
    ```


### PR DESCRIPTION
GitHub recommends blobless clones over shallow clones: https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/

> For these reasons we do not recommend shallow clones except for builds that delete the repository immediately afterwards. Fetching from shallow clones can cause more harm than good!

I've been using blobless clones for development for the last couple weeks. The blobless clone has the benefit of including the full repository history (for the cloned branch). Tools like `git blame` will be slower as git fetches the related blobs on-demand.

Benchmarks (using all the flags in the docs):
- The blobless clone is faster on my machine, taking 11.1 seconds versus 13.1 seconds for the shallow clone.
- The blobless clone takes up 256M on disk, versus 244M for the shallow clone. It's worse, but not by much.
