### PR TITLE
test(fixture): update assertion to correctly check

### DIFF
--- a/test/integration/import-attributes/test/index.test.js
+++ b/test/integration/import-attributes/test/index.test.js
@@ -7,8 +7,10 @@ function basic(context) {
   it('should handle json attributes', async () => {
     const esHtml = await renderViaHTTP(context.appPort, '/es')
     const tsHtml = await renderViaHTTP(context.appPort, '/ts')
-    expect(esHtml).toContain('foo')
-    expect(tsHtml).toContain('foo')
+    // checking json value `foo` is not suffecient, since parse error
+    // will include code stack include those values as source
+    expect(esHtml).toContain(`<div id="__next">foo</div>`)
+    expect(tsHtml).toContain(`<div id="__next">foo</div>`)
   })
 }
 

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -11418,8 +11418,9 @@
       "runtimeError": false
     },
     "test/integration/import-attributes/test/index.test.js": {
-      "passed": ["import-attributes dev should handle json attributes"],
+      "passed": [],
       "failed": [
+        "import-attributes dev should handle json attributes",
         "production mode import-attributes prod should handle json attributes"
       ],
       "pending": [],


### PR DESCRIPTION
### What

Newly added test in https://github.com/vercel/next.js/pull/59480 have incorrect assertion, since when we emit an error around source it also includes given value as well. 