### PR TITLE
Combine necessary file for edge route in size calculation

### DIFF
--- a/test/.stats-app/stats-config.js
+++ b/test/.stats-app/stats-config.js
@@ -40,12 +40,10 @@ const clientGlobs = [
           path.join(nextAppDir, '.next/server/middleware-manifest.json')
         )
         const manifest = JSON.parse(manifestJson)
-        console.log({ manifest, functions: manifest.functions })
         const manifestFileEntry = path.relative(
           path.join(nextAppDir, '.next'),
           path.join(nextAppDir, fileName)
         )
-        console.log({ manifestFileEntry })
 
         const functionEntry = Object.values(manifest.functions).find(
           (entry) => {

--- a/test/.stats-app/stats-config.js
+++ b/test/.stats-app/stats-config.js
@@ -1,3 +1,6 @@
+const fs = require('fs/promises')
+const path = require('path')
+
 const clientGlobs = [
   {
     name: 'Client Bundles (main, webpack)',
@@ -31,6 +34,39 @@ const clientGlobs = [
       '.next/server/pages/edge-ssr.js',
       '.next/server/app/app-edge-ssr/page.js',
     ],
+    getRequiredFiles: async (nextAppDir, fileName) => {
+      if (fileName.startsWith('.next/server/app')) {
+        const manifestJson = await fs.readFile(
+          path.join(nextAppDir, '.next/server/middleware-manifest.json')
+        )
+        const manifest = JSON.parse(manifestJson)
+        console.log({ manifest, functions: manifest.functions })
+        const manifestFileEntry = path.relative(
+          path.join(nextAppDir, '.next'),
+          path.join(nextAppDir, fileName)
+        )
+        console.log({ manifestFileEntry })
+
+        const functionEntry = Object.values(manifest.functions).find(
+          (entry) => {
+            return entry.files.includes(manifestFileEntry)
+          }
+        )
+
+        if (functionEntry === undefined) {
+          throw new Error(
+            `${manifestFileEntry} is not listed in the files files of any functions in the manifest:\n` +
+              JSON.stringify(manifest, null, 2)
+          )
+        }
+
+        return functionEntry.files.map((file) => {
+          return path.join('.next', file)
+        })
+      } else {
+        return [fileName]
+      }
+    },
   },
   {
     name: 'Middleware size',


### PR DESCRIPTION
Just including `page.js` in the size calculation isn't enough since it may require other chunks.

In a Webpack world we'd use the Webpack stats instead for accurate calculations without having to read from the filesystem. Turbopack doesn't have these available so we just read every file listed in the the `files` entry for that specific route in the middleware manifest.

I know not enough about all these manifest to be able to generalize this so for now this only works for the edge-ssr calculation which regressed in https://github.com/vercel/next.js/pull/64798 but wasn't caught since the significant bundle increase was in a different chunk.

Before:
![Screenshot 2024-04-26 at 17 41 40](https://github.com/vercel/next.js/assets/12292047/d965bdf7-b3df-415c-9ab9-60a600d6f5e2)
-- https://github.com/vercel/next.js/pull/64798#issuecomment-2067124032


After:
![Screenshot 2024-04-26 at 17 41 09](https://github.com/vercel/next.js/assets/12292047/cfb9b2c3-fa2a-44b8-99d0-550becc2bcef)
-- https://github.com/vercel/next.js/pull/65053#issuecomment-2077890361


Closes NEXT-3228