### PR TITLE
Support interrupts and focus in react-profiling-mode test

### DIFF
--- a/test/integration/react-profiling-mode/next.config.js
+++ b/test/integration/react-profiling-mode/next.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  reactProductionProfiling: true,
+  reactProductionProfiling: process.env.REACT_PRODUCTION_PROFILING === 'true',
 }

--- a/test/integration/react-profiling-mode/next.config.js
+++ b/test/integration/react-profiling-mode/next.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  reactProductionProfiling: process.env.REACT_PRODUCTION_PROFILING === 'true',
+  reactProductionProfiling: process.env.TEST_REACT_PRODUCTION_PROFILING === 'true',
 }

--- a/test/integration/react-profiling-mode/next.config.js
+++ b/test/integration/react-profiling-mode/next.config.js
@@ -1,3 +1,4 @@
 module.exports = {
-  reactProductionProfiling: process.env.TEST_REACT_PRODUCTION_PROFILING === 'true',
+  reactProductionProfiling:
+    process.env.TEST_REACT_PRODUCTION_PROFILING === 'true',
 }

--- a/test/integration/react-profiling-mode/test/index.test.js
+++ b/test/integration/react-profiling-mode/test/index.test.js
@@ -1,12 +1,10 @@
 /* eslint-env jest */
 
-import fs from 'fs-extra'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { nextBuild, nextStart, findPort, killApp } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
-const nextConfig = join(appDir, 'next.config.js')
 
 let appPort
 let app
@@ -17,20 +15,13 @@ describe('React Profiling Mode', () => {
     () => {
       describe('without config enabled', () => {
         beforeAll(async () => {
-          await fs.remove(nextConfig)
-          await nextBuild(appDir)
+          await nextBuild(appDir, [], {
+            env: { REACT_PRODUCTION_PROFILING: 'false' },
+          })
           appPort = await findPort()
           app = await nextStart(appDir, appPort)
         })
         afterAll(async () => {
-          await fs.writeFile(
-            nextConfig,
-            `
-        module.exports = {
-          reactProductionProfiling: true
-        }
-      `
-          )
           await killApp(app)
         })
 
@@ -44,7 +35,9 @@ describe('React Profiling Mode', () => {
 
       describe('with config enabled', () => {
         beforeAll(async () => {
-          await nextBuild(appDir, ['--profile'])
+          await nextBuild(appDir, ['--profile'], {
+            env: { REACT_PRODUCTION_PROFILING: 'true' },
+          })
           appPort = await findPort()
           app = await nextStart(appDir, appPort)
         })

--- a/test/integration/react-profiling-mode/test/index.test.js
+++ b/test/integration/react-profiling-mode/test/index.test.js
@@ -16,7 +16,7 @@ describe('React Profiling Mode', () => {
       describe('without config enabled', () => {
         beforeAll(async () => {
           await nextBuild(appDir, [], {
-            env: { REACT_PRODUCTION_PROFILING: 'false' },
+            env: { TEST_REACT_PRODUCTION_PROFILING: 'false' },
           })
           appPort = await findPort()
           app = await nextStart(appDir, appPort)
@@ -36,7 +36,7 @@ describe('React Profiling Mode', () => {
       describe('with config enabled', () => {
         beforeAll(async () => {
           await nextBuild(appDir, ['--profile'], {
-            env: { REACT_PRODUCTION_PROFILING: 'true' },
+            env: { TEST_REACT_PRODUCTION_PROFILING: 'true' },
           })
           appPort = await findPort()
           app = await nextStart(appDir, appPort)


### PR DESCRIPTION
Some tests relied on the `afterAll` of a prior `describe` block. This breaks support of `describe.skip` and `describe.only`. The tests also produces git diffs when interrupted which can be confusing. 

We can just use an environment variable in the config.

Closes NEXT-3263