### PR TITLE
[actions] Prevent cookies from being mutated during render

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -139,7 +139,7 @@ import {
 } from './future/route-modules/checks'
 import { PrefetchRSCPathnameNormalizer } from './future/normalizers/request/prefetch-rsc'
 import { NextDataPathnameNormalizer } from './future/normalizers/request/next-data'
-import { getIsServerAction } from './lib/server-action-request-meta'
+import { checkIsServerAction } from './lib/server-action-request-meta'
 import { isInterceptionRouteAppPath } from './future/helpers/interception-routes'
 import { toRoute } from './lib/to-route'
 import type { DeepReadonly } from '../shared/lib/deep-readonly'
@@ -1875,7 +1875,7 @@ export default abstract class Server<
 
     const hasServerProps = !!components.getServerSideProps
     let hasStaticPaths = !!components.getStaticPaths
-    const isServerAction = getIsServerAction(req)
+    const isServerAction = checkIsServerAction(req)
     const hasGetInitialProps = !!components.Component?.getInitialProps
     let isSSG = !!components.getStaticProps
 

--- a/packages/next/src/server/future/route-modules/app-route/module.ts
+++ b/packages/next/src/server/future/route-modules/app-route/module.ts
@@ -46,7 +46,7 @@ import { requestAsyncStorage } from '../../../../client/components/request-async
 import { staticGenerationAsyncStorage } from '../../../../client/components/static-generation-async-storage.external'
 import { actionAsyncStorage } from '../../../../client/components/action-async-storage.external'
 import * as sharedModules from './shared-modules'
-import { getIsServerAction } from '../../../lib/server-action-request-meta'
+import { checkIsServerAction } from '../../../lib/server-action-request-meta'
 import { RequestCookies } from 'next/dist/compiled/@edge-runtime/cookies'
 import { cleanURL } from './helpers/clean-url'
 import { StaticGenBailoutError } from '../../../../client/components/static-generation-bailout'
@@ -278,7 +278,7 @@ export class AppRouteRouteModule extends RouteModule<
     const response: unknown = await this.actionAsyncStorage.run(
       {
         isAppRoute: true,
-        isAction: getIsServerAction(rawRequest),
+        isAction: checkIsServerAction(rawRequest),
       },
       () =>
         RequestAsyncStorageWrapper.wrap(

--- a/packages/next/src/server/lib/server-action-request-meta.ts
+++ b/packages/next/src/server/lib/server-action-request-meta.ts
@@ -48,7 +48,7 @@ export function getServerActionRequestMetadata(
   }
 }
 
-export function getIsServerAction(
+export function checkIsServerAction(
   req: IncomingMessage | BaseNextRequest | NextRequest
 ): boolean {
   return getServerActionRequestMetadata(req).isServerAction

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1030,20 +1030,24 @@ describe('app-dir action handling', () => {
       // Modify the cookie
       await browser.elementByCss('#set-cookie').click()
 
-      const randomNumber = await browser
-        .waitForElementByCss('#random-cookie')
-        .text()
+      const randomNumber = await retry(async () => {
+        const cookie = await browser
+          .waitForElementByCss('#random-cookie')
+          .text()
 
-      expect(randomNumber).not.toEqual('')
+        expect(cookie).not.toEqual('')
+
+        return cookie
+      })
 
       await browser.elementByCss('#set-cookie').click()
 
       await retry(async () => {
-        const newRandomNumber = await browser
+        const cookie = await browser
           .waitForElementByCss('#random-cookie')
           .text()
 
-        expect(newRandomNumber).not.toBe(randomNumber)
+        expect(cookie).not.toBe(randomNumber)
       })
     })
 
@@ -1053,8 +1057,8 @@ describe('app-dir action handling', () => {
 
       let cookie
       await retry(async () => {
-        cookie = await browser.elementByCss('#value').text()
-
+        cookie = await browser.waitForElementByCss('#value').text()
+        expect(cookie).not.toBe('')
         expect(parseInt(cookie)).toBeGreaterThan(0)
       })
 
@@ -1066,8 +1070,8 @@ describe('app-dir action handling', () => {
       await browser.elementByCss('#update-cookie').click()
       let newCookie
       await retry(async () => {
-        newCookie = await browser.elementByCss('#value').text()
-
+        newCookie = await browser.waitForElementByCss('#value').text()
+        expect(newCookie).not.toBe('')
         expect(newCookie).not.toEqual(cookie)
         expect(parseInt(newCookie)).toBeGreaterThan(0)
       })

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1515,7 +1515,7 @@ describe('app-dir action handling', () => {
       })
 
       // Ensure we get a browser error response.
-      await browser.waitForElementByCss('#__next_error__')
+      await hasRedbox(browser)
     } finally {
       await browser.close()
     }

--- a/test/e2e/app-dir/actions/app/mutate-cookie/with-error/page.jsx
+++ b/test/e2e/app-dir/actions/app/mutate-cookie/with-error/page.jsx
@@ -1,0 +1,30 @@
+import { revalidatePath } from 'next/cache'
+import { cookies } from 'next/headers'
+
+let mutate = false
+
+async function updateCookie() {
+  'use server'
+  cookies().set('test-cookie-action', Date.now())
+  mutate = true
+  return revalidatePath('/mutate-cookie/with-error')
+}
+
+export default function WithErrorPage() {
+  if (mutate) {
+    mutate = false
+    cookies().set('test-cookie-render', Date.now())
+  }
+
+  return (
+    <>
+      <p id="action-value">{cookies().get('test-cookie-action')?.value}</p>
+      <p id="render-value">{cookies().get('test-cookie-render')?.value}</p>
+      <form action={updateCookie}>
+        <button id="update-cookie" type="submit">
+          Update Cookie
+        </button>
+      </form>
+    </>
+  )
+}

--- a/test/e2e/app-dir/actions/app/mutate-cookie/with-error/page.jsx
+++ b/test/e2e/app-dir/actions/app/mutate-cookie/with-error/page.jsx
@@ -1,4 +1,3 @@
-import { revalidatePath } from 'next/cache'
 import { cookies } from 'next/headers'
 
 let mutate = false
@@ -7,7 +6,6 @@ async function updateCookie() {
   'use server'
   cookies().set('test-cookie-action', Date.now())
   mutate = true
-  return revalidatePath('/mutate-cookie/with-error')
 }
 
 export default function WithErrorPage() {


### PR DESCRIPTION
Previously, when a page was being revalidated, it was possible to execute operations that modified the cookies as the async local storage that wraps actions was also wrapping the `generateFlight` invocation (thanks @gnoff for the catch). This modifies the logic for the action handler to ensure that the generate flight is executed outside the scope of the action storage.

Closes NEXT-3318