### PR TITLE
Implement createBufferedTransformStream

### DIFF
--- a/packages/next/src/server/stream-utils/stream-utils.edge.test.tsx
+++ b/packages/next/src/server/stream-utils/stream-utils.edge.test.tsx
@@ -1,0 +1,45 @@
+import { createBufferedTransformStream } from './stream-utils.edge'
+import { renderToReadableStream } from 'react-dom/server.edge'
+import { Suspense } from 'react'
+
+function App() {
+  const Data = async () => {
+    const data = await Promise.resolve('1')
+    return <h2>{data}</h2>
+  }
+
+  return (
+    <html>
+      <head>
+        <title>My App</title>
+      </head>
+      <body>
+        <h1>Hello, World!</h1>
+        <Suspense fallback={<h2>Fallback</h2>}>
+          <Data />
+        </Suspense>
+      </body>
+    </html>
+  )
+}
+
+async function createInput(app = <App />): Promise<ReadableStream<Uint8Array>> {
+  const stream = await renderToReadableStream(app)
+  await stream.allReady
+  return stream
+}
+
+describe('createBufferedTransformStream', () => {
+  it('should return a TransformStream that buffers input chunks across rendering boundaries', async () => {
+    const input = await createInput()
+    const actualStream = input.pipeThrough(createBufferedTransformStream())
+
+    const actualChunks = []
+    // @ts-expect-error
+    for await (const chunks of actualStream) {
+      actualChunks.push(chunks)
+    }
+
+    expect(actualChunks.length).toBe(1)
+  })
+})

--- a/packages/next/src/server/stream-utils/stream-utils.node.test.tsx
+++ b/packages/next/src/server/stream-utils/stream-utils.node.test.tsx
@@ -1,0 +1,78 @@
+import { createBufferedTransformStream } from './stream-utils.node'
+import { PassThrough, type Readable } from 'node:stream'
+import { renderToPipeableStream } from 'react-dom/server.node'
+import { Suspense } from 'react'
+import { streamToString } from '.'
+import { StringDecoder } from 'node:string_decoder'
+
+function App() {
+  const Data = async () => {
+    const data = await Promise.resolve('1')
+    return <h2>{data}</h2>
+  }
+  return (
+    <html>
+      <head>
+        <title>My App</title>
+      </head>
+      <body>
+        <h1>Hello, World!</h1>
+        <Suspense fallback={<h2>Fallback</h2>}>
+          <Data />
+        </Suspense>
+      </body>
+    </html>
+  )
+}
+
+function createInput(app = <App />): Promise<PassThrough> {
+  return new Promise((resolve) => {
+    const { pipe } = renderToPipeableStream(app, {
+      onShellReady() {
+        const pt = new PassThrough()
+        pipe(pt)
+        resolve(pt)
+      },
+    })
+  })
+}
+
+function getExpectedOutput(input: Readable) {
+  return streamToString(input.pipe(new PassThrough()))
+}
+
+describe('createBufferedTransformStream', () => {
+  it('should return a TransformStream that buffers input chunks across rendering boundaries', async () => {
+    const stream = createBufferedTransformStream()
+    const input = await createInput()
+    const output = input.pipe(stream)
+    const expectedCall = getExpectedOutput(input)
+
+    const actualChunks = await new Promise<Buffer[]>((resolve) => {
+      const chunks: Buffer[] = []
+      output.on('readable', () => {
+        let chunk
+        while (null !== (chunk = output.read())) {
+          chunks.push(chunk)
+        }
+      })
+      output.on('end', () => {
+        resolve(chunks)
+      })
+    })
+
+    const expected = await expectedCall
+
+    // React will send the suspense boundary piece second
+    expect(actualChunks.length).toBe(2)
+
+    let actual = ''
+    const decoder = new StringDecoder()
+    for (const chunk of actualChunks) {
+      actual += decoder.write(chunk)
+    }
+    actual += decoder.end()
+
+    expect(actual).toStrictEqual(expected)
+  })
+})

