### PR TITLE
fix(next/image)!: set upstream timeout to 7 seconds

### DIFF
--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -439,7 +439,7 @@ export async function optimizeImage({
 }): Promise<Buffer> {
   const sharp = getSharp()
   const transformer = sharp(buffer, { sequentialRead: true })
-    .timeout({ seconds: 10 })
+    .timeout({ seconds: 7 })
     .rotate()
 
   if (height) {
@@ -470,7 +470,21 @@ export async function optimizeImage({
 }
 
 export async function fetchExternalImage(href: string): Promise<ImageUpstream> {
-  const res = await fetch(href)
+  const res = await fetch(href, {
+    signal: AbortSignal.timeout(7_000),
+  }).catch((err) => err as Error)
+
+  if (res instanceof Error) {
+    const err = res as Error
+    if (err.name === 'TimeoutError') {
+      Log.error('upstream image response timed out for', href)
+      throw new ImageError(
+        504,
+        '"url" parameter is valid but upstream response timed out'
+      )
+    }
+    throw err
+  }
 
   if (!res.ok) {
     Log.error('upstream image response failed for', href, res.status)

--- a/test/integration/image-optimizer/test/util.ts
+++ b/test/integration/image-optimizer/test/util.ts
@@ -178,6 +178,13 @@ export function runTests(ctx: RunTestsCtx) {
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res.status).toBe(500)
     })
+
+    it('should timeout for upstream image exceeding 7 seconds', async () => {
+      const url = `http://localhost:${slowImageServer.port}/slow.png?delay=${8000}`
+      const query = { url, w: ctx.w, q: 100 }
+      const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
+      expect(res.status).toBe(504)
+    })
   }
 
   it('should return home page', async () => {


### PR DESCRIPTION
This PR sets the upstream image timeout to 7 seconds so its not unbounded (P99 is about 3 to 4 seconds).

We also set the sharp timeout to 7 seconds (P99 is about 2 seconds although it depends on CPU).

This means an image could take at most 14 seconds to fetch and optimize.