### PR TITLE
Emit polyfill-nomodule.js into the build manifest polyfillFiles

### DIFF
--- a/packages/next-swc/crates/next-api/src/app.rs
+++ b/packages/next-swc/crates/next-api/src/app.rs
@@ -7,7 +7,7 @@ use next_core::{
         get_entrypoints, Entrypoint as AppEntrypoint, Entrypoints as AppEntrypoints, LoaderTree,
         MetadataItem,
     },
-    get_edge_resolve_options_context,
+    get_edge_resolve_options_context, get_next_package,
     next_app::{
         app_client_references_chunks::get_app_server_reference_modules,
         get_app_client_references_chunks, get_app_client_shared_chunk_group, get_app_page_entry,
@@ -45,12 +45,15 @@ use turbopack_binding::{
     turbopack::{
         core::{
             asset::{Asset, AssetContent},
-            chunk::{availability_info::AvailabilityInfo, ChunkingContextExt, EvaluatableAssets},
+            chunk::{
+                availability_info::AvailabilityInfo, ChunkingContext, ChunkingContextExt,
+                EvaluatableAssets,
+            },
             file_source::FileSource,
             module::Module,
             output::{OutputAsset, OutputAssets},
-            reference_type::{CommonJsReferenceSubType, ReferenceType},
-            resolve::{node::node_cjs_resolve_options, parse::Request, resolve},
+            raw_module::RawModule,
+            resolve::{node::node_cjs_resolve_options, parse::Request},
             virtual_output::VirtualOutputAsset,
         },
         nodejs::EntryChunkGroupResult,
@@ -896,31 +899,26 @@ impl AppEndpoint {
             ));
             server_assets.push(app_build_manifest_output);
 
-            const POLYFILL_PATH: &str = "next/dist/build/polyfills/polyfill-nomodule.js";
-            let project_path = this.app_project.project().project_path();
-            let polyfill_path = resolve(
-                project_path,
-                Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
-                Request::parse_string(POLYFILL_PATH.to_string()),
-                node_cjs_resolve_options(project_path),
-            )
-            .as_raw_module_result()
-            .primary_output_assets()
-            .await?
-            .first()
-            .with_context(|| format!("failed to resolve {POLYFILL_PATH}"))?
-            .ident()
-            .await?
-            .path
-            .await?;
-            let polyfill_path = client_relative_path_ref
-                .get_path_to(&polyfill_path)
-                .context("failed to resolve client-relative path to polyfill")?;
-            let polyfill_paths = vec![polyfill_path.to_string()];
+            // polyfill-nomodule.js is a pre-compiled asset distributed as part of next,
+            // load it as a RawModule.
+            let next_package = get_next_package(this.app_project.project().project_path());
+            let polyfill_source_path =
+                next_package.join("dist/build/polyfills/polyfill-nomodule.js".to_string());
+            let polyfill_module = RawModule::new(Vc::upcast(FileSource::new(polyfill_source_path)));
+            let polyfill_output_path =
+                client_chunking_context.chunk_path(polyfill_module.ident(), ".js".to_string());
+            let polyfill_output_asset =
+                VirtualOutputAsset::new(polyfill_output_path, polyfill_module.content());
+            let polyfill_client_path = client_relative_path_ref
+                .get_path_to(&*polyfill_output_path.await?)
+                .context("failed to resolve client-relative path to polyfill")?
+                .to_string();
+            let polyfill_client_paths = vec![polyfill_client_path];
+            client_assets.push(Vc::upcast(polyfill_output_asset));
 
             let build_manifest = BuildManifest {
                 root_main_files: client_shared_chunks_paths,
-                polyfill_files: polyfill_paths,
+                polyfill_files: polyfill_client_paths,
                 ..Default::default()
             };
             let build_manifest_output = Vc::upcast(VirtualOutputAsset::new(

--- a/packages/next-swc/crates/next-api/src/app.rs
+++ b/packages/next-swc/crates/next-api/src/app.rs
@@ -52,8 +52,7 @@ use turbopack_binding::{
             file_source::FileSource,
             module::Module,
             output::{OutputAsset, OutputAssets},
-            raw_module::RawModule,
-            resolve::{node::node_cjs_resolve_options, parse::Request},
+            source::Source,
             virtual_output::VirtualOutputAsset,
         },
         nodejs::EntryChunkGroupResult,
@@ -902,13 +901,13 @@ impl AppEndpoint {
             // polyfill-nomodule.js is a pre-compiled asset distributed as part of next,
             // load it as a RawModule.
             let next_package = get_next_package(this.app_project.project().project_path());
-            let polyfill_source_path =
-                next_package.join("dist/build/polyfills/polyfill-nomodule.js".to_string());
-            let polyfill_module = RawModule::new(Vc::upcast(FileSource::new(polyfill_source_path)));
+            let polyfill_source = FileSource::new(
+                next_package.join("dist/build/polyfills/polyfill-nomodule.js".to_string()),
+            );
             let polyfill_output_path =
-                client_chunking_context.chunk_path(polyfill_module.ident(), ".js".to_string());
+                client_chunking_context.chunk_path(polyfill_source.ident(), ".js".to_string());
             let polyfill_output_asset =
-                VirtualOutputAsset::new(polyfill_output_path, polyfill_module.content());
+                VirtualOutputAsset::new(polyfill_output_path, polyfill_source.content());
             let polyfill_client_path = client_relative_path_ref
                 .get_path_to(&*polyfill_output_path.await?)
                 .context("failed to resolve client-relative path to polyfill")?

--- a/packages/next-swc/crates/next-core/src/lib.rs
+++ b/packages/next-swc/crates/next-core/src/lib.rs
@@ -45,6 +45,7 @@ pub use next_edge::context::{
     get_edge_chunking_context, get_edge_chunking_context_with_client_assets,
     get_edge_compile_time_info, get_edge_resolve_options_context,
 };
+pub use next_import_map::get_next_package;
 pub use page_loader::{create_page_loader_entry_module, PageLoaderAsset};
 use turbopack_binding::{turbo, turbopack};
 pub use util::{get_asset_path_from_pathname, pathname_for_path, PathType};

--- a/packages/next/src/server/dev/turbopack/manifest-loader.ts
+++ b/packages/next/src/server/dev/turbopack/manifest-loader.ts
@@ -268,27 +268,33 @@ export class TurbopackManifestLoader {
     )
   }
 
-  private mergeBuildManifests(manifests: Iterable<BuildManifest>) {
-    const manifest: Partial<BuildManifest> & Pick<BuildManifest, 'pages'> = {
-      pages: {
-        '/_app': [],
-      },
+  private mergeBuildManifests(
+    manifests: Iterable<BuildManifest>
+  ): Partial<BuildManifest> & Pick<BuildManifest, 'pages'> {
+    const polyfillFiles: string[] = []
+    const pages = {
+      '/_app': [],
+    }
+    let rootMainFiles: readonly string[] = []
+    for (const m of manifests) {
+      Object.assign(pages, m.pages)
+      if (m.rootMainFiles.length) rootMainFiles = m.rootMainFiles
+      polyfillFiles.push(...m.polyfillFiles)
+    }
+
+    return {
+      pages,
       // Something in next.js depends on these to exist even for app dir rendering
       devFiles: [],
       ampDevFiles: [],
-      polyfillFiles: [],
+      polyfillFiles,
       lowPriorityFiles: [
         'static/development/_ssgManifest.js',
         'static/development/_buildManifest.js',
       ],
-      rootMainFiles: [],
+      rootMainFiles,
       ampFirstPages: [],
     }
-    for (const m of manifests) {
-      Object.assign(manifest.pages, m.pages)
-      if (m.rootMainFiles.length) manifest.rootMainFiles = m.rootMainFiles
-    }
-    return manifest
   }
 
   private async writeBuildManifest(

--- a/packages/next/src/server/dev/turbopack/manifest-loader.ts
+++ b/packages/next/src/server/dev/turbopack/manifest-loader.ts
@@ -268,33 +268,29 @@ export class TurbopackManifestLoader {
     )
   }
 
-  private mergeBuildManifests(
-    manifests: Iterable<BuildManifest>
-  ): Partial<BuildManifest> & Pick<BuildManifest, 'pages'> {
-    const polyfillFiles: string[] = []
-    const pages = {
-      '/_app': [],
-    }
-    let rootMainFiles: readonly string[] = []
-    for (const m of manifests) {
-      Object.assign(pages, m.pages)
-      if (m.rootMainFiles.length) rootMainFiles = m.rootMainFiles
-      polyfillFiles.push(...m.polyfillFiles)
-    }
-
-    return {
-      pages,
+  private mergeBuildManifests(manifests: Iterable<BuildManifest>) {
+    const manifest: Partial<BuildManifest> & Pick<BuildManifest, 'pages'> = {
+      pages: {
+        '/_app': [],
+      },
       // Something in next.js depends on these to exist even for app dir rendering
       devFiles: [],
       ampDevFiles: [],
-      polyfillFiles,
+      polyfillFiles: [],
       lowPriorityFiles: [
         'static/development/_ssgManifest.js',
         'static/development/_buildManifest.js',
       ],
-      rootMainFiles,
+      rootMainFiles: [],
       ampFirstPages: [],
     }
+    for (const m of manifests) {
+      Object.assign(manifest.pages, m.pages)
+      if (m.rootMainFiles.length) manifest.rootMainFiles = m.rootMainFiles
+      // polyfillFiles should always be the same, so we can overwrite instead of actually merging
+      if (m.polyfillFiles.length) manifest.polyfillFiles = m.polyfillFiles
+    }
+    return manifest
   }
 
   private async writeBuildManifest(

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -376,7 +376,9 @@ describe('app dir - basic', () => {
     it('should serve polyfills for browsers that do not support modules', async () => {
       const html = await next.render('/dashboard/index')
       expect(html).toMatch(
-        /<script src="\/_next\/static\/chunks\/polyfills(-\w+)?\.js" noModule="">/
+        isTurbopack
+          ? /<script src="\/_next\/static\/chunks\/[\w-]*polyfill-nomodule\.js" noModule="">/
+          : /<script src="\/_next\/static\/chunks\/polyfills(-\w+)?\.js" noModule="">/
       )
     })
   }


### PR DESCRIPTION
### Why?

`polyfill-nomodule.js` is a pre-built file containing polyfills for older browsers (gated by the `<script>` tag `nomodule` attribute).

### How?

- The turbopack server needs to emit a raw OutputAsset for this file, so that it is copied into the output chunks directory.
- That file needs to be passed into `polyfillFiles`, and preserved when we're merging manifests inside of the development server.

### Test Plan

```
HEADLESS=true pnpm testonly-dev test/e2e/app-dir/app/index.test.ts -t 'should serve polyfills for browsers that do not support modules'
HEADLESS=true pnpm testonly-dev-turbo test/e2e/app-dir/app/index.test.ts -t 'should serve polyfills for browsers that do not support modules'
```

Build a project with `next dev --turbo` and inspect:

![Screenshot 2024-05-01 at 10.40.39 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/fe0214b2-ca56-4c03-a133-921f1dc51775.png)
![Screenshot 2024-05-01 at 10.40.20 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/d41dbf91-34d2-44c4-90ec-30e3212ce0f8.png)

Verify that the polyfill file exists and resolves in the browser.

Closes PACK-2993