### PR TITLE
fix(next/image): set max url length to 3072

### DIFF
--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -188,6 +188,10 @@ export class ImageOptimizerCache {
       return { errorMessage: '"url" parameter cannot be an array' }
     }
 
+    if (url.length > 3072) {
+      return { errorMessage: '"url" parameter is too long' }
+    }
+
     let isAbsolute: boolean
 
     if (url.startsWith('/')) {

--- a/test/integration/image-optimizer/test/util.ts
+++ b/test/integration/image-optimizer/test/util.ts
@@ -982,6 +982,13 @@ export function runTests(ctx: RunTestsCtx) {
     expect(await res.text()).toBe(`"url" parameter is invalid`)
   })
 
+  it('should fail when url is too long', async () => {
+    const query = { url: `/${'a'.repeat(4000)}`, w: ctx.w, q: 1 }
+    const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
+    expect(res.status).toBe(400)
+    expect(await res.text()).toBe(`"url" parameter is too long`)
+  })
+
   it('should fail when internal url is not an image', async () => {
     const url = `//<h1>not-an-image</h1>`
     const query = { url, w: ctx.w, q: 39 }


### PR DESCRIPTION
This PR sets the maximum `url` parameter length to 3072 for image optimization since browsers don't usually support anything larger than that.

Closes NEXT-3348