### PR TITLE
Separate app router cache entries from pages and use buffer

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -395,7 +395,7 @@ function createFlightDataResolver(ctx: AppRenderContext) {
   // Generate the flight data and as soon as it can, convert it into a string.
   const promise = generateFlight(ctx)
     .then(async (result) => ({
-      flightData: await result.toUnchunkedString(true),
+      flightData: await result.toUnchunkedBuffer(true),
     }))
     // Otherwise if it errored, return the error.
     .catch((err) => ({ err }))

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2528,13 +2528,26 @@ export default abstract class Server<
         return null
       }
 
+      if (metadata.flightData) {
+        return {
+          value: {
+            kind: 'APP_PAGE',
+            html: result,
+            rscData: metadata.flightData,
+            postponed: metadata.postponed,
+            headers,
+            status: isAppPath ? res.statusCode : undefined,
+          },
+          revalidate: metadata.revalidate,
+        }
+      }
+
       // We now have a valid HTML result that we can return to the user.
       return {
         value: {
           kind: 'PAGE',
           html: result,
-          pageData: metadata.pageData ?? metadata.flightData,
-          postponed: metadata.postponed,
+          pageData: metadata.pageData,
           headers,
           status: isAppPath ? res.statusCode : undefined,
         },

--- a/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
@@ -109,7 +109,10 @@ export default class FetchCache implements CacheHandler {
             }
             // rough estimate of size of cache value
             return (
-              value.html.length + (JSON.stringify(value.pageData)?.length || 0)
+              value.html.length +
+              (JSON.stringify(
+                value.kind === 'APP_PAGE' ? value.rscData : value.pageData
+              )?.length || 0)
             )
           },
         })

--- a/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
@@ -294,7 +294,7 @@ export default class FileSystemCache implements CacheHandler {
       }
     }
 
