### PR TITLE
Resolve global `next` Webpack alias last

### DIFF
--- a/packages/next/src/build/create-compiler-aliases.ts
+++ b/packages/next/src/build/create-compiler-aliases.ts
@@ -118,8 +118,6 @@ export function createWebpackAliases({
         }
       : undefined),
 
-    next: NEXT_PROJECT_ROOT,
-
     'styled-jsx/style$': defaultOverrides['styled-jsx/style'],
     'styled-jsx$': defaultOverrides['styled-jsx'],
 

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1682,6 +1682,13 @@ export default async function getBaseWebpackConfig(
             ]
           },
         },
+        {
+          resolve: {
+            alias: {
+              next: NEXT_PROJECT_ROOT,
+            },
+          },
+        },
       ],
     },
     plugins: [


### PR DESCRIPTION
Currently it takes precedence over any potential subsequent alias of `next/*` e.g. aliasing `next/dist/compiled/react` to `react.react-server`. Moving it to the last position still ensures `next/*` is aliased while also allowing aliasing `next/dist/compiled/react` which we'll need for https://github.com/vercel/next.js/pull/65058

Closes NEXT-3249