### PR TITLE
Ensure plugin-syntax-jsx doesn't have to be installed

### DIFF
--- a/packages/next/src/build/babel/loader/get-config.ts
+++ b/packages/next/src/build/babel/loader/get-config.ts
@@ -7,6 +7,7 @@ import loadConfig from 'next/dist/compiled/babel/core-lib-config'
 import type { NextBabelLoaderOptions, NextJsLoaderContext } from './types'
 import { consumeIterator } from './util'
 import * as Log from '../../output/log'
+import jsx from 'next/dist/compiled/babel/plugin-syntax-jsx'
 
 const nextDistPath =
   /(next[\\/]dist[\\/]shared[\\/]lib)|(next[\\/]dist[\\/]client)|(next[\\/]dist[\\/]pages)/
@@ -324,10 +325,7 @@ function getFreshConfig(
   }
 
   if (loaderOptions.transformMode === 'standalone') {
-    options.plugins = [
-      '@babel/plugin-syntax-jsx',
-      ...reactCompilerPluginsIfEnabled,
-    ]
+    options.plugins = [jsx, ...reactCompilerPluginsIfEnabled]
     options.presets = [
       [
         require('next/dist/compiled/babel/preset-typescript'),

--- a/packages/next/src/build/get-babel-loader-config.ts
+++ b/packages/next/src/build/get-babel-loader-config.ts
@@ -5,7 +5,7 @@ function getReactCompiler() {
   try {
     // It's in peerDependencies, so it should be available
     // eslint-disable-next-line import/no-extraneous-dependencies
-    return require('babel-plugin-react-compiler')
+    return require.resolve('babel-plugin-react-compiler')
   } catch {
     throw new Error(
       'Failed to load the `babel-plugin-react-compiler`. It is required to use the React Compiler. Please install it.'

--- a/packages/next/src/build/get-babel-loader-config.ts
+++ b/packages/next/src/build/get-babel-loader-config.ts
@@ -1,6 +1,18 @@
 import path from 'path'
 import type { ReactCompilerOptions } from '../server/config-shared'
 
+function getReactCompiler() {
+  try {
+    // It's in peerDependencies, so it should be available
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    return require('babel-plugin-react-compiler')
+  } catch {
+    throw new Error(
+      'Failed to load the `babel-plugin-react-compiler`. It is required to use the React Compiler. Please install it.'
+    )
+  }
+}
+
 const getReactCompilerPlugins = (
   options: boolean | ReactCompilerOptions | undefined,
   isDev: boolean,
@@ -14,7 +26,7 @@ const getReactCompilerPlugins = (
   if (options) {
     return [
       [
-        'babel-plugin-react-compiler',
+        getReactCompiler(),
         {
           panicThreshold: isDev ? undefined : 'NONE',
           ...compilerOptions,


### PR DESCRIPTION
Currently `reactCompiler: true` fails to load because babel plugin JSX is not installed, this PR ensures the correct version is used.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
