### PR TITLE
fix dynamic route interception not working when deployed with middleware

### DIFF
--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -1,6 +1,7 @@
 import type { ServerRuntime } from '../types'
 
 export const NEXT_QUERY_PARAM_PREFIX = 'nxtP'
+export const NEXT_INTERCEPTION_MARKER_PREFIX = 'nxtI'
 
 export const PRERENDER_REVALIDATE_HEADER = 'x-prerender-revalidate'
 export const PRERENDER_REVALIDATE_ONLY_GENERATED_HEADER =

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -111,11 +111,7 @@ import {
   fromNodeOutgoingHttpHeaders,
   toNodeOutgoingHttpHeaders,
 } from './web/utils'
-import {
-  CACHE_ONE_YEAR,
-  NEXT_CACHE_TAGS_HEADER,
-  NEXT_QUERY_PARAM_PREFIX,
-} from '../lib/constants'
+import { CACHE_ONE_YEAR, NEXT_CACHE_TAGS_HEADER } from '../lib/constants'
 import { normalizeLocalePath } from '../shared/lib/i18n/normalize-locale-path'
 import {
   NextRequestAdapter,

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -70,7 +70,7 @@ import { removeTrailingSlash } from '../shared/lib/router/utils/remove-trailing-
 import { denormalizePagePath } from '../shared/lib/page-path/denormalize-page-path'
 import * as Log from '../build/output/log'
 import escapePathDelimiters from '../shared/lib/router/utils/escape-path-delimiters'
-import { getUtils } from './server-utils'
+import { getUtils, normalizeNextQueryParam } from './server-utils'
 import isError, { getProperError } from '../lib/is-error'
 import {
   addRequestMeta,
@@ -1096,18 +1096,13 @@ export default abstract class Server<
           for (const key of Object.keys(parsedUrl.query)) {
             const value = parsedUrl.query[key]
 
-            if (
-              key !== NEXT_QUERY_PARAM_PREFIX &&
-              key.startsWith(NEXT_QUERY_PARAM_PREFIX)
-            ) {
-              const normalizedKey = key.substring(
-                NEXT_QUERY_PARAM_PREFIX.length
-              )
-              parsedUrl.query[normalizedKey] = value
+            normalizeNextQueryParam(key, (normalizedKey) => {
+              if (!parsedUrl) return // typeguard
 
+              parsedUrl.query[normalizedKey] = value
               routeParamKeys.add(normalizedKey)
               delete parsedUrl.query[key]
-            }
+            })
           }
 
           // interpolate dynamic params and normalize URL if needed

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -12,13 +12,13 @@ import { NextURL } from './next-url'
 import { stripInternalSearchParams } from '../internal-utils'
 import { normalizeRscURL } from '../../shared/lib/router/utils/app-paths'
 import { FLIGHT_PARAMETERS } from '../../client/components/app-router-headers'
-import { NEXT_QUERY_PARAM_PREFIX } from '../../lib/constants'
 import { ensureInstrumentationRegistered } from './globals'
 import { RequestAsyncStorageWrapper } from '../async-storage/request-async-storage-wrapper'
 import { requestAsyncStorage } from '../../client/components/request-async-storage.external'
 import { getTracer } from '../lib/trace/tracer'
 import type { TextMapGetter } from 'next/dist/compiled/@opentelemetry/api'
 import { MiddlewareSpan } from '../lib/trace/constants'
+import { normalizeNextQueryParam } from '../server-utils'
 
 export class NextRequestHint extends NextRequest {
   sourcePage: string
@@ -108,18 +108,14 @@ export async function adapter(
   for (const key of keys) {
     const value = requestUrl.searchParams.getAll(key)
 
-    if (
-      key !== NEXT_QUERY_PARAM_PREFIX &&
-      key.startsWith(NEXT_QUERY_PARAM_PREFIX)
-    ) {
-      const normalizedKey = key.substring(NEXT_QUERY_PARAM_PREFIX.length)
+    normalizeNextQueryParam(key, (normalizedKey) => {
       requestUrl.searchParams.delete(normalizedKey)
 
       for (const val of value) {
         requestUrl.searchParams.append(normalizedKey, val)
       }
       requestUrl.searchParams.delete(key)
-    }
+    })
   }
 
   // Ensure users only see page requests, never data requests.

--- a/packages/next/src/shared/lib/router/utils/route-regex.ts
+++ b/packages/next/src/shared/lib/router/utils/route-regex.ts
@@ -1,9 +1,10 @@
+import {
+  NEXT_INTERCEPTION_MARKER_PREFIX,
+  NEXT_QUERY_PARAM_PREFIX,
+} from '../../../../lib/constants'
 import { INTERCEPTION_ROUTE_MARKERS } from '../../../../server/future/helpers/interception-routes'
 import { escapeStringRegexp } from '../../escape-regexp'
 import { removeTrailingSlash } from './remove-trailing-slash'
-
-const NEXT_QUERY_PARAM_PREFIX = 'nxtP'
-const NEXT_INTERCEPTION_MARKER_PREFIX = 'nxtI'
 
 export interface Group {
   pos: number

--- a/scripts/run-related-test.mjs
+++ b/scripts/run-related-test.mjs
@@ -38,7 +38,7 @@ export async function getRelatedTests(args = []) {
   const manifest = JSON.parse(
     await readFile(relatedTestsManifest, 'utf-8').catch(() => '{}')
   )
-  const tests = ['test/e2e/app-dir/interception-dynamic-segment']
+  const tests = []
   const paths = args.length ? args : await getChangedFilesFromPackages()
   for (const path of paths) {
     const relatedTestsKey = Object.keys(manifest).find((key) =>

--- a/scripts/run-related-test.mjs
+++ b/scripts/run-related-test.mjs
@@ -38,7 +38,7 @@ export async function getRelatedTests(args = []) {
   const manifest = JSON.parse(
     await readFile(relatedTestsManifest, 'utf-8').catch(() => '{}')
   )
-  const tests = []
+  const tests = ['test/e2e/app-dir/interception-dynamic-segment']
   const paths = args.length ? args : await getChangedFilesFromPackages()
   for (const path of paths) {
     const relatedTestsKey = Object.keys(manifest).find((key) =>

--- a/test/e2e/app-dir/interception-dynamic-segment-middleware/app/[locale]/@modal/(.)[username]/p/[id]/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment-middleware/app/[locale]/@modal/(.)[username]/p/[id]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'intercepted'
+}

--- a/test/e2e/app-dir/interception-dynamic-segment-middleware/app/[locale]/@modal/default.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment-middleware/app/[locale]/@modal/default.tsx
@@ -1,0 +1,1 @@
+export default () => null

--- a/test/e2e/app-dir/interception-dynamic-segment-middleware/app/[locale]/[username]/p/[id]/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment-middleware/app/[locale]/[username]/p/[id]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'not intercepted'
+}

--- a/test/e2e/app-dir/interception-dynamic-segment-middleware/app/[locale]/layout.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment-middleware/app/[locale]/layout.tsx
@@ -1,0 +1,14 @@
+export default function Layout({
+  children,
+  modal,
+}: {
+  children: React.ReactNode
+  modal: React.ReactNode
+}) {
+  return (
+    <>
+      <div id="children">{children}</div>
+      <div id="modal">{modal}</div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/interception-dynamic-segment-middleware/app/[locale]/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment-middleware/app/[locale]/page.tsx
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <Link href="/foo/p/1">Foo</Link> <Link href="/foo/p/1">Foo</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/interception-dynamic-segment-middleware/app/default.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment-middleware/app/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/interception-dynamic-segment-middleware/app/layout.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment-middleware/app/layout.tsx
@@ -1,0 +1,9 @@
+export default function Layout(props: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <div>{props.children}</div>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/interception-dynamic-segment-middleware/interception-dynamic-segment-middleware.test.ts
+++ b/test/e2e/app-dir/interception-dynamic-segment-middleware/interception-dynamic-segment-middleware.test.ts
@@ -1,0 +1,23 @@
+import { createNextDescribe } from 'e2e-utils'
+import { check } from 'next-test-utils'
+
+createNextDescribe(
+  'interception-dynamic-segment-middleware',
+  {
+    files: __dirname,
+  },
+  ({ next }) => {
+    it('should work when interception route is paired with a dynamic segment & middleware', async () => {
+      const browser = await next.browser('/')
+
+      await browser.elementByCss('[href="/foo/p/1"]').click()
+      await check(() => browser.elementById('modal').text(), /intercepted/)
+      await browser.refresh()
+      await check(() => browser.elementById('modal').text(), '')
+      await check(
+        () => browser.elementById('children').text(),
+        /not intercepted/
+      )
+    })
+  }
+)

--- a/test/e2e/app-dir/interception-dynamic-segment-middleware/middleware.ts
+++ b/test/e2e/app-dir/interception-dynamic-segment-middleware/middleware.ts
@@ -1,0 +1,16 @@
+import { NextResponse, type NextRequest } from 'next/server'
+
+export default async function middleware(request: NextRequest) {
+  const locale = 'en'
+  const { pathname } = request.nextUrl
+  const pathnameHasLocale =
+    pathname.startsWith(`/${locale}/`) || pathname === `/${locale}`
+  if (pathnameHasLocale) return
+
+  request.nextUrl.pathname = `/en${pathname}`
+  return NextResponse.rewrite(request.nextUrl)
+}
+
+export const config = {
+  matcher: ['/((?!api|_next|_vercel|.*\\..*).*)'],
+}

--- a/test/e2e/app-dir/interception-dynamic-segment-middleware/next.config.js
+++ b/test/e2e/app-dir/interception-dynamic-segment-middleware/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
We currently have logic spread in multiple places that normalize `nxtP` parameters into their regular names, ie `nxtPfoo` -> `foo`. However we don't apply this same logic to `nxtI`, which conceptually is another parameter but for route interception. As a result, the interception route would 404 when deployed because it'd be missing the interception parameter.

This moves the normalization check into a util and updates the spots I could find where we handle `nxtP` to also handle `nxtI`.

### Test Plan
Added a new test, and validated via these deploys:

**Working**: [Link](https://vtest314-e2e-tests-m889gxi4p-vtest314-ijjk-testing.vercel.app/)
**Non-Working**: [Link](https://vtest314-e2e-tests-8sa5t9uau-vtest314-ijjk-testing.vercel.app/)

Fixes #62207
Closes NEXT-3204