### PR TITLE
Ensure edge prerender-manifest is minimal

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -352,7 +352,10 @@ async function writeEdgePartialPrerenderManifest(
   // Use env vars in JS bundle and inject the actual vars to edge manifest.
   const edgePartialPrerenderManifest: DeepReadonly<Partial<PrerenderManifest>> =
     {
-      ...manifest,
+      routes: {},
+      dynamicRoutes: {},
+      notFoundRoutes: [],
+      version: manifest.version,
       preview: {
         previewModeId: 'process.env.__NEXT_PREVIEW_MODE_ID',
         previewModeSigningKey: 'process.env.__NEXT_PREVIEW_MODE_SIGNING_KEY',

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -51,6 +51,12 @@ createNextDescribe(
         )
       })
 
+      it('should not have entire prerender-manifest for edge', async () => {
+        expect(
+          await next.readFile('.next/server/prerender-manifest.js')
+        ).not.toContain('initialRevalidate')
+      })
+
       if (!process.env.NEXT_EXPERIMENTAL_COMPILE) {
         it('should have correct size in build output', async () => {
           expect(next.cliOutput).toMatch(

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -53,7 +53,7 @@ createNextDescribe(
 
       it('should not have entire prerender-manifest for edge', async () => {
         expect(
-          await next.readFile('.next/server/prerender-manifest.js')
+          await next.readFile('.next/prerender-manifest.js')
         ).not.toContain('initialRevalidate')
       })
 

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -1105,6 +1105,7 @@
         "app dir - basic should not apply client router filter on shallow",
         "app dir - basic should not create new root layout when nested (optional)",
         "app dir - basic should not have loader generated function for edge runtime",
+        "app dir - basic should not have entire prerender-manifest for edge",
         "app dir - basic should not include parent when not in parent directory",
         "app dir - basic should not rerender layout when navigating between routes in the same layout",
         "app dir - basic should not serve when layout is provided but no folder index",


### PR DESCRIPTION
This ensures we don't include the entire prerender-manifest in edge runtime as it's un-necesary and can be very large. We only need the preview field in this manifest so this ensures we just include that. 

x-ref: [slack thread](https://vercel.slack.com/archives/C0289CGVAR2/p1713904966662599?thread_ts=1713798297.067699&cid=C0289CGVAR2)

Closes NEXT-3212