### PR TITLE
Change default of prerenderEarlyExit to true

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -878,7 +878,7 @@ export const defaultConfig: NextConfig = {
   modularizeImports: undefined,
   experimental: {
     flyingShuttle: false,
-    prerenderEarlyExit: false,
+    prerenderEarlyExit: true,
     serverMinification: true,
     serverSourceMaps: false,
     linkNoTouchStart: false,

--- a/test/e2e/app-dir/dynamic-data/fixtures/main/next.config.js
+++ b/test/e2e/app-dir/dynamic-data/fixtures/main/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    prerenderEarlyExit: false,
+  },
+}

--- a/test/e2e/app-dir/dynamic-data/fixtures/require-static/next.config.js
+++ b/test/e2e/app-dir/dynamic-data/fixtures/require-static/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    prerenderEarlyExit: false,
+  },
+}

--- a/test/e2e/app-dir/ppr-errors/next.config.js
+++ b/test/e2e/app-dir/ppr-errors/next.config.js
@@ -4,6 +4,7 @@
 const nextConfig = {
   experimental: {
     ppr: true,
+    prerenderEarlyExit: true,
   },
 }
 

--- a/test/e2e/app-dir/ppr-errors/next.config.js
+++ b/test/e2e/app-dir/ppr-errors/next.config.js
@@ -4,7 +4,7 @@
 const nextConfig = {
   experimental: {
     ppr: true,
-    prerenderEarlyExit: true,
+    prerenderEarlyExit: false,
   },
 }
 

--- a/test/integration/handles-export-errors/next.config.mjs
+++ b/test/integration/handles-export-errors/next.config.mjs
@@ -1,0 +1,5 @@
+export default {
+  experimental: {
+    prerenderEarlyExit: false,
+  },
+}

--- a/test/production/app-dir-hide-suppressed-error-during-next-export/next.config.js
+++ b/test/production/app-dir-hide-suppressed-error-during-next-export/next.config.js
@@ -1,4 +1,8 @@
 /** @type {import("next").NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  experimental: {
+    prerenderEarlyExit: false,
+  },
+}
 
 module.exports = nextConfig


### PR DESCRIPTION
## Background

Historically during prerendering we have waiting until all paths have been attempted before we exit the process and fail the build. This is nice if you want to collect all potential errors to address them at the same time although this has the drawback of slowing down builds if things are timing out or if the same error is occurring across numerous paths. 

## New Behavior

This changes our default behavior to immediately exit when the first error occurs during prerendering so that builds don't stall out from timeout errors or from the same error occurring across numerous paths. This will help from holding up CI or similar un-necessarily. 

If users want to opt-in to the previous behavior the flag is still present under `experimental.prerenderEarlyExit`. 