### PR TITLE
docs: fix Bun install command

### DIFF
--- a/docs/02-app/02-api-reference/06-create-next-app.mdx
+++ b/docs/02-app/02-api-reference/06-create-next-app.mdx
@@ -26,7 +26,7 @@ pnpm create next-app
 ```
 
 ```bash filename="Terminal"
-bunx create next-app
+bun create next-app
 ```
 
 You will then be asked the following prompts:


### PR DESCRIPTION
### What?

Corrects the Bun install command (again) on [this page](https://nextjs.org/docs/app/api-reference/create-next-app#interactive) of the docs.

### Why?

The Bun instructions were originally created in 7e165384857893a25eb59b800c5af585a7778c71 with a correct command to create a new Next.js project with Bun: `bunx create-next-app`.

Then, it was changed to `bunx create next-app` in 2ab4a443a20d3f8b977c18b94c93f23d4cecb413, which isn't correct because `bunx` acts like `npx` and tries to run a nonexistent package called `create`, specifying `next-app` as its argument.

This change was reverted in a42efae49db1d4302f4b0b5e07f9ee45742b0d95 two weeks ago, and a PR from today (#64972) reverts that correction.

Both `bunx create-next-app` and `bun create next-app` work on my machine as of Bun 1.0. `bunx create-next-app` is analogous to `npx create-next-app`, and `bun create next-app` is the same as `npm create next-app`.

| Command | Correct? | Similar NPM command | Note |
|---|---|---|---|
| `bun create next-app` | :white_check_mark: | `npm create next-app` | My proposed change |
| `bunx create-next-app` | :white_check_mark: | `npx create-next-app` | |
| `bunx create next-app` | :x: | `npx create next-app` (incorrect) | Currently listed in the Next.js docs |
| `bun create-next-app` | :x: | `npm create-next-app` (incorrect) | |

I think this confusion is caused by having two valid ways to run `create-next-app` with two very similar syntaxes. **It could be beneficial to include a note explaining the two correct syntaxes** to avoid future confusion, but for now, I have just changed `bunx` -> `bun` to keep the command similar to `yarn` and `pnpm`.