### PR TITLE
docs: Fix typo for `ReactDOM.prefetchDNS` method inside Resource Hints section

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
@@ -1041,7 +1041,7 @@ ReactDOM.prefetchDNS(href: string)
 >
 > - These methods are currently only supported in Client Components, which are still Server Side Rendered on initial page load.
 > - Next.js in-built features such as `next/font`, `next/image` and `next/script` automatically handle relevant resource hints.
-> - React 18.3 does not yet include type definitions for `ReactDOM.preload`, `ReactDOM.preconnect`, and `ReactDOM.preconnectDNS`. You can use `// @ts-ignore` as a temporary solution to avoid type errors.
+> - React 18.3 does not yet include type definitions for `ReactDOM.preload`, `ReactDOM.preconnect`, and `ReactDOM.prefetchDNS`. You can use `// @ts-ignore` as a temporary solution to avoid type errors.
 
 ## Types
 

--- a/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
@@ -1041,7 +1041,6 @@ ReactDOM.prefetchDNS(href: string)
 >
 > - These methods are currently only supported in Client Components, which are still Server Side Rendered on initial page load.
 > - Next.js in-built features such as `next/font`, `next/image` and `next/script` automatically handle relevant resource hints.
-> - React 18.3 does not yet include type definitions for `ReactDOM.preload`, `ReactDOM.preconnect`, and `ReactDOM.prefetchDNS`. You can use `// @ts-ignore` as a temporary solution to avoid type errors.
 
 ## Types
 


### PR DESCRIPTION
Closes https://github.com/vercel/next.js/issues/65110

Fixed a typo inside the [Resource Hints](https://nextjs.org/docs/app/api-reference/functions/generate-metadata#resource-hints) section that incorrectly stated the existence of `ReactDOM.preconnectDNS` when it should be declared as `ReactDOM.prefetchDNS` instead.

**Update: 29th April 2024** - As correctly stated by @eps1lon this line has now been removed completely, as the missing type definitions for `ReactDOM` have been available for a while now. See discussion 👉 https://github.com/vercel/next.js/pull/65111#discussion_r1581895761