### PR TITLE
docs: explain about the conditional default metadataBase on vercel de…

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
@@ -430,14 +430,14 @@ export const metadata = {
 
 If not configured, `metadataBase` has a **default value**.
 
-On Vercel deployment:
-When it's production deployment `VERCEL_PROJECT_PRODUCTION_URL` will be picked up.
-When it's preview deployments, `VERCEL_BRANCH_URL` will be preferred to pick up and fallback to `VERCEL_URL` if it's not present.
-See more details about these environment variables in [System Environment Variables Overview](https://vercel.com/docs/concepts/projects/environment-variables/system-environment-variables) docs.
-
-If these values are present they will be used as the **default value** of `metadataBase`, otherwise it falls back to `http://localhost:${process.env.PORT || 3000}`. This allows Open Graph images to work on both local build and Vercel preview and production deployments.
-
-When overriding the default, we recommend using environment variables to compute the URL. This allows configuring a URL for local development, staging, and production environments.
+> On Vercel:
+> 
+> - For production deployments, `VERCEL_PROJECT_PRODUCTION_URL` will be used.
+> - For preview deployments, `VERCEL_BRANCH_URL` will take priority, and fallback to `VERCEL_URL` if it's not present.
+>
+> If these values are present they will be used as the **default value** of `metadataBase`, otherwise it falls back to `http://localhost:${process.env.PORT || 3000}`. This allows Open Graph images to work on both local build and Vercel preview and production deployments. When overriding the default, we recommend using environment variables to compute the URL. This allows configuring a URL for local development, staging, and production environments.
+>
+> See more details about these environment variables in the [System Environment Variables](https://vercel.com/docs/concepts/projects/environment-variables/system-environment-variables) docs.
 
 #### URL Composition
 

--- a/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
@@ -430,8 +430,14 @@ export const metadata = {
 
 If not configured, `metadataBase` has a **default value**.
 
-- When [`VERCEL_PROJECT_PRODUCTION_URL`](https://vercel.com/docs/concepts/projects/environment-variables/system-environment-variables) or [`VERCEL_URL`](https://vercel.com/docs/concepts/projects/environment-variables/system-environment-variables) is detected, it will be used as the **default value**, otherwise it falls back to `http://localhost:${process.env.PORT || 3000}`. This allows Open Graph images to work on both preview and production deployments.
-- When overriding the default, we recommend using environment variables to compute the URL. This allows configuring a URL for local development, staging, and production environments.
+On Vercel deployment:
+When it's production deployment `VERCEL_PROJECT_PRODUCTION_URL` will be picked up.
+When it's preview deployments, `VERCEL_BRANCH_URL` will be preferred to pick up and fallback to `VERCEL_URL` if it's not present.
+See more details about these environment variables in [System Environment Variables Overview](https://vercel.com/docs/concepts/projects/environment-variables/system-environment-variables) docs.
+
+If these values are present they will be used as the **default value** of `metadataBase`, otherwise it falls back to `http://localhost:${process.env.PORT || 3000}`. This allows Open Graph images to work on both local build and Vercel preview and production deployments.
+
+When overriding the default, we recommend using environment variables to compute the URL. This allows configuring a URL for local development, staging, and production environments.
 
 #### URL Composition
 

--- a/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
@@ -431,7 +431,7 @@ export const metadata = {
 If not configured, `metadataBase` has a **default value**.
 
 > On Vercel:
-> 
+>
 > - For production deployments, `VERCEL_PROJECT_PRODUCTION_URL` will be used.
 > - For preview deployments, `VERCEL_BRANCH_URL` will take priority, and fallback to `VERCEL_URL` if it's not present.
 >


### PR DESCRIPTION
Explain more details about default `metadataBase` (where `metadataBase` is not defined) when it's on Vercel deployment

x-ref: https://github.com/vercel/next.js/pull/65089