### PR TITLE
Speed up createNext test suite isolation

### DIFF
--- a/.github/actions/next-stats-action/src/prepare/repo-setup.js
+++ b/.github/actions/next-stats-action/src/prepare/repo-setup.js
@@ -4,7 +4,12 @@ const { existsSync } = require('fs')
 const exec = require('../util/exec')
 const logger = require('../util/logger')
 const execa = require('execa')
-const { Span } = require('next/dist/trace')
+
+const mockSpan = () => ({
+  traceAsyncFn: (fn) => fn(mockTrace()),
+  traceFn: (fn) => fn(mockTrace()),
+  traceChild: () => mockTrace(),
+})
 
 module.exports = (actionInfo) => {
   return {
@@ -63,7 +68,7 @@ module.exports = (actionInfo) => {
     async linkPackages({ repoDir, nextSwcVersion, parentSpan }) {
       if (!parentSpan) {
         // Not all callers provide a parent span
-        parentSpan = new Span({ name: 'dummy' })
+        parentSpan = mockSpan()
       }
       /** @type {Map<string, string>} */
       const pkgPaths = new Map()

--- a/.github/actions/next-stats-action/src/prepare/repo-setup.js
+++ b/.github/actions/next-stats-action/src/prepare/repo-setup.js
@@ -174,10 +174,6 @@ module.exports = (actionInfo) => {
                   '@next/swc-linux-x64-gnu': nextSwcVersion,
                 })
               } else {
-                if (nextSwcPkg) {
-                  // packageJson.dependencies['@next/swc'] =
-                  //   nextSwcPkg.packedPackageTarPath
-                }
               }
             }
 

--- a/.github/actions/next-stats-action/src/prepare/repo-setup.js
+++ b/.github/actions/next-stats-action/src/prepare/repo-setup.js
@@ -4,6 +4,7 @@ const { existsSync } = require('fs')
 const exec = require('../util/exec')
 const logger = require('../util/logger')
 const execa = require('execa')
+const { Span } = require('next/dist/trace')
 
 module.exports = (actionInfo) => {
   return {
@@ -59,7 +60,11 @@ module.exports = (actionInfo) => {
      * @param {{ repoDir: string, nextSwcVersion: null | string }} options Required options
      * @returns {Promise<Map<string, string>>} List packages key is the package name, value is the path to the packed tar file.'
      */
-    async linkPackages({ repoDir, nextSwcVersion }) {
+    async linkPackages({ repoDir, nextSwcVersion, parentSpan }) {
+      if (!parentSpan) {
+        // Not all callers provide a parent span
+        parentSpan = new Span({ name: 'dummy' })
+      }
       /** @type {Map<string, string>} */
       const pkgPaths = new Map()
       /** @type {Map<string, { packageJsonPath: string, packagePath: string, packageJson: any, packedPackageTarPath: string }>} */
@@ -68,9 +73,11 @@ module.exports = (actionInfo) => {
       let packageFolders
 
       try {
-        packageFolders = await fs.promises.readdir(
-          path.join(repoDir, 'packages')
-        )
+        packageFolders = await parentSpan
+          .traceChild('read-packages-folder')
+          .traceAsyncFn(() =>
+            fs.promises.readdir(path.join(repoDir, 'packages'))
+          )
       } catch (err) {
         if (err.code === 'ENOENT') {
           require('console').log('no packages to link')
@@ -79,162 +86,190 @@ module.exports = (actionInfo) => {
         throw err
       }
 
-      for (const packageFolder of packageFolders) {
-        const packagePath = path.join(repoDir, 'packages', packageFolder)
-        const packedPackageTarPath = path.join(
-          packagePath,
-          `${packageFolder}-packed.tgz`
-        )
-        const packageJsonPath = path.join(packagePath, 'package.json')
-
-        if (!existsSync(packageJsonPath)) {
-          require('console').log(`Skipping ${packageFolder}, no package.json`)
-          continue
-        }
-
-        const packageJson = JSON.parse(fs.readFileSync(packageJsonPath))
-        const { name: packageName } = packageJson
-
-        pkgDatas.set(packageName, {
-          packageJsonPath,
-          packagePath,
-          packageJson,
-          packedPackageTarPath,
-        })
-        pkgPaths.set(packageName, packedPackageTarPath)
-      }
-
-      for (const [
-        packageName,
-        { packageJsonPath, packagePath, packageJson },
-      ] of pkgDatas.entries()) {
-        // This loops through all items to get the packagedPkgPath of each item and add it to pkgData.dependencies
-        for (const [
-          packageName,
-          { packedPackageTarPath },
-        ] of pkgDatas.entries()) {
-          if (
-            !packageJson.dependencies ||
-            !packageJson.dependencies[packageName]
+      parentSpan.traceChild('get-pkgdatas').traceFn(() => {
+        for (const packageFolder of packageFolders) {
+          const packagePath = path.join(repoDir, 'packages', packageFolder)
+          const packedPackageTarPath = path.join(
+            packagePath,
+            `${packageFolder}-packed.tgz`
           )
+          const packageJsonPath = path.join(packagePath, 'package.json')
+
+          if (!existsSync(packageJsonPath)) {
+            require('console').log(`Skipping ${packageFolder}, no package.json`)
             continue
-          // Edit the pkgData of the current item to point to the packed tgz
-          packageJson.dependencies[packageName] = packedPackageTarPath
-        }
-
-        // make sure native binaries are included in local linking
-        if (packageName === '@next/swc') {
-          packageJson.files ||= []
-
-          packageJson.files.push('native')
-
-          try {
-            const swcBinariesDirContents = (
-              await fs.promises.readdir(path.join(packagePath, 'native'))
-            ).filter((file) => file !== '.gitignore' && file !== 'index.d.ts')
-
-            require('console').log(
-              'using swc binaries: ',
-              swcBinariesDirContents.join(', ')
-            )
-          } catch (err) {
-            if (err.code === 'ENOENT') {
-              require('console').log('swc binaries dir is missing!')
-            }
-            throw err
           }
-        } else if (packageName === 'next') {
-          const nextSwcPkg = pkgDatas.get('@next/swc')
 
-          console.log('using swc dep', {
-            nextSwcVersion,
-            nextSwcPkg,
+          const packageJson = JSON.parse(fs.readFileSync(packageJsonPath))
+          const { name: packageName } = packageJson
+
+          pkgDatas.set(packageName, {
+            packageJsonPath,
+            packagePath,
+            packageJson,
+            packedPackageTarPath,
           })
-          if (nextSwcVersion) {
-            Object.assign(packageJson.dependencies, {
-              '@next/swc-linux-x64-gnu': nextSwcVersion,
-            })
-          } else {
-            if (nextSwcPkg) {
-              packageJson.dependencies['@next/swc'] =
-                nextSwcPkg.packedPackageTarPath
-            }
-          }
+          pkgPaths.set(packageName, packedPackageTarPath)
         }
+      })
 
-        await fs.promises.writeFile(
-          packageJsonPath,
-          JSON.stringify(packageJson, null, 2),
-          'utf8'
-        )
-      }
-
-      // wait to pack packages until after dependency paths have been updated
-      // to the correct versions
-      await Promise.all(
-        Array.from(pkgDatas.entries()).map(
-          async ([
+      await parentSpan
+        .traceChild('write-packagejson')
+        .traceAsyncFn(async () => {
+          for (const [
             packageName,
-            { packagePath: pkgPath, packedPackageTarPath: packedPkgPath },
-          ]) => {
-            /** @type {null | () => Promise<void>} */
-            let cleanup = null
+            { packageJsonPath, packagePath, packageJson },
+          ] of pkgDatas.entries()) {
+            // This loops through all items to get the packagedPkgPath of each item and add it to pkgData.dependencies
+            for (const [
+              packageName,
+              { packedPackageTarPath },
+            ] of pkgDatas.entries()) {
+              if (
+                !packageJson.dependencies ||
+                !packageJson.dependencies[packageName]
+              )
+                continue
+              // Edit the pkgData of the current item to point to the packed tgz
+              packageJson.dependencies[packageName] = packedPackageTarPath
+            }
 
+            // make sure native binaries are included in local linking
             if (packageName === '@next/swc') {
-              // next-swc uses a gitignore to prevent the committing of native builds but it doesn't
-              // use files in package.json because it publishes to individual packages based on architecture.
-              // When we used yarn to pack these packages the gitignore was ignored so the native builds were packed
-              // however npm does respect gitignore when packing so we need to remove it in this specific case
-              // to ensure the native builds are packed for use in gh actions and related scripts
+              packageJson.files ||= []
 
-              const nativeGitignorePath = path.join(
-                pkgPath,
-                'native/.gitignore'
-              )
-              const renamedGitignorePath = path.join(
-                pkgPath,
-                'disabled-native-gitignore'
-              )
+              packageJson.files.push('native')
 
-              await fs.promises.rename(
-                nativeGitignorePath,
-                renamedGitignorePath
-              )
-              cleanup = async () => {
-                await fs.promises.rename(
-                  renamedGitignorePath,
-                  nativeGitignorePath
+              try {
+                const swcBinariesDirContents = (
+                  await fs.promises.readdir(path.join(packagePath, 'native'))
+                ).filter(
+                  (file) => file !== '.gitignore' && file !== 'index.d.ts'
                 )
+
+                require('console').log(
+                  'using swc binaries: ',
+                  swcBinariesDirContents.join(', ')
+                )
+              } catch (err) {
+                if (err.code === 'ENOENT') {
+                  require('console').log('swc binaries dir is missing!')
+                }
+                throw err
+              }
+            } else if (packageName === 'next') {
+              const nextSwcPkg = pkgDatas.get('@next/swc')
+
+              console.log('using swc dep', {
+                nextSwcVersion,
+                nextSwcPkg,
+              })
+              if (nextSwcVersion) {
+                Object.assign(packageJson.dependencies, {
+                  '@next/swc-linux-x64-gnu': nextSwcVersion,
+                })
+              } else {
+                if (nextSwcPkg) {
+                  // packageJson.dependencies['@next/swc'] =
+                  //   nextSwcPkg.packedPackageTarPath
+                }
               }
             }
 
-            const options = {
-              cwd: pkgPath,
-              env: {
-                ...process.env,
-                COREPACK_ENABLE_STRICT: '0',
-              },
-            }
-            let execResult
-            try {
-              execResult = await execa('pnpm', ['pack'], options)
-            } catch {
-              execResult = await execa('pnpm', ['pack'], options)
-            }
-            const { stdout } = execResult
-
-            const packedFileName = stdout.trim()
-
-            await Promise.all([
-              fs.promises.rename(
-                path.join(pkgPath, packedFileName),
-                packedPkgPath
-              ),
-              cleanup?.(),
-            ])
+            await fs.promises.writeFile(
+              packageJsonPath,
+              JSON.stringify(packageJson, null, 2),
+              'utf8'
+            )
           }
-        )
-      )
+        })
+
+      await parentSpan
+        .traceChild('pnpm-packing')
+        .traceAsyncFn(async (packingSpan) => {
+          // wait to pack packages until after dependency paths have been updated
+          // to the correct versions
+          await Promise.all(
+            Array.from(pkgDatas.entries()).map(
+              async ([
+                packageName,
+                { packagePath: pkgPath, packedPackageTarPath: packedPkgPath },
+              ]) => {
+                return packingSpan
+                  .traceChild('handle-package', { packageName })
+                  .traceAsyncFn(async (handlePackageSpan) => {
+                    /** @type {null | () => Promise<void>} */
+                    let cleanup = null
+
+                    if (packageName === '@next/swc') {
+                      // next-swc uses a gitignore to prevent the committing of native builds but it doesn't
+                      // use files in package.json because it publishes to individual packages based on architecture.
+                      // When we used yarn to pack these packages the gitignore was ignored so the native builds were packed
+                      // however npm does respect gitignore when packing so we need to remove it in this specific case
+                      // to ensure the native builds are packed for use in gh actions and related scripts
+
+                      const nativeGitignorePath = path.join(
+                        pkgPath,
+                        'native/.gitignore'
+                      )
+                      const renamedGitignorePath = path.join(
+                        pkgPath,
+                        'disabled-native-gitignore'
+                      )
+
+                      await handlePackageSpan
+                        .traceChild('rename-gitignore')
+                        .traceAsyncFn(() =>
+                          fs.promises.rename(
+                            nativeGitignorePath,
+                            renamedGitignorePath
+                          )
+                        )
+                      cleanup = async () => {
+                        await fs.promises.rename(
+                          renamedGitignorePath,
+                          nativeGitignorePath
+                        )
+                      }
+                    }
+
+                    const options = {
+                      cwd: pkgPath,
+                      env: {
+                        ...process.env,
+                        COREPACK_ENABLE_STRICT: '0',
+                      },
+                    }
+                    let execResult
+                    try {
+                      execResult = await handlePackageSpan
+                        .traceChild('pnpm-pack-try-1')
+                        .traceAsyncFn(() => execa('pnpm', ['pack'], options))
+                    } catch {
+                      execResult = await handlePackageSpan
+                        .traceChild('pnpm-pack-try-2')
+                        .traceAsyncFn(() => execa('pnpm', ['pack'], options))
+                    }
+                    const { stdout } = execResult
+
+                    const packedFileName = stdout.trim()
+
+                    await handlePackageSpan
+                      .traceChild('rename-packed-tar-and-cleanup')
+                      .traceAsyncFn(() =>
+                        Promise.all([
+                          fs.promises.rename(
+                            path.join(pkgPath, packedFileName),
+                            packedPkgPath
+                          ),
+                          cleanup?.(),
+                        ])
+                      )
+                  })
+              }
+            )
+          )
+        })
 
       return pkgPaths
     },

--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -25,6 +25,6 @@
     "fontkit": "2.0.2"
   },
   "peerDependencies": {
-    "next": "*"
+    "next": "14.3.0-canary.15"
   }
 }

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1332,12 +1332,24 @@ function loadNative(importPath?: string) {
   let bindings: any
   let attempts: any[] = []
 
+  const NEXT_TEST_NATIVE_DIR = process.env.NEXT_TEST_NATIVE_DIR
   for (const triple of triples) {
-    try {
-      bindings = require(`@next/swc/native/next-swc.${triple.platformArchABI}.node`)
-      infoLog('next-swc build: local built @next/swc')
-      break
-    } catch (e) {}
+    if (NEXT_TEST_NATIVE_DIR) {
+      try {
+        // Use the binary directly to skip `pnpm pack` for testing as it's slow because of the large native binary.
+        bindings = require(`${NEXT_TEST_NATIVE_DIR}/next-swc.${triple.platformArchABI}.node`)
+        console.log(
+          'next-swc build: local built @next/swc from NEXT_TEST_NATIVE_DIR'
+        )
+        break
+      } catch (e) {}
+    } else {
+      try {
+        bindings = require(`@next/swc/native/next-swc.${triple.platformArchABI}.node`)
+        console.log('next-swc build: local built @next/swc')
+        break
+      } catch (e) {}
+    }
   }
 
   if (!bindings) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -793,8 +793,8 @@ importers:
   packages/font:
     dependencies:
       next:
-        specifier: '*'
-        version: 14.2.1(@babel/core@7.22.5)(@opentelemetry/api@1.4.1)(@playwright/test@1.19.2)(react-dom@18.2.0)(react@18.2.0)(sass@1.54.0)
+        specifier: 14.3.0-canary.15
+        version: link:../next
     devDependencies:
       '@types/fontkit':
         specifier: 2.0.0
@@ -1681,6 +1681,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/highlight': 7.22.20
+    dev: true
 
   /@babel/code-frame@7.22.13:
     resolution: {integrity: sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==}
@@ -2135,6 +2136,7 @@ packages:
       '@babel/core': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.22.5):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
@@ -2159,6 +2161,7 @@ packages:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.22.5)
+    dev: true
 
   /@babel/plugin-proposal-export-namespace-from@7.16.7(@babel/core@7.22.5):
     resolution: {integrity: sha512-ZxdtqDXLRGBL64ocZcs7ovt71L3jhC1RGSyR996svrCi3PYqHNkb3SwPJCs8RIzD86s+WPpt2S73+EHCGO+NUA==}
@@ -2170,6 +2173,7 @@ packages:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.22.5)
+    dev: true
 
   /@babel/plugin-proposal-export-namespace-from@7.18.9(@babel/core@7.22.5):
     resolution: {integrity: sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==}
@@ -2193,6 +2197,7 @@ packages:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.22.5)
+    dev: true
 
   /@babel/plugin-proposal-nullish-coalescing-operator@7.16.7(@babel/core@7.22.5):
     resolution: {integrity: sha512-aUOrYU3EVtjf62jQrCj63pYZ7k6vns2h/DQvHPWGmsJRYzWXZ6/AsfgpiRy6XiuIDADhJzP2Q9MwSMKauBQ+UQ==}
@@ -2215,6 +2220,7 @@ packages:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.22.5)
+    dev: true
 
   /@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.22.5):
     resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
@@ -2265,6 +2271,7 @@ packages:
       '@babel/core': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-proposal-private-property-in-object@7.16.7(@babel/core@7.22.5):
     resolution: {integrity: sha512-rMQkjcOFbm+ufe3bTZLyOfsOUOxyvLXZJCTARhJr+8UMSoZmqTe1K1BgkFcrW37rAchWg57yI69ORxiWvUINuQ==}
@@ -2278,6 +2285,7 @@ packages:
       '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.22.5)
+    dev: true
 
   /@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.22.5):
     resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
@@ -2751,6 +2759,7 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-simple-access': 7.22.5
       babel-plugin-dynamic-import-node: 2.3.3
+    dev: true
 
   /@babel/plugin-transform-modules-commonjs@7.22.5(@babel/core@7.22.5):
     resolution: {integrity: sha512-B4pzOXj+ONRmuaQTg05b3y/4DuFz3WcCNAXPLb2Q0GT0TrGKGxNKV4jwsXts+StaM0LQczZbOpj8o1DLPDJIiA==}
@@ -2974,6 +2983,7 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.22.5)
       '@babel/types': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-react-jsx@7.22.15(@babel/core@7.22.5):
     resolution: {integrity: sha512-oKckg2eZFa8771O/5vi7XeTvmM6+O9cxZu+kanTU7tD4sin5nO/G8jGJhq8Hvt2Z0kUoEDRayuZLaUlYl8QuGA==}
@@ -3294,6 +3304,7 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.22.15
       '@babel/plugin-transform-typescript': 7.22.15(@babel/core@7.22.5)
+    dev: true
 
   /@babel/preset-typescript@7.22.5(@babel/core@7.22.5):
     resolution: {integrity: sha512-YbPaal9LxztSGhmndR46FmAbkJ/1fAsw293tSU+I5E5h+cnJ3d4GTwyUgGYmOXJYdGA+uNePle4qbaRzj2NISQ==}
@@ -4481,6 +4492,7 @@ packages:
       '@types/node': 20.12.3
       '@types/yargs': 16.0.9
       chalk: 4.1.2
+    dev: true
 
   /@jest/types@29.5.0:
     resolution: {integrity: sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==}
@@ -5357,91 +5369,6 @@ packages:
     resolution: {integrity: sha512-HAPjR3bnCsdXBsATpDIP5WCrw0JcACwhhrwIAQhiR46n+jm+a2F8kBsfseAuWtSyQ+H3Yebt2k43B5dy+04yMA==}
     dev: true
 
-  /@next/env@14.2.1:
-    resolution: {integrity: sha512-qsHJle3GU3CmVx7pUoXcghX4sRN+vINkbLdH611T8ZlsP//grzqVW87BSUgOZeSAD4q7ZdZicdwNe/20U2janA==}
-    dev: false
-
-  /@next/swc-darwin-arm64@14.2.1:
-    resolution: {integrity: sha512-kGjnjcIJehEcd3rT/3NAATJQndAEELk0J9GmGMXHSC75TMnvpOhONcjNHbjtcWE5HUQnIHy5JVkatrnYm1QhVw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-darwin-x64@14.2.1:
-    resolution: {integrity: sha512-dAdWndgdQi7BK2WSXrx4lae7mYcOYjbHJUhvOUnJjMNYrmYhxbbvJ2xElZpxNxdfA6zkqagIB9He2tQk+l16ew==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-linux-arm64-gnu@14.2.1:
-    resolution: {integrity: sha512-2ZctfnyFOGvTkoD6L+DtQtO3BfFz4CapoHnyLTXkOxbZkVRgg3TQBUjTD/xKrO1QWeydeo8AWfZRg8539qNKrg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-linux-arm64-musl@14.2.1:
-    resolution: {integrity: sha512-jazZXctiaanemy4r+TPIpFP36t1mMwWCKMsmrTRVChRqE6putyAxZA4PDujx0SnfvZHosjdkx9xIq9BzBB5tWg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-linux-x64-gnu@14.2.1:
-    resolution: {integrity: sha512-VjCHWCjsAzQAAo8lkBOLEIkBZFdfW+Z18qcQ056kL4KpUYc8o59JhLDCBlhg+hINQRgzQ2UPGma2AURGOH0+Qg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-linux-x64-musl@14.2.1:
-    resolution: {integrity: sha512-7HZKYKvAp4nAHiHIbY04finRqjeYvkITOGOurP1aLMexIFG/1+oCnqhGogBdc4lao/lkMW1c+AkwWSzSlLasqw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-win32-arm64-msvc@14.2.1:
-    resolution: {integrity: sha512-YGHklaJ/Cj/F0Xd8jxgj2p8po4JTCi6H7Z3Yics3xJhm9CPIqtl8erlpK1CLv+HInDqEWfXilqatF8YsLxxA2Q==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-win32-ia32-msvc@14.2.1:
-    resolution: {integrity: sha512-o+ISKOlvU/L43ZhtAAfCjwIfcwuZstiHVXq/BDsZwGqQE0h/81td95MPHliWCnFoikzWcYqh+hz54ZB2FIT8RA==}
-    engines: {node: '>= 10'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-win32-x64-msvc@14.2.1:
-    resolution: {integrity: sha512-GmRoTiLcvCLifujlisknv4zu9/C4i9r0ktsA8E51EMqJL4bD4CpO7lDYr7SrUxCR0tS4RVcrqKmCak24T0ohaw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3:
     resolution: {integrity: sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==}
     requiresBuild: true
@@ -5927,6 +5854,7 @@ packages:
   /@opentelemetry/api@1.4.1:
     resolution: {integrity: sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==}
     engines: {node: '>=8.0.0'}
+    dev: true
 
   /@opentelemetry/api@1.6.0:
     resolution: {integrity: sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g==}
@@ -6019,6 +5947,7 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
+    dev: true
 
   /@playwright/test@1.41.2:
     resolution: {integrity: sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==}
@@ -6592,13 +6521,6 @@ packages:
     dependencies:
       tslib: 2.6.2
 
-  /@swc/helpers@0.5.5:
-    resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
-    dependencies:
-      '@swc/counter': 0.1.3
-      tslib: 2.6.2
-    dev: false
-
   /@swc/types@0.1.5:
     resolution: {integrity: sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==}
 
@@ -6963,11 +6885,13 @@ packages:
 
   /@types/istanbul-lib-coverage@2.0.4:
     resolution: {integrity: sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==}
+    dev: true
 
   /@types/istanbul-lib-report@3.0.0:
     resolution: {integrity: sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==}
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
+    dev: true
 
   /@types/istanbul-reports@3.0.0:
     resolution: {integrity: sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==}
@@ -6979,6 +6903,7 @@ packages:
     resolution: {integrity: sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==}
     dependencies:
       '@types/istanbul-lib-report': 3.0.0
+    dev: true
 
   /@types/jest@29.5.5:
     resolution: {integrity: sha512-ebylz2hnsWR9mYvmBFbXJXr+33UPc4+ZdxyDXh5w0FlPBTfCVN3wPL+kuOiQt3xvrK419v7XWeAs+AeOksafXg==}
@@ -7231,6 +7156,7 @@ packages:
 
   /@types/stack-utils@2.0.1:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
+    dev: true
 
   /@types/string-hash@1.1.1:
     resolution: {integrity: sha512-ijt3zdHi2DmZxQpQTmozXszzDo78V4R3EdvX0jFMfnMH2ZzQSmCbaWOMPGXFUYSzSIdStv78HDjg32m5dxc+tA==}
@@ -7292,11 +7218,13 @@ packages:
 
   /@types/yargs-parser@21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
+    dev: true
 
   /@types/yargs@16.0.9:
     resolution: {integrity: sha512-tHhzvkFXZQeTECenFoRljLBYPZJ7jAVxqqtEI0qTLOmuultnFp4I9yKE17vTuhf7BkhCu7I4XuemPgikDVuYqA==}
     dependencies:
       '@types/yargs-parser': 21.0.0
+    dev: true
 
   /@types/yargs@17.0.10:
     resolution: {integrity: sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==}
@@ -7309,6 +7237,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@types/node': 20.12.3
+    dev: true
     optional: true
 
   /@typescript-eslint/eslint-plugin@6.14.0(@typescript-eslint/parser@6.14.0)(eslint@8.56.0)(typescript@5.3.3):
@@ -7888,6 +7817,7 @@ packages:
       debug: 4.1.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /agentkeepalive@3.4.1:
     resolution: {integrity: sha512-MPIwsZU9PP9kOrZpyu2042kYA8Fdt/AedQYkYXucHgF9QoD9dXVp0ypuGnHXSR0hTstBxdt85Xkh4JolYfK5wg==}
@@ -8064,6 +7994,7 @@ packages:
   /ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+    dev: true
 
   /ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
@@ -8529,6 +8460,7 @@ packages:
     resolution: {integrity: sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==}
     dependencies:
       object.assign: 4.1.4
+    dev: true
 
   /babel-plugin-istanbul@6.1.1:
     resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
@@ -8580,6 +8512,7 @@ packages:
       pkg-up: 3.1.0
       reselect: 4.1.8
       resolve: 1.22.4
+    dev: true
 
   /babel-plugin-polyfill-corejs2@0.4.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-bM3gHc337Dta490gg+/AseNB9L4YLHxq1nGKZZSHbhXv4aTYU2MD2cjza1Ru4S6975YLTaL1K8uJf6ukJhhmtw==}
@@ -8940,6 +8873,7 @@ packages:
 
   /buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+    dev: true
 
   /buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -9622,6 +9556,7 @@ packages:
   /colors@1.4.0:
     resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
     engines: {node: '>=0.1.90'}
+    dev: true
 
   /columnify@1.5.4:
     resolution: {integrity: sha512-rFl+iXVT1nhLQPfGDw+3WcS8rmm7XsLKUmhsGE3ihzzpIikeGrTaZPIRKYWeLsLBypsHzjXIvYEltVUZS84XxQ==}
@@ -9669,6 +9604,7 @@ packages:
   /commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
+    dev: true
 
   /comment-json@3.0.3:
     resolution: {integrity: sha512-P7XwYkC3qjIK45EAa9c5Y3lR7SMXhJqwFdWg3niAIAcbk3zlpKDdajV8Hyz/Y3sGNn3l+YNMl8A2N/OubSArHg==}
@@ -10707,6 +10643,7 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+    dev: true
 
   /debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -10974,6 +10911,7 @@ packages:
   /diff-sequences@27.5.1:
     resolution: {integrity: sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dev: true
 
   /diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -11547,6 +11485,7 @@ packages:
   /escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
     engines: {node: '>=8'}
+    dev: true
 
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -12356,6 +12295,7 @@ packages:
       jest-matcher-utils: 27.5.1
       jest-message-util: 27.5.1
       jest-regex-util: 27.5.1
+    dev: true
 
   /expect@27.5.1:
     resolution: {integrity: sha512-E1q5hSUG2AmYQwQJ041nvgpkODHQvB+RKlB4IYdru6uJsyFTRyZAP463M+1lINorwbqAmUggi6+WwkD8lCS/Dw==}
@@ -12484,6 +12424,7 @@ packages:
       '@types/yauzl': 2.10.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /extsprintf@1.3.0:
     resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
@@ -12576,6 +12517,7 @@ packages:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
     dependencies:
       pend: 1.2.0
+    dev: true
 
   /fflate@0.7.4:
     resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
@@ -12671,6 +12613,7 @@ packages:
     dependencies:
       json5: 0.5.1
       path-exists: 3.0.0
+    dev: true
 
   /find-cache-dir@2.1.0:
     resolution: {integrity: sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==}
@@ -14036,6 +13979,7 @@ packages:
       debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
@@ -14385,6 +14329,7 @@ packages:
 
   /ip@2.0.0:
     resolution: {integrity: sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==}
+    dev: true
 
   /ipaddr.js@1.9.0:
     resolution: {integrity: sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==}
@@ -15297,6 +15242,7 @@ packages:
       diff-sequences: 27.5.1
       jest-get-type: 27.5.1
       pretty-format: 27.5.1
+    dev: true
 
   /jest-diff@29.7.0:
     resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
@@ -15401,6 +15347,7 @@ packages:
   /jest-get-type@27.5.1:
     resolution: {integrity: sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dev: true
 
   /jest-get-type@29.6.3:
     resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
@@ -15491,6 +15438,7 @@ packages:
       jest-diff: 27.5.1
       jest-get-type: 27.5.1
       pretty-format: 27.5.1
+    dev: true
 
   /jest-matcher-utils@27.5.1:
     resolution: {integrity: sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==}
@@ -15500,6 +15448,7 @@ packages:
       jest-diff: 27.5.1
       jest-get-type: 27.5.1
       pretty-format: 27.5.1
+    dev: true
 
   /jest-matcher-utils@29.7.0:
     resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
@@ -15524,6 +15473,7 @@ packages:
       pretty-format: 27.5.1
       slash: 3.0.0
       stack-utils: 2.0.6
+    dev: true
 
   /jest-message-util@29.7.0:
     resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
@@ -15593,6 +15543,7 @@ packages:
   /jest-regex-util@27.5.1:
     resolution: {integrity: sha512-4bfKq2zie+x16okqDXjXn9ql2B0dScQu+vcwe4TvFVhkVyuWLqpZrZtXxLLWoXYgn0E87I6r6GRYHF7wFZBUvg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dev: true
 
   /jest-regex-util@29.4.3:
     resolution: {integrity: sha512-O4FglZaMmWXbGHSQInfXewIsd1LMn9p3ZXB/6r4FOkyhX2/iP/soMG98jGvk/A3HAN78+5VWcBGO0BJAPRh4kg==}
@@ -15934,6 +15885,7 @@ packages:
 
   /jpeg-js@0.4.3:
     resolution: {integrity: sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==}
+    dev: true
 
   /js-base64@2.5.1:
     resolution: {integrity: sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==}
@@ -16102,6 +16054,7 @@ packages:
   /json5@0.5.1:
     resolution: {integrity: sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==}
     hasBin: true
+    dev: true
 
   /json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
@@ -16115,6 +16068,7 @@ packages:
     hasBin: true
     dependencies:
       minimist: 1.2.6
+    dev: true
 
   /json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -17679,6 +17633,7 @@ packages:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
     hasBin: true
+    dev: true
 
   /mimic-fn@1.2.0:
     resolution: {integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==}
@@ -18053,51 +18008,6 @@ packages:
   /next-tick@1.0.0:
     resolution: {integrity: sha1-yobR/ogoFpsBICCOPchCS524NCw=}
     dev: true
-
-  /next@14.2.1(@babel/core@7.22.5)(@opentelemetry/api@1.4.1)(@playwright/test@1.19.2)(react-dom@18.2.0)(react@18.2.0)(sass@1.54.0):
-    resolution: {integrity: sha512-SF3TJnKdH43PMkCcErLPv+x/DY1YCklslk3ZmwaVoyUfDgHKexuKlf9sEfBQ69w+ue8jQ3msLb+hSj1T19hGag==}
-    engines: {node: '>=18.17.0'}
-    hasBin: true
-    peerDependencies:
-      '@opentelemetry/api': ^1.1.0
-      '@playwright/test': ^1.41.2
-      react: ^18.2.0
-      react-dom: ^18.2.0
-      sass: ^1.3.0
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      '@playwright/test':
-        optional: true
-      sass:
-        optional: true
-    dependencies:
-      '@next/env': 14.2.1
-      '@opentelemetry/api': 1.4.1
-      '@playwright/test': 1.19.2
-      '@swc/helpers': 0.5.5
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001579
-      graceful-fs: 4.2.11
-      postcss: 8.4.31
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      sass: 1.54.0
-      styled-jsx: 5.1.1(@babel/core@7.22.5)(react@18.2.0)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 14.2.1
-      '@next/swc-darwin-x64': 14.2.1
-      '@next/swc-linux-arm64-gnu': 14.2.1
-      '@next/swc-linux-arm64-musl': 14.2.1
-      '@next/swc-linux-x64-gnu': 14.2.1
-      '@next/swc-linux-x64-musl': 14.2.1
-      '@next/swc-win32-arm64-msvc': 14.2.1
-      '@next/swc-win32-ia32-msvc': 14.2.1
-      '@next/swc-win32-x64-msvc': 14.2.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-    dev: false
 
   /nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
@@ -19282,6 +19192,7 @@ packages:
 
   /pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+    dev: true
 
   /performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
@@ -19343,6 +19254,7 @@ packages:
   /pirates@4.0.4:
     resolution: {integrity: sha512-ZIrVPH+A52Dw84R0L3/VS9Op04PuQ2SEoJL6bkshmiTic/HldyW9Tf7oH5mhJZBK7NmDx27vSMrYEXPXclpDKw==}
     engines: {node: '>= 6'}
+    dev: true
 
   /pirates@4.0.5:
     resolution: {integrity: sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==}
@@ -19353,6 +19265,7 @@ packages:
     hasBin: true
     dependencies:
       pngjs: 4.0.1
+    dev: true
 
   /pixrem@5.0.0:
     resolution: {integrity: sha512-ugJ4Imy92u55zeznaN/5d7iqOBIZjZ7q10/T+dcd0IuFtbLlsGDvAUabFu1cafER+G9f0T1WtTqvzm4KAdcDgQ==}
@@ -19382,6 +19295,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       find-up: 3.0.0
+    dev: true
 
   /platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
@@ -19421,6 +19335,7 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
+    dev: true
 
   /playwright-core@1.41.2:
     resolution: {integrity: sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==}
@@ -19452,10 +19367,12 @@ packages:
   /pngjs@4.0.1:
     resolution: {integrity: sha512-rf5+2/ioHeQxR6IxuYNYGFytUyG3lma/WW1nsmjeHlWwtb2aByla6dkVc8pmJ9nplzkTA0q2xx7mMWrOTqT4Gg==}
     engines: {node: '>=8.0.0'}
+    dev: true
 
   /pngjs@6.0.0:
     resolution: {integrity: sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==}
     engines: {node: '>=12.13.0'}
+    dev: true
 
   /posix-character-classes@0.1.1:
     resolution: {integrity: sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==}
@@ -20694,6 +20611,7 @@ packages:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
+    dev: true
 
   /pretty-format@29.5.0:
     resolution: {integrity: sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==}
@@ -20743,6 +20661,7 @@ packages:
   /progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
+    dev: true
 
   /promise-inflight@1.0.1:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
@@ -20820,6 +20739,7 @@ packages:
       graceful-fs: 4.2.11
       retry: 0.12.0
       signal-exit: 3.0.7
+    dev: true
 
   /property-information@5.6.0:
     resolution: {integrity: sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==}
@@ -20887,6 +20807,7 @@ packages:
 
   /proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+    dev: true
 
   /prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
@@ -21143,6 +21064,7 @@ packages:
 
   /react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+    dev: true
 
   /react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
@@ -21832,6 +21754,7 @@ packages:
 
   /reselect@4.1.8:
     resolution: {integrity: sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==}
+    dev: true
 
   /resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
@@ -21987,6 +21910,7 @@ packages:
   /retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
+    dev: true
 
   /retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
@@ -22621,6 +22545,7 @@ packages:
   /smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+    dev: true
 
   /snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
@@ -22683,6 +22608,7 @@ packages:
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /socks@2.7.1:
     resolution: {integrity: sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==}
@@ -22690,6 +22616,7 @@ packages:
     dependencies:
       ip: 2.0.0
       smart-buffer: 4.2.0
+    dev: true
 
   /sort-keys@2.0.0:
     resolution: {integrity: sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=}
@@ -22737,6 +22664,7 @@ packages:
     resolution: {integrity: sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==}
     dependencies:
       source-map: 0.5.7
+    dev: true
 
   /source-map-support@0.5.13:
     resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
@@ -22901,12 +22829,14 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       escape-string-regexp: 2.0.0
+    dev: true
 
   /stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
     dependencies:
       escape-string-regexp: 2.0.0
+    dev: true
 
   /stacktrace-parser@0.1.10:
     resolution: {integrity: sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==}
@@ -25402,6 +25332,7 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+    dev: true
 
   /xdg-basedir@3.0.0:
     resolution: {integrity: sha512-1Dly4xqlulvPD3fZUQJLY+FUIeqN3N2MM3uqe4rCJftAvOjFa3jFGfctOgluGx4ahPbUCsZkmJILiP0Vi4T6lQ==}
@@ -25534,11 +25465,13 @@ packages:
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
+    dev: true
 
   /yazl@2.5.1:
     resolution: {integrity: sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==}
     dependencies:
       buffer-crc32: 0.2.13
+    dev: true
 
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}

--- a/run-tests.js
+++ b/run-tests.js
@@ -85,6 +85,7 @@ const testFilters = {
 
 const mockTrace = () => ({
   traceAsyncFn: (fn) => fn(mockTrace()),
+  traceFn: (fn) => fn(mockTrace()),
   traceChild: () => mockTrace(),
 })
 

--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -79,8 +79,9 @@ async function createNextInstall({
                       !item.includes('node_modules') &&
                       !item.includes('pnpm-lock.yaml') &&
                       !item.includes('.DS_Store') &&
+                      !item.includes('next-swc') &&
                       // Exclude Rust compilation files
-                      !/next-swc[\\/]target/.test(item)
+                      !/packages[\\/]next-swc/.test(item)
                     )
                   },
                 }
@@ -88,44 +89,29 @@ async function createNextInstall({
             )
         }
 
-        await rootSpan
-          .traceChild('ensure swc binary')
-          .traceAsyncFn(async () => {
-            // ensure swc binary is present in the native folder if
-            // not already built
-            for (const folder of await fs.readdir(
-              path.join(origRepoDir, 'node_modules/@next')
-            )) {
-              if (folder.startsWith('swc-')) {
-                const swcPkgPath = path.join(
-                  origRepoDir,
-                  'node_modules/@next',
-                  folder
-                )
-                const outputPath = path.join(
-                  tmpRepoDir,
-                  'packages/next-swc/native'
-                )
-                await fs.copy(swcPkgPath, outputPath, {
-                  filter: (item) => {
-                    return (
-                      item === swcPkgPath ||
-                      (item.endsWith('.node') &&
-                        !fs.pathExistsSync(
-                          path.join(outputPath, path.basename(item))
-                        ))
-                    )
-                  },
-                })
-              }
-            }
-          })
+        const nativePath = path.join(origRepoDir, 'packages/next-swc/native')
 
-        pkgPaths = await rootSpan.traceChild('linkPackages').traceAsyncFn(() =>
-          linkPackages({
-            repoDir: tmpRepoDir,
-          })
-        )
+        const hasNativeBinary = fs
+          .readdirSync(nativePath)
+          .some((item) => item.endsWith('.node'))
+
+        if (hasNativeBinary) {
+          process.env.NEXT_TEST_NATIVE_DIR = nativePath
+        } else {
+          const swcDirectory = fs
+            .readdirSync(path.join(origRepoDir, 'node_modules/@next'))
+            .find((directory) => directory.startsWith('swc-'))
+          process.env.NEXT_TEST_NATIVE_DIR = swcDirectory
+        }
+
+        pkgPaths = await rootSpan
+          .traceChild('linkPackages')
+          .traceAsyncFn((span) =>
+            linkPackages({
+              repoDir: tmpRepoDir,
+              parentSpan: span,
+            })
+          )
       }
       const combinedDependencies = {
         next: pkgPaths.get('next'),
@@ -170,7 +156,7 @@ async function createNextInstall({
         })
       } else {
         await rootSpan
-          .traceChild('run generic install command')
+          .traceChild('run generic install command', combinedDependencies)
           .traceAsyncFn(() => installDependencies(installDir, tmpDir))
       }
 

--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -79,7 +79,6 @@ async function createNextInstall({
                       !item.includes('node_modules') &&
                       !item.includes('pnpm-lock.yaml') &&
                       !item.includes('.DS_Store') &&
-                      !item.includes('next-swc') &&
                       // Exclude Rust compilation files
                       !/packages[\\/]next-swc/.test(item)
                     )


### PR DESCRIPTION
## What?

Before: 25.71s

![CleanShot 2024-04-23 at 12 19 42@2x](https://github.com/vercel/next.js/assets/6324199/3a0ebb81-ac55-4b0c-8bfc-9a61ce138e6f)

After: 11.05s (-57%)

![CleanShot 2024-04-23 at 12 16 35@2x](https://github.com/vercel/next.js/assets/6324199/d7b6cd4c-d1e4-4dc2-a423-20b539186d25)

## How?

Currently the system for isolation looks like this:

- Copy `packages` folder to an isolated directory
- Run `pnpm pack` for all folders in `packages`
- Collect the pack files, add them as `dependencies` in package.json of the isolated application
- Run `pnpm install`

Because the `next-swc` (Turbopack + SWC, yes we still need to rename the package) binary file is quite large in development (900MB+) it means we have to copy, then zip (pnpm pack), then unzip (pnpm install) that binary, which takes about 3+ seconds in each step.

The change in this PR is to skip the copy/zip/unzip completely by providing the folder path for the binary directly to Next.js, as it's a binary we don't need the special isolation for this, it's already standalone so running it directly allows us to skip 14,6 seconds of work that is required for each isolated test in development.

This will likely have little effect on CI times as we already do some tricks like only running the packing at the start of the CI process. Only thing that could be better and is probably worth doing is adopting this change for the time it saves for unzipping, that's almost 4 seconds per test still.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-3200