### PR TITLE
Create `@next/package-manager-utils` to unify package manager utilities across the repo.

### DIFF
--- a/packages/next-package-manager-utils/README.md
+++ b/packages/next-package-manager-utils/README.md
@@ -1,0 +1,1 @@
+# @next/package-manager-utils

--- a/packages/next-package-manager-utils/index.ts
+++ b/packages/next-package-manager-utils/index.ts
@@ -59,7 +59,7 @@ const PackageManagers: readonly PackageManager[] = [
   {
     name: 'yarn',
     lockfile: 'yarn.lock',
-    registry: 'registry.yarnokg.com',
+    registry: 'registry.yarnpkg.com',
     install: {
       allDeps: 'install',
       addDep: 'add',

--- a/packages/next-package-manager-utils/package.json
+++ b/packages/next-package-manager-utils/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@next/package-manager-utils",
+  "version": "14.2.1-canary.2",
+  "description": "A set of utils for handling package managers. Used by Next.js CLI and create-next-app",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/next.js",
+    "directory": "packages/next-package-manager-utils"
+  },
+  "author": "Next.js Team <support@vercel.com>",
+  "license": "MIT",
+  "files": [
+    "dist"
+  ],
+  "scripts": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=18.17.0"
+  }
+}

--- a/packages/next-package-manager-utils/package.json
+++ b/packages/next-package-manager-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/package-manager-utils",
-  "version": "14.2.1-canary.2",
+  "version": "14.3.0-canary.26",
   "description": "A set of utils for handling package managers. Used by Next.js CLI and create-next-app",
   "repository": {
     "type": "git",
@@ -13,7 +13,9 @@
     "dist"
   ],
   "scripts": {},
-  "devDependencies": {},
+  "devDependencies": {
+    "@types/node": "20.12.3"
+  },
   "engines": {
     "node": ">=18.17.0"
   }

--- a/packages/next-package-manager-utils/package.json
+++ b/packages/next-package-manager-utils/package.json
@@ -18,5 +18,9 @@
   },
   "engines": {
     "node": ">=18.17.0"
+  },
+  "dependencies": {
+    "execa": "8.0.1",
+    "picocolors": "1.0.0"
   }
 }

