### PR TITLE
Stop installing React in tests

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -104,8 +104,6 @@
   "peerDependencies": {
     "@opentelemetry/api": "^1.1.0",
     "@playwright/test": "^1.41.2",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "sass": "^1.3.0"
   },
   "peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -826,12 +826,6 @@ importers:
       postcss:
         specifier: 8.4.31
         version: 8.4.31
-      react:
-        specifier: ^18.2.0
-        version: 18.2.0
-      react-dom:
-        specifier: ^18.2.0
-        version: 18.2.0(react@18.2.0)
       sass:
         specifier: ^1.3.0
         version: 1.54.0

--- a/run-tests.js
+++ b/run-tests.js
@@ -404,13 +404,8 @@ ${ENDGROUP}`)
     // a starter Next.js install to re-use to speed up tests
     // to avoid having to run yarn each time
     console.log(`${GROUP}Creating Next.js install for isolated tests`)
-    const reactVersion = process.env.NEXT_TEST_REACT_VERSION || 'latest'
     const { installDir, pkgPaths, tmpRepoDir } = await createNextInstall({
       parentSpan: mockTrace(),
-      dependencies: {
-        react: reactVersion,
-        'react-dom': reactVersion,
-      },
       keepRepoDir: true,
     })
 

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -158,12 +158,9 @@ export class NextInstance {
           }`
         )
 
-        const reactVersion = process.env.NEXT_TEST_REACT_VERSION || 'latest'
         const finalDependencies = {
-          react: reactVersion,
-          'react-dom': reactVersion,
-          '@types/react': reactVersion,
-          '@types/react-dom': reactVersion,
+          '@types/react': 'latest',
+          '@types/react-dom': 'latest',
           typescript: 'latest',
           '@types/node': 'latest',
           ...this.dependencies,


### PR DESCRIPTION
Showcasing that we're not always using the vendored React version. We can't just test this way because that wouldn't represent how our users use Next.js. Definitely helpful to validate our vendoring implementation.

TODO:
- install React for pages router

Closes NEXT-3182