### PR TITLE
Remove swc minify related code branches

### DIFF
--- a/packages/next-swc/crates/next-api/src/project.rs
+++ b/packages/next-swc/crates/next-api/src/project.rs
@@ -718,7 +718,6 @@ impl Project {
         // need to confirm what we'll do with turbopack.
         let config = self.next_config();
 
-        emit_event("swcMinify", *config.swc_minify().await?);
         emit_event(
             "skipMiddlewareUrlNormalize",
             *config.skip_middleware_url_normalize().await?,

--- a/packages/next-swc/crates/next-core/src/next_config.rs
+++ b/packages/next-swc/crates/next-core/src/next_config.rs
@@ -126,7 +126,6 @@ pub struct NextConfig {
     public_runtime_config: IndexMap<String, serde_json::Value>,
     server_runtime_config: IndexMap<String, serde_json::Value>,
     static_page_generation_timeout: f64,
-    swc_minify: Option<bool>,
     target: Option<String>,
     typescript: TypeScriptConfig,
     use_file_system_public_routes: bool,
@@ -535,7 +534,6 @@ pub struct ExperimentalConfig {
     server_minification: Option<bool>,
     /// Enables source maps generation for the server production bundle.
     server_source_maps: Option<bool>,
-    swc_minify: Option<bool>,
     swc_trace_profiling: Option<bool>,
     /// @internal Used by the Next.js internals only.
     trust_host_header: Option<bool>,
@@ -968,11 +966,6 @@ impl NextConfig {
         Ok(Vc::cell(
             self.await?.sass_options.clone().unwrap_or_default(),
         ))
-    }
-
-    #[turbo_tasks::function]
-    pub async fn swc_minify(self: Vc<Self>) -> Result<Vc<bool>> {
-        Ok(Vc::cell(self.await?.swc_minify.unwrap_or(false)))
     }
 
     #[turbo_tasks::function]

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1907,7 +1907,6 @@ export default async function getBaseWebpackConfig(
           new Map(
             [
               ['swcLoader', useSWCLoader],
-              ['swcMinify', config.swcMinify],
               ['swcRelay', !!config.compiler?.relay],
               ['swcStyledComponents', !!config.compiler?.styledComponents],
               [

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1078,9 +1078,6 @@ export default async function getBaseWebpackConfig(
             TerserPlugin,
           } = require('./webpack/plugins/terser-webpack-plugin/src/index.js')
           new TerserPlugin({
-            cacheDir: path.join(distDir, 'cache', 'next-minifier'),
-            parallel: config.experimental.cpus,
-            swcMinify: config.swcMinify,
             terserOptions: {
               ...terserOptions,
               compress: {
@@ -2067,7 +2064,6 @@ export default async function getBaseWebpackConfig(
     reactProductionProfiling,
     webpack: !!config.webpack,
     hasRewrites,
-    swcMinify: config.swcMinify,
     swcLoader: useSWCLoader,
     removeConsole: config.compiler?.removeConsole,
     reactRemoveProperties: config.compiler?.reactRemoveProperties,

--- a/packages/next/src/build/webpack/plugins/telemetry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/telemetry-plugin.ts
@@ -30,7 +30,6 @@ export type Feature =
   | 'next/font/google'
   | 'next/font/local'
   | 'swcLoader'
-  | 'swcMinify'
   | 'swcRelay'
   | 'swcStyledComponents'
   | 'swcReactRemoveProperties'
@@ -83,7 +82,6 @@ const FEATURE_MODULE_REGEXP_MAP: ReadonlyMap<Feature, RegExp> = new Map([
 // List of build features used in webpack configuration
 const BUILD_FEATURES: Array<Feature> = [
   'swcLoader',
-  'swcMinify',
   'swcRelay',
   'swcStyledComponents',
   'swcReactRemoveProperties',

--- a/packages/next/src/build/webpack/plugins/terser-webpack-plugin/src/index.ts
+++ b/packages/next/src/build/webpack/plugins/terser-webpack-plugin/src/index.ts
@@ -74,7 +74,6 @@ export class TerserPlugin {
       'terser-webpack-plugin-optimize'
     )
     terserSpan.setAttribute('compilationName', compilation.name)
-    terserSpan.setAttribute('swcMinify', 'true')
 
     return terserSpan.traceAsyncFn(async () => {
       const assetsList = Object.keys(assets)

--- a/packages/next/src/build/webpack/plugins/terser-webpack-plugin/src/index.ts
+++ b/packages/next/src/build/webpack/plugins/terser-webpack-plugin/src/index.ts
@@ -1,11 +1,9 @@
-import * as path from 'path'
 import {
   webpack,
   ModuleFilenameHelpers,
   sources,
 } from 'next/dist/compiled/webpack/webpack'
 import pLimit from 'next/dist/compiled/p-limit'
-import { Worker } from 'next/dist/compiled/jest-worker'
 import { spans } from '../../profiling-plugin'
 
 function getEcmaVersion(environment: any) {
@@ -49,13 +47,17 @@ function buildError(error: any, file: string) {
 const debugMinify = process.env.NEXT_DEBUG_MINIFY
 
 export class TerserPlugin {
-  options: any
-  constructor(options: any = {}) {
-    const { terserOptions = {}, parallel, swcMinify } = options
+  options: {
+    terserOptions: any
+  }
+  constructor(
+    options: {
+      terserOptions?: any
+    } = {}
+  ) {
+    const { terserOptions = {} } = options
 
     this.options = {
-      swcMinify,
-      parallel,
       terserOptions,
     }
   }
@@ -64,7 +66,6 @@ export class TerserPlugin {
     compiler: any,
     compilation: any,
     assets: any,
-    optimizeOptions: any,
     cache: any,
     { SourceMapSource, RawSource }: any
   ) {
@@ -73,10 +74,9 @@ export class TerserPlugin {
       'terser-webpack-plugin-optimize'
     )
     terserSpan.setAttribute('compilationName', compilation.name)
-    terserSpan.setAttribute('swcMinify', this.options.swcMinify)
+    terserSpan.setAttribute('swcMinify', 'true')
 
     return terserSpan.traceAsyncFn(async () => {
-      let numberOfAssetsForMinify = 0
       const assetsList = Object.keys(assets)
 
       const assetsForMinify = await Promise.all(
@@ -113,10 +113,6 @@ export class TerserPlugin {
             const eTag = cache.getLazyHashedEtag(source)
             const output = await cache.getPromise(name, eTag)
 
-            if (!output) {
-              numberOfAssetsForMinify += 1
-            }
-
             if (debugMinify && debugMinify === '1') {
               console.log(
                 JSON.stringify({
@@ -133,61 +129,34 @@ export class TerserPlugin {
           })
       )
 
-      const numberOfWorkers = Math.min(
-        numberOfAssetsForMinify,
-        optimizeOptions.availableNumberOfCores
-      )
-
       let initializedWorker: any
 
       // eslint-disable-next-line consistent-return
       const getWorker = () => {
-        if (this.options.swcMinify) {
-          return {
-            minify: async (options: any) => {
-              const result = await require('../../../../swc').minify(
-                options.input,
-                {
-                  ...(options.inputSourceMap
-                    ? {
-                        sourceMap: {
-                          content: JSON.stringify(options.inputSourceMap),
-                        },
-                      }
-                    : {}),
-                  compress: true,
-                  mangle: true,
-                }
-              )
+        return {
+          minify: async (options: any) => {
+            const result = await require('../../../../swc').minify(
+              options.input,
+              {
+                ...(options.inputSourceMap
+                  ? {
+                      sourceMap: {
+                        content: JSON.stringify(options.inputSourceMap),
+                      },
+                    }
+                  : {}),
+                compress: true,
+                mangle: true,
+              }
+            )
 
-              return result
-            },
-          }
+            return result
+          },
         }
-
-        if (initializedWorker) {
-          return initializedWorker
-        }
-
-        initializedWorker = new Worker(path.join(__dirname, './minify.js'), {
-          numWorkers: numberOfWorkers,
-          enableWorkerThreads: true,
-        })
-
-        initializedWorker.getStdout().pipe(process.stdout)
-        initializedWorker.getStderr().pipe(process.stderr)
-
-        return initializedWorker
       }
 
-      const limit = pLimit(
-        // When using the SWC minifier the limit will be handled by Node.js
-        this.options.swcMinify
-          ? Infinity
-          : numberOfAssetsForMinify > 0
-            ? numberOfWorkers
-            : Infinity
-      )
+      // The limit in the SWC minifier  will be handled by Node.js
+      const limit = pLimit(Infinity)
       const scheduledTasks = []
 
       for (const asset of assetsForMinify) {
@@ -281,7 +250,6 @@ export class TerserPlugin {
     }
 
     const pluginName = this.constructor.name
-    const availableNumberOfCores = this.options.parallel
 
     compiler.hooks.thisCompilation.tap(pluginName, (compilation: any) => {
       const cache = compilation.getCache('TerserWebpackPlugin')
@@ -306,16 +274,10 @@ export class TerserPlugin {
           stage: webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE,
         },
         (assets: any) =>
-          this.optimize(
-            compiler,
-            compilation,
-            assets,
-            {
-              availableNumberOfCores,
-            },
-            cache,
-            { SourceMapSource, RawSource }
-          )
+          this.optimize(compiler, compilation, assets, cache, {
+            SourceMapSource,
+            RawSource,
+          })
       )
 
       compilation.hooks.statsPrinter.tap(pluginName, (stats: any) => {

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -328,7 +328,6 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
           })
           .optional(),
         strictNextHead: z.boolean().optional(),
-        swcMinify: z.boolean().optional(),
         swcPlugins: z
           // The specific swc plugin's option is unknown, use z.any() here
           .array(z.tuple([z.string(), z.record(z.string(), z.any())]))
@@ -575,7 +574,6 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
     skipMiddlewareUrlNormalize: z.boolean().optional(),
     skipTrailingSlashRedirect: z.boolean().optional(),
     staticPageGenerationTimeout: z.number().optional(),
-    swcMinify: z.boolean().optional(),
     target: z.string().optional(),
     trailingSlash: z.boolean().optional(),
     transpilePackages: z.array(z.string()).optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -880,7 +880,6 @@ export const defaultConfig: NextConfig = {
     keepAlive: true,
   },
   staticPageGenerationTimeout: 60,
-  swcMinify: true,
   output: !!process.env.NEXT_PRIVATE_STANDALONE ? 'standalone' : undefined,
   modularizeImports: undefined,
   experimental: {

--- a/packages/next/src/telemetry/events/build.ts
+++ b/packages/next/src/telemetry/events/build.ts
@@ -157,7 +157,6 @@ export type EventBuildFeatureUsage = {
     | 'experimental/ppr'
     | 'optimizeFonts'
     | 'swcLoader'
-    | 'swcMinify'
     | 'swcRelay'
     | 'swcStyledComponents'
     | 'swcReactRemoveProperties'

--- a/test/development/basic/__snapshots__/next-rs-api.test.ts.snap
+++ b/test/development/basic/__snapshots__/next-rs-api.test.ts.snap
@@ -111,13 +111,6 @@ exports[`next.rs api should detect the correct routes: diagnostics 1`] = `
     "category": "NextFeatureTelemetry_category_tbd",
     "name": "EVENT_BUILD_FEATURE_USAGE",
     "payload": {
-      "swcMinify": "true",
-    },
-  },
-  {
-    "category": "NextFeatureTelemetry_category_tbd",
-    "name": "EVENT_BUILD_FEATURE_USAGE",
-    "payload": {
       "swcReactRemoveProperties": "false",
     },
   },

--- a/test/integration/config-validation/test/index.test.ts
+++ b/test/integration/config-validation/test/index.test.ts
@@ -13,7 +13,6 @@ describe('next.config.js validation', () => {
           name: 'invalid config types',
           configContent: `
         module.exports = {
-          swcMinify: 'hello',
           rewrites: true,
           images: {
             loader: 'something'
@@ -23,7 +22,6 @@ describe('next.config.js validation', () => {
           outputs: [
             `received 'something' at "images.loader"`,
             'Expected function, received boolean at "rewrites"',
-            'Expected boolean, received string at "swcMinify"',
           ],
         },
         {

--- a/test/integration/telemetry/next.config.swc
+++ b/test/integration/telemetry/next.config.swc
@@ -1,5 +1,4 @@
 module.exports = {
-  swcMinify: true,
   compiler: {
     relay: {
       // This should match relay.config.js

--- a/test/integration/telemetry/test/config.test.js
+++ b/test/integration/telemetry/test/config.test.js
@@ -328,10 +328,6 @@ describe('config telemetry', () => {
               invocationCount: 1,
             },
             {
-              featureName: 'swcMinify',
-              invocationCount: 1,
-            },
-            {
               featureName: 'swcRelay',
               invocationCount: 1,
             },

--- a/test/production/terser-class-static-blocks/terser-class-static-blocks.test.ts
+++ b/test/production/terser-class-static-blocks/terser-class-static-blocks.test.ts
@@ -3,9 +3,7 @@ import { nextTestSetup } from 'e2e-utils'
 describe('terser-class-static-blocks', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    nextConfig: {
-      swcMinify: false,
-    },
+    nextConfig: {},
   })
 
   it('should work using cheerio', async () => {


### PR DESCRIPTION
### What

Remove `swcMinify` related branches as the option is deprecated and it's always enabled

* Remove the related branches for checking `config.swcMinify`
* Remove the related telemetry about `swcMinify`