### PR TITLE
chore: add prettier update to blame ignore

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,3 +4,6 @@
 
 # chore(examples): use default prettier for examples/templates (#60530)
 4466ba436b996263307171d344cca199e8087744
+
+# chore: update prettier to 3.2.5 (#65092)
+64b718c6618b6c419872abbf22163ae543ac259e


### PR DESCRIPTION
### Why?

To make the git blame show functional changes instead.