### PR TITLE
Improve `Head > script` coverage

### DIFF
--- a/test/development/pages-dir/client-navigation/fixture/next.config.js
+++ b/test/development/pages-dir/client-navigation/fixture/next.config.js
@@ -4,6 +4,6 @@ module.exports = {
     maxInactiveAge: 1000 * 60 * 60,
   },
   experimental: {
-    strictNextHead: true,
+    strictNextHead: process.env.TEST_STRICT_NEXT_HEAD === 'true',
   },
 }

--- a/test/development/pages-dir/client-navigation/fixture/next.config.js
+++ b/test/development/pages-dir/client-navigation/fixture/next.config.js
@@ -4,6 +4,6 @@ module.exports = {
     maxInactiveAge: 1000 * 60 * 60,
   },
   experimental: {
-    strictNextHead: process.env.TEST_STRICT_NEXT_HEAD === 'true',
+    strictNextHead: process.env.TEST_STRICT_NEXT_HEAD !== 'false',
   },
 }

--- a/test/development/pages-dir/client-navigation/fixture/pages/head.js
+++ b/test/development/pages-dir/client-navigation/fixture/pages/head.js
@@ -1,145 +1,165 @@
 import React from 'react'
 import Head from 'next/head'
 
-export default () => (
-  <div>
-    <Head>
-      {/* this will not render */}
-      <meta charSet="utf-8" />
-      {/* this will get rendered */}
-      <meta charSet="iso-8859-5" />
+export default function HeadPage() {
+  const [shouldReverseScriptOrder, reverseScriptOrder] = React.useReducer(
+    (b) => !b,
+    false
+  )
+  const [shouldInsertScript, toggleScript] = React.useReducer((b) => !b, false)
 
-      {/* this will not render */}
-      <meta name="viewport" content="width=device-width" />
-      {/* this will override the default */}
-      <meta name="viewport" content="width=device-width,initial-scale=1" />
+  const scriptAsyncTrue = <script src="/test-async-true.js" async></script>
+  const scriptAsyncFalse = (
+    <script src="/test-async-false.js" async={false}></script>
+  )
 
-      <meta content="my meta" />
+  return (
+    <div>
+      <Head>
+        {/* this will not render */}
+        <meta charSet="utf-8" />
+        {/* this will get rendered */}
+        <meta charSet="iso-8859-5" />
 
-      {/* this will not render the content prop */}
-      <meta name="empty-content" content={undefined} />
+        {/* this will not render */}
+        <meta name="viewport" content="width=device-width" />
+        {/* this will override the default */}
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
 
-      {/* allow duplicates for specific tags */}
-      <meta property="article:tag" content="tag1" key="tag1key" />
-      <meta property="article:tag" content="tag2" key="tag2key" />
-      <meta property="dedupe:tag" content="tag3" key="same-key" />
-      <meta property="dedupe:tag" content="tag4" key="same-key" />
-      <meta property="og:image" content="ogImageTag1" key="ogImageTag1Key" />
-      <meta property="og:image" content="ogImageTag2" key="ogImageTag2Key" />
-      <meta
-        property="og:image:alt"
-        content="ogImageAltTag1"
-        key="ogImageAltTag1Key"
-      />
-      <meta
-        property="og:image:alt"
-        content="ogImageAltTag2"
-        key="ogImageAltTag2Key"
-      />
-      <meta
-        property="og:image:width"
-        content="ogImageWidthTag1"
-        key="ogImageWidthTag1Key"
-      />
-      <meta
-        property="og:image:width"
-        content="ogImageWidthTag2"
-        key="ogImageWidthTag2Key"
-      />
-      <meta
-        property="og:image:height"
-        content="ogImageHeightTag1"
-        key="ogImageHeightTag1Key"
-      />
-      <meta
-        property="og:image:height"
-        content="ogImageHeightTag2"
-        key="ogImageHeightTag2Key"
-      />
-      <meta
-        property="og:image:type"
-        content="ogImageTypeTag1"
-        key="ogImageTypeTag1Key"
-      />
-      <meta
-        property="og:image:type"
-        content="ogImageTypeTag2"
-        key="ogImageTypeTag2Key"
-      />
-      <meta
-        property="og:image:secure_url"
-        content="ogImageSecureUrlTag1"
-        key="ogImageSecureUrlTag1Key"
-      />
-      <meta
-        property="og:image:secure_url"
-        content="ogImageSecureUrlTag2"
-        key="ogImageSecureUrlTag2Key"
-      />
-      <meta
-        property="og:image:url"
-        content="ogImageUrlTag1"
-        key="ogImageUrlTag1Key"
-      />
-      <meta
-        property="og:image:url"
-        content="ogImageUrlTag2"
-        key="ogImageUrlTag2Key"
-      />
+        <meta content="my meta" />
 
-      <meta property="fb:pages" content="fbpages1" />
-      <meta property="fb:pages" content="fbpages2" />
+        {/* this will not render the content prop */}
+        <meta name="empty-content" content={undefined} />
 
-      {/* both meta tags will be rendered since they use unique keys */}
-      <meta
-        name="citation_author"
-        content="authorName1"
-        key="citationAuthorTag1"
-      />
-      <meta
-        name="citation_author"
-        content="authorName2"
-        key="citationAuthorTag2"
-      />
-
-      <React.Fragment>
-        <title>Fragment title</title>
-        <meta content="meta fragment" />
-      </React.Fragment>
-
-      {/* the following 2 link tags will both be rendered */}
-      <link rel="stylesheet" href="/dup-style.css" />
-      <link rel="stylesheet" href="/dup-style.css" />
-
-      {/* only one tag will be rendered as they have the same key */}
-      <link rel="stylesheet" href="dedupe-style.css" key="my-style" />
-      <link rel="stylesheet" href="dedupe-style.css" key="my-style" />
-
-      {/* this should not execute twice on the client */}
-      <script src="/test-async-true.js" async></script>
-      {/* this should have async set to false on the client */}
-      <script src="/test-async-false.js" async={false}></script>
-      {/* this should not execute twice on the client (intentionally sets defer to `yas` to test boolean coercion) */}
-      <script src="/test-defer.js" defer="yas"></script>
-
-      {/* such style can be used for alternate links on _app vs individual pages */}
-      {['pl', 'en'].map((language) => (
-        <link
-          rel="alternate"
-          key={language}
-          hrefLang={language}
-          href={'/first/' + language}
+        {/* allow duplicates for specific tags */}
+        <meta property="article:tag" content="tag1" key="tag1key" />
+        <meta property="article:tag" content="tag2" key="tag2key" />
+        <meta property="dedupe:tag" content="tag3" key="same-key" />
+        <meta property="dedupe:tag" content="tag4" key="same-key" />
+        <meta property="og:image" content="ogImageTag1" key="ogImageTag1Key" />
+        <meta property="og:image" content="ogImageTag2" key="ogImageTag2Key" />
+        <meta
+          property="og:image:alt"
+          content="ogImageAltTag1"
+          key="ogImageAltTag1Key"
         />
-      ))}
-      {['pl', 'en'].map((language) => (
-        <link
-          rel="alternate"
-          key={language}
-          hrefLang={language}
-          href={'/last/' + language}
+        <meta
+          property="og:image:alt"
+          content="ogImageAltTag2"
+          key="ogImageAltTag2Key"
         />
-      ))}
-    </Head>
-    <h1>I can have meta tags</h1>
-  </div>
-)
+        <meta
+          property="og:image:width"
+          content="ogImageWidthTag1"
+          key="ogImageWidthTag1Key"
+        />
+        <meta
+          property="og:image:width"
+          content="ogImageWidthTag2"
+          key="ogImageWidthTag2Key"
+        />
+        <meta
+          property="og:image:height"
+          content="ogImageHeightTag1"
+          key="ogImageHeightTag1Key"
+        />
+        <meta
+          property="og:image:height"
+          content="ogImageHeightTag2"
+          key="ogImageHeightTag2Key"
+        />
+        <meta
+          property="og:image:type"
+          content="ogImageTypeTag1"
+          key="ogImageTypeTag1Key"
+        />
+        <meta
+          property="og:image:type"
+          content="ogImageTypeTag2"
+          key="ogImageTypeTag2Key"
+        />
+        <meta
+          property="og:image:secure_url"
+          content="ogImageSecureUrlTag1"
+          key="ogImageSecureUrlTag1Key"
+        />
+        <meta
+          property="og:image:secure_url"
+          content="ogImageSecureUrlTag2"
+          key="ogImageSecureUrlTag2Key"
+        />
+        <meta
+          property="og:image:url"
+          content="ogImageUrlTag1"
+          key="ogImageUrlTag1Key"
+        />
+        <meta
+          property="og:image:url"
+          content="ogImageUrlTag2"
+          key="ogImageUrlTag2Key"
+        />
+
+        <meta property="fb:pages" content="fbpages1" />
+        <meta property="fb:pages" content="fbpages2" />
+
+        {/* both meta tags will be rendered since they use unique keys */}
+        <meta
+          name="citation_author"
+          content="authorName1"
+          key="citationAuthorTag1"
+        />
+        <meta
+          name="citation_author"
+          content="authorName2"
+          key="citationAuthorTag2"
+        />
+
+        <React.Fragment>
+          <title>Fragment title</title>
+          <meta content="meta fragment" />
+        </React.Fragment>
+
+        {/* the following 2 link tags will both be rendered */}
+        <link rel="stylesheet" href="/dup-style.css" />
+        <link rel="stylesheet" href="/dup-style.css" />
+
+        {/* only one tag will be rendered as they have the same key */}
+        <link rel="stylesheet" href="dedupe-style.css" key="my-style" />
+        <link rel="stylesheet" href="dedupe-style.css" key="my-style" />
+
+        {shouldInsertScript ? scriptAsyncTrue : null}
+        {/* this should not execute twice on the client */}
+        {shouldReverseScriptOrder ? scriptAsyncTrue : scriptAsyncFalse}
+        {/* this should have async set to false on the client */}
+        {shouldReverseScriptOrder ? scriptAsyncFalse : scriptAsyncTrue}
+        {/* this should not execute twice on the client (intentionally sets defer to `yas` to test boolean coercion) */}
+        <script src="/test-defer.js" defer="yas"></script>
+
+        {/* such style can be used for alternate links on _app vs individual pages */}
+        {['pl', 'en'].map((language) => (
+          <link
+            rel="alternate"
+            key={language}
+            hrefLang={language}
+            href={'/first/' + language}
+          />
+        ))}
+        {['pl', 'en'].map((language) => (
+          <link
+            rel="alternate"
+            key={language}
+            hrefLang={language}
+            href={'/last/' + language}
+          />
+        ))}
+      </Head>
+      <h1>I can have meta tags</h1>
+      <button id="reverseScriptOrder" onClick={reverseScriptOrder}>
+        Reverse script order
+      </button>
+      <button id="toggleScript" onClick={toggleScript}>
+        Toggle script
+      </button>
+    </div>
+  )
+}

