### PR TITLE
fix: lazy load sharp

### DIFF
--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -42,6 +42,9 @@ const BLUR_QUALITY = 70 // should match `next-image-loader`
 let _sharp: typeof import('sharp')
 
 function getSharp() {
+  if (_sharp) {
+    return _sharp
+  }
   try {
     _sharp = require('sharp')
     if (_sharp && _sharp.concurrency() > 1) {

--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -39,24 +39,27 @@ const VECTOR_TYPES = [SVG]
 const BLUR_IMG_SIZE = 8 // should match `next-image-loader`
 const BLUR_QUALITY = 70 // should match `next-image-loader`
 
-let sharp: typeof import('sharp')
+let _sharp: typeof import('sharp')
 
-try {
-  sharp = require('sharp')
-  if (sharp && sharp.concurrency() > 1) {
-    // Reducing concurrency should reduce the memory usage too.
-    // We more aggressively reduce in dev but also reduce in prod.
-    // https://sharp.pixelplumbing.com/api-utility#concurrency
-    const divisor = process.env.NODE_ENV === 'development' ? 4 : 2
-    sharp.concurrency(Math.floor(Math.max(cpus().length / divisor, 1)))
+function getSharp() {
+  try {
+    _sharp = require('sharp')
+    if (_sharp && _sharp.concurrency() > 1) {
+      // Reducing concurrency should reduce the memory usage too.
+      // We more aggressively reduce in dev but also reduce in prod.
+      // https://sharp.pixelplumbing.com/api-utility#concurrency
+      const divisor = process.env.NODE_ENV === 'development' ? 4 : 2
+      _sharp.concurrency(Math.floor(Math.max(cpus().length / divisor, 1)))
+    }
+  } catch (e: unknown) {
+    if (isError(e) && e.code === 'MODULE_NOT_FOUND') {
+      throw new Error(
+        'Module `sharp` not found. Please run `npm install --cpu=wasm32 sharp` to install it.'
+      )
+    }
+    throw e
   }
-} catch (e: unknown) {
-  if (isError(e) && e.code === 'MODULE_NOT_FOUND') {
-    throw new Error(
-      'Module `sharp` not found. Please run `npm install --cpu=wasm32 sharp` to install it.'
-    )
-  }
-  throw e
+  return _sharp
 }
 
 export interface ImageParamsResult {
@@ -433,7 +436,7 @@ export async function optimizeImage({
 }): Promise<Buffer> {
   let optimizedBuffer = buffer
 
-  // Begin sharp transformation logic
+  const sharp = getSharp()
   const transformer = sharp(buffer, {
     sequentialRead: true,
   })


### PR DESCRIPTION
> [!NOTE]  
> This PR is easiest to review without whitespace.
> See https://github.com/vercel/next.js/pull/65484/files?w=1

This PR fixes an issue where importing `./image-optimizer` was loading sharp but we don't want to load it until we attempt to optimize an image. So this PR changes it to lazy load on first invocation to avoid metadata trying to initialize sharp.

![image](https://github.com/vercel/next.js/assets/229881/61f45f3c-922a-45b6-8ba6-b32764fd0257)

Closes NEXT-3355

Fixes https://github.com/vercel/next.js/issues/65247