### PR TITLE
chore: Make use of Suspense conditional

### DIFF
--- a/packages/next/src/shared/lib/dynamic.tsx
+++ b/packages/next/src/shared/lib/dynamic.tsx
@@ -40,6 +40,7 @@ export type DynamicOptions<P = {}> = LoadableGeneratedOptions & {
   loader?: Loader<P> | LoaderMap
   loadableGenerated?: LoadableGeneratedOptions
   ssr?: boolean
+  useSuspense?: boolean
   /**
    * @deprecated `suspense` prop is not required anymore
    */


### PR DESCRIPTION
### Fixing a bug

- Related issues linked using fixes https://github.com/vercel/next.js/issues/64060 and https://github.com/vercel/next.js/issues/64687
- Tests added.

### What?
Extra Suspense boundary flashes the loading state for the next/dynamic components. For SSR, it shouldn't render loading by default. This was earlier fixed in the [PR](https://github.com/vercel/next.js/pull/64716) but [reverted later](https://github.com/vercel/next.js/pull/65309) as removing this led of the server side errors to bubble up leading the pages to crash.

This draft proposes to add this Suspense conditionally. The consumers can add a suspense within their client if they want to avoid the server-side errors to bubble up instead of the framework doing it mandatorily.

Fixes https://github.com/vercel/next.js/issues/64060 https://github.com/vercel/next.js/issues/64687