### PR TITLE
Revert "Remove ineffective webpack rules and unused app-page context modules"

### DIFF
--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
@@ -613,7 +613,11 @@ export class NextTypesPlugin {
         }
         return
       }
-      if (mod.layer !== WEBPACK_LAYERS.reactServerComponents) return
+      if (
+        mod.layer !== WEBPACK_LAYERS.reactServerComponents &&
+        mod.layer !== WEBPACK_LAYERS.appRouteHandler
+      )
+        return
 
       const IS_LAYOUT = /[/\\]layout\.[^./\\]+$/.test(mod.resource)
       const IS_PAGE = !IS_LAYOUT && /[/\\]page\.[^.]+$/.test(mod.resource)

--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -115,8 +115,7 @@ const WEBPACK_LAYERS_NAMES = {
    */
   shared: 'shared',
   /**
-   * The layer for server-only runtime and picking up `react-server` export conditions.
-   * Including app router RSC pages and app router custom routes.
+   * React Server Components layer (rsc).
    */
   reactServerComponents: 'rsc',
   /**
@@ -151,6 +150,10 @@ const WEBPACK_LAYERS_NAMES = {
    * The server bundle layer for metadata routes.
    */
   appMetadataRoute: 'app-metadata-route',
+  /**
+   * The layer for the server bundle for App Route handlers.
+   */
+  appRouteHandler: 'app-route-handler',
 } as const
 
 export type WebpackLayerName =
@@ -163,6 +166,7 @@ const WEBPACK_LAYERS = {
       WEBPACK_LAYERS_NAMES.reactServerComponents,
       WEBPACK_LAYERS_NAMES.actionBrowser,
       WEBPACK_LAYERS_NAMES.appMetadataRoute,
+      WEBPACK_LAYERS_NAMES.appRouteHandler,
       WEBPACK_LAYERS_NAMES.instrument,
     ],
     clientOnly: [
@@ -178,6 +182,7 @@ const WEBPACK_LAYERS = {
       WEBPACK_LAYERS_NAMES.reactServerComponents,
       WEBPACK_LAYERS_NAMES.actionBrowser,
       WEBPACK_LAYERS_NAMES.appMetadataRoute,
+      WEBPACK_LAYERS_NAMES.appRouteHandler,
       WEBPACK_LAYERS_NAMES.serverSideRendering,
       WEBPACK_LAYERS_NAMES.appPagesBrowser,
       WEBPACK_LAYERS_NAMES.shared,

--- a/packages/next/src/server/future/route-modules/app-page/vendored/contexts/entrypoints.ts
+++ b/packages/next/src/server/future/route-modules/app-page/vendored/contexts/entrypoints.ts
@@ -3,5 +3,8 @@ export * as ServerInsertedHtml from '../../../../../../shared/lib/server-inserte
 export * as AppRouterContext from '../../../../../../shared/lib/app-router-context.shared-runtime'
 export * as HooksClientContext from '../../../../../../shared/lib/hooks-client-context.shared-runtime'
 export * as RouterContext from '../../../../../../shared/lib/router-context.shared-runtime'
+export * as HtmlContext from '../../../../../../shared/lib/html-context.shared-runtime'
 export * as AmpContext from '../../../../../../shared/lib/amp-context.shared-runtime'
+export * as LoadableContext from '../../../../../../shared/lib/loadable-context.shared-runtime'
 export * as ImageConfigContext from '../../../../../../shared/lib/image-config-context.shared-runtime'
+export * as Loadable from '../../../../../../shared/lib/loadable.shared-runtime'

--- a/packages/next/src/server/future/route-modules/app-page/vendored/contexts/html-context.ts
+++ b/packages/next/src/server/future/route-modules/app-page/vendored/contexts/html-context.ts
@@ -1,0 +1,3 @@
+module.exports = require('../../module.compiled').vendored[
+  'contexts'
+].HtmlContext

--- a/packages/next/src/server/future/route-modules/app-page/vendored/contexts/loadable-context.ts
+++ b/packages/next/src/server/future/route-modules/app-page/vendored/contexts/loadable-context.ts
@@ -1,0 +1,3 @@
+module.exports = require('../../module.compiled').vendored[
+  'contexts'
+].LoadableContext

--- a/packages/next/src/server/future/route-modules/app-page/vendored/contexts/loadable.ts
+++ b/packages/next/src/server/future/route-modules/app-page/vendored/contexts/loadable.ts
@@ -1,0 +1,1 @@
+module.exports = require('../../module.compiled').vendored['contexts'].Loadable


### PR DESCRIPTION
Reverts vercel/next.js#65321

Missed covering `api` layer, got reported with below error. Revert it for now and will re-land it with more tests

```
../../node_modules/.pnpm/next@14.3.0-canary.51_@opentelemetry+api@1.7.0_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/client/components/navigation.js
02:23:13
Module not found: shared-runtime module app-router-context cannot be used in api layer
02:23:13
https://nextjs.org/docs/messages/module-not-found
```