### PR TITLE
Only add optimize packages to transpile packages during production build

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -392,9 +392,11 @@ export default async function getBaseWebpackConfig(
   // auto-include optimizePackageImports in transpilePackages
   const finalTranspilePackages: string[] = config.transpilePackages || []
 
-  for (const pkg of config.experimental.optimizePackageImports || []) {
-    if (!finalTranspilePackages.includes(pkg)) {
-      finalTranspilePackages.push(pkg)
+  if (!dev) {
+    for (const pkg of config.experimental.optimizePackageImports || []) {
+      if (!finalTranspilePackages.includes(pkg)) {
+        finalTranspilePackages.push(pkg)
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

#63537 introduced an issue where compilation of a new route (like an api route) on the pages router during local webpack dev caused the hash of _document.js to change, forcing active hmr pages to do a full page refresh.

This PR simply forces the above-mentioned PR to only apply during production builds and not during dev (likely the time you care about optimizing imports anyway)

### Why?

The above mentioned bug was causing issues for our local dev as the page would refresh as soon as we hit an api route