### PR TITLE
[eslint] Fix lint-staged to ensure eslint is ran

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -2,40 +2,47 @@ const { quote } = require('shell-quote')
 const { ESLint } = require('eslint')
 
 const eslint = new ESLint()
-const isWin = process.platform === 'win32'
+
+/**
+ * Escape filenames to ensure that spaces and such aren't interpreted as
+ * separators.
+ *
+ * @param {string[]} filenames
+ * @returns {string[]}
+ */
+function escape(filenames) {
+  if (process.platform === 'win32') {
+    return filenames
+  }
+
+  return filenames.map((filename) => quote([filename]).replace(/\\@/g, '@'))
+}
 
 module.exports = {
-  '**/*.{js,jsx,mjs,ts,tsx,mts}': (filenames) => {
-    const escapedFileNames = filenames
-      .map((filename) => (isWin ? filename : escape([filename])))
-      .join(' ')
+  '**/*.{js,jsx,mjs,ts,tsx,mts}': async (filenames) => {
+    const escapedFileNames = escape(filenames).join(' ')
+    const eslintFileNames = await Promise.all(
+      filenames.map(async (filename) => {
+        const ignored = await eslint.isPathIgnored(filename)
+        return ignored ? null : filename
+      })
+    )
+
     return [
       `prettier --with-node-modules --ignore-path .prettierignore --write ${escapedFileNames}`,
-      `eslint --no-ignore --max-warnings=0 --fix ${filenames
-        .filter((file) => !eslint.isPathIgnored(file))
-        .map((f) => `"${f}"`)
-        .join(' ')}`,
+      `eslint --no-ignore --max-warnings=0 --fix ${escape(eslintFileNames.filter((filename) => filename !== null)).join(' ')}`,
       `git add ${escapedFileNames}`,
     ]
   },
   '**/*.{json,md,mdx,css,html,yml,yaml,scss}': (filenames) => {
-    const escapedFileNames = filenames
-      .map((filename) => (isWin ? filename : escape([filename])))
-      .join(' ')
+    const escapedFileNames = escape(filenames).join(' ')
     return [
       `prettier --with-node-modules --ignore-path .prettierignore --write ${escapedFileNames}`,
       `git add ${escapedFileNames}`,
     ]
   },
   '**/*.rs': (filenames) => {
-    const escapedFileNames = filenames
-      .map((filename) => (isWin ? filename : escape([filename])))
-      .join(' ')
+    const escapedFileNames = escape(filenames).join(' ')
     return [`cargo fmt -- ${escapedFileNames}`, `git add ${escapedFileNames}`]
   },
-}
-
-function escape(str) {
-  const escaped = quote(str)
-  return escaped.replace(/\\@/g, '@')
 }


### PR DESCRIPTION
Previously, eslint was not running during lint-staged because `isPathIgnored` actually returns a promise. This changes it to async to make it work correctly.