### PR TITLE
Remove ineffective webpack rules and unused app-page context modules

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1273,14 +1273,6 @@ export default async function getBaseWebpackConfig(
         ...(hasAppDir
           ? [
               {
-                layer: WEBPACK_LAYERS.appRouteHandler,
-                test: new RegExp(
-                  `private-next-app-dir\\/.*\\/route\\.(${pageExtensions.join(
-                    '|'
-                  )})$`
-                ),
-              },
-              {
                 // Make sure that AsyncLocalStorage module instance is shared between server and client
                 // layers.
                 layer: WEBPACK_LAYERS.shared,
@@ -1699,23 +1691,17 @@ export default async function getBaseWebpackConfig(
               '.shared-runtime'
             )
             const layer = resource.contextInfo.issuerLayer
-
             let runtime
 
-            switch (layer) {
-              case WEBPACK_LAYERS.appRouteHandler:
-                runtime = 'app-route'
-                break
-              case WEBPACK_LAYERS.serverSideRendering:
-              case WEBPACK_LAYERS.reactServerComponents:
-              case WEBPACK_LAYERS.appPagesBrowser:
-              case WEBPACK_LAYERS.actionBrowser:
-                runtime = 'app-page'
-                break
-              default:
-                runtime = 'pages'
+            if (layer === WEBPACK_LAYERS.serverSideRendering) {
+              runtime = 'app-page'
+            } else if (!layer) {
+              runtime = 'pages'
+            } else {
+              throw new Error(
+                `shared-runtime module ${moduleName} cannot be used in ${layer} layer`
+              )
             }
-
             resource.request = `next/dist/server/future/route-modules/${runtime}/vendored/contexts/${moduleName}`
           }
         ),

--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
@@ -613,11 +613,7 @@ export class NextTypesPlugin {
         }
         return
       }
-      if (
-        mod.layer !== WEBPACK_LAYERS.reactServerComponents &&
-        mod.layer !== WEBPACK_LAYERS.appRouteHandler
-      )
-        return
+      if (mod.layer !== WEBPACK_LAYERS.reactServerComponents) return
 
       const IS_LAYOUT = /[/\\]layout\.[^./\\]+$/.test(mod.resource)
       const IS_PAGE = !IS_LAYOUT && /[/\\]page\.[^.]+$/.test(mod.resource)

--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -115,7 +115,8 @@ const WEBPACK_LAYERS_NAMES = {
    */
   shared: 'shared',
   /**
-   * React Server Components layer (rsc).
+   * The layer for server-only runtime and picking up `react-server` export conditions.
+   * Including app router RSC pages and app router custom routes.
    */
   reactServerComponents: 'rsc',
   /**
@@ -150,10 +151,6 @@ const WEBPACK_LAYERS_NAMES = {
    * The server bundle layer for metadata routes.
    */
   appMetadataRoute: 'app-metadata-route',
-  /**
-   * The layer for the server bundle for App Route handlers.
-   */
-  appRouteHandler: 'app-route-handler',
 } as const
 
 export type WebpackLayerName =
@@ -166,7 +163,6 @@ const WEBPACK_LAYERS = {
       WEBPACK_LAYERS_NAMES.reactServerComponents,
       WEBPACK_LAYERS_NAMES.actionBrowser,
       WEBPACK_LAYERS_NAMES.appMetadataRoute,
-      WEBPACK_LAYERS_NAMES.appRouteHandler,
       WEBPACK_LAYERS_NAMES.instrument,
     ],
     clientOnly: [
@@ -182,7 +178,6 @@ const WEBPACK_LAYERS = {
       WEBPACK_LAYERS_NAMES.reactServerComponents,
       WEBPACK_LAYERS_NAMES.actionBrowser,
       WEBPACK_LAYERS_NAMES.appMetadataRoute,
-      WEBPACK_LAYERS_NAMES.appRouteHandler,
       WEBPACK_LAYERS_NAMES.serverSideRendering,
       WEBPACK_LAYERS_NAMES.appPagesBrowser,
       WEBPACK_LAYERS_NAMES.shared,

--- a/packages/next/src/server/future/route-modules/app-page/vendored/contexts/amp-context.ts
+++ b/packages/next/src/server/future/route-modules/app-page/vendored/contexts/amp-context.ts
@@ -1,0 +1,3 @@
+module.exports = require('../../module.compiled').vendored[
+  'contexts'
+].AmpContext

--- a/packages/next/src/server/future/route-modules/app-page/vendored/contexts/amp-context.ts
+++ b/packages/next/src/server/future/route-modules/app-page/vendored/contexts/amp-context.ts
@@ -1,3 +1,0 @@
-module.exports = require('../../module.compiled').vendored[
-  'contexts'
-].AmpContext

--- a/packages/next/src/server/future/route-modules/app-page/vendored/contexts/entrypoints.ts
+++ b/packages/next/src/server/future/route-modules/app-page/vendored/contexts/entrypoints.ts
@@ -3,8 +3,4 @@ export * as ServerInsertedHtml from '../../../../../../shared/lib/server-inserte
 export * as AppRouterContext from '../../../../../../shared/lib/app-router-context.shared-runtime'
 export * as HooksClientContext from '../../../../../../shared/lib/hooks-client-context.shared-runtime'
 export * as RouterContext from '../../../../../../shared/lib/router-context.shared-runtime'
-export * as HtmlContext from '../../../../../../shared/lib/html-context.shared-runtime'
-export * as AmpContext from '../../../../../../shared/lib/amp-context.shared-runtime'
-export * as LoadableContext from '../../../../../../shared/lib/loadable-context.shared-runtime'
 export * as ImageConfigContext from '../../../../../../shared/lib/image-config-context.shared-runtime'
-export * as Loadable from '../../../../../../shared/lib/loadable.shared-runtime'

--- a/packages/next/src/server/future/route-modules/app-page/vendored/contexts/entrypoints.ts
+++ b/packages/next/src/server/future/route-modules/app-page/vendored/contexts/entrypoints.ts
@@ -3,4 +3,5 @@ export * as ServerInsertedHtml from '../../../../../../shared/lib/server-inserte
 export * as AppRouterContext from '../../../../../../shared/lib/app-router-context.shared-runtime'
 export * as HooksClientContext from '../../../../../../shared/lib/hooks-client-context.shared-runtime'
 export * as RouterContext from '../../../../../../shared/lib/router-context.shared-runtime'
+export * as AmpContext from '../../../../../../shared/lib/amp-context.shared-runtime'
 export * as ImageConfigContext from '../../../../../../shared/lib/image-config-context.shared-runtime'

--- a/packages/next/src/server/future/route-modules/app-page/vendored/contexts/html-context.ts
+++ b/packages/next/src/server/future/route-modules/app-page/vendored/contexts/html-context.ts
@@ -1,3 +1,0 @@
-module.exports = require('../../module.compiled').vendored[
-  'contexts'
-].HtmlContext

--- a/packages/next/src/server/future/route-modules/app-page/vendored/contexts/loadable-context.ts
+++ b/packages/next/src/server/future/route-modules/app-page/vendored/contexts/loadable-context.ts
@@ -1,3 +1,0 @@
-module.exports = require('../../module.compiled').vendored[
-  'contexts'
-].LoadableContext

--- a/packages/next/src/server/future/route-modules/app-page/vendored/contexts/loadable.ts
+++ b/packages/next/src/server/future/route-modules/app-page/vendored/contexts/loadable.ts
@@ -1,1 +1,0 @@
-module.exports = require('../../module.compiled').vendored['contexts'].Loadable


### PR DESCRIPTION
### What

* Remove the `private-next-app-dir` condition for `WEBPACK_LAYERS.appRouteHandler` layer since it's not effective as the `rule.test` will match the actual file path. App routes are actually bundled in rsc layer atm as expected.
* Should only let shared-runtime modules working in either ssr layer or non-layer (unbundling pages router).
* Remove the pages router context modules for app-page runtime. Still need to keep amp-context as it's used in `head.js` and `head.js` used in `next/image`. Not easy to remove unless we have separate implementation of `next/image` for pages and app router

Closes NEXT-3312