### PR TITLE
Implement insertion stream utilities for Node.js Streams

### DIFF
--- a/packages/next/src/server/stream-utils/index.d.ts
+++ b/packages/next/src/server/stream-utils/index.d.ts
@@ -19,7 +19,7 @@ export function streamToString(
   stream: Readable | ReadableStream
 ): Promise<string>
 
-export function chainStreams<T>(
-  ...streams: ReadableStream<T>[]
-): ReadableStream<T>
+export function chainStreams(
+  ...streams: ReadableStream<Uint8Array>[]
+): ReadableStream<Uint8Array>
 export function chainStreams(...streams: Readable[]): Readable

--- a/packages/next/src/server/stream-utils/index.d.ts
+++ b/packages/next/src/server/stream-utils/index.d.ts
@@ -18,3 +18,8 @@ export function renderToString(element: React.ReactElement): Promise<string>
 export function streamToString(
   stream: Readable | ReadableStream
 ): Promise<string>
+
+export function chainStreams<T>(
+  ...streams: ReadableStream<T>[]
+): ReadableStream<T>
+export function chainStreams(...streams: Readable[]): Readable

--- a/packages/next/src/server/stream-utils/stream-utils.edge.test.tsx
+++ b/packages/next/src/server/stream-utils/stream-utils.edge.test.tsx
@@ -1,0 +1,45 @@
+import { createBufferedTransformStream } from './stream-utils.edge'
+import { renderToReadableStream } from 'react-dom/server.edge'
+import { Suspense } from 'react'
+
+function App() {
+  const Data = async () => {
+    const data = await Promise.resolve('1')
+    return <h2>{data}</h2>
+  }
+
+  return (
+    <html>
+      <head>
+        <title>My App</title>
+      </head>
+      <body>
+        <h1>Hello, World!</h1>
+        <Suspense fallback={<h2>Fallback</h2>}>
+          <Data />
+        </Suspense>
+      </body>
+    </html>
+  )
+}
+
+async function createInput(app = <App />): Promise<ReadableStream<Uint8Array>> {
+  const stream = await renderToReadableStream(app)
+  await stream.allReady
+  return stream
+}
+
+describe('createBufferedTransformStream', () => {
+  it('should return a TransformStream that buffers input chunks across rendering boundaries', async () => {
+    const input = await createInput()
+    const actualStream = input.pipeThrough(createBufferedTransformStream())
+
+    const actualChunks = []
+    // @ts-expect-error
+    for await (const chunks of actualStream) {
+      actualChunks.push(chunks)
+    }
+
+    expect(actualChunks.length).toBe(1)
+  })
+})

--- a/packages/next/src/server/stream-utils/stream-utils.node.test.tsx
+++ b/packages/next/src/server/stream-utils/stream-utils.node.test.tsx
@@ -1,0 +1,78 @@
+import { createBufferedTransformStream } from './stream-utils.node'
+import { PassThrough, type Readable } from 'node:stream'
+import { renderToPipeableStream } from 'react-dom/server.node'
+import { Suspense } from 'react'
+import { streamToString } from '.'
+import { StringDecoder } from 'node:string_decoder'
+
+function App() {
+  const Data = async () => {
+    const data = await Promise.resolve('1')
+    return <h2>{data}</h2>
+  }
+  return (
+    <html>
+      <head>
+        <title>My App</title>
+      </head>
+      <body>
+        <h1>Hello, World!</h1>
+        <Suspense fallback={<h2>Fallback</h2>}>
+          <Data />
+        </Suspense>
+      </body>
+    </html>
+  )
+}
+
+function createInput(app = <App />): Promise<PassThrough> {
+  return new Promise((resolve) => {
+    const { pipe } = renderToPipeableStream(app, {
+      onShellReady() {
+        const pt = new PassThrough()
+        pipe(pt)
+        resolve(pt)
+      },
+    })
+  })
+}
+
+function getExpectedOutput(input: Readable) {
+  return streamToString(input.pipe(new PassThrough()))
+}
+
+describe('createBufferedTransformStream', () => {
+  it('should return a TransformStream that buffers input chunks across rendering boundaries', async () => {
+    const stream = createBufferedTransformStream()
+    const input = await createInput()
+    const output = input.pipe(stream)
+    const expectedCall = getExpectedOutput(input)
+
+    const actualChunks = await new Promise<Buffer[]>((resolve) => {
+      const chunks: Buffer[] = []
+      output.on('readable', () => {
+        let chunk
+        while (null !== (chunk = output.read())) {
+          chunks.push(chunk)
+        }
+      })
+      output.on('end', () => {
+        resolve(chunks)
+      })
+    })
+
+    const expected = await expectedCall
+
+    // React will send the suspense boundary piece second
+    expect(actualChunks.length).toBe(2)
+
+    let actual = ''
+    const decoder = new StringDecoder()
+    for (const chunk of actualChunks) {
+      actual += decoder.write(chunk)
+    }
+    actual += decoder.end()
+
+    expect(actual).toStrictEqual(expected)
+  })
+})