--- a/test/development/pages-dir/client-navigation/index.test.ts
+++ b/test/development/pages-dir/client-navigation/index.test.ts
@@ -1676,6 +1676,20 @@ describe.each([[false], [true]])(
         expect(
           Number(await browser.eval('window.__test_defer_executions'))
         ).toBe(1)
+
+        await browser.elementByCss('#reverseScriptOrder').click()
+        await waitFor(2000)
+
+        expect(
+          Number(await browser.eval('window.__test_async_executions'))
+        ).toBe(1)
+
+        await browser.elementByCss('#toggleScript').click()
+        await waitFor(2000)
+
+        expect(
+          Number(await browser.eval('window.__test_async_executions'))
+        ).toBe(1)
       } finally {
         if (browser) {
           await browser.close()

--- a/test/development/pages-dir/client-navigation/index.test.ts
+++ b/test/development/pages-dir/client-navigation/index.test.ts
@@ -5,13 +5,11 @@ import {
   getRedboxSource,
   hasRedbox,
   getRedboxHeader,
-  renderViaHTTP,
   waitFor,
   check,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import path from 'path'
-import renderingSuite from './rendering'
 import { nextTestSetup } from 'e2e-utils'
 
 describe('Client Navigation', () => {
@@ -1845,11 +1843,4 @@ describe('Client Navigation', () => {
 
     await browser.close()
   })
-
-  renderingSuite(
-    next,
-    (p, q) => renderViaHTTP(next.appPort, p, q),
-    (p, q) => fetchViaHTTP(next.appPort, p, q),
-    next
-  )
 })

--- a/test/development/pages-dir/client-navigation/rendering.test.ts
+++ b/test/development/pages-dir/client-navigation/rendering.test.ts
@@ -13,9 +13,12 @@ import { BUILD_MANIFEST, REACT_LOADABLE_MANIFEST } from 'next/constants'
 import path from 'path'
 import url from 'url'
 
-describe('Client Navigation rendering ', () => {
+describe('Client Navigation rendering', () => {
   const { next } = nextTestSetup({
     files: path.join(__dirname, 'fixture'),
+    env: {
+      TEST_STRICT_NEXT_HEAD: String(true),
+    },
   })
 
   function render(
@@ -56,14 +59,6 @@ describe('Client Navigation rendering ', () => {
       })
     })
 
-    it('should handle undefined prop in head server-side', async () => {
-      const html = await render('/head')
-      const $ = cheerio.load(html)
-      const value = 'content' in $('meta[name="empty-content"]').attr()
-
-      expect(value).toBe(false)
-    })
-
     test('renders with fragment syntax', async () => {
       const html = await render('/fragment-syntax')
       expect(html.includes('My component!')).toBeTruthy()
@@ -79,150 +74,6 @@ describe('Client Navigation rendering ', () => {
     test('renders when component is a memo instance', async () => {
       const html = await render('/memo-component')
       expect(html.includes('Memo component')).toBeTruthy()
-    })
-
-    // default-head contains an empty <Head />.
-    test('header renders default charset', async () => {
-      const html = await render('/default-head')
-      expect(html.includes('<meta charSet="utf-8"/>')).toBeTruthy()
-      expect(html.includes('next-head, but only once.')).toBeTruthy()
-    })
-
-    test('header renders default viewport', async () => {
-      const html = await render('/default-head')
-      expect(html).toContain(
-        '<meta name="viewport" content="width=device-width"/>'
-      )
-    })
-
-    test('header helper renders header information', async () => {
-      const html = await render('/head')
-      expect(html.includes('<meta charSet="iso-8859-5"/>')).toBeTruthy()
-      expect(html.includes('<meta content="my meta"/>')).toBeTruthy()
-      expect(html).toContain(
-        '<meta name="viewport" content="width=device-width,initial-scale=1"/>'
-      )
-      expect(html.includes('I can have meta tags')).toBeTruthy()
-    })
-
-    test('header helper dedupes tags', async () => {
-      const html = await render('/head')
-      expect(html).toContain('<meta charSet="iso-8859-5"/>')
-      expect(html).not.toContain('<meta charSet="utf-8"/>')
-      expect(html).toContain(
-        '<meta name="viewport" content="width=device-width,initial-scale=1"/>'
-      )
-      // Should contain only one viewport
-      expect(html.match(/<meta name="viewport" /g).length).toBe(1)
-      expect(html).not.toContain(
-        '<meta name="viewport" content="width=device-width"/>'
-      )
-      expect(html).toContain('<meta content="my meta"/>')
-      expect(html).toContain(
-        '<link rel="stylesheet" href="/dup-style.css"/><meta name="next-head" content="1"/><link rel="stylesheet" href="/dup-style.css"/>'
-      )
-      const dedupeLink = '<link rel="stylesheet" href="dedupe-style.css"/>'
-      expect(html).toContain(dedupeLink)
-      expect(
-        html.substring(html.indexOf(dedupeLink) + dedupeLink.length)
-      ).not.toContain('<link rel="stylesheet" href="dedupe-style.css"/>')
-      expect(html).toContain(
-        '<link rel="alternate" hrefLang="en" href="/last/en"/>'
-      )
-      expect(html).not.toContain(
-        '<link rel="alternate" hrefLang="en" href="/first/en"/>'
-      )
-    })
-
-    test('header helper dedupes tags with the same key as the default', async () => {
-      const html = await render('/head-duplicate-default-keys')
-      // Expect exactly one `charSet`
-      expect((html.match(/charSet=/g) || []).length).toBe(1)
-      // Expect exactly one `viewport`
-      expect((html.match(/name="viewport"/g) || []).length).toBe(1)
-      expect(html).toContain('<meta charSet="iso-8859-1"/>')
-      expect(html).toContain('<meta name="viewport" content="width=500"/>')
-    })
-
-    test('header helper avoids dedupe of specific tags', async () => {
-      const html = await render('/head')
-      expect(html).toContain('<meta property="article:tag" content="tag1"/>')
-      expect(html).toContain('<meta property="article:tag" content="tag2"/>')
-      expect(html).not.toContain('<meta property="dedupe:tag" content="tag3"/>')
-      expect(html).toContain('<meta property="dedupe:tag" content="tag4"/>')
-      expect(html).toContain(
-        '<meta property="og:image" content="ogImageTag1"/>'
-      )
-      expect(html).toContain(
-        '<meta property="og:image" content="ogImageTag2"/>'
-      )
-      expect(html).toContain(
-        '<meta property="og:image:alt" content="ogImageAltTag1"/>'
-      )
-      expect(html).toContain(
-        '<meta property="og:image:alt" content="ogImageAltTag2"/>'
-      )
-      expect(html).toContain(
-        '<meta property="og:image:width" content="ogImageWidthTag1"/>'
-      )
-      expect(html).toContain(
-        '<meta property="og:image:width" content="ogImageWidthTag2"/>'
-      )
-      expect(html).toContain(
-        '<meta property="og:image:height" content="ogImageHeightTag1"/>'
-      )
-      expect(html).toContain(
-        '<meta property="og:image:height" content="ogImageHeightTag2"/>'
-      )
-      expect(html).toContain(
-        '<meta property="og:image:type" content="ogImageTypeTag1"/>'
-      )
-      expect(html).toContain(
-        '<meta property="og:image:type" content="ogImageTypeTag2"/>'
-      )
-      expect(html).toContain(
-        '<meta property="og:image:secure_url" content="ogImageSecureUrlTag1"/>'
-      )
-      expect(html).toContain(
-        '<meta property="og:image:secure_url" content="ogImageSecureUrlTag2"/>'
-      )
-      expect(html).toContain(
-        '<meta property="og:image:url" content="ogImageUrlTag1"/>'
-      )
-      expect(html).toContain('<meta property="fb:pages" content="fbpages1"/>')
-      expect(html).toContain('<meta property="fb:pages" content="fbpages2"/>')
-    })
-
-    test('header helper avoids dedupe of meta tags with the same name if they use unique keys', async () => {
-      const html = await render('/head')
-      expect(html).toContain(
-        '<meta name="citation_author" content="authorName1"/>'
-      )
-      expect(html).toContain(
-        '<meta name="citation_author" content="authorName2"/>'
-      )
-    })
-
-    test('header helper renders Fragment children', async () => {
-      const html = await render('/head')
-      expect(html).toContain('<title>Fragment title</title>')
-      expect(html).toContain('<meta content="meta fragment"/>')
-    })
-
-    test('header helper renders boolean attributes correctly children', async () => {
-      const html = await render('/head')
-      expect(html).toContain('<script src="/test-async-true.js" async="">')
-      expect(html).toContain('<script src="/test-async-false.js">')
-      expect(html).toContain('<script src="/test-defer.js" defer="">')
-    })
-
-    it('should place charset element at the top of <head>', async () => {
-      const html = await render('/head-priority')
-      const nextHeadElement =
-        '<meta charSet="iso-8859-5"/><meta name="next-head" content="1"/><meta name="viewport" content="width=device-width,initial-scale=1"/><meta name="next-head" content="1"/><meta name="title" content="head title"/>'
-      const documentHeadElement =
-        '<meta name="keywords" content="document head test"/>'
-      expect(html).toContain(`${nextHeadElement}${documentHeadElement}`)
     })
 
     it('should render the page with custom extension', async () => {
@@ -469,3 +320,182 @@ describe('Client Navigation rendering ', () => {
     })
   })
 })
+
+describe.each([[false], [true]])(
+  'Client Navigation rendering <Head /> with strictNextHead=%s',
+  (strictNextHead) => {
+    const { next } = nextTestSetup({
+      files: path.join(__dirname, 'fixture'),
+      env: {
+        TEST_STRICT_NEXT_HEAD: String(strictNextHead),
+      },
+    })
+
+    function render(
+      pathname: Parameters<typeof renderViaHTTP>[1],
+      query?: Parameters<typeof renderViaHTTP>[2]
+    ) {
+      return renderViaHTTP(next.appPort, pathname, query)
+    }
+
+    it('should handle undefined prop in head server-side', async () => {
+      const html = await render('/head')
+      const $ = cheerio.load(html)
+      const value = 'content' in $('meta[name="empty-content"]').attr()
+
+      expect(value).toBe(false)
+    })
+
+    // default-head contains an empty <Head />.
+    test('header renders default charset', async () => {
+      const html = await render('/default-head')
+      expect(html.includes('<meta charSet="utf-8"/>')).toBeTruthy()
+      expect(html.includes('next-head, but only once.')).toBeTruthy()
+    })
+
+    test('header renders default viewport', async () => {
+      const html = await render('/default-head')
+      expect(html).toContain(
+        '<meta name="viewport" content="width=device-width"/>'
+      )
+    })
+
+    test('header helper renders header information', async () => {
+      const html = await render('/head')
+      expect(html.includes('<meta charSet="iso-8859-5"/>')).toBeTruthy()
+      expect(html.includes('<meta content="my meta"/>')).toBeTruthy()
+      expect(html).toContain(
+        '<meta name="viewport" content="width=device-width,initial-scale=1"/>'
+      )
+      expect(html.includes('I can have meta tags')).toBeTruthy()
+    })
+
+    test('header helper dedupes tags', async () => {
+      const html = await render('/head')
+      expect(html).toContain('<meta charSet="iso-8859-5"/>')
+      expect(html).not.toContain('<meta charSet="utf-8"/>')
+      expect(html).toContain(
+        '<meta name="viewport" content="width=device-width,initial-scale=1"/>'
+      )
+      // Should contain only one viewport
+      expect(html.match(/<meta name="viewport" /g).length).toBe(1)
+      expect(html).not.toContain(
+        '<meta name="viewport" content="width=device-width"/>'
+      )
+      expect(html).toContain('<meta content="my meta"/>')
+      expect(html).toContain(
+        strictNextHead
+          ? '<link rel="stylesheet" href="/dup-style.css"/><meta name="next-head" content="1"/><link rel="stylesheet" href="/dup-style.css"/>'
+          : '<link rel="stylesheet" href="/dup-style.css"/><link rel="stylesheet" href="/dup-style.css"/>'
+      )
+      const dedupeLink = '<link rel="stylesheet" href="dedupe-style.css"/>'
+      expect(html).toContain(dedupeLink)
+      expect(
+        html.substring(html.indexOf(dedupeLink) + dedupeLink.length)
+      ).not.toContain('<link rel="stylesheet" href="dedupe-style.css"/>')
+      expect(html).toContain(
+        '<link rel="alternate" hrefLang="en" href="/last/en"/>'
+      )
+      expect(html).not.toContain(
+        '<link rel="alternate" hrefLang="en" href="/first/en"/>'
+      )
+    })
+
+    test('header helper dedupes tags with the same key as the default', async () => {
+      const html = await render('/head-duplicate-default-keys')
+      // Expect exactly one `charSet`
+      expect((html.match(/charSet=/g) || []).length).toBe(1)
+      // Expect exactly one `viewport`
+      expect((html.match(/name="viewport"/g) || []).length).toBe(1)
+      expect(html).toContain('<meta charSet="iso-8859-1"/>')
+      expect(html).toContain('<meta name="viewport" content="width=500"/>')
+    })
+
+    test('header helper avoids dedupe of specific tags', async () => {
+      const html = await render('/head')
+      expect(html).toContain('<meta property="article:tag" content="tag1"/>')
+      expect(html).toContain('<meta property="article:tag" content="tag2"/>')
+      expect(html).not.toContain('<meta property="dedupe:tag" content="tag3"/>')
+      expect(html).toContain('<meta property="dedupe:tag" content="tag4"/>')
+      expect(html).toContain(
+        '<meta property="og:image" content="ogImageTag1"/>'
+      )
+      expect(html).toContain(
+        '<meta property="og:image" content="ogImageTag2"/>'
+      )
+      expect(html).toContain(
+        '<meta property="og:image:alt" content="ogImageAltTag1"/>'
+      )
+      expect(html).toContain(
+        '<meta property="og:image:alt" content="ogImageAltTag2"/>'
+      )
+      expect(html).toContain(
+        '<meta property="og:image:width" content="ogImageWidthTag1"/>'
+      )
+      expect(html).toContain(
+        '<meta property="og:image:width" content="ogImageWidthTag2"/>'
+      )
+      expect(html).toContain(
+        '<meta property="og:image:height" content="ogImageHeightTag1"/>'
+      )
+      expect(html).toContain(
+        '<meta property="og:image:height" content="ogImageHeightTag2"/>'
+      )
+      expect(html).toContain(
+        '<meta property="og:image:type" content="ogImageTypeTag1"/>'
+      )
+      expect(html).toContain(
+        '<meta property="og:image:type" content="ogImageTypeTag2"/>'
+      )
+      expect(html).toContain(
+        '<meta property="og:image:secure_url" content="ogImageSecureUrlTag1"/>'
+      )
+      expect(html).toContain(
+        '<meta property="og:image:secure_url" content="ogImageSecureUrlTag2"/>'
+      )
+      expect(html).toContain(
+        '<meta property="og:image:url" content="ogImageUrlTag1"/>'
+      )
+      expect(html).toContain('<meta property="fb:pages" content="fbpages1"/>')
+      expect(html).toContain('<meta property="fb:pages" content="fbpages2"/>')
+    })
+
+    test('header helper avoids dedupe of meta tags with the same name if they use unique keys', async () => {
+      const html = await render('/head')
+      expect(html).toContain(
+        '<meta name="citation_author" content="authorName1"/>'
+      )
+      expect(html).toContain(
+        '<meta name="citation_author" content="authorName2"/>'
+      )
+    })
+
+    test('header helper renders Fragment children', async () => {
+      const html = await render('/head')
+      expect(html).toContain('<title>Fragment title</title>')
+      expect(html).toContain('<meta content="meta fragment"/>')
+    })
+
+    test('header helper renders boolean attributes correctly children', async () => {
+      const html = await render('/head')
+      expect(html).toContain('<script src="/test-async-true.js" async="">')
+      expect(html).toContain('<script src="/test-async-false.js">')
+      expect(html).toContain('<script src="/test-defer.js" defer="">')
+    })
+
+    it('should place charset element at the top of <head>', async () => {
+      const html = await render('/head-priority')
+      const nextHeadElement = strictNextHead
+        ? '<meta charSet="iso-8859-5"/><meta name="next-head" content="1"/><meta name="viewport" content="width=device-width,initial-scale=1"/><meta name="next-head" content="1"/><meta name="title" content="head title"/>'
+        : '<meta charSet="iso-8859-5"/><meta name="viewport" content="width=device-width,initial-scale=1"/><meta name="title" content="head title"/><meta name="next-head-count" content="3"/>'
+      const documentHeadElement =
+        '<meta name="keywords" content="document head test"/>'
+
+      // charset is not actually at the top.
+      // data-next-hide-fouc comes first
+      expect(html).toContain(
+        `</style></noscript>${nextHeadElement}${documentHeadElement}`
+      )
+    })
+  }
+)

--- a/test/development/pages-dir/client-navigation/rendering.test.ts
+++ b/test/development/pages-dir/client-navigation/rendering.test.ts
@@ -1,13 +1,37 @@
 /* eslint-env jest */
 
 import cheerio from 'cheerio'
-import { type NextInstance } from 'e2e-utils'
-import { getRedboxHeader, hasRedbox } from 'next-test-utils'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  fetchViaHTTP,
+  getRedboxHeader,
+  hasRedbox,
+  renderViaHTTP,
+} from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { BUILD_MANIFEST, REACT_LOADABLE_MANIFEST } from 'next/constants'
+import path from 'path'
 import url from 'url'
 
-export default function (next: NextInstance, render, fetch, ctx) {
+describe('Client Navigation rendering ', () => {
+  const { next } = nextTestSetup({
+    files: path.join(__dirname, 'fixture'),
+  })
+
+  function render(
+    pathname: Parameters<typeof renderViaHTTP>[1],
+    query?: Parameters<typeof renderViaHTTP>[2]
+  ) {
+    return renderViaHTTP(next.appPort, pathname, query)
+  }
+
+  function fetch(
+    pathname: Parameters<typeof renderViaHTTP>[1],
+    query?: Parameters<typeof renderViaHTTP>[2]
+  ) {
+    return fetchViaHTTP(next.appPort, pathname, query)
+  }
+
   async function get$(path: any, query?: any) {
     const html = await render(path, query)
     return cheerio.load(html)
@@ -254,7 +278,7 @@ export default function (next: NextInstance, render, fetch, ctx) {
     })
 
     test('getInitialProps circular structure', async () => {
-      const browser = await webdriver(ctx.appPort, '/circular-json-error')
+      const browser = await webdriver(next.appPort, '/circular-json-error')
       const expectedErrorMessage =
         'Circular structure in "getInitialProps" result of page "/circular-json-error".'
 
@@ -265,7 +289,7 @@ export default function (next: NextInstance, render, fetch, ctx) {
 
     test('getInitialProps should be class method', async () => {
       const browser = await webdriver(
-        ctx.appPort,
+        next.appPort,
         '/instance-get-initial-props'
       )
 
@@ -278,7 +302,7 @@ export default function (next: NextInstance, render, fetch, ctx) {
     })
 
     test('getInitialProps resolves to null', async () => {
-      const browser = await webdriver(ctx.appPort, '/empty-get-initial-props')
+      const browser = await webdriver(next.appPort, '/empty-get-initial-props')
       const expectedErrorMessage =
         '"EmptyInitialPropsPage.getInitialProps()" should resolve to an object. But found "null" instead.'
 
@@ -317,14 +341,14 @@ export default function (next: NextInstance, render, fetch, ctx) {
     })
 
     test('default export is not a React Component', async () => {
-      const browser = await webdriver(ctx.appPort, '/no-default-export')
+      const browser = await webdriver(next.appPort, '/no-default-export')
       expect(await hasRedbox(browser)).toBe(true)
       const text = await getRedboxHeader(browser)
       expect(text).toMatch(/The default export is not a React Component/)
     })
 
     test('error-inside-page', async () => {
-      const browser = await webdriver(ctx.appPort, '/error-inside-page')
+      const browser = await webdriver(next.appPort, '/error-inside-page')
       expect(await hasRedbox(browser)).toBe(true)
       const text = await getRedboxHeader(browser)
       expect(text).toMatch(/This is an expected error/)
@@ -332,7 +356,10 @@ export default function (next: NextInstance, render, fetch, ctx) {
     })
 
     test('error-in-the-global-scope', async () => {
-      const browser = await webdriver(ctx.appPort, '/error-in-the-global-scope')
+      const browser = await webdriver(
+        next.appPort,
+        '/error-in-the-global-scope'
+      )
       expect(await hasRedbox(browser)).toBe(true)
       const text = await getRedboxHeader(browser)
       expect(text).toMatch(/aa is not defined/)
@@ -432,7 +459,7 @@ export default function (next: NextInstance, render, fetch, ctx) {
     })
 
     it('should show a valid error when undefined is thrown', async () => {
-      const browser = await webdriver(ctx.appPort, '/throw-undefined')
+      const browser = await webdriver(next.appPort, '/throw-undefined')
       expect(await hasRedbox(browser)).toBe(true)
       const text = await getRedboxHeader(browser)
 
@@ -441,4 +468,4 @@ export default function (next: NextInstance, render, fetch, ctx) {
       )
     })
   })
-}
+})


### PR DESCRIPTION
The "Client navigation" tests for `Head` now run for each value of `nextStrictHead`. I also added some tests for how reordering `<script>` behaves client-side.



Closes NEXT-3324