### PR TITLE
Set default stale-while-revalidate header value to 1 year

### DIFF
--- a/packages/next/src/server/lib/revalidate.ts
+++ b/packages/next/src/server/lib/revalidate.ts
@@ -17,9 +17,10 @@ export function formatRevalidate({
   revalidate: Revalidate
   swrDelta?: SwrDelta
 }): string {
-  const swrHeader = swrDelta
-    ? `stale-while-revalidate=${swrDelta}`
-    : 'stale-while-revalidate'
+  const swrHeader =
+    swrDelta === undefined
+      ? `stale-while-revalidate=${CACHE_ONE_YEAR}`
+      : `stale-while-revalidate=${swrDelta}`
 
   if (revalidate === 0) {
     return 'private, no-cache, no-store, max-age=0, must-revalidate'


### PR DESCRIPTION

This follows 2 previous PRs, https://github.com/vercel/next.js/pull/52251 and https://github.com/vercel/next.js/pull/61330 by making a 1 year expiry the default for the `stale-while-revalidate` header.

As far as I can tell, the current default is invalid according to [RFC 5861](https://httpwg.org/specs/rfc5861.html#n-the-stale-while-revalidate-cache-control-extension). 

Any user deploying Next.js behind any CDN other Vercel expects SWR to work correctly, but it does not because there is no default expiry value.

This change will make the default work for all Next.js users and greatly reduce frustration for those of us deploying Next.js places besides Vercel.

This also fixes a small edge case where `experimental.swrDelta = 0` would not function as expected.

Thank you!