### PR TITLE
initialize ALS with cookies in middleware

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2818,6 +2818,10 @@ export default async function build(
                   // normalize header values as initialHeaders
                   // must be Record<string, string>
                   for (const key of headerKeys) {
+                    // set-cookie is already handled - the middleware cookie setting case
+                    // isn't needed for the prerender manifest since it can't read cookies
+                    if (key === 'x-middleware-set-cookie') continue
+
                     let value = exportHeaders[key]
 
                     if (Array.isArray(value)) {

--- a/packages/next/src/server/web/spec-extension/response.ts
+++ b/packages/next/src/server/web/spec-extension/response.ts
@@ -1,6 +1,7 @@
 import type { I18NConfig } from '../../config-shared'
 import { NextURL } from '../next-url'
 import { toNodeOutgoingHttpHeaders, validateURL } from '../utils'
+import { ReflectAdapter } from './adapters/reflect'
 
 import { ResponseCookies } from './cookies'
 
@@ -41,11 +42,37 @@ export class NextResponse<Body = unknown> extends Response {
   constructor(body?: BodyInit | null, init: ResponseInit = {}) {
     super(body, init)
 
+    const headers = this.headers
+    const cookies = new ResponseCookies(headers)
+
+    const cookiesProxy = new Proxy(cookies, {
+      get(target, prop, receiver) {
+        switch (prop) {
+          case 'delete':
+          case 'set': {
+            return (...args: [string, string]) => {
+              const result = Reflect.apply(target[prop], target, args)
+              const newHeaders = new Headers(headers)
+
+              if (result instanceof ResponseCookies) {
+                headers.set('x-middleware-set-cookie', result.toString())
+              }
+
+              handleMiddlewareField(init, newHeaders)
+              return result
+            }
+          }
+          default:
+            return ReflectAdapter.get(target, prop, receiver)
+        }
+      },
+    })
+
     this[INTERNALS] = {
-      cookies: new ResponseCookies(this.headers),
+      cookies: cookiesProxy,
       url: init.url
         ? new NextURL(init.url, {
-            headers: toNodeOutgoingHttpHeaders(this.headers),
+            headers: toNodeOutgoingHttpHeaders(headers),
             nextConfig: init.nextConfig,
           })
         : undefined,

--- a/test/e2e/app-dir/app-middleware/app/rsc-cookies-delete/page.js
+++ b/test/e2e/app-dir/app-middleware/app/rsc-cookies-delete/page.js
@@ -1,0 +1,13 @@
+import { cookies } from 'next/headers'
+
+export default function Page() {
+  const rscCookie1 = cookies().get('rsc-cookie-value-1')?.value
+  const rscCookie2 = cookies().get('rsc-cookie-value-2')?.value
+
+  return (
+    <div>
+      <p id="rsc-cookie-1">Cookie 1: {rscCookie1}</p>
+      <p id="rsc-cookie-2">Cookie 2: {rscCookie2}</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-middleware/app/rsc-cookies/page.js
+++ b/test/e2e/app-dir/app-middleware/app/rsc-cookies/page.js
@@ -1,0 +1,15 @@
+import { cookies } from 'next/headers'
+import Link from 'next/link'
+
+export default function Page() {
+  const rscCookie1 = cookies().get('rsc-cookie-value-1')?.value
+  const rscCookie2 = cookies().get('rsc-cookie-value-2')?.value
+
+  return (
+    <div>
+      <p id="rsc-cookie-1">Cookie 1: {rscCookie1}</p>
+      <p id="rsc-cookie-2">Cookie 2: {rscCookie2}</p>
+      <Link href="/rsc-cookies-delete">To Delete Cookies Route</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-middleware/middleware.js
+++ b/test/e2e/app-dir/app-middleware/middleware.js
@@ -44,6 +44,21 @@ export async function middleware(request) {
     return NextResponse.rewrite(request.nextUrl)
   }
 
+  if (request.nextUrl.pathname === '/rsc-cookies') {
+    const res = NextResponse.next()
+    res.cookies.set('rsc-cookie-value-1', `${Math.random()}`)
+    res.cookies.set('rsc-cookie-value-2', `${Math.random()}`)
+
+    return res
+  }
+
+  if (request.nextUrl.pathname === '/rsc-cookies-delete') {
+    const res = NextResponse.next()
+    res.cookies.delete('rsc-cookie-value-1')
+
+    return res
+  }
+
   return NextResponse.next({
     request: {
       headers: headersFromRequest,


### PR DESCRIPTION
### What
Cookies set/updated/removed in middleware won't be accessible during the render in which they were set

### Why
Middleware will properly set a `set-cookie` header to inform the client of the cookie change, but this means the `AsyncLocalStorage` context containing the cookies value wouldn't be updated until the next time the request headers were parsed. In other words, on the first request the cookie would be sent but wouldn't be available in the `cookies()` context. And then the following request would properly have the cookie values.

### How
This uses a proxy on the `ResponseCookies` used in middleware to add a middleware override header with the cookie value. When we instantiate the cached cookies, we merge in whatever headers would have been set by middleware, so that they're available in the same render that invoked middleware. 

### Test Plan
This changeset adds a test to confirm cookies set/deleted in middleware are available in a single pass. Verified with a deployment [here](https://vtest314-e2e-tests-ldx7olfl1-ztanner.vercel.app/rsc-cookies).

Fixes #49442
Closes NEXT-1126
