### PR TITLE
docs: edit `dynamicParams`'s default value and add details about cache

### DIFF
--- a/docs/02-app/02-api-reference/02-file-conventions/route-segment-config.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/route-segment-config.mdx
@@ -8,7 +8,7 @@ The Route Segment options allows you to configure the behavior of a [Page](/docs
 | Option                                | Type                                                                                                                      | Default                    |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
 | [`dynamic`](#dynamic)                 | `'auto' \| 'force-dynamic' \| 'error' \| 'force-static'`                                                                  | `'auto'`                   |
-| [`dynamicParams`](#dynamicparams)     | `boolean`                                                                                                                 | `true`                     |
+| [`dynamicParams`](#dynamicparams)     | `true \| false \| undefined`                                                                                                                 | `undefined`                     |
 | [`revalidate`](#revalidate)           | `false \| 0 \| number`                                                                                                    | `false`                    |
 | [`fetchCache`](#fetchcache)           | `'auto' \| 'default-cache' \| 'only-cache' \| 'force-cache' \| 'force-no-store' \| 'default-no-store' \| 'only-no-store'` | `'auto'`                   |
 | [`runtime`](#runtime)                 | `'nodejs' \| 'edge'`                                                                                                      | `'nodejs'`                 |
@@ -56,14 +56,15 @@ export const dynamic = 'auto'
 Control what happens when a dynamic segment is visited that was not generated with [generateStaticParams](/docs/app/api-reference/functions/generate-static-params).
 
 ```tsx filename="layout.tsx | page.tsx" switcher
-export const dynamicParams = true // true | false,
+export const dynamicParams = true // true | false | undefined
 ```
 
 ```js filename="layout.js | page.js | route.js" switcher
-export const dynamicParams = true // true | false,
+export const dynamicParams = true // true | false | undefined
 ```
 
-- **`true`** (default): Dynamic segments not included in `generateStaticParams` are generated on demand.
+- **`undefined`** (default): Dynamic segments not included in `generateStaticParams` are generated on demand and not cached.
+- **`true`**: Dynamic segments not included in `generateStaticParams` are generated on demand and cached in [Full Route Cache](https://nextjs.org/docs/app/building-your-application/caching#full-route-cache).
 - **`false`**: Dynamic segments not included in `generateStaticParams` will return a 404.
 
 > **Good to know**:


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

I found that `dynamicParams`'s default value is not `true`.

When I **omit** `export const dynamicParams = true` in page.tsx, dynamic segments are generated on-demand but not cached.
But when I write this line in page.tsx, dynamic routes are generated on-demand and cached.
(tested with next.js 14.1.4)

Thank you for reviewing.
