### PR TITLE
fix(test-utils): more robust server teardown

### DIFF
--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -543,6 +543,23 @@ export async function killApp(
   }
 }
 
+async function startListen(server: http.Server, port?: number) {
+  const listenerPromise = new Promise((resolve) => {
+    server['__socketSet'] = new Set()
+    const listener = server.listen(port, () => {
+      resolve(null)
+    })
+
+    listener.on('connection', function (socket) {
+      server['__socketSet'].add(socket)
+      socket.on('close', () => {
+        server['__socketSet'].delete(socket)
+      })
+    })
+  })
+  await listenerPromise
+}
+
 export async function startApp(app: NextServer) {
   // force require usage instead of dynamic import in jest
   // x-ref: https://github.com/nodejs/node/issues/35889
@@ -556,7 +573,7 @@ export async function startApp(app: NextServer) {
   const server = http.createServer(handler)
   server['__app'] = app
 
-  await promisify(server.listen).apply(server)
+  await startListen(server)
 
   return server
 }
@@ -565,9 +582,22 @@ export async function stopApp(server: http.Server | undefined) {
   if (!server) {
     return
   }
+
   if (server['__app']) {
     await server['__app'].close()
   }
+
+  // Node.js's http::close() prevents new connections from being accepted,
+  // but doesn't close existing connections and if there are any leftover
+  // whole process teardown will wait until it's being closed.
+  // Instead, force close connections since this is teardown fn that we expect
+  // any connections to be closed already.
+  server['__socketSet']?.forEach(function (socket) {
+    if (!socket.closed && !socket.destroyed) {
+      socket.destroy()
+    }
+  })
+
   await promisify(server.close).apply(server)
 }
 
@@ -590,7 +620,7 @@ export async function startStaticServer(
     })
   }
 
-  await promisify(server.listen).call(server, fixedPort)
+  await startListen(server, fixedPort)
   return server
 }
 
@@ -599,7 +629,7 @@ export async function startCleanStaticServer(dir: string) {
   const server = http.createServer(app)
   app.use(express.static(dir, { extensions: ['html'] }))
 
-  await promisify(server.listen).apply(server)
+  await startListen(server)
   return server
 }
 


### PR DESCRIPTION
### What

See the PR's comment for the detail - TL:DR there is cases where test case creates a connection to socket and it becomes a runaway, so teardown logic hangs indefinitely. PR updates teardown to server to force close any existing connections to prevents unexpected timeout.