### PR TITLE
test(fixture): prevent unexpected errored exit with leaking error

### DIFF
--- a/test/integration/absolute-assetprefix/test/index.test.js
+++ b/test/integration/absolute-assetprefix/test/index.test.js
@@ -42,10 +42,27 @@ describe('absolute assetPrefix with path prefix', () => {
                 'Access-Control-Allow-Origin'
               ] = `http://localhost:${appPort}`
               clientRes.writeHead(proxyRes.statusCode, proxyRes.headers)
+              // [NOTE] if socket doesn't have a handler to error event and if error
+              // event leaks, node.js ends its process with errored exit code.
+              // However, there can be failing socket event while running test
+              // as long as assertion is correct, do not care indiviual socket errors.
+              proxyRes.on('error', (e) => {
+                require('console').error(e)
+              })
+              clientRes.on('error', (e) => {
+                require('console').error(e)
+              })
+
               proxyRes.pipe(clientRes, { end: true })
             }
           )
 
+          proxyReq.on('error', (e) => {
+            require('console').error(e)
+          })
+          clientReq.on('error', (e) => {
+            require('console').error(e)
+          })
           clientReq.pipe(proxyReq, { end: true })
         })
         await new Promise((resolve) => cdn.listen(cdnPort, resolve))

--- a/test/integration/ssg-data-404/test/index.test.js
+++ b/test/integration/ssg-data-404/test/index.test.js
@@ -65,6 +65,12 @@ describe('SSG data 404', () => {
         proxyPort = await findPort()
 
         proxyServer = http.createServer((req, res) => {
+          req.on('error', (e) => {
+            require('console').error(e)
+          })
+          res.on('error', (e) => {
+            require('console').error(e)
+          })
           if (should404Data && req.url.match(/\/_next\/data/)) {
             res.statusCode = 404
             return res.end('not found')
@@ -99,11 +105,19 @@ describe('SSG data 404', () => {
         proxyPort = await findPort()
 
         proxyServer = http.createServer((req, res) => {
+          req.on('error', (e) => {
+            require('console').error(e)
+          })
+          res.on('error', (e) => {
+            require('console').error(e)
+          })
           if (should404Data && req.url.match(/\/_next\/data/)) {
             res.statusCode = 404
             return res.end('not found')
           }
-          proxy.web(req, res)
+          proxy.web(req, res, undefined, (e) => {
+            require('console').error(e)
+          })
         })
 
         await new Promise((resolve) => {


### PR DESCRIPTION
### What

In case of socket raises errors and there aren't any listener to handle it, node.js exits with non-0 exit code. So even test passes with all assertion if socket raises an error while teardown (i.e socket destroyed due to server process killed by test teardown) test will fail.

PR adjusts fixture setup by wiring empty error handler to write console message to avoid those. If test assertion fails due to legit socket error, we'll see error message. Otherwise we consider socket error is not related with test.

- Closes PACK-3002