### PR TITLE
chore: match label name during autolabeling

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -17,9 +17,10 @@ jobs:
     name: Nissuer
     runs-on: ubuntu-latest
     steps:
-      - uses: balazsorban44/nissuer@1.9.3
+      - uses: balazsorban44/nissuer@1.10.0
         with:
           label-area-prefix: ''
+          label-area-match: 'name'
           label-area-section: 'Which area\(s\) are affected\? \(Select all that apply\)(.*)### Additional context'
           label-comments: |
             {


### PR DESCRIPTION
### What?

Bumping [`nissuer`](https://github.com/balazsorban44/nissuer)

### Why?

Recently we refactored our labels to be more useful for maintainers (#63713), but it broke auto-labeling, as it previously matched the label descriptions at https://github.com/vercel/next.js/blob/a532e32ecaae506ddd67d976cc54110aaa90c49c/.github/ISSUE_TEMPLATE/1.bug_report.yml?plain=1#L72-L96 instead of label names.

### How?

`nissuer` supports matching on the label name now, tested here:

https://github.com/balazsorban44/nissuer/issues/39#issuecomment-2066228176

[Slack thread](https://vercel.slack.com/archives/C04LGE5SYEB/p1713446581166399)

Closes NEXT-3165