### PR TITLE
[actions] Enforce body limit using Transform stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@swc/helpers": "0.5.5",
     "@testing-library/jest-dom": "6.1.2",
     "@testing-library/react": "13.0.0",
+    "@types/busboy": "1.5.3",
     "@types/cheerio": "0.22.16",
     "@types/cookie": "0.3.3",
     "@types/cross-spawn": "6.0.0",

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -353,6 +353,11 @@ type ServerModuleMap = Record<
   | undefined
 >
 
+type ServerActionsConfig = {
+  bodySizeLimit?: SizeLimit
+  allowedOrigins?: string[]
+}
+
 export async function handleAction({
   req,
   res,
@@ -371,10 +376,7 @@ export async function handleAction({
   generateFlight: GenerateFlight
   staticGenerationStore: StaticGenerationStore
   requestStore: RequestStore
-  serverActions?: {
-    bodySizeLimit?: SizeLimit
-    allowedOrigins?: string[]
-  }
+  serverActions?: ServerActionsConfig
   ctx: AppRenderContext
 }): Promise<
   | undefined
@@ -552,10 +554,11 @@ export async function handleAction({
       ) {
         // Use react-server-dom-webpack/server.edge
         const { decodeReply, decodeAction, decodeFormState } = ComponentMod
-
         if (!req.body) {
           throw new Error('invariant: Missing request body.')
         }
+
+        // TODO: add body limit
 
         if (isMultipartAction) {
           // TODO-APP: Add streaming support
@@ -619,20 +622,52 @@ export async function handleAction({
           decodeFormState,
         } = require(`./react-server.node`)
 
+        const { Transform } =
+          require('node:stream') as typeof import('node:stream')
+
+        const defaultBodySizeLimit = '1 MB'
+        const bodySizeLimit =
+          serverActions?.bodySizeLimit ?? defaultBodySizeLimit
+        const bodySizeLimitBytes =
+          bodySizeLimit !== defaultBodySizeLimit
+            ? (
+                require('next/dist/compiled/bytes') as typeof import('bytes')
+              ).parse(bodySizeLimit)
+            : 1024 * 1024 // 1 MB
+
+        let size = 0
+        const body = req.body.pipe(
+          new Transform({
+            transform(chunk, encoding, callback) {
+              size += Buffer.byteLength(chunk, encoding)
+              if (size > bodySizeLimitBytes) {
+                const { ApiError } = require('../api-utils')
+
+                callback(
+                  new ApiError(
+                    413,
+                    `Body exceeded ${bodySizeLimit} limit.
+                To configure the body size limit for Server Actions, see: https://nextjs.org/docs/app/api-reference/next-config-js/serverActions#bodysizelimit`
+                  )
+                )
+                return
+              }
+
+              callback(null, chunk)
+            },
+          })
+        )
+
         if (isMultipartAction) {
           if (isFetchAction) {
-            const readableLimit = serverActions?.bodySizeLimit ?? '1 MB'
-            const limit = require('next/dist/compiled/bytes').parse(
-              readableLimit
-            )
-            const busboy = require('busboy')
-            const bb = busboy({
+            const busboy = (require('busboy') as typeof import('busboy'))({
               headers: req.headers,
-              limits: { fieldSize: limit },
+              limits: { fieldSize: bodySizeLimitBytes },
             })
-            req.body.pipe(bb)
 
-            bound = await decodeReplyFromBusboy(bb, serverModuleMap)
+            body.pipe(busboy)
+
+            bound = await decodeReplyFromBusboy(busboy, serverModuleMap)
           } else {
             // React doesn't yet publish a busboy version of decodeAction
             // so we polyfill the parsing of FormData.
@@ -640,7 +675,19 @@ export async function handleAction({
               method: 'POST',
               // @ts-expect-error
               headers: { 'Content-Type': contentType },
-              body: req.stream(),
+              body: new ReadableStream({
+                start: (controller) => {
+                  body.on('data', (chunk) => {
+                    controller.enqueue(new Uint8Array(chunk))
+                  })
+                  body.on('end', () => {
+                    controller.close()
+                  })
+                  body.on('error', (err) => {
+                    controller.error(err)
+                  })
+                },
+              }),
               duplex: 'half',
             })
             const formData = await fakeRequest.formData()
@@ -667,25 +714,12 @@ export async function handleAction({
             }
           }
 
-          const chunks = []
-
+          const chunks: Buffer[] = []
           for await (const chunk of req.body) {
             chunks.push(Buffer.from(chunk))
           }
 
           const actionData = Buffer.concat(chunks).toString('utf-8')
-
-          const readableLimit = serverActions?.bodySizeLimit ?? '1 MB'
-          const limit = require('next/dist/compiled/bytes').parse(readableLimit)
-
-          if (actionData.length > limit) {
-            const { ApiError } = require('../api-utils')
-            throw new ApiError(
-              413,
-              `Body exceeded ${readableLimit} limit.
-To configure the body size limit for Server Actions, see: https://nextjs.org/docs/app/api-reference/next-config-js/serverActions#bodysizelimit`
-            )
-          }
 
           if (isURLEncodedAction) {
             const formData = formDataFromSearchQueryString(actionData)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       '@testing-library/react':
         specifier: 13.0.0
         version: 13.0.0(react-dom@18.2.0)(react@18.2.0)
+      '@types/busboy':
+        specifier: 1.5.3
+        version: 1.5.3
       '@types/cheerio':
         specifier: 0.22.16
         version: 0.22.16
@@ -6782,6 +6785,12 @@ packages:
 
   /@types/btoa-lite@1.0.0:
     resolution: {integrity: sha512-wJsiX1tosQ+J5+bY5LrSahHxr2wT+uME5UDwdN1kg4frt40euqA+wzECkmq4t5QbveHiJepfdThgQrPw6KiSlg==}
+    dev: true
+
+  /@types/busboy@1.5.3:
+    resolution: {integrity: sha512-YMBLFN/xBD8bnqywIlGyYqsNFXu6bsiY7h3Ae0kO17qEuTjsqeyYMRPSUDacIKIquws2Y6KjmxAyNx8xB3xQbw==}
+    dependencies:
+      '@types/node': 20.12.3
     dev: true
 
   /@types/bytes@3.1.1:

--- a/test/e2e/app-dir/actions/account-for-overhead.js
+++ b/test/e2e/app-dir/actions/account-for-overhead.js
@@ -1,0 +1,11 @@
+/**
+ * This function accounts for the overhead of encoding the data to be sent
+ * over the network via a multipart request.
+ *
+ * @param {number} megaBytes
+ * @returns {number}
+ */
+export function accountForOverhead(megaBytes) {
+  // We are sending {megaBytes} - 5% to account for encoding overhead
+  return Math.floor(1024 * 1024 * megaBytes * 0.95)
+}

--- a/test/e2e/app-dir/actions/app/file/form.js
+++ b/test/e2e/app-dir/actions/app/file/form.js
@@ -1,7 +1,10 @@
 'use client'
+import { accountForOverhead } from '../../account-for-overhead'
 
 export default function Form({ action }) {
-  const submit = (n) => action('a'.repeat(1024 * 1024 * n))
+  const submit = (megaBytes) =>
+    action('a'.repeat(accountForOverhead(megaBytes)))
+
   return (
     <>
       <button id="size-1mb" onClick={() => submit(1)}>

--- a/test/e2e/app-dir/actions/app/form/page.js
+++ b/test/e2e/app-dir/actions/app/form/page.js
@@ -1,3 +1,5 @@
+import { accountForOverhead } from '../../account-for-overhead'
+
 async function action(formData) {
   'use server'
   const payload = formData.get('payload').toString()
@@ -11,7 +13,7 @@ export default function Page() {
         <input
           type="hidden"
           name="payload"
-          value={'a'.repeat(1024 * 1024 * 1)}
+          value={'a'.repeat(accountForOverhead(1))}
         />
         <button type="submit" id="size-1mb">
           SUBMIT 1mb
@@ -21,7 +23,7 @@ export default function Page() {
         <input
           type="hidden"
           name="payload"
-          value={'a'.repeat(1024 * 1024 * 2)}
+          value={'a'.repeat(accountForOverhead(2))}
         />
         <button type="submit" id="size-2mb">
           SUBMIT 2mb
@@ -31,7 +33,7 @@ export default function Page() {
         <input
           type="hidden"
           name="payload"
-          value={'a'.repeat(1024 * 1024 * 3)}
+          value={'a'.repeat(accountForOverhead(3))}
         />
         <button type="submit" id="size-3mb">
           SUBMIT 3mb


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

This ensures that the body limit option is enforced on all request bodies sent to the Node.js runtime, not just the multipart field size limits.

### Why?

The documentation states that this should limit the body size, previously it only limited the field size.

### How?

This uses a `Transform` stream from Node.js. [Based on my benchmarks](https://gist.github.com/wyattjoh/c470d98095da2f95f5920396aba2a206) using the transform stream added next to no overhead, yet it did simplify the implementation quite a bit. Assuming this is due to the already performant stream support within Node.js.
 

Closes NEXT-3151