### PR TITLE
Fix typo prevents navigation in authentication docs

### DIFF
--- a/docs/02-app/01-building-your-application/09-authentication/index.mdx
+++ b/docs/02-app/01-building-your-application/09-authentication/index.mdx
@@ -1135,7 +1135,7 @@ export const config = {
 }
 ```
 
-While Middleware can be useful for initial checks, it should not be your only line of defense in protecting your data. The majority of security checks should be performed as close as possible to your data source, see [Data Access Layer](#creating-a-data-access-layer-dal) for more information.
+While Middleware can be useful for initial checks, it should not be your only line of defense in protecting your data. The majority of security checks should be performed as close as possible to your data source, see [Data Access Layer](#creating-a-data-access-layer-dal-1) for more information.
 
 > **Tips**:
 >


### PR DESCRIPTION

### Fixed typo in authentication documentation

### Typo Prevents navigation in page - https://nextjs.org/docs/pages/building-your-application/authentication