### PR TITLE
Use vercel deployment url for metadataBase fallbacks

### DIFF
--- a/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
@@ -171,7 +171,7 @@ describe('getSocialImageFallbackMetadataBase', () => {
     it('should return project production url in production deployment', () => {
       // @ts-expect-error override process env
       process.env.NODE_ENV = 'production'
-      process.env.VERCEL_ENV = 'preview'
+      process.env.VERCEL_ENV = 'production'
       process.env.VERCEL_URL = 'vercel-url'
       process.env.VERCEL_PROJECT_PRODUCTION_URL = 'production-url'
       expect(getSocialImageFallbackMetadataBaseHelper()).toBe(

--- a/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
@@ -125,6 +125,8 @@ describe('getSocialImageFallbackMetadataBase', () => {
     afterEach(() => {
       delete process.env.VERCEL_URL
       delete process.env.VERCEL_ENV
+      delete process.env.VERCEL_BRANCH_URL
+      delete process.env.VERCEL_PROJECT_PRODUCTION_URL
 
       process.env = originalEnv
     })
@@ -145,17 +147,28 @@ describe('getSocialImageFallbackMetadataBase', () => {
       )
     })
 
-    it('preview deployment', () => {
+    it('should prefer branch url in preview deployment if presents', () => {
       // @ts-expect-error override process env
       process.env.NODE_ENV = 'production'
       process.env.VERCEL_ENV = 'preview'
       process.env.VERCEL_BRANCH_URL = 'branch-url'
+      process.env.VERCEL_URL = 'vercel-url'
       expect(getSocialImageFallbackMetadataBaseHelper()).toBe(
         'https://branch-url/'
       )
     })
 
-    it('production deployment', () => {
+    it('should return vercel url in preview deployment if only it presents', () => {
+      // @ts-expect-error override process env
+      process.env.NODE_ENV = 'production'
+      process.env.VERCEL_ENV = 'preview'
+      process.env.VERCEL_URL = 'vercel-url'
+      expect(getSocialImageFallbackMetadataBaseHelper()).toBe(
+        'https://vercel-url/'
+      )
+    })
+
+    it('should return project production url in production deployment', () => {
       // @ts-expect-error override process env
       process.env.NODE_ENV = 'production'
       process.env.VERCEL_PROJECT_PRODUCTION_URL = 'production-url'

--- a/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
@@ -112,7 +112,7 @@ describe('resolveAbsoluteUrlWithPathname', () => {
 })
 
 describe('getSocialImageFallbackMetadataBase', () => {
-  describe('fallbackMetadataBase', () => {
+  describe('fallbackMetadataBase when metadataBase is not present', () => {
     let originalEnv: NodeJS.ProcessEnv
     function getSocialImageFallbackMetadataBaseHelper(): string {
       return getSocialImageFallbackMetadataBase(null).fallbackMetadataBase.href
@@ -139,7 +139,7 @@ describe('getSocialImageFallbackMetadataBase', () => {
       )
     })
 
-    it('should return metadataBase ', () => {
+    it('should return local url in local build mode', () => {
       // @ts-expect-error override process env
       process.env.NODE_ENV = 'production'
       expect(getSocialImageFallbackMetadataBaseHelper()).toBe(
@@ -171,6 +171,8 @@ describe('getSocialImageFallbackMetadataBase', () => {
     it('should return project production url in production deployment', () => {
       // @ts-expect-error override process env
       process.env.NODE_ENV = 'production'
+      process.env.VERCEL_ENV = 'preview'
+      process.env.VERCEL_URL = 'vercel-url'
       process.env.VERCEL_PROJECT_PRODUCTION_URL = 'production-url'
       expect(getSocialImageFallbackMetadataBaseHelper()).toBe(
         'https://production-url/'

--- a/packages/next/src/lib/metadata/resolvers/resolve-url.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.ts
@@ -11,14 +11,12 @@ function createLocalMetadataBase() {
 
 function getPreviewDeploymentUrl(): URL | undefined {
   const origin = process.env.VERCEL_BRANCH_URL || process.env.VERCEL_URL
-  if (!origin) return undefined
-  return new URL(`https://${origin}`)
+  return origin ? new URL(`https://${origin}`) : undefined
 }
 
 function getProductionDeploymentUrl(): URL | undefined {
   const origin = process.env.VERCEL_PROJECT_PRODUCTION_URL
-  if (!origin) return undefined
-  return new URL(`https://${origin}`)
+  return origin ? new URL(`https://${origin}`) : undefined
 }
 
 // For deployment url for metadata routes, prefer to use the deployment url if possible

--- a/packages/next/src/lib/metadata/resolvers/resolve-url.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.ts
@@ -9,6 +9,18 @@ function createLocalMetadataBase() {
   return new URL(`http://localhost:${process.env.PORT || 3000}`)
 }
 
+function getPreviewDeploymentUrl(): URL | undefined {
+  const origin = process.env.VERCEL_BRANCH_URL || process.env.VERCEL_URL
+  if (!origin) return undefined
+  return new URL(`https://${origin}`)
+}
+
+function getProductionDeploymentUrl(): URL | undefined {
+  const origin = process.env.VERCEL_PROJECT_PRODUCTION_URL
+  if (!origin) return undefined
+  return new URL(`https://${origin}`)
+}
+
 // For deployment url for metadata routes, prefer to use the deployment url if possible
 // as these routes are unique to the deployments url.
 export function getSocialImageFallbackMetadataBase(metadataBase: URL | null): {
@@ -17,8 +29,8 @@ export function getSocialImageFallbackMetadataBase(metadataBase: URL | null): {
 } {
   const isMetadataBaseMissing = !metadataBase
   const defaultMetadataBase = createLocalMetadataBase()
-  const deploymentUrl =
-    process.env.VERCEL_URL && new URL(`https://${process.env.VERCEL_URL}`)
+  const previewDeploymentUrl = getPreviewDeploymentUrl()
+  const productionDeploymentUrl = getProductionDeploymentUrl()
 
   let fallbackMetadataBase
   if (process.env.NODE_ENV === 'development') {
@@ -26,10 +38,10 @@ export function getSocialImageFallbackMetadataBase(metadataBase: URL | null): {
   } else {
     fallbackMetadataBase =
       process.env.NODE_ENV === 'production' &&
-      deploymentUrl &&
+      previewDeploymentUrl &&
       process.env.VERCEL_ENV === 'preview'
-        ? deploymentUrl
-        : metadataBase || deploymentUrl || defaultMetadataBase
+        ? previewDeploymentUrl
+        : metadataBase || productionDeploymentUrl || defaultMetadataBase
   }
 
   return {


### PR DESCRIPTION
Leveraging the system env vars for fallback logic

x-ref: https://vercel.com/docs/projects/environment-variables/system-environment-variables

For preview deployment: prefer using `VERCEL_BRANCH_URL`, fallback to `VERCEL_URL`
For production deployment: prefer using `VERCEL_PROJECT_PRODUCTION_URL`

Closes NEXT-3237