### PR TITLE
Fix the mdx-components examples

### DIFF
--- a/docs/02-app/01-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/05-mdx.mdx
@@ -65,20 +65,20 @@ This allows `.md` and `.mdx` files to act as pages, routes, or imports in your a
 Create a `mdx-components.tsx` (or `.js`) file in the root of your project to define global MDX Components. For example, at the same level as `pages` or `app`, or inside `src` if applicable.
 
 ```tsx filename="mdx-components.tsx" switcher
-import type { MDXComponents } from 'mdx/types'
+const components = {}
 
-export function useMDXComponents(components: MDXComponents): MDXComponents {
-  return {
-    ...components,
-  }
+declare global {
+  type MDXProvidedComponents = typeof components
+}
+
+export function useMDXComponents(): MDXProvidedComponents {
+  return components
 }
 ```
 
 ```js filename="mdx-components.js" switcher
-export function useMDXComponents(components) {
-  return {
-    ...components,
-  }
+export function useMDXComponents() {
+  return {}
 }
 ```
 
@@ -283,7 +283,6 @@ To style your markdown, you can provide custom components that map to the genera
 Adding styles and components in `mdx-components.tsx` will affect _all_ MDX files in your application.
 
 ```tsx filename="mdx-components.tsx" switcher
-import type { MDXComponents } from 'mdx/types'
 import Image, { ImageProps } from 'next/image'
 
 // This file allows you to provide custom React components
@@ -291,21 +290,26 @@ import Image, { ImageProps } from 'next/image'
 // React component you want, including inline styles,
 // components from other libraries, and more.
 
-export function useMDXComponents(components: MDXComponents): MDXComponents {
-  return {
-    // Allows customizing built-in components, e.g. to add styling.
-    h1: ({ children }) => (
-      <h1 style={{ color: 'red', fontSize: '48px' }}>{children}</h1>
-    ),
-    img: (props) => (
-      <Image
-        sizes="100vw"
-        style={{ width: '100%', height: 'auto' }}
-        {...(props as ImageProps)}
-      />
-    ),
-    ...components,
-  }
+const components = {
+  // Allows customizing built-in components, e.g. to add styling.
+  h1: ({ children }) => (
+    <h1 style={{ color: 'red', fontSize: '48px' }}>{children}</h1>
+  ),
+  img: (props) => (
+    <Image
+      sizes="100vw"
+      style={{ width: '100%', height: 'auto' }}
+      {...(props as ImageProps)}
+    />
+  ),
+}
+
+declare global {
+  type MDXProvidedComponents = typeof components
+}
+
+export function useMDXComponents(): MDXProvidedComponents {
+  return components
 }
 ```
 
@@ -317,7 +321,7 @@ import Image from 'next/image'
 // React component you want, including inline styles,
 // components from other libraries, and more.
 
