### PR TITLE
fix(next-core): mark turbopack embed fs to be internals

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_client/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/context.rs
@@ -178,6 +178,16 @@ pub async fn get_client_resolve_options_context(
     .cell())
 }
 
+fn internal_assets_conditions() -> ContextCondition {
+    ContextCondition::any(vec![
+        ContextCondition::InPath(next_js_fs().root()),
+        ContextCondition::InPath(
+            turbopack_binding::turbopack::ecmascript_runtime::embed_fs().root(),
+        ),
+        ContextCondition::InPath(turbopack_binding::turbopack::node::embed_js::embed_fs().root()),
+    ])
+}
+
 #[turbo_tasks::function]
 pub async fn get_client_module_options_context(
     project_path: Vc<FileSystemPath>,
@@ -288,10 +298,8 @@ pub async fn get_client_module_options_context(
                 foreign_code_context_condition(next_config, project_path).await?,
                 foreign_codes_options_context.cell(),
             ),
-            // If the module is an internal asset (i.e overlay, fallback) coming from the embedded
-            // FS, don't apply user defined transforms.
             (
-                ContextCondition::InPath(next_js_fs().root()),
+                internal_assets_conditions(),
                 ModuleOptionsContext {
                     enable_typescript_transform: Some(TypescriptTransformOptions::default().cell()),
                     enable_jsx: Some(JsxTransformOptions::default().cell()),

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -312,6 +312,23 @@ pub async fn get_server_compile_time_info(
     .cell()
 }
 
+/// Determins if the module is an internal asset (i.e overlay, fallback) coming
+/// from the embedded FS, don't apply user defined transforms.
+///
+/// [TODO] turbopack specific embed fs should be handled by internals of
+/// turbopack itself and user config should not try to leak this. However,
+/// currently we apply few transform options subject to next.js's configuration
+/// even if it's embedded assets.
+fn internal_assets_conditions() -> ContextCondition {
+    ContextCondition::any(vec![
+        ContextCondition::InPath(next_js_fs().root()),
+        ContextCondition::InPath(
+            turbopack_binding::turbopack::ecmascript_runtime::embed_fs().root(),
+        ),
+        ContextCondition::InPath(turbopack_binding::turbopack::node::embed_js::embed_fs().root()),
+    ])
+}
+
 #[turbo_tasks::function]
 pub async fn get_server_module_options_context(
     project_path: Vc<FileSystemPath>,
@@ -485,7 +502,7 @@ pub async fn get_server_module_options_context(
                         foreign_code_module_options_context.cell(),
                     ),
                     (
-                        ContextCondition::InPath(next_js_fs().root()),
+                        internal_assets_conditions(),
                         internal_module_options_context.cell(),
                     ),
                 ],
@@ -537,7 +554,7 @@ pub async fn get_server_module_options_context(
                         foreign_code_module_options_context.cell(),
                     ),
                     (
-                        ContextCondition::InPath(next_js_fs().root()),
+                        internal_assets_conditions(),
                         internal_module_options_context.cell(),
                     ),
                 ],
@@ -604,7 +621,7 @@ pub async fn get_server_module_options_context(
                         foreign_code_module_options_context.cell(),
                     ),
                     (
-                        ContextCondition::InPath(next_js_fs().root()),
+                        internal_assets_conditions(),
                         internal_module_options_context.cell(),
                     ),
                 ],
@@ -667,7 +684,7 @@ pub async fn get_server_module_options_context(
                         foreign_code_module_options_context.cell(),
                     ),
                     (
-                        ContextCondition::InPath(next_js_fs().root()),
+                        internal_assets_conditions(),
                         internal_module_options_context.cell(),
                     ),
                 ],
@@ -714,7 +731,7 @@ pub async fn get_server_module_options_context(
                         foreign_code_module_options_context.cell(),
                     ),
                     (
-                        ContextCondition::InPath(next_js_fs().root()),
+                        internal_assets_conditions(),
                         internal_module_options_context.cell(),
                     ),
                 ],


### PR DESCRIPTION

### What?

We were marking only next.js specific embed_fs as internals, in result user transform runs against turbopack's runtime.