--- a/packages/next/src/server/stream-utils/stream-utils.node.test.tsx
+++ b/packages/next/src/server/stream-utils/stream-utils.node.test.tsx
@@ -1,17 +1,14 @@
-import {
-  createBufferedTransformStream,
-  streamToString,
-} from './stream-utils.node'
+import { createBufferedTransformStream } from './stream-utils.node'
 import { PassThrough } from 'node:stream'
 import { renderToPipeableStream } from 'react-dom/server.node'
 import { Suspense } from 'react'
-import { StringDecoder } from 'node:string_decoder'
 
 function App() {
   const Data = async () => {
     const data = await Promise.resolve('1')
     return <h2>{data}</h2>
   }
+
   return (
     <html>
       <head>
@@ -28,51 +25,33 @@ function App() {
 }
 
 function createInput(app = <App />): Promise<PassThrough> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const { pipe } = renderToPipeableStream(app, {
-      onShellReady() {
-        const pt = new PassThrough()
-        pipe(pt)
-        resolve(pt)
+      onAllReady() {
+        resolve(pipe(new PassThrough()))
+      },
+      onShellError(error) {
+        reject(error)
       },
     })
   })
 }
 
 describe('createBufferedTransformStream', () => {
-  it('should return a TransformStream that buffers input chunks across rendering boundaries', async () => {
-    const stream = createBufferedTransformStream()
-    const input = await createInput()
-    // This is essentially equivalent to a ReadableStream.tee()
-    // The important part is that both `pipe` calls happen before any read operation do.
-    const output = input.pipe(stream)
-    const expectedOutput = input.pipe(new PassThrough())
-
-    const actualChunks = await new Promise<Buffer[]>((resolve) => {
-      const chunks: Buffer[] = []
-      output.on('readable', () => {
-        let chunk
-        while (null !== (chunk = output.read())) {
-          chunks.push(chunk)
-        }
+  it('should return a TransformStream that buffers input chunks across rendering boundaries', (done) => {
+    createInput().then((input) => {
+      const stream = input.pipe(createBufferedTransformStream())
+      const actualChunks = []
+      stream.on('data', (chunk) => {
+        actualChunks.push(chunk)
       })
-      output.on('end', () => {
-        resolve(chunks)
+
+      stream.resume()
+
+      stream.on('finish', () => {
+        expect(actualChunks.length).toBe(1)
+        done()
       })
     })
-
-    const expected = await streamToString(expectedOutput)
-
-    // React will send the suspense boundary piece second
-    expect(actualChunks.length).toBe(2)
-
-    let actual = ''
-    const decoder = new StringDecoder()
-    for (const chunk of actualChunks) {
-      actual += decoder.write(chunk)
-    }
-    actual += decoder.end()
-
-    expect(actual).toStrictEqual(expected)
   })
 })

--- a/packages/next/src/server/stream-utils/stream-utils.node.ts
+++ b/packages/next/src/server/stream-utils/stream-utils.node.ts
@@ -107,7 +107,7 @@ export function streamFromString(string: string): Readable {
 }
 
 export function createBufferedTransformStream(): Transform {
-  let buffered: Buffer[] = []
+  let buffered: Uint8Array[] = []
   let byteLength = 0
   let pending = false
 
@@ -118,7 +118,7 @@ export function createBufferedTransformStream(): Transform {
 
     process.nextTick(() => {
       try {
-        const chunk = Buffer.alloc(byteLength)
+        const chunk = new Uint8Array(byteLength)
         let copiedBytes = 0
         for (let i = 0; i < buffered.length; i++) {
           chunk.set(buffered[i], copiedBytes)


### PR DESCRIPTION
This pull request includes a new buffered transform stream function and associated tests. The `createBufferedTransformStream` function returns a TransformStream that buffers input chunks across rendering boundaries. This function and the test cases for it appear in `stream-utils.node.ts` and `stream-utils.node.test.tsx` respectively. This change will help improve the stream processing capabilities in Next.js server.

