### PR TITLE
Fix HMR with full assetPrefix URLs

### DIFF
--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -650,8 +650,15 @@ export async function initialize(opts: {
       if (opts.dev && developmentBundler && req.url) {
         const { basePath, assetPrefix } = config
 
+        // only prefix the URL with the asset prefix if it lacks a protocol
+        const prefix =
+          assetPrefix.startsWith('http://') ||
+          assetPrefix.startsWith('https://')
+            ? ''
+            : assetPrefix || basePath
+
         const isHMRRequest = req.url.startsWith(
-          ensureLeadingSlash(`${assetPrefix || basePath}/_next/webpack-hmr`)
+          ensureLeadingSlash(`${prefix}/_next/webpack-hmr`)
         )
 
         // only handle HMR requests if the basePath in the request


### PR DESCRIPTION
We have a Next.js server running on a different host from the client-facing app. We set `assetPrefix` accordingly (e.g. `http://localhost:3000`) which works fine, except for HMR, which has the following error repeating in the console:

```
WebSocket connection to http://localhost:3000/_next/webpack-hmr failed:
```

With no further detail.

This works fine in Next.js 13.5 but breaks in 14.x.

This patch generates the correct URL for the HMR endpoint when `assetPrefix` is a full http/https URL.