### PR TITLE
Show the new key of experimental config change warnings

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -132,17 +132,16 @@ export function warnOptionHasBeenDeprecated(
 
 export function warnOptionHasBeenMovedOutOfExperimental(
   config: NextConfig,
-  oldKey: string,
+  oldExperimentalKey: string,
   newKey: string,
   configFileName: string,
   silent: boolean
 ) {
-  if (config.experimental && oldKey in config.experimental) {
+  if (config.experimental && oldExperimentalKey in config.experimental) {
     if (!silent) {
       Log.warn(
-        `\`${oldKey}\` has been moved out of \`experimental\`` +
-          ` and into \`${newKey}\`` +
-          `. Please update your ${configFileName} file accordingly.`
+        `\`experimental.${oldExperimentalKey}\` has been moved to \`${newKey}\`. ` +
+          `Please update your ${configFileName} file accordingly.`
       )
     }
 
@@ -153,7 +152,7 @@ export function warnOptionHasBeenMovedOutOfExperimental(
       current[key] = current[key] || {}
       current = current[key]
     }
-    current[newKeys.shift()!] = (config.experimental as any)[oldKey]
+    current[newKeys.shift()!] = (config.experimental as any)[oldExperimentalKey]
   }
 
   return config

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -141,7 +141,7 @@ export function warnOptionHasBeenMovedOutOfExperimental(
     if (!silent) {
       Log.warn(
         `\`${oldKey}\` has been moved out of \`experimental\`` +
-          (newKey.includes('.') ? ` and into \`${newKey}\`` : '') +
+          ` and into \`${newKey}\`` +
           `. Please update your ${configFileName} file accordingly.`
       )
     }

--- a/test/unit/warn-removed-experimental-config.test.ts
+++ b/test/unit/warn-removed-experimental-config.test.ts
@@ -46,7 +46,7 @@ describe('warnOptionHasBeenMovedOutOfExperimental', () => {
 
     expect(spy).toHaveBeenCalledWith(
       expect.stringContaining('⚠'),
-      '`skipTrailingSlashRedirect` has been moved out of `experimental` and into `skipTrailingSlashRedirect`. Please update your next.config.js file accordingly.'
+      '`experimental.skipTrailingSlashRedirect` has been moved to `skipTrailingSlashRedirect`. Please update your next.config.js file accordingly.'
     )
   })
 
@@ -65,7 +65,7 @@ describe('warnOptionHasBeenMovedOutOfExperimental', () => {
 
     expect(spy).toHaveBeenCalledWith(
       expect.stringContaining('⚠'),
-      '`relay` has been moved out of `experimental` and into `compiler.relay`. Please update your next.config.js file accordingly.'
+      '`experimental.relay` has been moved to `compiler.relay`. Please update your next.config.js file accordingly.'
     )
   })
 
@@ -122,7 +122,7 @@ describe('warnOptionHasBeenMovedOutOfExperimental', () => {
 
     expect(spy).toHaveBeenCalledWith(
       expect.stringContaining('⚠'),
-      '`bundlePagesExternals` has been moved out of `experimental` and into `bundlePagesRouterDependencies`. Please update your next.config.js file accordingly.'
+      '`experimental.bundlePagesExternals` has been moved to `bundlePagesRouterDependencies`. Please update your next.config.js file accordingly.'
     )
   })
 })

--- a/test/unit/warn-removed-experimental-config.test.ts
+++ b/test/unit/warn-removed-experimental-config.test.ts
@@ -46,7 +46,7 @@ describe('warnOptionHasBeenMovedOutOfExperimental', () => {
 
     expect(spy).toHaveBeenCalledWith(
       expect.stringContaining('⚠'),
-      '`skipTrailingSlashRedirect` has been moved out of `experimental`. Please update your next.config.js file accordingly.'
+      '`skipTrailingSlashRedirect` has been moved out of `experimental` and into `skipTrailingSlashRedirect`. Please update your next.config.js file accordingly.'
     )
   })
 
@@ -103,6 +103,27 @@ describe('warnOptionHasBeenMovedOutOfExperimental', () => {
 
     expect(config.experimental.foo).toBe('bar')
     expect(config.deep.prop.baz).toBe('bar')
+  })
+
+  it('should show the new key name in the warning', () => {
+    const config = {
+      experimental: {
+        bundlePagesExternals: true,
+      },
+    } as any
+
+    warnOptionHasBeenMovedOutOfExperimental(
+      config,
+      'bundlePagesExternals',
+      'bundlePagesRouterDependencies',
+      'next.config.js',
+      false
+    )
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('⚠'),
+      '`bundlePagesExternals` has been moved out of `experimental` and into `bundlePagesRouterDependencies`. Please update your next.config.js file accordingly.'
+    )
   })
 })
 


### PR DESCRIPTION
Previously we only display the warning when it's a new key format `<object>.<property>`, we should display all cases to help users understand where the new key is moved to

x-ref: https://x.com/huozhi/status/1789335665252921381