### PR TITLE
Ensure latest canary of Next.js is installed in repros

### DIFF
--- a/examples/reproduction-template-pages/.codesandbox/tasks.json
+++ b/examples/reproduction-template-pages/.codesandbox/tasks.json
@@ -8,7 +8,7 @@
   "tasks": {
     "dev": {
       "name": "dev",
-      "command": "pnpm update next && pnpm dev",
+      "command": "pnpm update next@canary && pnpm dev",
       "runAtStart": true,
       "restartOn": {
         "clone": true

--- a/examples/reproduction-template/.codesandbox/tasks.json
+++ b/examples/reproduction-template/.codesandbox/tasks.json
@@ -8,7 +8,7 @@
   "tasks": {
     "dev": {
       "name": "dev",
-      "command": "pnpm update next && pnpm dev",
+      "command": "pnpm update next@canary && pnpm dev",
       "runAtStart": true,
       "restartOn": {
         "clone": true


### PR DESCRIPTION
### What?

Always use latest canary in reproduction templates

### Why?

Following up with the new PR #64967, it appears that CodeSandbox caches `package.json` and the changes made to it from `pnpm update next` - which uses an outdated canary version of Next.js

Eg. currently, the reproduction template URL uses `next@14.3.0-canary.26` is not the latest canary

https://codesandbox.io/p/sandbox/github/vercel/next.js/tree/canary/examples/reproduction-template

![Screenshot 2024-04-30 at 12 44 24](https://github.com/vercel/next.js/assets/1935696/fdbebbae-b4b9-4e51-a1f5-46d1a59c7b76)

### How?

Switch CodeSandbox "dev" task to update the pinned canary version of Next.js in the cached `package.json` to the latest Next.js canary:

- old: `pnpm update next`
- new: `pnpm update next@canary`

```bash
$ pnpm update next@canary
Packages: +4 -4
++++----
Progress: resolved 65, reused 43, downloaded 0, added 0, done

dependencies:
- next 14.3.0-canary.26
+ next 14.3.0-canary.32

Done in 2.9s
```

This will:

A) upgrade the pinned version in the cached `package.json` file
B) perform this upgrade on forking of the sandbox (because of `restartOn.clone = true`)

### Caveats

Users restarting the `dev` task for any reason will get the (potentially unwanted) side effect of upgrading Next.js to the latest canary:

1.⁠ User creates a reproduction on a certain canary version
2.⁠ ⁠⁠New canary version is released
3.⁠ ⁠⁠User restarts the `dev` task for any reason
4.⁠ ⁠⁠Next.js version updated, potentially leading to the bug disappearing from the reproduction (URL may be published somewhere publicly) 💥

This could be seen as unexpected behavior / a "paper cut".

However, it seems like the tradeoff is worth it, as having the latest canary on all new reproductions is higher value than allowing the potential (less common) action of restarting the `dev` task in a devbox.

In future, I would however like to explore solutions with CodeSandbox that will allow for restarting the dev server without this unwanted side effect, eg. potentially [with an environment variable or something similar](https://github.com/vercel/next.js/pull/64967#issuecomment-2083480368).

cc @styfle