--- a/packages/next/src/server/stream-utils/stream-utils.node.test.tsx
+++ b/packages/next/src/server/stream-utils/stream-utils.node.test.tsx
@@ -1,17 +1,14 @@
-import {
-  createBufferedTransformStream,
-  streamToString,
-} from './stream-utils.node'
+import { createBufferedTransformStream } from './stream-utils.node'
 import { PassThrough } from 'node:stream'
 import { renderToPipeableStream } from 'react-dom/server.node'
 import { Suspense } from 'react'
-import { StringDecoder } from 'node:string_decoder'
 
 function App() {
   const Data = async () => {
     const data = await Promise.resolve('1')
     return <h2>{data}</h2>
   }
+
   return (
     <html>
       <head>
@@ -28,51 +25,33 @@ function App() {
 }
 
 function createInput(app = <App />): Promise<PassThrough> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const { pipe } = renderToPipeableStream(app, {
-      onShellReady() {
-        const pt = new PassThrough()
-        pipe(pt)
-        resolve(pt)
+      onAllReady() {
+        resolve(pipe(new PassThrough()))
+      },
+      onShellError(error) {
+        reject(error)
       },
     })
   })
 }
 
 describe('createBufferedTransformStream', () => {
-  it('should return a TransformStream that buffers input chunks across rendering boundaries', async () => {
-    const stream = createBufferedTransformStream()
-    const input = await createInput()
-    // This is essentially equivalent to a ReadableStream.tee()
-    // The important part is that both `pipe` calls happen before any read operation do.
-    const output = input.pipe(stream)
-    const expectedOutput = input.pipe(new PassThrough())
-
-    const actualChunks = await new Promise<Buffer[]>((resolve) => {
-      const chunks: Buffer[] = []
-      output.on('readable', () => {
-        let chunk
-        while (null !== (chunk = output.read())) {
-          chunks.push(chunk)
-        }
+  it('should return a TransformStream that buffers input chunks across rendering boundaries', (done) => {
+    createInput().then((input) => {
+      const stream = input.pipe(createBufferedTransformStream())
+      const actualChunks = []
+      stream.on('data', (chunk) => {
+        actualChunks.push(chunk)
       })
-      output.on('end', () => {
-        resolve(chunks)
+
+      stream.resume()
+
+      stream.on('finish', () => {
+        expect(actualChunks.length).toBe(1)
+        done()
       })
     })
-
-    const expected = await streamToString(expectedOutput)
-
-    // React will send the suspense boundary piece second
-    expect(actualChunks.length).toBe(2)
-
-    let actual = ''
-    const decoder = new StringDecoder()
-    for (const chunk of actualChunks) {
-      actual += decoder.write(chunk)
-    }
-    actual += decoder.end()
-
-    expect(actual).toStrictEqual(expected)
   })
 })

--- a/packages/next/src/server/stream-utils/stream-utils.node.ts
+++ b/packages/next/src/server/stream-utils/stream-utils.node.ts
@@ -107,7 +107,7 @@ export function streamFromString(string: string): Readable {
 }
 
 export function createBufferedTransformStream(): Transform {
-  let buffered: Buffer[] = []
+  let buffered: Uint8Array[] = []
   let byteLength = 0
   let pending = false
 
@@ -118,7 +118,7 @@ export function createBufferedTransformStream(): Transform {
 
     process.nextTick(() => {
       try {
-        const chunk = Buffer.alloc(byteLength)
+        const chunk = new Uint8Array(byteLength)
         let copiedBytes = 0
         for (let i = 0; i < buffered.length; i++) {
           chunk.set(buffered[i], copiedBytes)

--- a/packages/next/src/server/stream-utils/stream-utils.node.ts
+++ b/packages/next/src/server/stream-utils/stream-utils.node.ts
@@ -2,7 +2,13 @@
  * By default, this file exports the methods from streams-utils.edge since all of those are based on Node.js web streams.
  * This file will then be an incremental re-implementation of all of those methods into Node.js only versions (based on proper Node.js Streams).
  */
-import { PassThrough, type Readable, Transform, Writable, pipeline } from 'node:stream'
+import {
+  PassThrough,
+  type Readable,
+  Transform,
+  Writable,
+  pipeline,
+} from 'node:stream'
 import type { Options as RenderToPipeableStreamOptions } from 'react-dom/server.node'
 
 export * from './stream-utils.edge'
@@ -86,8 +92,11 @@ export function chainStreams(...streams: Readable[]): Readable {
 
   const transform = new Transform()
 
-  pipeline(streams, transform, () => {
-    /* do nothing */
+  pipeline(streams, transform, (err) => {
+    // to match `stream-utils.edge.ts`, this error is just ignored.
+    // but maybe we at least log it?
+    console.log(`Invariant: error when pipelining streams`)
+    console.error(err)
   })
 
   return transform

--- a/packages/next/src/server/stream-utils/stream-utils.node.ts
+++ b/packages/next/src/server/stream-utils/stream-utils.node.ts
@@ -11,6 +11,9 @@ import {
 } from 'node:stream'
 import type { Options as RenderToPipeableStreamOptions } from 'react-dom/server.node'
 import { DetachedPromise } from '../../lib/detached-promise'
+import { indexOfUint8Array } from './uint8array-helpers'
+import { ENCODED_TAGS } from './encodedTags'
+
 
 export * from './stream-utils.edge'
 
@@ -148,6 +151,96 @@ export function createBufferedTransformStream(): Transform {
       if (!pending) callback()
 
       pending?.promise.then(() => callback())
+    },
+  })
+}
+
+export function createInsertedHTMLStream(
+  getServerInsertedHTML: () => Promise<string>
+): Transform {
+  return new Transform({
+    transform(chunk, _, callback) {
+      getServerInsertedHTML().then((html) => {
+        if (html) {
+          this.push(Buffer.from(html))
+        }
+
+        return callback(null, chunk)
+      })
+    },
+  })
+}
+
+export function createHeadInsertionTransformStream(
+  insert: () => Promise<string>
+): Transform {
+  let inserted = false
+  let freezing = false
+  let hasBytes = false
+  return new Transform({
+    transform(chunk, _, callback) {
+      hasBytes = true
+      if (freezing) {
+        return callback(null, chunk)
+      }
+      insert()
+        .then((insertion) => {
+          if (inserted) {
+            if (insertion) {
+              this.push(Buffer.from(insertion))
+            }
+            this.push(chunk)
+            freezing = true
+          } else {
+            const index = indexOfUint8Array(chunk, ENCODED_TAGS.CLOSED.HEAD)
+            if (index !== -1) {
+              if (insertion) {
+                const encodedInsertion = Buffer.from(insertion)
+                const insertedHeadContent = Buffer.alloc(
+                  chunk.length + encodedInsertion.length
+                )
+                insertedHeadContent.set(chunk.slice(0, index))
+                insertedHeadContent.set(encodedInsertion, index)
+                insertedHeadContent.set(
+                  chunk.slice(index),
+                  index + encodedInsertion.length
+                )
+                this.push(insertedHeadContent)
+              } else {
+                this.push(chunk)
+              }
+              freezing = true
+              inserted = true
+            }
+          }
+
+          if (!inserted) {
+            this.push(chunk)
+          } else {
+            process.nextTick(() => {
+              freezing = false
+            })
+          }
+
+          callback()
+        })
+        .catch((err) => {
+          callback(err)
+        })
+    },
+    final(callback) {
+      if (hasBytes) {
+        insert()
+          .then((insertion) => {
+            if (insertion) {
+              this.push(Buffer.from(insertion))
+              callback()
+            }
+          })
+          .catch((err) => {
+            callback(err)
+          })
+      }
     },
   })
 }

--- a/packages/next/src/server/stream-utils/stream-utils.node.ts
+++ b/packages/next/src/server/stream-utils/stream-utils.node.ts
@@ -2,8 +2,7 @@
  * By default, this file exports the methods from streams-utils.edge since all of those are based on Node.js web streams.
  * This file will then be an incremental re-implementation of all of those methods into Node.js only versions (based on proper Node.js Streams).
  */
-
-import { PassThrough, type Readable, Writable } from 'node:stream'
+import { PassThrough, type Readable, Transform, Writable, pipeline } from 'node:stream'
 import type { Options as RenderToPipeableStreamOptions } from 'react-dom/server.node'
 
 export * from './stream-utils.edge'
@@ -75,4 +74,21 @@ export async function streamToString(stream: Readable) {
   string += decoder.decode()
 
   return string
+}
+
+export function chainStreams(...streams: Readable[]): Readable {
+  if (streams.length === 0) {
+    throw new Error('Invariant: chainStreams requires at least one stream')
+  }
+  if (streams.length === 1) {
+    return streams[0]
+  }
+
+  const transform = new Transform()
+
+  pipeline(streams, transform, () => {
+    /* do nothing */
+  })
+
+  return transform
 }


### PR DESCRIPTION
This pull request includes changes to stream-utils.node.ts to incorporate two new functions createInsertedHTMLStream and createHeadInsertionTransformStream. These functions are used to generate transformation streams for inserting HTML and head content respectively.