### PR TITLE
test: consolidate action flaky test

### DIFF
--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -890,13 +890,12 @@ describe('app-dir action handling', () => {
       await browser.elementByCss('#redirect-pages').click()
 
       await retry(async () => {
+        expect(await browser.elementByCss('body').text()).toContain(
+          'Hello from a pages route'
+        )
         expect(await browser.url()).toBe(`${next.url}/pages-dir`)
         expect(mpaTriggered).toBe(true)
       })
-
-      expect(await browser.elementByCss('body').text()).toContain(
-        'Hello from a pages route'
-      )
     })
 
     // TODO: investigate flakey behavior with revalidate

--- a/test/e2e/app-dir/actions/app/client/actions-lib.js
+++ b/test/e2e/app-dir/actions/app/client/actions-lib.js
@@ -2,7 +2,7 @@
 
 // Any arbitrary library just to ensure it's bundled.
 // https://github.com/vercel/next.js/pull/51367
-import nanoid from 'nanoid'
+import { nanoid } from 'nanoid'
 
 export async function test() {
   console.log(nanoid)


### PR DESCRIPTION
This test failed in dev. It has 2 problems:

1. the nanoid only contains named export
2. we should wait for the content changed then check the browser url

```
  ● app-dir action handling › fetch actions › should handle redirects to routes that provide an
invalid RSC response

    expect(received).toBe(expected) // Object.is equality

    Expected: "http://localhost:50473/pages-dir"
    Received: "http://localhost:50473/client"

      891 |
      892 |       await retry(async () => {
    > 893 |         expect(await browser.url()).toBe(`${next.url}/pages-dir`)
 ```


Closes NEXT-3369