### PR TITLE
update reproduction templates to use correct React

### DIFF
--- a/examples/reproduction-template-pages/package.json
+++ b/examples/reproduction-template-pages/package.json
@@ -7,8 +7,8 @@
   },
   "dependencies": {
     "next": "canary",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "19.0.0-beta-4508873393-20240430",
+    "react-dom": "19.0.0-beta-4508873393-20240430"
   },
   "devDependencies": {
     "@types/node": "20.4.5",

--- a/examples/reproduction-template/package.json
+++ b/examples/reproduction-template/package.json
@@ -7,8 +7,8 @@
   },
   "dependencies": {
     "next": "canary",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "19.0.0-beta-4508873393-20240430",
+    "react-dom": "19.0.0-beta-4508873393-20240430"
   },
   "devDependencies": {
     "@types/node": "20.4.5",


### PR DESCRIPTION
Our reproduction templates are pinned to `next@canary`. This updates to use the correct `react` & `react-dom` dependencies since `canary` is pointed to React 19. 

Fixes #65619
