### PR TITLE
remove legacy deprecated warnings

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_config.rs
+++ b/packages/next-swc/crates/next-core/src/next_config.rs
@@ -109,7 +109,6 @@ pub struct NextConfig {
     generate_etags: bool,
     http_agent_options: HttpAgentConfig,
     on_demand_entries: OnDemandEntriesConfig,
-    output_file_tracing: bool,
     powered_by_header: bool,
     production_browser_source_maps: bool,
     public_runtime_config: IndexMap<String, serde_json::Value>,

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2383,7 +2383,7 @@ export default async function build(
 
       await writeFunctionsConfigManifest(distDir, functionsConfigManifest)
 
-      if (!isGenerateMode && config.outputFileTracing && !buildTracesPromise) {
+      if (!isGenerateMode && !buildTracesPromise) {
         buildTracesPromise = collectBuildTraces({
           dir,
           config,

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1769,12 +1769,6 @@ export async function isPageStatic({
         ? {}
         : componentsResult.pageConfig
 
-      if (config.unstable_includeFiles || config.unstable_excludeFiles) {
-        Log.warn(
-          `unstable_includeFiles/unstable_excludeFiles has been removed in favor of the option in next.config.js.\nSee more info here: https://nextjs.org/docs/advanced-features/output-file-tracing#caveats`
-        )
-      }
-
       let isStatic = false
       if (!hasStaticProps && !hasGetInitialProps && !hasServerProps) {
         isStatic = true

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1761,8 +1761,7 @@ export default async function getBaseWebpackConfig(
           dev,
         }),
       (isClient || isEdgeServer) && new DropClientPage(),
-      config.outputFileTracing &&
-        isNodeServer &&
+      isNodeServer &&
         !dev &&
         new (require('./webpack/plugins/next-trace-entrypoints-plugin')
           .TraceEntryPointsPlugin as typeof import('./webpack/plugins/next-trace-entrypoints-plugin').TraceEntryPointsPlugin)(

--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -51,7 +51,6 @@ const unsupportedTurbopackNextConfigOptions = [
 
 // The following will need to be supported by `next build --turbo`
 const unsupportedProductionSpecificTurbopackNextConfigOptions = [
-  'outputFileTracing',
   // TODO: Support disabling sourcemaps, currently they're always enabled.
   // 'productionBrowserSourceMaps',
   'reactProductionProfiling',

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -541,7 +541,6 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
       .optional(),
     optimizeFonts: z.boolean().optional(),
     output: z.enum(['standalone', 'export']).optional(),
-    outputFileTracing: z.boolean().optional(),
     pageExtensions: z.array(z.string()).min(1).optional(),
     poweredByHeader: z.boolean().optional(),
     productionBrowserSourceMaps: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -224,17 +224,7 @@ export interface ExperimentalConfig {
    * much as possible, even when this leads to many requests.
    */
   cssChunking?: 'strict' | 'loose'
-  /**
-   * @deprecated use config.cacheHandler instead
-   */
-  incrementalCacheHandlerPath?: string
-  /**
-   * @deprecated use config.cacheMaxMemorySize instead
-   *
-   */
-  isrMemoryCacheSize?: number
   disablePostcssPresetEnv?: boolean
-  swcMinify?: boolean
   cpus?: number
   memoryBasedWorkersCount?: boolean
   proxyTimeout?: number
@@ -729,16 +719,6 @@ export interface NextConfig extends Record<string, any> {
   httpAgentOptions?: { keepAlive?: boolean }
 
   /**
-   * During a build, Next.js will automatically trace each page and its dependencies to determine all of the files
-   * that are needed for deploying a production version of your application.
-   *
-   * @see [Output File Tracing](https://nextjs.org/docs/advanced-features/output-file-tracing)
-   * @deprecated will be enabled by default and removed in Next.js 15
-   *
-   */
-  outputFileTracing?: boolean
-
-  /**
    * Timeout after waiting to generate static pages in seconds
    *
    * @default 60
@@ -752,14 +732,6 @@ export interface NextConfig extends Record<string, any> {
    * @see [`crossorigin` attribute documentation](https://developer.mozilla.org/docs/Web/HTML/Attributes/crossorigin)
    */
   crossOrigin?: 'anonymous' | 'use-credentials'
-
-  /**
-   * Use [SWC compiler](https://swc.rs) to minify the generated JavaScript
-   * @deprecated will be enabled by default and removed in Next.js 15
-   *
-   * @see [SWC Minification](https://nextjs.org/docs/advanced-features/compiler#minification)
-   */
-  swcMinify?: boolean
 
   /**
    * Optionally enable compiler transforms

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -867,7 +867,6 @@ export const defaultConfig: NextConfig = {
   httpAgentOptions: {
     keepAlive: true,
   },
-  outputFileTracing: true,
   staticPageGenerationTimeout: 60,
   swcMinify: true,
   output: !!process.env.NEXT_PRIVATE_STANDALONE ? 'standalone' : undefined,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -465,56 +465,6 @@ function assignDefaults(
     }
   }
 
-  if (result.experimental?.incrementalCacheHandlerPath) {
-    // TODO: Remove this warning in Next.js 15
-    warnOptionHasBeenDeprecated(
-      result,
-      'experimental.incrementalCacheHandlerPath',
-      'The "experimental.incrementalCacheHandlerPath" option has been renamed to "cacheHandler". Please update your next.config.js.',
-      silent
-    )
-  }
-
-  if (result.experimental?.isrMemoryCacheSize) {
-    // TODO: Remove this warning in Next.js 15
-    warnOptionHasBeenDeprecated(
-      result,
-      'experimental.isrMemoryCacheSize',
-      'The "experimental.isrMemoryCacheSize" option has been renamed to "cacheMaxMemorySize". Please update your next.config.js.',
-      silent
-    )
-  }
-
-  if (typeof result.experimental?.serverActions === 'boolean') {
-    // TODO: Remove this warning in Next.js 15
-    warnOptionHasBeenDeprecated(
-      result,
-      'experimental.serverActions',
-      'Server Actions are available by default now, `experimental.serverActions` option can be safely removed.',
-      silent
-    )
-  }
-
-  if (result.swcMinify === false) {
-    // TODO: Remove this warning in Next.js 15
-    warnOptionHasBeenDeprecated(
-      result,
-      'swcMinify',
-      'Disabling SWC Minifier will not be an option in the next major version. Please report any issues you may be experiencing to https://github.com/vercel/next.js/issues',
-      silent
-    )
-  }
-
-  if (result.outputFileTracing === false) {
-    // TODO: Remove this warning in Next.js 15
-    warnOptionHasBeenDeprecated(
-      result,
-      'outputFileTracing',
-      'Disabling outputFileTracing will not be an option in the next major version. Please report any issues you may be experiencing to https://github.com/vercel/next.js/issues',
-      silent
-    )
-  }
-
   warnOptionHasBeenMovedOutOfExperimental(
     result,
     'relay',

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -581,15 +581,6 @@ function assignDefaults(
     }
   }
 
-  if (result.output === 'standalone' && !result.outputFileTracing) {
-    if (!silent) {
-      Log.warn(
-        `"output: 'standalone'" requires outputFileTracing not be disabled please enable it to leverage the standalone build`
-      )
-    }
-    result.output = undefined
-  }
-
   setHttpClientAndAgentOptions(result || defaultConfig)
 
   if (result.i18n) {

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -160,7 +160,7 @@ export type PreviewData = string | false | object | undefined
  */
 export type GetStaticPropsContext<
   Params extends ParsedUrlQuery = ParsedUrlQuery,
-  Preview extends PreviewData = PreviewData
+  Preview extends PreviewData = PreviewData,
 > = {
   params?: Params
   preview?: boolean
@@ -195,7 +195,7 @@ export type GetStaticPropsResult<Props> =
 export type GetStaticProps<
   Props extends { [key: string]: any } = { [key: string]: any },
   Params extends ParsedUrlQuery = ParsedUrlQuery,
-  Preview extends PreviewData = PreviewData
+  Preview extends PreviewData = PreviewData,
 > = (
   context: GetStaticPropsContext<Params, Preview>
 ) => Promise<GetStaticPropsResult<Props>> | GetStaticPropsResult<Props>
@@ -215,7 +215,7 @@ export type GetStaticPathsContext = {
  * @link https://nextjs.org/docs/api-reference/data-fetching/get-static-paths#getstaticpaths-return-values
  */
 export type GetStaticPathsResult<
-  Params extends ParsedUrlQuery = ParsedUrlQuery
+  Params extends ParsedUrlQuery = ParsedUrlQuery,
 > = {
   paths: Array<string | { params: Params; locale?: string }>
   fallback: boolean | 'blocking'
@@ -242,7 +242,7 @@ export type GetStaticPaths<Params extends ParsedUrlQuery = ParsedUrlQuery> = (
  */
 export type GetServerSidePropsContext<
   Params extends ParsedUrlQuery = ParsedUrlQuery,
-  Preview extends PreviewData = PreviewData
+  Preview extends PreviewData = PreviewData,
 > = {
   req: IncomingMessage & {
     cookies: NextApiRequestCookies
@@ -281,7 +281,7 @@ export type GetServerSidePropsResult<Props> =
 export type GetServerSideProps<
   Props extends { [key: string]: any } = { [key: string]: any },
   Params extends ParsedUrlQuery = ParsedUrlQuery,
-  Preview extends PreviewData = PreviewData
+  Preview extends PreviewData = PreviewData,
 > = (
   context: GetServerSidePropsContext<Params, Preview>
 ) => Promise<GetServerSidePropsResult<Props>>
@@ -305,7 +305,7 @@ declare global {
         | Float32Array
         | Float64Array
         | DataView
-        | null
+        | null,
     >(
       array: T
     ): T

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -142,16 +142,6 @@ export type PageConfig = {
   runtime?: ServerRuntime
   unstable_runtimeJS?: false
   unstable_JsPreload?: false
-  /**
-   * @deprecated this config has been removed in favor of the next.config.js option
-   */
-  // TODO: remove in next minor release (current v13.1.1)
-  unstable_includeFiles?: string[]
-  /**
-   * @deprecated this config has been removed in favor of the next.config.js option
-   */
-  // TODO: remove in next minor release (current v13.1.1)
-  unstable_excludeFiles?: string[]
 }
 
 export type {
@@ -170,7 +160,7 @@ export type PreviewData = string | false | object | undefined
  */
 export type GetStaticPropsContext<
   Params extends ParsedUrlQuery = ParsedUrlQuery,
-  Preview extends PreviewData = PreviewData,
+  Preview extends PreviewData = PreviewData
 > = {
   params?: Params
   preview?: boolean
@@ -205,7 +195,7 @@ export type GetStaticPropsResult<Props> =
 export type GetStaticProps<
   Props extends { [key: string]: any } = { [key: string]: any },
   Params extends ParsedUrlQuery = ParsedUrlQuery,
-  Preview extends PreviewData = PreviewData,
+  Preview extends PreviewData = PreviewData
 > = (
   context: GetStaticPropsContext<Params, Preview>
 ) => Promise<GetStaticPropsResult<Props>> | GetStaticPropsResult<Props>
@@ -225,7 +215,7 @@ export type GetStaticPathsContext = {
  * @link https://nextjs.org/docs/api-reference/data-fetching/get-static-paths#getstaticpaths-return-values
  */
 export type GetStaticPathsResult<
-  Params extends ParsedUrlQuery = ParsedUrlQuery,
+  Params extends ParsedUrlQuery = ParsedUrlQuery
 > = {
   paths: Array<string | { params: Params; locale?: string }>
   fallback: boolean | 'blocking'
@@ -252,7 +242,7 @@ export type GetStaticPaths<Params extends ParsedUrlQuery = ParsedUrlQuery> = (
  */
 export type GetServerSidePropsContext<
   Params extends ParsedUrlQuery = ParsedUrlQuery,
-  Preview extends PreviewData = PreviewData,
+  Preview extends PreviewData = PreviewData
 > = {
   req: IncomingMessage & {
     cookies: NextApiRequestCookies
@@ -291,7 +281,7 @@ export type GetServerSidePropsResult<Props> =
 export type GetServerSideProps<
   Props extends { [key: string]: any } = { [key: string]: any },
   Params extends ParsedUrlQuery = ParsedUrlQuery,
-  Preview extends PreviewData = PreviewData,
+  Preview extends PreviewData = PreviewData
 > = (
   context: GetServerSidePropsContext<Params, Preview>
 ) => Promise<GetServerSidePropsResult<Props>>
@@ -315,7 +305,7 @@ declare global {
         | Float32Array
         | Float64Array
         | DataView
-        | null,
+        | null
     >(
       array: T
     ): T


### PR DESCRIPTION
# What
Remove the previous deprecated flags and warnings

Removed deprecated types:

In `next.config.js`
- `experimental.incrementalCacheHandlerPath` (has moved to new options in next 14)
- `experimental.isrMemoryCacheSize` (has moved to new options in next 14)
- `outputFileTracing` (not support customization anymore)
- `swcMinify` (not support customization anymore)

In `next/types`
- `unstable_includeFiles` (already deprecated for a while)
- `unstable_excludeFiles` (already deprecated for a while)