### PR TITLE
Fix the runtime for rsc layer

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1710,14 +1710,15 @@ export default async function getBaseWebpackConfig(
             const layer = resource.contextInfo.issuerLayer
             let runtime
 
-            if (layer === WEBPACK_LAYERS.serverSideRendering) {
-              runtime = 'app-page'
-            } else if (!layer || layer === WEBPACK_LAYERS.api) {
-              runtime = 'pages'
-            } else {
-              throw new Error(
-                `shared-runtime module ${moduleName} cannot be used in ${layer} layer`
-              )
+            switch (layer) {
+              case WEBPACK_LAYERS.serverSideRendering:
+              case WEBPACK_LAYERS.reactServerComponents:
+              case WEBPACK_LAYERS.appPagesBrowser:
+              case WEBPACK_LAYERS.actionBrowser:
+                runtime = 'app-page'
+                break
+              default:
+                runtime = 'pages'
             }
             resource.request = `next/dist/server/future/route-modules/${runtime}/vendored/contexts/${moduleName}`
           }

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -909,12 +909,4 @@ describe('app dir - navigation', () => {
       })
     })
   })
-
-  describe('pages api', () => {
-    it('should not error if just import the navigation api in pages/api', async () => {
-      const res = await next.fetch('/api/navigation')
-      expect(res.status).toBe(200)
-      expect(await res.text()).toBe('function,function')
-    })
-  })
 })

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -914,6 +914,7 @@ describe('app dir - navigation', () => {
     it('should not error if just import the navigation api in pages/api', async () => {
       const res = await next.fetch('/api/navigation')
       expect(res.status).toBe(200)
+      expect(await res.text()).toBe('function,function')
     })
   })
 })

--- a/test/e2e/app-dir/navigation/pages/api/navigation.js
+++ b/test/e2e/app-dir/navigation/pages/api/navigation.js
@@ -1,5 +1,10 @@
 import { useParams } from 'next/navigation'
+import { useRouter } from 'next/router'
 
 export default function handle(_, res) {
-  res.send(`${typeof useParams}`)
+  const values = [
+    typeof useRouter,
+    typeof useParams
+  ]
+  res.send(values.join())
 }

--- a/test/e2e/app-dir/navigation/pages/api/navigation.js
+++ b/test/e2e/app-dir/navigation/pages/api/navigation.js
@@ -1,7 +1,0 @@
-import { useParams } from 'next/navigation'
-import { useRouter } from 'next/router'
-
-export default function handle(_, res) {
-  const values = [typeof useRouter, typeof useParams]
-  res.send(values.join())
-}

--- a/test/e2e/app-dir/navigation/pages/api/navigation.js
+++ b/test/e2e/app-dir/navigation/pages/api/navigation.js
@@ -2,9 +2,6 @@ import { useParams } from 'next/navigation'
 import { useRouter } from 'next/router'
 
 export default function handle(_, res) {
-  const values = [
-    typeof useRouter,
-    typeof useParams
-  ]
+  const values = [typeof useRouter, typeof useParams]
   res.send(values.join())
 }

--- a/test/e2e/app-dir/rsc-basic/app/shared-context/server/page.js
+++ b/test/e2e/app-dir/rsc-basic/app/shared-context/server/page.js
@@ -1,0 +1,5 @@
+require('next/router')
+
+export default function Page() {
+  return <p>just work</p>
+}

--- a/test/e2e/app-dir/rsc-basic/pages/api/navigation.js
+++ b/test/e2e/app-dir/rsc-basic/pages/api/navigation.js
@@ -1,0 +1,6 @@
+// Use `require` to skip the api check
+require('next/navigation')
+
+export default function handle(_, res) {
+  res.send('just work')
+}

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -59,6 +59,20 @@ describe('app dir - rsc basics', () => {
     })
   }
 
+  describe('next internal shared context should work correctly', () => {
+    it('should not error if just load next/navigation module in pages/api', async () => {
+      const res = await next.fetch('/api/navigation')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('just work')
+    })
+
+    it('should not error if just load next/router module in app page', async () => {
+      const res = await next.fetch('/shared-context/server')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain('just work')
+    })
+  })
+
   it('should correctly render page returning null', async () => {
     const homeHTML = await next.render('/return-null/page')
     const $ = cheerio.load(homeHTML)

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -59,7 +59,7 @@ describe('app dir - rsc basics', () => {
     })
   }
 
-  describe('next internal shared context should work correctly', () => {
+  describe('next internal shared context', () => {
     it('should not error if just load next/navigation module in pages/api', async () => {
       const res = await next.fetch('/api/navigation')
       expect(res.status).toBe(200)

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -2890,8 +2890,8 @@
         "app dir - rsc basics should suspense next/legacy/image in server components",
         "app dir - rsc basics should track client components in dynamic imports",
         "app dir - rsc basics should use canary react for app",
-        "app dir - next internal shared context should not error if just load next/navigation module in pages/api",
-        "app dir - next internal shared context should not error if just load next/router module in app page"
+        "app dir - rsc basics next internal shared context should not error if just load next/navigation module in pages/api",
+        "app dir - rsc basics next internal shared context should not error if just load next/router module in app page"
       ],
       "pending": [
         "app dir - rsc basics should support partial hydration with inlined server data in browser",

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -2889,7 +2889,9 @@
         "app dir - rsc basics should suspense next/image in server components",
         "app dir - rsc basics should suspense next/legacy/image in server components",
         "app dir - rsc basics should track client components in dynamic imports",
-        "app dir - rsc basics should use canary react for app"
+        "app dir - rsc basics should use canary react for app",
+        "app dir - next internal shared context should not error if just load next/navigation module in pages/api",
+        "app dir - next internal shared context should not error if just load next/router module in app page"
       ],
       "pending": [
         "app dir - rsc basics should support partial hydration with inlined server data in browser",


### PR DESCRIPTION
### What

Fix a bug introduced in #65694 , use app-page runtime for app router layers

### Why

This is basically reverted the route context picking up logic we had before.

During the test we found the error thrown
> Module not found: shared-runtime module router-context cannot be used in rsc layer

Which is caused by a `next/router` imports in rsc page. Decided to revert to what it was before as the most safe way to load share module contexts.

It's caused by `next-contentlayer` usage that they're using `next/router` in server component MDX, but we cannot lint error that from node_modules. (We actually can, but disabled that due to various mis-usage of server/client hooks we had before)
