### PR TITLE
refactor: updated waitUntil types

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -106,7 +106,7 @@ import { AppRouteRouteMatcherProvider } from './future/route-matcher-providers/a
 import { PagesAPIRouteMatcherProvider } from './future/route-matcher-providers/pages-api-route-matcher-provider'
 import { PagesRouteMatcherProvider } from './future/route-matcher-providers/pages-route-matcher-provider'
 import { ServerManifestLoader } from './future/route-matcher-providers/helpers/manifest-loaders/server-manifest-loader'
-import { getTracer, isBubbledError, SpanKind } from './lib/trace/tracer'
+import { getTracer, SpanKind } from './lib/trace/tracer'
 import { BaseServerSpan } from './lib/trace/constants'
 import { I18NProvider } from './future/helpers/i18n-provider'
 import { sendResponse } from './send-response'
@@ -150,6 +150,7 @@ import {
   getBuiltinRequestContext,
   type WaitUntil,
 } from './after/builtin-request-context'
+import { BubbledError, isBubbledError } from './lib/trace/bubble-error'
 
 export type FindComponentsResult = {
   components: LoadComponentsReturnType
@@ -1378,16 +1379,11 @@ export default abstract class Server<
         )
         if (finished) return
 
-        const err = new Error()
-        ;(err as any).result = {
+        throw new BubbledError(true, {
           response: new Response(null, {
-            headers: {
-              'x-middleware-next': '1',
-            },
+            headers: { 'x-middleware-next': '1' },
           }),
-        }
-        ;(err as any).bubble = true
-        throw err
+        })
       }
 
       // This wasn't a request via the matched path or the invoke path, so

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -379,7 +379,7 @@ export default class DevServer extends Server {
         return result
       }
 
-      result.waitUntil.catch((error) => {
+      result.waitUntil?.catch((error) => {
         this.logErrorWithOriginalStack(error, 'unhandledRejection')
       })
       return result

--- a/packages/next/src/server/lib/trace/bubble-error.ts
+++ b/packages/next/src/server/lib/trace/bubble-error.ts
@@ -1,0 +1,15 @@
+import type { FetchEventResult } from '../../web/types'
+
+export class BubbledError extends Error {
+  constructor(
+    public readonly bubble?: boolean,
+    public readonly result?: FetchEventResult
+  ) {
+    super()
+  }
+}
+
+export function isBubbledError(error: unknown): error is BubbledError {
+  if (typeof error !== 'object' || error === null) return false
+  return error instanceof BubbledError
+}

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -1,5 +1,5 @@
-import type { FetchEventResult } from '../../web/types'
 import type { TextMapSetter } from '@opentelemetry/api'
+import { isBubbledError } from './bubble-error'
 import type { SpanTypes } from './constants'
 import { LogSpanAllowList, NextVanillaSpanAllowlist } from './constants'
 
@@ -36,20 +36,6 @@ const { context, propagation, trace, SpanStatusCode, SpanKind, ROOT_CONTEXT } =
 
 const isPromise = <T>(p: any): p is Promise<T> => {
   return p !== null && typeof p === 'object' && typeof p.then === 'function'
-}
-
-export class BubbledError extends Error {
-  constructor(
-    public readonly bubble?: boolean,
-    public readonly result?: FetchEventResult
-  ) {
-    super()
-  }
-}
-
-export function isBubbledError(error: unknown): error is BubbledError {
-  if (typeof error !== 'object' || error === null) return false
-  return error instanceof BubbledError
 }
 
 const closeSpanWithError = (span: Span, error?: Error) => {

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -88,7 +88,7 @@ import {
   INSTRUMENTATION_HOOK_FILENAME,
   RSC_PREFETCH_SUFFIX,
 } from '../lib/constants'
-import { BubbledError, getTracer } from './lib/trace/tracer'
+import { getTracer } from './lib/trace/tracer'
 import { NextNodeServerSpan } from './lib/trace/constants'
 import { nodeFs } from './lib/node-fs-methods'
 import { getRouteRegex } from '../shared/lib/router/utils/route-regex'
@@ -105,6 +105,7 @@ import { formatDynamicImportPath } from '../lib/format-dynamic-import-path'
 import type { NextFontManifest } from '../build/webpack/plugins/next-font-manifest-plugin'
 import { isInterceptionRouteRewrite } from '../lib/generate-interception-routes-rewrites'
 import { stripNextRscUnionQuery } from '../lib/url'
+import { BubbledError } from './lib/trace/bubble-error'
 
 export * from './base-server'
 
@@ -1607,7 +1608,7 @@ export default class NextNodeServer extends BaseServer<
     })
 
     if (!this.renderOpts.dev) {
-      result.waitUntil.catch((error) => {
+      result.waitUntil?.catch((error) => {
         console.error(`Uncaught: middleware waitUntil errored`, error)
       })
     }

--- a/packages/next/src/server/web/types.ts
+++ b/packages/next/src/server/web/types.ts
@@ -40,7 +40,7 @@ export type NodejsRequestData = Omit<RequestData, 'body'> & {
 
 export interface FetchEventResult {
   response: Response
-  waitUntil: Promise<any>
+  waitUntil?: Promise<any>
   fetchMetrics?: FetchMetrics
 }
 


### PR DESCRIPTION
This uses the proper error class for bubbled errors as well as fixes the `waitUntil` property type that affected the bubble error construction.