### PR TITLE
tests: fixed some test types and fixed darwin support

### DIFF
--- a/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
@@ -10,11 +10,12 @@ import {
   initNextServerScript,
   killApp,
 } from 'next-test-utils'
+import { ChildProcess } from 'child_process'
 
 describe('required server files app router', () => {
   let next: NextInstance
-  let server
-  let appPort
+  let server: ChildProcess
+  let appPort: number | string
   let delayedPostpone
   let rewritePostpone
 
@@ -93,7 +94,7 @@ describe('required server files app router', () => {
       /- Local:/,
       {
         ...process.env,
-        PORT: appPort,
+        PORT: `${appPort}`,
       },
       undefined,
       {


### PR DESCRIPTION
This fixes some tests so that they can run on macOS that previously had some issues with IPv6 during testing as well as updated some of the tests to use `retry` over `check`.