### PR TITLE
docs: warning for public env variables

### DIFF
--- a/docs/02-app/01-building-your-application/07-configuring/03-environment-variables.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/03-environment-variables.mdx
@@ -104,6 +104,7 @@ In order to make the value of an environment variable accessible in the browser,
 ```txt filename="Terminal"
 NEXT_PUBLIC_ANALYTICS_ID=abcdefghijk
 ```
+> **Note**: All environment variables using NEXT_PUBLIC_ are rendered in plain text during build time, avoid using sensitive environment variables on client side, this could possibly compromise security and leak sensitive data.
 
 This will tell Next.js to replace all references to `process.env.NEXT_PUBLIC_ANALYTICS_ID` in the Node.js environment with the value from the environment in which you run `next build`, allowing you to use it anywhere in your code. It will be inlined into any JavaScript sent to the browser.
 


### PR DESCRIPTION
### What?
When using NEXT_PUBLIC_ variables the docs suggest variables are rendered inline replacing the
the references to public environment variables

This commit adds a formal warning suggesting
to not use NEXT_PUBLIC_ variables on client side
for sensitive information.


### Why?
Adding a  warning in docs will help people avoid 
storing sensitive information in public environment variables.


