### PR TITLE
fix(create-next-app): Update CNA templates' .gitignore files for parity with Yarn recommendations

### DIFF
--- a/packages/create-next-app/templates/app-empty/js/gitignore
+++ b/packages/create-next-app/templates/app-empty/js/gitignore
@@ -3,8 +3,12 @@
 # dependencies
 /node_modules
 /.pnp
-.pnp.js
-.yarn/install-state.gz
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
 
 # testing
 /coverage

--- a/packages/create-next-app/templates/app-empty/ts/gitignore
+++ b/packages/create-next-app/templates/app-empty/ts/gitignore
@@ -3,8 +3,12 @@
 # dependencies
 /node_modules
 /.pnp
-.pnp.js
-.yarn/install-state.gz
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
 
 # testing
 /coverage

--- a/packages/create-next-app/templates/app-tw-empty/js/gitignore
+++ b/packages/create-next-app/templates/app-tw-empty/js/gitignore
@@ -3,8 +3,12 @@
 # dependencies
 /node_modules
 /.pnp
-.pnp.js
-.yarn/install-state.gz
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
 
 # testing
 /coverage

--- a/packages/create-next-app/templates/app-tw-empty/ts/gitignore
+++ b/packages/create-next-app/templates/app-tw-empty/ts/gitignore
@@ -3,8 +3,12 @@
 # dependencies
 /node_modules
 /.pnp
-.pnp.js
-.yarn/install-state.gz
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
 
 # testing
 /coverage

--- a/packages/create-next-app/templates/app-tw/js/gitignore
+++ b/packages/create-next-app/templates/app-tw/js/gitignore
@@ -3,8 +3,12 @@
 # dependencies
 /node_modules
 /.pnp
-.pnp.js
-.yarn/install-state.gz
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
 
 # testing
 /coverage

--- a/packages/create-next-app/templates/app-tw/ts/gitignore
+++ b/packages/create-next-app/templates/app-tw/ts/gitignore
@@ -3,8 +3,12 @@
 # dependencies
 /node_modules
 /.pnp
-.pnp.js
-.yarn/install-state.gz
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
 
 # testing
 /coverage

--- a/packages/create-next-app/templates/app/js/gitignore
+++ b/packages/create-next-app/templates/app/js/gitignore
@@ -3,8 +3,12 @@
 # dependencies
 /node_modules
 /.pnp
-.pnp.js
-.yarn/install-state.gz
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
 
 # testing
 /coverage

--- a/packages/create-next-app/templates/app/ts/gitignore
+++ b/packages/create-next-app/templates/app/ts/gitignore
@@ -3,8 +3,12 @@
 # dependencies
 /node_modules
 /.pnp
-.pnp.js
-.yarn/install-state.gz
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
 
 # testing
 /coverage

--- a/packages/create-next-app/templates/default-empty/js/gitignore
+++ b/packages/create-next-app/templates/default-empty/js/gitignore
@@ -3,8 +3,12 @@
 # dependencies
 /node_modules
 /.pnp
-.pnp.js
-.yarn/install-state.gz
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
 
 # testing
 /coverage

--- a/packages/create-next-app/templates/default-empty/ts/gitignore
+++ b/packages/create-next-app/templates/default-empty/ts/gitignore
@@ -3,8 +3,12 @@
 # dependencies
 /node_modules
 /.pnp
-.pnp.js
-.yarn/install-state.gz
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
 
 # testing
 /coverage

--- a/packages/create-next-app/templates/default-tw-empty/js/gitignore
+++ b/packages/create-next-app/templates/default-tw-empty/js/gitignore
@@ -3,8 +3,12 @@
 # dependencies
 /node_modules
 /.pnp
-.pnp.js
-.yarn/install-state.gz
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
 
 # testing
 /coverage

--- a/packages/create-next-app/templates/default-tw-empty/ts/gitignore
+++ b/packages/create-next-app/templates/default-tw-empty/ts/gitignore
@@ -3,8 +3,12 @@
 # dependencies
 /node_modules
 /.pnp
-.pnp.js
-.yarn/install-state.gz
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
 
 # testing
 /coverage

--- a/packages/create-next-app/templates/default-tw/js/gitignore
+++ b/packages/create-next-app/templates/default-tw/js/gitignore
@@ -3,8 +3,12 @@
 # dependencies
 /node_modules
 /.pnp
-.pnp.js
-.yarn/install-state.gz
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
 
 # testing
 /coverage

--- a/packages/create-next-app/templates/default-tw/ts/gitignore
+++ b/packages/create-next-app/templates/default-tw/ts/gitignore
@@ -3,8 +3,12 @@
 # dependencies
 /node_modules
 /.pnp
-.pnp.js
-.yarn/install-state.gz
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
 
 # testing
 /coverage

--- a/packages/create-next-app/templates/default/js/gitignore
+++ b/packages/create-next-app/templates/default/js/gitignore
@@ -3,8 +3,12 @@
 # dependencies
 /node_modules
 /.pnp
-.pnp.js
-.yarn/install-state.gz
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
 
 # testing
 /coverage

--- a/packages/create-next-app/templates/default/ts/gitignore
+++ b/packages/create-next-app/templates/default/ts/gitignore
@@ -3,8 +3,12 @@
 # dependencies
 /node_modules
 /.pnp
-.pnp.js
-.yarn/install-state.gz
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
 
 # testing
 /coverage


### PR DESCRIPTION
### What?

Updates create-next-app's templates' `.gitignore` files for parity with [Yarn's official recommendations](https://v3.yarnpkg.com/getting-started/qa#which-files-should-be-gitignored), accounting for Yarn's modern Plug-n-Play functionality.

Fixes #65586 

### Why?

New projects initialized with create-next-app presently add various extraneous files from the Yarn cache to the initial commit. This is most notable in the case of the Next SWC binary, which may exceed 100M in some environments (empirically, 64-bit Darwin and WSL2 Ubuntu, and very probably other unix/linux environments), and prevent users from pushing their new projects to free GitHub repositories without rewriting the commit history to exclude the extraneous files, or unnecessarily setting up Git LFS to include them.

### How?

I have errored on the side of exclusion to enable users to push their CNA projects to GitHub as-is and for parity with other package managers, while still providing the opportunity to opt in to additional functionality provided by modern Yarn.

These changes follow the recommendations for non-[Zero-Install](https://yarnpkg.com/features/caching#zero-installs) configurations, as Zero-Install functionality is an extension on top of the base package manager experience, and may necessitate additional configuration and present additional complications for unsuspecting users, so I think it's best left up to the user to opt-in. On account of the majority of publicly available Next.js-based projects comprising general consumer-facing websites, it is my belief that the majority of Next projects would not benefit from Yarn's Zero-Install functionality, and that explicitly facilitating it by default would break status quo with all other non-Yarn CNA projects.

Contrary to the example `.gitignore`s provided by Yarn, I've excluded the `.yarn/sdks` directory as it contains IDE-specific tooling;  I feel it would be presumptuous for an environmentally-agnostic tool to target and provide package-manager-specific tooling for specific editors. This too should be left to the user to opt-in to and provide for their project if they deem necessary.

I have retained the current `.gitignore`'s exclusion of the `/.pnp` directory for backwards compatibility with older versions of Yarn (the files therein have since been reallocated to the `.yarn` directory addressed by these changes, but I am not clear on when that delineation occurred or the prevalence of Yarn installations which depend on the former convention). Maintaining the exclusion here, in the worst case, implies additional downloads (on an order of magnitude merely similar to using npm from the outset) rather than failure.