### PR TITLE
fix(page-static-info): refine warning message to emit once

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
@@ -100,6 +100,8 @@ impl CustomTransformer for NextPageStaticInfo {
                         messages.push(format!("- `export const preferredRegion = {}`", regions));
                     }
 
+                    messages.push("Visit https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config for more information.".to_string());
+
                     PageStaticInfoIssue {
                         file_path: ctx.file_path,
                         messages,

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -62,10 +62,29 @@ export function isWellKnownError(issue: Issue): boolean {
   return false
 }
 
+const onceErrorSet = new Set()
+/**
+ * Check if given issue is a warning to be display only once.
+ * This miimics behavior of get-page-static-info's warnOnce.
+ * @param issue
+ * @returns
+ */
+function shouldEmitOnceWarning(issue: Issue): boolean {
+  const { severity, title } = issue
+  if (severity === 'warning' && title.value === 'Invalid page configuration') {
+    if (onceErrorSet.has(issue)) {
+      return false
+    }
+    onceErrorSet.add(issue)
+  }
+
+  return true
+}
+
 /// Print out an issue to the console which should not block
 /// the build by throwing out or blocking error overlay.
 export function printNonFatalIssue(issue: Issue) {
-  if (isRelevantWarning(issue)) {
+  if (isRelevantWarning(issue) && shouldEmitOnceWarning(issue)) {
     Log.warn(formatIssue(issue))
   }
 }


### PR DESCRIPTION
### What

- closes #65052 

Emitting warning itself is correct, however

- we emit warning multiple times
- missing additional detail to provide link to the docs

PR fixes those 2.