### PR TITLE
Update turbopack & swc_core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "serde",
  "smallvec",
@@ -452,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.64.23"
+version = "0.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a30675e0f0406190035d0acdf826e65eb8b91e3d27464d83ede9570ee4ea33"
+checksum = "ee3f426fc63b42e1c6e6e0974d3fa3fe08513c5b441d80fd24d0c0a54b661dfa"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -464,9 +464,9 @@ dependencies = [
  "serde-wasm-bindgen",
  "swc",
  "swc_common",
- "swc_ecma_ast 0.112.8",
+ "swc_ecma_ast",
  "swc_ecma_transforms",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_visit",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -1144,7 +1144,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.10.1",
+ "phf 0.11.2",
  "serde",
  "smallvec",
 ]
@@ -2678,9 +2678,9 @@ dependencies = [
 
 [[package]]
 name = "markdown"
-version = "1.0.0-alpha.16"
+version = "1.0.0-alpha.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0f0025e8c0d89b84d6dc63e859475e40e8e82ab1a08be0a93ad5731513a508"
+checksum = "21e27d6220ce21f80ce5c4201f23a37c6f1ad037c72c9d1ff215c2919605a5d6"
 dependencies = [
  "unicode-id",
 ]
@@ -2721,13 +2721,13 @@ dependencies = [
 
 [[package]]
 name = "mdxjs"
-version = "0.1.23"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539f014f8de0298191ec2c05cb91b8bab0530be56b268dffedac7944c9c5f36a"
+checksum = "e5860860bfc09972a5d99bfb866dde39485fe397210f8a9ccf68a6c6740d687b"
 dependencies = [
  "markdown",
  "serde",
- "swc_core 0.90.37",
+ "swc_core",
 ]
 
 [[package]]
@@ -2871,8 +2871,8 @@ dependencies = [
  "swc_atoms",
  "swc_cached",
  "swc_common",
- "swc_ecma_ast 0.113.2",
- "swc_ecma_visit 0.99.1",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -3056,7 +3056,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "swc_core 0.92.4",
+ "swc_core",
  "tracing",
  "turbopack-binding",
  "walkdir",
@@ -3097,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "serde",
@@ -3567,9 +3567,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
- "phf_macros 0.10.0",
  "phf_shared 0.10.0",
- "proc-macro-hack",
 ]
 
 [[package]]
@@ -3578,7 +3576,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
- "phf_macros 0.11.2",
+ "phf_macros",
  "phf_shared 0.11.2",
 ]
 
@@ -3610,20 +3608,6 @@ checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
  "rand",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
-dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -3819,12 +3803,6 @@ dependencies = [
  "quote",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -4037,8 +4015,8 @@ dependencies = [
  "swc_atoms",
  "swc_cached",
  "swc_common",
- "swc_ecma_ast 0.113.2",
- "swc_ecma_visit 0.99.1",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -4154,8 +4132,8 @@ dependencies = [
  "swc_atoms",
  "swc_cached",
  "swc_common",
- "swc_ecma_ast 0.113.2",
- "swc_ecma_visit 0.99.1",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -5030,9 +5008,9 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.2",
- "swc_ecma_utils 0.128.1",
- "swc_ecma_visit 0.99.1",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tracing",
 ]
 
@@ -5055,11 +5033,11 @@ dependencies = [
  "swc_css_parser",
  "swc_css_prefixer",
  "swc_css_visit",
- "swc_ecma_ast 0.113.2",
- "swc_ecma_minifier 0.194.4",
- "swc_ecma_parser 0.144.1",
- "swc_ecma_utils 0.128.1",
- "swc_ecma_visit 0.99.1",
+ "swc_ecma_ast",
+ "swc_ecma_minifier",
+ "swc_ecma_parser",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_plugin_macro",
  "tracing",
 ]
@@ -5100,9 +5078,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.273.28"
+version = "0.275.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d35c301a839c955401a81bf9d78d91d1750191969788266b2191aac371acf8a4"
+checksum = "2ac38cd938ce20693b58b26a5d1926a46074db09cf90a251d83cf17cdaea6031"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -5126,20 +5104,20 @@ dependencies = [
  "swc_common",
  "swc_compiler_base",
  "swc_config",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_codegen 0.148.18",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
  "swc_ecma_ext_transforms",
  "swc_ecma_lints",
  "swc_ecma_loader",
- "swc_ecma_minifier 0.192.23",
- "swc_ecma_parser 0.143.16",
+ "swc_ecma_minifier",
+ "swc_ecma_parser",
  "swc_ecma_preset_env",
  "swc_ecma_transforms",
- "swc_ecma_transforms_base 0.137.21",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_compat",
- "swc_ecma_transforms_optimization 0.198.22",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_transforms_optimization",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_error_reporters",
  "swc_node_comments",
  "swc_plugin_proxy",
@@ -5167,9 +5145,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.225.19"
+version = "0.227.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dda466636577e45b76ff019d040ba5f7973228cb821734460c636350ff4f3ae"
+checksum = "d1a212bd08b1121c7204a04407ea055779fc00cf80024fc666dd97b00749cf87"
 dependencies = [
  "anyhow",
  "crc",
@@ -5184,14 +5162,14 @@ dependencies = [
  "relative-path",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_codegen 0.148.18",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
  "swc_ecma_loader",
- "swc_ecma_parser 0.143.16",
- "swc_ecma_transforms_base 0.137.21",
- "swc_ecma_transforms_optimization 0.198.22",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
+ "swc_ecma_transforms_optimization",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_fast_graph",
  "swc_graph_analyzer",
  "tracing",
@@ -5246,9 +5224,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "0.7.20"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7a0a78d52886c01786246fad54aa614cc145154d18607ddda72a180d1cb56c"
+checksum = "754058388d4f51df61f9aced73dfca96d81fed1c0a46583dc7b3da07688af80d"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -5261,11 +5239,11 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_codegen 0.148.18",
- "swc_ecma_minifier 0.192.23",
- "swc_ecma_parser 0.143.16",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_minifier",
+ "swc_ecma_parser",
+ "swc_ecma_visit",
  "swc_timer",
 ]
 
@@ -5298,9 +5276,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.90.37"
+version = "0.92.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecbbbf25e5d035165bde87f2388f9fbe6d5ce38ddd2c6cb9f24084823a9c0044"
+checksum = "e317f6f8b15019358d1e48631c0e6d098d9a3d00d666ea99650201661abea855"
 dependencies = [
  "binding_macros",
  "swc",
@@ -5314,43 +5292,27 @@ dependencies = [
  "swc_css_modules",
  "swc_css_parser",
  "swc_css_visit",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_codegen 0.148.18",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
  "swc_ecma_lints",
  "swc_ecma_loader",
- "swc_ecma_minifier 0.192.23",
- "swc_ecma_parser 0.143.16",
+ "swc_ecma_minifier",
+ "swc_ecma_parser",
  "swc_ecma_preset_env",
- "swc_ecma_quote_macros 0.54.13",
- "swc_ecma_transforms_base 0.137.21",
+ "swc_ecma_quote_macros",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_module",
- "swc_ecma_transforms_optimization 0.198.22",
+ "swc_ecma_transforms_optimization",
  "swc_ecma_transforms_proposal",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_testing",
  "swc_ecma_transforms_typescript",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_nodejs_common",
  "swc_plugin_proxy",
  "swc_plugin_runner",
  "testing",
- "vergen 8.2.6",
-]
-
-[[package]]
-name = "swc_core"
-version = "0.92.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d047aa3506175f1dbaca493341d533eacbeb60d1393d49c0ffd9d3ff63aaa4c3"
-dependencies = [
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.113.2",
- "swc_ecma_loader",
- "swc_ecma_quote_macros 0.55.1",
- "swc_ecma_transforms_base 0.138.2",
- "swc_ecma_visit 0.99.1",
  "vergen 8.2.6",
 ]
 
@@ -5502,9 +5464,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.112.8"
+version = "0.113.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1d5c33c22ad50e8e34b3080a6fb133316d2eaa7d00400fc5018151f5ca44c5a"
+checksum = "29f7cbdc8d3f31a863224649258942a537be44e37cb8f5413da63b51159779b9"
 dependencies = [
  "bitflags 2.5.0",
  "bytecheck",
@@ -5521,43 +5483,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_ecma_ast"
-version = "0.113.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f7cbdc8d3f31a863224649258942a537be44e37cb8f5413da63b51159779b9"
-dependencies = [
- "bitflags 2.5.0",
- "is-macro",
- "num-bigint",
- "phf 0.11.2",
- "scoped-tls",
- "serde",
- "string_enum",
- "swc_atoms",
- "swc_common",
- "unicode-id-start",
-]
-
-[[package]]
-name = "swc_ecma_codegen"
-version = "0.148.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154d03dc43e4033b668bc5021bd67088ff27f0d8da054348b5cd4e6fe94e7f26"
-dependencies = [
- "memchr",
- "num-bigint",
- "once_cell",
- "rustc-hash",
- "serde",
- "sourcemap",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_codegen_macros",
- "tracing",
-]
-
-[[package]]
 name = "swc_ecma_codegen"
 version = "0.149.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5571,7 +5496,7 @@ dependencies = [
  "sourcemap",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.2",
+ "swc_ecma_ast",
  "swc_ecma_codegen_macros",
  "tracing",
 ]
@@ -5590,39 +5515,39 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "0.4.18"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5396aca4707f5bb34bee83160864209a45b7117ea76932daedcb9109541f40"
+checksum = "47dad0d8b1c4ca3264a8c5ac59a10127e4f1c3ec5ed271692c8897228f306d05"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.112.8",
+ "swc_ecma_ast",
  "swc_ecma_compat_es2015",
- "swc_ecma_transforms_base 0.137.21",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_common"
-version = "0.4.13"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b06844b66a86b8f3bad66888500fd8fe1e4ac09612c5ae0946ca3f77b81f6b0"
+checksum = "d888bcaea9c3b8178ea4abf65adf64457a95a5dd3a3c109a69e02c3c38878e96"
 dependencies = [
  "swc_common",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "0.4.20"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f406983b4800c4326370bbb52e66e4981cefc348f2d9233cf76aac352b4831"
+checksum = "248532f9ae603be6bf4763f66f74ad0dfd82d6307be876ccf4c5d081826a1161"
 dependencies = [
  "arrayvec",
  "indexmap 2.2.3",
@@ -5633,174 +5558,174 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast 0.112.8",
+ "swc_ecma_ast",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base 0.137.21",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "0.4.16"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75e868ae64fe2625c8aae1f929bae734500ae336d37731f6d4bdf66b8e3b8d3"
+checksum = "8d7222c8114ae47fb2e46a65f426b125edab523192e835aecbe3136541f96500"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_transforms_base 0.137.21",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "0.4.18"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceca63fdd1fe640f2f2957d26c6380cf2199aa71c9183f2e24f8fa2f8c373c6b"
+checksum = "8ccdc725616ef5a558fb905b991cf328a3a36a4d1b8423173708a02568077a14"
 dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_transforms_base 0.137.21",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "0.4.17"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cced4ec764d3bda35ef5451a260dc747e5ce1f179372aa09ff77bb57c42cfb0c"
+checksum = "4a6c329c3980fb20c6c3f7f2afc94975bfe640d53dbb90b74a4707a514f16882"
 dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.112.8",
+ "swc_ecma_ast",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base 0.137.21",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "0.4.16"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a984708b06d662df1c10c2fc06bf98562c6ea3bb93c0e4d5491ee8e61c08e00"
+checksum = "f1934f5021e80f6b76e5e0bd06e331d719eb9541c13cb5c128a2b994931952a4"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_transforms_base 0.137.21",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "0.4.17"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d4b23ada85bf580f4e1639e54ab237c566a7c319c6e2d1f8010ae5323d0d1ba"
+checksum = "0aeddeba198fef2e0ed2bc4a5a0b412a04063f062dc47f93e191b492fc07db4f"
 dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.112.8",
+ "swc_ecma_ast",
  "swc_ecma_compat_es2022",
- "swc_ecma_transforms_base 0.137.21",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "0.4.16"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab566642dff583a16b7b188cf9effc6ae603ea2172769f7a3e7fc1aaf41b67b3"
+checksum = "288ad7b2cc410dc4fb08687915c1f588f6a714d737e0a4d4128657124902bcae"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_transforms_base 0.137.21",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "0.4.17"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a3b535284aa37b89b608544508a12ac9770193eec5b2a3c015e94d32f32cfd"
+checksum = "8d4a8a9fde6f96316e8b0792a72baa209277e0ce3050b476ee3ab408ec579a2d"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.112.8",
+ "swc_ecma_ast",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base 0.137.21",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es3"
-version = "0.4.16"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3678f2454374d8aefe0997fa32089dd2c3f06d20ecaa0d1fa30c0d3e9871c79b"
+checksum = "bc88d41bf1d86c163997a48b10ad47a40d2d0c8b9c6ee03ead151d0022975789"
 dependencies = [
  "swc_common",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_transforms_base 0.137.21",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.113.13"
+version = "0.114.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d02e315207f4c6fd0a1a475039b2874392e46a04d1a297c9c66ef0082d9fce"
+checksum = "259b7b69630aafde63c6304eeacb93fd54619cbdb199c978549acc76cd512d76"
 dependencies = [
  "phf 0.11.2",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.92.21"
+version = "0.93.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c5c0dc62f29e6aafa3714b585a67280f2102a6925f1ed280ac1826a352ff26"
+checksum = "e66af960e41704f081a2e5dd012c304f9e74bacf8846d70f5c653b32b7f7845a"
 dependencies = [
  "auto_impl",
  "dashmap",
@@ -5811,9 +5736,9 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -5840,9 +5765,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.192.23"
+version = "0.194.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1feab97d24c9931c5e88dca7730e6a6d4c7689ced9ba05814d9092651b3534db"
+checksum = "4dbee669d44953537b6dcaad4a07aa00034fb9eabe4974b5b60acdd1fa9ce209"
 dependencies = [
  "arrayvec",
  "indexmap 2.2.3",
@@ -5860,71 +5785,16 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_codegen 0.148.18",
- "swc_ecma_parser 0.143.16",
- "swc_ecma_transforms_base 0.137.21",
- "swc_ecma_transforms_optimization 0.198.22",
- "swc_ecma_usage_analyzer 0.23.14",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
+ "swc_ecma_transforms_optimization",
+ "swc_ecma_usage_analyzer",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_timer",
  "tracing",
-]
-
-[[package]]
-name = "swc_ecma_minifier"
-version = "0.194.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dbee669d44953537b6dcaad4a07aa00034fb9eabe4974b5b60acdd1fa9ce209"
-dependencies = [
- "arrayvec",
- "indexmap 2.2.3",
- "num-bigint",
- "num_cpus",
- "once_cell",
- "parking_lot",
- "radix_fmt",
- "regex",
- "rustc-hash",
- "ryu-js",
- "serde",
- "serde_json",
- "swc_atoms",
- "swc_common",
- "swc_config",
- "swc_ecma_ast 0.113.2",
- "swc_ecma_codegen 0.149.1",
- "swc_ecma_parser 0.144.1",
- "swc_ecma_transforms_base 0.138.2",
- "swc_ecma_transforms_optimization 0.199.1",
- "swc_ecma_usage_analyzer 0.24.1",
- "swc_ecma_utils 0.128.1",
- "swc_ecma_visit 0.99.1",
- "swc_timer",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_parser"
-version = "0.143.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b7faa481ac015b330f1c4bc8df2c9947242020e23ccdb10bc7a8ef84342509"
-dependencies = [
- "either",
- "new_debug_unreachable",
- "num-bigint",
- "num-traits",
- "phf 0.11.2",
- "serde",
- "smallvec",
- "smartstring",
- "stacker",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.112.8",
- "tracing",
- "typed-arena",
 ]
 
 [[package]]
@@ -5944,16 +5814,16 @@ dependencies = [
  "stacker",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.2",
+ "swc_ecma_ast",
  "tracing",
  "typed-arena",
 ]
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.206.17"
+version = "0.207.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e30d4cf2d63c2094d22a2778537353ea817f91c42c2e3bafc88cbe064b1f681"
+checksum = "b5969314bf66a4cca45b0401689dd0c74e568c69243ce46f2342d59219e1283c"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -5968,27 +5838,10 @@ dependencies = [
  "string_enum",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.112.8",
+ "swc_ecma_ast",
  "swc_ecma_transforms",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
-]
-
-[[package]]
-name = "swc_ecma_quote_macros"
-version = "0.54.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a0e789f5cced50904847f0fefef0f416156c12f0e0cf8b054f6fba6233023a"
-dependencies = [
- "anyhow",
- "proc-macro2",
- "quote",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_parser 0.143.16",
- "swc_macros_common",
- "syn 2.0.58",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -6002,8 +5855,8 @@ dependencies = [
  "quote",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.2",
- "swc_ecma_parser 0.144.1",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
  "swc_macros_common",
  "syn 2.0.58",
 ]
@@ -6023,46 +5876,22 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.229.18"
+version = "0.230.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb90c2d122976f3e32bf41a2bf710f01e51ef34ef50108992b185cc1cc53e28"
+checksum = "b37b4301415b83165109b94c99f9ac62b38fd1da625bfc830883d65d29a473f9"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_transforms_base 0.137.21",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_compat",
  "swc_ecma_transforms_module",
- "swc_ecma_transforms_optimization 0.198.22",
+ "swc_ecma_transforms_optimization",
  "swc_ecma_transforms_proposal",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_typescript",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
-]
-
-[[package]]
-name = "swc_ecma_transforms_base"
-version = "0.137.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660badfe2eed8b6213ec9dcd71aa0786f8fb46ffa012e0313bcba1fe4a9a5c73"
-dependencies = [
- "better_scoped_tls",
- "bitflags 2.5.0",
- "indexmap 2.2.3",
- "once_cell",
- "phf 0.11.2",
- "rayon",
- "rustc-hash",
- "serde",
- "smallvec",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_parser 0.143.16",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
- "tracing",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -6076,37 +5905,38 @@ dependencies = [
  "indexmap 2.2.3",
  "once_cell",
  "phf 0.11.2",
+ "rayon",
  "rustc-hash",
  "serde",
  "smallvec",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.2",
- "swc_ecma_parser 0.144.1",
- "swc_ecma_utils 0.128.1",
- "swc_ecma_visit 0.99.1",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.126.16"
+version = "0.127.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47af84e64f0216f110839f5552a615d07ed74b45757927f29482700966ab4e97"
+checksum = "53043d81678f3c693604eeb1d1f0fe6ba10f303104a31b954dbeebed9cadf530"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_transforms_base 0.137.21",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.163.19"
+version = "0.164.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed183e0eb761a1eddd9ef2232612bcd6790a9fb8b6dd1885b2a9ea0a2f93752c"
+checksum = "7d4e2942c5d8b7afdf81b8d1eec2f4a961aa9fc89ab05ebe5cbd0f6066b60afc"
 dependencies = [
  "arrayvec",
  "indexmap 2.2.3",
@@ -6118,7 +5948,7 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast 0.112.8",
+ "swc_ecma_ast",
  "swc_ecma_compat_bugfixes",
  "swc_ecma_compat_common",
  "swc_ecma_compat_es2015",
@@ -6130,11 +5960,11 @@ dependencies = [
  "swc_ecma_compat_es2021",
  "swc_ecma_compat_es2022",
  "swc_ecma_compat_es3",
- "swc_ecma_transforms_base 0.137.21",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -6153,9 +5983,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.180.19"
+version = "0.181.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914cbfb4d9e9aa4b0a5a63c01fb4c2edfa8d7486bec0b891a5e15a94615453a2"
+checksum = "477b6ac686dc1e4ab1af5cc6e8417facca0d4e71ce27df0e759c94d8c365c8e2"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -6169,37 +5999,12 @@ dependencies = [
  "swc_atoms",
  "swc_cached",
  "swc_common",
- "swc_ecma_ast 0.112.8",
+ "swc_ecma_ast",
  "swc_ecma_loader",
- "swc_ecma_parser 0.143.16",
- "swc_ecma_transforms_base 0.137.21",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_transforms_optimization"
-version = "0.198.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e8de92a02fbd61965c723669f9d425dc1544831507abd78d9fca24c3974324"
-dependencies = [
- "dashmap",
- "indexmap 2.2.3",
- "once_cell",
- "petgraph",
- "rayon",
- "rustc-hash",
- "serde_json",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_parser 0.143.16",
- "swc_ecma_transforms_base 0.137.21",
- "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
- "swc_fast_graph",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tracing",
 ]
 
@@ -6213,25 +6018,26 @@ dependencies = [
  "indexmap 2.2.3",
  "once_cell",
  "petgraph",
+ "rayon",
  "rustc-hash",
  "serde_json",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.2",
- "swc_ecma_parser 0.144.1",
- "swc_ecma_transforms_base 0.138.2",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.128.1",
- "swc_ecma_visit 0.99.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_fast_graph",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.171.23"
+version = "0.172.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00e0cc7d9cfb3935354a43455116636b001d34d103304883b90837cd87f048c"
+checksum = "7fbc414d6a9c5479cfb4c6e92fcdac504582bd7bc89a0ed7f8808b72dc8bd1f0"
 dependencies = [
  "either",
  "rustc-hash",
@@ -6239,19 +6045,19 @@ dependencies = [
  "smallvec",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_transforms_base 0.137.21",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.183.19"
+version = "0.184.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2570aa788b03d38404558d4822c7b88a35a930a47cf2417cc7732a032015e43d"
+checksum = "565a76c4ca47ce31d78301c0beab878e4c2cb4f624691254d834ec8c0e236755"
 dependencies = [
  "base64 0.21.4",
  "dashmap",
@@ -6264,19 +6070,19 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_parser 0.143.16",
- "swc_ecma_transforms_base 0.137.21",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.140.18"
+version = "0.141.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0ea6f85b7bf04391a172d7a369e49865effa77ec3a6cd0e969a274cfcb982d"
+checksum = "686445efd086ca6dd52874b4d1935663914e2fb76514c0ad7b0105cec7859451"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -6287,49 +6093,32 @@ dependencies = [
  "sha2",
  "sourcemap",
  "swc_common",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_codegen 0.148.18",
- "swc_ecma_parser 0.143.16",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_parser",
  "swc_ecma_testing",
- "swc_ecma_transforms_base 0.137.21",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tempfile",
  "testing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.188.19"
+version = "0.189.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4aa805d31f534cf230ea43282c1d58e580da2c470e3a95cb9f06f5039e5377"
+checksum = "e209026c1d3c577cafac257d87e7c0d23119282fbdc8ed03d7f56077e95beb90"
 dependencies = [
  "ryu-js",
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_transforms_base 0.137.21",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_react",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
-]
-
-[[package]]
-name = "swc_ecma_usage_analyzer"
-version = "0.23.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b82af8ae5c6e5c1c1bdef70d5fb3ef16917985031f8688a7342c10a2123cfa6b"
-dependencies = [
- "indexmap 2.2.3",
- "rustc-hash",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_utils 0.127.20",
- "swc_ecma_visit 0.98.7",
- "swc_timer",
- "tracing",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -6342,30 +6131,11 @@ dependencies = [
  "rustc-hash",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.2",
- "swc_ecma_utils 0.128.1",
- "swc_ecma_visit 0.99.1",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_timer",
  "tracing",
-]
-
-[[package]]
-name = "swc_ecma_utils"
-version = "0.127.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d40abfc4f3a7bfdf54d11ac705cc9dd0836c48bf085b359143b4d40b50cb31"
-dependencies = [
- "indexmap 2.2.3",
- "num_cpus",
- "once_cell",
- "rayon",
- "rustc-hash",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.112.8",
- "swc_ecma_visit 0.98.7",
- "tracing",
- "unicode-id",
 ]
 
 [[package]]
@@ -6377,28 +6147,14 @@ dependencies = [
  "indexmap 2.2.3",
  "num_cpus",
  "once_cell",
+ "rayon",
  "rustc-hash",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.2",
- "swc_ecma_visit 0.99.1",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
  "tracing",
  "unicode-id",
-]
-
-[[package]]
-name = "swc_ecma_visit"
-version = "0.98.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93692bdcdbb63db8f5e10fea5d202b5487cb27eb443aec424f4335c88f9864af"
-dependencies = [
- "num-bigint",
- "serde",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.112.8",
- "swc_visit",
- "tracing",
 ]
 
 [[package]]
@@ -6411,7 +6167,7 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.2",
+ "swc_ecma_ast",
  "swc_visit",
  "tracing",
 ]
@@ -6432,10 +6188,10 @@ dependencies = [
  "sourcemap",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.2",
- "swc_ecma_codegen 0.149.1",
- "swc_ecma_utils 0.128.1",
- "swc_ecma_visit 0.99.1",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -6538,23 +6294,23 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.41.7"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e09ebf5da9eb13f431ebfb916cd3378a87ffae927ba896261ebc9dc094457ae"
+checksum = "98974702046356b67da841a8de561480fd75f963f5d406eee40d690e014e4b55"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
  "swc_common",
- "swc_ecma_ast 0.112.8",
+ "swc_ecma_ast",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.106.16"
+version = "0.107.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c4b6d5c4ea05c3ddd68702736cf524661cde1200185ee8c27f10c4a5811a3d"
+checksum = "73640537e0967a88a537c853de4a41ba6cdf77bfff1999f7c6c449e5bc550eed"
 dependencies = [
  "anyhow",
  "enumset",
@@ -6564,7 +6320,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_common",
- "swc_ecma_ast 0.112.8",
+ "swc_ecma_ast",
  "swc_plugin_proxy",
  "tokio",
  "tracing",
@@ -6587,9 +6343,9 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.2",
- "swc_ecma_utils 0.128.1",
- "swc_ecma_visit 0.99.1",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tracing",
 ]
 
@@ -7187,7 +6943,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7218,7 +6974,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7230,7 +6986,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7244,7 +7000,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7258,7 +7014,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -7274,7 +7030,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7306,7 +7062,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "base16",
  "hex",
@@ -7318,7 +7074,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "proc-macro-error",
@@ -7332,7 +7088,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7342,7 +7098,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "mimalloc",
 ]
@@ -7350,7 +7106,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7376,7 +7132,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7406,7 +7162,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7414,7 +7170,7 @@ dependencies = [
  "node-file-trace",
  "styled_components",
  "styled_jsx",
- "swc_core 0.90.37",
+ "swc_core",
  "swc_emotion",
  "swc_relay",
  "testing",
@@ -7447,7 +7203,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7470,7 +7226,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "clap",
@@ -7487,7 +7243,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7504,7 +7260,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sourcemap",
- "swc_core 0.90.37",
+ "swc_core",
  "tracing",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -7516,7 +7272,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7528,7 +7284,7 @@ dependencies = [
  "regex",
  "serde",
  "smallvec",
- "swc_core 0.90.37",
+ "swc_core",
  "tracing",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -7543,7 +7299,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7579,7 +7335,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7597,7 +7353,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sourcemap",
- "swc_core 0.90.37",
+ "swc_core",
  "tokio",
  "tracing",
  "turbo-tasks",
@@ -7614,7 +7370,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "serde",
  "serde_json",
@@ -7625,7 +7381,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7636,7 +7392,7 @@ dependencies = [
  "serde_json",
  "styled_components",
  "styled_jsx",
- "swc_core 0.90.37",
+ "swc_core",
  "swc_emotion",
  "swc_relay",
  "turbo-tasks",
@@ -7649,7 +7405,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7665,7 +7421,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7681,7 +7437,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7700,7 +7456,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "serde",
@@ -7715,7 +7471,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7730,7 +7486,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7764,7 +7520,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7784,7 +7540,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7802,7 +7558,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "serde",
@@ -7818,9 +7574,9 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
- "swc_core 0.90.37",
+ "swc_core",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbopack-core",
@@ -7829,7 +7585,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "either",
@@ -7848,7 +7604,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -7864,7 +7620,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
+source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -8338,7 +8094,7 @@ dependencies = [
  "next-custom-transforms",
  "serde-wasm-bindgen",
  "serde_json",
- "swc_core 0.92.4",
+ "swc_core",
  "tracing",
  "turbopack-binding",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6577,9 +6577,9 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.44.10"
+version = "0.44.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fa7fc355bfca45459bb07dfc05b1672ae17204b6e284aaa6b21d4ee03ff2129"
+checksum = "b36a22861087d88f0ae4d78800b6fd44e2dc5b541f8da53e81388c611bab0ef9"
 dependencies = [
  "once_cell",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "ast_node"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e521452c6bce47ee5a5461c5e5d707212907826de14124962c58fcaf463115e"
+checksum = "2ab31376d309dd3bfc9cfb3c11c93ce0e0741bbe0354b20e7f8c60b044730b79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -458,9 +458,9 @@ dependencies = [
  "serde-wasm-bindgen",
  "swc",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.112.8",
  "swc_ecma_transforms",
- "swc_ecma_visit",
+ "swc_ecma_visit 0.98.7",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -633,7 +633,7 @@ version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "031718ddb8f78aa5def78a09e90defe30151d1f6c672f937af4dd916429ed996"
 dependencies = [
- "semver 1.0.18",
+ "semver 1.0.23",
  "serde",
  "toml 0.5.11",
  "url",
@@ -656,7 +656,7 @@ checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.18",
+ "semver 1.0.23",
  "serde",
  "serde_json",
  "thiserror",
@@ -1624,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "from_variant"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a0b11eeb173ce52f84ebd943d42e58813a2ebb78a6a3ff0a243b71c5199cd7b"
+checksum = "fdc9cc75639b041067353b9bce2450d6847e547276c6fbe4487d7407980e07db"
 dependencies = [
  "proc-macro2",
  "swc_macros_common",
@@ -2727,7 +2727,7 @@ checksum = "539f014f8de0298191ec2c05cb91b8bab0530be56b268dffedac7944c9c5f36a"
 dependencies = [
  "markdown",
  "serde",
- "swc_core",
+ "swc_core 0.90.37",
 ]
 
 [[package]]
@@ -2859,9 +2859,9 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.68.9"
+version = "0.68.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef94a126a88f5ba86c3b2e366fef393d27992693df15d44ff56de2f4e7d1344"
+checksum = "7300d63ae070022a5b39bfd492a04b33dd5d49bed0c6b2d515a006f23d753093"
 dependencies = [
  "convert_case 0.5.0",
  "handlebars",
@@ -2871,8 +2871,8 @@ dependencies = [
  "swc_atoms",
  "swc_cached",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.113.1",
+ "swc_ecma_visit 0.99.1",
 ]
 
 [[package]]
@@ -2935,7 +2935,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "semver 1.0.18",
+ "semver 1.0.23",
  "syn 2.0.58",
 ]
 
@@ -3056,7 +3056,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "swc_core",
+ "swc_core 0.92.0",
  "tracing",
  "turbopack-binding",
  "walkdir",
@@ -3734,9 +3734,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "preset_env_base"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276bbd6eba6fd9963e5304e8fa960b40b68c7c5dd8f689b26e301142499466dd"
+checksum = "08ccd15679953ae0d5fa716af78b58c0bfdc69a0534bfe9ea423abd1eaaf527b"
 dependencies = [
  "ahash 0.8.9",
  "anyhow",
@@ -3744,7 +3744,7 @@ dependencies = [
  "dashmap",
  "from_variant",
  "once_cell",
- "semver 1.0.18",
+ "semver 1.0.23",
  "serde",
  "st-map",
  "tracing",
@@ -4007,16 +4007,16 @@ dependencies = [
 
 [[package]]
 name = "react_remove_properties"
-version = "0.24.7"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd07f7e48a14e0864a09c598987223f3ada89cba2054d2ad3c1146301e49bcf"
+checksum = "a038f8a0e17048e66c4701d45cef55d5761e0b5614286e1490bb7e206b832ffc"
 dependencies = [
  "serde",
  "swc_atoms",
  "swc_cached",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.113.1",
+ "swc_ecma_visit 0.99.1",
 ]
 
 [[package]]
@@ -4124,16 +4124,16 @@ checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 
 [[package]]
 name = "remove_console"
-version = "0.25.7"
+version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1e77c5ede7244b521831458cfb0f8d5285e0d463479af4c306c20d3c44259d"
+checksum = "61b4db7538cf236701ee7fbc3d821d75f8da87f4474e16a5a75152ff188d5d7d"
 dependencies = [
  "serde",
  "swc_atoms",
  "swc_cached",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.113.1",
+ "swc_ecma_visit 0.99.1",
 ]
 
 [[package]]
@@ -4296,7 +4296,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.18",
+ "semver 1.0.23",
 ]
 
 [[package]]
@@ -4456,9 +4456,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.18"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 dependencies = [
  "serde",
 ]
@@ -4974,9 +4974,9 @@ dependencies = [
 
 [[package]]
 name = "string_enum"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6960defec35d15d58331ffb8a315d551634f757fe139c7b3d6063cae88ec90f6"
+checksum = "05e383308aebc257e7d7920224fa055c632478d92744eca77f99be8fa1545b90"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4998,9 +4998,9 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "styled_components"
-version = "0.96.8"
+version = "0.96.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f13af1b2e9b55614b681c785ddcf96e059076be58393c1055b795c8283a956"
+checksum = "6c90d12ab02e599c668c39ead3f06f07b188fb08395e246440adb26ac8883c2d"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -5008,17 +5008,17 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.113.1",
+ "swc_ecma_utils 0.128.1",
+ "swc_ecma_visit 0.99.1",
  "tracing",
 ]
 
 [[package]]
 name = "styled_jsx"
-version = "0.73.13"
+version = "0.73.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6eeab19721dd473f4b9c3c17f45aec015bc8bf626ab238ecd781cda90c9ddf"
+checksum = "711b37d65c10632c07d07130a9d8623c8b54688728fd1f308fb652bfa1994eff"
 dependencies = [
  "anyhow",
  "lightningcss",
@@ -5033,11 +5033,11 @@ dependencies = [
  "swc_css_parser",
  "swc_css_prefixer",
  "swc_css_visit",
- "swc_ecma_ast",
- "swc_ecma_minifier",
- "swc_ecma_parser",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.113.1",
+ "swc_ecma_minifier 0.193.3",
+ "swc_ecma_parser 0.144.1",
+ "swc_ecma_utils 0.128.1",
+ "swc_ecma_visit 0.99.1",
  "swc_plugin_macro",
  "tracing",
 ]
@@ -5078,9 +5078,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.273.26"
+version = "0.273.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b71ac791abe45ebdbf3d547595f9dc6406d3a294d23c22c8edd0ad9bb040d0f"
+checksum = "d35c301a839c955401a81bf9d78d91d1750191969788266b2191aac371acf8a4"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -5104,20 +5104,20 @@ dependencies = [
  "swc_common",
  "swc_compiler_base",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_codegen",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_codegen 0.148.18",
  "swc_ecma_ext_transforms",
  "swc_ecma_lints",
  "swc_ecma_loader",
- "swc_ecma_minifier",
- "swc_ecma_parser",
+ "swc_ecma_minifier 0.192.23",
+ "swc_ecma_parser 0.143.16",
  "swc_ecma_preset_env",
  "swc_ecma_transforms",
- "swc_ecma_transforms_base",
+ "swc_ecma_transforms_base 0.137.21",
  "swc_ecma_transforms_compat",
- "swc_ecma_transforms_optimization",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_transforms_optimization 0.198.22",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
  "swc_error_reporters",
  "swc_node_comments",
  "swc_plugin_proxy",
@@ -5162,14 +5162,14 @@ dependencies = [
  "relative-path",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_codegen",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_codegen 0.148.18",
  "swc_ecma_loader",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
- "swc_ecma_transforms_optimization",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_parser 0.143.16",
+ "swc_ecma_transforms_base 0.137.21",
+ "swc_ecma_transforms_optimization 0.198.22",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
  "swc_fast_graph",
  "swc_graph_analyzer",
  "tracing",
@@ -5191,9 +5191,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.33.24"
+version = "0.33.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a6a61c748b650cc498748f54b3bf86ba478b5f9f590abcf62bc939e1093ef99"
+checksum = "a2f9706038906e66f3919028f9f7a37f3ed552f1b85578e93f4468742e2da438"
 dependencies = [
  "ahash 0.8.9",
  "anyhow",
@@ -5239,19 +5239,19 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_minifier",
- "swc_ecma_parser",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_codegen 0.148.18",
+ "swc_ecma_minifier 0.192.23",
+ "swc_ecma_parser 0.143.16",
+ "swc_ecma_visit 0.98.7",
  "swc_timer",
 ]
 
 [[package]]
 name = "swc_config"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada712ac5e28a301683c8af957e8a56deca675cbc376473dd207a527b989efb5"
+checksum = "7be1a689e146be1eae53139482cb061dcf0fa01dff296bbe7b96fff92d8e2936"
 dependencies = [
  "anyhow",
  "indexmap 2.2.3",
@@ -5264,9 +5264,9 @@ dependencies = [
 
 [[package]]
 name = "swc_config_macro"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2574f75082322a27d990116cd2a24de52945fc94172b24ca0b3e9e2a6ceb6b"
+checksum = "7c5f56139042c1a95b54f5ca48baa0e0172d369bcc9d3d473dad1de36bae8399"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5276,9 +5276,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.90.33"
+version = "0.90.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b671d6b61601035da37d2734797321644821152f87db4502405eed6574de728b"
+checksum = "ecbbbf25e5d035165bde87f2388f9fbe6d5ce38ddd2c6cb9f24084823a9c0044"
 dependencies = [
  "binding_macros",
  "swc",
@@ -5292,23 +5292,23 @@ dependencies = [
  "swc_css_modules",
  "swc_css_parser",
  "swc_css_visit",
- "swc_ecma_ast",
- "swc_ecma_codegen",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_codegen 0.148.18",
  "swc_ecma_lints",
  "swc_ecma_loader",
- "swc_ecma_minifier",
- "swc_ecma_parser",
+ "swc_ecma_minifier 0.192.23",
+ "swc_ecma_parser 0.143.16",
  "swc_ecma_preset_env",
- "swc_ecma_quote_macros",
- "swc_ecma_transforms_base",
+ "swc_ecma_quote_macros 0.54.13",
+ "swc_ecma_transforms_base 0.137.21",
  "swc_ecma_transforms_module",
- "swc_ecma_transforms_optimization",
+ "swc_ecma_transforms_optimization 0.198.22",
  "swc_ecma_transforms_proposal",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_testing",
  "swc_ecma_transforms_typescript",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
  "swc_nodejs_common",
  "swc_plugin_proxy",
  "swc_plugin_runner",
@@ -5317,10 +5317,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_css_ast"
-version = "0.140.22"
+name = "swc_core"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eeb244560d41d5885c5d86623c0fb25d1e3783edcdf878f2572d1952010955e"
+checksum = "563b5324754cb00a8a6b5bec51215ff30d0c6b9913e7df1902577fd83899a105"
+dependencies = [
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.113.1",
+ "swc_ecma_loader",
+ "swc_ecma_quote_macros 0.55.1",
+ "swc_ecma_transforms_base 0.138.1",
+ "swc_ecma_visit 0.99.1",
+ "vergen 8.2.6",
+]
+
+[[package]]
+name = "swc_css_ast"
+version = "0.140.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be69b267990e9727881125d39b3a2b8204bb2f85b9ece2ad3e212a1fe5c79bea"
 dependencies = [
  "is-macro",
  "string_enum",
@@ -5330,9 +5346,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.151.33"
+version = "0.151.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4dc37f8b8ee3cac9b24bb385c63ddd7bda41a641e147fd18e90036604a9acf1"
+checksum = "dc65d732bd6fd1757a14dc4636b762d9224fc83f1f978b6a5840b843a3964bde"
 dependencies = [
  "auto_impl",
  "bitflags 2.5.0",
@@ -5347,9 +5363,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen_macros"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db1d634bcd2df2b694e2bf9320b8f808db3451e35d70e36252966b551a11ef4"
+checksum = "de2ece8c7dbdde85aa1bcc9764c5f41f7450d8bf1312eac2375b8dc0ecbc13d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5359,9 +5375,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_compat"
-version = "0.27.34"
+version = "0.27.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65ee8377e112ffe8e1a01147ef5622a51e9c9bf63e85ed21e0a184f91f50f41"
+checksum = "c3973cc69eb96e64798f506fe57c5ad1d9a24fd7cf870250144e110d000ce045"
 dependencies = [
  "bitflags 2.5.0",
  "once_cell",
@@ -5376,9 +5392,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_minifier"
-version = "0.116.33"
+version = "0.116.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee993aeb2314bad3b1ac2449f142a230c204443749a96a3c807f34bf8d845ad6"
+checksum = "1bee9bb889f46af0e7426ace32cc2150d4e56f1a3376377d9ed51101bea29d35"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -5390,9 +5406,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_modules"
-version = "0.29.34"
+version = "0.29.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209966e658fb11773a8d14c004554fdc667f6d44128942c47f3d0195cf483613"
+checksum = "33a367c7ec6afd24bb3fcc2df95a2adf5d7462367d5b13afd8e43a7beba44358"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -5406,9 +5422,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.150.32"
+version = "0.150.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b402ad8f51d62e8af1d22ea093881147dbc6fd46cba2634df66add05945ec"
+checksum = "174995d62f066e4a4091c03ce9d35233cf8a2e23d729c2041cd5c2b3e2af2d1e"
 dependencies = [
  "lexical",
  "serde",
@@ -5419,9 +5435,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_prefixer"
-version = "0.153.36"
+version = "0.153.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f202bf9b7eec1e87c74bf4be8677e1086d8bbf9832f57829f5d106c62a6e715"
+checksum = "12416e97bced06666368f3cf7801abacb1a8962c9a4b9b2924faa4f45dc512aa"
 dependencies = [
  "once_cell",
  "preset_env_base",
@@ -5436,9 +5452,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "0.137.22"
+version = "0.137.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb7bc3fd90d4e0ad270b255d20e7172f26c26bd91d8b8c709b54690a2f209a3"
+checksum = "a890e543134dc78ac46d0ffce3028d37b639f8854f25aaef67178111459ba021"
 dependencies = [
  "once_cell",
  "serde",
@@ -5451,9 +5467,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "0.139.21"
+version = "0.139.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bc4deb5540e3869f74e09997b2dd9e1d7b3f750ba2c910f88041f8027868c5"
+checksum = "d5f0f267339cff49928e87b68ba453e85808eb11d660c720b3eb9c1c8510ad7a"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -5483,10 +5499,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_ecma_codegen"
-version = "0.148.16"
+name = "swc_ecma_ast"
+version = "0.113.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb89c03991afedda9dc1ea1bff66dc560a3921a90367927a3831938dc59a0f0"
+checksum = "cae9f905b3485ab348bf9009f71852f27c560d28a0d1f1ec69f0640b86eb1adc"
+dependencies = [
+ "bitflags 2.5.0",
+ "is-macro",
+ "num-bigint",
+ "phf 0.11.2",
+ "scoped-tls",
+ "serde",
+ "string_enum",
+ "swc_atoms",
+ "swc_common",
+ "unicode-id-start",
+]
+
+[[package]]
+name = "swc_ecma_codegen"
+version = "0.148.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "154d03dc43e4033b668bc5021bd67088ff27f0d8da054348b5cd4e6fe94e7f26"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -5496,16 +5530,35 @@ dependencies = [
  "sourcemap",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_codegen_macros",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_codegen"
+version = "0.149.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fef147127a2926ca26171c7afcbf028ff86dc543ced87d316713f25620a15b9"
+dependencies = [
+ "memchr",
+ "num-bigint",
+ "once_cell",
+ "rustc-hash",
+ "serde",
+ "sourcemap",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.113.1",
  "swc_ecma_codegen_macros",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_codegen_macros"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ab87ba81ae05efd394ab4a8cbdba595ac3554a5e393c76699449d47c43582e"
+checksum = "090e409af49c8d1a3c13b3aab1ed09dd4eda982207eb3e63c2ad342f072b49c8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5521,11 +5574,11 @@ checksum = "4f5396aca4707f5bb34bee83160864209a45b7117ea76932daedcb9109541f40"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.112.8",
  "swc_ecma_compat_es2015",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_transforms_base 0.137.21",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
  "swc_trace_macro",
  "tracing",
 ]
@@ -5537,17 +5590,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b06844b66a86b8f3bad66888500fd8fe1e4ac09612c5ae0946ca3f77b81f6b0"
 dependencies = [
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
  "swc_trace_macro",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260948998b33771db552037ea693a7a3e5c853b62431691272185878edab17f7"
+checksum = "c4f406983b4800c4326370bbb52e66e4981cefc348f2d9233cf76aac352b4831"
 dependencies = [
  "arrayvec",
  "indexmap 2.2.3",
@@ -5558,13 +5611,13 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.112.8",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base",
+ "swc_ecma_transforms_base 0.137.21",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
  "swc_trace_macro",
  "tracing",
 ]
@@ -5577,29 +5630,29 @@ checksum = "c75e868ae64fe2625c8aae1f929bae734500ae336d37731f6d4bdf66b8e3b8d3"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_transforms_base 0.137.21",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a4b59b144c818b639e741b0538fb70cd08500e03b3f399e3aef7b774dac1cf1"
+checksum = "ceca63fdd1fe640f2f2957d26c6380cf2199aa71c9183f2e24f8fa2f8c373c6b"
 dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_transforms_base 0.137.21",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
  "swc_trace_macro",
  "tracing",
 ]
@@ -5613,12 +5666,12 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.112.8",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base",
+ "swc_ecma_transforms_base 0.137.21",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
  "swc_trace_macro",
  "tracing",
 ]
@@ -5631,10 +5684,10 @@ checksum = "6a984708b06d662df1c10c2fc06bf98562c6ea3bb93c0e4d5491ee8e61c08e00"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_transforms_base 0.137.21",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
  "swc_trace_macro",
  "tracing",
 ]
@@ -5648,11 +5701,11 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.112.8",
  "swc_ecma_compat_es2022",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_transforms_base 0.137.21",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
  "swc_trace_macro",
  "tracing",
 ]
@@ -5665,10 +5718,10 @@ checksum = "ab566642dff583a16b7b188cf9effc6ae603ea2172769f7a3e7fc1aaf41b67b3"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_transforms_base 0.137.21",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
  "swc_trace_macro",
  "tracing",
 ]
@@ -5681,13 +5734,13 @@ checksum = "75a3b535284aa37b89b608544508a12ac9770193eec5b2a3c015e94d32f32cfd"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.112.8",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base",
+ "swc_ecma_transforms_base 0.137.21",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
  "swc_trace_macro",
  "tracing",
 ]
@@ -5699,10 +5752,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3678f2454374d8aefe0997fa32089dd2c3f06d20ecaa0d1fa30c0d3e9871c79b"
 dependencies = [
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_transforms_base 0.137.21",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
  "swc_trace_macro",
  "tracing",
 ]
@@ -5716,9 +5769,9 @@ dependencies = [
  "phf 0.11.2",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
 ]
 
 [[package]]
@@ -5736,16 +5789,16 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
 ]
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.45.26"
+version = "0.45.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46ed3847b7c2a70af9a422b24430f7386d70bf3d0408a54991be383f1c3aa954"
+checksum = "92c68f934bd2c51f29c4ad0bcae09924e9dc30d7ce0680367d45b42d40338a67"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -5785,23 +5838,56 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
- "swc_ecma_transforms_optimization",
- "swc_ecma_usage_analyzer",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_codegen 0.148.18",
+ "swc_ecma_parser 0.143.16",
+ "swc_ecma_transforms_base 0.137.21",
+ "swc_ecma_transforms_optimization 0.198.22",
+ "swc_ecma_usage_analyzer 0.23.14",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
+ "swc_timer",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_minifier"
+version = "0.193.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba7b29710862eb0266dc7bf3360ceac33d6af6b999b89906db9e5b6aefa857c2"
+dependencies = [
+ "arrayvec",
+ "indexmap 2.2.3",
+ "num-bigint",
+ "num_cpus",
+ "once_cell",
+ "parking_lot",
+ "radix_fmt",
+ "regex",
+ "rustc-hash",
+ "ryu-js",
+ "serde",
+ "serde_json",
+ "swc_atoms",
+ "swc_common",
+ "swc_config",
+ "swc_ecma_ast 0.113.1",
+ "swc_ecma_codegen 0.149.1",
+ "swc_ecma_parser 0.144.1",
+ "swc_ecma_transforms_base 0.138.1",
+ "swc_ecma_transforms_optimization 0.199.1",
+ "swc_ecma_usage_analyzer 0.24.1",
+ "swc_ecma_utils 0.128.1",
+ "swc_ecma_visit 0.99.1",
  "swc_timer",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.143.15"
+version = "0.143.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6a9fcc676d603f70f32797f20c2909c14117b5d510092e049c71c93595764d4"
+checksum = "40b7faa481ac015b330f1c4bc8df2c9947242020e23ccdb10bc7a8ef84342509"
 dependencies = [
  "either",
  "new_debug_unreachable",
@@ -5814,7 +5900,29 @@ dependencies = [
  "stacker",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.112.8",
+ "tracing",
+ "typed-arena",
+]
+
+[[package]]
+name = "swc_ecma_parser"
+version = "0.144.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0499e69683ae5d67a20ff0279b94bc90f29df7922a46331b54d5dd367bf89570"
+dependencies = [
+ "either",
+ "new_debug_unreachable",
+ "num-bigint",
+ "num-traits",
+ "phf 0.11.2",
+ "serde",
+ "smallvec",
+ "smartstring",
+ "stacker",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.113.1",
  "tracing",
  "typed-arena",
 ]
@@ -5831,17 +5939,17 @@ dependencies = [
  "once_cell",
  "preset_env_base",
  "rustc-hash",
- "semver 1.0.18",
+ "semver 1.0.23",
  "serde",
  "serde_json",
  "st-map",
  "string_enum",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.112.8",
  "swc_ecma_transforms",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
 ]
 
 [[package]]
@@ -5855,17 +5963,34 @@ dependencies = [
  "quote",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_parser 0.143.16",
+ "swc_macros_common",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "swc_ecma_quote_macros"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc3a759d2885a78cd2a6ac1c1865eb6be02cafe35fbb6c5abd3720d0fca559a"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.113.1",
+ "swc_ecma_parser 0.144.1",
  "swc_macros_common",
  "syn 2.0.58",
 ]
 
 [[package]]
 name = "swc_ecma_testing"
-version = "0.22.22"
+version = "0.22.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5704ef494b1805bc4566ff566b964bc1e9d3fb0f0e046ad6392b09a54de844"
+checksum = "dbe778ce5eae6a7e620e1f6b5326e78f00203c4548e0c659fd22da8be0538fd1"
 dependencies = [
  "anyhow",
  "hex",
@@ -5882,23 +6007,23 @@ checksum = "8eb90c2d122976f3e32bf41a2bf710f01e51ef34ef50108992b185cc1cc53e28"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_transforms_base 0.137.21",
  "swc_ecma_transforms_compat",
  "swc_ecma_transforms_module",
- "swc_ecma_transforms_optimization",
+ "swc_ecma_transforms_optimization 0.198.22",
  "swc_ecma_transforms_proposal",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_typescript",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.137.20"
+version = "0.137.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b59fad924fb4fbd7a67e3992751a3f8d205f1f548ce73b9e5abdf5bd83af370"
+checksum = "660badfe2eed8b6213ec9dcd71aa0786f8fb46ffa012e0313bcba1fe4a9a5c73"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.5.0",
@@ -5911,10 +6036,33 @@ dependencies = [
  "smallvec",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_parser 0.143.16",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_transforms_base"
+version = "0.138.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6511cbe8c60eced9a8e77b66aadbda26424f14a1662c68c17aeb73ac78ad83c2"
+dependencies = [
+ "better_scoped_tls",
+ "bitflags 2.5.0",
+ "indexmap 2.2.3",
+ "once_cell",
+ "phf 0.11.2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.113.1",
+ "swc_ecma_parser 0.144.1",
+ "swc_ecma_utils 0.128.1",
+ "swc_ecma_visit 0.99.1",
  "tracing",
 ]
 
@@ -5926,10 +6074,10 @@ checksum = "47af84e64f0216f110839f5552a615d07ed74b45757927f29482700966ab4e97"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_transforms_base 0.137.21",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
 ]
 
 [[package]]
@@ -5948,7 +6096,7 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.112.8",
  "swc_ecma_compat_bugfixes",
  "swc_ecma_compat_common",
  "swc_ecma_compat_es2015",
@@ -5960,20 +6108,20 @@ dependencies = [
  "swc_ecma_compat_es2021",
  "swc_ecma_compat_es2022",
  "swc_ecma_compat_es3",
- "swc_ecma_transforms_base",
+ "swc_ecma_transforms_base 0.137.21",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_macros"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e309b88f337da54ef7fe4c5b99c2c522927071f797ee6c9fb8b6bf2d100481"
+checksum = "500a1dadad1e0e41e417d633b3d6d5de677c9e0d3159b94ba3348436cdb15aab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5999,20 +6147,20 @@ dependencies = [
  "swc_atoms",
  "swc_cached",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.112.8",
  "swc_ecma_loader",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_parser 0.143.16",
+ "swc_ecma_transforms_base 0.137.21",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.198.21"
+version = "0.198.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9f79c85fadc9e4d06cafba9b646a559d0c401ca2d2dc0b5ec8600351042c8b7"
+checksum = "73e8de92a02fbd61965c723669f9d425dc1544831507abd78d9fca24c3974324"
 dependencies = [
  "dashmap",
  "indexmap 2.2.3",
@@ -6023,12 +6171,36 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_parser 0.143.16",
+ "swc_ecma_transforms_base 0.137.21",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
+ "swc_fast_graph",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_transforms_optimization"
+version = "0.199.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32ea30b3df748236c619409f222f0ba68ebeebc08dfff109d2195664a15689f9"
+dependencies = [
+ "dashmap",
+ "indexmap 2.2.3",
+ "once_cell",
+ "petgraph",
+ "rustc-hash",
+ "serde_json",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.113.1",
+ "swc_ecma_parser 0.144.1",
+ "swc_ecma_transforms_base 0.138.1",
+ "swc_ecma_transforms_macros",
+ "swc_ecma_utils 0.128.1",
+ "swc_ecma_visit 0.99.1",
  "swc_fast_graph",
  "tracing",
 ]
@@ -6045,12 +6217,12 @@ dependencies = [
  "smallvec",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_transforms_base 0.137.21",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
 ]
 
 [[package]]
@@ -6070,12 +6242,12 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_parser 0.143.16",
+ "swc_ecma_transforms_base 0.137.21",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
 ]
 
 [[package]]
@@ -6093,13 +6265,13 @@ dependencies = [
  "sha2",
  "sourcemap",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_parser",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_codegen 0.148.18",
+ "swc_ecma_parser 0.143.16",
  "swc_ecma_testing",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_transforms_base 0.137.21",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
  "tempfile",
  "testing",
 ]
@@ -6114,11 +6286,11 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_transforms_base 0.137.21",
  "swc_ecma_transforms_react",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
 ]
 
 [[package]]
@@ -6131,18 +6303,35 @@ dependencies = [
  "rustc-hash",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_utils 0.127.20",
+ "swc_ecma_visit 0.98.7",
+ "swc_timer",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_usage_analyzer"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98a693898bd44782a234d9a4122d52b93accf447282d08c2364eb739ae864154"
+dependencies = [
+ "indexmap 2.2.3",
+ "rustc-hash",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.113.1",
+ "swc_ecma_utils 0.128.1",
+ "swc_ecma_visit 0.99.1",
  "swc_timer",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.127.19"
+version = "0.127.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95eb7d0729c17e7b1bddfc67b26f120efa69ae0c9f39738bb5eb8aa154a31cb9"
+checksum = "15d40abfc4f3a7bfdf54d11ac705cc9dd0836c48bf085b359143b4d40b50cb31"
 dependencies = [
  "indexmap 2.2.3",
  "num_cpus",
@@ -6151,8 +6340,26 @@ dependencies = [
  "rustc-hash",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.112.8",
+ "swc_ecma_visit 0.98.7",
+ "tracing",
+ "unicode-id",
+]
+
+[[package]]
+name = "swc_ecma_utils"
+version = "0.128.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5242670bc74e0a0b64b9d4912b37be36944517ce0881314162aeb4381272c3"
+dependencies = [
+ "indexmap 2.2.3",
+ "num_cpus",
+ "once_cell",
+ "rustc-hash",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.113.1",
+ "swc_ecma_visit 0.99.1",
  "tracing",
  "unicode-id",
 ]
@@ -6167,16 +6374,31 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.112.8",
+ "swc_visit",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_visit"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6ce28ad8e591f8d627f1f9cb26b25e5d83052a9bc1b674d95fc28040cfa98"
+dependencies = [
+ "num-bigint",
+ "serde",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.113.1",
  "swc_visit",
  "tracing",
 ]
 
 [[package]]
 name = "swc_emotion"
-version = "0.72.8"
+version = "0.72.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43a5946f5e0ea03341b23786e43e3fa07eaa014f03fb39cf584b02c38e9c80c"
+checksum = "fc9c4f4c1763d436176971911fa4ab4cb12f824bef40ca7d98af9c3a348b0b3c"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -6188,10 +6410,10 @@ dependencies = [
  "sourcemap",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.113.1",
+ "swc_ecma_codegen 0.149.1",
+ "swc_ecma_utils 0.128.1",
+ "swc_ecma_visit 0.99.1",
  "swc_trace_macro",
  "tracing",
 ]
@@ -6209,9 +6431,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.17.19"
+version = "0.17.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3329e73f159a3d38d4cd5f606a0918eeff39f5bbdbdafd9b6fecb290d2e9a32d"
+checksum = "72100a5f7b0c178adf7bcc5e7c8ad9d4180f499a5f5bae9faf3f417c7cbc4915"
 dependencies = [
  "anyhow",
  "miette",
@@ -6222,9 +6444,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.21.21"
+version = "0.21.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54db83cdbd924cc8b5082ab54ff2a1b4f53ecde8f53c87b9f9c877c9daef4569"
+checksum = "f3fdd64bc3d161d6c1ea9a8ae5779e4ba132afc67e7b8ece5420bfc9c6e1275d"
 dependencies = [
  "indexmap 2.2.3",
  "petgraph",
@@ -6234,9 +6456,9 @@ dependencies = [
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "0.22.22"
+version = "0.22.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b66d0e18899b3a69eca103e5b4af2f0c837427aa07a60be1c4ceb4346ea245"
+checksum = "c728a8f9b82b7160a1ae246e31232177b371f827eb0d01006c0f120a3494871c"
 dependencies = [
  "auto_impl",
  "petgraph",
@@ -6247,9 +6469,9 @@ dependencies = [
 
 [[package]]
 name = "swc_macros_common"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5be7766a95a2840ded618baeaab63809b71230ef19094b34f76c8af4d85aa2"
+checksum = "91745f3561057493d2da768437c427c0e979dff7396507ae02f16c981c4a8466"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6258,9 +6480,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "0.20.19"
+version = "0.20.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd75c635e4b54961c1c8dc693bb16eb70497eb8a2564f303089a9a66e81ed7ae"
+checksum = "d39218bffecf32538d94a22791a12ff6f65e618edcc632d42e065a4e9c773065"
 dependencies = [
  "dashmap",
  "swc_atoms",
@@ -6301,7 +6523,7 @@ dependencies = [
  "better_scoped_tls",
  "rkyv",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.112.8",
  "swc_trace_macro",
  "tracing",
 ]
@@ -6320,7 +6542,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.112.8",
  "swc_plugin_proxy",
  "tokio",
  "tracing",
@@ -6333,9 +6555,9 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.44.8"
+version = "0.44.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68cd77d63c87626434782b9542e4a1335490200cee86e03e1cb6c61fccc71a30"
+checksum = "5fa7fc355bfca45459bb07dfc05b1672ae17204b6e284aaa6b21d4ee03ff2129"
 dependencies = [
  "once_cell",
  "regex",
@@ -6343,17 +6565,17 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.113.1",
+ "swc_ecma_utils 0.128.1",
+ "swc_ecma_visit 0.99.1",
  "tracing",
 ]
 
 [[package]]
 name = "swc_timer"
-version = "0.21.21"
+version = "0.21.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75ce0373fd1b75a021073d796201d5af15106857fc0a801e31379e9e04891e9"
+checksum = "0c05c13aecc7a128f86273004f57b5964a6e8828a90e542f362deaed7985504f"
 dependencies = [
  "tracing",
 ]
@@ -6371,9 +6593,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0263be55289abfe9c877ffef83d877b5bdfac036ffe2de793f48f5e47e41dbae"
+checksum = "043d11fe683dcb934583ead49405c0896a5af5face522e4682c16971ef7871b9"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -6381,9 +6603,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit_macros"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33fc817055fe127b4285dc85058596768bfde7537ae37da82c67815557f03e33"
+checksum = "4ae9ef18ff8daffa999f729db056d2821cd2f790f3a11e46422d19f46bb193e7"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -6523,9 +6745,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.35.23"
+version = "0.35.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689e2661712768726869f62945ccbe5d76ab3a3957b88221275bebe22a0761c8"
+checksum = "c71dd5265f4921fe51b386b1496c63ac058589d8cd38de6b61489a98c6019a16"
 dependencies = [
  "ansi_term",
  "cargo_metadata",
@@ -7170,7 +7392,7 @@ dependencies = [
  "node-file-trace",
  "styled_components",
  "styled_jsx",
- "swc_core",
+ "swc_core 0.90.37",
  "swc_emotion",
  "swc_relay",
  "testing",
@@ -7260,7 +7482,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sourcemap",
- "swc_core",
+ "swc_core 0.90.37",
  "tracing",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -7284,7 +7506,7 @@ dependencies = [
  "regex",
  "serde",
  "smallvec",
- "swc_core",
+ "swc_core 0.90.37",
  "tracing",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -7353,7 +7575,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sourcemap",
- "swc_core",
+ "swc_core 0.90.37",
  "tokio",
  "tracing",
  "turbo-tasks",
@@ -7392,7 +7614,7 @@ dependencies = [
  "serde_json",
  "styled_components",
  "styled_jsx",
- "swc_core",
+ "swc_core 0.90.37",
  "swc_emotion",
  "swc_relay",
  "turbo-tasks",
@@ -7576,7 +7798,7 @@ name = "turbopack-swc-utils"
 version = "0.1.0"
 source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240516.1#993891fa67a7dc3576ee8322408fb2c00da85304"
 dependencies = [
- "swc_core",
+ "swc_core 0.90.37",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbopack-core",
@@ -8094,7 +8316,7 @@ dependencies = [
  "next-custom-transforms",
  "serde-wasm-bindgen",
  "serde_json",
- "swc_core",
+ "swc_core 0.92.0",
  "tracing",
  "turbopack-binding",
  "wasm-bindgen",
@@ -8285,7 +8507,7 @@ dependencies = [
  "anyhow",
  "derive_builder",
  "indexmap 2.2.3",
- "semver 1.0.18",
+ "semver 1.0.23",
  "serde",
  "serde_cbor",
  "serde_json",
@@ -8368,7 +8590,7 @@ dependencies = [
  "pin-project",
  "rand",
  "rusty_pool",
- "semver 1.0.18",
+ "semver 1.0.23",
  "serde",
  "serde_cbor",
  "serde_derive",
@@ -8447,7 +8669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dfcdb72d96f01e6c85b6bf20102e7423bdbaad5c337301bab2bbf253d26413c"
 dependencies = [
  "indexmap 2.2.3",
- "semver 1.0.18",
+ "semver 1.0.23",
 ]
 
 [[package]]
@@ -8498,7 +8720,7 @@ dependencies = [
  "once_cell",
  "path-clean 1.0.1",
  "rand",
- "semver 1.0.18",
+ "semver 1.0.23",
  "serde",
  "serde_cbor",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4062,14 +4062,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.8",
- "regex-syntax 0.7.5",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -4083,13 +4083,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -4100,9 +4100,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "region"
@@ -4479,9 +4479,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
 dependencies = [
  "serde_derive",
 ]
@@ -4528,9 +4528,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64-simd"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,12 +869,6 @@ checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 
 [[package]]
 name = "convert_case"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
-
-[[package]]
-name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
@@ -1144,7 +1144,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.11.2",
+ "phf 0.10.1",
  "serde",
  "smallvec",
 ]
@@ -1877,9 +1877,9 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "handlebars"
-version = "4.3.6"
+version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "035ef95d03713f2c347a72547b7cd38cbc9af7cd51e6099fb62d586d4a6dee3a"
+checksum = "d08485b96a0e6393e9e4d1b8d48cf74ad6c063cd905eb33f42c1ce3f0377539b"
 dependencies = [
  "log",
  "pest",
@@ -2560,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "lightningcss"
-version = "1.0.0-alpha.54"
+version = "1.0.0-alpha.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d306844e5af1753490c420c0d6ae3d814b00725092d106332762827ca8f0fe"
+checksum = "3bd5bed3814fb631bfc1e24c2be6f7e86a9837c660909acab79a38374dcb8798"
 dependencies = [
  "ahash 0.8.9",
  "bitflags 2.5.0",
@@ -2859,11 +2859,11 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.68.11"
+version = "0.68.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300d63ae070022a5b39bfd492a04b33dd5d49bed0c6b2d515a006f23d753093"
+checksum = "440dfda6d4b4cfa76c0b12b564c9b8d643b5c2bc8a63ed5dfc2a46cf1c68ac61"
 dependencies = [
- "convert_case 0.5.0",
+ "convert_case",
  "handlebars",
  "once_cell",
  "regex",
@@ -2917,7 +2917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7622f0dbe0968af2dacdd64870eee6dee94f93c989c841f1ad8f300cf1abd514"
 dependencies = [
  "cfg-if",
- "convert_case 0.6.0",
+ "convert_case",
  "napi-derive-backend",
  "proc-macro2",
  "quote",
@@ -2930,7 +2930,7 @@ version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cf2d74ac66fd1cccb646be75fdd1c1dce8acfe20a68f61566a31da0d3eb9786"
 dependencies = [
- "convert_case 0.6.0",
+ "convert_case",
  "once_cell",
  "proc-macro2",
  "quote",
@@ -3567,7 +3567,9 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
+ "phf_macros 0.10.0",
  "phf_shared 0.10.0",
+ "proc-macro-hack",
 ]
 
 [[package]]
@@ -3576,7 +3578,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.11.2",
  "phf_shared 0.11.2",
 ]
 
@@ -3608,6 +3610,20 @@ checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
  "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3803,6 +3819,12 @@ dependencies = [
  "quote",
  "version_check",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -4998,9 +5020,9 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "styled_components"
-version = "0.96.12"
+version = "0.96.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c90d12ab02e599c668c39ead3f06f07b188fb08395e246440adb26ac8883c2d"
+checksum = "2d7e14a22b6bf299ed8c2072e719c27324be5060a39b2bd70e62ad2a9505fe71"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -5016,9 +5038,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.73.16"
+version = "0.73.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b37d65c10632c07d07130a9d8623c8b54688728fd1f308fb652bfa1994eff"
+checksum = "441654f465db08fc2c3c36c598c89e8d27fb445d4c97263fb701b07029e9755b"
 dependencies = [
  "anyhow",
  "lightningcss",
@@ -5034,7 +5056,7 @@ dependencies = [
  "swc_css_prefixer",
  "swc_css_visit",
  "swc_ecma_ast 0.113.2",
- "swc_ecma_minifier 0.193.3",
+ "swc_ecma_minifier 0.194.4",
  "swc_ecma_parser 0.144.1",
  "swc_ecma_utils 0.128.1",
  "swc_ecma_visit 0.99.1",
@@ -5327,7 +5349,7 @@ dependencies = [
  "swc_ecma_ast 0.113.2",
  "swc_ecma_loader",
  "swc_ecma_quote_macros 0.55.1",
- "swc_ecma_transforms_base 0.138.1",
+ "swc_ecma_transforms_base 0.138.2",
  "swc_ecma_visit 0.99.1",
  "vergen 8.2.6",
 ]
@@ -5852,9 +5874,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.193.3"
+version = "0.194.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7b29710862eb0266dc7bf3360ceac33d6af6b999b89906db9e5b6aefa857c2"
+checksum = "4dbee669d44953537b6dcaad4a07aa00034fb9eabe4974b5b60acdd1fa9ce209"
 dependencies = [
  "arrayvec",
  "indexmap 2.2.3",
@@ -5874,7 +5896,7 @@ dependencies = [
  "swc_ecma_ast 0.113.2",
  "swc_ecma_codegen 0.149.1",
  "swc_ecma_parser 0.144.1",
- "swc_ecma_transforms_base 0.138.1",
+ "swc_ecma_transforms_base 0.138.2",
  "swc_ecma_transforms_optimization 0.199.1",
  "swc_ecma_usage_analyzer 0.24.1",
  "swc_ecma_utils 0.128.1",
@@ -6045,9 +6067,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.138.1"
+version = "0.138.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6511cbe8c60eced9a8e77b66aadbda26424f14a1662c68c17aeb73ac78ad83c2"
+checksum = "eddb95c2bdad1c9c29edf35712e1e0f9b9ddc1cdb5ba2d582fd93468cb075a03"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.5.0",
@@ -6197,7 +6219,7 @@ dependencies = [
  "swc_common",
  "swc_ecma_ast 0.113.2",
  "swc_ecma_parser 0.144.1",
- "swc_ecma_transforms_base 0.138.1",
+ "swc_ecma_transforms_base 0.138.2",
  "swc_ecma_transforms_macros",
  "swc_ecma_utils 0.128.1",
  "swc_ecma_visit 0.99.1",
@@ -6396,11 +6418,11 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.72.10"
+version = "0.72.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc9c4f4c1763d436176971911fa4ab4cb12f824bef40ca7d98af9c3a348b0b3c"
+checksum = "4b454c1b99da4da9aab3731ab34d7582d2eab96e47670d0c62711053886ef7e2"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
  "byteorder",
  "fxhash",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "serde",
  "smallvec",
@@ -1144,7 +1144,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.11.2",
+ "phf 0.10.1",
  "serde",
  "smallvec",
 ]
@@ -3097,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "serde",
@@ -3567,7 +3567,9 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
+ "phf_macros 0.10.0",
  "phf_shared 0.10.0",
+ "proc-macro-hack",
 ]
 
 [[package]]
@@ -3576,7 +3578,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.11.2",
  "phf_shared 0.11.2",
 ]
 
@@ -3608,6 +3610,20 @@ checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
  "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3803,6 +3819,12 @@ dependencies = [
  "quote",
  "version_check",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -5464,9 +5486,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.113.2"
+version = "0.113.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f7cbdc8d3f31a863224649258942a537be44e37cb8f5413da63b51159779b9"
+checksum = "dc1690cc0c9ab60b44ac0225ba1e231ac532f7ba1d754df761c6ee607561afae"
 dependencies = [
  "bitflags 2.5.0",
  "bytecheck",
@@ -6943,7 +6965,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6969,12 +6991,13 @@ dependencies = [
  "turbo-tasks-build",
  "turbo-tasks-hash",
  "turbo-tasks-macros",
+ "turbo-tasks-malloc",
 ]
 
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -6986,7 +7009,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7000,7 +7023,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7014,7 +7037,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -7030,7 +7053,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7062,7 +7085,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "base16",
  "hex",
@@ -7074,7 +7097,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "proc-macro-error",
@@ -7088,7 +7111,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7098,7 +7121,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "mimalloc",
 ]
@@ -7106,7 +7129,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7132,7 +7155,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7162,7 +7185,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7203,7 +7226,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7226,7 +7249,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "clap",
@@ -7243,7 +7266,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7272,7 +7295,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7299,7 +7322,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7335,7 +7358,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7370,7 +7393,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "serde",
  "serde_json",
@@ -7381,7 +7404,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7405,7 +7428,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7421,7 +7444,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7437,7 +7460,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7456,7 +7479,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "serde",
@@ -7471,7 +7494,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7486,7 +7509,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7520,7 +7543,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7540,7 +7563,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7558,7 +7581,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "serde",
@@ -7574,7 +7597,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7585,7 +7608,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "either",
@@ -7604,7 +7627,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -7620,7 +7643,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=kdy1/swc-core-0-92-1#e73ca0d44c2299b18d92ca0d1809539fd33a6963"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240517.2#a56214480242960a36ad6940ce6c5e84664e8705"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7718,9 +7741,9 @@ checksum = "d70b6494226b36008c8366c288d77190b3fad2eb4c10533139c1c1f461127f1a"
 
 [[package]]
 name = "unicode-id-start"
-version = "1.1.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f73150333cb58412db36f2aca8f2875b013049705cc77b94ded70a1ab1f5da"
+checksum = "02aebfa694eccbbbffdd92922c7de136b9fe764396d2f10e21bce1681477cfc1"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2871,7 +2871,7 @@ dependencies = [
  "swc_atoms",
  "swc_cached",
  "swc_common",
- "swc_ecma_ast 0.113.1",
+ "swc_ecma_ast 0.113.2",
  "swc_ecma_visit 0.99.1",
 ]
 
@@ -4007,15 +4007,15 @@ dependencies = [
 
 [[package]]
 name = "react_remove_properties"
-version = "0.24.9"
+version = "0.24.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a038f8a0e17048e66c4701d45cef55d5761e0b5614286e1490bb7e206b832ffc"
+checksum = "5fb434309dc6f664c8f531b3965dd7f99b7f8a52d4171697bb9de6af83564265"
 dependencies = [
  "serde",
  "swc_atoms",
  "swc_cached",
  "swc_common",
- "swc_ecma_ast 0.113.1",
+ "swc_ecma_ast 0.113.2",
  "swc_ecma_visit 0.99.1",
 ]
 
@@ -4124,15 +4124,15 @@ checksum = "c707298afce11da2efef2f600116fa93ffa7a032b5d7b628aa17711ec81383ca"
 
 [[package]]
 name = "remove_console"
-version = "0.25.9"
+version = "0.25.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b4db7538cf236701ee7fbc3d821d75f8da87f4474e16a5a75152ff188d5d7d"
+checksum = "ad1f807e0b5d9565a8558139ad4f1ec9703dd8cfa15607e347f3f66c4b7a0327"
 dependencies = [
  "serde",
  "swc_atoms",
  "swc_cached",
  "swc_common",
- "swc_ecma_ast 0.113.1",
+ "swc_ecma_ast 0.113.2",
  "swc_ecma_visit 0.99.1",
 ]
 
@@ -5008,7 +5008,7 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.1",
+ "swc_ecma_ast 0.113.2",
  "swc_ecma_utils 0.128.1",
  "swc_ecma_visit 0.99.1",
  "tracing",
@@ -5033,7 +5033,7 @@ dependencies = [
  "swc_css_parser",
  "swc_css_prefixer",
  "swc_css_visit",
- "swc_ecma_ast 0.113.1",
+ "swc_ecma_ast 0.113.2",
  "swc_ecma_minifier 0.193.3",
  "swc_ecma_parser 0.144.1",
  "swc_ecma_utils 0.128.1",
@@ -5324,7 +5324,7 @@ checksum = "d047aa3506175f1dbaca493341d533eacbeb60d1393d49c0ffd9d3ff63aaa4c3"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.1",
+ "swc_ecma_ast 0.113.2",
  "swc_ecma_loader",
  "swc_ecma_quote_macros 0.55.1",
  "swc_ecma_transforms_base 0.138.1",
@@ -5500,9 +5500,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.113.1"
+version = "0.113.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae9f905b3485ab348bf9009f71852f27c560d28a0d1f1ec69f0640b86eb1adc"
+checksum = "29f7cbdc8d3f31a863224649258942a537be44e37cb8f5413da63b51159779b9"
 dependencies = [
  "bitflags 2.5.0",
  "is-macro",
@@ -5549,7 +5549,7 @@ dependencies = [
  "sourcemap",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.1",
+ "swc_ecma_ast 0.113.2",
  "swc_ecma_codegen_macros",
  "tracing",
 ]
@@ -5871,7 +5871,7 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast 0.113.1",
+ "swc_ecma_ast 0.113.2",
  "swc_ecma_codegen 0.149.1",
  "swc_ecma_parser 0.144.1",
  "swc_ecma_transforms_base 0.138.1",
@@ -5922,7 +5922,7 @@ dependencies = [
  "stacker",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.1",
+ "swc_ecma_ast 0.113.2",
  "tracing",
  "typed-arena",
 ]
@@ -5980,7 +5980,7 @@ dependencies = [
  "quote",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.1",
+ "swc_ecma_ast 0.113.2",
  "swc_ecma_parser 0.144.1",
  "swc_macros_common",
  "syn 2.0.58",
@@ -6059,7 +6059,7 @@ dependencies = [
  "smallvec",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.1",
+ "swc_ecma_ast 0.113.2",
  "swc_ecma_parser 0.144.1",
  "swc_ecma_utils 0.128.1",
  "swc_ecma_visit 0.99.1",
@@ -6195,7 +6195,7 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.1",
+ "swc_ecma_ast 0.113.2",
  "swc_ecma_parser 0.144.1",
  "swc_ecma_transforms_base 0.138.1",
  "swc_ecma_transforms_macros",
@@ -6320,7 +6320,7 @@ dependencies = [
  "rustc-hash",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.1",
+ "swc_ecma_ast 0.113.2",
  "swc_ecma_utils 0.128.1",
  "swc_ecma_visit 0.99.1",
  "swc_timer",
@@ -6358,7 +6358,7 @@ dependencies = [
  "rustc-hash",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.1",
+ "swc_ecma_ast 0.113.2",
  "swc_ecma_visit 0.99.1",
  "tracing",
  "unicode-id",
@@ -6389,7 +6389,7 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.1",
+ "swc_ecma_ast 0.113.2",
  "swc_visit",
  "tracing",
 ]
@@ -6410,7 +6410,7 @@ dependencies = [
  "sourcemap",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.1",
+ "swc_ecma_ast 0.113.2",
  "swc_ecma_codegen 0.149.1",
  "swc_ecma_utils 0.128.1",
  "swc_ecma_visit 0.99.1",
@@ -6565,7 +6565,7 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.113.1",
+ "swc_ecma_ast 0.113.2",
  "swc_ecma_utils 0.128.1",
  "swc_ecma_visit 0.99.1",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3056,7 +3056,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "swc_core 0.92.0",
+ "swc_core 0.92.4",
  "tracing",
  "turbopack-binding",
  "walkdir",
@@ -5318,9 +5318,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.92.0"
+version = "0.92.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563b5324754cb00a8a6b5bec51215ff30d0c6b9913e7df1902577fd83899a105"
+checksum = "d047aa3506175f1dbaca493341d533eacbeb60d1393d49c0ffd9d3ff63aaa4c3"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8316,7 +8316,7 @@ dependencies = [
  "next-custom-transforms",
  "serde-wasm-bindgen",
  "serde_json",
- "swc_core 0.92.0",
+ "swc_core 0.92.4",
  "tracing",
  "turbopack-binding",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ next-core = { path = "packages/next-swc/crates/next-core" }
 next-custom-transforms = { path = "packages/next-swc/crates/next-custom-transforms" }
 
 # SWC crates
-swc_core = { version = "0.90.33", features = [
+swc_core = { version = "0.92.0", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ indoc = "2.0.0"
 itertools = "0.10.5"
 lazy_static = "1.4.0"
 log = "0.4.17"
-lightningcss = { version = "=1.0.0-alpha.54", features = [
+lightningcss = { version = "1.0.0-alpha.54", features = [
   "serde",
   "visitor",
   "into_owned",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.92.5", features = [
 testing = { version = "0.35.24" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swc-core-0-92-1" } # last tag: "turbopack-240516.1"
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240517.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swc-core-0-92-1" } # last tag: "turbopack-240516.1"
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240517.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swc-core-0-92-1" } # last tag: "turbopack-240516.1"
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240517.2" }
 
 # General Deps
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,11 @@ next-core = { path = "packages/next-swc/crates/next-core" }
 next-custom-transforms = { path = "packages/next-swc/crates/next-custom-transforms" }
 
 # SWC crates
-swc_core = { version = "0.92.0", features = [
+swc_core = { version = "0.92.4", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }
-testing = { version = "0.35.22" }
+testing = { version = "0.35.24" }
 
 # Turbo crates
 turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240516.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ next-core = { path = "packages/next-swc/crates/next-core" }
 next-custom-transforms = { path = "packages/next-swc/crates/next-custom-transforms" }
 
 # SWC crates
-swc_core = { version = "0.92.4", features = [
+swc_core = { version = "0.92.5", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.92.5", features = [
 testing = { version = "0.35.24" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240516.1" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swc-core-0-92-1" } # last tag: "turbopack-240516.1"
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240516.1" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swc-core-0-92-1" } # last tag: "turbopack-240516.1"
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240516.1" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "kdy1/swc-core-0-92-1" } # last tag: "turbopack-240516.1"
 
 # General Deps
 

--- a/packages/next-swc/crates/next-custom-transforms/Cargo.toml
+++ b/packages/next-swc/crates/next-custom-transforms/Cargo.toml
@@ -38,8 +38,8 @@ turbopack-binding = { workspace = true, features = [
 ] }
 # To allow quote! macro works
 swc_core = { workspace = true, features = ["ecma_quote"] }
-react_remove_properties = "0.24.7"
-remove_console = "0.25.7"
+react_remove_properties = "0.24.9"
+remove_console = "0.25.9"
 preset_env_base = "0.4.12"
 
 [dev-dependencies]

--- a/packages/next-swc/crates/next-custom-transforms/Cargo.toml
+++ b/packages/next-swc/crates/next-custom-transforms/Cargo.toml
@@ -38,8 +38,8 @@ turbopack-binding = { workspace = true, features = [
 ] }
 # To allow quote! macro works
 swc_core = { workspace = true, features = ["ecma_quote"] }
-react_remove_properties = "0.24.9"
-remove_console = "0.25.9"
+react_remove_properties = "0.24.12"
+remove_console = "0.25.12"
 preset_env_base = "0.4.12"
 
 [dev-dependencies]

--- a/packages/next-swc/crates/next-custom-transforms/tests/full/example/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/full/example/output.js
@@ -1,6 +1,6 @@
 import "@swc/helpers/_/_class_call_check";
 import { _ as e } from "@swc/helpers/_/_sliced_to_array";
-import r from "other";
+import r from 'other';
 e(r, 1)[0];
 export var __N_SSG = !0;
 export default function t() {

--- a/packages/next-swc/crates/next-custom-transforms/tests/loader/auto-cjs/2/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/loader/auto-cjs/2/output.js
@@ -1,4 +1,4 @@
 export default 1;
-Object.defineProperty(exports, "__esModule", {
+Object.defineProperty(exports, '__esModule', {
     value: true
 });

--- a/packages/next-swc/crates/next-custom-transforms/tests/loader/auto-cjs/3/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/loader/auto-cjs/3/output.js
@@ -1,6 +1,6 @@
 export default 1;
-console.log("__esModule");
-Object.defineProperty({}, "__esModule", {
+console.log('__esModule');
+Object.defineProperty({}, '__esModule', {
     value: true
 });
 Object.defineProperty();

--- a/packages/next-swc/crates/next-custom-transforms/tests/loader/auto-cjs/pack-2074/1/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/loader/auto-cjs/pack-2074/1/output.js
@@ -1,4 +1,4 @@
 export default function(module) {
     module.exports = {};
 };
-export var value = "mixed-syntax-esm";
+export var value = 'mixed-syntax-esm';

--- a/packages/next-swc/crates/next-custom-transforms/tests/loader/auto-cjs/pack-2074/2/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/loader/auto-cjs/pack-2074/2/output.js
@@ -1,4 +1,4 @@
 function foo(module) {
-    module.exports = "this is just normal assignment of scope variable";
+    module.exports = 'this is just normal assignment of scope variable';
 }
-export var value = "mixed-syntax-esm";
+export var value = 'mixed-syntax-esm';

--- a/packages/next-swc/crates/next-custom-transforms/tests/loader/example/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/loader/example/output.js
@@ -1,6 +1,6 @@
 import { _ as _class_call_check } from "@swc/helpers/_/_class_call_check";
 import { _ as _sliced_to_array } from "@swc/helpers/_/_sliced_to_array";
-import other from "other";
+import other from 'other';
 var _other = _sliced_to_array(other, 1), foo = _other[0];
 var Foo = function Foo() {
     "use strict";

--- a/packages/next-swc/crates/next-custom-transforms/tests/loader/issue-31627/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/loader/issue-31627/output.js
@@ -1,6 +1,6 @@
 import { _ as _class_call_check } from "@swc/helpers/_/_class_call_check";
-import { useEffect } from "react";
-import { select, selectAll } from "d3-selection";
+import { useEffect } from 'react';
+import { select, selectAll } from 'd3-selection';
 export default function Home() {
     useEffect(function() {
         new MyClass();
@@ -14,7 +14,7 @@ export default function Home() {
 var MyClass = function MyClass() {
     "use strict";
     _class_call_check(this, MyClass);
-    selectAll(".group").each(function() {
-        select(this).selectAll("path");
+    selectAll('.group').each(function() {
+        select(this).selectAll('path');
     });
 };

--- a/packages/next-swc/crates/next-custom-transforms/tests/loader/issue-32553/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/loader/issue-32553/output.js
@@ -1,2 +1,2 @@
 /*#__PURE__*/ React.createElement("div", null, "children");
-"<>hello</>";
+'<>hello</>';

--- a/packages/next-swc/crates/next-custom-transforms/tests/loader/styled-components/1/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/loader/styled-components/1/output.js
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled from 'styled-components';
 export var foo = styled.input.withConfig({
     displayName: "input__foo",
     componentId: "sc-21a13c03-0"

--- a/packages/next-swc/crates/wasm/src/mdx.rs
+++ b/packages/next-swc/crates/wasm/src/mdx.rs
@@ -10,7 +10,9 @@ pub fn mdx_compile_sync(value: JsString, opts: JsValue) -> Result<JsValue, JsVal
 
     compile(value.as_str(), &option)
         .map(|v| serde_wasm_bindgen::to_value(&v).expect("Should able to convert to JsValue"))
-        .map_err(|v| serde_wasm_bindgen::to_value(&v).expect("Should able to convert to JsValue"))
+        .map_err(|v| {
+            serde_wasm_bindgen::to_value(&v.to_string()).expect("Should able to convert to JsValue")
+        })
 }
 
 #[wasm_bindgen(js_name = "mdxCompile")]

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -206,7 +206,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.27.1",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240516.1",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?b5e0b7e7562b8d96232eb9852dbcb37fe1755094",
     "acorn": "8.11.3",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -206,7 +206,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.27.1",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?b5e0b7e7562b8d96232eb9852dbcb37fe1755094",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240517.2",
     "acorn": "8.11.3",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1085,8 +1085,8 @@ importers:
         specifier: 0.27.1
         version: 0.27.1
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240516.1
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240516.1'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?b5e0b7e7562b8d96232eb9852dbcb37fe1755094
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?b5e0b7e7562b8d96232eb9852dbcb37fe1755094'
       acorn:
         specifier: 8.11.3
         version: 8.11.3
@@ -25782,8 +25782,8 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240516.1':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240516.1}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?b5e0b7e7562b8d96232eb9852dbcb37fe1755094':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?b5e0b7e7562b8d96232eb9852dbcb37fe1755094}
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1085,8 +1085,8 @@ importers:
         specifier: 0.27.1
         version: 0.27.1
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?b5e0b7e7562b8d96232eb9852dbcb37fe1755094
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?b5e0b7e7562b8d96232eb9852dbcb37fe1755094'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240517.2
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240517.2'
       acorn:
         specifier: 8.11.3
         version: 8.11.3
@@ -25782,8 +25782,8 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?b5e0b7e7562b8d96232eb9852dbcb37fe1755094':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?b5e0b7e7562b8d96232eb9852dbcb37fe1755094}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240517.2':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240517.2}
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/test/unit/next-swc.test.ts
+++ b/test/unit/next-swc.test.ts
@@ -67,7 +67,7 @@ describe('next/swc', () => {
             if (n === "Map" || n === "Set") return Array.from(n);
             if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _array_like_to_array(o, minLen);
         }
-        import { useState } from "react";
+        import { useState } from 'react';
         var _useState = _sliced_to_array(useState(0), 2), count = _useState[0], setCount = _useState[1];
         "
       `)
@@ -107,7 +107,7 @@ describe('next/swc', () => {
             if (n === "Map" || n === "Set") return Array.from(n);
             if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _array_like_to_array(o, minLen);
         }
-        import { useState } from "react";
+        import { useState } from 'react';
         var _useState = _to_array(useState(0)), copy = _useState.slice(0);
         "
       `)


### PR DESCRIPTION
### What?

* https://github.com/vercel/turbo/pull/8101 <!-- Tobias Koppers - fix off-by-one bug while reading heaptrack files  -->
* https://github.com/vercel/turbo/pull/8130 <!-- Tobias Koppers - refactor memory tracking  -->
* https://github.com/vercel/turbo/pull/8097 <!-- Donny/강동윤 - build: Update `swc_core` to `v0.92.5`  -->

Update swc_core.


### Why?

To keep in sync and fix styled-jsx issues

### How?

Closes PACK-3042
