### PR TITLE
Fix `/dynamic` in `test/.stats-app`

### DIFF
--- a/test/.stats-app/pages/dynamic.js
+++ b/test/.stats-app/pages/dynamic.js
@@ -1,6 +1,8 @@
 import dynamic from 'next/dynamic'
 
-const DynamicHello = dynamic(() => import('../components/hello'))
+const DynamicHello = dynamic(() =>
+  import('../components/hello').then((mod) => mod.Hello)
+)
 
 const Page = () => (
   <>


### PR DESCRIPTION
Noticed while doing some testing that this route was broken in this application. We use some parts of this app to generate statistics - I'm planning to use more of the routes for benchmarking so I wanted to ensure it was working.

Closes NEXT-3371