### PR TITLE
Ensure `next/dist/compiled/react-dom` is never treated as an external

### DIFF
--- a/packages/next/src/build/webpack/alias/react-dom-server-browser-experimental.js
+++ b/packages/next/src/build/webpack/alias/react-dom-server-browser-experimental.js
@@ -1,11 +1,5 @@
-var l, s
-if (process.env.NODE_ENV === 'production') {
-  l = require('next/dist/compiled/react-dom-experimental/cjs/react-dom-server-legacy.browser.production.min.js')
-  s = require('next/dist/compiled/react-dom-experimental/cjs/react-dom-server.browser.production.min.js')
-} else {
-  l = require('next/dist/compiled/react-dom-experimental/cjs/react-dom-server-legacy.browser.development.js')
-  s = require('next/dist/compiled/react-dom-experimental/cjs/react-dom-server.browser.development.js')
-}
+const l = require('next/dist/compiled/react-dom-experimental/server.browser')
+const s = require('next/dist/compiled/react-dom-experimental/server.browser')
 
 exports.version = l.version
 exports.renderToString = l.renderToString

--- a/packages/next/src/build/webpack/alias/react-dom-server-browser.js
+++ b/packages/next/src/build/webpack/alias/react-dom-server-browser.js
@@ -1,11 +1,5 @@
-var l, s
-if (process.env.NODE_ENV === 'production') {
-  l = require('next/dist/compiled/react-dom/cjs/react-dom-server-legacy.browser.production.min.js')
-  s = require('next/dist/compiled/react-dom/cjs/react-dom-server.browser.production.min.js')
-} else {
-  l = require('next/dist/compiled/react-dom/cjs/react-dom-server-legacy.browser.development.js')
-  s = require('next/dist/compiled/react-dom/cjs/react-dom-server.browser.development.js')
-}
+const l = require('next/dist/compiled/react-dom-experimental/server.browser')
+const s = require('next/dist/compiled/react-dom-experimental/server.browser')
 
 exports.version = l.version
 exports.renderToString = l.renderToString

--- a/packages/next/src/build/webpack/alias/react-dom-server-edge-experimental.js
+++ b/packages/next/src/build/webpack/alias/react-dom-server-edge-experimental.js
@@ -5,12 +5,7 @@ function error() {
   throw new Error(ERROR_MESSAGE)
 }
 
-var b
-if (process.env.NODE_ENV === 'production') {
-  b = require('next/dist/compiled/react-dom-experimental/cjs/react-dom-server.edge.production.min.js')
-} else {
-  b = require('next/dist/compiled/react-dom-experimental/cjs/react-dom-server.edge.development.js')
-}
+const b = require('next/dist/compiled/react-dom-experimental/server.edge')
 
 exports.version = b.version
 exports.renderToReadableStream = b.renderToReadableStream

--- a/packages/next/src/build/webpack/alias/react-dom-server-edge.js
+++ b/packages/next/src/build/webpack/alias/react-dom-server-edge.js
@@ -5,12 +5,7 @@ function error() {
   throw new Error(ERROR_MESSAGE)
 }
 
-var b
-if (process.env.NODE_ENV === 'production') {
-  b = require('next/dist/compiled/react-dom/cjs/react-dom-server.edge.production.min.js')
-} else {
-  b = require('next/dist/compiled/react-dom/cjs/react-dom-server.edge.development.js')
-}
+const b = require('next/dist/compiled/react-dom/server.edge')
 
 exports.version = b.version
 exports.renderToReadableStream = b.renderToReadableStream


### PR DESCRIPTION
Previous require source tricked Webpack into treating `react-dom/server.edge` as an external which isn't supported.

Closes NEXT-3217