### PR TITLE
Fix export function name on docs/routing/layouts-and-templates

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/03-layouts-and-templates.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/03-layouts-and-templates.mdx
@@ -229,7 +229,7 @@ Since `usePathname()` is a client hook, you need to extract the nav links into a
 import { usePathname } from 'next/navigation'
 import Link from 'next/link'
 
-export function Links() {
+export function NavLinks() {
   const pathname = usePathname()
 
   return (

--- a/examples/with-turso/README.md
+++ b/examples/with-turso/README.md
@@ -2,14 +2,14 @@
 
 [Turso](https://turso.tech) is a SQLite-compatible database built on libSQL, the Open Contribution fork of SQLite. It enables scaling to hundreds of thousands of databases per organization and supports replication to any location, including your own servers, for microsecond-latency access.
 
-* [Turso Documentation](https://docs.turso.tech)
-* [Turso Support](https://discord.com/invite/4B5D7hYwub)
+- [Turso Documentation](https://docs.turso.tech)
+- [Turso Support](https://discord.com/invite/4B5D7hYwub)
 
 ## Features
 
-* Uses SQLite `dev.db` locally
-* App Router
-* Server Actions
+- Uses SQLite `dev.db` locally
+- App Router
+- Server Actions
 
 ## How to use
 
@@ -54,52 +54,52 @@ You can deploy this app to Vercel in a few simple steps:
 
 1. **Signup to Turso**
 
-    Install the Turso CLI and login using GitHub:
+   Install the Turso CLI and login using GitHub:
 
-    ```bash
-    # macOS
-    brew install tursodatabase/tap/turso
+   ```bash
+   # macOS
+   brew install tursodatabase/tap/turso
 
-    # Windows (WSL) & Linux:
-    # curl -sSfL https://get.tur.so/install.sh | bash
-    ```
+   # Windows (WSL) & Linux:
+   # curl -sSfL https://get.tur.so/install.sh | bash
+   ```
 
 2. **Create a database**
 
-    Begin by creating your first database:
+   Begin by creating your first database:
 
-    ```bash
-    turso db create [database-name]
-    ```
+   ```bash
+   turso db create [database-name]
+   ```
 
 3. **Create a table**
 
-    Connect to the turso shell and create your first table:
+   Connect to the turso shell and create your first table:
 
-    ```bash
-    turso db shell <database-name>
-    ```
+   ```bash
+   turso db shell <database-name>
+   ```
 
-    ```bash
-    CREATE TABLE todos(id INTEGER PRIMARY KEY AUTOINCREMENT, description TEXT NOT NULL)
-    ```
+   ```bash
+   CREATE TABLE todos(id INTEGER PRIMARY KEY AUTOINCREMENT, description TEXT NOT NULL)
+   ```
 
 4. **Retrieve database URL**
 
-    You'll need to fetch your database URL and assign it to `TURSO_DB_URL` on deployment:
+   You'll need to fetch your database URL and assign it to `TURSO_DB_URL` on deployment:
 
-    ```bash
-    turso db show <database-name> --url
-    ```
+   ```bash
+   turso db show <database-name> --url
+   ```
 
 5. **Create database auth token**
 
-    Now create an access token and assign it to `TURSO_DB_TOKEN` on deployment:
+   Now create an access token and assign it to `TURSO_DB_TOKEN` on deployment:
 
-    ```bash
-    turso db tokens create <database-name>
-    ```
+   ```bash
+   turso db tokens create <database-name>
+   ```
 
 6. **Deploy to Vercel**
 
-    [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fnext.js%2Ftree%2Fcanary%2Fexamples%2Fwith-turso&env=TURSO_DB_URL,TURSO_DB_TOKEN)
+   [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fnext.js%2Ftree%2Fcanary%2Fexamples%2Fwith-turso&env=TURSO_DB_URL,TURSO_DB_TOKEN)

--- a/examples/with-turso/app/page.tsx
+++ b/examples/with-turso/app/page.tsx
@@ -1,10 +1,9 @@
-import { TodoList } from './todo-list'
+import { TodoList } from "./todo-list";
 import { Form } from "./form";
 
 export default function Home() {
   return (
     <main className="max-w-2xl mx-auto space-y-12 px-6 py-32">
-
       <div className="space-y-3 text-center">
         <h1 className="text-3xl font-medium">Turso</h1>
         <p className="text-gray-500">Local SQLite with libSQL and Turso</p>
@@ -14,6 +13,6 @@ export default function Home() {
         <TodoList />
         <Form />
       </div>
-    </main >
+    </main>
   );
 }

--- a/examples/with-turso/app/todo-list.tsx
+++ b/examples/with-turso/app/todo-list.tsx
@@ -5,15 +5,19 @@ import { db } from "@/lib/turso";
 // The code below can be removed in production apps
 // Useful for getting started locally with SQLite
 async function findOrCreateTodosTable() {
-  const result = await db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='todos'")
+  const result = await db.execute(
+    "SELECT name FROM sqlite_master WHERE type='table' AND name='todos'",
+  );
 
   if (!result || result?.rows?.length === 0) {
-    await db.execute("CREATE TABLE todos(id INTEGER PRIMARY KEY AUTOINCREMENT, description TEXT NOT NULL)")
+    await db.execute(
+      "CREATE TABLE todos(id INTEGER PRIMARY KEY AUTOINCREMENT, description TEXT NOT NULL)",
+    );
   }
 }
 
 export async function TodoList() {
-  await findOrCreateTodosTable()
+  await findOrCreateTodosTable();
   const result = await db.execute("SELECT * FROM todos");
   const rows = result.rows as unknown as TodoItem[];
 


### PR DESCRIPTION
### What?
Fix export function name on docs/routing/layouts-and-templates

### Why?
The way it is, it will return an error to the user following the tutorial:  `Unsupported Server Component type: undefined / next js 13`

### How?
- Change `Links()` function export to `NavLinks()`
