### PR TITLE
fix to include cookies in older browser when requesting server action from client component

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -61,6 +61,8 @@ async function fetchServerAction(
 
   const res = await fetch('', {
     method: 'POST',
+    // Backwards compat for older browsers. `same-origin` is the default in modern browsers.
+    credentials: 'same-origin',
     headers: {
       Accept: RSC_CONTENT_TYPE_HEADER,
       [ACTION]: actionId,


### PR DESCRIPTION
when calling a server action from a client component in a browser older than Chromium 57, cookies are not being included by default so this one add the credentials option for backward compatibility 

fixes [63872](https://github.com/vercel/next.js/issues/63872)