### PR TITLE
feat: extend gtag.js with debugmode config released in GA4

### DIFF
--- a/packages/third-parties/src/google/ga.tsx
+++ b/packages/third-parties/src/google/ga.tsx
@@ -14,7 +14,7 @@ declare global {
 let currDataLayerName: string | undefined = undefined
 
 export function GoogleAnalytics(props: GAParams) {
-  const { gaId, dataLayerName = 'dataLayer' } = props
+  const { gaId, dataLayerName = 'dataLayer', debugMode } = props;
 
   if (currDataLayerName === undefined) {
     currDataLayerName = dataLayerName
@@ -43,7 +43,7 @@ export function GoogleAnalytics(props: GAParams) {
           function gtag(){window['${dataLayerName}'].push(arguments);}
           gtag('js', new Date());
 
-          gtag('config', '${gaId}');`,
+          gtag('config', '${gaId}' ${debugMode ? ",{ 'debug_mode': true }" : ''});`,
         }}
       />
       <Script

--- a/packages/third-parties/src/types/google.ts
+++ b/packages/third-parties/src/types/google.ts
@@ -16,6 +16,7 @@ export type GTMParams = {
 export type GAParams = {
   gaId: string
   dataLayerName?: string
+  debugMode?: boolean
 }
 
 export type GoogleMapsEmbed = {


### PR DESCRIPTION
## Overview
Extend gtag.js with `debugmode` config released in GA4

## Changes
- add `debugmode` config into `gtag.js` referenced to [[GA4] Monitor events in DebugView](https://support.google.com/analytics/answer/7201382?hl=en#zippy=)

## Conclusion
If purpose of this PR is pure and focused enough and  seems like a good adjustment, it'd be cool to see it become part of the library. Finally, appreciated for your time, and kudos for your fantastic works in open-source 🙇