### PR TITLE
[Docs] Fix `sendGAEvent` example in `@next/third-parties`

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/12-third-party-libraries.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/12-third-party-libraries.mdx
@@ -294,7 +294,7 @@ export function EventButton() {
   return (
     <div>
       <button
-        onClick={() => sendGAEvent({ event: 'buttonClicked', value: 'xyz' })}
+        onClick={() => sendGAEvent('event', 'buttonClicked', { value: 'xyz' })}
       >
         Send Event
       </button>
@@ -314,7 +314,7 @@ export function EventButton() {
   return (
     <div>
       <button
-        onClick={() => sendGAEvent({ event: 'buttonClicked', value: 'xyz' })}
+        onClick={() => sendGAEvent('event', 'buttonClicked', { value: 'xyz' })}
       >
         Send Event
       </button>


### PR DESCRIPTION
Fixes the usage example for `sendGAEvent()` exposed by `@next/third-parties`.

This pushes to GTAG's dataLayer, which means it needs to follow the structure set out in [the Google docs here](https://developers.google.com/analytics/devguides/collection/ga4/event-parameters?client_type=gtag#set-up-event-parameters):

```js
gtag('event', 'screen_view', {
  'app_name': 'myAppName',
  'screen_name': 'Home'
});
```

This also matches with the function signature, which looks like this: `function sendGAEvent(..._args: Object[])`