### PR TITLE
Use `@testing-library` instead of react-dom/test-utils

### DIFF
--- a/test/integration/link-without-router/test/index.test.js
+++ b/test/integration/link-without-router/test/index.test.js
@@ -2,38 +2,16 @@
  * @jest-environment jsdom
  */
 import React from 'react'
-// eslint-disable-next-line react/no-deprecated
-import { render, unmountComponentAtNode } from 'react-dom'
-import { act } from 'react-dom/test-utils'
+import { render } from '@testing-library/react'
 
 import Hello from '../components/hello'
 
 describe('Link without a router', () => {
-  let container = null
-
-  beforeEach(() => {
-    container = document.createElement('div')
-    document.body.appendChild(container)
-  })
-
-  afterEach(() => {
-    unmountComponentAtNode(container)
-    container.remove()
-    container = null
-  })
   ;(process.env.TURBOPACK_BUILD ? describe.skip : describe)(
     'development mode',
     () => {
       it('should not throw when rendered', () => {
-        jest.useFakeTimers()
-
-        act(() => {
-          render(<Hello />, container)
-        })
-
-        act(() => {
-          jest.runAllTimers()
-        })
+        const { container } = render(<Hello />)
 
         expect(container.textContent).toBe('Click me')
       })
@@ -44,15 +22,7 @@ describe('Link without a router', () => {
     () => {
       // eslint-disable-next-line jest/no-identical-title
       it('should not throw when rendered', () => {
-        jest.useFakeTimers()
-
-        act(() => {
-          render(<Hello />, container)
-        })
-
-        act(() => {
-          jest.runAllTimers()
-        })
+        const { container } = render(<Hello />)
 
         expect(container.textContent).toBe('Click me')
       })


### PR DESCRIPTION
`react-dom/test-utils` is deprecated in favor of `@testing-library/react`.

Closes NEXT-3313