-    if (data?.value?.kind === 'PAGE') {
+    if (data?.value?.kind === 'APP_PAGE' || data?.value?.kind === 'PAGE') {
       let cacheTags: undefined | string[]
       const tagsHeader = data.value.headers?.[NEXT_CACHE_TAGS_HEADER]
 
@@ -379,7 +379,7 @@ export default class FileSystemCache implements CacheHandler {
     }
 
     if (data?.kind === 'PAGE' || data?.kind === 'APP_PAGE') {
-      const isAppPath = data.kind === 'APP_PAGE'
+      const isAppPath = 'rscData' in data
       const htmlPath = this.getFilePath(
         `${key}.html`,
         isAppPath ? 'app' : 'pages'

--- a/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
@@ -77,7 +77,10 @@ export default class FileSystemCache implements CacheHandler {
             }
             // rough estimate of size of cache value
             return (
-              value.html.length + (JSON.stringify(value.pageData)?.length || 0)
+              value.html.length +
+              (JSON.stringify(
+                value.kind === 'APP_PAGE' ? value.rscData : value.pageData
+              )?.length || 0)
             )
           },
         })
@@ -229,23 +232,6 @@ export default class FileSystemCache implements CacheHandler {
             }
           }
         } else {
-          const pageData = isAppPath
-            ? await this.fs.readFile(
-                this.getFilePath(
-                  `${key}${
-                    this.isAppPPREnabled ? RSC_PREFETCH_SUFFIX : RSC_SUFFIX
-                  }`,
-                  'app'
-                ),
-                'utf8'
-              )
-            : JSON.parse(
-                await this.fs.readFile(
-                  this.getFilePath(`${key}${NEXT_DATA_SUFFIX}`, 'pages'),
-                  'utf8'
-                )
-              )
-
           let meta: RouteMetadata | undefined
 
           if (isAppPath) {
@@ -259,16 +245,44 @@ export default class FileSystemCache implements CacheHandler {
             } catch {}
           }
 
-          data = {
-            lastModified: mtime.getTime(),
-            value: {
-              kind: 'PAGE',
-              html: fileData,
-              pageData,
-              postponed: meta?.postponed,
-              headers: meta?.headers,
-              status: meta?.status,
-            },
+          if (isAppPath) {
+            const rscData = await this.fs.readFile(
+              this.getFilePath(
+                `${key}${
+                  this.isAppPPREnabled ? RSC_PREFETCH_SUFFIX : RSC_SUFFIX
+                }`,
+                'app'
+              )
+            )
+            data = {
+              lastModified: mtime.getTime(),
+              value: {
+                kind: 'APP_PAGE',
+                html: fileData,
+                rscData,
+                postponed: meta?.postponed,
+                headers: meta?.headers,
+                status: meta?.status,
+              },
+            }
+          } else {
+            const pageData = JSON.parse(
+              await this.fs.readFile(
+                this.getFilePath(`${key}${NEXT_DATA_SUFFIX}`, 'pages'),
+                'utf8'
+              )
+            )
+
+            data = {
+              lastModified: mtime.getTime(),
+              value: {
+                kind: 'PAGE',
+                html: fileData,
+                pageData,
+                headers: meta?.headers,
+                status: meta?.status,
+              },
+            }
           }
         }
 
@@ -364,8 +378,8 @@ export default class FileSystemCache implements CacheHandler {
       return
     }
 
-    if (data?.kind === 'PAGE') {
-      const isAppPath = typeof data.pageData === 'string'
+    if (data?.kind === 'PAGE' || data?.kind === 'APP_PAGE') {
+      const isAppPath = data.kind === 'APP_PAGE'
       const htmlPath = this.getFilePath(
         `${key}.html`,
         isAppPath ? 'app' : 'pages'
@@ -384,14 +398,14 @@ export default class FileSystemCache implements CacheHandler {
           }`,
           isAppPath ? 'app' : 'pages'
         ),
-        isAppPath ? data.pageData : JSON.stringify(data.pageData)
+        isAppPath ? data.rscData : JSON.stringify(data.pageData)
       )
 
       if (data.headers || data.status) {
         const meta: RouteMetadata = {
           headers: data.headers,
           status: data.status,
-          postponed: data.postponed,
+          postponed: isAppPath ? data.postponed : undefined,
         }
 
         await this.fs.writeFile(

--- a/packages/next/src/server/render-result.ts
+++ b/packages/next/src/server/render-result.ts
@@ -188,7 +188,7 @@ export default class RenderResult<
     }
 
     if (Buffer.isBuffer(this.response)) {
-      throw new Error(`Invariant: buffer response cannot be streamed`)
+      return streamFromBuffer(this.response)
     }
 
     // If the response is an array of streams, then chain them together.

--- a/packages/next/src/server/render-result.ts
+++ b/packages/next/src/server/render-result.ts
@@ -4,7 +4,9 @@ import type { FetchMetrics } from './base-http'
 
 import {
   chainStreams,
+  streamFromBuffer,
   streamFromString,
+  streamToBuffer,
   streamToString,
 } from './stream-utils/node-web-streams-helper'
 import { isAbortError, pipeToNodeResponse } from './pipe-readable'
@@ -12,7 +14,7 @@ import { isAbortError, pipeToNodeResponse } from './pipe-readable'
 type ContentTypeOption = string | undefined
 
 export type AppPageRenderResultMetadata = {
-  flightData?: string
+  flightData?: Buffer
   revalidate?: Revalidate
   staticBailoutInfo?: {
     stack?: string
@@ -50,6 +52,7 @@ export type RenderResultResponse =
   | ReadableStream<Uint8Array>[]
   | ReadableStream<Uint8Array>
   | string
+  | Buffer
   | null
 
 export type RenderResultOptions<
@@ -89,7 +92,7 @@ export default class RenderResult<
    * @param value the static response value
    * @returns a new RenderResult instance
    */
-  public static fromStatic(value: string) {
+  public static fromStatic(value: string | Buffer) {
     return new RenderResult<StaticRenderResultMetadata>(value, { metadata: {} })
   }
 
@@ -123,6 +126,26 @@ export default class RenderResult<
    */
   public get isDynamic(): boolean {
     return typeof this.response !== 'string'
+  }
+
+  public toUnchunkedBuffer(stream?: false): Buffer
+  public toUnchunkedBuffer(stream: true): Promise<Buffer>
+  public toUnchunkedBuffer(stream = false): Promise<Buffer> | Buffer {
+    if (this.response === null) {
+      throw new Error('Invariant: null responses cannot be unchunked')
+    }
+
+    if (typeof this.response !== 'string') {
+      if (!stream) {
+        throw new Error(
+          'Invariant: dynamic responses cannot be unchunked. This is a bug in Next.js'
+        )
+      }
+
+      return streamToBuffer(this.readable)
+    }
+
+    return Buffer.from(this.response)
   }
 
   /**
@@ -164,6 +187,10 @@ export default class RenderResult<
       throw new Error('Invariant: static responses cannot be streamed')
     }
 
+    if (Buffer.isBuffer(this.response)) {
+      throw new Error(`Invariant: buffer response cannot be streamed`)
+    }
+
     // If the response is an array of streams, then chain them together.
     if (Array.isArray(this.response)) {
       return chainStreams(...this.response)
@@ -191,6 +218,8 @@ export default class RenderResult<
       responses = [streamFromString(this.response)]
     } else if (Array.isArray(this.response)) {
       responses = this.response
+    } else if (Buffer.isBuffer(this.response)) {
+      responses = [streamFromBuffer(this.response)]
     } else {
       responses = [this.response]
     }

--- a/packages/next/src/server/response-cache/types.ts
+++ b/packages/next/src/server/response-cache/types.ts
@@ -40,12 +40,22 @@ export interface CachedRedirectValue {
   props: Object
 }
 
-interface CachedPageValue {
+export interface CachedAppPageValue {
+  kind: 'APP_PAGE'
+  // this needs to be a RenderResult so since renderResponse
+  // expects that type instead of a string
+  html: RenderResult
+  rscData: Buffer
+  status: number | undefined
+  postponed: string | undefined
+  headers: OutgoingHttpHeaders | undefined
+}
+
+export interface CachedPageValue {
   kind: 'PAGE'
   // this needs to be a RenderResult so since renderResponse
   // expects that type instead of a string
   html: RenderResult
-  postponed: string | undefined
   pageData: Object
   status: number | undefined
   headers: OutgoingHttpHeaders | undefined
@@ -69,13 +79,23 @@ export interface CachedImageValue {
   isStale?: boolean
 }
 
-interface IncrementalCachedPageValue {
+export interface IncrementalCachedAppPageValue {
+  kind: 'APP_PAGE'
+  // this needs to be a string since the cache expects to store
+  // the string value
+  html: string
+  rscData: Buffer
+  headers: OutgoingHttpHeaders | undefined
+  postponed: string | undefined
+  status: number | undefined
+}
+
+export interface IncrementalCachedPageValue {
   kind: 'PAGE'
   // this needs to be a string since the cache expects to store
   // the string value
   html: string
   pageData: Object
-  postponed: string | undefined
   headers: OutgoingHttpHeaders | undefined
   status: number | undefined
 }
@@ -92,6 +112,7 @@ export type IncrementalCacheEntry = {
 export type IncrementalCacheValue =
   | CachedRedirectValue
   | IncrementalCachedPageValue
+  | IncrementalCachedAppPageValue
   | CachedImageValue
   | CachedFetchValue
   | CachedRouteValue
@@ -99,6 +120,7 @@ export type IncrementalCacheValue =
 export type ResponseCacheValue =
   | CachedRedirectValue
   | CachedPageValue
+  | CachedAppPageValue
   | CachedImageValue
   | CachedRouteValue
 

--- a/packages/next/src/server/response-cache/types.ts
+++ b/packages/next/src/server/response-cache/types.ts
@@ -45,7 +45,7 @@ export interface CachedAppPageValue {
   // this needs to be a RenderResult so since renderResponse
   // expects that type instead of a string
   html: RenderResult
-  rscData: Buffer
+  rscData: Buffer | undefined
   status: number | undefined
   postponed: string | undefined
   headers: OutgoingHttpHeaders | undefined
@@ -84,7 +84,7 @@ export interface IncrementalCachedAppPageValue {
   // this needs to be a string since the cache expects to store
   // the string value
   html: string
-  rscData: Buffer
+  rscData: Buffer | undefined
   headers: OutgoingHttpHeaders | undefined
   postponed: string | undefined
   status: number | undefined

--- a/packages/next/src/server/response-cache/utils.ts
+++ b/packages/next/src/server/response-cache/utils.ts
@@ -12,12 +12,20 @@ export async function fromResponseCacheEntry(
         ? {
             kind: 'PAGE',
             html: await cacheEntry.value.html.toUnchunkedString(true),
-            postponed: cacheEntry.value.postponed,
             pageData: cacheEntry.value.pageData,
             headers: cacheEntry.value.headers,
             status: cacheEntry.value.status,
           }
-        : cacheEntry.value,
+        : cacheEntry.value?.kind === 'APP_PAGE'
+          ? {
+              kind: 'APP_PAGE',
+              html: await cacheEntry.value.html.toUnchunkedString(true),
+              postponed: cacheEntry.value.postponed,
+              rscData: cacheEntry.value.rscData,
+              headers: cacheEntry.value.headers,
+              status: cacheEntry.value.status,
+            }
+          : cacheEntry.value,
   }
 }
 
@@ -42,10 +50,18 @@ export async function toResponseCacheEntry(
             kind: 'PAGE',
             html: RenderResult.fromStatic(response.value.html),
             pageData: response.value.pageData,
-            postponed: response.value.postponed,
             headers: response.value.headers,
             status: response.value.status,
           }
-        : response.value,
+        : response.value?.kind === 'APP_PAGE'
+          ? {
+              kind: 'APP_PAGE',
+              html: RenderResult.fromStatic(response.value.html),
+              rscData: response.value.rscData,
+              headers: response.value.headers,
+              status: response.value.status,
+              postponed: response.value.postponed,
+            }
+          : response.value,
   }
 }

--- a/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.ts
@@ -73,6 +73,28 @@ export function streamFromString(str: string): ReadableStream<Uint8Array> {
   })
 }
 
+export function streamFromBuffer(chunk: Buffer): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(chunk)
+      controller.close()
+    },
+  })
+}
+
+export async function streamToBuffer(
+  stream: ReadableStream<Uint8Array>
+): Promise<Buffer> {
+  const buffers: Buffer[] = []
+
+  // @ts-expect-error TypeScript gets this wrong (https://nodejs.org/api/webstreams.html#async-iteration)
+  for await (const chunk of stream) {
+    buffers.push(chunk)
+  }
+
+  return Buffer.concat(buffers)
+}
+
 export async function streamToString(
   stream: ReadableStream<Uint8Array>
 ): Promise<string> {


### PR DESCRIPTION
Continues https://github.com/vercel/next.js/pull/65664/files and fixes use stringifying the RSC payload un-necessarily which is causing encoding issues. 