### PR TITLE
remove special-cased prefetch kind in dev mode

### DIFF
--- a/packages/next/src/client/components/router-reducer/prefetch-cache-utils.ts
+++ b/packages/next/src/client/components/router-reducer/prefetch-cache-utils.ts
@@ -110,12 +110,7 @@ export function getOrCreatePrefetchCacheEntry({
     buildId,
     nextUrl,
     prefetchCache,
-    kind:
-      kind ||
-      // in dev, there's never gonna be a prefetch entry so we want to prefetch here
-      (process.env.NODE_ENV === 'development'
-        ? PrefetchKind.AUTO
-        : PrefetchKind.TEMPORARY),
+    kind: kind || PrefetchKind.TEMPORARY,
   })
 }
 

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -846,8 +846,8 @@ createNextDescribe(
           .click()
 
         await retry(async () => {
-          // dev + PPR doesn't trigger the loading boundary as it's not prefetched
-          if (!(isNextDev && process.env.__NEXT_EXPERIMENTAL_PPR)) {
+          // dev doesn't trigger the loading boundary as it's not prefetched
+          if (!isNextDev) {
             expect(await browser.eval(`window.shownLoading`)).toBe(true)
           }
 


### PR DESCRIPTION
### What
The "auto" prefetching behavior differs between dev/prod, resulting in confusing DX when configuring `experimental.staleTimes = { static: 0, dynamic: 0 }`.

### Why
Prefetching is intentionally disabled in dev, but we still will create an "auto" prefetch on navigation. When configuring `experimental.staleTimes` to have a `0` value in both static/dynamic cases (a pattern that isn't a good idea, but should still have consistent DX), it means that any auto prefetching that happens is effectively discarded immediately, as we also would also not be able to re-use the loading data.

In prod, we would have created a "temporary" prefetch for this case, which is effectively not a prefetch at all and gets the full RSC data. However in dev, we've special-cased these prefetches to be "auto", so the client won't ever receive fresh data after the first time the cache is seeded.


### How
This removes the special-handling for dev to instead be similar to other prefetches that are created ad-hoc, and marks it as a "temporary" prefetch kind. This has the added benefit of not triggering 2 separate RSC calls in dev when only one is really needed. 

### Test Plan
Client cache tests were previously disabled in dev because caching behavior does intentionally differ between dev/prod. But we can at the very least assert that the "auto" prefetching behavior is consistent between the two environments, so that's what has been added to the tests here.

This also adds a test for the `experimental.staleTimes = { static: 0, dynamic: 0 }` case. 

x-ref: https://github.com/vercel/next.js/discussions/54075#discussioncomment-9202650

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-3209