### PR TITLE
Pages router: Enable strict `next/head` children reconciler by default

### DIFF
--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -220,7 +220,7 @@ export function getDefineEnv({
     ...getImageConfig(config, dev),
     'process.env.__NEXT_ROUTER_BASEPATH': config.basePath,
     'process.env.__NEXT_STRICT_NEXT_HEAD':
-      config.experimental.strictNextHead ?? false,
+      config.experimental.strictNextHead ?? true,
     'process.env.__NEXT_HAS_REWRITES': hasRewrites,
     'process.env.__NEXT_CONFIG_OUTPUT': config.output,
     'process.env.__NEXT_I18N_SUPPORT': !!config.i18n,

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -419,7 +419,7 @@ export async function exportAppImpl(
           serverActionsManifest,
         }
       : {}),
-    strictNextHead: !!nextConfig.experimental.strictNextHead,
+    strictNextHead: nextConfig.experimental.strictNextHead ?? true,
     deploymentId: nextConfig.deploymentId,
     experimental: {
       ppr: nextConfig.experimental.ppr === true,

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -511,7 +511,7 @@ export default abstract class Server<
       supportsDynamicHTML: true,
       trailingSlash: this.nextConfig.trailingSlash,
       deploymentId: this.nextConfig.deploymentId,
-      strictNextHead: !!this.nextConfig.experimental.strictNextHead,
+      strictNextHead: this.nextConfig.experimental.strictNextHead ?? true,
       poweredByHeader: this.nextConfig.poweredByHeader,
       canonicalBase: this.nextConfig.amp.canonicalBase || '',
       buildId: this.buildId,

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -188,6 +188,7 @@ export interface ExperimentalConfig {
   caseSensitiveRoutes?: boolean
   appDocumentPreloading?: boolean
   preloadEntriesOnStart?: boolean
+  /** @default true */
   strictNextHead?: boolean
   clientRouterFilter?: boolean
   clientRouterFilterRedirects?: boolean

--- a/test/e2e/next-head/index.test.ts
+++ b/test/e2e/next-head/index.test.ts
@@ -14,11 +14,6 @@ describe('next/head', () => {
         pages: new FileRef(join(__dirname, 'app/pages')),
         components: new FileRef(join(__dirname, 'app/components')),
       },
-      nextConfig: {
-        experimental: {
-          strictNextHead: true,
-        },
-      },
     })
   })
   afterAll(() => next.destroy())


### PR DESCRIPTION
Enables the new `hext/head` children reconciler introduced in https://github.com/vercel/next.js/pull/65408 by default.

The non-strict one is not compatible with React 19. To opt-out, explicitly set `experimental.strictNextHead` to `false`. `undefined` or `null` will still enable the new reconciler.

Closes NEXT-3330