### PR TITLE
Add types for `config.future`

### DIFF
--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -419,6 +419,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
       )
       .returns(z.union([zExportMap, z.promise(zExportMap)]))
       .optional(),
+    future: z.strictObject({}).optional(),
     generateBuildId: z
       .function()
       .args()

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -809,6 +809,11 @@ export interface NextConfig extends Record<string, any> {
    * Enable experimental features. Note that all experimental features are subject to breaking changes in the future.
    */
   experimental?: ExperimentalConfig
+
+  /**
+   * Enables behavior that will become the default in a future major release.
+   */
+  future?: Record<string, never>
 }
 
 export const defaultConfig: NextConfig = {


### PR DESCRIPTION
`config.future` will hold options for behavior that will be the default in future major releases. It's better to type them as an empty object for proper typechecking. Removing properties from `config` means that the removed property will now be typed as `any` since our config `extends Record<string, any>` for backwards compatibility.

In https://github.com/vercel/next.js/pull/64779, we'll add `hardenedXSSProtection` to `config.future`

Closes NEXT-3190