### PR TITLE
Fix dev server ignores ENOENT error when loading page

### DIFF
--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -867,34 +867,27 @@ export default class DevServer extends Server {
       // Wrap build errors so that they don't get logged again
       throw new WrappedBuildError(compilationErr)
     }
-    try {
-      if (shouldEnsure || this.serverOptions.customServer) {
-        await this.ensurePage({
-          page,
-          appPaths,
-          clientOnly: false,
-          definition: undefined,
-          url,
-        })
-      }
-
-      this.nextFontManifest = super.getNextFontManifest()
-
-      return await super.findPageComponents({
-        locale,
+    if (shouldEnsure || this.serverOptions.customServer) {
+      await this.ensurePage({
         page,
-        query,
-        params,
-        isAppPath,
-        shouldEnsure,
+        appPaths,
+        clientOnly: false,
+        definition: undefined,
         url,
       })
-    } catch (err) {
-      if ((err as any).code !== 'ENOENT') {
-        throw err
-      }
-      return null
     }
+
+    this.nextFontManifest = super.getNextFontManifest()
+
+    return await super.findPageComponents({
+      page,
+      query,
+      params,
+      locale,
+      isAppPath,
+      shouldEnsure,
+      url,
+    })
   }
 
   protected async getFallbackErrorComponents(

--- a/test/development/enoent-during-require/app/route.ts
+++ b/test/development/enoent-during-require/app/route.ts
@@ -1,0 +1,7 @@
+import fs from 'fs'
+
+fs.readFileSync('does-not-exist.txt')
+
+export default function handler() {
+  return null
+}

--- a/test/development/enoent-during-require/index.test.ts
+++ b/test/development/enoent-during-require/index.test.ts
@@ -1,0 +1,19 @@
+import { nextTestSetup } from 'e2e-utils'
+import { check } from 'next-test-utils'
+
+describe('ENOENT during require', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should show ENOENT error correctly', async () => {
+    await next.fetch('/')
+
+    await check(() => {
+      expect(next.cliOutput).toContain(
+        "ENOENT: no such file or directory, open 'does-not-exist.txt'"
+      )
+      return 'yes'
+    }, 'yes')
+  })
+})


### PR DESCRIPTION
The dev server ignores ENOENT errors when loading a page which can easily happen if you try to read a file and mess up the path.

```ts
import { readFileSync } from "fs";

const nope = readFileSync("notavailable.txt", "utf8").split("\n");

export function GET() {
  return new Response("Hello, world!", {
    status: 200,
  });
}
```

The dev server treats this as 404 which is quite confusing.

This issue was fixed previously in https://github.com/vercel/next.js/pull/37486 but only for prod.

Closes NEXT-3188
Fixes #53792

