### PR TITLE
Fix windows CI due to node release

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -529,7 +529,8 @@ ${ENDGROUP}`)
           ...process.env,
           ...env,
         },
-        shell: true,
+        // See: https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
+        shell: process.platform === 'win32',
       })
       child.stdout.on('data', stdout)
       child.stderr.on('data', handleOutput('stderr'))

--- a/run-tests.js
+++ b/run-tests.js
@@ -529,6 +529,7 @@ ${ENDGROUP}`)
           ...process.env,
           ...env,
         },
+        shell: true,
       })
       child.stdout.on('data', stdout)
       child.stderr.on('data', handleOutput('stderr'))


### PR DESCRIPTION
There was a breaking change made in newer node versions on windows affecting our usage of spawn for running tests so this ensures the `shell: true` arg is set to avoid the `EINV` error doesn't occur. 

x-ref: https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
x-ref: [CI failure](https://dev.azure.com/nextjs/next.js/_build/results?buildId=85755&view=logs&jobId=22321aea-e36d-5ae1-4163-9a2b553ce318&j=8af7cf9c-43a1-584d-6f5c-57bad8880974&t=2b758e06-e4c9-54eb-5d48-87d8a97da130)

Closes NEXT-3214