### PR TITLE
fix(next-swc): correct path interop to filepath for wasm

### DIFF
--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -337,7 +337,7 @@ async function tryLoadWasmWithFallback(attempts: any) {
       downloadWasmPromise = downloadWasmSwc(nextVersion, wasmDirectory)
     }
     await downloadWasmPromise
-    let bindings = await loadWasm(pathToFileURL(wasmDirectory).href)
+    let bindings = await loadWasm(wasmDirectory)
     // @ts-expect-error TODO: this event has a wrong type.
     eventSwcLoadFailure({
       wasm: 'fallback',


### PR DESCRIPTION
### What

For loading wasm, path interop to absolute file path occurs in here (https://github.com/vercel/next.js/blob/canary/packages/next/src/build/swc/index.ts#L1249) already so shouldn't pre-populate import path when call loading wasm to make internal path operation (https://github.com/vercel/next.js/blob/canary/packages/next/src/build/swc/index.ts#L1247) work.