### PR TITLE
fix!: add sharp timeout of 10 seconds

### DIFF
--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -437,14 +437,10 @@ export async function optimizeImage({
   height?: number
   nextConfigOutput?: 'standalone' | 'export'
 }): Promise<Buffer> {
-  let optimizedBuffer = buffer
-
   const sharp = getSharp()
-  const transformer = sharp(buffer, {
-    sequentialRead: true,
-  })
-
-  transformer.rotate()
+  const transformer = sharp(buffer, { sequentialRead: true })
+    .timeout({ seconds: 10 })
+    .rotate()
 
   if (height) {
     transformer.resize(width, height)
@@ -468,7 +464,7 @@ export async function optimizeImage({
     transformer.jpeg({ quality, progressive: true })
   }
 
-  optimizedBuffer = await transformer.toBuffer()
+  const optimizedBuffer = await transformer.toBuffer()
 
   return optimizedBuffer
 }


### PR DESCRIPTION
This PR [configures sharp](https://sharp.pixelplumbing.com/api-output#timeout) with a timeout of 10 seconds when optimizing an image.

Anything longer will throw an error which we will catch and [fallback to serving the unoptimized source image](https://github.com/vercel/next.js/blob/c942006d83d504822ff2f6822fa2608e8e773324/packages/next/src/server/image-optimizer.ts#L637).



Closes NEXT-3359