### PR TITLE
Allow StackBlitz repro links in bug reports on GitHub

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -31,7 +31,7 @@ jobs:
               "resolved": ".github/comments/resolved.md"
             }
           reproduction-comment: '.github/comments/invalid-link.md'
-          reproduction-hosts: 'github.com,codesandbox.io'
+          reproduction-hosts: 'github.com,codesandbox.io,stackblitz.com'
           reproduction-blocklist: 'github.com/vercel/next.js.*,github.com/\\w*/?$,github.com$'
           reproduction-link-section: '### Link to the code that reproduces this issue(.*)### To Reproduce'
           reproduction-invalid-label: 'invalid link'


### PR DESCRIPTION
### What?

This change will prevent GitHub actions from auto-closing bug reports that supply a StackBlitz repro link.

### Why?

I was sad that my carefully crafted repro was rejected when GitHub actions summarily closed https://github.com/vercel/next.js/issues/64933

### How?

Allowlist it.

Fixes #64934