### PR TITLE
[ppr] Enable static shell debugging in other environments

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1432,7 +1432,7 @@ async function renderToHTMLOrFlightImpl(
   if (
     staticGenerationStore.prerenderState &&
     usedDynamicAPIs(staticGenerationStore.prerenderState) &&
-    staticGenerationStore.prerenderState?.isDebugSkeleton
+    staticGenerationStore.prerenderState?.isDebugDynamicAccesses
   ) {
     warn('The following dynamic usage was detected:')
     for (const access of formatDynamicAPIAccesses(

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -49,7 +49,7 @@ export type PrerenderState = {
   /**
    * When true, stack information will also be tracked during dynamic access.
    */
-  readonly isDebugSkeleton: boolean | undefined
+  readonly isDebugDynamicAccesses: boolean | undefined
 
   /**
    * The dynamic accesses that occurred during the render.
@@ -58,10 +58,10 @@ export type PrerenderState = {
 }
 
 export function createPrerenderState(
-  isDebugSkeleton: boolean | undefined
+  isDebugDynamicAccesses: boolean | undefined
 ): PrerenderState {
   return {
-    isDebugSkeleton,
+    isDebugDynamicAccesses,
     dynamicAccesses: [],
   }
 }
@@ -194,7 +194,9 @@ function postponeWithTracking(
   prerenderState.dynamicAccesses.push({
     // When we aren't debugging, we don't need to create another error for the
     // stack trace.
-    stack: prerenderState.isDebugSkeleton ? new Error().stack : undefined,
+    stack: prerenderState.isDebugDynamicAccesses
+      ? new Error().stack
+      : undefined,
     expression,
   })
 

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -172,10 +172,17 @@ export interface RenderOptsPartial {
   }
   postponed?: string
   /**
-   * When true, only the skeleton of the PPR page will be rendered. This will
-   * also enable other debugging features such as logging.
+   * When true, only the static shell of the page will be rendered. This will
+   * also enable other debugging features such as logging in development.
    */
-  isDebugPPRSkeleton?: boolean
+  isDebugStaticShell?: boolean
+
+  /**
+   * When true, the page will be rendered using the static rendering to detect
+   * any dynamic API's that would have stopped the page from being fully
+   * statically generated.
+   */
+  isDebugDynamicAccesses?: boolean
   isStaticGeneration?: boolean
 }
 

--- a/packages/next/src/server/async-storage/static-generation-async-storage-wrapper.ts
+++ b/packages/next/src/server/async-storage/static-generation-async-storage-wrapper.ts
@@ -45,7 +45,7 @@ export type StaticGenerationContext = {
     | 'isRevalidate'
     | 'nextExport'
     | 'isDraftMode'
-    | 'isDebugPPRSkeleton'
+    | 'isDebugDynamicAccesses'
   > &
     Partial<RequestLifecycleOpts>
 }
@@ -83,7 +83,7 @@ export const StaticGenerationAsyncStorageWrapper: AsyncStorageWrapper<
 
     const prerenderState: StaticGenerationStore['prerenderState'] =
       isStaticGeneration && renderOpts.experimental?.isRoutePPREnabled
-        ? createPrerenderState(renderOpts.isDebugPPRSkeleton)
+        ? createPrerenderState(renderOpts.isDebugDynamicAccesses)
         : null
 
     const store: StaticGenerationStore = {

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2014,8 +2014,12 @@ export default abstract class Server<
       typeof routeModule !== 'undefined' &&
       isAppPageRouteModule(routeModule)
 
+    // When enabled, this will allow the use of the `?__nextppronly` query to
+    // enable debugging of the static shell.
     const hasDebugStaticShellQuery =
-      typeof query.__nextppronly !== 'undefined' && couldSupportPPR
+      process.env.__NEXT_EXPERIMENTAL_STATIC_SHELL_DEBUGGING === '1' &&
+      typeof query.__nextppronly !== 'undefined' &&
+      couldSupportPPR
 
     // This page supports PPR if it has `experimentalPPR` set to `true` in the
     // prerender manifest and this is an app page.

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2014,29 +2014,34 @@ export default abstract class Server<
       typeof routeModule !== 'undefined' &&
       isAppPageRouteModule(routeModule)
 
-    // If this is a request that's rendering an app page that support's PPR,
-    // then if we're in development mode (or using the experimental test
-    // proxy) and the query parameter is set, then we should render the
-    // skeleton. We assume that if the page _could_ support it, we should
-    // show the skeleton in development. Ideally we would check the appConfig
-    // to see if this page has it enabled or not, but that would require
-    // plumbing the appConfig through to the server during development.
-    const isDebugPPRSkeleton =
-      query.__nextppronly &&
-      couldSupportPPR &&
-      (this.renderOpts.dev || this.experimentalTestProxy)
-        ? true
-        : false
+    const hasDebugStaticShellQuery =
+      typeof query.__nextppronly !== 'undefined' && couldSupportPPR
 
     // This page supports PPR if it has `experimentalPPR` set to `true` in the
     // prerender manifest and this is an app page.
     const isRoutePPREnabled: boolean =
       couldSupportPPR &&
+      // In production, we'd expect to see the `experimentalPPR` flag set in the
+      // prerender manifest.
       ((
         prerenderManifest.routes[pathname] ??
         prerenderManifest.dynamicRoutes[pathname]
       )?.experimentalPPR === true ||
-        isDebugPPRSkeleton)
+        // Ideally we'd want to check the appConfig to see if this page has PPR
+        // enabled or not, but that would require plumbing the appConfig through
+        // to the server during development. We assume that the page supports it
+        // but only during development.
+        (hasDebugStaticShellQuery &&
+          (this.renderOpts.dev === true ||
+            this.experimentalTestProxy === true)))
+
+    const isDebugStaticShell: boolean =
+      hasDebugStaticShellQuery && isRoutePPREnabled
+
+    // We should enable debugging dynamic accesses when the static shell
+    // debugging has been enabled and we're also in development mode.
+    const isDebugDynamicAccesses =
+      isDebugStaticShell && this.renderOpts.dev === true
 
     // If we're in minimal mode, then try to get the postponed information from
     // the request metadata. If available, use it for resuming the postponed
@@ -2274,13 +2279,16 @@ export default abstract class Server<
     // TODO: investigate, this is not safe across multiple concurrent requests
     incrementalCache?.resetRequestCache()
 
-    type Renderer = (context: {
+    type RendererContext = {
       /**
        * The postponed data for this render. This is only provided when resuming
        * a render that has been postponed.
        */
       postponed: string | undefined
-    }) => Promise<ResponseCacheEntry | null>
+    }
+    type Renderer = (
+      context: RendererContext
+    ) => Promise<ResponseCacheEntry | null>
 
     const doRender: Renderer = async ({ postponed }) => {
       // In development, we always want to generate dynamic HTML.
@@ -2360,13 +2368,14 @@ export default abstract class Server<
         onClose: res.onClose.bind(res),
       }
 
-      if (isDebugPPRSkeleton) {
+      if (isDebugStaticShell || isDebugDynamicAccesses) {
         supportsDynamicResponse = false
         renderOpts.nextExport = true
         renderOpts.supportsDynamicResponse = false
         renderOpts.isStaticGeneration = true
         renderOpts.isRevalidate = true
-        renderOpts.isDebugPPRSkeleton = true
+        renderOpts.isDebugStaticShell = isDebugStaticShell
+        renderOpts.isDebugDynamicAccesses = isDebugDynamicAccesses
       }
 
       // Legacy render methods will return a render result that needs to be
@@ -2744,17 +2753,37 @@ export default abstract class Server<
         }
       }
 
-      const result = await doRender({
+      const context: RendererContext = {
         // Only requests that aren't revalidating can be resumed. If we have the
         // minimal postponed data, then we should resume the render with it.
         postponed:
           !isOnDemandRevalidate && !isRevalidating && minimalPostponed
             ? minimalPostponed
             : undefined,
-      })
-      if (!result) {
-        return null
       }
+
+      // When we're in minimal mode, if we're trying to debug the static shell,
+      // we should just return nothing instead of resuming the dynamic render.
+      if (
+        (isDebugStaticShell || isDebugDynamicAccesses) &&
+        typeof context.postponed !== 'undefined'
+      ) {
+        return {
+          revalidate: 1,
+          value: {
+            kind: 'PAGE',
+            html: RenderResult.fromStatic(''),
+            pageData: {},
+            postponed: undefined,
+            headers: undefined,
+            status: undefined,
+          },
+        }
+      }
+
+      // Perform the render.
+      const result = await doRender(context)
+      if (!result) return null
 
       return {
         ...result,
@@ -3055,9 +3084,11 @@ export default abstract class Server<
         }
       }
 
-      // If we're debugging the skeleton, we should just serve the HTML without
-      // resuming the render. The returned HTML will be the static shell.
-      if (isDebugPPRSkeleton) {
+      // If we're debugging the static shell or the dynamic API accesses, we
+      // should just serve the HTML without resuming the render. The returned
+      // HTML will be the static shell so all the Dynamic API's will be used
+      // during static generation.
+      if (isDebugStaticShell || isDebugDynamicAccesses) {
         return { type: 'html', body, revalidate: 0 }
       }
 

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -12,6 +12,10 @@ describe('app dir - basic', () => {
   const { next, isNextDev, isNextStart, isNextDeploy, isTurbopack } =
     nextTestSetup({
       files: __dirname,
+      env: {
+        // This won't take affect until PPR is also enabled for this build.
+        __NEXT_EXPERIMENTAL_STATIC_SHELL_DEBUGGING: '1',
+      },
       buildCommand: process.env.NEXT_EXPERIMENTAL_COMPILE
         ? `pnpm next build --experimental-build-mode=compile`
         : undefined,

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -12,10 +12,6 @@ describe('app dir - basic', () => {
   const { next, isNextDev, isNextStart, isNextDeploy, isTurbopack } =
     nextTestSetup({
       files: __dirname,
-      env: {
-        // This won't take affect until PPR is also enabled for this build.
-        __NEXT_EXPERIMENTAL_STATIC_SHELL_DEBUGGING: '1',
-      },
       buildCommand: process.env.NEXT_EXPERIMENTAL_COMPILE
         ? `pnpm next build --experimental-build-mode=compile`
         : undefined,
@@ -23,17 +19,6 @@ describe('app dir - basic', () => {
         nanoid: '4.0.1',
       },
     })
-
-  if (isPPREnabledByDefault) {
-    it('should allow returning just skeleton in dev with query', async () => {
-      const res = await next.fetch('/skeleton?__nextppronly=1')
-      expect(res.status).toBe(200)
-
-      const html = await res.text()
-      expect(html).toContain('Skeleton')
-      expect(html).not.toContain('suspended content')
-    })
-  }
 
   if (process.env.NEXT_EXPERIMENTAL_COMPILE) {
     it('should provide query for getStaticProps page correctly', async () => {

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -9,23 +9,18 @@ import stripAnsi from 'strip-ansi'
 const isPPREnabledByDefault = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
 
 describe('app dir - basic', () => {
-  const {
-    next,
-    isNextDev: isDev,
-    isNextStart,
-    isNextDeploy,
-    isTurbopack,
-  } = nextTestSetup({
-    files: __dirname,
-    buildCommand: process.env.NEXT_EXPERIMENTAL_COMPILE
-      ? `pnpm next build --experimental-build-mode=compile`
-      : undefined,
-    dependencies: {
-      nanoid: '4.0.1',
-    },
-  })
+  const { next, isNextDev, isNextStart, isNextDeploy, isTurbopack } =
+    nextTestSetup({
+      files: __dirname,
+      buildCommand: process.env.NEXT_EXPERIMENTAL_COMPILE
+        ? `pnpm next build --experimental-build-mode=compile`
+        : undefined,
+      dependencies: {
+        nanoid: '4.0.1',
+      },
+    })
 
-  if (isDev && isPPREnabledByDefault) {
+  if (isPPREnabledByDefault) {
     it('should allow returning just skeleton in dev with query', async () => {
       const res = await next.fetch('/skeleton?__nextppronly=1')
       expect(res.status).toBe(200)
@@ -142,7 +137,7 @@ describe('app dir - basic', () => {
     })
   })
 
-  if (!isDev) {
+  if (!isNextDev) {
     it('should successfully detect app route during prefetch', async () => {
       const browser = await next.browser('/')
 
@@ -229,7 +224,7 @@ describe('app dir - basic', () => {
     expect(await browser.eval('window.beforeNav')).toBe(1)
   })
 
-  if (isDev) {
+  if (isNextDev) {
     it('should not have duplicate config warnings', async () => {
       await next.fetch('/')
       expect(
@@ -573,7 +568,7 @@ describe('app dir - basic', () => {
   })
 
   // TODO-APP: Enable in development
-  ;(isDev ||
+  ;(isNextDev ||
     // When PPR is enabled, the shared layouts re-render because we prefetch
     // from the root. This will be addressed before GA.
     isPPREnabledByDefault
@@ -1148,7 +1143,7 @@ describe('app dir - basic', () => {
     })
   })
 
-  if (isDev) {
+  if (isNextDev) {
     describe('HMR', () => {
       it('should HMR correctly for server component', async () => {
         const filePath = 'app/dashboard/index/page.js'
@@ -1368,7 +1363,7 @@ describe('app dir - basic', () => {
     })
 
     // TODO-APP: disable failing test and investigate later
-    ;(isDev ||
+    ;(isNextDev ||
       // When PPR is enabled, the shared layouts re-render because we prefetch
       // from the root. This will be addressed before GA.
       isPPREnabledByDefault
@@ -1508,7 +1503,7 @@ describe('app dir - basic', () => {
         const val2 = await browser.elementByCss('#value-2').text()
 
         // TODO: enable when fetch cache is enabled in dev
-        if (!isDev) {
+        if (!isNextDev) {
           expect(val1).toBe(val2)
         }
       })
@@ -1701,7 +1696,7 @@ describe('app dir - basic', () => {
         expect(element.attribs.nonce).toBeTruthy()
       })
 
-      if (!isDev) {
+      if (!isNextDev) {
         const browser = await next.browser('/script-nonce')
 
         await retry(async () => {
@@ -1744,7 +1739,7 @@ describe('app dir - basic', () => {
     })
 
     // Turbopack doesn't use eval by default, so we can check strict CSP.
-    if (!isDev || isTurbopack) {
+    if (!isNextDev || isTurbopack) {
       // This test is here to ensure that we don't accidentally turn CSP off
       // for the prod version.
       it('should successfully bootstrap even when using CSP', async () => {

--- a/test/e2e/app-dir/static-shell-debugging/app/layout.jsx
+++ b/test/e2e/app-dir/static-shell-debugging/app/layout.jsx
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/static-shell-debugging/app/page.jsx
+++ b/test/e2e/app-dir/static-shell-debugging/app/page.jsx
@@ -1,0 +1,17 @@
+import { unstable_noStore } from 'next/cache'
+import { Suspense } from 'react'
+
+function Dynamic() {
+  unstable_noStore()
+  return <div>Dynamic</div>
+}
+
+export default function Page() {
+  return (
+    <div>
+      <Suspense fallback={<div>Fallback</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/static-shell-debugging/static-shell-debugging.test.ts
+++ b/test/e2e/app-dir/static-shell-debugging/static-shell-debugging.test.ts
@@ -1,0 +1,40 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('static-shell-debugging', () => {
+  describe.each([
+    { ppr: true, debugging: true },
+    { ppr: false, debugging: true },
+    { ppr: true, debugging: false },
+    { ppr: false, debugging: false },
+  ])('ppr = $ppr, debugging = $debugging', (context) => {
+    const { next } = nextTestSetup({
+      files: __dirname,
+      env: {
+        __NEXT_EXPERIMENTAL_STATIC_SHELL_DEBUGGING: context.debugging
+          ? '1'
+          : undefined,
+      },
+      nextConfig: { experimental: { ppr: context.ppr } },
+    })
+
+    if (context.debugging && context.ppr) {
+      it('should only render the static shell', async () => {
+        const res = await next.fetch('/?__nextppronly=1')
+        expect(res.status).toBe(200)
+
+        const html = await res.text()
+        expect(html).toContain('Fallback')
+        expect(html).not.toContain('Dynamic')
+      })
+    } else {
+      it('should render the full page', async () => {
+        const res = await next.fetch('/?__nextppronly=1')
+        expect(res.status).toBe(200)
+
+        const html = await res.text()
+        expect(html).toContain('Fallback')
+        expect(html).toContain('Dynamic')
+      })
+    }
+  })
+})


### PR DESCRIPTION
To assist with the development and testing of the new partial prerendering (PPR) paradigm, this introduces a stop-gap solution to let us verify issues with pages in preview and production environments if enabled. When a Next.js app is built and ran with the `__NEXT_EXPERIMENTAL_STATIC_SHELL_DEBUGGING=1` environment variable, pages that have PPR enabled in production and preview environments can have only their static shell served when accessed with a `?__nextppronly=1` query parameter.

If your project is not using PPR, it will not change anything. If a page is accessed in production or development with the query parameter but PPR is not enabled, it will not change anything. Tests have been added to validate that going forward.