### PR TITLE
Update code example to use 'next/navigation' instead of 'next/router'

### DIFF
--- a/docs/02-app/01-building-your-application/09-authentication/index.mdx
+++ b/docs/02-app/01-building-your-application/09-authentication/index.mdx
@@ -420,7 +420,7 @@ Consider a login form where users can input their credentials:
 
 ```tsx filename="pages/login.tsx" switcher
 import { FormEvent } from 'react'
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 
 export default function LoginPage() {
   const router = useRouter()
@@ -457,7 +457,7 @@ export default function LoginPage() {
 
 ```jsx filename="pages/login.jsx" switcher
 import { FormEvent } from 'react'
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/navigation'
 
 export default function LoginPage() {
   const router = useRouter()


### PR DESCRIPTION
This pull request updates a code example to use the new 'next/navigation' instead of the previously used 'next/router'. This change is in line with the latest Next.js documentation and migration guide.

What?
The 'next/router' hook has been replaced with 'next/navigation' in the code example.

Why?
According to the Next.js documentation, when using the App Router, the 'useRouter' hook should be imported from 'next/navigation' and not 'next/router'. This change aligns our codebase with the latest best practices and ensures compatibility with future updates.

How?
The following changes have been made:
 - Import 'useRouter' from 'next/navigation' instead of 'next/router'.