### PR TITLE
Fix react version in create next e2e util

### DIFF
--- a/test/lib/e2e-utils.ts
+++ b/test/lib/e2e-utils.ts
@@ -158,10 +158,16 @@ const setupTracing = () => {
 export async function createNext(
   opts: NextInstanceOpts & { skipStart?: boolean }
 ): Promise<NextInstance> {
-  if (!semver.intersects(opts.dependencies.react, '^19.x')) {
+  if (
+    opts.dependencies.react &&
+    !semver.intersects(opts.dependencies.react, '^19.x')
+  ) {
     opts.dependencies.react = '19.0.0-beta-4508873393-20240430'
   }
-  if (!semver.intersects(opts.dependencies['react-dom'], '^19.x')) {
+  if (
+    opts.dependencies['react-dom'] &&
+    !semver.intersects(opts.dependencies['react-dom'], '^19.x')
+  ) {
     opts.dependencies['react-dom'] = '19.0.0-beta-4508873393-20240430'
   }
   try {

--- a/test/lib/e2e-utils.ts
+++ b/test/lib/e2e-utils.ts
@@ -159,13 +159,13 @@ export async function createNext(
   opts: NextInstanceOpts & { skipStart?: boolean }
 ): Promise<NextInstance> {
   if (
-    opts.dependencies.react &&
+    opts.dependencies?.react &&
     !semver.intersects(opts.dependencies.react, '^19.x')
   ) {
     opts.dependencies.react = '19.0.0-beta-4508873393-20240430'
   }
   if (
-    opts.dependencies['react-dom'] &&
+    opts.dependencies?.['react-dom'] &&
     !semver.intersects(opts.dependencies['react-dom'], '^19.x')
   ) {
     opts.dependencies['react-dom'] = '19.0.0-beta-4508873393-20240430'

--- a/test/lib/e2e-utils.ts
+++ b/test/lib/e2e-utils.ts
@@ -7,6 +7,7 @@ import { NextDevInstance } from './next-modes/next-dev'
 import { NextStartInstance } from './next-modes/next-start'
 import { NextDeployInstance } from './next-modes/next-deploy'
 import { shouldRunTurboDevTest } from './next-test-utils'
+import semver from 'semver'
 
 export type { NextInstance }
 
@@ -157,6 +158,12 @@ const setupTracing = () => {
 export async function createNext(
   opts: NextInstanceOpts & { skipStart?: boolean }
 ): Promise<NextInstance> {
+  if (semver.satisfies(opts.dependencies.react, '<19')) {
+    opts.dependencies.react = '^19'
+  }
+  if (semver.satisfies(opts.dependencies['react-dom'], '<19')) {
+    opts.dependencies['react-dom'] = '^19'
+  }
   try {
     if (nextInstance) {
       throw new Error(`createNext called without destroying previous instance`)

--- a/test/lib/e2e-utils.ts
+++ b/test/lib/e2e-utils.ts
@@ -158,11 +158,11 @@ const setupTracing = () => {
 export async function createNext(
   opts: NextInstanceOpts & { skipStart?: boolean }
 ): Promise<NextInstance> {
-  if (semver.satisfies(opts.dependencies.react, '<19')) {
-    opts.dependencies.react = '^19'
+  if (!semver.intersects(opts.dependencies.react, '^19.x')) {
+    opts.dependencies.react = '19.0.0-beta-4508873393-20240430'
   }
-  if (semver.satisfies(opts.dependencies['react-dom'], '<19')) {
-    opts.dependencies['react-dom'] = '^19'
+  if (!semver.intersects(opts.dependencies['react-dom'], '^19.x')) {
+    opts.dependencies['react-dom'] = '19.0.0-beta-4508873393-20240430'
   }
   try {
     if (nextInstance) {


### PR DESCRIPTION
Some of our e2e tests use repos with out-of-date React version that are incompatible with the Next.js canary requirements. 

This check will ensure that those test cases get the correct React.js version.

I cherry-picked this onto my other branch that was having failing tests and this solution fixed the failing tests.