### PR TITLE
Update page.mdx to use Record for type definition of searchParams

### DIFF
--- a/docs/02-app/02-api-reference/02-file-conventions/page.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/page.mdx
@@ -11,7 +11,7 @@ export default function Page({
   searchParams,
 }: {
   params: { slug: string }
-  searchParams: { [key: string]: string | string[] | undefined }
+  searchParams: Record<string, unknown>
 }) {
   return <h1>My Page</h1>
 }


### PR DESCRIPTION
If you use the current documentation for the typings of `searchParams` the following eslint error occurs:

`Error: A record is preferred over an index signature.  @typescript-eslint/consistent-indexed-object-style`

This PR edits the docs to suggest using a `Record`.