### PR TITLE
Fixes with-supertokens example

### DIFF
--- a/examples/with-supertokens/app/components/callApiButton.tsx
+++ b/examples/with-supertokens/app/components/callApiButton.tsx
@@ -1,16 +1,10 @@
 "use client";
 
-import Session from "supertokens-auth-react/recipe/session";
 import styles from "../page.module.css";
 
 export const CallAPIButton = () => {
   const fetchUserData = async () => {
-    const accessToken = await Session.getAccessToken();
-    const userInfoResponse = await fetch("http://localhost:3000/api/user", {
-      headers: {
-        Authorization: "Bearer " + accessToken,
-      },
-    });
+    const userInfoResponse = await fetch("http://localhost:3000/api/user");
 
     alert(JSON.stringify(await userInfoResponse.json()));
   };

--- a/examples/with-supertokens/package.json
+++ b/examples/with-supertokens/package.json
@@ -11,8 +11,7 @@
     "react": "^18",
     "react-dom": "^18",
     "supertokens-auth-react": "latest",
-    "supertokens-node": "latest",
-    "supertokens-web-js": "latest"
+    "supertokens-node": "latest"
   },
   "devDependencies": {
     "@types/cookie": "^0.5.2",


### PR DESCRIPTION
This PR fixes how a protected API is called once the user is logged in, in the `with-supertokens` example app.