### PR TITLE
use backticks instead of quotes

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/turbo.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/turbo.mdx
@@ -50,7 +50,7 @@ The following loaders have been tested to work with Turbopack's webpack loader i
 - [`yaml-loader`](https://www.npmjs.com/package/yaml-loader)
 - [`string-replace-loader`](https://www.npmjs.com/package/string-replace-loader)
 - [`raw-loader`](https://www.npmjs.com/package/raw-loader)
-- ['sass-loader'](https://www.npmjs.com/package/sass-loader)
+- [`sass-loader`](https://www.npmjs.com/package/sass-loader)
 
 ## Resolve aliases
 


### PR DESCRIPTION
Fixes minor typo on docs