### PR TITLE
Trigger error for stream on client when it is not finished as expected

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -136,13 +136,12 @@ const DOMContentLoaded = function () {
   initialServerDataLoaded = true
 }
 
-const queueTask = queueMicrotask || ((fn: Function) => setTimeout(fn, 0))
-
 // It's possible that the DOM is already loaded.
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', DOMContentLoaded, false)
 } else {
-  queueTask(DOMContentLoaded)
+  // Delayed in marco task to ensure it's executed later than hydration
+  setTimeout(DOMContentLoaded)
 }
 
 const nextServerDataLoadingGlobal = ((self as any).__next_f =

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -135,11 +135,14 @@ const DOMContentLoaded = function () {
   }
   initialServerDataLoaded = true
 }
+
+const queueTask = queueMicrotask || ((fn: Function) => setTimeout(fn, 0))
+
 // It's possible that the DOM is already loaded.
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', DOMContentLoaded, false)
 } else {
-  DOMContentLoaded()
+  queueTask(DOMContentLoaded)
 }
 
 const nextServerDataLoadingGlobal = ((self as any).__next_f =


### PR DESCRIPTION
### What

* Error on case that readable stream controller tries to close but stream is either errored or unfinished
* Delay the DOMContentLoaded event to avoid "Connection Closed" error


### Why

Regarding to the new error about readbale stream controller, the new error we added here is for identifying the connection is closing before the last bit has been received that's an error case not intentional close. It's not a proper state for close more for erroring.


As for adding the queuing for the task of dom content loaded callback, after investigation, I found that if the DOMLoaded execute earlier the readable stream controller cuold close earlier on client, which lead to the "Connection Closed." error. Hence we added a `queueMicroTask` here to delay it after hydrate call. 

x-ref: [slack thread](https://vercel.slack.com/archives/C01A2M9R8RZ/p1715188343813489)