### PR TITLE
wip: add support for https with draft mode

### DIFF
--- a/packages/next/src/client/components/request-async-storage.external.ts
+++ b/packages/next/src/client/components/request-async-storage.external.ts
@@ -17,6 +17,7 @@ export interface RequestStore {
     Record<string, { files: string[] }>
   >
   readonly assetPrefix: string
+  readonly experimentalHttpsServer: boolean
 }
 
 export type RequestAsyncStorage = AsyncLocalStorage<RequestStore>

--- a/packages/next/src/server/api-utils/index.ts
+++ b/packages/next/src/server/api-utils/index.ts
@@ -107,12 +107,16 @@ export function clearPreviewData<T>(
   res: NextApiResponse<T>,
   options: {
     path?: string
+    experimentalHttpsServer: boolean
   } = {}
 ): NextApiResponse<T> {
   if (SYMBOL_CLEARED_COOKIES in res) {
     return res
   }
 
+  const secure = Boolean(
+    process.env.NODE_ENV !== 'development' || options.experimentalHttpsServer
+  )
   const { serialize } =
     require('next/dist/compiled/cookie') as typeof import('cookie')
   const previous = res.getHeader('Set-Cookie')
@@ -128,8 +132,8 @@ export function clearPreviewData<T>(
       // `Max-Age: 0` is not valid, thus ignored, and the cookie is persisted.
       expires: new Date(0),
       httpOnly: true,
-      sameSite: process.env.NODE_ENV !== 'development' ? 'none' : 'lax',
-      secure: process.env.NODE_ENV !== 'development',
+      sameSite: secure ? 'none' : 'lax',
+      secure,
       path: '/',
       ...(options.path !== undefined
         ? ({ path: options.path } as CookieSerializeOptions)
@@ -141,8 +145,8 @@ export function clearPreviewData<T>(
       // `Max-Age: 0` is not valid, thus ignored, and the cookie is persisted.
       expires: new Date(0),
       httpOnly: true,
-      sameSite: process.env.NODE_ENV !== 'development' ? 'none' : 'lax',
-      secure: process.env.NODE_ENV !== 'development',
+      sameSite: secure ? 'none' : 'lax',
+      secure,
       path: '/',
       ...(options.path !== undefined
         ? ({ path: options.path } as CookieSerializeOptions)

--- a/packages/next/src/server/async-storage/request-async-storage-wrapper.ts
+++ b/packages/next/src/server/async-storage/request-async-storage-wrapper.ts
@@ -142,7 +142,8 @@ export const RequestAsyncStorageWrapper: AsyncStorageWrapper<
             previewProps,
             req,
             this.cookies,
-            this.mutableCookies
+            this.mutableCookies,
+            this.experimentalHttpsServer
           )
         }
 


### PR DESCRIPTION
# Work in progress

This adds support for https when using draft mode so the cookie can use the correct value of `Secure` and `SameSite`.

- Fixes https://github.com/vercel/next.js/issues/49927
