### PR TITLE
Remove extra suspense boundary for default next/dynamic

### DIFF
--- a/packages/next/src/shared/lib/dynamic.tsx
+++ b/packages/next/src/shared/lib/dynamic.tsx
@@ -41,6 +41,7 @@ export type DynamicOptions<P = {}> = LoadableGeneratedOptions & {
   loadableGenerated?: LoadableGeneratedOptions
   ssr?: boolean
   /**
+   * TODO: remove this in next major version v15
    * @deprecated `suspense` prop is not required anymore
    */
   suspense?: boolean

--- a/packages/next/src/shared/lib/lazy-dynamic/loadable.tsx
+++ b/packages/next/src/shared/lib/lazy-dynamic/loadable.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy } from 'react'
+import { Suspense, Fragment, lazy } from 'react'
 import { BailoutToCSR } from './dynamic-bailout-to-csr'
 import type { ComponentModule } from './types'
 import { PreloadCss } from './preload-css'
@@ -48,6 +48,10 @@ function Loadable(options: LoadableOptions) {
       <Loading isLoading={true} pastDelay={true} error={null} />
     ) : null
 
+    const isCsrOrHasLoading = Boolean(!opts.ssr || Loading)
+    const Wrap = isCsrOrHasLoading ? Suspense : Fragment
+    const wrapProps = isCsrOrHasLoading ? { fallback: fallbackElement } : {}
+
     const children = opts.ssr ? (
       <>
         {/* During SSR, we need to preload the CSS from the dynamic component to avoid flash of unstyled content */}
@@ -62,7 +66,7 @@ function Loadable(options: LoadableOptions) {
       </BailoutToCSR>
     )
 
-    return <Suspense fallback={fallbackElement}>{children}</Suspense>
+    return <Wrap {...wrapProps}>{children}</Wrap>
   }
 
   LoadableComponent.displayName = 'LoadableComponent'

--- a/packages/next/src/shared/lib/lazy-dynamic/loadable.tsx
+++ b/packages/next/src/shared/lib/lazy-dynamic/loadable.tsx
@@ -48,11 +48,10 @@ function Loadable(options: LoadableOptions) {
       <Loading isLoading={true} pastDelay={true} error={null} />
     ) : null
 
-    const isCsrOrHasLoading = Boolean(!opts.ssr || Loading)
-    const Wrap = isCsrOrHasLoading ? Suspense : Fragment
-    const wrapProps = isCsrOrHasLoading ? { fallback: fallbackElement } : {}
-
-    const children = opts.ssr ? (
+    const isSSR = opts.ssr
+    const Wrap = isSSR ? Fragment : Suspense
+    const wrapProps = isSSR ? {} : { fallback: fallbackElement }
+    const children = isSSR ? (
       <>
         {/* During SSR, we need to preload the CSS from the dynamic component to avoid flash of unstyled content */}
         {typeof window === 'undefined' ? (

--- a/test/e2e/app-dir/dynamic/app/default/dynamic-component.js
+++ b/test/e2e/app-dir/dynamic/app/default/dynamic-component.js
@@ -1,0 +1,12 @@
+const isDevTest = false
+
+const DynamicImportComponent = () => {
+  if (isDevTest && typeof window === 'undefined') {
+    throw new Error('This component should only be rendered on the client side')
+  }
+  return (
+    <div id="dynamic-component">This is a dynamically imported component</div>
+  )
+}
+
+export default DynamicImportComponent

--- a/test/e2e/app-dir/dynamic/app/default/page.js
+++ b/test/e2e/app-dir/dynamic/app/default/page.js
@@ -1,0 +1,17 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+const DynamicHeader = dynamic(() => import('./dynamic-component'), {
+  loading: () => <p>Loading...</p>,
+})
+
+const ClientWrapper = () => {
+  return (
+    <div>
+      <DynamicHeader />
+    </div>
+  )
+}
+
+export default ClientWrapper


### PR DESCRIPTION
### What

Removing the Suspense boundary on top of `next/dynamic` by default, make it as `React.lazy` component with preloading CSS feature.

### Why

Extra Suspense boundary is causing extra useless rendering. For SSR, it shouldn't render `loading` by default

Related: #64060
Related: #64687
Closes [NEXT-3074](https://linear.app/vercel/issue/NEXT-3074/app-router-content-flickering-with-reactcreatecontext-and-nextdynamic)

This is sort of a breaking change, since removing the Suspense boundary on top of `next/dynamic` by default. If there's error happening in side the dynamic component you need to wrap an extra Suspense boundary on top of it
