### PR TITLE
Improve test assertions

### DIFF
--- a/test/integration/auto-export/test/index.test.js
+++ b/test/integration/auto-export/test/index.test.js
@@ -93,13 +93,16 @@ describe('Auto Export', () => {
     it('should include error link when hydration error does occur', async () => {
       const browser = await webdriver(appPort, '/post-1/hydrate-error')
       const logs = await browser.log()
-      expect(
-        logs.some((log) =>
-          log.message.includes(
-            'See more info here: https://nextjs.org/docs/messages/react-hydration-error'
-          )
-        )
-      ).toBe(true)
+      expect(logs).toEqual(
+        expect.arrayContaining([
+          {
+            message: expect.stringContaining(
+              'See more info here: https://nextjs.org/docs/messages/react-hydration-error'
+            ),
+            source: 'error',
+          },
+        ])
+      )
     })
   })
 })


### PR DESCRIPTION
Cherry-picked from https://github.com/vercel/next.js/pull/65058 where this test was originally failing.

Usually, you want to keep your value on the left side of the assertion as complete as possible so that the testing framework can display a rich diff in case the test fails. Comparing booleans would not provide a rich diff. For example, `Array.prototype.some` on the left side can become `expect.arrayContaining()` or `String.prototype.includes` can become `expect.stringContaining`.

Closes NEXT-3286