### PR TITLE
fix: watch experimental/testmode in when running "pnpm dev"

### DIFF
--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -2629,6 +2629,7 @@ export default async function (task) {
     ['nextbuild', 'nextbuild_esm', 'nextbuildjest'],
     opts
   )
+  await task.watch('src/experimental/testmode', 'experimental_testmode', opts)
   await task.watch('src/export', 'nextbuildstatic', opts)
   await task.watch('src/export', 'nextbuildstatic_esm', opts)
   await task.watch('src/client', 'client', opts)
@@ -2705,7 +2706,9 @@ export async function server_wasm(task, opts) {
 export async function experimental_testmode(task, opts) {
   await task
     .source('src/experimental/testmode/**/!(*.test).+(js|ts|tsx)')
-    .swc('server', {})
+    .swc('server', {
+      dev: opts.dev,
+    })
     .target('dist/experimental/testmode')
 }
 


### PR DESCRIPTION
Fixes the taskfile so that `experimental/testmode` is auto-recompiled when running `pnpm dev`.

cc @Ethan-Arrowood 