### PR TITLE
chore: exit running related tests if there was no match

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -251,7 +251,8 @@ async function main() {
       if (testPatternRegex) {
         console.log('Running related tests:', testPatternRegex.toString())
       } else {
-        console.log('No matching related tests.')
+        console.log('No matching related tests, exiting.')
+        process.exit(0)
       }
     }
 


### PR DESCRIPTION
### What?

Do not run related tests if none are found.

### Why?

Jest will exit with an error code if no tests are present.

See: https://github.com/vercel/next.js/actions/runs/8751717698/job/24017910049?pr=64770#step:6:119


### How?

`process.exit(0)` if no matching tests were found

Closes NEXT-3166