### PR TITLE
Fix multi-zone test by removing dependency list

### DIFF
--- a/test/e2e/multi-zone/app/package.json
+++ b/test/e2e/multi-zone/app/package.json
@@ -1,12 +1,5 @@
 {
   "name": "with-zones",
   "version": "1.0.0",
-  "private": true,
-  "dependencies": {
-    "@types/react": "18.0.28",
-    "next": "canary",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "typescript": "^4.9.3"
-  }
+  "private": true
 }


### PR DESCRIPTION
This test was failing with my changes in https://github.com/vercel/next.js/pull/64932 because it was using the new Next.js changes, but not the corresponding react-dom changes. 

An alternative solution would be to update the react-dom versions to match those in the rest of the project (19 beta), but I think this is better overall.

After removing the dependencies, this test works in my branch.