### PR TITLE
Remove broken `#[turbo_tasks::value(transparent)]` attributes

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
+++ b/packages/next-swc/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
@@ -15,7 +15,7 @@ use turbopack_binding::turbopack::{
 
 /// A [`CssClientReferenceModule`] is a marker module used to indicate which
 /// client reference should appear in the client reference manifest.
-#[turbo_tasks::value(transparent)]
+#[turbo_tasks::value]
 pub struct CssClientReferenceModule {
     pub client_module: Vc<Box<dyn CssChunkPlaceable>>,
 }

--- a/packages/next-swc/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/packages/next-swc/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -13,7 +13,7 @@ use turbopack_binding::turbopack::{
 /// An [EcmascriptClientReferenceModule] is a marker module, used by the
 /// [super::ecmascript_client_reference_proxy_module::EcmascriptClientReferenceProxyModule] to indicate which client reference
 /// should appear in the client reference manifest.
-#[turbo_tasks::value(transparent)]
+#[turbo_tasks::value]
 pub struct EcmascriptClientReferenceModule {
     pub server_ident: Vc<AssetIdent>,
     pub client_module: Vc<Box<dyn EcmascriptChunkPlaceable>>,

--- a/packages/next-swc/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
+++ b/packages/next-swc/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
@@ -30,7 +30,7 @@ use super::ecmascript_client_reference_module::EcmascriptClientReferenceModule;
 
 /// A [`EcmascriptClientReferenceProxyModule`] is used in RSC to represent
 /// a client or SSR asset.
-#[turbo_tasks::value(transparent)]
+#[turbo_tasks::value]
 pub struct EcmascriptClientReferenceProxyModule {
     server_module_ident: Vc<AssetIdent>,
     server_asset_context: Vc<Box<dyn AssetContext>>,

--- a/packages/next-swc/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/packages/next-swc/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -56,7 +56,7 @@ pub struct ClientReferenceGraphResult {
 #[turbo_tasks::value(transparent)]
 pub struct ClientReferenceTypes(IndexSet<ClientReferenceType>);
 
-#[turbo_tasks::value(transparent)]
+#[turbo_tasks::value]
 pub struct ClientReferenceGraph {
     graph: AdjacencyMap<VisitClientReferenceNode>,
 }

--- a/packages/next-swc/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/packages/next-swc/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -11,7 +11,7 @@ use turbopack_binding::turbopack::core::{
 
 /// A [`NextDynamicEntryModule`] is a marker asset used to indicate which
 /// dynamic assets should appear in the dynamic manifest.
-#[turbo_tasks::value(transparent)]
+#[turbo_tasks::value]
 pub struct NextDynamicEntryModule {
     pub client_entry_module: Vc<Box<dyn Module>>,
 }


### PR DESCRIPTION
The `transparent` option only does something when the struct is a field-less unit struct with a single item.

Right now, an invalid `transparent` option is silently ignored. I'm working on a PR to change this to a compilation error, so that it's obvious that the option won't work. These are the callsites in `next.js` that my tweak brought up as potential issues.

Functionally, this PR should be a no-op.