### PR TITLE
Fix Server Action redirection with absolute, basePath not matched external URL

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -255,7 +255,9 @@ async function createRedirectRenderResult(
   const parsedRedirectUrl = new URL(redirectUrl, 'http://n')
   const isAppRelativeRedirect =
     redirectUrl.startsWith('/') ||
-    (originalHost && originalHost.value === parsedRedirectUrl.host)
+    (originalHost &&
+      originalHost.value === parsedRedirectUrl.host &&
+      parsedRedirectUrl.pathname.startsWith(basePath))
 
   if (isAppRelativeRedirect) {
     if (!originalHost) {

--- a/test/e2e/app-dir/app-basepath/app/actions-redirect/actions.js
+++ b/test/e2e/app-dir/app-basepath/app/actions-redirect/actions.js
@@ -1,0 +1,9 @@
+'use server'
+
+import 'server-only'
+
+import { redirect } from 'next/navigation'
+
+export async function redirectAction(path) {
+  redirect(path)
+}

--- a/test/e2e/app-dir/app-basepath/app/actions-redirect/page.js
+++ b/test/e2e/app-dir/app-basepath/app/actions-redirect/page.js
@@ -1,0 +1,16 @@
+'use client'
+
+import { redirectAction } from './actions'
+
+export default function Counter() {
+  return (
+    <form>
+      <button
+        id="redirect-external"
+        formAction={() => redirectAction(`${window.location.origin}/external`)}
+      >
+        redirect external
+      </button>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/app-basepath/index.test.ts
+++ b/test/e2e/app-dir/app-basepath/index.test.ts
@@ -94,4 +94,15 @@ describe('app dir - basepath', () => {
       })
     }
   )
+
+  it('should handle redirects with absolute, basePath not matched external URL', async () => {
+    const browser = await next.browser('/base/actions-redirect')
+
+    await browser.elementByCss('#redirect-external').click()
+
+    await retry(async () => {
+      expect(await browser.url()).toBe(`${next.url}/external`)
+      expect(await browser.elementByCss('h1').text()).toBe('Example Domain')
+    })
+  })
 })

--- a/test/e2e/app-dir/app-basepath/next.config.js
+++ b/test/e2e/app-dir/app-basepath/next.config.js
@@ -1,3 +1,12 @@
 module.exports = {
   basePath: '/base',
+  async rewrites() {
+    return [
+      {
+        source: '/external',
+        destination: 'https://example.vercel.sh',
+        basePath: false,
+      },
+    ]
+  },
 }


### PR DESCRIPTION
### What?

When redirecting to an external URL, which has the same origin, but does not match basePath, Next.js takes it as an internal URL, and responses the 404 page unexpectedly.

### Why?

It's because it has not been considered whether the basePath is matched when handling the redirection.

### How?

This PR resolves the issue by comparing the redirecting URL pathname prefix with the basePath.

Fixes #65257 