### PR TITLE
chore: rename 'example bug' label to 'examples'

### DIFF
--- a/.github/ISSUE_TEMPLATE/2.example_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/2.example_bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report for Examples
 description: Create a bug report for one of the Next.js examples
-labels: ['example bug']
+labels: ['examples']
 body:
   - type: markdown
     attributes:

--- a/contributing/repository/triaging.md
+++ b/contributing/repository/triaging.md
@@ -8,7 +8,7 @@ Issues are opened with one of these labels:
 
 - `bug` - issue with Next.js itself
 - `documentation` - feedback for improvement or an issue with the Next.js documentation
-- `example bug` - an issue with one of the examples in the [`examples`](https://github.com/vercel/next.js/tree/canary/examples) folder
+- `examples` - an issue with one of the examples in the [`examples`](https://github.com/vercel/next.js/tree/canary/examples) folder
 
 ## Bug reports
 


### PR DESCRIPTION
We also have PRs currently labeled with `example bug` which does not make sense.

Follow-up on #63713

Closes NEXT-3167