### PR TITLE
fext(next): extend next.config for mdxRs support options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "serde",
  "smallvec",
@@ -3094,7 +3094,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "serde",
@@ -5035,9 +5035,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.73.10"
+version = "0.73.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7b2381ed0b1ba760b75671388d45be3196ab8514a6429b4fca05ab9dcfc86c"
+checksum = "9e6eeab19721dd473f4b9c3c17f45aec015bc8bf626ab238ecd781cda90c9ddf"
 dependencies = [
  "anyhow",
  "lightningcss",
@@ -6943,7 +6943,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6974,7 +6974,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -6986,7 +6986,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7000,7 +7000,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7014,7 +7014,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -7030,7 +7030,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7062,7 +7062,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "base16",
  "hex",
@@ -7074,7 +7074,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "proc-macro-error",
@@ -7087,7 +7087,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7097,7 +7097,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "mimalloc",
 ]
@@ -7105,7 +7105,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7130,7 +7130,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7160,7 +7160,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7200,7 +7200,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7223,7 +7223,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "clap",
@@ -7240,7 +7240,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7269,7 +7269,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7296,7 +7296,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7332,7 +7332,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7367,7 +7367,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "serde",
  "serde_json",
@@ -7378,7 +7378,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7402,7 +7402,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7418,7 +7418,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7434,7 +7434,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7453,7 +7453,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "serde",
@@ -7468,7 +7468,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7483,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7517,7 +7517,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7537,7 +7537,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7555,7 +7555,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "serde",
@@ -7571,7 +7571,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7582,7 +7582,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -7598,7 +7598,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240417.1#e7a5c60a3b899d0c4293589c2844016da82442f7"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240422.2#ca565a7c52555bca8045e7290bedf6f6f65fbd84"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.90.33", features = [
 testing = { version = "0.35.22" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240417.1" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240422.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240417.1" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240422.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240417.1" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240422.2" }
 
 # General Deps
 

