### PR TITLE
refactor: remove isRSCRequestCheck

### DIFF
--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -59,7 +59,7 @@ import type {
   NextEnabledDirectories,
   BaseRequestHandler,
 } from './base-server'
-import BaseServer, { NoFallbackError, isRSCRequestCheck } from './base-server'
+import BaseServer, { NoFallbackError } from './base-server'
 import { getMaybePagePath, getPagePath, requireFontManifest } from './require'
 import { denormalizePagePath } from '../shared/lib/page-path/denormalize-page-path'
 import { normalizePagePath } from '../shared/lib/page-path/normalize-page-path'
@@ -1130,7 +1130,10 @@ export default class NextNodeServer extends BaseServer<
 
           if (!routeMatch || isMiddlewareRequest) return
 
-          const isRSC = isRSCRequestCheck(normalizedReq)
+          // NOTE: this is only attached after handle has started, this runs
+          // after the response has been sent, so it should have it set.
+          const isRSC = getRequestMeta(normalizedReq, 'isRSCRequest')
+
           const reqEnd = Date.now()
           const fetchMetrics = normalizedReq.fetchMetrics || []
           const reqDuration = reqEnd - reqStart


### PR DESCRIPTION
In preparation for the following request adapter work, this removes a helper function for checking if a request is an RSC one, instead preferring to use the metadata directly.

This helps readability because we know where it's coming from, and it keeps the implementation simple.