### PR TITLE
update turbopack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "serde",
  "smallvec",
@@ -3086,7 +3086,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "serde",
@@ -6935,7 +6935,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6966,7 +6966,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -6978,7 +6978,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6992,7 +6992,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7006,7 +7006,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -7022,7 +7022,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7054,7 +7054,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "base16",
  "hex",
@@ -7066,7 +7066,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "proc-macro-error",
@@ -7079,7 +7079,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7089,7 +7089,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "mimalloc",
 ]
@@ -7097,7 +7097,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7122,7 +7122,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7152,7 +7152,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7192,7 +7192,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7215,7 +7215,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "clap",
@@ -7232,7 +7232,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7261,7 +7261,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7288,7 +7288,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7324,7 +7324,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7359,7 +7359,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "serde",
  "serde_json",
@@ -7370,7 +7370,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7394,7 +7394,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7410,7 +7410,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7426,7 +7426,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7445,7 +7445,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "serde",
@@ -7460,7 +7460,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7475,7 +7475,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7509,7 +7509,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7529,7 +7529,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7547,7 +7547,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "serde",
@@ -7563,7 +7563,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7574,7 +7574,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -7590,7 +7590,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240503.1#844f4d6ce023536e0e18abe74348228dcc4c7b75"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240508.2#fdf21e050b271309fe247628c0c8d22c51c1e065"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.90.33", features = [
 testing = { version = "0.35.22" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240503.1" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240508.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240503.1" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240508.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240503.1" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240508.2" }
 
 # General Deps
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -200,7 +200,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.26.4",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240503.1",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240508.2",
     "acorn": "8.5.0",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1076,8 +1076,8 @@ importers:
         specifier: 0.26.4
         version: 0.26.4
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240503.1
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240503.1'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240508.2
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240508.2'
       acorn:
         specifier: 8.5.0
         version: 8.5.0
@@ -25731,8 +25731,8 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240503.1':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240503.1}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240508.2':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240508.2}
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
* https://github.com/vercel/turbo/pull/8073 <!-- OJ Kwon - feat(webpack-loaders): support dummy span interface  -->
* https://github.com/vercel/turbo/pull/8083 <!-- OJ Kwon - fix(webpack): print resource, project path when relative calc fails  -->
* https://github.com/vercel/turbo/pull/8094 <!-- Tim Neutkens - Implement bindings for Turbopack trace server  -->
* https://github.com/vercel/turbo/pull/8061 <!-- Tobias Koppers - reduce memory usage in analyser  -->
* https://github.com/vercel/turbo/pull/8077 <!-- Alexander Lyon - Remove async-trait from a few crates  -->
* https://github.com/vercel/turbo/pull/8102 <!-- Tobias Koppers - fix memory counting without custom allocator  -->
* https://github.com/vercel/turbo/pull/8096 <!-- Benjamin Woodruff - turbo-tasks: Expand `<T as TaskOutput>::Return` values in macros  -->
* https://github.com/vercel/turbo/pull/8105 <!-- Benjamin Woodruff - turbopack-node: Use path.join for postcss loader  -->
* https://github.com/vercel/turbo/pull/8099 <!-- Tim Neutkens - Replace websocket with tungstenite for turbo-trace-server  -->
* https://github.com/vercel/turbo/pull/8060 <!-- Donny/강동윤 - feat: Add lint for `grid-template-areas`  -->
* https://github.com/vercel/turbo/pull/8110 <!-- Tobias Koppers - fix lockfile  -->