### PR TITLE
add explicit test for parallel routes in a root layout

### DIFF
--- a/test/e2e/app-dir/parallel-routes-root-slot/app/@slot/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-root-slot/app/@slot/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return '@slot rendered'
+}

--- a/test/e2e/app-dir/parallel-routes-root-slot/app/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-root-slot/app/layout.tsx
@@ -1,0 +1,16 @@
+export default function Layout({
+  children,
+  slot,
+}: {
+  children: React.ReactNode
+  slot: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>
+        {children}
+        {slot}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-root-slot/app/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-root-slot/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div id="children-slot">@children rendered</div>
+}

--- a/test/e2e/app-dir/parallel-routes-root-slot/next.config.js
+++ b/test/e2e/app-dir/parallel-routes-root-slot/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/parallel-routes-root-slot/parallel-routes-root-slot.test.ts
+++ b/test/e2e/app-dir/parallel-routes-root-slot/parallel-routes-root-slot.test.ts
@@ -1,0 +1,18 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('parallel-routes-root-slot', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('Should render the root parallel route', async () => {
+    const browser = await next.browser('/')
+    // both the page slot (children) and the parallel slot should be rendered at the root layout
+    expect(await browser.elementByCss('body').text()).toContain(
+      '@children rendered'
+    )
+    expect(await browser.elementByCss('body').text()).toContain(
+      '@slot rendered'
+    )
+  })
+})


### PR DESCRIPTION
Didn't seem like we had any tests that explicitly check a non-nested parallel route works in a root layout, so adding one here. 

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes NEXT-3317