### PR TITLE
Fix mock span

### DIFF
--- a/.github/actions/next-stats-action/src/prepare/repo-setup.js
+++ b/.github/actions/next-stats-action/src/prepare/repo-setup.js
@@ -6,9 +6,9 @@ const logger = require('../util/logger')
 const execa = require('execa')
 
 const mockSpan = () => ({
-  traceAsyncFn: (fn) => fn(mockTrace()),
-  traceFn: (fn) => fn(mockTrace()),
-  traceChild: () => mockTrace(),
+  traceAsyncFn: (fn) => fn(mockSpan()),
+  traceFn: (fn) => fn(mockSpan()),
+  traceChild: () => mockSpan(),
 })
 
 module.exports = (actionInfo) => {


### PR DESCRIPTION
Seems this was incorrectly referencing the wrong instance. 

x-ref: https://github.com/vercel/next.js/pull/64909
x-ref: https://github.com/vercel/next.js/actions/runs/8806556249/job/24171671288?pr=64691#step:7:839

Closes NEXT-3210