--- a/packages/next-package-manager-utils/tsconfig.json
+++ b/packages/next-package-manager-utils/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "moduleResolution": "node",
+    "strict": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": false
+  },
+  "exclude": ["dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1502,6 +1502,12 @@ importers:
         specifier: ^0.7.0
         version: 0.7.3
 
+  packages/next-package-manager-utils:
+    devDependencies:
+      '@types/node':
+        specifier: 20.12.3
+        version: 20.12.3
+
   packages/next-plugin-storybook: {}
 
   packages/next-polyfill-module:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1503,6 +1503,13 @@ importers:
         version: 0.7.3
 
   packages/next-package-manager-utils:
+    dependencies:
+      execa:
+        specifier: 8.0.1
+        version: 8.0.1
+      picocolors:
+        specifier: 1.0.0
+        version: 1.0.0
     devDependencies:
       '@types/node':
         specifier: 20.12.3
@@ -12474,7 +12481,7 @@ packages:
     dev: true
 
   /execa@0.4.0:
-    resolution: {integrity: sha1-TrZGejaglfq7KXD/nV4/t7zm68M=}
+    resolution: {integrity: sha512-QPexBaNjeOjyiZ47q0FCukTO1kX3F+HMM0EWpnxXddcr3MZtElILMkz9Y38nmSZtp03+ZiSRMffrKWBPOIoSIg==}
     engines: {node: '>=0.12'}
     dependencies:
       cross-spawn-async: 2.2.5
@@ -12528,6 +12535,21 @@ packages:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
     dev: true
+
+  /execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+    dev: false
 
   /exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
@@ -13335,6 +13357,11 @@ packages:
     resolution: {integrity: sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==}
     engines: {node: '>=10'}
     dev: true
+
+  /get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
+    dev: false
 
   /get-symbol-description@1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
@@ -14262,6 +14289,11 @@ packages:
     engines: {node: '>=10.17.0'}
     dev: true
 
+  /human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
+    dev: false
+
   /humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
     dependencies:
@@ -15092,6 +15124,11 @@ packages:
   /is-stream@2.0.0:
     resolution: {integrity: sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==}
     engines: {node: '>=8'}
+
+  /is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: false
 
   /is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
@@ -17892,6 +17929,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+    dev: false
+
   /mimic-response@1.0.1:
     resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
     engines: {node: '>=4'}
@@ -18645,6 +18687,13 @@ packages:
     dependencies:
       path-key: 3.1.1
 
+  /npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      path-key: 4.0.0
+    dev: false
+
   /npmlog@4.1.2:
     resolution: {integrity: sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==}
     dependencies:
@@ -18870,6 +18919,13 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       mimic-fn: 2.1.0
+
+  /onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      mimic-fn: 4.0.0
+    dev: false
 
   /open@8.4.0:
     resolution: {integrity: sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==}
@@ -19417,6 +19473,11 @@ packages:
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  /path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+    dev: false
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -22760,6 +22821,11 @@ packages:
     resolution: {integrity: sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==}
     engines: {node: '>=14'}
 
+  /signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+    dev: false
+
   /simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
     requiresBuild: true
@@ -23448,6 +23514,11 @@ packages:
   /strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
+
+  /strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+    dev: false
 
   /strip-indent@1.0.1:
     resolution: {integrity: sha512-I5iQq6aFMM62fBEAIB/hXzwJD6EEZ0xEGCX2t7oXqaKPIRgt4WruAQ285BISgdkP+HLGWyeGmNJcpIwFeRYRUA==}


### PR DESCRIPTION
I've noticed that we have duplicate, inconsistent, and untested logic for package manager utilities. This PR creates a new package (for internal use only?) that unifies these utilities in a single location. This enables us to make updates to them easier, have consistent usage across the repo, and properly test their functionality. Today we rely on our integration/e2e testing only and they do not cover all cases such as the issue I fixed here: https://github.com/vercel/next.js/pull/64418.

The files in consideration include:
- [packages/next/src/lib/helpers/get-pkg-manager.ts](https://github.com/vercel/next.js/tree/canary/packages/next/src/lib/helpers/get-pkg-manager.ts)
- [packages/next/src/lib/helpers/get-registry.ts](https://github.com/vercel/next.js/tree/canary/packages/next/src/lib/helpers/get-registry.ts)
- [packages/next/src/lib/helpers/get-online.ts](https://github.com/vercel/next.js/tree/canary/packages/next/src/lib/helpers/get-online.ts)
- [packages/next/src/lib/helpers/get-npx-commands.ts](https://github.com/vercel/next.js/tree/canary/packages/next/src/lib/helpers/get-npx-commands.ts)
- [packages/next/src/lib/helpers/install.ts](https://github.com/vercel/next.js/tree/canary/packages/next/src/lib/helpers/install.ts)
- [packages/create-next-app/helpers/get-pkg-manager.ts](https://github.com/vercel/next.js/tree/canary/packages/create-next-app/helpers/get-pkg-manager.ts)
- [packages/create-next-app/helpers/is-online.ts](https://github.com/vercel/next.js/tree/canary/packages/create-next-app/helpers/is-online.ts)
- [packages/create-next-app/helpers/install.ts](https://github.com/vercel/next.js/tree/canary/packages/create-next-app/helpers/install.ts)

The plan is to introduce these changes in parts. First, I'd like to unify the major overlap (`get-pkg-manager`, `is-online`, and `install`). Afterwards, I'll work on moving some of the other utilities over. I also need to look over the remaining packages and see if any of them have similar logic to include in this work. 