### PR TITLE
Fix peerDependencies in next package

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -104,8 +104,8 @@
   "peerDependencies": {
     "@opentelemetry/api": "^1.1.0",
     "@playwright/test": "^1.41.2",
-    "react": "19.0.0-beta-4508873393-20240430",
-    "react-dom": "19.0.0-beta-4508873393-20240430",
+    "react": "^18.2.0 || 19.0.0-beta-4508873393-20240430",
+    "react-dom": "^18.2.0 || 19.0.0-beta-4508873393-20240430",
     "sass": "^1.3.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Seems our `peerDependencies` was bumped too high in https://github.com/vercel/next.js/pull/65058 so this ensures we still allow the previous range for `react` and `react-dom`. 

Closes NEXT-3361