### PR TITLE
chore(fetch-cache): remove zod from fetch cache

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
@@ -1,4 +1,5 @@
 import type { CacheHandler, CacheHandlerContext, CacheHandlerValue } from './'
+import type { IncrementalCacheValue } from '../../response-cache'
 
 import LRUCache from 'next/dist/compiled/lru-cache'
 import {
@@ -233,7 +234,7 @@ export default class FetchCache implements CacheHandler {
           throw new Error(`invalid response from cache ${res.status}`)
         }
 
-        const cached = await res.json()
+        const cached: IncrementalCacheValue = await res.json()
 
         if (!cached || cached.kind !== 'FETCH') {
           this.debug && console.log({ cached })

--- a/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
@@ -245,7 +245,7 @@ export default class FetchCache implements CacheHandler {
           cached.tags ??= []
           for (const tag of tags ?? []) {
             if (!cached.tags.includes(tag)) {
-              cached.tag.push(tag)
+              cached.tags.push(tag)
             }
           }
         }

--- a/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
@@ -238,7 +238,7 @@ export default class FetchCache implements CacheHandler {
 
         if (!cached || cached.kind !== 'FETCH') {
           this.debug && console.log({ cached })
-          throw new Error(`invalid cache value`)
+          throw new Error('invalid cache value')
         }
 
         // if new tags were specified, merge those tags to the existing tags

--- a/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
@@ -1,14 +1,6 @@
 import type { CacheHandler, CacheHandlerContext, CacheHandlerValue } from './'
-import type {
-  CachedFetchValue,
-  IncrementalCacheValue,
-} from '../../response-cache'
 
 import LRUCache from 'next/dist/compiled/lru-cache'
-
-import { z } from 'next/dist/compiled/zod'
-import type zod from 'next/dist/compiled/zod'
-
 import {
   CACHE_ONE_YEAR,
   NEXT_CACHE_SOFT_TAGS_HEADER,
@@ -30,18 +22,6 @@ const CACHE_STATE_HEADER = 'x-vercel-cache-state' as const
 const CACHE_REVALIDATE_HEADER = 'x-vercel-revalidate' as const
 const CACHE_FETCH_URL_HEADER = 'x-vercel-cache-item-name' as const
 const CACHE_CONTROL_VALUE_HEADER = 'x-vercel-cache-control' as const
-
-const zCachedFetchValue: zod.ZodType<CachedFetchValue> = z.object({
-  kind: z.literal('FETCH'),
-  data: z.object({
-    headers: z.record(z.string()),
-    body: z.string(),
-    url: z.string(),
-    status: z.number().optional(),
-  }),
-  tags: z.array(z.string()).optional(),
-  revalidate: z.number(),
-})
 
 export default class FetchCache implements CacheHandler {
   private headers: Record<string, string>
@@ -253,22 +233,19 @@ export default class FetchCache implements CacheHandler {
           throw new Error(`invalid response from cache ${res.status}`)
         }
 
-        const json: IncrementalCacheValue = await res.json()
-        const parsed = zCachedFetchValue.safeParse(json)
+        const cached = await res.json()
 
-        if (!parsed.success) {
-          this.debug && console.log({ json })
-          throw new Error('invalid cache value')
+        if (!cached || cached.kind !== 'FETCH') {
+          this.debug && console.log({ cached })
+          throw new Error(`invalid cache value`)
         }
-
-        const { data: cached } = parsed
 
         // if new tags were specified, merge those tags to the existing tags
         if (cached.kind === 'FETCH') {
           cached.tags ??= []
           for (const tag of tags ?? []) {
             if (!cached.tags.includes(tag)) {
-              cached.tags.push(tag)
+              cached.tag.push(tag)
             }
           }
         }


### PR DESCRIPTION
## Why?

Revert zod validation due to it increasing the next-runtime size.

Closes NEXT-3234