### PR TITLE
docs: fix skipTrailingSlashRedirect middleware example

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/14-middleware.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/14-middleware.mdx
@@ -541,8 +541,9 @@ export default async function middleware(req) {
     !pathname.endsWith('/') &&
     !pathname.match(/((?!\.well-known(?:\/.*)?)(?:[^/]+\/)*[^/]+\.\w+)/)
   ) {
-    req.nextUrl.pathname += '/'
-    return NextResponse.redirect(req.nextUrl)
+    return NextResponse.redirect(
+      new URL(`${req.nextUrl.pathname}/`, req.nextUrl)
+    )
   }
 }
 ```


### PR DESCRIPTION
The example here only updates the pathname, but the redirect path is determined by taking the `req.nextUrl` object and stringifying it, which means it would return the wrong redirect location.

Closes NEXT-3260
