### PR TITLE
Apply react-server conditions to middleware

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_edge/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_edge/context.rs
@@ -99,9 +99,6 @@ pub async fn get_edge_resolve_options_context(
         get_next_edge_import_map(project_path, ty, next_config, execution_context);
 
     let ty = ty.into_value();
-    let invalid_client_only_resolve_plugin = get_invalid_client_only_resolve_plugin(project_path);
-    let invalid_styled_jsx_client_only_resolve_plugin =
-        get_invalid_styled_jsx_resolve_plugin(project_path);
 
     let mut plugins = match ty {
         ServerContextType::Pages { .. }
@@ -115,8 +112,8 @@ pub async fn get_edge_resolve_options_context(
         | ServerContextType::Middleware { .. }
         | ServerContextType::Instrumentation => {
             vec![
-                Vc::upcast(invalid_client_only_resolve_plugin),
-                Vc::upcast(invalid_styled_jsx_client_only_resolve_plugin),
+                Vc::upcast(get_invalid_client_only_resolve_plugin(project_path)),
+                Vc::upcast(get_invalid_styled_jsx_resolve_plugin(project_path)),
             ]
         }
     };

--- a/packages/next-swc/crates/next-core/src/next_edge/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_edge/context.rs
@@ -104,12 +104,13 @@ pub async fn get_edge_resolve_options_context(
         get_invalid_styled_jsx_resolve_plugin(project_path);
 
     let plugins = match ty {
-        ServerContextType::Pages { .. } => {
+        ServerContextType::AppSSR { .. }
+        | ServerContextType::PagesData { .. }
+        | ServerContextType::PagesApi { .. }
+        | ServerContextType::Pages { .. } => {
             vec![]
         }
-        ServerContextType::PagesData { .. }
-        | ServerContextType::PagesApi { .. }
-        | ServerContextType::AppRSC { .. }
+        ServerContextType::AppRSC { .. }
         | ServerContextType::AppRoute { .. }
         | ServerContextType::Middleware { .. }
         | ServerContextType::Instrumentation => {
@@ -117,9 +118,6 @@ pub async fn get_edge_resolve_options_context(
                 Vc::upcast(invalid_client_only_resolve_plugin),
                 Vc::upcast(invalid_styled_jsx_client_only_resolve_plugin),
             ]
-        }
-        ServerContextType::AppSSR { .. } => {
-            vec![]
         }
     };
 

--- a/packages/next-swc/crates/next-core/src/next_edge/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_edge/context.rs
@@ -105,13 +105,13 @@ pub async fn get_edge_resolve_options_context(
 
     let mut plugins = match ty {
         ServerContextType::Pages { .. }
-        | ServerContextType::PagesData { .. }
-        | ServerContextType::PagesApi { .. } => {
+        | ServerContextType::PagesApi { .. }
+        | ServerContextType::AppSSR { .. } => {
             vec![]
         }
         ServerContextType::AppRSC { .. }
-        | ServerContextType::AppSSR { .. }
         | ServerContextType::AppRoute { .. }
+        | ServerContextType::PagesData { .. }
         | ServerContextType::Middleware { .. }
         | ServerContextType::Instrumentation => {
             vec![

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -613,6 +613,7 @@ async fn insert_next_server_special_aliases(
         | ServerContextType::PagesApi { .. }
         | ServerContextType::AppRSC { .. }
         | ServerContextType::AppRoute { .. }
+        | ServerContextType::Middleware { .. }
         | ServerContextType::Instrumentation => {
             insert_exact_alias_map(
                 import_map,
@@ -636,23 +637,24 @@ async fn insert_next_server_special_aliases(
                     "next/dist/compiled/client-only" => "next/dist/compiled/client-only/index".to_string(),
                 },
             );
-        }
-        // Potential the bundle introduced into middleware and api can be poisoned by
-        // client-only but not being used, so we disabled the `client-only` erroring
-        // on these layers. `server-only` is still available.
-        ServerContextType::Middleware => {
-            insert_exact_alias_map(
-                import_map,
-                project_path,
-                indexmap! {
-                    "server-only" => "next/dist/compiled/server-only/empty".to_string(),
-                    "client-only" => "next/dist/compiled/client-only/index".to_string(),
-                    "next/dist/compiled/server-only" => "next/dist/compiled/server-only/empty".to_string(),
-                    "next/dist/compiled/client-only" => "next/dist/compiled/client-only/index".to_string(),
-                    "next/dist/compiled/client-only/error" => "next/dist/compiled/client-only/index".to_string(),
-                },
-            );
-        }
+        } /* Potential the bundle introduced into middleware and api can be poisoned by
+           * client-only but not being used, so we disabled the `client-only` erroring
+           * on these layers. `server-only` is still available.
+           * ServerContextType::Middleware => {
+           *     insert_exact_alias_map(
+           *         import_map,
+           *         project_path,
+           *         indexmap! {
+           *             "server-only" => "next/dist/compiled/server-only/empty".to_string(),
+           *             "client-only" => "next/dist/compiled/client-only/index".to_string(),
+           *             "next/dist/compiled/server-only" =>
+           * "next/dist/compiled/server-only/empty".to_string(),
+           * "next/dist/compiled/client-only" =>
+           * "next/dist/compiled/client-only/index".to_string(),
+           * "next/dist/compiled/client-only/error" =>
+           * "next/dist/compiled/client-only/index".to_string(),         },
+           *     );
+           * } */
     }
 
     import_map.insert_exact_alias(

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -637,24 +637,7 @@ async fn insert_next_server_special_aliases(
                     "next/dist/compiled/client-only" => "next/dist/compiled/client-only/index".to_string(),
                 },
             );
-        } /* Potential the bundle introduced into middleware and api can be poisoned by
-           * client-only but not being used, so we disabled the `client-only` erroring
-           * on these layers. `server-only` is still available.
-           * ServerContextType::Middleware => {
-           *     insert_exact_alias_map(
-           *         import_map,
-           *         project_path,
-           *         indexmap! {
-           *             "server-only" => "next/dist/compiled/server-only/empty".to_string(),
-           *             "client-only" => "next/dist/compiled/client-only/index".to_string(),
-           *             "next/dist/compiled/server-only" =>
-           * "next/dist/compiled/server-only/empty".to_string(),
-           * "next/dist/compiled/client-only" =>
-           * "next/dist/compiled/client-only/index".to_string(),
-           * "next/dist/compiled/client-only/error" =>
-           * "next/dist/compiled/client-only/index".to_string(),         },
-           *     );
-           * } */
+        }
     }
 
     import_map.insert_exact_alias(

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -232,6 +232,7 @@ pub async fn get_server_resolve_options_context(
         | ServerContextType::PagesApi { .. }
         | ServerContextType::AppRSC { .. }
         | ServerContextType::AppRoute { .. }
+        | ServerContextType::Middleware { .. }
         | ServerContextType::Instrumentation => {
             plugins.push(Vc::upcast(invalid_client_only_resolve_plugin));
             plugins.push(Vc::upcast(invalid_styled_jsx_client_only_resolve_plugin));
@@ -239,10 +240,9 @@ pub async fn get_server_resolve_options_context(
         ServerContextType::AppSSR { .. } => {
             //[TODO] Build error in this context makes rsc-build-error.ts fail which expects runtime error code
             // looks like webpack and turbopack have different order, webpack runs rsc transform first, turbopack triggers resolve plugin first.
-        }
-        ServerContextType::Middleware => {
-            //noop
-        }
+        } /* ServerContextType::Middleware => {
+           *     //noop
+           * } */
     }
 
     let resolve_options_context = ResolveOptionsContext {

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -188,7 +188,8 @@ pub async fn get_server_resolve_options_context(
                 Vc::upcast(next_external_plugin),
             ]
         }
-        ServerContextType::AppSSR { .. }
+        ServerContextType::PagesData { .. }
+        | ServerContextType::AppSSR { .. }
         | ServerContextType::AppRSC { .. }
         | ServerContextType::AppRoute { .. } => {
             vec![

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -179,7 +179,9 @@ pub async fn get_server_resolve_options_context(
         NextNodeSharedRuntimeResolvePlugin::new(project_path, Value::new(ty));
 
     let mut plugins = match ty {
-        ServerContextType::Pages { .. } | ServerContextType::PagesApi { .. } => {
+        ServerContextType::Pages { .. }
+        | ServerContextType::PagesApi { .. }
+        | ServerContextType::PagesData { .. } => {
             vec![
                 Vc::upcast(module_feature_report_resolve_plugin),
                 Vc::upcast(unsupported_modules_resolve_plugin),
@@ -188,8 +190,7 @@ pub async fn get_server_resolve_options_context(
                 Vc::upcast(next_external_plugin),
             ]
         }
-        ServerContextType::PagesData { .. }
-        | ServerContextType::AppSSR { .. }
+        ServerContextType::AppSSR { .. }
         | ServerContextType::AppRSC { .. }
         | ServerContextType::AppRoute { .. } => {
             vec![

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -105,6 +105,7 @@ impl ServerContextType {
             ServerContextType::AppRSC { .. }
                 | ServerContextType::AppRoute { .. }
                 | ServerContextType::PagesApi { .. }
+                | ServerContextType::Middleware { .. }
         )
     }
 }

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -179,9 +179,7 @@ pub async fn get_server_resolve_options_context(
         NextNodeSharedRuntimeResolvePlugin::new(project_path, Value::new(ty));
 
     let mut plugins = match ty {
-        ServerContextType::Pages { .. }
-        | ServerContextType::PagesData { .. }
-        | ServerContextType::PagesApi { .. } => {
+        ServerContextType::Pages { .. } | ServerContextType::PagesApi { .. } => {
             vec![
                 Vc::upcast(module_feature_report_resolve_plugin),
                 Vc::upcast(unsupported_modules_resolve_plugin),
@@ -226,11 +224,10 @@ pub async fn get_server_resolve_options_context(
     // means each resolve plugin must be injected only for the context where the
     // alias resolves into the error. The alias lives in here: https://github.com/vercel/next.js/blob/0060de1c4905593ea875fa7250d4b5d5ce10897d/packages/next-swc/crates/next-core/src/next_import_map.rs#L534
     match ty {
-        ServerContextType::Pages { .. } => {
+        ServerContextType::Pages { .. } | ServerContextType::PagesApi { .. } => {
             //noop
         }
         ServerContextType::PagesData { .. }
-        | ServerContextType::PagesApi { .. }
         | ServerContextType::AppRSC { .. }
         | ServerContextType::AppRoute { .. }
         | ServerContextType::Middleware { .. }
@@ -241,9 +238,7 @@ pub async fn get_server_resolve_options_context(
         ServerContextType::AppSSR { .. } => {
             //[TODO] Build error in this context makes rsc-build-error.ts fail which expects runtime error code
             // looks like webpack and turbopack have different order, webpack runs rsc transform first, turbopack triggers resolve plugin first.
-        } /* ServerContextType::Middleware => {
-           *     //noop
-           * } */
+        }
     }
 
     let resolve_options_context = ResolveOptionsContext {

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -6,6 +6,7 @@ import type {
   StyledComponentsConfig,
 } from '../../server/config-shared'
 import type { ResolvedBaseUrl } from '../load-jsconfig'
+import { isWebpackServerOnlyLayer } from '../utils'
 
 const nextDistPath =
   /(next[\\/]dist[\\/]shared[\\/]lib)|(next[\\/]dist[\\/]client)|(next[\\/]dist[\\/]pages)/
@@ -78,8 +79,7 @@ function getBaseSWCOptions({
   serverComponents?: boolean
   bundleLayer?: WebpackLayerName
 }) {
-  const isReactServerLayer =
-    bundleLayer === WEBPACK_LAYERS.reactServerComponents
+  const isReactServerLayer = isWebpackServerOnlyLayer(bundleLayer)
   const parserConfig = getParserOptions({ filename, jsConfig })
   const paths = jsConfig?.compilerOptions?.paths
   const enableDecorators = Boolean(

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -509,7 +509,7 @@ export default async function getBaseWebpackConfig(
     // This will cause some performance overhead but
     // acceptable as Babel will not be recommended.
     getSwcLoader({
-      serverComponents: false,
+      serverComponents: true,
       bundleLayer: WEBPACK_LAYERS.middleware,
     }),
     babelLoader,
@@ -560,7 +560,7 @@ export default async function getBaseWebpackConfig(
   const apiRoutesLayerLoaders =
     hasAppDir && useSWCLoader
       ? getSwcLoader({
-          serverComponents: false,
+          serverComponents: true,
           bundleLayer: WEBPACK_LAYERS.api,
         })
       : defaultLoaders.babel
@@ -1206,10 +1206,7 @@ export default async function getBaseWebpackConfig(
         // Alias server-only and client-only to proper exports based on bundling layers
         {
           issuerLayer: {
-            or: [
-              ...WEBPACK_LAYERS.GROUP.serverOnly,
-              ...WEBPACK_LAYERS.GROUP.nonClientServerTarget,
-            ],
+            or: WEBPACK_LAYERS.GROUP.serverOnly,
           },
           resolve: {
             // Error on client-only but allow server-only
@@ -1218,10 +1215,7 @@ export default async function getBaseWebpackConfig(
         },
         {
           issuerLayer: {
-            not: [
-              ...WEBPACK_LAYERS.GROUP.serverOnly,
-              ...WEBPACK_LAYERS.GROUP.nonClientServerTarget,
-            ],
+            not: WEBPACK_LAYERS.GROUP.serverOnly,
           },
           resolve: {
             // Error on server-only but allow client-only
@@ -1250,10 +1244,7 @@ export default async function getBaseWebpackConfig(
           ],
           loader: 'next-invalid-import-error-loader',
           issuerLayer: {
-            not: [
-              ...WEBPACK_LAYERS.GROUP.serverOnly,
-              ...WEBPACK_LAYERS.GROUP.nonClientServerTarget,
-            ],
+            not: WEBPACK_LAYERS.GROUP.serverOnly,
           },
           options: {
             message:
@@ -1270,7 +1261,7 @@ export default async function getBaseWebpackConfig(
           ],
           loader: 'empty-loader',
           issuerLayer: {
-            or: WEBPACK_LAYERS.GROUP.nonClientServerTarget,
+            not: WEBPACK_LAYERS.GROUP.serverOnly,
           },
         },
         ...(hasAppDir

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -509,7 +509,7 @@ export default async function getBaseWebpackConfig(
     // This will cause some performance overhead but
     // acceptable as Babel will not be recommended.
     getSwcLoader({
-      serverComponents: true,
+      serverComponents: false,
       bundleLayer: WEBPACK_LAYERS.middleware,
     }),
     babelLoader,
@@ -560,7 +560,7 @@ export default async function getBaseWebpackConfig(
   const apiRoutesLayerLoaders =
     hasAppDir && useSWCLoader
       ? getSwcLoader({
-          serverComponents: true,
+          serverComponents: false,
           bundleLayer: WEBPACK_LAYERS.api,
         })
       : defaultLoaders.babel
@@ -1206,7 +1206,10 @@ export default async function getBaseWebpackConfig(
         // Alias server-only and client-only to proper exports based on bundling layers
         {
           issuerLayer: {
-            or: WEBPACK_LAYERS.GROUP.serverOnly,
+            or: [
+              ...WEBPACK_LAYERS.GROUP.serverOnly,
+              ...WEBPACK_LAYERS.GROUP.neutralTarget,
+            ],
           },
           resolve: {
             // Error on client-only but allow server-only
@@ -1215,7 +1218,10 @@ export default async function getBaseWebpackConfig(
         },
         {
           issuerLayer: {
-            not: WEBPACK_LAYERS.GROUP.serverOnly,
+            not: [
+              ...WEBPACK_LAYERS.GROUP.serverOnly,
+              ...WEBPACK_LAYERS.GROUP.neutralTarget,
+            ],
           },
           resolve: {
             // Error on server-only but allow client-only
@@ -1244,7 +1250,10 @@ export default async function getBaseWebpackConfig(
           ],
           loader: 'next-invalid-import-error-loader',
           issuerLayer: {
-            not: WEBPACK_LAYERS.GROUP.serverOnly,
+            not: [
+              ...WEBPACK_LAYERS.GROUP.serverOnly,
+              ...WEBPACK_LAYERS.GROUP.neutralTarget,
+            ],
           },
           options: {
             message:
@@ -1261,7 +1270,7 @@ export default async function getBaseWebpackConfig(
           ],
           loader: 'empty-loader',
           issuerLayer: {
-            not: WEBPACK_LAYERS.GROUP.serverOnly,
+            or: WEBPACK_LAYERS.GROUP.neutralTarget,
           },
         },
         ...(hasAppDir

--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -168,15 +168,12 @@ const WEBPACK_LAYERS = {
       WEBPACK_LAYERS_NAMES.appMetadataRoute,
       WEBPACK_LAYERS_NAMES.appRouteHandler,
       WEBPACK_LAYERS_NAMES.instrument,
+      WEBPACK_LAYERS_NAMES.middleware,
+      WEBPACK_LAYERS_NAMES.api,
     ],
     clientOnly: [
       WEBPACK_LAYERS_NAMES.serverSideRendering,
       WEBPACK_LAYERS_NAMES.appPagesBrowser,
-    ],
-    nonClientServerTarget: [
-      // middleware and pages api
-      WEBPACK_LAYERS_NAMES.middleware,
-      WEBPACK_LAYERS_NAMES.api,
     ],
     app: [
       WEBPACK_LAYERS_NAMES.reactServerComponents,

--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -169,6 +169,9 @@ const WEBPACK_LAYERS = {
       WEBPACK_LAYERS_NAMES.appRouteHandler,
       WEBPACK_LAYERS_NAMES.instrument,
       WEBPACK_LAYERS_NAMES.middleware,
+    ],
+    neutralTarget: [
+      // pages api
       WEBPACK_LAYERS_NAMES.api,
     ],
     clientOnly: [

--- a/test/e2e/module-layer/middleware.js
+++ b/test/e2e/module-layer/middleware.js
@@ -1,7 +1,11 @@
 import 'server-only'
+import React from 'react'
 import { NextResponse } from 'next/server'
 // import './lib/mixed-lib'
 
 export function middleware(request) {
+  if (React.useState) {
+    throw new Error('React.useState should not be defined in server layer')
+  }
   return NextResponse.next()
 }

--- a/test/e2e/module-layer/module-layer.test.ts
+++ b/test/e2e/module-layer/module-layer.test.ts
@@ -112,15 +112,10 @@ describe('module layer', () => {
         await next.patchFile(pagesApiFile, pagesApiContent)
       })
 
-      it('should error when import client packages in pages/api', async () => {
-        const existingCliOutputLength = next.cliOutput.length
+      it('should not error when import client packages in pages/api', async () => {
         await retry(async () => {
-          await next.fetch('/api/mixed')
-          const newCliOutput = next.cliOutput.slice(existingCliOutputLength)
-          expect(newCliOutput).toContain('./pages/api/mixed.js')
-          expect(newCliOutput).toContain(
-            `'client-only' cannot be imported from a Server Component module. It should only be used from a Client Component.`
-          )
+          const { status } = await next.fetch('/api/mixed')
+          expect(status).toBe(200)
         })
       })
     })

--- a/test/e2e/module-layer/module-layer.test.ts
+++ b/test/e2e/module-layer/module-layer.test.ts
@@ -1,7 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
 
 describe('module layer', () => {
-  const { next, isNextStart } = nextTestSetup({
+  const { next, isNextStart, isNextDev } = nextTestSetup({
     files: __dirname,
   })
 
@@ -59,43 +60,72 @@ describe('module layer', () => {
     }
   }
 
-  describe('no server-only in server targets', () => {
-    const middlewareFile = 'middleware.js'
-    // const pagesApiFile = 'pages/api/hello.js'
-    let middlewareContent = ''
-    // let pagesApiContent = ''
+  if (isNextDev) {
+    describe('client packages in middleware', () => {
+      const middlewareFile = 'middleware.js'
+      let middlewareContent = ''
 
-    beforeAll(async () => {
-      await next.stop()
+      beforeAll(async () => {
+        await next.stop()
 
-      middlewareContent = await next.readFile(middlewareFile)
-      // pagesApiContent = await next.readFile(pagesApiFile)
+        middlewareContent = await next.readFile(middlewareFile)
 
-      await next.patchFile(
-        middlewareFile,
-        middlewareContent
-          .replace("import 'server-only'", "// import 'server-only'")
-          .replace("// import './lib/mixed-lib'", "import './lib/mixed-lib'")
-      )
+        await next.patchFile(
+          middlewareFile,
+          middlewareContent
+            .replace("import 'server-only'", "// import 'server-only'")
+            .replace("// import './lib/mixed-lib'", "import './lib/mixed-lib'")
+        )
 
-      // await next.patchFile(
-      //   pagesApiFile,
-      //   pagesApiContent
-      //     .replace("import 'server-only'", "// import 'server-only'")
-      //     .replace(
-      //       "// import '../../lib/mixed-lib'",
-      //       "import '../../lib/mixed-lib'"
-      //     )
-      // )
+        await next.start()
+      })
+      afterAll(async () => {
+        await next.patchFile(middlewareFile, middlewareContent)
+      })
 
-      await next.start()
+      it('should error when import server packages in middleware', async () => {
+        const existingCliOutputLength = next.cliOutput.length
+        await next.fetch('/')
+
+        const newCliOutput = next.cliOutput.slice(existingCliOutputLength)
+        expect(newCliOutput).toContain('./middleware.js')
+        expect(newCliOutput).toContain(
+          `'client-only' cannot be imported from a Server Component module. It should only be used from a Client Component`
+        )
+      })
     })
-    afterAll(async () => {
-      await next.patchFile(middlewareFile, middlewareContent)
-      // await next.patchFile(pagesApiFile, pagesApiContent)
+
+    describe('client packages in pages api', () => {
+      const pagesApiFile = 'pages/api/mixed.js'
+      let pagesApiContent
+      beforeAll(async () => {
+        pagesApiContent = await next.readFile(pagesApiFile)
+        await next.patchFile(
+          pagesApiFile,
+          pagesApiContent.replace(
+            "// import '../../lib/mixed-lib'",
+            "import '../../lib/mixed-lib'"
+          )
+        )
+      })
+      afterAll(async () => {
+        await next.patchFile(pagesApiFile, pagesApiContent)
+      })
+
+      it('should error when import client packages in pages/api', async () => {
+        const existingCliOutputLength = next.cliOutput.length
+        await retry(async () => {
+          await next.fetch('/api/mixed')
+          const newCliOutput = next.cliOutput.slice(existingCliOutputLength)
+          expect(newCliOutput).toContain('./pages/api/mixed.js')
+          expect(newCliOutput).toContain(
+            `'client-only' cannot be imported from a Server Component module. It should only be used from a Client Component.`
+          )
+        })
+      })
     })
-    runTests()
-  })
+  }
+
   describe('with server-only in server targets', () => {
     runTests()
   })

--- a/test/e2e/module-layer/module-layer.test.ts
+++ b/test/e2e/module-layer/module-layer.test.ts
@@ -99,31 +99,6 @@ describe('module layer', () => {
         }
       })
     })
-
-    describe('client packages in pages api', () => {
-      const pagesApiFile = 'pages/api/mixed.js'
-      let pagesApiContent
-      beforeAll(async () => {
-        pagesApiContent = await next.readFile(pagesApiFile)
-        await next.patchFile(
-          pagesApiFile,
-          pagesApiContent.replace(
-            "// import '../../lib/mixed-lib'",
-            "import '../../lib/mixed-lib'"
-          )
-        )
-      })
-      afterAll(async () => {
-        await next.patchFile(pagesApiFile, pagesApiContent)
-      })
-
-      it('should not error when import client packages in pages/api', async () => {
-        await retry(async () => {
-          const { status } = await next.fetch('/api/mixed')
-          expect(status).toBe(200)
-        })
-      })
-    })
   }
 
   describe('with server-only in server targets', () => {

--- a/test/e2e/module-layer/pages/api/hello.js
+++ b/test/e2e/module-layer/pages/api/hello.js
@@ -1,5 +1,9 @@
 import 'server-only'
+import React from 'react'
 
 export default function handler(req, res) {
+  if (React.useState) {
+    throw new Error('React.useState should not be defined in server layer')
+  }
   return res.send('pages/api/hello.js:')
 }

--- a/test/e2e/module-layer/pages/api/hello.js
+++ b/test/e2e/module-layer/pages/api/hello.js
@@ -1,9 +1,5 @@
 import 'server-only'
-import React from 'react'
 
 export default function handler(req, res) {
-  if (React.useState) {
-    throw new Error('React.useState should not be defined in server layer')
-  }
-  return res.send('pages/api/hello.js:')
+  return res.send('pages/api/hello.js')
 }

--- a/test/e2e/module-layer/pages/api/mixed.js
+++ b/test/e2e/module-layer/pages/api/mixed.js
@@ -1,4 +1,4 @@
-import '../../lib/mixed-lib'
+// import '../../lib/mixed-lib'
 
 export default function handler(req, res) {
   return res.send('pages/api/mixed.js:')

--- a/test/e2e/module-layer/pages/api/mixed.js
+++ b/test/e2e/module-layer/pages/api/mixed.js
@@ -1,4 +1,4 @@
-// import '../../lib/mixed-lib'
+import '../../lib/mixed-lib'
 
 export default function handler(req, res) {
   return res.send('pages/api/mixed.js:')


### PR DESCRIPTION
### What

Reland #57448 , add react-server condition resolving and apply server-only rules to middleware

Closes NEXT-1653
Closes NEXT-3333

### Why

Middleware as the pre-routing layer that is indended to be light-weight. Since it's on edge runtime and only run on server but not on client, it doesn't need to include the client react bundles. Hence we apply `react-server` export condition, that if users import React we can only bundle server required APIs and if users use React client hooks we can error.