### PR TITLE
docs: fix default.js params example

### DIFF
--- a/docs/02-app/02-api-reference/02-file-conventions/default.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/default.mdx
@@ -35,5 +35,5 @@ An object containing the [dynamic route parameters](/docs/app/building-your-appl
 
 | Example                                    | URL          | `params`                            |
 | ------------------------------------------ | ------------ | ----------------------------------- |
-| `app/@sidebar/[artist]/default.js`         | `/zack`      | `{ artist: 'zack' }`                |
-| `app/@sidebar/[artist]/[album]/default.js` | `/zack/next` | `{ artist: 'zack', album: 'next' }` |
+| `app/[artist]/@sidebar/default.js`         | `/zack`      | `{ artist: 'zack' }`                |
+| `app/[artist]/[album]/@sidebar/default.js` | `/zack/next` | `{ artist: 'zack', album: 'next' }` |


### PR DESCRIPTION
The `params` example in the docs for `default.js` have the slot/params in the wrong order, giving the impression that you can deeply nest `default` slots.

This clarifies that the params received by a slot are based on the dynamic params leading up to the segment containing the slot. 

Fixes #64708


Closes NEXT-3160