### PR TITLE
Replace ts-ignore with ts-expect-error

### DIFF
--- a/packages/next/src/build/babel/loader/index.ts
+++ b/packages/next/src/build/babel/loader/index.ts
@@ -12,7 +12,6 @@ async function nextBabelLoader(
   const target = this.target
   const loaderOptions = parentTrace
     .traceChild('get-options')
-    // @ts-ignore TODO: remove ignore once webpack 5 types are used
     .traceFn(() => this.getOptions())
 
   const loaderSpanInner = parentTrace.traceChild('next-babel-turbo-transform')

--- a/packages/next/src/build/babel/loader/transform.ts
+++ b/packages/next/src/build/babel/loader/transform.ts
@@ -52,7 +52,7 @@ function transformAstPass(file: any, pluginPairs: any[], parentSpan: Span) {
   const visitor = traverse.visitors.merge(
     visitors,
     passes,
-    // @ts-ignore - the exported types are incorrect here
+    // @ts-expect-error - the exported types are incorrect here
     file.opts.wrapPluginVisitorMethod
   )
 

--- a/packages/next/src/build/compiler.ts
+++ b/packages/next/src/build/compiler.ts
@@ -30,7 +30,6 @@ function generateStats(
 // Webpack 4 does not have this close method so in order to be backwards compatible we check if it exists
 function closeCompiler(compiler: webpack.Compiler | webpack.MultiCompiler) {
   return new Promise<void>((resolve, reject) => {
-    // @ts-ignore Close only exists on the compiler in webpack 5
     return compiler.close((err: any) => (err ? reject(err) : resolve()))
   })
 }

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -203,11 +203,9 @@ export async function loadBindings(
   // see https://github.com/napi-rs/napi-rs/issues/1630
   // and https://github.com/nodejs/node/blob/main/doc/api/process.md#a-note-on-process-io
   if (process.stdout._handle != null) {
-    // @ts-ignore
     process.stdout._handle.setBlocking?.(true)
   }
   if (process.stderr._handle != null) {
-    // @ts-ignore
     process.stderr._handle.setBlocking?.(true)
   }
 

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -843,7 +843,7 @@ export default async function getBaseWebpackConfig(
   let webpackConfig: webpack.Configuration = {
     parallelism: Number(process.env.NEXT_WEBPACK_PARALLELISM) || undefined,
     ...(isNodeServer ? { externalsPresets: { node: true } } : {}),
-    // @ts-ignore
+    // @ts-expect-error
     externals:
       isClient || isEdgeServer
         ? // make sure importing "next" is handled gracefully for client
@@ -1072,7 +1072,6 @@ export default async function getBaseWebpackConfig(
       minimizer: [
         // Minify JavaScript
         (compiler: webpack.Compiler) => {
-          // @ts-ignore No typings yet
           const {
             TerserPlugin,
           } = require('./webpack/plugins/terser-webpack-plugin/src/index.js')
@@ -2165,7 +2164,7 @@ export default async function getBaseWebpackConfig(
     serverSourceMaps: config.experimental.serverSourceMaps,
   })
 
-  // @ts-ignore Cache exists
+  // @ts-expect-error Cache exists
   webpackConfig.cache.name = `${webpackConfig.name}-${webpackConfig.mode}${
     isDevFallback ? '-fallback' : ''
   }`
@@ -2438,7 +2437,6 @@ export default async function getBaseWebpackConfig(
 
       return entry
     }
-    // @ts-ignore webpack 5 typings needed
     webpackConfig.entry = updatedEntry
   }
 

--- a/packages/next/src/build/webpack/config/blocks/css/index.ts
+++ b/packages/next/src/build/webpack/config/blocks/css/index.ts
@@ -63,7 +63,7 @@ export async function lazyPostCSS(
   if (!postcssInstancePromise) {
     postcssInstancePromise = (async () => {
       const postcss = require('postcss')
-      // @ts-ignore backwards compat
+      // @ts-expect-error backwards compat
       postcss.plugin = function postcssPlugin(name, initializer) {
         function creator(...args: any) {
           let transformer = initializer(...args)
@@ -91,7 +91,6 @@ export async function lazyPostCSS(
         return creator
       }
 
-      // @ts-ignore backwards compat
       postcss.vendor = {
         /**
          * Returns the vendor prefix extracted from an input string.
@@ -595,7 +594,7 @@ export const css = curry(async function css(
       require('../../../plugins/mini-css-extract-plugin').default
     fns.push(
       plugin(
-        // @ts-ignore webpack 5 compat
+        // @ts-expect-error webpack 5 compat
         new MiniCssExtractPlugin({
           filename: ctx.isProduction
             ? 'static/css/[contenthash].css'

--- a/packages/next/src/build/webpack/loaders/error-loader.ts
+++ b/packages/next/src/build/webpack/loaders/error-loader.ts
@@ -3,7 +3,6 @@ import path from 'path'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 
 const ErrorLoader: webpack.LoaderDefinitionFunction = function () {
-  // @ts-ignore exists
   const options = this.getOptions() || ({} as any)
 
   const { reason = 'An unknown error has occurred' } = options

--- a/packages/next/src/build/webpack/loaders/lightningcss-loader/src/minify.ts
+++ b/packages/next/src/build/webpack/loaders/lightningcss-loader/src/minify.ts
@@ -1,7 +1,6 @@
-// @ts-ignore
 import { ModuleFilenameHelpers } from 'next/dist/compiled/webpack/webpack'
 import { webpack } from 'next/dist/compiled/webpack/webpack'
-// @ts-ignore
+// @ts-expect-error
 import { RawSource, SourceMapSource } from 'next/dist/compiled/webpack-sources3'
 import { ECacheKey } from './interface'
 import type { Compilation, Compiler } from 'webpack'
@@ -51,9 +50,9 @@ export class LightningCssMinifyPlugin {
       compilation.hooks.statsPrinter.tap(PLUGIN_NAME, (statsPrinter) => {
         statsPrinter.hooks.print
           .for('asset.info.minimized')
-          // @ts-ignore
+          // @ts-expect-error
           .tap(PLUGIN_NAME, (minimized, { green, formatFlag }) => {
-            // @ts-ignore
+            // @ts-expect-error
             return minimized ? green(formatFlag('minimized')) : undefined
           })
       })
@@ -114,7 +113,6 @@ export class LightningCssMinifyPlugin {
 
         compilation.updateAsset(
           asset.name,
-          // @ts-ignore
           sourcemap
             ? new SourceMapSource(
                 codeString,

--- a/packages/next/src/build/webpack/plugins/font-stylesheet-gathering-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/font-stylesheet-gathering-plugin.ts
@@ -94,7 +94,6 @@ export class FontStylesheetGatheringPlugin {
               let result
               if (node.name === '_jsx' || node.name === '__jsx') {
                 result = new BasicEvaluatedExpression()
-                // @ts-ignore
                 result.setRange(node.range)
                 result.setExpression(node)
                 result.setIdentifier(node.name)

--- a/packages/next/src/build/webpack/plugins/mini-css-extract-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/mini-css-extract-plugin.ts
@@ -1,4 +1,4 @@
-// @ts-ignore: TODO: remove when webpack 5 is stable
+// @ts-expect-error: TODO: remove when webpack 5 is stable
 import MiniCssExtractPlugin from 'next/dist/compiled/mini-css-extract-plugin'
 
 export default class NextMiniCssExtractPlugin extends MiniCssExtractPlugin {

--- a/packages/next/src/build/webpack/plugins/next-drop-client-page-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-drop-client-page-plugin.ts
@@ -38,7 +38,7 @@ export class DropClientPage implements webpack.WebpackPluginInstance {
               return
             }
 
-            // @ts-ignore buildInfo exists on Module
+            // @ts-expect-error buildInfo exists on Module
             entryModule.buildInfo.NEXT_ampFirst = true
           }
 

--- a/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -491,7 +491,6 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
                   ignore: ignoreFn,
                   mixedModules: true,
                 })
-                // @ts-ignore
                 fileList = result.fileList
                 result.esmFileList.forEach((file) => fileList.add(file))
                 reasons = result.reasons

--- a/packages/next/src/build/webpack/plugins/terser-webpack-plugin/src/minify.ts
+++ b/packages/next/src/build/webpack/plugins/terser-webpack-plugin/src/minify.ts
@@ -26,7 +26,6 @@ export async function minify(options: any) {
 
   // Let terser generate a SourceMap
   if (inputSourceMap) {
-    // @ts-ignore
     opts.sourceMap = { asObject: true }
   }
 

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -1,8 +1,6 @@
 import '../build/polyfills/polyfill-module'
-// @ts-ignore react-dom/client exists when using React 18
 import ReactDOMClient from 'react-dom/client'
 import React, { use } from 'react'
-// @ts-ignore
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { createFromReadableStream } from 'react-server-dom-webpack/client'
 

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -430,7 +430,7 @@ function Router({
     useEffect(() => {
       // Add `window.nd` for debugging purposes.
       // This is not meant for use in applications as concurrent rendering will affect the cache/tree/router.
-      // @ts-ignore this is for debugging
+      // @ts-expect-error this is for debugging
       window.nd = {
         router: appRouter,
         cache,

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -1,6 +1,5 @@
 'use client'
 
-// @ts-ignore
 // eslint-disable-next-line import/no-extraneous-dependencies
 // import { createFromFetch } from 'react-server-dom-webpack/client'
 const { createFromFetch } = (

--- a/packages/next/src/client/image-component.tsx
+++ b/packages/next/src/client/image-component.tsx
@@ -29,7 +29,7 @@ import { ImageConfigContext } from '../shared/lib/image-config-context.shared-ru
 import { warnOnce } from '../shared/lib/utils/warn-once'
 import { RouterContext } from '../shared/lib/router-context.shared-runtime'
 
-// @ts-ignore - This is replaced by webpack alias
+// @ts-expect-error - This is replaced by webpack alias
 import defaultLoader from 'next/dist/shared/lib/image-loader'
 
 // This is replaced by webpack define plugin
@@ -237,7 +237,6 @@ const ImageElement = forwardRef<HTMLImageElement | null, ImageElementProps>(
             if (forwardedRef) {
               if (typeof forwardedRef === 'function') forwardedRef(img)
               else if (typeof forwardedRef === 'object') {
-                // @ts-ignore - .current is read only it's usually assigned by react internally
                 forwardedRef.current = img
               }
             }

--- a/packages/next/src/client/index.tsx
+++ b/packages/next/src/client/index.tsx
@@ -139,7 +139,7 @@ class Container extends React.Component<{
             ),
           asPath,
           {
-            // @ts-ignore
+            // @ts-expect-error
             // WARNING: `_h` is an internal option for handing Next.js
             // client-side hydration. Your app should _never_ use this property.
             // It may change at any time without notice.

--- a/packages/next/src/client/legacy/image.tsx
+++ b/packages/next/src/client/legacy/image.tsx
@@ -565,7 +565,6 @@ const ImageElement = ({
         <noscript>
           <img
             {...rest}
-            // @ts-ignore - TODO: upgrade to `@types/react@17`
             loading={loading}
             decoding="async"
             data-nimg={layout}
@@ -860,7 +859,7 @@ export default function Image({
       ) {
         perfObserver = new PerformanceObserver((entryList) => {
           for (const entry of entryList.getEntries()) {
-            // @ts-ignore - missing "LargestContentfulPaint" class with "element" prop
+            // @ts-expect-error - missing "LargestContentfulPaint" class with "element" prop
             const imgSrc = entry?.element?.src || ''
             const lcpImage = allImgs.get(imgSrc)
             if (

--- a/packages/next/src/client/page-loader.ts
+++ b/packages/next/src/client/page-loader.ts
@@ -97,7 +97,7 @@ export default class PageLoader {
       } else {
         if (!this.promisedMiddlewareMatchers) {
           // TODO: Decide what should happen when fetching fails instead of asserting
-          // @ts-ignore
+          // @ts-expect-error
           this.promisedMiddlewareMatchers = fetch(
             `${this.assetPrefix}/_next/static/${this.buildId}/${DEV_MIDDLEWARE_MANIFEST}`,
             { credentials: 'same-origin' }

--- a/packages/next/src/client/script.tsx
+++ b/packages/next/src/client/script.tsx
@@ -328,7 +328,6 @@ function Script(props: ScriptProps): JSX.Element | null {
           />
         )
       } else {
-        // @ts-ignore
         ReactDOM.preload(
           src,
           restProps.integrity
@@ -349,7 +348,6 @@ function Script(props: ScriptProps): JSX.Element | null {
       }
     } else if (strategy === 'afterInteractive') {
       if (src) {
-        // @ts-ignore
         ReactDOM.preload(
           src,
           restProps.integrity

--- a/packages/next/src/compiled/@edge-runtime/primitives/load.js
+++ b/packages/next/src/compiled/@edge-runtime/primitives/load.js
@@ -220,7 +220,7 @@ function getCrypto(context, scopedContext) {
       SubtleCrypto: scopedContext.SubtleCrypto || globalThis.SubtleCrypto
     };
   } else if (
-    // @ts-ignore
+    // @ts-expect-error
     import_crypto.default.webcrypto
   ) {
     const webcrypto = import_crypto.default.webcrypto;

--- a/packages/next/src/experimental/testmode/fetch.ts
+++ b/packages/next/src/experimental/testmode/fetch.ts
@@ -99,7 +99,7 @@ export async function handleFetch(
     method: 'POST',
     body: JSON.stringify(proxyRequest),
     next: {
-      // @ts-ignore
+      // @ts-expect-error
       internal: true,
     },
   })
@@ -129,7 +129,7 @@ export function interceptFetch(originalFetch: Fetch) {
     init?: FetchInitArg
   ): Promise<Response> {
     // Passthrough internal requests.
-    // @ts-ignore
+    // @ts-expect-error
     if (init?.next?.internal) {
       return originalFetch(input, init)
     }

--- a/packages/next/src/lib/memory/startup.ts
+++ b/packages/next/src/lib/memory/startup.ts
@@ -9,7 +9,6 @@ export function enableMemoryDebuggingMode(): void {
   // memory limit. It does not give any warning to the user though which
   // can be jarring. If memory is large, this may take a long time.
   if ('setHeapSnapshotNearHeapLimit' in v8) {
-    // @ts-expect-error - this method exists since Node 16.
     v8.setHeapSnapshotNearHeapLimit(1)
   }
 

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -244,7 +244,7 @@ function mergeMetadata({
       case 'referrer':
       case 'formatDetection':
       case 'manifest':
-        // @ts-ignore TODO: support inferring
+        // @ts-expect-error TODO: support inferring
         target[key] = source[key] || null
         break
       case 'other':
@@ -299,7 +299,7 @@ function mergeViewport({
         break
       default:
         if (typeof source[key] !== 'undefined') {
-          // @ts-ignore viewport properties
+          // @ts-expect-error viewport properties
           target[key] = source[key]
         }
         break

--- a/packages/next/src/lib/metadata/resolvers/resolve-basics.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-basics.ts
@@ -233,7 +233,7 @@ export const resolveAppleWebApp: FieldResolver<'appleWebApp'> = (appWebApp) => {
 export const resolveAppLinks: FieldResolver<'appLinks'> = (appLinks) => {
   if (!appLinks) return null
   for (const key in appLinks) {
-    // @ts-ignore // TODO: type infer
+    // @ts-expect-error // TODO: type infer
     appLinks[key] = resolveAsArrayOrUndefined(appLinks[key])
   }
   return appLinks as ResolvedMetadata['appLinks']

--- a/packages/next/src/lib/patch-incorrect-lockfile.ts
+++ b/packages/next/src/lib/patch-incorrect-lockfile.ts
@@ -1,7 +1,6 @@
 import { promises } from 'fs'
 import * as Log from '../build/output/log'
 import findUp from 'next/dist/compiled/find-up'
-// @ts-ignore no-json types
 import nextPkgJson from 'next/package.json'
 import type { UnwrapPromise } from './coalesced-function'
 import { isCI } from '../telemetry/ci-info'

--- a/packages/next/src/pages/_document.tsx
+++ b/packages/next/src/pages/_document.tsx
@@ -114,14 +114,14 @@ function AmpStyles({
     ? (styles as React.ReactElement[])
     : []
   if (
-    // @ts-ignore Property 'props' does not exist on type ReactElement
+    // @ts-expect-error Property 'props' does not exist on type ReactElement
     styles.props &&
-    // @ts-ignore Property 'props' does not exist on type ReactElement
+    // @ts-expect-error Property 'props' does not exist on type ReactElement
     Array.isArray(styles.props.children)
   ) {
     const hasStyles = (el: React.ReactElement) =>
       el?.props?.dangerouslySetInnerHTML?.__html
-    // @ts-ignore Property 'props' does not exist on type ReactElement
+    // @ts-expect-error Property 'props' does not exist on type ReactElement
     styles.props.children.forEach((child: React.ReactElement) => {
       if (Array.isArray(child)) {
         child.forEach((el) => hasStyles(el) && curStyles.push(el))
@@ -218,7 +218,7 @@ function getPreNextWorkerScripts(context: HtmlProps, props: OriginProps) {
   try {
     let {
       partytownSnippet,
-      // @ts-ignore: Prevent webpack from processing this require
+      // @ts-expect-error: Prevent webpack from processing this require
     } = __non_webpack_require__('@builder.io/partytown/integration'!)
 
     const children = Array.isArray(props.children)
@@ -1205,7 +1205,7 @@ export function Html(
 export function Main() {
   const { docComponentsRendered } = useHtmlContext()
   docComponentsRendered.Main = true
-  // @ts-ignore
+  // @ts-expect-error
   return <next-js-internal-body-render-target />
 }
 

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -207,7 +207,7 @@ async function createForwardedActionResponse(
       duplex: 'half',
       headers: forwardedHeaders,
       next: {
-        // @ts-ignore
+        // @ts-expect-error
         internal: 1,
       },
     })
@@ -293,7 +293,7 @@ async function createRedirectRenderResult(
         method: 'GET',
         headers: forwardedHeaders,
         next: {
-          // @ts-ignore
+          // @ts-expect-error
           internal: 1,
         },
       })

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -619,9 +619,9 @@ async function renderToHTMLOrFlightImpl(
   // react-server-dom-webpack. This is a hack until we find a better way.
   if (ComponentMod.__next_app__) {
     const instrumented = wrapClientComponentLoader(ComponentMod)
-    // @ts-ignore
+    // @ts-expect-error
     globalThis.__next_require__ = instrumented.require
-    // @ts-ignore
+    // @ts-expect-error
     globalThis.__next_chunk_load__ = instrumented.loadChunk
   }
 

--- a/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
+++ b/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
@@ -46,7 +46,7 @@ export async function createComponentStylesAndScripts<
           <link
             rel="stylesheet"
             href={fullHref}
-            // @ts-ignore
+            // @ts-expect-error
             precedence={precedence}
             crossOrigin={ctx.renderOpts.crossOrigin}
             key={index}

--- a/packages/next/src/server/app-render/encryption-utils.ts
+++ b/packages/next/src/server/app-render/encryption-utils.ts
@@ -127,7 +127,7 @@ export function setReferenceManifestsSingleton({
     }
   }
 }) {
-  // @ts-ignore
+  // @ts-expect-error
   globalThis[SERVER_ACTION_MANIFESTS_SINGLETON] = {
     clientReferenceManifest,
     serverActionsManifest,

--- a/packages/next/src/server/app-render/get-layer-assets.tsx
+++ b/packages/next/src/server/app-render/get-layer-assets.tsx
@@ -84,7 +84,7 @@ export function getLayerAssets({
           <link
             rel="stylesheet"
             href={fullHref}
-            // @ts-ignore
+            // @ts-expect-error
             precedence={precedence}
             crossOrigin={ctx.renderOpts.crossOrigin}
             key={index}

--- a/packages/next/src/server/app-render/rsc/taint.ts
+++ b/packages/next/src/server/app-render/rsc/taint.ts
@@ -17,14 +17,12 @@ export const taintObjectReference: (
   message: string | undefined,
   object: Reference
 ) => void = process.env.__NEXT_EXPERIMENTAL_REACT
-  ? // @ts-ignore
-    React.experimental_taintObjectReference
+  ? React.experimental_taintObjectReference
   : notImplemented
 export const taintUniqueValue: (
   message: string | undefined,
   lifetime: Reference,
   value: TaintableUniqueValue
 ) => void = process.env.__NEXT_EXPERIMENTAL_REACT
-  ? // @ts-ignore
-    React.experimental_taintUniqueValue
+  ? React.experimental_taintUniqueValue
   : notImplemented

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -714,7 +714,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
     this.fallbackWatcher = await new Promise((resolve) => {
       let bootedFallbackCompiler = false
       fallbackCompiler.watch(
-        // @ts-ignore webpack supports an array of watchOptions when using a multiCompiler
+        // @ts-expect-error webpack supports an array of watchOptions when using a multiCompiler
         fallbackConfig.watchOptions,
         // Errors are handled separately
         (_err: any) => {
@@ -759,7 +759,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       config.entry = async (...args) => {
         const outputPath = this.multiCompiler?.outputPath || ''
         const entries = getEntries(outputPath)
-        // @ts-ignore entry is always a function
+        // @ts-expect-error entry is always a function
         const entrypoints = await defaultEntry(...args)
         const isClientCompilation = config.name === COMPILER_NAMES.client
         const isNodeServerCompilation = config.name === COMPILER_NAMES.server
@@ -1060,7 +1060,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
     }
 
     // Enable building of client compilation before server compilation in development
-    // @ts-ignore webpack 5
+    // @ts-expect-error webpack 5
     this.activeWebpackConfigs.parallelism = 1
 
     this.multiCompiler = webpack(
@@ -1431,7 +1431,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
 
     this.watcher = await new Promise((resolve) => {
       const watcher = this.multiCompiler?.watch(
-        // @ts-ignore webpack supports an array of watchOptions when using a multiCompiler
+        // @ts-expect-error webpack supports an array of watchOptions when using a multiCompiler
         this.activeWebpackConfigs.map((config) => config.watchOptions!),
         // Errors are handled separately
         (_err: any) => {

--- a/packages/next/src/server/future/helpers/module-loader/node-module-loader.ts
+++ b/packages/next/src/server/future/helpers/module-loader/node-module-loader.ts
@@ -8,7 +8,7 @@ export class NodeModuleLoader implements ModuleLoader {
     if (process.env.NEXT_RUNTIME !== 'edge') {
       // Need to `await` to cover the case that route is marked ESM modules by ESM escalation.
       return await (process.env.NEXT_MINIMAL
-        ? // @ts-ignore
+        ? // @ts-expect-error
           __non_webpack_require__(id)
         : require(id))
     }

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -74,7 +74,7 @@ export async function initialize(opts: {
   startServerSpan?: Span
 }): Promise<[WorkerRequestHandler, WorkerUpgradeHandler, NextServer]> {
   if (!process.env.NODE_ENV) {
-    // @ts-ignore not readonly
+    // @ts-expect-error not readonly
     process.env.NODE_ENV = opts.dev ? 'development' : 'production'
   }
 

--- a/packages/next/src/server/lib/server-ipc/invoke-request.ts
+++ b/packages/next/src/server/lib/server-ipc/invoke-request.ts
@@ -35,7 +35,7 @@ export const invokeRequest = async (
       : {}),
 
     next: {
-      // @ts-ignore
+      // @ts-expect-error
       internal: true,
     },
   })

--- a/packages/next/src/server/lib/squoosh/codecs.ts
+++ b/packages/next/src/server/lib/squoosh/codecs.ts
@@ -36,46 +36,46 @@ export interface RotateOptions {
 
 // MozJPEG
 import type { MozJPEGModule as MozJPEGEncodeModule } from './mozjpeg/mozjpeg_enc'
-// @ts-ignore
+// @ts-expect-error
 import mozEnc from './mozjpeg/mozjpeg_node_enc.js'
 const mozEncWasm = path.resolve(__dirname, './mozjpeg/mozjpeg_node_enc.wasm')
-// @ts-ignore
+// @ts-expect-error
 import mozDec from './mozjpeg/mozjpeg_node_dec.js'
 const mozDecWasm = path.resolve(__dirname, './mozjpeg/mozjpeg_node_dec.wasm')
 
 // WebP
 import type { WebPModule as WebPEncodeModule } from './webp/webp_enc'
-// @ts-ignore
+// @ts-expect-error
 import webpEnc from './webp/webp_node_enc.js'
 const webpEncWasm = path.resolve(__dirname, './webp/webp_node_enc.wasm')
-// @ts-ignore
+// @ts-expect-error
 import webpDec from './webp/webp_node_dec.js'
 const webpDecWasm = path.resolve(__dirname, './webp/webp_node_dec.wasm')
 
 // AVIF
 import type { AVIFModule as AVIFEncodeModule } from './avif/avif_enc'
-// @ts-ignore
+// @ts-expect-error
 import avifEnc from './avif/avif_node_enc.js'
 const avifEncWasm = path.resolve(__dirname, './avif/avif_node_enc.wasm')
-// @ts-ignore
+// @ts-expect-error
 import avifDec from './avif/avif_node_dec.js'
 const avifDecWasm = path.resolve(__dirname, './avif/avif_node_dec.wasm')
 
 // PNG
-// @ts-ignore
+// @ts-expect-error
 import * as pngEncDec from './png/squoosh_png.js'
 const pngEncDecWasm = path.resolve(__dirname, './png/squoosh_png_bg.wasm')
 const pngEncDecInit = () =>
   pngEncDec.default(fsp.readFile(pathify(pngEncDecWasm)))
 
 // OxiPNG
-// @ts-ignore
+// @ts-expect-error
 import * as oxipng from './png/squoosh_oxipng.js'
 const oxipngWasm = path.resolve(__dirname, './png/squoosh_oxipng_bg.wasm')
 const oxipngInit = () => oxipng.default(fsp.readFile(pathify(oxipngWasm)))
 
 // Resize
-// @ts-ignore
+// @ts-expect-error
 import * as resize from './resize/squoosh_resize.js'
 const resizeWasm = path.resolve(__dirname, './resize/squoosh_resize_bg.wasm')
 const resizeInit = () => resize.default(fsp.readFile(pathify(resizeWasm)))

--- a/packages/next/src/server/post-process.ts
+++ b/packages/next/src/server/post-process.ts
@@ -267,7 +267,6 @@ registerPostProcessor(
   'Inline-Fonts',
   new FontOptimizerMiddleware(),
   // Using process.env because passing Experimental flag through loader is not possible.
-  // @ts-ignore
   (options) => options.optimizeFonts || process.env.__NEXT_OPTIMIZE_FONTS
 )
 

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -1357,7 +1357,7 @@ export async function renderToHTMLImpl(
 
     const contentHTML = rawStyledJsxInsertedHTML + content
 
-    // @ts-ignore: documentInitialPropsRes is set
+    // @ts-expect-error: documentInitialPropsRes is set
     const { docProps } = (documentInitialPropsRes as any) || {}
     const documentElement = (htmlProps: any) => {
       if (process.env.NEXT_RUNTIME === 'edge') {

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -219,7 +219,7 @@ export function getNextInternalQuery(
 
   for (const key of keysToInclude) {
     if (key in query) {
-      // @ts-ignore this can't be typed correctly
+      // @ts-expect-error this can't be typed correctly
       nextInternalQuery[key] = query[key]
     }
   }

--- a/packages/next/src/server/require-hook.ts
+++ b/packages/next/src/server/require-hook.ts
@@ -9,7 +9,7 @@ const originalRequire = mod.prototype.require
 const resolveFilename = mod._resolveFilename
 
 let resolve: typeof require.resolve = process.env.NEXT_MINIMAL
-  ? // @ts-ignore
+  ? // @ts-expect-error
     __non_webpack_require__.resolve
   : require.resolve
 

--- a/packages/next/src/server/require.ts
+++ b/packages/next/src/server/require.ts
@@ -122,7 +122,7 @@ export async function requirePage(
   try {
     process.env.__NEXT_PRIVATE_RUNTIME_TYPE = isAppPath ? 'app' : 'pages'
     const mod = process.env.NEXT_MINIMAL
-      ? // @ts-ignore
+      ? // @ts-expect-error
         __non_webpack_require__(pagePath)
       : require(pagePath)
     return mod

--- a/packages/next/src/server/web/internal-edge-wait-until.ts
+++ b/packages/next/src/server/web/internal-edge-wait-until.ts
@@ -9,9 +9,9 @@ const state: {
   waitUntilResolve: () => void
   waitUntilPromise: Promise<void> | null
 } =
-  // @ts-ignore
+  // @ts-expect-error
   globalThis[GLOBAL_KEY] ||
-  // @ts-ignore
+  // @ts-expect-error
   (globalThis[GLOBAL_KEY] = {
     waitUntilCounter: 0,
     waitUntilResolve: undefined,

--- a/packages/next/src/server/web/sandbox/context.ts
+++ b/packages/next/src/server/web/sandbox/context.ts
@@ -429,19 +429,17 @@ Learn More: https://nextjs.org/docs/messages/edge-dynamic-code-evaluation`),
 
       context.AsyncLocalStorage = AsyncLocalStorage
 
-      // @ts-ignore the timeouts have weird types in the edge runtime
+      // @ts-expect-error the timeouts have weird types in the edge runtime
       context.setInterval = (...args: Parameters<typeof setInterval>) =>
         intervalsManager.add(args)
 
-      // @ts-ignore the timeouts have weird types in the edge runtime
       context.clearInterval = (interval: number) =>
         intervalsManager.remove(interval)
 
-      // @ts-ignore the timeouts have weird types in the edge runtime
+      // @ts-expect-error the timeouts have weird types in the edge runtime
       context.setTimeout = (...args: Parameters<typeof setTimeout>) =>
         timeoutsManager.add(args)
 
-      // @ts-ignore the timeouts have weird types in the edge runtime
       context.clearTimeout = (timeout: number) =>
         timeoutsManager.remove(timeout)
 

--- a/packages/next/src/shared/lib/get-img-props.ts
+++ b/packages/next/src/shared/lib/get-img-props.ts
@@ -562,7 +562,7 @@ export function getImgProps(
     ) {
       perfObserver = new PerformanceObserver((entryList) => {
         for (const entry of entryList.getEntries()) {
-          // @ts-ignore - missing "LargestContentfulPaint" class with "element" prop
+          // @ts-expect-error - missing "LargestContentfulPaint" class with "element" prop
           const imgSrc = entry?.element?.src || ''
           const lcpImage = allImgs.get(imgSrc)
           if (

--- a/packages/next/src/shared/lib/image-external.tsx
+++ b/packages/next/src/shared/lib/image-external.tsx
@@ -4,7 +4,7 @@ import type { ImageProps, ImageLoader, StaticImageData } from './get-img-props'
 import { getImgProps } from './get-img-props'
 import { Image } from '../../client/image-component'
 
-// @ts-ignore - This is replaced by webpack alias
+// @ts-expect-error - This is replaced by webpack alias
 import defaultLoader from 'next/dist/shared/lib/image-loader'
 
 /**

--- a/packages/next/src/shared/lib/lazy-dynamic/preload-css.tsx
+++ b/packages/next/src/shared/lib/lazy-dynamic/preload-css.tsx
@@ -35,7 +35,7 @@ export function PreloadCss({ moduleIds }: { moduleIds: string[] | undefined }) {
         return (
           <link
             key={file}
-            // @ts-ignore
+            // @ts-expect-error
             precedence={'dynamic'}
             rel="stylesheet"
             href={`${requestStore.assetPrefix}/_next/${encodeURI(file)}`}

--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -989,7 +989,7 @@ export default class Router implements BaseRouter {
       Object.assign<{}, TransitionOptions, TransitionOptions>({}, options, {
         shallow: options.shallow && this._shallow,
         locale: options.locale || this.defaultLocale,
-        // @ts-ignore internal value not exposed on types
+        // @ts-expect-error internal value not exposed on types
         _h: 0,
       }),
       forcedScroll

--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -377,7 +377,7 @@ export async function loadGetInitialProps<
 
   if (!App.getInitialProps) {
     if (ctx.ctx && ctx.Component) {
-      // @ts-ignore pageProps default
+      // @ts-expect-error pageProps default
       return {
         pageProps: await loadGetInitialProps(ctx.Component, ctx.ctx),
       }

--- a/packages/next/src/telemetry/events/swc-load-failure.ts
+++ b/packages/next/src/telemetry/events/swc-load-failure.ts
@@ -1,6 +1,5 @@
 import { traceGlobals } from '../../trace/shared'
 import type { Telemetry } from '../storage'
-// @ts-ignore JSON
 import { version as nextVersion, optionalDependencies } from 'next/package.json'
 
 const EVENT_PLUGIN_PRESENT = 'NEXT_SWC_LOAD_FAILURE'
@@ -29,7 +28,7 @@ export async function eventSwcLoadFailure(
   let installedSwcPackages
 
   try {
-    // @ts-ignore
+    // @ts-expect-error
     glibcVersion = process.report?.getReport().header.glibcVersionRuntime
   } catch {}
 


### PR DESCRIPTION
...and remove the unused directives. Most of them were resolved at some point when upgrading type declarations.

Noticed this after I spotted a ts-ignore that was unused after upgrading to TypeScript 5.3.

I'll explore later if we can/should apply this to the whole codebase.



Closes NEXT-3192