### PR TITLE
Provide non-dynamic segments to catch-all parallel routes

### DIFF
--- a/packages/next/src/shared/lib/router/utils/route-regex.ts
+++ b/packages/next/src/shared/lib/router/utils/route-regex.ts
@@ -25,7 +25,7 @@ export interface RouteRegex {
  *   - `[foo]` -> `{ key: 'foo', repeat: false, optional: true }`
  *   - `bar` -> `{ key: 'bar', repeat: false, optional: false }`
  */
-function parseParameter(param: string) {
+export function parseParameter(param: string) {
   const optional = param.startsWith('[') && param.endsWith(']')
   if (optional) {
     param = param.slice(1, -1)

--- a/test/e2e/app-dir/parallel-routes-breadcrumbs/app/@slot/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-breadcrumbs/app/@slot/[...catchAll]/page.tsx
@@ -1,4 +1,4 @@
-export default function Page({ params: { catchAll } }) {
+export default function Page({ params: { catchAll = [] } }) {
   return (
     <div id="slot">
       <h1>Parallel Route!</h1>

--- a/test/e2e/app-dir/parallel-routes-breadcrumbs/app/foo/[lang]/bar/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-breadcrumbs/app/foo/[lang]/bar/page.tsx
@@ -1,0 +1,7 @@
+export default function StaticPage() {
+  return (
+    <div>
+      <h2>/foo/[lang]/bar Page!</h2>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-breadcrumbs/parallel-routes-breadcrumbs.test.ts
+++ b/test/e2e/app-dir/parallel-routes-breadcrumbs/parallel-routes-breadcrumbs.test.ts
@@ -44,4 +44,19 @@ describe('parallel-routes-breadcrumbs', () => {
     expect(await slot.text()).toContain('Album: album2')
     expect(await slot.text()).toContain('Track: track3')
   })
+
+  it('should render the breadcrumbs correctly with the non-dynamic route segments', async () => {
+    const browser = await next.browser('/foo/en/bar')
+    const slot = await browser.waitForElementByCss('#slot')
+
+    expect(await browser.elementByCss('h1').text()).toBe('Parallel Route!')
+    expect(await browser.elementByCss('h2').text()).toBe(
+      '/foo/[lang]/bar Page!'
+    )
+
+    // verify slot is rendering the params
+    expect(await slot.text()).toContain('Artist: foo')
+    expect(await slot.text()).toContain('Album: en')
+    expect(await slot.text()).toContain('Track: bar')
+  })
 })


### PR DESCRIPTION
Fixes an issue with https://github.com/vercel/next.js/pull/65063 where the catch-all param only contains dynamic segments and is missing non-dynamic route segments.

This makes building breadcrumbs extremely hard as we're missing information to properly render the correct breadcrumb components.  

This fix makes parallel route catch-all params behave like the standard catch-all params in non-parallel routes
