### PR TITLE
chore: add git blame ignore-revs support to gitlens for vscode configuration

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -7,3 +7,6 @@
 
 # chore: update prettier to 3.2.5 (#65092)
 64b718c6618b6c419872abbf22163ae543ac259e
+
+# Replace createNextDescribe with nextTestSetup
+c6320ed87ab41eee6f3ac54352ad02a239f329b2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -77,5 +77,9 @@
       "scheme": "file"
     }
   ],
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "gitlens.advanced.blame.customArguments": [
+    "--ignore-revs-file",
+    "${workspaceRoot}/.git-blame-ignore-revs"
+  ]
 }


### PR DESCRIPTION
To help improve the developer experience for framework authors, this enables the git blame ignore option to ignore some code changes that were added to the project .git-blame-ignore-revs file.
