### PR TITLE
Update `@testing-library/react` used in tests

### DIFF
--- a/test/production/jest/index.test.ts
+++ b/test/production/jest/index.test.ts
@@ -140,10 +140,6 @@ describe('next/jest', () => {
           // Runs jest and bails if jest fails
           build: 'next build && jest test/mock.test.js test/dynamic.test.js',
         },
-        resolutions: {
-          // https://github.com/dperini/nwsapi/issues/108
-          nwsapi: '2.2.7',
-        },
       },
       installCommand: 'pnpm i',
       buildCommand: `pnpm build`,

--- a/test/production/jest/index.test.ts
+++ b/test/production/jest/index.test.ts
@@ -76,17 +76,18 @@ describe('next/jest', () => {
           
           describe("Home", () => {
             it("renders a heading", () => {
-              act(() => {
-                render(<Home />);
+              const { unmount } = render(<Home />);
           
-                const heading = screen.getByRole("heading", {
-                  name: /Loading/i,
-                });
-          
-                expect(heading).toBeInTheDocument();
+              const heading = screen.getByRole("heading", {
+                name: /Loading/i,
               });
+          
+              expect(heading).toBeInTheDocument();
+          
+              unmount();
             });
           });
+        
         `,
         'lib/hello.mjs': `
           import path from 'path'
@@ -128,15 +129,20 @@ describe('next/jest', () => {
       },
       dependencies: {
         '@next/font': 'canary',
-        jest: '27.4.7',
+        jest: '29.7.0',
+        'jest-environment-jsdom': '29.7.0',
         '@testing-library/jest-dom': '5.16.1',
-        '@testing-library/react': '12.1.2',
-        '@testing-library/user-event': '13.5.0',
+        '@testing-library/react': '15.0.2',
+        '@testing-library/user-event': '14.5.2',
       },
       packageJson: {
         scripts: {
           // Runs jest and bails if jest fails
           build: 'next build && jest test/mock.test.js test/dynamic.test.js',
+        },
+        resolutions: {
+          // https://github.com/dperini/nwsapi/issues/108
+          nwsapi: '2.2.7',
         },
       },
       installCommand: 'pnpm i',

--- a/test/production/jest/new-link-behavior.test.ts
+++ b/test/production/jest/new-link-behavior.test.ts
@@ -19,12 +19,10 @@ describe('next/jest newLinkBehavior', () => {
           import Page from '../pages/index'
 
           it('Link', () => {
-            act(() => {
-              render(<Page />)
+            render(<Page />)
 
-              const link = screen.getByRole('link', { name: 'Hello World!' })
-              expect(link.getAttribute('href')).toBe('https://example.com')
-            })
+            const link = screen.getByRole('link', { name: 'Hello World!' })
+            expect(link.getAttribute('href')).toBe('https://example.com')
           })
         `,
         'jest.config.js': `
@@ -36,8 +34,9 @@ describe('next/jest newLinkBehavior', () => {
         `,
       },
       dependencies: {
-        jest: '27.4.7',
-        '@testing-library/react': '12.1.2',
+        jest: '29.7.0',
+        'jest-environment-jsdom': '29.7.0',
+        '@testing-library/react': '15.0.2',
       },
       packageJson: {
         scripts: {

--- a/test/production/jest/next-image-preload/next-image-preload.test.ts
+++ b/test/production/jest/next-image-preload/next-image-preload.test.ts
@@ -26,9 +26,9 @@ describe('next/jest', () => {
         'jest.config.js': new FileRef(path.join(appDir, 'jest.config.js')),
       },
       dependencies: {
-        jest: '29.6.2',
-        'jest-environment-jsdom': '29.6.2',
-        '@testing-library/react': '14.0.0',
+        jest: '29.7.0',
+        'jest-environment-jsdom': '29.7.0',
+        '@testing-library/react': '15.0.2',
         '@testing-library/jest-dom': '5.17.0',
       },
     })

--- a/test/production/jest/relay/relay-jest.test.ts
+++ b/test/production/jest/relay/relay-jest.test.ts
@@ -13,7 +13,7 @@ describe('next/jest', () => {
         components: new FileRef(path.join(appDir, 'components')),
         pages: new FileRef(path.join(appDir, 'pages')),
         'tests/entry.test.tsx': `
-        import { render as renderFn, waitFor } from '@testing-library/react'
+        import { render, waitFor } from '@testing-library/react'
         import { RelayEnvironmentProvider } from 'react-relay'
         import { createMockEnvironment, MockPayloadGenerator } from 'relay-test-utils'
         
@@ -23,7 +23,7 @@ describe('next/jest', () => {
           it('should work', async () => {
             let environment = createMockEnvironment()
         
-            const { getByText } = renderFn(
+            const { getByText } = render(
               <RelayEnvironmentProvider environment={environment}>
                 <Page />
               </RelayEnvironmentProvider>
@@ -49,7 +49,7 @@ describe('next/jest', () => {
       dependencies: {
         jest: '27.4.7',
         'react-relay': '13.2.0',
-        '@testing-library/react': '13.1.1',
+        '@testing-library/react': '15.0.2',
         '@types/jest': '27.4.1',
         'babel-jest': '27.5.1',
         'babel-plugin-relay': '13.2.0',

--- a/test/production/jest/remove-react-properties/remove-react-properties-jest.test.ts
+++ b/test/production/jest/remove-react-properties/remove-react-properties-jest.test.ts
@@ -13,14 +13,14 @@ describe('next/jest', () => {
       files: {
         pages: new FileRef(path.join(appDir, 'pages')),
         'tests/index.test.tsx': `
-        import { render as renderFn, waitFor } from '@testing-library/react'
+        import { render, waitFor } from '@testing-library/react'
         import '@testing-library/jest-dom/extend-expect';
 
         import Page from '@/pages'
 
         describe('testid', () => {
           it('data-testid should be available in the test', async () => {
-            const { getByTestId } = renderFn(
+            const { getByTestId } = render(
               <Page />
             )
             expect(getByTestId('main-text')).toHaveTextContent('Hello World')
@@ -33,9 +33,9 @@ describe('next/jest', () => {
         'tsconfig.json': new FileRef(path.join(appDir, 'tsconfig.json')),
       },
       dependencies: {
-        jest: '27.4.7',
-        '@testing-library/react': '^13.1.1',
-        jsdom: '^19.0.0',
+        jest: '29.7.0',
+        'jest-environment-jsdom': '29.7.0',
+        '@testing-library/react': '15.0.2',
         '@testing-library/jest-dom': '5.16.4',
       },
       packageJson: {


### PR DESCRIPTION
The tests flaked for me because at least one test was still using legacy roots: https://github.com/vercel/next.js/actions/runs/8774705217/job/24076576796?pr=64842#step:27:379

Updates to latest version that's also compatible with React 19 Canary. Updated Jest where it seemed easy.



Closes NEXT-3183