### PR TITLE
Fix mixed exports in server component with barrel optimization

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-barrel-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-barrel-loader.ts
@@ -225,8 +225,6 @@ async function getBarrelMapping(
           if (targetMatches) {
             // Merge the export list
             exportList = exportList.concat(targetMatches.exportList)
-            // Inherit the client boundary from the target matched file
-            isClientEntry = isClientEntry || targetMatches.isClientEntry
           }
         })
       )

--- a/test/production/app-dir/barrel-optimization/basic/app/mixed-barrel-imports/page.js
+++ b/test/production/app-dir/barrel-optimization/basic/app/mixed-barrel-imports/page.js
@@ -1,0 +1,9 @@
+import { buttonStyle, Button } from 'mixed-lib'
+
+export default function Page() {
+  return (
+    <div>
+      <Button id="component" style={buttonStyle()} />
+    </div>
+  )
+}

--- a/test/production/app-dir/barrel-optimization/basic/index.test.ts
+++ b/test/production/app-dir/barrel-optimization/basic/index.test.ts
@@ -8,9 +8,13 @@ describe('Skipped in Turbopack', () => {
     },
     ({ next }) => {
       it('should build successfully', async () => {
-        // Ensure that MUI is working
         const $ = await next.render$('/')
         expect(await $('#client-mod').text()).toContain('client:default')
+      })
+
+      it('should handle mixed imports from barrel optimized lib correctly', async () => {
+        const $ = await next.render$('/mixed-barrel-imports')
+        expect(await $('#component').attr('style')).toContain('color:blue')
       })
     }
   )

--- a/test/production/app-dir/barrel-optimization/basic/next.config.js
+++ b/test/production/app-dir/barrel-optimization/basic/next.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   experimental: {
-    optimizePackageImports: ['my-lib'],
+    optimizePackageImports: ['my-lib', 'mixed-lib'],
   },
 }

--- a/test/production/app-dir/barrel-optimization/basic/node_modules/mixed-lib/button.js
+++ b/test/production/app-dir/barrel-optimization/basic/node_modules/mixed-lib/button.js
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export function Button(props) {
+  return React.createElement('button', props, 'button')
+}
+
+export function buttonStyle() {
+  return {
+    color: 'blue',
+  }
+}

--- a/test/production/app-dir/barrel-optimization/basic/node_modules/mixed-lib/index.js
+++ b/test/production/app-dir/barrel-optimization/basic/node_modules/mixed-lib/index.js
@@ -1,0 +1,1 @@
+export * from './button'

--- a/test/production/app-dir/barrel-optimization/basic/node_modules/mixed-lib/package.json
+++ b/test/production/app-dir/barrel-optimization/basic/node_modules/mixed-lib/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "mixed-lib",
+  "type": "module",
+  "exports": "./index.js"
+}

--- a/test/production/app-dir/barrel-optimization/basic/node_modules/my-lib/client/index.js
+++ b/test/production/app-dir/barrel-optimization/basic/node_modules/my-lib/client/index.js
@@ -1,4 +1,2 @@
-'use client'
-
 export { default } from './client-module'
 export * from './client-module'


### PR DESCRIPTION
### What

* Remove the change added in #64467, but still kept tests.
* Add more tests for mixed imports (component and function) from shared component with `optimizePackageImports`

### Why

The fix in #64467 was not correct, as mixing `export *` with `"use client"` should error if Next.js detect it properly.
When there's mixed exports, that a shared function will become a client reference if the target file inherits the client boundary.

The original issue #64467 fixed was actually related to tree-shaking, which is fixed in #64681. 

Closes NEXT-3197