### PR TITLE
fix(next): add experimental_ppr to TypeScript Plugin Allowed Exports

### DIFF
--- a/packages/next/src/server/typescript/rules/config.ts
+++ b/packages/next/src/server/typescript/rules/config.ts
@@ -139,6 +139,18 @@ const API_DOCS: Record<
       '`maxDuration` allows you to set max default execution time for your function. If it is not specified, the default value is dependent on your deployment platform and plan.',
     link: 'https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#maxduration',
   },
+  experimental_ppr: {
+    description:
+      'The `experimental_ppr` option enables Partial Prerendering (PPR) for the segment and its descending segments. To use this option, the `experimental.ppr` configuration in `next.config.js` must be set to `"incremental"`.',
+    options: {
+      true: 'Enable PPR for the segment and its descending segments.',
+      false: 'Disable PPR for the segment and its descending segments.',
+    },
+    link: 'https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#experimental_ppr',
+    isValid: (value: string) => {
+      return value === 'true' || value === 'false'
+    }
+  },
 }
 
 function visitEntryConfig(

--- a/packages/next/src/server/typescript/rules/config.ts
+++ b/packages/next/src/server/typescript/rules/config.ts
@@ -149,7 +149,7 @@ const API_DOCS: Record<
     link: 'https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#experimental_ppr',
     isValid: (value: string) => {
       return value === 'true' || value === 'false'
-    }
+    },
   },
 }
 


### PR DESCRIPTION
## Description
Following [this pull request](https://github.com/vercel/next.js/pull/63847) recently merged, this pull request adds `experimental_ppr` to the TypeScript plugin's allowed exports. According to the [documentation](https://github.com/vercel/next.js/pull/65603/commits/8f09765c124057510f59f5c31652b141baff8f1d#diff-5f27a09078dfb897cb6f1eafaca503cffbf79502ad330123d543dc752b3724e2) and [this similar pull request](https://github.com/vercel/next.js/pull/59193) done for `maxDuration`, `experimental_ppr` should be a valid export. 

Currently, the TypeScript plugin throws an error when this option is used : 
<img width="775" alt="image" src="https://github.com/vercel/next.js/assets/8122069/a3b12eab-c2c1-41d9-91c5-679ba8101ae9">


## Changes
Added `experimental_ppr` to the list of allowed exports in the TypeScript plugin.

## Context
This change ensures that the `experimental_ppr` configuration option, which enables Partial Prerendering (PPR) for segments and their descendants, is correctly recognized by the TypeScript plugin, preventing unnecessary errors.
