### PR TITLE
Improve test assertions

### DIFF
--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -2115,12 +2115,16 @@ describe('Prerender', () => {
           const { version, files } = JSON.parse(contents)
           expect(version).toBe(1)
 
-          console.log(
-            check.tests.map((item) => files.some((file) => item.test(file)))
-          )
-          expect(
-            check.tests.every((item) => files.some((file) => item.test(file)))
-          ).toBe(true)
+          try {
+            expect(check.tests).toEqual(
+              expect.toSatisfyAll((item) =>
+                files.some((file) => item.test(file))
+              )
+            )
+          } catch (error) {
+            error.message += `\n\nFiles:\n${files.join('\n')}`
+            throw error
+          }
 
           if (sep === '/') {
             expect(


### PR DESCRIPTION
Similar to https://github.com/vercel/next.js/pull/65285 but this time replacing `expect(array.every(fn))` with `expect(array).toEqual(expect.toSatisfyAll(fn))`

Example error message:

```
Expected: toSatisfyAll<(item)=>files.some((file)=>item.test(file))>
    Received: [/webpack-runtime\.js/, /node_modules\/react\/index\.js/, /node_modules\/react\/package\.json/, /node_modules\/react\/cjs\/react\.production\.min\.js/]

    Files:
    ../../../node_modules/.pnpm/file+..+next-repo-5b034bd6b78c2033850d0e1023acbd1ab12119a7393ab39760ba15867e730958+packages+n_mklgnekaf5rcxiuphg5rfolud4/node_modules/next/dist/pages/_app.js
    ../../../node_modules/.pnpm/react@19.0.0-beta-4508873393-20240430/node_modules/react/cjs/react-jsx-runtime.development.js
    ../../../node_modules/.pnpm/react@19.0.0-beta-4508873393-20240430/node_modules/react/cjs/react-jsx-runtime.production.js
    ../../../node_modules/.pnpm/react@19.0.0-beta-4508873393-20240430/node_modules/react/cjs/react.development.js
    ../../../node_modules/.pnpm/react@19.0.0-beta-4508873393-20240430/node_modules/react/cjs/react.production.js
    ../../../node_modules/.pnpm/react@19.0.0-beta-4508873393-20240430/node_modules/react/index.js
    ../../../node_modules/.pnpm/react@19.0.0-beta-4508873393-20240430/node_modules/react/jsx-runtime.js
    ../../../node_modules/.pnpm/react@19.0.0-beta-4508873393-20240430/node_modules/react/package.json
    ../../../node_modules/react
    ../../../package.json
    ../../package.json
    ../webpack-runtime.js
```

Made it easier to spot that this is just an outdated Regex in https://github.com/vercel/next.js/pull/65058 since minified bundles were removed.

Closes NEXT-3310