-export function useMDXComponents(components) {
+export function useMDXComponents() {
   return {
     // Allows customizing built-in components, e.g. to add styling.
     h1: ({ children }) => (
@@ -330,7 +334,6 @@ export function useMDXComponents(components) {
         {...props}
       />
     ),
-    ...components,
   }
 }
 ```

--- a/docs/02-app/02-api-reference/02-file-conventions/mdx-components.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/mdx-components.mdx
@@ -12,20 +12,20 @@ The `mdx-components.js|tsx` file is **required** to use [`@next/mdx` with App Ro
 Use the file `mdx-components.tsx` (or `.js`) in the root of your project to define MDX Components. For example, at the same level as `pages` or `app`, or inside `src` if applicable.
 
 ```tsx filename="mdx-components.tsx" switcher
-import type { MDXComponents } from 'mdx/types'
+const components = {}
 
-export function useMDXComponents(components: MDXComponents): MDXComponents {
-  return {
-    ...components,
-  }
+declare global {
+  type MDXProvidedComponents = typeof components
+}
+
+export function useMDXComponents(): MDXProvidedComponents {
+  return components
 }
 ```
 
 ```js filename="mdx-components.js" switcher
 export function useMDXComponents(components) {
-  return {
-    ...components,
-  }
+  return {}
 }
 ```
 
@@ -36,20 +36,20 @@ export function useMDXComponents(components) {
 The file must export a single function, either as a default export or named `useMDXComponents`.
 
 ```tsx filename="mdx-components.tsx" switcher
-import type { MDXComponents } from 'mdx/types'
+const components = {}
 
-export function useMDXComponents(components: MDXComponents): MDXComponents {
-  return {
-    ...components,
-  }
+declare global {
+  type MDXProvidedComponents = typeof components
+}
+
+export function useMDXComponents(): MDXProvidedComponents {
+  return components
 }
 ```
 
 ```js filename="mdx-components.js" switcher
-export function useMDXComponents(components) {
-  return {
-    ...components,
-  }
+export function useMDXComponents() {
+  return {}
 }
 ```
 

--- a/examples/app-dir-mdx/mdx-components.tsx
+++ b/examples/app-dir-mdx/mdx-components.tsx
@@ -1,10 +1,9 @@
-import type { MDXComponents } from "mdx/types";
+const components = {};
 
-// This file is required to use MDX in `app` directory.
-export function useMDXComponents(components: MDXComponents): MDXComponents {
-  return {
-    // Allows customizing built-in components, e.g. to add styling.
-    // h1: ({ children }) => <h1 style={{ fontSize: "100px" }}>{children}</h1>,
-    ...components,
-  };
+declare global {
+  type MDXProvidedComponents = typeof components;
+}
+
+export function useMDXComponents(): MDXProvidedComponents {
+  return components;
 }

--- a/examples/app-dir-mdx/tsconfig.json
+++ b/examples/app-dir-mdx/tsconfig.json
@@ -20,6 +20,12 @@
       }
     ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.mdx",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/packages/next-mdx/readme.md
+++ b/packages/next-mdx/readme.md
@@ -106,8 +106,8 @@ Create a `mdx-components.js` file at the root of your project with the following
 
 ```js
 // This file is required to use @next/mdx in the `app` directory.
-export function useMDXComponents(components) {
-  return components
+export function useMDXComponents() {
+  return {}
   // Allows customizing built-in components, e.g. to add styling.
   // return {
   //   h1: ({ children }) => <h1 style={{ fontSize: "100px" }}>{children}</h1>,

--- a/test/development/acceptance-app/fixtures/app-hmr-changes/mdx-components.ts
+++ b/test/development/acceptance-app/fixtures/app-hmr-changes/mdx-components.ts
@@ -15,30 +15,33 @@ import { Callout } from 'app/(post)/components/callout'
 import { Ref, FootNotes, FootNote } from 'app/(post)/components/footnotes'
 import { Blockquote as blockquote } from 'app/(post)/components/blockquote'
 
-export function useMDXComponents(components: {
-  [component: string]: React.ComponentType
-}) {
-  return {
-    ...components,
-    a,
-    h1,
-    h2,
-    h3,
-    p,
-    ol,
-    ul,
-    li,
-    hr,
-    pre: Snippet,
-    img: Image,
-    blockquote,
-    Tweet,
-    Image,
-    Snippet,
-    Caption,
-    Callout,
-    Ref,
-    FootNotes,
-    FootNote,
-  }
+const components = {
+  a,
+  h1,
+  h2,
+  h3,
+  p,
+  ol,
+  ul,
+  li,
+  hr,
+  pre: Snippet,
+  img: Image,
+  blockquote,
+  Tweet,
+  Image,
+  Snippet,
+  Caption,
+  Callout,
+  Ref,
+  FootNotes,
+  FootNote,
+}
+
+declare global {
+  type MDXProvidedComponents = typeof components
+}
+
+export function useMDXComponents(): MDXProvidedComponents {
+  return components
 }

--- a/test/development/acceptance-app/fixtures/app-hmr-changes/tsconfig.json
+++ b/test/development/acceptance-app/fixtures/app-hmr-changes/tsconfig.json
@@ -17,5 +17,5 @@
     "baseUrl": "."
   },
   "exclude": ["node_modules"],
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]
+  "include": ["next-env.d.ts", "**/*.mdx", "**/*.ts", "**/*.tsx"]
 }

--- a/test/e2e/app-dir/app-css/mdx-components.jsx
+++ b/test/e2e/app-dir/app-css/mdx-components.jsx
@@ -1,1 +1,3 @@
-export const useMDXComponents = (components) => components
+export function useMDXComponents() {
+  return {}
+}

--- a/test/e2e/app-dir/modularizeimports/mdx-components.tsx
+++ b/test/e2e/app-dir/modularizeimports/mdx-components.tsx
@@ -1,5 +1,3 @@
-export function useMDXComponents(components) {
-  return {
-    ...components,
-  }
+export function useMDXComponents() {
+  return {}
 }

--- a/test/e2e/app-dir/modularizeimports/tsconfig.json
+++ b/test/e2e/app-dir/modularizeimports/tsconfig.json
@@ -20,6 +20,12 @@
     ],
     "strictNullChecks": true
   },
-  "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.mdx",
+    ".next/types/**/*.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
   "exclude": ["node_modules"]
 }

--- a/test/integration/plugin-mdx-rs/mdx-components.js
+++ b/test/integration/plugin-mdx-rs/mdx-components.js
@@ -1,8 +1,7 @@
 import { Marker } from './components/marker'
 
-export function useMDXComponents(components) {
+export function useMDXComponents() {
   return {
-    ...components,
     Marker,
   }
 }


### PR DESCRIPTION
`useMDXComponents` doesn’t receive any arguments. Also the TypeScript examples now define the global type `MDXProvidedComponents`, which provides TypeScript features such as completion inside MDX files.
