### PR TITLE
fix(next-swc): load wasm fallback if native bindings fail to load

### DIFF
--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -274,6 +274,14 @@ export async function loadBindings(
       attempts = attempts.concat(a)
     }
 
+    // For these platforms we already tried to load wasm and failed, skip reattempt
+    if (!shouldLoadWasmFallbackFirst && !disableWasmFallback) {
+      const fallbackBindings = await tryLoadWasmWithFallback(attempts)
+      if (fallbackBindings) {
+        return resolve(fallbackBindings)
+      }
+    }
+
     logLoadFailure(attempts, true)
   })
   return pendingBindings


### PR DESCRIPTION
### What

This PR fixes regressions introduced at https://github.com/vercel/next.js/pull/57437/files#diff-907b7be0cfc75bd37773e5ebc38d1deffa40861b8ac1cde92e4992e284a1ee59L245, which removes to try load wasm fallback if 1. platform is supported 2. fail to load native bindings for some reason.