### PR TITLE
Implement Node.js Streams support for `chainStreams`

### DIFF
--- a/packages/next/src/server/stream-utils/index.d.ts
+++ b/packages/next/src/server/stream-utils/index.d.ts
@@ -19,7 +19,7 @@ export function streamToString(
   stream: Readable | ReadableStream
 ): Promise<string>
 
-export function chainStreams<T>(
-  ...streams: ReadableStream<T>[]
-): ReadableStream<T>
+export function chainStreams(
+  ...streams: ReadableStream<Uint8Array>[]
+): ReadableStream<Uint8Array>
 export function chainStreams(...streams: Readable[]): Readable

--- a/packages/next/src/server/stream-utils/index.d.ts
+++ b/packages/next/src/server/stream-utils/index.d.ts
@@ -18,3 +18,8 @@ export function renderToString(element: React.ReactElement): Promise<string>
 export function streamToString(
   stream: Readable | ReadableStream
 ): Promise<string>
+
+export function chainStreams<T>(
+  ...streams: ReadableStream<T>[]
+): ReadableStream<T>
+export function chainStreams(...streams: Readable[]): Readable

--- a/packages/next/src/server/stream-utils/stream-utils.node.ts
+++ b/packages/next/src/server/stream-utils/stream-utils.node.ts
@@ -2,7 +2,13 @@
  * By default, this file exports the methods from streams-utils.edge since all of those are based on Node.js web streams.
  * This file will then be an incremental re-implementation of all of those methods into Node.js only versions (based on proper Node.js Streams).
  */
-import { PassThrough, type Readable, Transform, Writable, pipeline } from 'node:stream'
+import {
+  PassThrough,
+  type Readable,
+  Transform,
+  Writable,
+  pipeline,
+} from 'node:stream'
 import type { Options as RenderToPipeableStreamOptions } from 'react-dom/server.node'
 
 export * from './stream-utils.edge'
@@ -86,8 +92,11 @@ export function chainStreams(...streams: Readable[]): Readable {
 
   const transform = new Transform()
 
-  pipeline(streams, transform, () => {
-    /* do nothing */
+  pipeline(streams, transform, (err) => {
+    // to match `stream-utils.edge.ts`, this error is just ignored.
+    // but maybe we at least log it?
+    console.log(`Invariant: error when pipelining streams`)
+    console.error(err)
   })
 
   return transform

--- a/packages/next/src/server/stream-utils/stream-utils.node.ts
+++ b/packages/next/src/server/stream-utils/stream-utils.node.ts
@@ -2,8 +2,7 @@
  * By default, this file exports the methods from streams-utils.edge since all of those are based on Node.js web streams.
  * This file will then be an incremental re-implementation of all of those methods into Node.js only versions (based on proper Node.js Streams).
  */
-
-import { PassThrough, type Readable, Writable } from 'node:stream'
+import { PassThrough, type Readable, Transform, Writable, pipeline } from 'node:stream'
 import type { Options as RenderToPipeableStreamOptions } from 'react-dom/server.node'
 
 export * from './stream-utils.edge'
@@ -75,4 +74,21 @@ export async function streamToString(stream: Readable) {
   string += decoder.decode()
 
   return string
+}
+
+export function chainStreams(...streams: Readable[]): Readable {
+  if (streams.length === 0) {
+    throw new Error('Invariant: chainStreams requires at least one stream')
+  }
+  if (streams.length === 1) {
+    return streams[0]
+  }
+
+  const transform = new Transform()
+
+  pipeline(streams, transform, () => {
+    /* do nothing */
+  })
+
+  return transform
 }


### PR DESCRIPTION
Implements support for Node.js Streams in the `chainStreams` method.



Closes NEXT-3213