--- a/docs/02-app/01-building-your-application/07-configuring/05-mdx.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/05-mdx.mdx
@@ -768,6 +768,20 @@ module.exports = withMDX({
 })
 ```
 
+`mdxRs` also accepts an object to configure how to transform mdx files.
+
+```js filename="next.config.js"
+module.exports = withMDX({
+  experimental: {
+    mdxRs: {
+      jsxRuntime?: string            // Custom jsx runtime
+      jsxImportSource?: string       // Custom jsx import source,
+      mdxType?: 'gfm' | 'commonmark' // Configure what kind of mdx syntax will be used to parse & transform
+    },
+  },
+})
+```
+
 ## Helpful Links
 
 - [MDX](https://mdxjs.com)

--- a/packages/next-mdx/index.js
+++ b/packages/next-mdx/index.js
@@ -3,12 +3,15 @@ module.exports =
   (nextConfig = {}) => {
     const extension = pluginOptions.extension || /\.mdx$/
 
-    const loader = nextConfig?.experimental?.mdxRs
+    const mdxRsOptions = nextConfig?.experimental?.mdxRs
+    const loader = mdxRsOptions
       ? {
           loader: require.resolve('./mdx-rs-loader'),
           options: {
             providerImportSource: 'next-mdx-import-source-file',
             ...pluginOptions.options,
+            // mdxRsOptions is a union of boolean and object type of MdxTransformOptions
+            ...(mdxRsOptions === true ? {} : mdxRsOptions),
           },
         }
       : {

--- a/packages/next-mdx/mdx-rs-loader.js
+++ b/packages/next-mdx/mdx-rs-loader.js
@@ -20,6 +20,38 @@ const own = {}.hasOwnProperty
 const marker = {}
 const cache = new WeakMap()
 
+/*
+ * From next.config.js's mdxRs option, construct an actual option object that mdxRs compiler accepts.
+ */
+function coereceMdxTransformOptions(options = {}) {
+  const { mdxType, ...restOptions } = options
+
+  let parse = undefined
+  switch (mdxType) {
+    case 'gfm':
+      parse = {
+        constructs: {
+          gfmAutolinkLiteral: true,
+          gfmFootnoteDefinition: true,
+          gfmLabelStartFootnote: true,
+          gfmStrikethrough: true,
+          gfmTable: true,
+          gfmTaskListItem: true,
+        },
+      }
+      break
+    case 'commonMark':
+    default:
+      parse = { gfmStrikethroughSingleTilde: true, mathTextSingleDollar: true }
+      break
+  }
+
+  return {
+    ...restOptions,
+    parse,
+  }
+}
+
 /**
  * A webpack loader for mdx-rs. This is largely based on existing @mdx-js/loader,
  * replaces internal compilation logic to use mdx-rs instead.
@@ -41,7 +73,10 @@ function loader(value, bindings, callback) {
   let process = map.get(hash)
 
   if (!process) {
-    process = createFormatAwareProcessors(bindings, config).compile
+    process = createFormatAwareProcessors(
+      bindings,
+      coereceMdxTransformOptions(config)
+    ).compile
     map.set(hash, process)
   }
 

--- a/packages/next-swc/crates/napi/src/mdx.rs
+++ b/packages/next-swc/crates/napi/src/mdx.rs
@@ -12,6 +12,7 @@ impl Task for MdxCompileTask {
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
         let options: Options = serde_json::from_slice(&self.option)?;
+
         compile(&self.input, &options)
             .map_err(|err| napi::Error::new(Status::GenericFailure, format!("{:?}", err)))
     }

--- a/packages/next-swc/crates/next-core/src/next_client/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/context.rs
@@ -25,8 +25,8 @@ use turbopack_binding::{
         turbopack::{
             condition::ContextCondition,
             module_options::{
-                module_options_context::ModuleOptionsContext, JsxTransformOptions,
-                MdxTransformModuleOptions, ModuleRule, TypescriptTransformOptions,
+                module_options_context::ModuleOptionsContext, JsxTransformOptions, ModuleRule,
+                TypescriptTransformOptions,
             },
             resolve_options_context::ResolveOptionsContext,
         },
@@ -42,7 +42,7 @@ use crate::{
     next_config::NextConfig,
     next_import_map::{
         get_next_client_fallback_import_map, get_next_client_import_map,
-        get_next_client_resolved_map, mdx_import_source_file,
+        get_next_client_resolved_map,
     },
     next_shared::{
         resolve::{
@@ -192,16 +192,7 @@ pub async fn get_client_module_options_context(
 
     let tsconfig = get_typescript_transform_options(project_path);
     let decorators_options = get_decorators_transform_options(project_path);
-    let enable_mdx_rs = if *next_config.mdx_rs().await? {
-        Some(
-            MdxTransformModuleOptions {
-                provider_import_source: Some(mdx_import_source_file()),
-            }
-            .cell(),
-        )
-    } else {
-        None
-    };
+    let enable_mdx_rs = *next_config.mdx_rs().await?;
     let jsx_runtime_options = get_jsx_transform_options(
         project_path,
         mode,

--- a/packages/next-swc/crates/next-core/src/next_client/transforms.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/transforms.rs
@@ -30,15 +30,15 @@ pub async fn get_next_client_transforms_rules(
     let mut rules = vec![];
 
     let modularize_imports_config = &next_config.await?.modularize_imports;
+    let enable_mdx_rs = next_config.mdx_rs().await?.is_some();
     if let Some(modularize_imports_config) = modularize_imports_config {
         rules.push(get_next_modularize_imports_rule(
             modularize_imports_config,
-            *next_config.mdx_rs().await?,
+            enable_mdx_rs,
         ));
     }
 
-    let mdx_rs = *next_config.mdx_rs().await?;
-    rules.push(get_next_font_transform_rule(mdx_rs));
+    rules.push(get_next_font_transform_rule(enable_mdx_rs));
 
     match context_ty {
         ClientContextType::Pages { pages_dir } => {
@@ -47,36 +47,36 @@ pub async fn get_next_client_transforms_rules(
                     get_next_pages_transforms_rule(
                         pages_dir,
                         ExportFilter::StripDataExports,
-                        mdx_rs,
+                        enable_mdx_rs,
                     )
                     .await?,
                 );
                 rules.push(get_next_disallow_export_all_in_page_rule(
-                    mdx_rs,
+                    enable_mdx_rs,
                     pages_dir.await?,
                 ));
-                rules.push(get_next_page_config_rule(mdx_rs, pages_dir.await?));
+                rules.push(get_next_page_config_rule(enable_mdx_rs, pages_dir.await?));
             }
         }
         ClientContextType::App { .. } => {
             rules.push(get_server_actions_transform_rule(
                 ActionsTransform::Client,
-                mdx_rs,
+                enable_mdx_rs,
             ));
         }
         ClientContextType::Fallback | ClientContextType::Other => {}
     };
 
     if !foreign_code {
-        rules.push(get_next_amp_attr_rule(mdx_rs));
-        rules.push(get_next_cjs_optimizer_rule(mdx_rs));
-        rules.push(get_next_pure_rule(mdx_rs));
+        rules.push(get_next_amp_attr_rule(enable_mdx_rs));
+        rules.push(get_next_cjs_optimizer_rule(enable_mdx_rs));
+        rules.push(get_next_pure_rule(enable_mdx_rs));
 
-        rules.push(get_next_dynamic_transform_rule(false, false, mode, mdx_rs).await?);
+        rules.push(get_next_dynamic_transform_rule(false, false, mode, enable_mdx_rs).await?);
 
         rules.push(get_next_image_rule());
         rules.push(get_next_page_static_info_assert_rule(
-            mdx_rs,
+            enable_mdx_rs,
             None,
             Some(context_ty),
         ));

--- a/packages/next-swc/crates/next-core/src/next_config.rs
+++ b/packages/next-swc/crates/next-core/src/next_config.rs
@@ -23,7 +23,9 @@ use turbopack_binding::{
     },
 };
 
-use crate::next_shared::transforms::ModularizeImportPackageConfig;
+use crate::{
+    next_import_map::mdx_import_source_file, next_shared::transforms::ModularizeImportPackageConfig,
+};
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -849,12 +851,26 @@ impl NextConfig {
         let options = &self.await?.experimental.mdx_rs;
 
         let options = match options {
-            Some(MdxRsOptions::Boolean(true)) => {
-                OptionalMdxTransformOptions(Some(MdxTransformOptions::default().cell()))
-            }
-            Some(MdxRsOptions::Option(options)) => {
-                OptionalMdxTransformOptions(Some(options.clone().cell()))
-            }
+            Some(MdxRsOptions::Boolean(true)) => OptionalMdxTransformOptions(Some(
+                MdxTransformOptions {
+                    provider_import_source: Some(mdx_import_source_file()),
+                    ..Default::default()
+                }
+                .cell(),
+            )),
+            Some(MdxRsOptions::Option(options)) => OptionalMdxTransformOptions(Some(
+                MdxTransformOptions {
+                    provider_import_source: Some(
+                        options
+                            .provider_import_source
+                            .as_ref()
+                            .map(|s| s.to_string())
+                            .unwrap_or(mdx_import_source_file()),
+                    ),
+                    ..options.clone()
+                }
+                .cell(),
+            )),
             _ => OptionalMdxTransformOptions(None),
         };
 

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -783,7 +783,7 @@ async fn insert_next_shared_aliases(
 ) -> Result<()> {
     let package_root = next_js_fs().root();
 
-    if *next_config.mdx_rs().await? {
+    if next_config.mdx_rs().await?.is_some() {
         insert_alias_to_alternatives(
             import_map,
             mdx_import_source_file(),

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -27,8 +27,7 @@ use turbopack_binding::{
         turbopack::{
             condition::ContextCondition,
             module_options::{
-                JsxTransformOptions, MdxTransformModuleOptions, ModuleOptionsContext, ModuleRule,
-                TypescriptTransformOptions,
+                JsxTransformOptions, ModuleOptionsContext, ModuleRule, TypescriptTransformOptions,
             },
             resolve_options_context::ResolveOptionsContext,
             transition::Transition,
@@ -46,7 +45,7 @@ use crate::{
     next_build::get_postcss_package_mapping,
     next_client::RuntimeEntries,
     next_config::NextConfig,
-    next_import_map::{get_next_server_import_map, mdx_import_source_file},
+    next_import_map::get_next_server_import_map,
     next_server::resolve::ExternalPredicate,
     next_shared::{
         resolve::{
@@ -325,9 +324,11 @@ pub async fn get_server_module_options_context(
     let mut foreign_next_server_rules =
         get_next_server_transforms_rules(next_config, ty.into_value(), mode, true, next_runtime)
             .await?;
-    let internal_custom_rules =
-        get_next_server_internal_transforms_rules(ty.into_value(), *next_config.mdx_rs().await?)
-            .await?;
+    let internal_custom_rules = get_next_server_internal_transforms_rules(
+        ty.into_value(),
+        next_config.mdx_rs().await?.is_some(),
+    )
+    .await?;
 
     let foreign_code_context_condition =
         foreign_code_context_condition(next_config, project_path).await?;
@@ -375,16 +376,7 @@ pub async fn get_server_module_options_context(
     // ModuleOptionsContext related options
     let tsconfig = get_typescript_transform_options(project_path);
     let decorators_options = get_decorators_transform_options(project_path);
-    let enable_mdx_rs = if *next_config.mdx_rs().await? {
-        Some(
-            MdxTransformModuleOptions {
-                provider_import_source: Some(mdx_import_source_file()),
-            }
-            .cell(),
-        )
-    } else {
-        None
-    };
+    let enable_mdx_rs = *next_config.mdx_rs().await?;
 
     // Get the jsx transform options for the `client` side.
     // This matches to the behavior of existing webpack config, if issuer layer is

--- a/packages/next-swc/crates/next-core/src/next_server/transforms.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/transforms.rs
@@ -33,7 +33,7 @@ pub async fn get_next_server_transforms_rules(
     let mut rules = vec![];
 
     let modularize_imports_config = &next_config.await?.modularize_imports;
-    let mdx_rs = *next_config.mdx_rs().await?;
+    let mdx_rs = next_config.mdx_rs().await?.is_some();
     if let Some(modularize_imports_config) = modularize_imports_config {
         rules.push(get_next_modularize_imports_rule(
             modularize_imports_config,

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/emotion.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/emotion.rs
@@ -9,7 +9,7 @@ use super::get_ecma_transform_rule;
 use crate::next_config::{EmotionTransformOptionsOrBoolean, NextConfig};
 
 pub async fn get_emotion_transform_rule(next_config: Vc<NextConfig>) -> Result<Option<ModuleRule>> {
-    let enable_mdx_rs = *next_config.mdx_rs().await?;
+    let enable_mdx_rs = next_config.mdx_rs().await?.is_some();
     let module_rule = next_config
         .await?
         .compiler

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
@@ -37,7 +37,7 @@ pub async fn get_next_react_server_components_transform_rule(
     is_react_server_layer: bool,
     app_dir: Option<Vc<FileSystemPath>>,
 ) -> Result<ModuleRule> {
-    let enable_mdx_rs = *next_config.mdx_rs().await?;
+    let enable_mdx_rs = next_config.mdx_rs().await?.is_some();
     Ok(get_ecma_transform_rule(
         Box::new(NextJsReactServerComponents::new(
             is_react_server_layer,

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/relay.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/relay.rs
@@ -9,7 +9,7 @@ use crate::next_config::NextConfig;
 
 /// Returns a transform rule for the relay graphql transform.
 pub async fn get_relay_transform_rule(next_config: Vc<NextConfig>) -> Result<Option<ModuleRule>> {
-    let enable_mdx_rs = *next_config.mdx_rs().await?;
+    let enable_mdx_rs = next_config.mdx_rs().await?.is_some();
     let module_rule = next_config.await?.compiler.as_ref().and_then(|value| {
         value.relay.as_ref().map(|config| {
             get_ecma_transform_rule(Box::new(RelayTransformer::new(config)), enable_mdx_rs, true)

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/styled_components.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/styled_components.rs
@@ -13,7 +13,7 @@ use crate::{
 pub async fn get_styled_components_transform_rule(
     next_config: Vc<NextConfig>,
 ) -> Result<Option<ModuleRule>> {
-    let enable_mdx_rs = *next_config.mdx_rs().await?;
+    let enable_mdx_rs = next_config.mdx_rs().await?.is_some();
 
     let module_rule = next_config
         .await?

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/styled_jsx.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/styled_jsx.rs
@@ -14,7 +14,7 @@ pub async fn get_styled_jsx_transform_rule(
     next_config: Vc<NextConfig>,
     target_browsers: Vc<RuntimeVersions>,
 ) -> Result<Option<ModuleRule>> {
-    let enable_mdx_rs = *next_config.mdx_rs().await?;
+    let enable_mdx_rs = next_config.mdx_rs().await?.is_some();
     let use_swc_css = *next_config.use_swc_css().await?;
     let versions = *target_browsers.await?;
 

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -13,7 +13,7 @@ pub async fn get_swc_ecma_transform_plugin_rule(
         Some(plugin_configs) if !plugin_configs.is_empty() => {
             #[cfg(feature = "plugin")]
             {
-                let enable_mdx_rs = *next_config.mdx_rs().await?;
+                let enable_mdx_rs = next_config.mdx_rs().await?.is_some();
                 get_swc_ecma_transform_rule_impl(project_path, plugin_configs, enable_mdx_rs).await
             }
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -197,7 +197,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.4",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240417.1",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240422.2",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1500,10 +1500,7 @@ function getMdxOptions(options: any = {}) {
     ...options,
     development: options.development ?? false,
     jsx: options.jsx ?? false,
-    parse: options.parse ?? {
-      gfmStrikethroughSingleTilde: true,
-      mathTextSingleDollar: true,
-    },
+    mdxType: options.mdxType ?? 'commonMark',
   }
 }
 

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -344,7 +344,20 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
             ])
           )
           .optional(),
-        mdxRs: z.boolean().optional(),
+        // This is partial set of mdx-rs transform options we support, aligned
+        // with next_core::next_config::MdxRsOptions. Ensure both types are kept in sync.
+        mdxRs: z
+          .union([
+            z.boolean(),
+            z.object({
+              development: z.boolean().optional(),
+              jsxRuntime: z.string().optional(),
+              jsxImportSource: z.string().optional(),
+              providerImportSource: z.string().optional(),
+              mdxType: z.enum(['gfm', 'commonmark']).optional(),
+            }),
+          ])
+          .optional(),
         typedRoutes: z.boolean().optional(),
         webpackBuildWorker: z.boolean().optional(),
         turbo: z

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -317,7 +317,16 @@ export interface ExperimentalConfig {
    * For use with `@next/mdx`. Compile MDX files using the new Rust compiler.
    * @see https://nextjs.org/docs/app/api-reference/next-config-js/mdxRs
    */
-  mdxRs?: boolean
+  mdxRs?:
+    | boolean
+    | {
+        development?: boolean
+        jsx?: boolean
+        jsxRuntime?: string
+        jsxImportSource?: string
+        providerImportSource?: string
+        mdxType?: 'gfm' | 'commonmark'
+      }
 
   /**
    * Generate Route types and enable type checking for Link and Router.push, etc.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1071,8 +1071,8 @@ importers:
         specifier: 0.26.4
         version: 0.26.4
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240417.1
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240417.1'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240422.2
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240422.2'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -2155,7 +2155,6 @@ packages:
   /@babel/plugin-proposal-dynamic-import@7.16.7(@babel/core@7.22.5):
     resolution: {integrity: sha512-I8SW9Ho3/8DRSdmDdH3gORdyUuYnk1m4cMxUAdu5oy4n3OfN8flDEH+d60iG7dUfi0KkYwSvoalHzzdRzpWHTg==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-dynamic-import instead.
     peerDependencies:
       '@babel/core': 7.22.5
     dependencies:
@@ -2166,7 +2165,6 @@ packages:
   /@babel/plugin-proposal-export-namespace-from@7.16.7(@babel/core@7.22.5):
     resolution: {integrity: sha512-ZxdtqDXLRGBL64ocZcs7ovt71L3jhC1RGSyR996svrCi3PYqHNkb3SwPJCs8RIzD86s+WPpt2S73+EHCGO+NUA==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-export-namespace-from instead.
     peerDependencies:
       '@babel/core': 7.22.5
     dependencies:
@@ -2189,7 +2187,6 @@ packages:
   /@babel/plugin-proposal-logical-assignment-operators@7.16.7(@babel/core@7.22.5):
     resolution: {integrity: sha512-K3XzyZJGQCr00+EtYtrDjmwX7o7PLK6U9bi1nCwkQioRFVUv6dJoxbQjtWVtP+bCPy82bONBKG8NPyQ4+i6yjg==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-logical-assignment-operators instead.
     peerDependencies:
       '@babel/core': 7.22.5
     dependencies:
@@ -2211,7 +2208,6 @@ packages:
   /@babel/plugin-proposal-numeric-separator@7.16.7(@babel/core@7.22.5):
     resolution: {integrity: sha512-vQgPMknOIgiuVqbokToyXbkY/OmmjAzr/0lhSIbG/KmnzXPGwW/AdhdKpi+O4X/VkWiWjnkKOBiqJrTaC98VKw==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.
     peerDependencies:
       '@babel/core': 7.22.5
     dependencies:
@@ -2261,7 +2257,6 @@ packages:
   /@babel/plugin-proposal-private-methods@7.16.11(@babel/core@7.22.5):
     resolution: {integrity: sha512-F/2uAkPlXDr8+BHpZvo19w3hLFKge+k75XUprE6jaqKxjGkSYcK+4c+bup5PdW/7W/Rpjwql7FTVEDW+fRAQsw==}
     engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
     peerDependencies:
       '@babel/core': 7.22.5
     dependencies:
@@ -25573,8 +25568,8 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240417.1':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240417.1}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240422.2':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240422.2}
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/test/integration/plugin-mdx-rs/pages/gfm.mdx
+++ b/test/integration/plugin-mdx-rs/pages/gfm.mdx
@@ -1,0 +1,7 @@
+## Hello MDX
+
+Here's a simple gfm mdx file!!
+
+| foo | bar |
+| --- | --- |
+| baz | bim |

--- a/test/integration/plugin-mdx-rs/test/index.test.js
+++ b/test/integration/plugin-mdx-rs/test/index.test.js
@@ -1,20 +1,26 @@
 /* eslint-env jest */
 
 import { join } from 'path'
-import { renderViaHTTP, findPort, launchApp, killApp } from 'next-test-utils'
+import {
+  renderViaHTTP,
+  findPort,
+  launchApp,
+  killApp,
+  File,
+} from 'next-test-utils'
 
+const appDir = join(__dirname, '..')
 const context = {}
 
 describe('MDX-rs Configuration', () => {
-  beforeAll(async () => {
-    context.appPort = await findPort()
-    context.server = await launchApp(join(__dirname, '../'), context.appPort)
-  })
-  afterAll(() => {
-    killApp(context.server)
-  })
-
   describe('MDX-rs Plugin support', () => {
+    beforeAll(async () => {
+      context.appPort = await findPort()
+      context.server = await launchApp(join(__dirname, '../'), context.appPort)
+    })
+    afterAll(() => {
+      killApp(context.server)
+    })
     it('should render an MDX page correctly', async () => {
       expect(await renderViaHTTP(context.appPort, '/')).toMatch(/Hello MDX/)
     })
@@ -28,6 +34,40 @@ describe('MDX-rs Configuration', () => {
     it('should render an MDX page with globally provided components (from `mdx-components.js`) correctly', async () => {
       expect(await renderViaHTTP(context.appPort, '/provider')).toMatch(
         /Marker was rendered!/
+      )
+    })
+  })
+
+  describe('MDX-rs Plugin support with mdx transform options', () => {
+    let nextConfig
+    beforeAll(async () => {
+      nextConfig = new File(join(appDir, 'next.config.js'))
+
+      nextConfig.write(`
+      const withMDX = require('@next/mdx')({
+        extension: /\\.mdx?$/,
+      })
+      module.exports = withMDX({
+        pageExtensions: ['js', 'jsx', 'mdx'],
+        experimental: {
+          mdxRs: {
+            mdxType: 'gfm'
+          },
+        },
+      })
+    `)
+
+      context.appPort = await findPort()
+      context.server = await launchApp(join(__dirname, '../'), context.appPort)
+    })
+    afterAll(() => {
+      killApp(context.server)
+      nextConfig.restore()
+    })
+
+    it('should render an MDX page correctly', async () => {
+      expect(await renderViaHTTP(context.appPort, '/gfm')).toMatch(
+        /<table>\n<thead>\n<tr>\n<th>foo/
       )
     })
   })


### PR DESCRIPTION
### What

Closes PACK-2978, requires https://github.com/vercel/turbo/pull/8005.

PR extends existing mdxRs config from accepting object as well in addition to current boolean flag, mainly to allow to specify what kind of markdown types will be used between gfm and commonmark.