### PR TITLE
feat(turbopack): add support for `bundlePagesRouterDependencies`

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_config.rs
+++ b/packages/next-swc/crates/next-core/src/next_config.rs
@@ -88,6 +88,18 @@ pub struct NextConfig {
     pub dev_indicators: Option<DevIndicatorsConfig>,
     pub output: Option<OutputType>,
 
+    /// Enables the bundling of node_modules packages (externals) for pages
+    /// server-side bundles.
+    ///
+    /// [API Reference](https://nextjs.org/docs/pages/api-reference/next-config-js/bundlePagesRouterDependencies)
+    pub bundle_pages_router_dependencies: Option<bool>,
+
+    /// A list of packages that should be treated as external on the server
+    /// build.
+    ///
+    /// [API Reference](https://nextjs.org/docs/app/api-reference/next-config-js/serverExternalPackages)
+    pub server_external_packages: Option<Vec<String>>,
+
     #[serde(rename = "_originalRedirects")]
     pub original_redirects: Option<Vec<Redirect>>,
 
@@ -120,9 +132,6 @@ pub struct NextConfig {
     typescript: TypeScriptConfig,
     use_file_system_public_routes: bool,
     webpack: Option<serde_json::Value>,
-    /// A list of packages that should be treated as external in the RSC server
-    /// build. @see [api reference](https://nextjs.org/docs/app/api-reference/next-config-js/server_external_packages)
-    pub server_external_packages: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs)]
@@ -734,6 +743,11 @@ impl NextConfig {
         let config: NextConfig = serde_json::from_str(&string)
             .with_context(|| format!("failed to parse next.config.js: {}", string))?;
         Ok(config.cell())
+    }
+
+    #[turbo_tasks::function]
+    pub fn bundle_pages_router_dependencies(&self) -> Vc<bool> {
+        Vc::cell(self.bundle_pages_router_dependencies.unwrap_or_default())
     }
 
     #[turbo_tasks::function]

--- a/packages/next/src/build/handle-externals.ts
+++ b/packages/next/src/build/handle-externals.ts
@@ -181,7 +181,7 @@ export function makeExternalHandler({
     // Absolute requires (require('/foo')) are extremely uncommon, but
     // also have no need for customization as they're already resolved.
     if (!isLocal) {
-      if (/^(?:next$)/.test(request)) {
+      if (/^next$/.test(request)) {
         return `commonjs ${request}`
       }
 
@@ -380,6 +380,7 @@ function resolveBundlingOptOutPackages({
   if (nodeModulesRegex.test(resolvedRes)) {
     const shouldBundlePages =
       !isAppLayer && config.bundlePagesRouterDependencies && !isOptOutBundling
+
     const shouldBeBundled =
       shouldBundlePages ||
       isResourceInPackages(
@@ -387,6 +388,7 @@ function resolveBundlingOptOutPackages({
         config.transpilePackages,
         resolvedExternalPackageDirs
       )
+
     if (!shouldBeBundled) {
       return `${externalType} ${request}` // Externalize if not bundled or opted out
     }

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -836,11 +836,12 @@ export interface NextConfig extends Record<string, any> {
 
   /**
    * Enables the bundling of node_modules packages (externals) for pages server-side bundles.
+   * @see https://nextjs.org/docs/pages/api-reference/next-config-js/bundlePagesRouterDependencies
    */
   bundlePagesRouterDependencies?: boolean
 
   /**
-   * A list of packages that should be treated as external in the RSC server build.
+   * A list of packages that should be treated as external in the server build.
    * @see https://nextjs.org/docs/app/api-reference/next-config-js/serverExternalPackages
    */
   serverExternalPackages?: string[]
@@ -955,10 +956,10 @@ export const defaultConfig: NextConfig = {
       // If we're testing, and the `__NEXT_EXPERIMENTAL_PPR` environment variable
       // has been set to `true`, enable the experimental PPR feature so long as it
       // wasn't explicitly disabled in the config.
-      process.env.__NEXT_TEST_MODE &&
-      process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
-        ? true
-        : false,
+      !!(
+        process.env.__NEXT_TEST_MODE &&
+        process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+      ),
     webpackBuildWorker: undefined,
     missingSuspenseWithCSRBailout: true,
     optimizeServerReact: true,

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -8483,11 +8483,11 @@
       "runtimeError": false
     },
     "test/integration/externals-pages-bundle/test/index.test.js": {
-      "passed": [],
-      "failed": [
+      "passed": [
         "bundle pages externals with config.bundlePagesRouterDependencies production mode should have no externals with the config set",
         "bundle pages externals with config.bundlePagesRouterDependencies production mode should respect the serverExternalPackages config"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false


### PR DESCRIPTION
### What?

This also makes the behavior of `transpilePackages` and `serverExternalPackages` match a bit more closely to webpack.

Closes PACK-3047

