### PR TITLE
Add oslo, @node-rs/argon2, and @node-rs/bcrypt to external packages

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/serverComponentsExternalPackages.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/serverComponentsExternalPackages.mdx
@@ -30,6 +30,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `@mikro-orm/core`
 - `@mikro-orm/knex`
 - `@node-rs/argon2`
+- `@node-rs/bcrypt`
 - `@prisma/client`
 - `@react-pdf/renderer`
 - `@sentry/profiling-node`

--- a/docs/02-app/02-api-reference/05-next-config-js/serverComponentsExternalPackages.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/serverComponentsExternalPackages.mdx
@@ -29,6 +29,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `@libsql/client`
 - `@mikro-orm/core`
 - `@mikro-orm/knex`
+- `@node-rs/argon2`
 - `@prisma/client`
 - `@react-pdf/renderer`
 - `@sentry/profiling-node`

--- a/docs/02-app/02-api-reference/05-next-config-js/serverComponentsExternalPackages.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/serverComponentsExternalPackages.mdx
@@ -56,6 +56,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `next-seo`
 - `node-pty`
 - `node-web-audio-api`
+- `oslo`
 - `pg`
 - `playwright`
 - `postcss`

--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -8,6 +8,7 @@
   "@libsql/client",
   "@mikro-orm/core",
   "@mikro-orm/knex",
+  "@node-rs/argon2",
   "@prisma/client",
   "@react-pdf/renderer",
   "@sentry/profiling-node",

--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -9,6 +9,7 @@
   "@mikro-orm/core",
   "@mikro-orm/knex",
   "@node-rs/argon2",
+  "@node-rs/bcrypt",
   "@prisma/client",
   "@react-pdf/renderer",
   "@sentry/profiling-node",

--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -35,6 +35,7 @@
   "next-seo",
   "node-pty",
   "node-web-audio-api",
+  "oslo",
   "pg",
   "playwright",
   "postcss",


### PR DESCRIPTION
## What?

Initially added `@node-rs/argon2` to the list as `argon2` was already in the list to make the provided reproduction pass, however, when digging deeper into Lucia I found that `oslo` also uses `@node-rs/bcrypt`. 

I also looked at Lucia example [1](https://github.com/lucia-auth/examples/blob/main/nextjs-app/username-and-password/next.config.js#L2-L6) and [2](https://github.com/lucia-auth/examples/blob/main/nextjs-app/username-and-password/next.config.js#L2-L6) which show that this configuration is always added: `serverComponentsExternalPackages: ["oslo"]`.

That shouldn't be needed as we keep a list of packages that can't be bundled in Next.js itself, so I've updated the list to add `oslo`, `@node-rs/argon2`, and `@node-rs/bcrypt`. 

This makes it so that you don't have to add additional configuration to use Lucia.

Fixes #63850


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-3264