### PR TITLE
chore: improve instructions in developing-using-local-app.md

### DIFF
--- a/contributing/core/developing-using-local-app.md
+++ b/contributing/core/developing-using-local-app.md
@@ -21,10 +21,10 @@ If you already have an app and it has dependencies, you can follow these steps:
 2. In your app's root directory, run:
 
    ```sh
-   pnpm add ./path/to/next.js/{packages/next,node_modules/{react,react-dom}}
+   pnpm add ./path/to/next.js/{packages/next,node_modules/{react,react-dom,@types/react,@types/react-dom}}
    ```
 
-   to re-install all of the dependencies and point `next`, `react` and `react-dom` to the monorepo versions.
+   to re-install all of the dependencies and point `next`, `react`, `react-dom`, `@types/react` and `@types/react-dom` to the monorepo versions. Replace `./path/to/next.js/` with the path to your next.js monorepo root.
 
    Note that Next.js will be copied from the locally compiled version as opposed to being downloaded from the NPM registry.
 


### PR DESCRIPTION
### What?

Improves the command to install next.js from your local next.js monorepo in the `developing-using-local-app.md` and clarifies instructions. 

### Why?

If we do not install the `@types/react` and `@types/react-dom` packages from the next monorepo, I'm getting a build error, as I now have mismatching `@types/react` versions installed:

![CleanShot 2024-05-07 at 15 37 52](https://github.com/vercel/next.js/assets/70709113/243f1e5a-63cf-43f6-beb6-eac749c5928a)

Adding them to the pnpm add command ensures that the right, matching versions are installed

