### PR TITLE
Fix `NEXT_SKIP_ISOLATE=1` log for testing

### DIFF
--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -140,14 +140,16 @@ export class NextInstance {
     if (this.isDestroyed) {
       throw new Error('next instance already destroyed')
     }
-    require('console').log(
-      `Creating test directory with isolated next... (use NEXT_SKIP_ISOLATE=1 to opt-out)`
-    )
 
     await parentSpan
       .traceChild('createTestDir')
       .traceAsyncFn(async (rootSpan) => {
         const skipIsolatedNext = !!process.env.NEXT_SKIP_ISOLATE
+        if (!skipIsolatedNext) {
+          require('console').log(
+            `Creating test directory with isolated next... (use NEXT_SKIP_ISOLATE=1 to opt-out)`
+          )
+        }
         const tmpDir = skipIsolatedNext
           ? path.join(__dirname, '../../tmp')
           : process.env.NEXT_TEST_DIR || (await fs.realpath(os.tmpdir()))


### PR DESCRIPTION
This log was firing even when the env var is specified. Now it only logs when appropriate. 