### PR TITLE
[tests] Deprecate check

### DIFF
--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -2,9 +2,9 @@
 import { sandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import {
-  check,
   describeVariants as describe,
   expandCallStack,
+  retry,
 } from 'next-test-utils'
 import path from 'path'
 import { outdent } from 'outdent'
@@ -757,17 +757,19 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
 
     // Unhandled error in event handler
     await browser.elementById('unhandled-error').click()
-    await check(
-      () => browser.elementByCss('.nextjs-toast-errors').text(),
-      /3 errors/
-    )
+    await retry(async () => {
+      expect(await browser.elementByCss('.nextjs-toast-errors').text()).toMatch(
+        /3 errors/
+      )
+    })
 
     // Unhandled rejection in event handler
     await browser.elementById('unhandled-rejection').click()
-    await check(
-      () => browser.elementByCss('.nextjs-toast-errors').text(),
-      /4 errors/
-    )
+    await retry(async () => {
+      expect(await browser.elementByCss('.nextjs-toast-errors').text()).toMatch(
+        /4 errors/
+      )
+    })
     expect(await session.hasRedbox()).toBe(false)
 
     // Add Component error

--- a/test/development/acceptance-app/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance-app/ReactRefreshRegression.test.ts
@@ -2,7 +2,7 @@
 import { sandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { outdent } from 'outdent'
 
 describe('ReactRefreshRegression app', () => {
@@ -176,17 +176,19 @@ describe('ReactRefreshRegression app', () => {
       `
     )
 
-    await check(
-      () => session.evaluate(() => document.querySelector('p').textContent),
-      '0'
-    )
+    await retry(async () => {
+      expect(
+        await session.evaluate(() => document.querySelector('p').textContent)
+      ).toEqual('0')
+    })
 
     await session.evaluate(() => document.querySelector('button').click())
 
-    await check(
-      () => session.evaluate(() => document.querySelector('p').textContent),
-      '1'
-    )
+    await retry(async () => {
+      expect(
+        await session.evaluate(() => document.querySelector('p').textContent)
+      ).toEqual('1')
+    })
 
     await session.patch(
       'index.js',
@@ -207,17 +209,19 @@ describe('ReactRefreshRegression app', () => {
       `
     )
 
-    await check(
-      () => session.evaluate(() => document.querySelector('p').textContent),
-      'Count: 1'
-    )
+    await retry(async () => {
+      expect(
+        await session.evaluate(() => document.querySelector('p').textContent)
+      ).toEqual('Count: 1')
+    })
 
     await session.evaluate(() => document.querySelector('button').click())
 
-    await check(
-      () => session.evaluate(() => document.querySelector('p').textContent),
-      'Count: 2'
-    )
+    await retry(async () => {
+      expect(
+        await session.evaluate(() => document.querySelector('p').textContent)
+      ).toEqual('Count: 2')
+    })
 
     await cleanup()
   })
@@ -259,10 +263,11 @@ describe('ReactRefreshRegression app', () => {
       `
     )
 
-    await check(
-      () => session.evaluate(() => document.querySelector('p').textContent),
-      '0'
-    )
+    await retry(async () => {
+      expect(
+        await session.evaluate(() => document.querySelector('p').textContent)
+      ).toEqual('0')
+    })
 
     await session.evaluate(() => document.querySelector('button').click())
     expect(

--- a/test/development/acceptance-app/editor-links.test.ts
+++ b/test/development/acceptance-app/editor-links.test.ts
@@ -1,4 +1,4 @@
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import { sandbox } from 'development-sandbox'
@@ -71,7 +71,9 @@ describe('Error overlay - editor links', () => {
 
     expect(await session.hasRedbox()).toBe(true)
     await clickSourceFile(browser)
-    await check(() => editorRequestsCount, /1/)
+    await retry(async () => {
+      expect(await editorRequestsCount).toMatch(/1/)
+    })
 
     await cleanup()
   })
@@ -116,7 +118,9 @@ describe('Error overlay - editor links', () => {
 
         expect(await session.hasRedbox()).toBe(true)
         await clickImportTraceFiles(browser)
-        await check(() => editorRequestsCount, /4/)
+        await retry(async () => {
+          expect(await editorRequestsCount).toMatch(/4/)
+        })
 
         await cleanup()
       })
@@ -159,7 +163,9 @@ describe('Error overlay - editor links', () => {
 
         expect(await session.hasRedbox()).toBe(true)
         await clickImportTraceFiles(browser)
-        await check(() => editorRequestsCount, /3/)
+        await retry(async () => {
+          expect(await editorRequestsCount).toMatch(/3/)
+        })
 
         await cleanup()
       })

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -1,5 +1,5 @@
 import { FileRef, nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import path from 'path'
 import { sandbox } from 'development-sandbox'
 import { outdent } from 'outdent'
@@ -368,10 +368,11 @@ describe('Error overlay - RSC build errors', () => {
     )
 
     expect(await session.hasRedbox()).toBe(true)
-    await check(
-      () => session.getRedboxSource(),
-      /must be a Client \n| Component/
-    )
+    await retry(async () => {
+      expect(await session.getRedboxSource()).toMatch(
+        /must be a Client \n| Component/
+      )
+    })
     if (process.env.TURBOPACK) {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
         .toMatchInlineSnapshot(`
@@ -417,7 +418,11 @@ describe('Error overlay - RSC build errors', () => {
     await session.patch('app/server-with-errors/error-file/error.js', '')
 
     expect(await session.hasRedbox()).toBe(true)
-    await check(() => session.getRedboxSource(), /must be a Client Component/)
+    await retry(async () => {
+      expect(await session.getRedboxSource()).toMatch(
+        /must be a Client Component/
+      )
+    })
 
     // TODO: investigate flakey snapshot due to spacing below
     // expect(next.normalizeTestDirContent(await session.getRedboxSource()))
@@ -463,10 +468,9 @@ describe('Error overlay - RSC build errors', () => {
 
     await session.patch(pagePath, content)
 
-    await check(
-      async () => ((await session.hasRedbox()) ? 'success' : 'fail'),
-      /success/
-    )
+    await retry(async () => {
+      expect(await session.hasRedbox()).toBeTruthy()
+    })
 
     expect(await session.getRedboxDescription()).toContain(
       'Cannot add property x, object is not extensible'

--- a/test/development/acceptance-app/rsc-runtime-errors.test.ts
+++ b/test/development/acceptance-app/rsc-runtime-errors.test.ts
@@ -2,7 +2,6 @@ import path from 'path'
 import { outdent } from 'outdent'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import {
-  check,
   getRedboxDescription,
   getRedboxSource,
   getVersionCheckerText,
@@ -29,10 +28,9 @@ describe('Error overlay - RSC runtime errors', () => {
 
     const browser = await next.browser('/server')
 
-    await check(
-      async () => ((await hasRedbox(browser)) ? 'success' : 'fail'),
-      /success/
-    )
+    await retry(async () => {
+      expect(await hasRedbox(browser)).toBeTruthy()
+    })
     const errorDescription = await getRedboxDescription(browser)
 
     expect(errorDescription).toContain(
@@ -55,10 +53,9 @@ describe('Error overlay - RSC runtime errors', () => {
 
     const browser = await next.browser('/client')
 
-    await check(
-      async () => ((await hasRedbox(browser)) ? 'success' : 'fail'),
-      /success/
-    )
+    await retry(async () => {
+      expect(await hasRedbox(browser)).toBeTruthy()
+    })
     const errorDescription = await getRedboxDescription(browser)
 
     expect(errorDescription).toContain(
@@ -77,10 +74,9 @@ describe('Error overlay - RSC runtime errors', () => {
     )
 
     const browser = await next.browser('/server')
-    await check(
-      async () => ((await hasRedbox(browser)) ? 'success' : 'fail'),
-      /success/
-    )
+    await retry(async () => {
+      expect(await hasRedbox(browser)).toBeTruthy()
+    })
 
     const errorDescription = await getRedboxDescription(browser)
 
@@ -98,10 +94,9 @@ describe('Error overlay - RSC runtime errors', () => {
         `
     )
     const browser = await next.browser('/server')
-    await check(
-      async () => ((await hasRedbox(browser)) ? 'success' : 'fail'),
-      /success/
-    )
+    await retry(async () => {
+      expect(await hasRedbox(browser)).toBeTruthy()
+    })
 
     const source = await getRedboxSource(browser)
     // Can show the original source code

--- a/test/development/acceptance-app/server-components.test.ts
+++ b/test/development/acceptance-app/server-components.test.ts
@@ -2,7 +2,7 @@
 import { sandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { outdent } from 'outdent'
 
 describe('Error Overlay for server components', () => {
@@ -39,7 +39,7 @@ describe('Error Overlay for server components', () => {
         ])
       )
 
-      await check(async () => {
+      await retry(async () => {
         expect(
           await browser
             .waitForElementByCss('#nextjs__container_errors_desc')
@@ -47,8 +47,7 @@ describe('Error Overlay for server components', () => {
         ).toContain(
           'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
         )
-        return 'success'
-      }, 'success')
+      })
 
       expect(next.cliOutput).toContain(
         'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
@@ -95,7 +94,7 @@ describe('Error Overlay for server components', () => {
         ])
       )
 
-      await check(async () => {
+      await retry(async () => {
         expect(
           await browser
             .waitForElementByCss('#nextjs__container_errors_desc')
@@ -103,8 +102,7 @@ describe('Error Overlay for server components', () => {
         ).toContain(
           'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
         )
-        return 'success'
-      }, 'success')
+      })
 
       expect(next.cliOutput).toContain(
         'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
@@ -150,7 +148,7 @@ describe('Error Overlay for server components', () => {
           ],
         ])
       )
-      await check(async () => {
+      await retry(async () => {
         expect(
           await browser
             .waitForElementByCss('#nextjs__container_errors_desc')
@@ -158,8 +156,7 @@ describe('Error Overlay for server components', () => {
         ).toContain(
           'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
         )
-        return 'success'
-      }, 'success')
+      })
 
       expect(next.cliOutput).toContain(
         'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
@@ -187,7 +184,7 @@ describe('Error Overlay for server components', () => {
         ])
       )
 
-      await check(async () => {
+      await retry(async () => {
         expect(
           await browser
             .waitForElementByCss('#nextjs__container_errors_desc')
@@ -195,8 +192,7 @@ describe('Error Overlay for server components', () => {
         ).toContain(
           'useRef only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
         )
-        return 'success'
-      }, 'success')
+      })
 
       expect(next.cliOutput).toContain(
         'useRef only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
@@ -222,7 +218,7 @@ describe('Error Overlay for server components', () => {
         ])
       )
 
-      await check(async () => {
+      await retry(async () => {
         expect(
           await browser
             .waitForElementByCss('#nextjs__container_errors_desc')
@@ -230,8 +226,7 @@ describe('Error Overlay for server components', () => {
         ).toContain(
           'experimental_useOptimistic only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
         )
-        return 'success'
-      }, 'success')
+      })
 
       expect(next.cliOutput).toContain(
         'experimental_useOptimistic only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
@@ -257,11 +252,10 @@ describe('Error Overlay for server components', () => {
         ])
       )
 
-      await check(async () => {
+      await retry(async () => {
         const html = await browser.eval('document.documentElement.innerHTML')
         expect(html).toContain('experimental_useOptimistic')
-        return 'success'
-      }, 'success')
+      })
 
       expect(next.cliOutput).toContain('experimental_useOptimistic')
 
@@ -303,7 +297,7 @@ describe('Error Overlay for server components', () => {
         ])
       )
 
-      await check(async () => {
+      await retry(async () => {
         expect(
           await browser
             .waitForElementByCss('#nextjs__container_errors_desc')
@@ -311,8 +305,7 @@ describe('Error Overlay for server components', () => {
         ).toContain(
           'useState only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
         )
-        return 'success'
-      }, 'success')
+      })
 
       expect(next.cliOutput).toContain(
         'useState only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
@@ -356,7 +349,7 @@ describe('Error Overlay for server components', () => {
         ])
       )
 
-      await check(async () => {
+      await retry(async () => {
         expect(
           await browser
             .waitForElementByCss('#nextjs__container_errors_desc')
@@ -364,8 +357,7 @@ describe('Error Overlay for server components', () => {
         ).toContain(
           'useEffect only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
         )
-        return 'success'
-      }, 'success')
+      })
 
       expect(next.cliOutput).toContain(
         'useEffect only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
@@ -394,7 +386,7 @@ describe('Error Overlay for server components', () => {
         ])
       )
 
-      await check(async () => {
+      await retry(async () => {
         expect(
           await browser
             .waitForElementByCss('#nextjs__container_errors_desc')
@@ -402,8 +394,7 @@ describe('Error Overlay for server components', () => {
         ).toContain(
           'This might be caused by a React Class Component being rendered in a Server Component'
         )
-        return 'success'
-      }, 'success')
+      })
 
       expect(next.cliOutput).toContain(
         'This might be caused by a React Class Component being rendered in a Server Component'
@@ -448,7 +439,7 @@ describe('Error Overlay for server components', () => {
         ])
       )
 
-      await check(async () => {
+      await retry(async () => {
         expect(
           await browser
             .waitForElementByCss('#nextjs__container_errors_desc')
@@ -456,8 +447,7 @@ describe('Error Overlay for server components', () => {
         ).toContain(
           'This might be caused by a React Class Component being rendered in a Server Component'
         )
-        return 'success'
-      }, 'success')
+      })
 
       expect(next.cliOutput).toContain(
         'This might be caused by a React Class Component being rendered in a Server Component'
@@ -502,7 +492,7 @@ describe('Error Overlay for server components', () => {
         ])
       )
 
-      await check(async () => {
+      await retry(async () => {
         expect(
           await browser
             .waitForElementByCss('#nextjs__container_errors_desc')
@@ -510,8 +500,7 @@ describe('Error Overlay for server components', () => {
         ).toContain(
           'This might be caused by a React Class Component being rendered in a Server Component'
         )
-        return 'success'
-      }, 'success')
+      })
 
       expect(next.cliOutput).toContain(
         'This might be caused by a React Class Component being rendered in a Server Component'

--- a/test/development/acceptance/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance/ReactRefreshRegression.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import { sandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { outdent } from 'outdent'
 import path from 'path'
 
@@ -229,10 +229,11 @@ describe('ReactRefreshRegression', () => {
       `
     )
 
-    await check(
-      () => session.evaluate(() => document.querySelector('p').textContent),
-      '0'
-    )
+    await retry(async () => {
+      expect(
+        await session.evaluate(() => document.querySelector('p').textContent)
+      ).toEqual('0')
+    })
 
     await session.evaluate(() => document.querySelector('button').click())
     expect(

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import { sandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
-import { check, describeVariants as describe } from 'next-test-utils'
+import { describeVariants as describe, retry } from 'next-test-utils'
 import { outdent } from 'outdent'
 import path from 'path'
 
@@ -62,10 +62,11 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
       `
     )
 
-    await check(
-      () => session.evaluate(() => document.querySelector('p').textContent),
-      /Count: 1/
-    )
+    await retry(async () => {
+      expect(
+        await session.evaluate(() => document.querySelector('p').textContent)
+      ).toMatch(/Count: 1/)
+    })
 
     expect(await session.hasRedbox()).toBe(false)
 
@@ -303,10 +304,10 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox %s', () => {
     )
     expect(await session.hasRedbox()).toBe(true)
 
-    await check(async () => {
+    await retry(async () => {
       const source = await session.getRedboxSource()
-      return source?.includes('render() {') ? 'success' : source
-    }, 'success')
+      expect(source?.includes('render() {')).toBeTruthy()
+    })
 
     expect(await session.getRedboxSource()).toInclude(
       "throw new Error('nooo');"

--- a/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
+++ b/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { sandbox } from 'development-sandbox'
 import { outdent } from 'outdent'
 
@@ -49,10 +49,11 @@ describe('Error Overlay for server components compiler errors in pages', () => {
     )
 
     expect(await session.hasRedbox()).toBe(true)
-    await check(
-      () => session.getRedboxSource(),
-      /That only works in a Server Component/
-    )
+    await retry(async () => {
+      expect(await session.getRedboxSource()).toMatch(
+        /That only works in a Server Component/
+      )
+    })
 
     if (process.env.TURBOPACK) {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
@@ -108,10 +109,11 @@ describe('Error Overlay for server components compiler errors in pages', () => {
     )
 
     expect(await session.hasRedbox()).toBe(true)
-    await check(
-      () => session.getRedboxSource(),
-      /That only works in a Server Component/
-    )
+    await retry(async () => {
+      expect(await session.getRedboxSource()).toMatch(
+        /That only works in a Server Component/
+      )
+    })
 
     if (process.env.TURBOPACK) {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))

--- a/test/development/app-dir/app-routes-error/index.test.ts
+++ b/test/development/app-dir/app-routes-error/index.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('app-dir - app routes errors', () => {
   const { next } = nextTestSetup({
@@ -20,7 +20,7 @@ describe('app-dir - app routes errors', () => {
       async (method: string) => {
         await next.fetch('/lowercase/' + method)
 
-        await check(() => {
+        await retry(() => {
           expect(next.cliOutput).toContain(
             `Detected lowercase method '${method}' in`
           )
@@ -30,8 +30,7 @@ describe('app-dir - app routes errors', () => {
           expect(next.cliOutput).toMatch(
             /Detected lowercase method '.+' in '.+\/route\.js'\. Export the uppercase '.+' method name to fix this error\./
           )
-          return 'yes'
-        }, 'yes')
+        })
       }
     )
   })

--- a/test/development/app-dir/strict-mode-enabled-by-default/strict-mode-enabled-by-default.test.ts
+++ b/test/development/app-dir/strict-mode-enabled-by-default/strict-mode-enabled-by-default.test.ts
@@ -1,6 +1,6 @@
 import { type BrowserInterface } from 'next-webdriver'
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('Strict Mode enabled by default', () => {
   const { next } = nextTestSetup({
@@ -9,10 +9,9 @@ describe('Strict Mode enabled by default', () => {
   // TODO: modern StrictMode does not double invoke effects during hydration: https://github.com/facebook/react/pull/28951
   it.skip('should work using browser', async () => {
     const browser: BrowserInterface = await next.browser('/')
-    await check(async () => {
+    await retry(async () => {
       const text = await browser.elementByCss('p').text()
-      // FIXME: Bug in React. Strict Effects no longer work in current beta.
-      return text === '1' ? 'success' : `failed: ${text}`
-    }, 'success')
+      expect(text === '1').toBeTruthy()
+    })
   })
 })

--- a/test/development/app-hmr/hmr.test.ts
+++ b/test/development/app-hmr/hmr.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check, waitFor } from 'next-test-utils'
+import { waitFor, retry } from 'next-test-utils'
 
 const envFile = '.env.development.local'
 
@@ -40,11 +40,10 @@ describe(`app-dir-hmr`, () => {
 
       try {
         // Should be 404 in a few seconds
-        await check(async () => {
+        await retry(async () => {
           const body = await browser.elementByCss('body').text()
           expect(body).toContain('404')
-          return 'success'
-        }, 'success')
+        })
 
         // The new page should be rendered
         const newHTML = await next.render('/folder-renamed')
@@ -62,10 +61,9 @@ describe(`app-dir-hmr`, () => {
       await next.patchFile(envFile, 'MY_DEVICE="ipad"')
 
       try {
-        await check(async () => {
+        await retry(async () => {
           expect(await browser.elementByCss('p').text()).toBe('ipad')
-          return 'success'
-        }, /success/)
+        })
       } finally {
         await next.patchFile(envFile, envContent)
       }
@@ -78,10 +76,9 @@ describe(`app-dir-hmr`, () => {
       await next.patchFile(envFile, 'MY_DEVICE="ipad"')
 
       try {
-        await check(async () => {
+        await retry(async () => {
           expect(await browser.elementByCss('p').text()).toBe('ipad')
-          return 'success'
-        }, /success/)
+        })
       } finally {
         await next.patchFile(envFile, envContent)
       }

--- a/test/development/app-render-error-log/app-render-error-log.test.ts
+++ b/test/development/app-render-error-log/app-render-error-log.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('app-render-error-log', () => {
   const { next } = nextTestSetup({
@@ -9,10 +9,14 @@ describe('app-render-error-log', () => {
     const outputIndex = next.cliOutput.length
     await next.fetch('/')
 
-    await check(() => next.cliOutput.slice(outputIndex), /at Page/)
+    await retry(async () => {
+      expect(await next.cliOutput.slice(outputIndex)).toMatch(/at Page/)
+    })
     const cliOutput = next.cliOutput.slice(outputIndex)
 
-    await check(() => cliOutput, /digest:/)
+    await retry(async () => {
+      expect(await cliOutput).toMatch(/digest:/)
+    })
     expect(cliOutput).toInclude('Error: boom')
     expect(cliOutput).toInclude('at fn2 (./app/fn.ts')
     expect(cliOutput).toMatch(/at (Module\.)?fn1 \(\.\/app\/fn\.ts/)
@@ -25,10 +29,14 @@ describe('app-render-error-log', () => {
     const outputIndex = next.cliOutput.length
     await next.fetch('/edge')
 
-    await check(() => next.cliOutput.slice(outputIndex), /at EdgePage/)
+    await retry(async () => {
+      expect(await next.cliOutput.slice(outputIndex)).toMatch(/at EdgePage/)
+    })
     const cliOutput = next.cliOutput.slice(outputIndex)
 
-    await check(() => cliOutput, /digest:/)
+    await retry(async () => {
+      expect(await cliOutput).toMatch(/digest:/)
+    })
     expect(cliOutput).toInclude('Error: boom')
     expect(cliOutput).toInclude('at fn2 (./app/fn.ts')
     expect(cliOutput).toMatch(/at (Module\.)?fn1 \(\.\/app\/fn\.ts/)

--- a/test/development/basic/asset-prefix/asset-prefix.test.ts
+++ b/test/development/basic/asset-prefix/asset-prefix.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('asset-prefix', () => {
   const { next } = nextTestSetup({
@@ -13,13 +13,13 @@ describe('asset-prefix', () => {
 
     expect(await browser.elementByCss('div').text()).toBe('Hello World')
 
-    await check(async () => {
+    await retry(async () => {
       const logs = await browser.log()
       const hasError = logs.some((log) =>
         log.message.includes('Failed to fetch')
       )
-      return hasError ? 'error' : 'success'
-    }, 'success')
+      expect(hasError).toBeFalsy()
+    })
 
     expect(await browser.eval(`window.__v`)).toBe(1)
   })

--- a/test/development/basic/define-class-fields/define-class-fields.test.ts
+++ b/test/development/basic/define-class-fields/define-class-fields.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('useDefineForClassFields SWC option', () => {
   const { next } = nextTestSetup({
@@ -20,10 +20,11 @@ describe('useDefineForClassFields SWC option', () => {
     try {
       browser = await webdriver(next.url, '/')
       await browser.elementByCss('#action').click()
-      await check(
-        () => browser.elementByCss('#name').text(),
-        /this is my name: next/
-      )
+      await retry(async () => {
+        expect(await browser.elementByCss('#name').text()).toMatch(
+          /this is my name: next/
+        )
+      })
     } finally {
       if (browser) {
         await browser.close()

--- a/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
+++ b/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
@@ -3,7 +3,7 @@
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
-import { check, getRedboxHeader, hasRedbox } from 'next-test-utils'
+import { getRedboxHeader, hasRedbox, retry } from 'next-test-utils'
 import { NextInstance } from 'e2e-utils'
 
 const installCheckVisible = (browser) => {
@@ -34,7 +34,9 @@ describe('GS(S)P Server-Side Change Reloading', () => {
 
   it('should not reload page when client-side is changed too GSP', async () => {
     const browser = await webdriver(next.url, '/gsp-blog/first')
-    await check(() => browser.elementByCss('#change').text(), 'change me')
+    await retry(async () => {
+      expect(await browser.elementByCss('#change').text()).toEqual('change me')
+    })
     await browser.eval(`window.beforeChange = 'hi'`)
 
     const props = JSON.parse(await browser.elementByCss('#props').text())
@@ -43,14 +45,18 @@ describe('GS(S)P Server-Side Change Reloading', () => {
     const originalContent = await next.readFile(page)
     await next.patchFile(page, originalContent.replace('change me', 'changed'))
 
-    await check(() => browser.elementByCss('#change').text(), 'changed')
+    await retry(async () => {
+      expect(await browser.elementByCss('#change').text()).toEqual('changed')
+    })
     expect(await browser.eval(`window.beforeChange`)).toBe('hi')
 
     const props2 = JSON.parse(await browser.elementByCss('#props').text())
     expect(props).toEqual(props2)
 
     await next.patchFile(page, originalContent)
-    await check(() => browser.elementByCss('#change').text(), 'change me')
+    await retry(async () => {
+      expect(await browser.elementByCss('#change').text()).toEqual('change me')
+    })
   })
 
   it('should update page when getStaticProps is changed only', async () => {
@@ -67,19 +73,21 @@ describe('GS(S)P Server-Side Change Reloading', () => {
       originalContent.replace('count = 1', 'count = 2')
     )
 
-    await check(
-      async () =>
-        JSON.parse(await browser.elementByCss('#props').text()).count + '',
-      '2'
-    )
+    await retry(async () => {
+      expect(
+        (await JSON.parse(await browser.elementByCss('#props').text()).count) +
+          ''
+      ).toEqual('2')
+    })
     expect(await browser.eval(`window.beforeChange`)).toBe('hi')
     await next.patchFile(page, originalContent)
 
-    await check(
-      async () =>
-        JSON.parse(await browser.elementByCss('#props').text()).count + '',
-      '1'
-    )
+    await retry(async () => {
+      expect(
+        (await JSON.parse(await browser.elementByCss('#props').text()).count) +
+          ''
+      ).toEqual('1')
+    })
   })
 
   it('should show indicator when re-fetching data', async () => {
@@ -97,20 +105,22 @@ describe('GS(S)P Server-Side Change Reloading', () => {
       originalContent.replace('count = 1', 'count = 2')
     )
 
-    await check(
-      async () =>
-        JSON.parse(await browser.elementByCss('#props').text()).count + '',
-      '2'
-    )
+    await retry(async () => {
+      expect(
+        (await JSON.parse(await browser.elementByCss('#props').text()).count) +
+          ''
+      ).toEqual('2')
+    })
     expect(await browser.eval(`window.beforeChange`)).toBe('hi')
     expect(await browser.eval(`window.showedBuilder`)).toBe(true)
 
     await next.patchFile(page, originalContent)
-    await check(
-      async () =>
-        JSON.parse(await browser.elementByCss('#props').text()).count + '',
-      '1'
-    )
+    await retry(async () => {
+      expect(
+        (await JSON.parse(await browser.elementByCss('#props').text()).count) +
+          ''
+      ).toEqual('1')
+    })
   })
 
   it('should update page when getStaticPaths is changed only', async () => {
@@ -163,11 +173,12 @@ describe('GS(S)P Server-Side Change Reloading', () => {
       originalContent.replace('count = 1', 'count = 2')
     )
 
-    await check(
-      async () =>
-        JSON.parse(await browser.elementByCss('#props').text()).count + '',
-      '2'
-    )
+    await retry(async () => {
+      expect(
+        (await JSON.parse(await browser.elementByCss('#props').text()).count) +
+          ''
+      ).toEqual('2')
+    })
     expect(await browser.eval('window.beforeChange')).toBe('hi')
     await next.patchFile(page, originalContent)
   })
@@ -192,11 +203,12 @@ describe('GS(S)P Server-Side Change Reloading', () => {
       originalContent.replace('count = 1', 'count = 2')
     )
 
-    await check(
-      async () =>
-        JSON.parse(await browser.elementByCss('#props').text()).count + '',
-      '2'
-    )
+    await retry(async () => {
+      expect(
+        (await JSON.parse(await browser.elementByCss('#props').text()).count) +
+          ''
+      ).toEqual('2')
+    })
     expect(await browser.eval('window.beforeChange')).toBe('hi')
     expect(await browser.eval('document.documentElement.scrollTop')).toBe(
       scrollPosition
@@ -206,7 +218,9 @@ describe('GS(S)P Server-Side Change Reloading', () => {
 
   it('should not reload page when client-side is changed too GSSP', async () => {
     const browser = await webdriver(next.url, '/gssp-blog/first')
-    await check(() => browser.elementByCss('#change').text(), 'change me')
+    await retry(async () => {
+      expect(await browser.elementByCss('#change').text()).toEqual('change me')
+    })
     await browser.eval(`window.beforeChange = 'hi'`)
 
     const props = JSON.parse(await browser.elementByCss('#props').text())
@@ -215,23 +229,28 @@ describe('GS(S)P Server-Side Change Reloading', () => {
     const originalContent = await next.readFile(page)
     await next.patchFile(page, originalContent.replace('change me', 'changed'))
 
-    await check(() => browser.elementByCss('#change').text(), 'changed')
+    await retry(async () => {
+      expect(await browser.elementByCss('#change').text()).toEqual('changed')
+    })
     expect(await browser.eval(`window.beforeChange`)).toBe('hi')
 
     const props2 = JSON.parse(await browser.elementByCss('#props').text())
     expect(props).toEqual(props2)
 
     await next.patchFile(page, originalContent)
-    await check(() => browser.elementByCss('#change').text(), 'change me')
+    await retry(async () => {
+      expect(await browser.elementByCss('#change').text()).toEqual('change me')
+    })
   })
 
   it('should update page when getServerSideProps is changed only', async () => {
     const browser = await webdriver(next.url, '/gssp-blog/first')
-    await check(
-      async () =>
-        JSON.parse(await browser.elementByCss('#props').text()).count + '',
-      '1'
-    )
+    await retry(async () => {
+      expect(
+        (await JSON.parse(await browser.elementByCss('#props').text()).count) +
+          ''
+      ).toEqual('1')
+    })
     await browser.eval(`window.beforeChange = 'hi'`)
 
     const props = JSON.parse(await browser.elementByCss('#props').text())
@@ -244,19 +263,21 @@ describe('GS(S)P Server-Side Change Reloading', () => {
       originalContent.replace('count = 1', 'count = 2')
     )
 
-    await check(
-      async () =>
-        JSON.parse(await browser.elementByCss('#props').text()).count + '',
-      '2'
-    )
+    await retry(async () => {
+      expect(
+        (await JSON.parse(await browser.elementByCss('#props').text()).count) +
+          ''
+      ).toEqual('2')
+    })
     expect(await browser.eval(`window.beforeChange`)).toBe('hi')
     await next.patchFile(page, originalContent)
 
-    await check(
-      async () =>
-        JSON.parse(await browser.elementByCss('#props').text()).count + '',
-      '1'
-    )
+    await retry(async () => {
+      expect(
+        (await JSON.parse(await browser.elementByCss('#props').text()).count) +
+          ''
+      ).toEqual('1')
+    })
   })
 
   it('should update on props error in getStaticProps', async () => {
@@ -324,21 +345,19 @@ describe('GS(S)P Server-Side Change Reloading', () => {
 
     try {
       await next.patchFile(page, JSON.stringify({ hello: 'replaced!!' }))
-      await check(async () => {
+      await retry(async () => {
         const props = JSON.parse(await browser.elementByCss('#props').text())
-        return props.count === 1 && props.data.hello === 'replaced!!'
-          ? 'success'
-          : JSON.stringify(props)
-      }, 'success')
+        expect(
+          props.count === 1 && props.data.hello === 'replaced!!'
+        ).toBeTruthy()
+      })
       expect(await browser.eval('window.beforeChange')).toBe('hi')
 
       await next.patchFile(page, originalContent)
-      await check(async () => {
+      await retry(async () => {
         const props = JSON.parse(await browser.elementByCss('#props').text())
-        return props.count === 1 && props.data.hello === 'world'
-          ? 'success'
-          : JSON.stringify(props)
-      }, 'success')
+        expect(props.count === 1 && props.data.hello === 'world').toBeTruthy()
+      })
     } finally {
       await next.patchFile(page, originalContent)
     }

--- a/test/development/basic/hmr.test.ts
+++ b/test/development/basic/hmr.test.ts
@@ -2,7 +2,6 @@ import { join } from 'path'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
 import {
-  check,
   getBrowserBodyText,
   getRedboxHeader,
   getRedboxDescription,
@@ -66,9 +65,9 @@ describe.each([[''], ['/docs']])(
         basePath + '/auto-export-is-ready?hello=world'
       )
 
-      await check(async () => {
-        return browser.elementByCss('#ready').text()
-      }, 'yes')
+      await retry(async () => {
+        expect(await browser.elementByCss('#ready').text()).toEqual('yes')
+      })
       expect(JSON.parse(await browser.elementByCss('#query').text())).toEqual({
         hello: 'world',
       })
@@ -87,9 +86,9 @@ describe.each([[''], ['/docs']])(
         basePath + '/gsp-is-ready?hello=world'
       )
 
-      await check(async () => {
-        return browser.elementByCss('#ready').text()
-      }, 'yes')
+      await retry(async () => {
+        expect(await browser.elementByCss('#ready').text()).toEqual('yes')
+      })
       expect(JSON.parse(await browser.elementByCss('#query').text())).toEqual({
         hello: 'world',
       })
@@ -109,19 +108,21 @@ describe.each([[''], ['/docs']])(
             // Rename the file to mimic a deleted page
             await next.renameFile(contactPagePath, newContactPagePath)
 
-            await check(
-              () => getBrowserBodyText(browser),
-              /This page could not be found/
-            )
+            await retry(async () => {
+              expect(await getBrowserBodyText(browser)).toMatch(
+                /This page could not be found/
+              )
+            })
 
             // Rename the file back to the original filename
             await next.renameFile(newContactPagePath, contactPagePath)
 
             // wait until the page comes back
-            await check(
-              () => getBrowserBodyText(browser),
-              /This is the contact page/
-            )
+            await retry(async () => {
+              expect(await getBrowserBodyText(browser)).toMatch(
+                /This is the contact page/
+              )
+            })
 
             expect(next.cliOutput).toContain('Compiled /_error')
           } finally {
@@ -154,16 +155,19 @@ describe.each([[''], ['/docs']])(
             // change the content
             try {
               await next.patchFile(aboutPagePath, editedContent)
-              await check(() => getBrowserBodyText(browser), /COOL page/)
+              await retry(async () => {
+                expect(await getBrowserBodyText(browser)).toMatch(/COOL page/)
+              })
             } finally {
               // add the original content
               await next.patchFile(aboutPagePath, originalContent)
             }
 
-            await check(
-              () => getBrowserBodyText(browser),
-              /This is the about page/
-            )
+            await retry(async () => {
+              expect(await getBrowserBodyText(browser)).toMatch(
+                /This is the about page/
+              )
+            })
           } finally {
             if (browser) {
               await browser.close()
@@ -197,7 +201,11 @@ describe.each([[''], ['/docs']])(
               await next.patchFile(aboutPagePath, editedContent)
 
               // Check whether the this page has reloaded or not.
-              await check(() => browser.elementByCss('p').text(), /COUNT: 2/)
+              await retry(async () => {
+                expect(await browser.elementByCss('p').text()).toMatch(
+                  /COUNT: 2/
+                )
+              })
             } finally {
               // restore the about page content.
               await next.patchFile(aboutPagePath, originalContent)
@@ -230,11 +238,13 @@ describe.each([[''], ['/docs']])(
 
             try {
               // Check whether the this page has reloaded or not.
-              await check(async () => {
+              await retry(async () => {
                 const editedPTag =
                   await browser.elementByCss('.hmr-style-page p')
-                return editedPTag.getComputedCss('font-size')
-              }, /200px/)
+                expect(await editedPTag.getComputedCss('font-size')).toMatch(
+                  /200px/
+                )
+              })
             } finally {
               // Finally is used so that we revert the content back to the original regardless of the test outcome
               // restore the about page content.
@@ -268,10 +278,12 @@ describe.each([[''], ['/docs']])(
             await next.patchFile(pagePath, editedContent)
 
             // Check whether the this page has reloaded or not.
-            await check(async () => {
+            await retry(async () => {
               const editedPTag = await browser.elementByCss('.hmr-style-page p')
-              return editedPTag.getComputedCss('font-size')
-            }, /200px/)
+              expect(await editedPTag.getComputedCss('font-size')).toMatch(
+                /200px/
+              )
+            })
           } finally {
             if (browser) {
               await browser.close()
@@ -382,14 +394,17 @@ describe.each([[''], ['/docs']])(
             'export default () => (<div id="new-page">the-new-page</div>)'
           )
 
-          await check(() => getBrowserBodyText(browser), /the-new-page/)
+          await retry(async () => {
+            expect(await getBrowserBodyText(browser)).toMatch(/the-new-page/)
+          })
 
           await next.deleteFile(newPage)
 
-          await check(
-            () => getBrowserBodyText(browser),
-            /This page could not be found/
-          )
+          await retry(async () => {
+            expect(await getBrowserBodyText(browser)).toMatch(
+              /This page could not be found/
+            )
+          })
 
           expect(next.cliOutput).toContain('Compiled /_error')
         } catch (err) {
@@ -419,14 +434,17 @@ describe.each([[''], ['/docs']])(
             'export default () => (<div id="new-page">the-new-page</div>)'
           )
 
-          await check(() => getBrowserBodyText(browser), /the-new-page/)
+          await retry(async () => {
+            expect(await getBrowserBodyText(browser)).toMatch(/the-new-page/)
+          })
 
           await next.deleteFile(newPage)
 
-          await check(
-            () => getBrowserBodyText(browser),
-            /This page could not be found/
-          )
+          await retry(async () => {
+            expect(await getBrowserBodyText(browser)).toMatch(
+              /This page could not be found/
+            )
+          })
 
           expect(next.cliOutput).toContain('Compiled /_error')
         } catch (err) {
@@ -470,7 +488,9 @@ describe.each([[''], ['/docs']])(
           // navigate to a 404 page
           await webdriver(next.url, basePath + '/does-not-exist')
 
-          await check(() => next.cliOutput, /getInitialProps called/)
+          await retry(async () => {
+            expect(await next.cliOutput).toMatch(/getInitialProps called/)
+          })
 
           const outputIndex = next.cliOutput.length
 
@@ -613,17 +633,19 @@ describe.each([[''], ['/docs']])(
 
             await next.patchFile(aboutPage, aboutContent)
 
-            await check(
-              () => getBrowserBodyText(browser),
-              /This is the contact page/
-            )
+            await retry(async () => {
+              expect(await getBrowserBodyText(browser)).toMatch(
+                /This is the contact page/
+              )
+            })
           } catch (err) {
             await next.patchFile(aboutPage, aboutContent)
             if (browser) {
-              await check(
-                () => getBrowserBodyText(browser),
-                /This is the contact page/
-              )
+              await retry(async () => {
+                expect(await getBrowserBodyText(browser)).toMatch(
+                  /This is the contact page/
+                )
+              })
             }
 
             throw err
@@ -641,10 +663,11 @@ describe.each([[''], ['/docs']])(
         const aboutContent = await next.readFile(aboutPage)
         try {
           browser = await webdriver(next.url, basePath + '/hmr/about3')
-          await check(
-            () => getBrowserBodyText(browser),
-            /This is the about page/
-          )
+          await retry(async () => {
+            expect(await getBrowserBodyText(browser)).toMatch(
+              /This is the about page/
+            )
+          })
 
           await next.patchFile(
             aboutPage,
@@ -656,10 +679,11 @@ describe.each([[''], ['/docs']])(
 
           await next.patchFile(aboutPage, aboutContent)
 
-          await check(
-            () => getBrowserBodyText(browser),
-            /This is the about page/
-          )
+          await retry(async () => {
+            expect(await getBrowserBodyText(browser)).toMatch(
+              /This is the about page/
+            )
+          })
         } finally {
           await next.patchFile(aboutPage, aboutContent)
           if (browser) {
@@ -674,10 +698,11 @@ describe.each([[''], ['/docs']])(
         const aboutContent = await next.readFile(aboutPage)
         try {
           browser = await webdriver(next.url, basePath + '/hmr/about4')
-          await check(
-            () => getBrowserBodyText(browser),
-            /This is the about page/
-          )
+          await retry(async () => {
+            expect(await getBrowserBodyText(browser)).toMatch(
+              /This is the about page/
+            )
+          })
 
           await next.patchFile(
             aboutPage,
@@ -692,17 +717,19 @@ describe.each([[''], ['/docs']])(
 
           await next.patchFile(aboutPage, aboutContent)
 
-          await check(
-            () => getBrowserBodyText(browser),
-            /This is the about page/
-          )
+          await retry(async () => {
+            expect(await getBrowserBodyText(browser)).toMatch(
+              /This is the about page/
+            )
+          })
         } catch (err) {
           await next.patchFile(aboutPage, aboutContent)
           if (browser) {
-            await check(
-              () => getBrowserBodyText(browser),
-              /This is the about page/
-            )
+            await retry(async () => {
+              expect(await getBrowserBodyText(browser)).toMatch(
+                /This is the about page/
+              )
+            })
           }
 
           throw err
@@ -719,10 +746,11 @@ describe.each([[''], ['/docs']])(
         const aboutContent = await next.readFile(aboutPage)
         try {
           browser = await webdriver(next.url, basePath + '/hmr/about5')
-          await check(
-            () => getBrowserBodyText(browser),
-            /This is the about page/
-          )
+          await retry(async () => {
+            expect(await getBrowserBodyText(browser)).toMatch(
+              /This is the about page/
+            )
+          })
 
           await next.patchFile(
             aboutPage,
@@ -739,18 +767,20 @@ describe.each([[''], ['/docs']])(
 
           await next.patchFile(aboutPage, aboutContent)
 
-          await check(
-            () => getBrowserBodyText(browser),
-            /This is the about page/
-          )
+          await retry(async () => {
+            expect(await getBrowserBodyText(browser)).toMatch(
+              /This is the about page/
+            )
+          })
         } catch (err) {
           await next.patchFile(aboutPage, aboutContent)
 
           if (browser) {
-            await check(
-              () => getBrowserBodyText(browser),
-              /This is the about page/
-            )
+            await retry(async () => {
+              expect(await getBrowserBodyText(browser)).toMatch(
+                /This is the about page/
+              )
+            })
           }
 
           throw err
@@ -767,10 +797,11 @@ describe.each([[''], ['/docs']])(
         const aboutContent = await next.readFile(aboutPage)
         try {
           browser = await webdriver(next.url, basePath + '/hmr/about6')
-          await check(
-            () => getBrowserBodyText(browser),
-            /This is the about page/
-          )
+          await retry(async () => {
+            expect(await getBrowserBodyText(browser)).toMatch(
+              /This is the about page/
+            )
+          })
 
           await next.patchFile(
             aboutPage,
@@ -788,18 +819,20 @@ describe.each([[''], ['/docs']])(
 
           await next.patchFile(aboutPage, aboutContent)
 
-          await check(
-            () => getBrowserBodyText(browser),
-            /This is the about page/
-          )
+          await retry(async () => {
+            expect(await getBrowserBodyText(browser)).toMatch(
+              /This is the about page/
+            )
+          })
         } catch (err) {
           await next.patchFile(aboutPage, aboutContent)
 
           if (browser) {
-            await check(
-              () => getBrowserBodyText(browser),
-              /This is the about page/
-            )
+            await retry(async () => {
+              expect(await getBrowserBodyText(browser)).toMatch(
+                /This is the about page/
+              )
+            })
           }
 
           throw err
@@ -817,10 +850,11 @@ describe.each([[''], ['/docs']])(
         const aboutContent = await next.readFile(aboutPage)
         try {
           browser = await webdriver(next.url, basePath + '/hmr/about7')
-          await check(
-            () => getBrowserBodyText(browser),
-            /This is the about page/
-          )
+          await retry(async () => {
+            expect(await getBrowserBodyText(browser)).toMatch(
+              /This is the about page/
+            )
+          })
 
           await next.patchFile(
             aboutPage,
@@ -837,19 +871,21 @@ describe.each([[''], ['/docs']])(
 
           await next.patchFile(aboutPage, aboutContent)
 
-          await check(
-            () => getBrowserBodyText(browser),
-            /This is the about page/
-          )
+          await retry(async () => {
+            expect(await getBrowserBodyText(browser)).toMatch(
+              /This is the about page/
+            )
+          })
           expect(await hasRedbox(browser)).toBe(false)
         } catch (err) {
           await next.patchFile(aboutPage, aboutContent)
 
           if (browser) {
-            await check(
-              () => getBrowserBodyText(browser),
-              /This is the about page/
-            )
+            await retry(async () => {
+              expect(await getBrowserBodyText(browser)).toMatch(
+                /This is the about page/
+              )
+            })
           }
 
           throw err
@@ -867,10 +903,11 @@ describe.each([[''], ['/docs']])(
         const aboutContent = await next.readFile(aboutPage)
         try {
           browser = await webdriver(next.appPort, basePath + '/hmr/about8')
-          await check(
-            () => getBrowserBodyText(browser),
-            /This is the about page/
-          )
+          await retry(async () => {
+            expect(await getBrowserBodyText(browser)).toMatch(
+              /This is the about page/
+            )
+          })
 
           await next.patchFile(
             aboutPage,
@@ -909,19 +946,21 @@ describe.each([[''], ['/docs']])(
           }
           await next.patchFile(aboutPage, aboutContent)
 
-          await check(
-            () => getBrowserBodyText(browser),
-            /This is the about page/
-          )
+          await retry(async () => {
+            expect(await getBrowserBodyText(browser)).toMatch(
+              /This is the about page/
+            )
+          })
           expect(await hasRedbox(browser)).toBe(false)
         } catch (err) {
           await next.patchFile(aboutPage, aboutContent)
 
           if (browser) {
-            await check(
-              () => getBrowserBodyText(browser),
-              /This is the about page/
-            )
+            await retry(async () => {
+              expect(await getBrowserBodyText(browser)).toMatch(
+                /This is the about page/
+              )
+            })
           }
 
           throw err
@@ -939,10 +978,11 @@ describe.each([[''], ['/docs']])(
         const aboutContent = await next.readFile(aboutPage)
         try {
           browser = await webdriver(next.appPort, basePath + '/hmr/about9')
-          await check(
-            () => getBrowserBodyText(browser),
-            /This is the about page/
-          )
+          await retry(async () => {
+            expect(await getBrowserBodyText(browser)).toMatch(
+              /This is the about page/
+            )
+          })
 
           await next.patchFile(
             aboutPage,
@@ -995,19 +1035,21 @@ describe.each([[''], ['/docs']])(
 
           await next.patchFile(aboutPage, aboutContent)
 
-          await check(
-            () => getBrowserBodyText(browser),
-            /This is the about page/
-          )
+          await retry(async () => {
+            expect(await getBrowserBodyText(browser)).toMatch(
+              /This is the about page/
+            )
+          })
           expect(await hasRedbox(browser)).toBe(false)
         } catch (err) {
           await next.patchFile(aboutPage, aboutContent)
 
           if (browser) {
-            await check(
-              () => getBrowserBodyText(browser),
-              /This is the about page/
-            )
+            await retry(async () => {
+              expect(await getBrowserBodyText(browser)).toMatch(
+                /This is the about page/
+              )
+            })
           }
         } finally {
           if (browser) {
@@ -1034,19 +1076,23 @@ describe.each([[''], ['/docs']])(
             errorContent.replace('throw error', 'return {}')
           )
 
-          await check(() => getBrowserBodyText(browser), /Hello/)
+          await retry(async () => {
+            expect(await getBrowserBodyText(browser)).toMatch(/Hello/)
+          })
 
           await next.patchFile(erroredPage, errorContent)
 
-          await check(async () => {
+          await retry(async () => {
             await browser.refresh()
             await waitFor(2000)
             const text = await getBrowserBodyText(browser)
             if (text.includes('Hello')) {
               throw new Error('waiting')
             }
-            return getRedboxSource(browser)
-          }, /an-expected-error-in-gip/)
+            expect(await getRedboxSource(browser)).toMatch(
+              /an-expected-error-in-gip/
+            )
+          })
         } catch (err) {
           await next.patchFile(erroredPage, errorContent)
 
@@ -1077,19 +1123,23 @@ describe.each([[''], ['/docs']])(
             errorContent.replace('throw error', 'return {}')
           )
 
-          await check(() => getBrowserBodyText(browser), /Hello/)
+          await retry(async () => {
+            expect(await getBrowserBodyText(browser)).toMatch(/Hello/)
+          })
 
           await next.patchFile(erroredPage, errorContent)
 
-          await check(async () => {
+          await retry(async () => {
             await browser.refresh()
             await waitFor(2000)
             const text = await getBrowserBodyText(browser)
             if (text.includes('Hello')) {
               throw new Error('waiting')
             }
-            return getRedboxSource(browser)
-          }, /an-expected-error-in-gip/)
+            expect(await getRedboxSource(browser)).toMatch(
+              /an-expected-error-in-gip/
+            )
+          })
         } catch (err) {
           await next.patchFile(erroredPage, errorContent)
 
@@ -1154,10 +1204,11 @@ describe.each([[''], ['/docs']])(
         const cliWarning =
           'Fast Refresh had to perform a full reload due to a runtime error.'
 
-        await check(
-          () => getRedboxHeader(browser),
-          /ReferenceError: whoops is not defined/
-        )
+        await retry(async () => {
+          expect(await getRedboxHeader(browser)).toMatch(
+            /ReferenceError: whoops is not defined/
+          )
+        })
         expect(next.cliOutput.slice(start)).not.toContain(cliWarning)
 
         const currentFileContent = await next.readFile(
@@ -1215,10 +1266,11 @@ describe.each([[''], ['/docs']])(
         expect(await hasRedbox(browser)).toBe(true)
         await waitFor(3000)
         await next.patchFile(pageName, originalContent)
-        await check(
-          () => next.cliOutput.substring(outputLength),
-          /Compiled.*?/i
-        )
+        await retry(async () => {
+          expect(await next.cliOutput.substring(outputLength)).toMatch(
+            /Compiled.*?/i
+          )
+        })
         const compileTimeStr = next.cliOutput.substring(outputLength)
 
         const matches = [

--- a/test/development/basic/legacy-decorators.test.ts
+++ b/test/development/basic/legacy-decorators.test.ts
@@ -2,7 +2,7 @@ import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('Legacy decorators SWC option', () => {
   let next: NextInstance
@@ -30,10 +30,11 @@ describe('Legacy decorators SWC option', () => {
       const text = await browser.elementByCss('#count').text()
       expect(text).toBe('Current number: 0')
       await browser.elementByCss('#increase').click()
-      await check(
-        () => browser.elementByCss('#count').text(),
-        /Current number: 1/
-      )
+      await retry(async () => {
+        expect(await browser.elementByCss('#count').text()).toMatch(
+          /Current number: 1/
+        )
+      })
     } finally {
       if (browser) {
         await browser.close()

--- a/test/development/basic/next-dynamic/next-dynamic.test.ts
+++ b/test/development/basic/next-dynamic/next-dynamic.test.ts
@@ -2,7 +2,7 @@ import { join } from 'path'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
-import { renderViaHTTP, check, hasRedbox } from 'next-test-utils'
+import { renderViaHTTP, hasRedbox, retry } from 'next-test-utils'
 import { NextInstance } from 'e2e-utils'
 
 const customDocumentGipContent = `\
@@ -84,14 +84,16 @@ describe('next/dynamic', () => {
         let browser
         try {
           browser = await webdriver(next.url, basePath + '/dynamic/no-chunk')
-          await check(
-            () => browser.elementByCss('body').text(),
-            /Welcome, normal/
-          )
-          await check(
-            () => browser.elementByCss('body').text(),
-            /Welcome, dynamic/
-          )
+          await retry(async () => {
+            expect(await browser.elementByCss('body').text()).toMatch(
+              /Welcome, normal/
+            )
+          })
+          await retry(async () => {
+            expect(await browser.elementByCss('body').text()).toMatch(
+              /Welcome, dynamic/
+            )
+          })
         } finally {
           if (browser) {
             await browser.close()
@@ -111,12 +113,21 @@ describe('next/dynamic', () => {
         let browser
         try {
           browser = await webdriver(next.url, basePath + '/dynamic/nested')
-          await check(() => browser.elementByCss('body').text(), /Nested 1/)
-          await check(() => browser.elementByCss('body').text(), /Nested 2/)
-          await check(
-            () => browser.elementByCss('body').text(),
-            /Browser hydrated/
-          )
+          await retry(async () => {
+            expect(await browser.elementByCss('body').text()).toMatch(
+              /Nested 1/
+            )
+          })
+          await retry(async () => {
+            expect(await browser.elementByCss('body').text()).toMatch(
+              /Nested 2/
+            )
+          })
+          await retry(async () => {
+            expect(await browser.elementByCss('body').text()).toMatch(
+              /Browser hydrated/
+            )
+          })
 
           if ((global as any).browserName === 'chrome') {
             const logs = await browser.log('browser')
@@ -138,7 +149,9 @@ describe('next/dynamic', () => {
         let browser
         try {
           browser = await webdriver(next.url, basePath + '/dynamic/head')
-          await check(() => browser.elementByCss('body').text(), /test/)
+          await retry(async () => {
+            expect(await browser.elementByCss('body').text()).toMatch(/test/)
+          })
           const backgroundColor = await browser
             .elementByCss('.dynamic-style')
             .getComputedCss('background-color')
@@ -165,7 +178,11 @@ describe('next/dynamic', () => {
         let browser
         try {
           browser = await webdriver(next.url, basePath + '/dynamic/no-ssr')
-          await check(() => browser.elementByCss('body').text(), /navigator/)
+          await retry(async () => {
+            expect(await browser.elementByCss('body').text()).toMatch(
+              /navigator/
+            )
+          })
           expect(await hasRedbox(browser)).toBe(false)
         } finally {
           if (browser) {
@@ -178,7 +195,9 @@ describe('next/dynamic', () => {
         let browser
         try {
           browser = await webdriver(next.url, basePath + '/dynamic/no-ssr-esm')
-          await check(() => browser.elementByCss('body').text(), /esm.mjs/)
+          await retry(async () => {
+            expect(await browser.elementByCss('body').text()).toMatch(/esm.mjs/)
+          })
           expect(await hasRedbox(browser)).toBe(false)
         } finally {
           if (browser) {
@@ -199,10 +218,11 @@ describe('next/dynamic', () => {
         let browser
         try {
           browser = await webdriver(next.url, basePath + '/dynamic/ssr-true')
-          await check(
-            () => browser.elementByCss('body').text(),
-            /Hello World 1/
-          )
+          await retry(async () => {
+            expect(await browser.elementByCss('body').text()).toMatch(
+              /Hello World 1/
+            )
+          })
         } finally {
           if (browser) {
             await browser.close()
@@ -236,10 +256,11 @@ describe('next/dynamic', () => {
               next.url,
               basePath + '/dynamic/chunkfilename'
             )
-            await check(
-              () => browser.elementByCss('body').text(),
-              /test chunkfilename/
-            )
+            await retry(async () => {
+              expect(await browser.elementByCss('body').text()).toMatch(
+                /test chunkfilename/
+              )
+            })
           } finally {
             if (browser) {
               await browser.close()
@@ -262,10 +283,11 @@ describe('next/dynamic', () => {
             next.url,
             basePath + '/dynamic/no-ssr-custom-loading'
           )
-          await check(
-            () => browser.elementByCss('body').text(),
-            /Hello World 1/
-          )
+          await retry(async () => {
+            expect(await browser.elementByCss('body').text()).toMatch(
+              /Hello World 1/
+            )
+          })
         } finally {
           if (browser) {
             await browser.close()

--- a/test/development/basic/tailwind-jit.test.ts
+++ b/test/development/basic/tailwind-jit.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import webdriver, { BrowserInterface } from 'next-webdriver'
 import { FileRef, nextTestSetup } from 'e2e-utils'
-import { check, shouldRunTurboDevTest } from 'next-test-utils'
+import { shouldRunTurboDevTest, retry } from 'next-test-utils'
 
 // [TODO]: It is unclear why turbopack takes longer to run this test
 // remove once it's fixed
@@ -49,10 +49,11 @@ describe('TailwindCSS JIT', () => {
       // change the content
       try {
         await next.patchFile(aboutPagePath, editedContent)
-        await check(
-          () => browser.elementByCss('#test-link').getComputedCss('color'),
-          /rgb\(220, 38, 38\)/
-        )
+        await retry(async () => {
+          expect(
+            await browser.elementByCss('#test-link').getComputedCss('color')
+          ).toMatch(/rgb\(220, 38, 38\)/)
+        })
         expect(await browser.eval('window.REAL_HMR')).toBe(1)
       } finally {
         // add the original content

--- a/test/development/client-dev-overlay/index.test.ts
+++ b/test/development/client-dev-overlay/index.test.ts
@@ -2,7 +2,7 @@ import { createNext, FileRef } from 'e2e-utils'
 import webdriver, { BrowserInterface } from 'next-webdriver'
 import { NextInstance } from 'e2e-utils'
 import { join } from 'path'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('client-dev-overlay', () => {
   let next: NextInstance
@@ -46,13 +46,11 @@ describe('client-dev-overlay', () => {
     await getMinimizeButton().click()
     await getToast().click()
 
-    await check(async () => {
-      return (await elementExistsInNextJSPortalShadowDOM(
-        selectors.fullScreenDialog
-      ))
-        ? 'success'
-        : 'missing'
-    }, 'success')
+    await retry(async () => {
+      expect(
+        await elementExistsInNextJSPortalShadowDOM(selectors.fullScreenDialog)
+      ).toBeTruthy()
+    })
   })
 
   it('should be able to minimize the fullscreen overlay', async () => {
@@ -66,17 +64,17 @@ describe('client-dev-overlay', () => {
     await getMinimizeButton().click()
     await getHideButton().click()
 
-    await check(async () => {
+    await retry(async () => {
       const exists = await elementExistsInNextJSPortalShadowDOM('div')
-      return exists ? 'found' : 'success'
-    }, 'success')
+      expect(exists).toBeFalsy()
+    })
   })
 
   it('should have a role of "dialog" if the page is focused', async () => {
-    await check(async () => {
-      return (await elementExistsInNextJSPortalShadowDOM('[role="dialog"]'))
-        ? 'exists'
-        : 'missing'
-    }, 'exists')
+    await retry(async () => {
+      expect(
+        await elementExistsInNextJSPortalShadowDOM('[role="dialog"]')
+      ).toBeTruthy()
+    })
   })
 })

--- a/test/development/correct-tsconfig-defaults/index.test.ts
+++ b/test/development/correct-tsconfig-defaults/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { NextInstance } from 'e2e-utils'
 
 describe('correct tsconfig.json defaults', () => {
@@ -30,10 +30,10 @@ describe('correct tsconfig.json defaults', () => {
 
       let content: string
       // wait for tsconfig to be written
-      await check(async () => {
+      await retry(async () => {
         content = await next.readFile('tsconfig.json')
-        return content && content !== '{}' ? 'ready' : 'retry'
-      }, 'ready')
+        expect(content && content !== '{}').toBeTruthy()
+      })
 
       const tsconfig = JSON.parse(content)
       expect(next.cliOutput).not.toContain('moduleResolution')

--- a/test/development/jsconfig-path-reloading/index.test.ts
+++ b/test/development/jsconfig-path-reloading/index.test.ts
@@ -1,10 +1,10 @@
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
 import {
-  check,
   hasRedbox,
   renderViaHTTP,
   getRedboxSource,
+  retry,
 } from 'next-test-utils'
 import cheerio from 'cheerio'
 import { join } from 'path'
@@ -114,13 +114,13 @@ describe('jsconfig-path-reloading', () => {
       } finally {
         await next.patchFile(indexPage, indexContent)
         await next.patchFile(tsConfigFile, tsconfigContent)
-        await check(async () => {
+        await retry(async () => {
           const html3 = await browser.eval('document.documentElement.innerHTML')
-          return html3.includes('id="first-data"') &&
-            !html3.includes('second-data')
-            ? 'success'
-            : html3
-        }, 'success')
+
+          expect(
+            html3.includes('id="first-data"') && !html3.includes('second-data')
+          ).toBeTruthy()
+        })
       }
     })
 
@@ -161,24 +161,23 @@ describe('jsconfig-path-reloading', () => {
 
         expect(await hasRedbox(browser)).toBe(false)
 
-        await check(async () => {
+        await retry(async () => {
           const html2 = await browser.eval('document.documentElement.innerHTML')
           expect(html2).toContain('first button')
           expect(html2).not.toContain('second button')
           expect(html2).toContain('third button')
           expect(html2).toContain('first-data')
-          return 'success'
-        }, 'success')
+        })
       } finally {
         await next.patchFile(indexPage, indexContent)
         await next.patchFile(tsConfigFile, tsconfigContent)
-        await check(async () => {
+        await retry(async () => {
           const html3 = await browser.eval('document.documentElement.innerHTML')
-          return html3.includes('first button') &&
-            !html3.includes('third button')
-            ? 'success'
-            : html3
-        }, 'success')
+
+          expect(
+            html3.includes('first button') && !html3.includes('third button')
+          ).toBeTruthy()
+        })
       }
     })
   }

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -1,4 +1,4 @@
-import { check, getRedboxSource, hasRedbox } from 'next-test-utils'
+import { getRedboxSource, hasRedbox, retry } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 import { nextTestSetup } from 'e2e-utils'
 
@@ -27,7 +27,7 @@ describe('middleware - development errors', () => {
     it('logs the error correctly', async () => {
       await next.fetch('/')
       const output = stripAnsi(next.cliOutput)
-      await check(() => {
+      await retry(() => {
         if (process.env.TURBOPACK) {
           expect(stripAnsi(next.cliOutput)).toMatch(
             /middleware.js \(\d+:\d+\) @ Object.__TURBOPACK__default__export__ \[as handler\]/
@@ -39,8 +39,7 @@ describe('middleware - development errors', () => {
         }
 
         expect(stripAnsi(next.cliOutput)).toMatch(/boom/)
-        return 'success'
-      }, 'success')
+      })
       expect(output).not.toContain(
         'webpack-internal:///(middleware)/./middleware.js'
       )
@@ -74,10 +73,11 @@ describe('middleware - development errors', () => {
 
     it('logs the error correctly', async () => {
       await next.fetch('/')
-      await check(
-        () => stripAnsi(next.cliOutput),
-        new RegExp(`unhandledRejection: Error: async boom!`, 'm')
-      )
+      await retry(async () => {
+        expect(await stripAnsi(next.cliOutput)).toMatch(
+          new RegExp(`unhandledRejection: Error: async boom!`, 'm')
+        )
+      })
       // expect(output).not.toContain(
       //   'webpack-internal:///(middleware)/./middleware.js'
       // )
@@ -108,13 +108,12 @@ describe('middleware - development errors', () => {
     it('logs the error correctly', async () => {
       await next.fetch('/')
       const output = stripAnsi(next.cliOutput)
-      await check(() => {
+      await retry(() => {
         expect(stripAnsi(next.cliOutput)).toMatch(
           /middleware.js \(\d+:\d+\) @ eval/
         )
         expect(stripAnsi(next.cliOutput)).toMatch(/test is not defined/)
-        return 'success'
-      }, 'success')
+      })
       expect(output).not.toContain(
         'webpack-internal:///(middleware)/./middleware.js'
       )
@@ -146,13 +145,12 @@ describe('middleware - development errors', () => {
     it('logs the error correctly', async () => {
       await next.fetch('/')
       const output = stripAnsi(next.cliOutput)
-      await check(() => {
+      await retry(() => {
         expect(stripAnsi(next.cliOutput)).toMatch(
           /middleware.js \(\d+:\d+\) @ <unknown>/
         )
         expect(stripAnsi(next.cliOutput)).toMatch(/booooom!/)
-        return 'success'
-      }, 'success')
+      })
       expect(output).not.toContain(
         'webpack-internal:///(middleware)/./middleware.js'
       )
@@ -190,10 +188,11 @@ describe('middleware - development errors', () => {
 
     it('logs the error correctly', async () => {
       await next.fetch('/')
-      await check(
-        () => stripAnsi(next.cliOutput),
-        new RegExp(`unhandledRejection: Error: you shall see me`, 'm')
-      )
+      await retry(async () => {
+        expect(await stripAnsi(next.cliOutput)).toMatch(
+          new RegExp(`unhandledRejection: Error: you shall see me`, 'm')
+        )
+      })
       // expect(output).not.toContain(
       //   'webpack-internal:///(middleware)/./middleware.js'
       // )
@@ -225,13 +224,14 @@ describe('middleware - development errors', () => {
     it('logs the error correctly', async () => {
       await next.fetch('/')
       const output = stripAnsi(next.cliOutput)
-      await check(
-        () => stripAnsi(next.cliOutput),
-        new RegExp(
-          ` uncaughtException: Error: This file asynchronously fails while loading`,
-          'm'
+      await retry(async () => {
+        expect(await stripAnsi(next.cliOutput)).toMatch(
+          new RegExp(
+            ` uncaughtException: Error: This file asynchronously fails while loading`,
+            'm'
+          )
         )
-      )
+      })
       expect(output).not.toContain(
         'webpack-internal:///(middleware)/./middleware.js'
       )
@@ -253,14 +253,12 @@ describe('middleware - development errors', () => {
 
     it('logs the error correctly', async () => {
       await next.fetch('/')
-      await check(async () => {
+      await retry(() => {
         expect(next.cliOutput).toContain(`Expected '{', got '}'`)
         expect(
           next.cliOutput.split(`Expected '{', got '}'`).length
         ).toBeGreaterThanOrEqual(2)
-
-        return 'success'
-      }, 'success')
+      })
     })
 
     it('renders the error correctly and recovers', async () => {
@@ -286,11 +284,10 @@ describe('middleware - development errors', () => {
       await next.patchFile('middleware.js', `export default function () }`)
       await next.fetch('/')
 
-      await check(() => {
+      await retry(() => {
         expect(next.cliOutput).toContain(`Expected '{', got '}'`)
         expect(next.cliOutput.split(`Expected '{', got '}'`).length).toEqual(2)
-        return 'success'
-      }, 'success')
+      })
     })
 
     it('renders the error correctly and recovers', async () => {

--- a/test/development/next-font/deprecated-package.test.ts
+++ b/test/development/next-font/deprecated-package.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('Deprecated @next/font warning', () => {
   const { next, skipped } = nextTestSetup({
@@ -18,11 +18,14 @@ describe('Deprecated @next/font warning', () => {
 
   it('should warn if @next/font is in deps', async () => {
     await next.start()
-    await check(() => next.cliOutput, /ready/i)
-    await check(
-      () => next.cliOutput,
-      new RegExp('please use the built-in `next/font` instead')
-    )
+    await retry(async () => {
+      expect(await next.cliOutput).toMatch(/ready/i)
+    })
+    await retry(async () => {
+      expect(await next.cliOutput).toMatch(
+        new RegExp('please use the built-in `next/font` instead')
+      )
+    })
 
     await next.stop()
     await next.clean()
@@ -35,7 +38,9 @@ describe('Deprecated @next/font warning', () => {
     await next.patchFile('package.json', JSON.stringify(packageJson))
 
     await next.start()
-    await check(() => next.cliOutput, /ready/i)
+    await retry(async () => {
+      expect(await next.cliOutput).toMatch(/ready/i)
+    })
     expect(next.cliOutput).not.toInclude(
       'please use the built-in `next/font` instead'
     )

--- a/test/development/pages-dir/client-navigation/index.test.ts
+++ b/test/development/pages-dir/client-navigation/index.test.ts
@@ -6,7 +6,7 @@ import {
   hasRedbox,
   getRedboxHeader,
   waitFor,
-  check,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import path from 'path'
@@ -126,10 +126,11 @@ describe('Client Navigation', () => {
         `/absolute-url?port=${next.appPort}`
       )
       await browser.waitForElementByCss('#absolute-link').click()
-      await check(
-        () => browser.eval(() => window.location.origin),
-        'https://vercel.com'
-      )
+      await retry(async () => {
+        expect(await browser.eval(() => window.location.origin)).toEqual(
+          'https://vercel.com'
+        )
+      })
     })
 
     it('should call mouse handlers with an absolute url', async () => {
@@ -967,10 +968,10 @@ describe('Client Navigation', () => {
     expect(scrollPosition).toBeGreaterThan(3000)
 
     await browser.elementByCss('#increaseWithScroll').click()
-    await check(async () => {
+    await retry(async () => {
       const newScrollPosition = await browser.eval('window.pageYOffset')
-      return newScrollPosition === 0 ? 'success' : 'fail'
-    }, 'success')
+      expect(newScrollPosition === 0).toBeTruthy()
+    })
   })
 
   describe('with URL objects', () => {
@@ -1067,7 +1068,11 @@ describe('Client Navigation', () => {
       try {
         await browser.elementByCss('#link').click()
 
-        await check(() => browser.waitForElementByCss('#prop').text(), 'foo')
+        await retry(async () => {
+          expect(await browser.waitForElementByCss('#prop').text()).toEqual(
+            'foo'
+          )
+        })
       } finally {
         await browser.close()
       }
@@ -1078,7 +1083,11 @@ describe('Client Navigation', () => {
       try {
         await browser.elementByCss('#router-push').click()
 
-        await check(() => browser.waitForElementByCss('#prop').text(), 'bar')
+        await retry(async () => {
+          expect(await browser.waitForElementByCss('#prop').text()).toEqual(
+            'bar'
+          )
+        })
       } finally {
         await browser.close()
       }
@@ -1089,7 +1098,11 @@ describe('Client Navigation', () => {
       try {
         await browser.elementByCss('#router-replace').click()
 
-        await check(() => browser.waitForElementByCss('#prop').text(), 'baz')
+        await retry(async () => {
+          expect(await browser.waitForElementByCss('#prop').text()).toEqual(
+            'baz'
+          )
+        })
       } finally {
         await browser.close()
       }
@@ -1102,10 +1115,11 @@ describe('Client Navigation', () => {
         // the error occurs on every replace() after the first one
         await browser.elementByCss('#router-replace').click()
 
-        await check(
-          () => browser.waitForElementByCss('#routeState').text(),
-          '{"completed":2,"errors":0}'
-        )
+        await retry(async () => {
+          expect(
+            await browser.waitForElementByCss('#routeState').text()
+          ).toEqual('{"completed":2,"errors":0}')
+        })
       } finally {
         await browser.close()
       }
@@ -1244,10 +1258,11 @@ describe('Client Navigation', () => {
           `/absolute-url?port=${next.appPort}`
         )
         await browser.waitForElementByCss('#router-push').click()
-        await check(
-          () => browser.eval(() => window.location.origin),
-          'https://vercel.com'
-        )
+        await retry(async () => {
+          expect(await browser.eval(() => window.location.origin)).toEqual(
+            'https://vercel.com'
+          )
+        })
       })
 
       it('should navigate an absolute url on replace', async () => {
@@ -1256,10 +1271,11 @@ describe('Client Navigation', () => {
           `/absolute-url?port=${next.appPort}`
         )
         await browser.waitForElementByCss('#router-replace').click()
-        await check(
-          () => browser.eval(() => window.location.origin),
-          'https://vercel.com'
-        )
+        await retry(async () => {
+          expect(await browser.eval(() => window.location.origin)).toEqual(
+            'https://vercel.com'
+          )
+        })
       })
 
       it('should navigate an absolute local url on push', async () => {
@@ -1604,10 +1620,10 @@ describe('Client Navigation', () => {
       window.next.router.push('#third')
     })()`)
 
-    await check(async () => {
+    await retry(async () => {
       const errorCount = await browser.eval('window.routeErrors.length')
-      return errorCount > 0 ? 'success' : errorCount
-    }, 'success')
+      expect(errorCount > 0).toBeTruthy()
+    })
   })
 
   it('should navigate to paths relative to the current page', async () => {

--- a/test/development/pages-dir/custom-app-hmr/index.test.ts
+++ b/test/development/pages-dir/custom-app-hmr/index.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('custom-app-hmr', () => {
   const { next } = nextTestSetup({
@@ -17,27 +17,23 @@ describe('custom-app-hmr', () => {
     )
     await next.patchFile(customAppFilePath, newCustomAppContent)
 
-    await check(async () => {
+    await retry(async () => {
       const pText = await browser.elementByCss('h1').text()
       expect(pText).toBe('hmr text changed')
 
       // Should keep the value on window, which indicates there's no full reload
       const hmrConstantValue = await browser.eval('window.hmrConstantValue')
       expect(hmrConstantValue).toBe('should-not-change')
-
-      return 'success'
-    }, 'success')
+    })
 
     await next.patchFile(customAppFilePath, customAppContent)
-    await check(async () => {
+    await retry(async () => {
       const pText = await browser.elementByCss('h1').text()
       expect(pText).toBe('hmr text origin')
 
       // Should keep the value on window, which indicates there's no full reload
       const hmrConstantValue = await browser.eval('window.hmrConstantValue')
       expect(hmrConstantValue).toBe('should-not-change')
-
-      return 'success'
-    }, 'success')
+    })
   })
 })

--- a/test/development/tsconfig-path-reloading/index.test.ts
+++ b/test/development/tsconfig-path-reloading/index.test.ts
@@ -1,10 +1,10 @@
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
 import {
-  check,
   hasRedbox,
   renderViaHTTP,
   getRedboxSource,
+  retry,
 } from 'next-test-utils'
 import cheerio from 'cheerio'
 import { join } from 'path'
@@ -114,13 +114,14 @@ describe('tsconfig-path-reloading', () => {
       } finally {
         await next.patchFile(indexPage, indexContent)
         await next.patchFile(tsConfigFile, tsconfigContent)
-        await check(async () => {
+        await retry(async () => {
           const html3 = await browser.eval('document.documentElement.innerHTML')
-          return html3.includes('id="first-data"') &&
-            !html3.includes('id="second-data"')
-            ? 'success'
-            : html3
-        }, 'success')
+
+          expect(
+            html3.includes('id="first-data"') &&
+              !html3.includes('id="second-data"')
+          ).toBeTruthy()
+        })
       }
     })
 
@@ -161,24 +162,23 @@ describe('tsconfig-path-reloading', () => {
 
         expect(await hasRedbox(browser)).toBe(false)
 
-        await check(async () => {
+        await retry(async () => {
           const html2 = await browser.eval('document.documentElement.innerHTML')
           expect(html2).toContain('first button')
           expect(html2).not.toContain('second button')
           expect(html2).toContain('third button')
           expect(html2).toContain('first-data')
-          return 'success'
-        }, 'success')
+        })
       } finally {
         await next.patchFile(indexPage, indexContent)
         await next.patchFile(tsConfigFile, tsconfigContent)
-        await check(async () => {
+        await retry(async () => {
           const html3 = await browser.eval('document.documentElement.innerHTML')
-          return html3.includes('first button') &&
-            !html3.includes('third button')
-            ? 'success'
-            : html3
-        }, 'success')
+
+          expect(
+            html3.includes('first button') && !html3.includes('third button')
+          ).toBeTruthy()
+        })
       }
     })
   }

--- a/test/development/typescript-auto-install/index.test.ts
+++ b/test/development/typescript-auto-install/index.test.ts
@@ -1,6 +1,6 @@
 import { createNext } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check, renderViaHTTP } from 'next-test-utils'
+import { renderViaHTTP, retry } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import stripAnsi from 'strip-ansi'
 
@@ -40,29 +40,33 @@ describe('typescript-auto-install', () => {
     const browser = await webdriver(next.url, '/')
     const pageContent = await next.readFile('pages/index.js')
 
-    await check(
-      () => browser.eval('document.documentElement.innerHTML'),
-      /hello world/
-    )
+    await retry(async () => {
+      expect(await browser.eval('document.documentElement.innerHTML')).toMatch(
+        /hello world/
+      )
+    })
     await next.renameFile('pages/index.js', 'pages/index.tsx')
 
-    await check(
-      () => stripAnsi(next.cliOutput),
-      /We detected TypeScript in your project and created a tsconfig\.json file for you/i
-    )
+    await retry(async () => {
+      expect(await stripAnsi(next.cliOutput)).toMatch(
+        /We detected TypeScript in your project and created a tsconfig\.json file for you/i
+      )
+    })
 
-    await check(
-      () => browser.eval('document.documentElement.innerHTML'),
-      /hello world/
-    )
+    await retry(async () => {
+      expect(await browser.eval('document.documentElement.innerHTML')).toMatch(
+        /hello world/
+      )
+    })
     await next.patchFile(
       'pages/index.tsx',
       pageContent.replace('hello world', 'hello again')
     )
 
-    await check(
-      () => browser.eval('document.documentElement.innerHTML'),
-      /hello again/
-    )
+    await retry(async () => {
+      expect(await browser.eval('document.documentElement.innerHTML')).toMatch(
+        /hello again/
+      )
+    })
   })
 })

--- a/test/development/watch-config-file/index.test.ts
+++ b/test/development/watch-config-file/index.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { join } from 'path'
 
 describe('watch-config-file', () => {
@@ -7,9 +7,11 @@ describe('watch-config-file', () => {
     files: join(__dirname, 'fixture'),
   })
   it('should output config file change', async () => {
-    await check(async () => next.cliOutput, /ready/i)
+    await retry(async () => {
+      expect(await next.cliOutput).toMatch(/ready/i)
+    })
 
-    await check(async () => {
+    await retry(async () => {
       await next.patchFile(
         'next.config.js',
         `
@@ -28,9 +30,14 @@ describe('watch-config-file', () => {
             }
             module.exports = nextConfig`
       )
-      return next.cliOutput
-    }, /Found a change in next\.config\.js\. Restarting the server to apply the changes\.\.\./)
 
-    await check(() => next.fetch('/about').then((res) => res.status), 200)
+      expect(await next.cliOutput).toMatch(
+        /Found a change in next\.config\.js\. Restarting the server to apply the changes\.\.\./
+      )
+    })
+
+    await retry(() => {
+      expect(next.fetch('/about').then((res) => res.status)).toBe(200)
+    })
   })
 })

--- a/test/e2e/404-page-router/index.test.ts
+++ b/test/e2e/404-page-router/index.test.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import fs from 'fs-extra'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef, type NextInstance } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 const pathnames = {
   '/404': ['/not/a/real/page?with=query', '/not/a/real/page'],
@@ -126,10 +126,11 @@ describe('404-page-router', () => {
           const browser = await webdriver(next.url, url)
 
           try {
-            await check(
-              () => browser.eval('next.router.isReady ? "yes" : "no"'),
-              'yes'
-            )
+            await retry(async () => {
+              expect(
+                await browser.eval('next.router.isReady ? "yes" : "no"')
+              ).toEqual('yes')
+            })
             expect(await browser.elementById('pathname').text()).toEqual(
               pathname
             )
@@ -145,10 +146,11 @@ describe('404-page-router', () => {
       // https://github.com/vercel/next.js/issues/44293
       it('should not throw any errors when re-fetching the route info', async () => {
         const browser = await webdriver(next.url, '/?test=1')
-        await check(
-          () => browser.eval('next.router.isReady ? "yes" : "no"'),
-          'yes'
-        )
+        await retry(async () => {
+          expect(
+            await browser.eval('next.router.isReady ? "yes" : "no"')
+          ).toEqual('yes')
+        })
         expect(await browser.elementById('query').text()).toEqual('test=1')
       })
     }

--- a/test/e2e/app-dir/actions-allowed-origins/app-action-allowed-origins.test.ts
+++ b/test/e2e/app-dir/actions-allowed-origins/app-action-allowed-origins.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { join } from 'path'
 
 describe('app-dir action allowed origins', () => {
@@ -24,8 +24,8 @@ describe('app-dir action allowed origins', () => {
 
     await browser.elementByCss('button').click()
 
-    await check(async () => {
-      return await browser.elementByCss('#res').text()
-    }, 'hi')
+    await retry(async () => {
+      expect(await browser.elementByCss('#res').text()).toEqual('hi')
+    })
   })
 })

--- a/test/e2e/app-dir/actions-allowed-origins/app-action-disallowed-origins.test.ts
+++ b/test/e2e/app-dir/actions-allowed-origins/app-action-disallowed-origins.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { join } from 'path'
 
 describe('app-dir action disallowed origins', () => {
@@ -23,13 +23,14 @@ describe('app-dir action disallowed origins', () => {
 
     await browser.elementByCss('button').click()
 
-    await check(async () => {
+    await retry(async () => {
       const t = await browser.elementByCss('#res').text()
-      return t.includes('Invalid Server Actions request.') ||
-        // In prod the message is hidden
-        t.includes('An error occurred in the Server Components render.')
-        ? 'yes'
-        : 'no'
-    }, 'yes')
+
+      expect(
+        t.includes('Invalid Server Actions request.') ||
+          // In prod the message is hidden
+          t.includes('An error occurred in the Server Components render.')
+      ).toBeTruthy()
+    })
   })
 })

--- a/test/e2e/app-dir/actions-navigation/index.test.ts
+++ b/test/e2e/app-dir/actions-navigation/index.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check, waitFor } from 'next-test-utils'
+import { waitFor, retry } from 'next-test-utils'
 
 describe('app-dir action handling', () => {
   const { next } = nextTestSetup({
@@ -17,9 +17,9 @@ describe('app-dir action handling', () => {
 
     await browser.elementByCss('#submit').click()
 
-    await check(() => {
-      return browser.elementByCss('#form').text()
-    }, /Loading.../)
+    await retry(async () => {
+      expect(await browser.elementByCss('#form').text()).toMatch(/Loading.../)
+    })
 
     // wait for 2 seconds, since the action takes a second to resolve
     await waitFor(2000)
@@ -40,8 +40,8 @@ describe('app-dir action handling', () => {
 
     await browser.elementByCss('button').click()
 
-    await check(() => {
-      return (next.cliOutput.match(/addToCart/g) || []).length
-    }, 1)
+    await retry(() => {
+      expect((next.cliOutput.match(/addToCart/g) || []).length).toBe(1)
+    })
   })
 })

--- a/test/e2e/app-dir/actions/app-action-form-state.test.ts
+++ b/test/e2e/app-dir/actions/app-action-form-state.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable jest/no-standalone-expect */
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('app-dir action useActionState', () => {
   const { next } = nextTestSetup({
@@ -16,9 +16,11 @@ describe('app-dir action useActionState', () => {
     await browser.eval(`document.getElementById('name-input').value = 'test'`)
     await browser.elementByCss('#submit-form').click()
 
-    await check(() => {
-      return browser.elementByCss('#form-state').text()
-    }, 'initial-state:test')
+    await retry(async () => {
+      expect(await browser.elementByCss('#form-state').text()).toEqual(
+        'initial-state:test'
+      )
+    })
   })
 
   it('should support submitting form state without JS', async () => {
@@ -30,9 +32,11 @@ describe('app-dir action useActionState', () => {
     await browser.elementByCss('#submit-form').click()
 
     // It should inline the form state into HTML so it can still be hydrated.
-    await check(() => {
-      return browser.elementByCss('#form-state').text()
-    }, 'initial-state:test')
+    await retry(async () => {
+      expect(await browser.elementByCss('#form-state').text()).toEqual(
+        'initial-state:test'
+      )
+    })
   })
 
   it('should support hydrating the app from progressively enhanced form request', async () => {
@@ -42,14 +46,16 @@ describe('app-dir action useActionState', () => {
     await browser.eval(`document.getElementById('name-input').value = 'test'`)
     await browser.eval(`document.getElementById('form-state-form').submit()`)
 
-    await check(() => {
-      return browser.elementByCss('#form-state').text()
-    }, 'initial-state:test')
+    await retry(async () => {
+      expect(await browser.elementByCss('#form-state').text()).toEqual(
+        'initial-state:test'
+      )
+    })
 
     // Should hydrate successfully
-    await check(() => {
-      return browser.elementByCss('#hydrated').text()
-    }, 'hydrated')
+    await retry(async () => {
+      expect(await browser.elementByCss('#hydrated').text()).toEqual('hydrated')
+    })
   })
 
   it('should send the action to the provided permalink with form state when JS disabled', async () => {
@@ -63,8 +69,10 @@ describe('app-dir action useActionState', () => {
     )
     await browser.eval(`document.getElementById('form-state-form').submit()`)
 
-    await check(() => {
-      return browser.elementByCss('#form-state').text()
-    }, 'initial-state:test-permalink')
+    await retry(async () => {
+      expect(await browser.elementByCss('#form-state').text()).toEqual(
+        'initial-state:test-permalink'
+      )
+    })
   })
 })

--- a/test/e2e/app-dir/actions/app-action-progressive-enhancement.test.ts
+++ b/test/e2e/app-dir/actions/app-action-progressive-enhancement.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable jest/no-standalone-expect */
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import type { Response } from 'playwright'
 
 describe('app-dir action progressive enhancement', () => {
@@ -32,9 +32,11 @@ describe('app-dir action progressive enhancement', () => {
     await browser.eval(`document.getElementById('name').value = 'test'`)
     await browser.elementByCss('#submit').click()
 
-    await check(() => {
-      return browser.eval('window.location.pathname + window.location.search')
-    }, '/header?name=test&hidden-info=hi')
+    await retry(async () => {
+      expect(
+        await browser.eval('window.location.pathname + window.location.search')
+      ).toEqual('/header?name=test&hidden-info=hi')
+    })
 
     expect(responseCode).toBe(303)
   })
@@ -47,8 +49,10 @@ describe('app-dir action progressive enhancement', () => {
     await browser.eval(`document.getElementById('client-name').value = 'test'`)
     await browser.elementByCss('#there').click()
 
-    await check(() => {
-      return browser.eval('window.location.pathname + window.location.search')
-    }, '/header?name=test&hidden-info=hi')
+    await retry(async () => {
+      expect(
+        await browser.eval('window.location.pathname + window.location.search')
+      ).toEqual('/header?name=test&hidden-info=hi')
+    })
   })
 })

--- a/test/e2e/app-dir/app-a11y/index.test.ts
+++ b/test/e2e/app-dir/app-a11y/index.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import type { BrowserInterface } from 'next-webdriver'
 
 describe('app a11y features', () => {
@@ -22,25 +22,33 @@ describe('app a11y features', () => {
 
     it('should not announce the initital title', async () => {
       const browser = await next.browser('/page-with-h1')
-      await check(() => getAnnouncerContent(browser), '')
+      await retry(async () => {
+        expect(await getAnnouncerContent(browser)).toEqual('')
+      })
     })
 
     it('should announce document.title changes', async () => {
       const browser = await next.browser('/page-with-h1')
       await browser.elementById('page-with-title').click()
-      await check(() => getAnnouncerContent(browser), 'page-with-title')
+      await retry(async () => {
+        expect(await getAnnouncerContent(browser)).toEqual('page-with-title')
+      })
     })
 
     it('should announce h1 changes', async () => {
       const browser = await next.browser('/page-with-h1')
       await browser.elementById('noop-layout-page-1').click()
-      await check(() => getAnnouncerContent(browser), 'noop-layout/page-1')
+      await retry(async () => {
+        expect(await getAnnouncerContent(browser)).toEqual('noop-layout/page-1')
+      })
     })
 
     it('should announce route changes when h1 changes inside an inner layout', async () => {
       const browser = await next.browser('/noop-layout/page-1')
       await browser.elementById('noop-layout-page-2').click()
-      await check(() => getAnnouncerContent(browser), 'noop-layout/page-2')
+      await retry(async () => {
+        expect(await getAnnouncerContent(browser)).toEqual('noop-layout/page-2')
+      })
     })
   })
 })

--- a/test/e2e/app-dir/app-basepath-custom-server/index.test.ts
+++ b/test/e2e/app-dir/app-basepath-custom-server/index.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check, retry } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { join } from 'path'
 
 describe('custom-app-server-action-redirect', () => {
@@ -50,13 +50,15 @@ describe('custom-app-server-action-redirect', () => {
     expect(await browser.url()).toBe(
       `http://localhost:${next.appPort}/base/another`
     )
-    await check(
-      () => browser.eval('document.cookie'),
-      /custom-server-test-cookie/
-    )
-    await check(
-      () => browser.eval('document.cookie'),
-      /custom-server-action-test-cookie/
-    )
+    await retry(async () => {
+      expect(await browser.eval('document.cookie')).toMatch(
+        /custom-server-test-cookie/
+      )
+    })
+    await retry(async () => {
+      expect(await browser.eval('document.cookie')).toMatch(
+        /custom-server-action-test-cookie/
+      )
+    })
   })
 })

--- a/test/e2e/app-dir/app-client-cache/client-cache.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { BrowserInterface } from 'next-webdriver'
 import {
   browserConfigWithFixedTime,
@@ -77,14 +77,14 @@ describe('app dir client cache semantics', () => {
       it('should prefetch the full page', async () => {
         const { getRequests, clearRequests } =
           await createRequestsListener(browser)
-        await check(() => {
-          return getRequests().some(
-            ([url, didPartialPrefetch]) =>
-              getPathname(url) === '/0' && !didPartialPrefetch
-          )
-            ? 'success'
-            : 'fail'
-        }, 'success')
+        await retry(() => {
+          expect(
+            getRequests().some(
+              ([url, didPartialPrefetch]) =>
+                getPathname(url) === '/0' && !didPartialPrefetch
+            )
+          ).toBeTruthy()
+        })
 
         clearRequests()
 
@@ -131,14 +131,14 @@ describe('app dir client cache semantics', () => {
         const { getRequests, clearRequests } =
           await createRequestsListener(browser)
 
-        await check(() => {
-          return getRequests().some(
-            ([url, didPartialPrefetch]) =>
-              getPathname(url) === '/0' && !didPartialPrefetch
-          )
-            ? 'success'
-            : 'fail'
-        }, 'success')
+        await retry(() => {
+          expect(
+            getRequests().some(
+              ([url, didPartialPrefetch]) =>
+                getPathname(url) === '/0' && !didPartialPrefetch
+            )
+          ).toBeTruthy()
+        })
 
         const randomNumber = await browser
           .elementByCss('[href="/0?timeout=0"]')
@@ -151,14 +151,14 @@ describe('app dir client cache semantics', () => {
 
         await browser.elementByCss('[href="/"]').click()
 
-        await check(() => {
-          return getRequests().some(
-            ([url, didPartialPrefetch]) =>
-              getPathname(url) === '/0' && !didPartialPrefetch
-          )
-            ? 'success'
-            : 'fail'
-        }, 'success')
+        await retry(() => {
+          expect(
+            getRequests().some(
+              ([url, didPartialPrefetch]) =>
+                getPathname(url) === '/0' && !didPartialPrefetch
+            )
+          ).toBeTruthy()
+        })
 
         const number = await browser
           .elementByCss('[href="/0?timeout=0"]')
@@ -241,14 +241,14 @@ describe('app dir client cache semantics', () => {
         const { getRequests, clearRequests } =
           await createRequestsListener(browser)
 
-        await check(() => {
-          return getRequests().some(
-            ([url, didPartialPrefetch]) =>
-              getPathname(url) === '/1' && didPartialPrefetch
-          )
-            ? 'success'
-            : 'fail'
-        }, 'success')
+        await retry(() => {
+          expect(
+            getRequests().some(
+              ([url, didPartialPrefetch]) =>
+                getPathname(url) === '/1' && didPartialPrefetch
+            )
+          ).toBeTruthy()
+        })
 
         clearRequests()
 

--- a/test/e2e/app-dir/app-compilation/index.test.ts
+++ b/test/e2e/app-dir/app-compilation/index.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check, hasRedbox, waitFor } from 'next-test-utils'
+import { hasRedbox, waitFor, retry } from 'next-test-utils'
 
 describe('app dir', () => {
   const { next, isNextDev, isNextStart } = nextTestSetup({
@@ -19,10 +19,11 @@ describe('app dir', () => {
     describe('HMR', () => {
       it('should not cause error when removing loading.js', async () => {
         const browser = await next.browser('/page-with-loading')
-        await check(
-          () => browser.elementByCss('h1').text(),
-          'hello from slow page'
-        )
+        await retry(async () => {
+          expect(await browser.elementByCss('h1').text()).toEqual(
+            'hello from slow page'
+          )
+        })
 
         await next.renameFile(
           'app/page-with-loading/loading.js',
@@ -40,10 +41,11 @@ describe('app dir', () => {
           'app/page-with-loading/page.js',
           code.replace('hello from slow page', 'hello from new page')
         )
-        await check(
-          () => browser.elementByCss('h1').text(),
-          'hello from new page'
-        )
+        await retry(async () => {
+          expect(await browser.elementByCss('h1').text()).toEqual(
+            'hello from new page'
+          )
+        })
       })
     })
   }

--- a/test/e2e/app-dir/app-css/index.test.ts
+++ b/test/e2e/app-dir/app-css/index.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('app dir - css', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
@@ -24,68 +24,68 @@ describe('app dir - css', () => {
         const browser = await next.browser('/dashboard')
 
         // Should body text in red
-        await check(
-          async () =>
+        await retry(async () => {
+          expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('.p')).color`
-            ),
-          'rgb(255, 0, 0)'
-        )
+            )
+          ).toEqual('rgb(255, 0, 0)')
+        })
 
         // Should inject global css for .green selectors
-        await check(
-          async () =>
+        await retry(async () => {
+          expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('.green')).color`
-            ),
-          'rgb(0, 128, 0)'
-        )
+            )
+          ).toEqual('rgb(0, 128, 0)')
+        })
       })
 
       it('should support css modules inside server layouts', async () => {
         const browser = await next.browser('/css/css-nested')
-        await check(
-          async () =>
+        await retry(async () => {
+          expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('#server-cssm')).color`
-            ),
-          'rgb(0, 128, 0)'
-        )
+            )
+          ).toEqual('rgb(0, 128, 0)')
+        })
       })
 
       it('should support external css imports', async () => {
         const browser = await next.browser('/css/css-external')
-        await check(
-          async () =>
+        await retry(async () => {
+          expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('main')).paddingTop`
-            ),
-          '80px'
-        )
+            )
+          ).toEqual('80px')
+        })
       })
     })
 
     describe('server pages', () => {
       it('should support global css inside server pages', async () => {
         const browser = await next.browser('/css/css-page')
-        await check(
-          async () =>
+        await retry(async () => {
+          expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('h1')).color`
-            ),
-          'rgb(255, 0, 0)'
-        )
+            )
+          ).toEqual('rgb(255, 0, 0)')
+        })
       })
 
       it('should support css modules inside server pages', async () => {
         const browser = await next.browser('/css/css-page')
-        await check(
-          async () =>
+        await retry(async () => {
+          expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('#cssm')).color`
-            ),
-          'rgb(0, 0, 255)'
-        )
+            )
+          ).toEqual('rgb(0, 0, 255)')
+        })
       })
 
       it('should not contain pages css in app dir page', async () => {
@@ -99,26 +99,26 @@ describe('app dir - css', () => {
         const browser = await next.browser('/client-nested')
 
         // Should render h1 in red
-        await check(
-          async () =>
+        await retry(async () => {
+          expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('h1')).color`
-            ),
-          'rgb(255, 0, 0)'
-        )
+            )
+          ).toEqual('rgb(255, 0, 0)')
+        })
       })
 
       it('should support global css inside client layouts', async () => {
         const browser = await next.browser('/client-nested')
 
         // Should render button in red
-        await check(
-          async () =>
+        await retry(async () => {
+          expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('button')).color`
-            ),
-          'rgb(255, 0, 0)'
-        )
+            )
+          ).toEqual('rgb(255, 0, 0)')
+        })
       })
     })
 
@@ -127,26 +127,26 @@ describe('app dir - css', () => {
         const browser = await next.browser('/client-component-route')
 
         // Should render p in red
-        await check(
-          async () =>
+        await retry(async () => {
+          expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('p')).color`
-            ),
-          'rgb(255, 0, 0)'
-        )
+            )
+          ).toEqual('rgb(255, 0, 0)')
+        })
       })
 
       it('should support global css inside client pages', async () => {
         const browser = await next.browser('/client-component-route')
 
         // Should render `b` in blue
-        await check(
-          async () =>
+        await retry(async () => {
+          expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('b')).color`
-            ),
-          'rgb(0, 0, 255)'
-        )
+            )
+          ).toEqual('rgb(0, 0, 255)')
+        })
       })
     })
 
@@ -154,25 +154,25 @@ describe('app dir - css', () => {
       it('should support css modules inside client page', async () => {
         const browser = await next.browser('/css/css-client')
 
-        await check(
-          async () =>
+        await retry(async () => {
+          expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('#css-modules')).fontSize`
-            ),
-          '100px'
-        )
+            )
+          ).toEqual('100px')
+        })
       })
 
       it('should support css modules inside client components', async () => {
         const browser = await next.browser('/css/css-client/inner')
 
-        await check(
-          async () =>
+        await retry(async () => {
+          expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('#client-component')).fontSize`
-            ),
-          '100px'
-        )
+            )
+          ).toEqual('100px')
+        })
       })
     })
 
@@ -187,75 +187,75 @@ describe('app dir - css', () => {
 
       it('should include css imported in client template.js', async () => {
         const browser = await next.browser('/template/clientcomponent')
-        await check(
-          async () =>
+        await retry(async () => {
+          expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('button')).fontSize`
-            ),
-          '100px'
-        )
+            )
+          ).toEqual('100px')
+        })
       })
 
       it('should include css imported in server template.js', async () => {
         const browser = await next.browser('/template/servercomponent')
-        await check(
-          async () =>
+        await retry(async () => {
+          expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('h1')).color`
-            ),
-          'rgb(255, 0, 0)'
-        )
+            )
+          ).toEqual('rgb(255, 0, 0)')
+        })
       })
 
       it('should include css imported in client not-found.js', async () => {
         const browser = await next.browser('/not-found/clientcomponent')
-        await check(
-          async () =>
+        await retry(async () => {
+          expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('h1')).color`
-            ),
-          'rgb(255, 0, 0)'
-        )
+            )
+          ).toEqual('rgb(255, 0, 0)')
+        })
       })
 
       it('should include css imported in server not-found.js', async () => {
         const browser = await next.browser('/not-found/servercomponent')
-        await check(
-          async () =>
+        await retry(async () => {
+          expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('h1')).color`
-            ),
-          'rgb(255, 0, 0)'
-        )
+            )
+          ).toEqual('rgb(255, 0, 0)')
+        })
       })
 
       it('should include root layout css for root not-found.js', async () => {
         const browser = await next.browser('/this-path-does-not-exist')
-        await check(
-          async () =>
+        await retry(async () => {
+          expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('h1')).color`
-            ),
-          'rgb(210, 105, 30)'
-        )
+            )
+          ).toEqual('rgb(210, 105, 30)')
+        })
       })
 
       it('should include css imported in root not-found.js', async () => {
         const browser = await next.browser('/random-non-existing-path')
-        await check(
-          async () =>
+        await retry(async () => {
+          expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('h1')).color`
-            ),
-          'rgb(210, 105, 30)'
-        )
-        await check(
-          async () =>
+            )
+          ).toEqual('rgb(210, 105, 30)')
+        })
+        await retry(async () => {
+          expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('h1')).backgroundColor`
-            ),
-          'rgb(0, 0, 0)'
-        )
+            )
+          ).toEqual('rgb(0, 0, 0)')
+        })
       })
 
       it('should include css imported in error.js', async () => {
@@ -265,26 +265,26 @@ describe('app dir - css', () => {
         // Wait for error page to render and CSS to be loaded
         await new Promise((resolve) => setTimeout(resolve, 2000))
 
-        await check(
-          async () =>
+        await retry(async () => {
+          expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('button')).fontSize`
-            ),
-          '50px'
-        )
+            )
+          ).toEqual('50px')
+        })
       })
     })
 
     describe('page extensions', () => {
       it('should include css imported in MDX pages', async () => {
         const browser = await next.browser('/mdx')
-        await check(
-          async () =>
+        await retry(async () => {
+          expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('h1')).color`
-            ),
-          'rgb(255, 0, 0)'
-        )
+            )
+          ).toEqual('rgb(255, 0, 0)')
+        })
       })
     })
 
@@ -343,10 +343,11 @@ describe('app dir - css', () => {
           )
 
           // Wait for HMR to trigger
-          await check(
-            () => browser.eval(`document.querySelector('h1').textContent`),
-            'Hello!'
-          )
+          await retry(async () => {
+            expect(
+              await browser.eval(`document.querySelector('h1').textContent`)
+            ).toEqual('Hello!')
+          })
           expect(
             await browser.eval(
               `window.getComputedStyle(document.querySelector('h1')).color`
@@ -380,10 +381,11 @@ describe('app dir - css', () => {
             )
 
             // Wait for HMR to trigger
-            await check(
-              () => browser.elementByCss('body').text(),
-              'hello world!'
-            )
+            await retry(async () => {
+              expect(await browser.elementByCss('body').text()).toEqual(
+                'hello world!'
+              )
+            })
 
             // there should be only 1 preload link
             expect(
@@ -426,13 +428,13 @@ describe('app dir - css', () => {
           )
 
           // Wait for HMR to trigger
-          await check(
-            () =>
-              browser.eval(
+          await retry(async () => {
+            expect(
+              await browser.eval(
                 `window.getComputedStyle(document.querySelector('body')).backgroundColor`
-              ),
-            'rgb(0, 0, 255)'
-          )
+              )
+            ).toEqual('rgb(0, 0, 255)')
+          })
         } finally {
           await next.patchFile(filePath, origContent)
         }
@@ -452,20 +454,20 @@ describe('app dir - css', () => {
 
         it('should deduplicate styles on the module level', async () => {
           const browser = await next.browser('/css/css-conflict-layers')
-          await check(
-            () =>
-              browser.eval(
+          await retry(async () => {
+            expect(
+              await browser.eval(
                 `window.getComputedStyle(document.querySelector('.btn:not(.btn-blue)')).backgroundColor`
-              ),
-            'rgb(255, 255, 255)'
-          )
-          await check(
-            () =>
-              browser.eval(
+              )
+            ).toEqual('rgb(255, 255, 255)')
+          })
+          await retry(async () => {
+            expect(
+              await browser.eval(
                 `window.getComputedStyle(document.querySelector('.btn.btn-blue')).backgroundColor`
-              ),
-            'rgb(0, 0, 255)'
-          )
+              )
+            ).toEqual('rgb(0, 0, 255)')
+          })
         })
 
         it('should only include the same style once in the flight data', async () => {
@@ -621,21 +623,21 @@ describe('app dir - css', () => {
         const browser = await next.browser('/css/sass-client/inner')
 
         // .sass
-        await check(
-          () =>
-            browser.eval(
+        await retry(async () => {
+          expect(
+            await browser.eval(
               `window.getComputedStyle(document.querySelector('#sass-client-page')).color`
-            ),
-          'rgb(245, 222, 179)'
-        )
+            )
+          ).toEqual('rgb(245, 222, 179)')
+        })
         // .scss
-        await check(
-          () =>
-            browser.eval(
+        await retry(async () => {
+          expect(
+            await browser.eval(
               `window.getComputedStyle(document.querySelector('#scss-client-page')).color`
-            ),
-          'rgb(255, 99, 71)'
-        )
+            )
+          ).toEqual('rgb(255, 99, 71)')
+        })
       })
 
       it('should support sass/scss modules inside client pages', async () => {
@@ -696,13 +698,13 @@ describe('app dir - css', () => {
           await next.patchFile(filePath, origContent.replace('red', 'blue'))
 
           // Wait for HMR to trigger
-          await check(
-            () =>
-              browser.eval(
+          await retry(async () => {
+            expect(
+              await browser.eval(
                 `window.getComputedStyle(document.querySelector('h1')).color`
-              ),
-            'rgb(0, 0, 255)'
-          )
+              )
+            ).toEqual('rgb(0, 0, 255)')
+          })
         } finally {
           await next.patchFile(filePath, origContent)
         }
@@ -723,13 +725,13 @@ describe('app dir - css', () => {
         try {
           await next.patchFile(filePath, origContent.replace('red', 'blue'))
 
-          await check(
-            () =>
-              browser.eval(
+          await retry(async () => {
+            expect(
+              await browser.eval(
                 `window.getComputedStyle(document.querySelector('h1')).color`
-              ),
-            'rgb(0, 0, 255)'
-          )
+              )
+            ).toEqual('rgb(0, 0, 255)')
+          })
         } finally {
           await next.patchFile(filePath, origContent)
         }
@@ -743,7 +745,9 @@ describe('app dir - css', () => {
         await browser.eval(`window.__v = 1`)
         try {
           await next.patchFile(filePath, origContent.replace('hello!', 'hmr!'))
-          await check(() => browser.elementByCss('body').text(), 'hmr!')
+          await retry(async () => {
+            expect(await browser.elementByCss('body').text()).toEqual('hmr!')
+          })
 
           // Make sure it doesn't reload the page
           expect(await browser.eval(`window.__v`)).toBe(1)
@@ -762,28 +766,28 @@ describe('app dir - css', () => {
             filePath,
             origContent.replace('background: gray;', 'background: red;')
           )
-          await check(
-            () =>
-              browser.eval(
+          await retry(async () => {
+            expect(
+              await browser.eval(
                 `window.getComputedStyle(document.querySelector('body')).backgroundColor`
-              ),
-            'rgb(255, 0, 0)'
-          )
+              )
+            ).toEqual('rgb(255, 0, 0)')
+          })
 
-          await check(
-            () =>
+          await retry(() => {
+            expect(
               browser.eval(
                 `(() => {
-                  const tags = document.querySelectorAll('link[rel="stylesheet"][href^="/_next/static"]')
-                  const counts = new Map();
-                  for (const tag of tags) {
-                    counts.set(tag.href, (counts.get(tag.href) || 0) + 1)
-                  }
-                  return Math.max(...counts.values())
-                })()`
-              ),
-            1
-          )
+                const tags = document.querySelectorAll('link[rel="stylesheet"][href^="/_next/static"]')
+                const counts = new Map();
+                for (const tag of tags) {
+                  counts.set(tag.href, (counts.get(tag.href) || 0) + 1)
+                }
+                return Math.max(...counts.values())
+              })()`
+              )
+            ).toBe(1)
+          })
         } finally {
           await next.patchFile(filePath, origContent)
         }
@@ -814,13 +818,13 @@ describe('app dir - css', () => {
             filePath1,
             origContent1.replace('color: burlywood;', 'color: red;')
           )
-          await check(
-            () =>
-              browser.eval(
+          await retry(async () => {
+            expect(
+              await browser.eval(
                 `window.getComputedStyle(document.querySelector('#scss-server-layout')).color`
-              ),
-            'rgb(255, 0, 0)'
-          )
+              )
+            ).toEqual('rgb(255, 0, 0)')
+          })
         } finally {
           await next.patchFile(filePath1, origContent1)
         }
@@ -830,13 +834,13 @@ describe('app dir - css', () => {
             filePath2,
             origContent2.replace('color: brown', 'color: red')
           )
-          await check(
-            () =>
-              browser.eval(
+          await retry(async () => {
+            expect(
+              await browser.eval(
                 `window.getComputedStyle(document.querySelector('#sass-server-layout')).color`
-              ),
-            'rgb(255, 0, 0)'
-          )
+              )
+            ).toEqual('rgb(255, 0, 0)')
+          })
         } finally {
           await next.patchFile(filePath2, origContent2)
         }
@@ -849,10 +853,16 @@ describe('app dir - css', () => {
       it('should suspend on CSS imports if its slow on client navigation', async () => {
         const browser = await next.browser('/suspensey-css')
         await browser.elementByCss('#slow').click()
-        await check(() => browser.eval(`document.body.innerText`), 'Get back')
-        await check(async () => {
-          return await browser.eval(`window.__log`)
-        }, /background = rgb\(255, 255, 0\)/)
+        await retry(async () => {
+          expect(await browser.eval(`document.body.innerText`)).toEqual(
+            'Get back'
+          )
+        })
+        await retry(async () => {
+          expect(await browser.eval(`window.__log`)).toMatch(
+            /background = rgb\(255, 255, 0\)/
+          )
+        })
       })
     })
   }

--- a/test/e2e/app-dir/app-custom-cache-handler/index.test.ts
+++ b/test/e2e/app-dir/app-custom-cache-handler/index.test.ts
@@ -1,5 +1,5 @@
 import { type NextInstance, nextTestSetup, FileRef } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import fs from 'fs'
 
 const originalNextConfig = fs.readFileSync(
@@ -16,13 +16,12 @@ function runTests(
       if (isNextDev) {
         await next.fetch('/')
       }
-      await check(() => {
+      await retry(() => {
         expect(next.cliOutput).toContain('cache handler - ' + exportType)
         expect(next.cliOutput).toContain('initialized custom cache-handler')
         expect(next.cliOutput).toContain('cache-handler get')
         expect(next.cliOutput).toContain('cache-handler set')
-        return 'success'
-      }, 'success')
+      })
     })
   })
 }

--- a/test/e2e/app-dir/app-edge/app-edge.test.ts
+++ b/test/e2e/app-dir/app-edge/app-edge.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('app-dir edge SSR', () => {
   const { next, skipped } = nextTestSetup({
@@ -86,17 +86,17 @@ describe('app-dir edge SSR', () => {
       // Update rendered content
       const updatedContent = content.replace('Edge!', 'edge-hmr')
       await next.patchFile(pageFile, updatedContent)
-      await check(async () => {
+      await retry(async () => {
         const html = await next.render('/edge/basic')
-        return html
-      }, /edge-hmr/)
+        expect(await html).toMatch(/edge-hmr/)
+      })
 
       // Revert
       await next.patchFile(pageFile, content)
-      await check(async () => {
+      await retry(async () => {
         const html = await next.render('/edge/basic')
-        return html
-      }, /Edge!/)
+        expect(await html).toMatch(/Edge!/)
+      })
     })
   } else {
     // Production tests

--- a/test/e2e/app-dir/app-external/app-external.test.ts
+++ b/test/e2e/app-dir/app-external/app-external.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check, hasRedbox, retry, shouldRunTurboDevTest } from 'next-test-utils'
+import { hasRedbox, retry, shouldRunTurboDevTest } from 'next-test-utils'
 
 async function resolveStreamResponse(response: any, onData?: any) {
   let result = ''
@@ -284,14 +284,13 @@ describe('app dir - external dependency', () => {
       expect(await browser.elementByCss('#dual-pkg-outout p').text()).toBe('')
 
       browser.elementByCss('#dual-pkg-outout button').click()
-      await check(async () => {
+      await retry(async () => {
         const text = await browser.elementByCss('#dual-pkg-outout p').text()
         // TODO: enable esm externals for app router in turbopack for actions
         expect(text).toBe(
           isTurbopack ? 'dual-pkg-optout:cjs' : 'dual-pkg-optout:mjs'
         )
-        return 'success'
-      }, /success/)
+      })
     })
 
     it('should compile server actions from node_modules in client components', async () => {
@@ -300,10 +299,9 @@ describe('app dir - external dependency', () => {
       const browser = await next.browser('/action/client')
       await browser.elementByCss('#action').click()
 
-      await check(() => {
+      await retry(() => {
         expect(next.cliOutput).toContain('action-log:server:action1')
-        return 'success'
-      }, /success/)
+      })
     })
   })
 

--- a/test/e2e/app-dir/app-invalid-revalidate/app-invalid-revalidate.test.ts
+++ b/test/e2e/app-dir/app-invalid-revalidate/app-invalid-revalidate.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('app-invalid-revalidate', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
@@ -23,12 +23,15 @@ describe('app-invalid-revalidate', () => {
       )
       await next.start().catch(() => {})
 
-      await check(async () => {
+      await retry(async () => {
         if (isNextDev) {
           await next.fetch('/')
         }
-        return next.cliOutput
-      }, /Invalid revalidate value "1" on "\/", must be a non-negative number or "false"/)
+
+        expect(await next.cliOutput).toMatch(
+          /Invalid revalidate value "1" on "\/", must be a non-negative number or "false"/
+        )
+      })
     } finally {
       await next.patchFile('app/layout.tsx', origText)
     }
@@ -45,12 +48,15 @@ describe('app-invalid-revalidate', () => {
       )
       await next.start().catch(() => {})
 
-      await check(async () => {
+      await retry(async () => {
         if (isNextDev) {
           await next.fetch('/')
         }
-        return next.cliOutput
-      }, /Invalid revalidate value "1" on "\/", must be a non-negative number or "false"/)
+
+        expect(await next.cliOutput).toMatch(
+          /Invalid revalidate value "1" on "\/", must be a non-negative number or "false"/
+        )
+      })
     } finally {
       await next.patchFile('app/page.tsx', origText)
     }
@@ -67,12 +73,15 @@ describe('app-invalid-revalidate', () => {
       )
       await next.start().catch(() => {})
 
-      await check(async () => {
+      await retry(async () => {
         if (isNextDev) {
           await next.fetch('/')
         }
-        return next.cliOutput
-      }, /Invalid revalidate value "1" on "\/", must be a non-negative number or "false"/)
+
+        expect(await next.cliOutput).toMatch(
+          /Invalid revalidate value "1" on "\/", must be a non-negative number or "false"/
+        )
+      })
     } finally {
       await next.patchFile('app/page.tsx', origText)
     }
@@ -89,12 +98,14 @@ describe('app-invalid-revalidate', () => {
       )
       await next.start().catch(() => {})
 
-      await check(async () => {
+      await retry(async () => {
         if (isNextDev) {
           await next.fetch('/')
         }
-        return next.cliOutput
-      }, /Invalid revalidate value "1" on "unstable_cache/)
+        expect(await next.cliOutput).toMatch(
+          /Invalid revalidate value "1" on "unstable_cache/
+        )
+      })
     } finally {
       await next.patchFile('app/page.tsx', origText)
     }

--- a/test/e2e/app-dir/app-middleware/app-middleware.test.ts
+++ b/test/e2e/app-dir/app-middleware/app-middleware.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import path from 'path'
 import cheerio from 'cheerio'
-import { check, retry, withQuery } from 'next-test-utils'
+import { retry, withQuery } from 'next-test-utils'
 import { nextTestSetup, FileRef } from 'e2e-utils'
 import type { Response } from 'node-fetch'
 
@@ -21,9 +21,11 @@ describe('app-dir with middleware', () => {
     await browser.eval('window.beforeNav = 1')
     await browser.eval('window.next.router.push("/rewrite-to-app")')
 
-    await check(async () => {
-      return browser.eval('document.documentElement.innerHTML')
-    }, /app-dir/)
+    await retry(async () => {
+      expect(await browser.eval('document.documentElement.innerHTML')).toMatch(
+        /app-dir/
+      )
+    })
   })
 
   describe.each([

--- a/test/e2e/app-dir/app-prefetch-false-loading/app-prefetch-false-loading.test.ts
+++ b/test/e2e/app-dir/app-prefetch-false-loading/app-prefetch-false-loading.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('app-prefetch-false-loading', () => {
   const { next } = nextTestSetup({
@@ -19,21 +19,22 @@ describe('app-prefetch-false-loading', () => {
     await browser.elementByCss('[href="/en/testing/test"]').click()
     expect(await browser.hasElementByCssSelector('#loading')).toBeFalsy()
 
-    await check(
-      () => browser.hasElementByCssSelector('#nested-testing-page'),
-      true
-    )
+    await retry(async () => {
+      expect(
+        await browser.hasElementByCssSelector('#nested-testing-page')
+      ).toMatch(true)
+    })
 
     const newRandomNumber = await browser.elementById('random-number').text()
 
     expect(initialRandomNumber).toBe(newRandomNumber)
 
-    await check(() => {
+    await retry(() => {
       const logOccurrences =
         next.cliOutput.slice(logStartIndex).split('re-fetching in layout')
           .length - 1
 
-      return logOccurrences
-    }, 1)
+      expect(logOccurrences).toBe(1)
+    })
   })
 })

--- a/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check, waitFor } from 'next-test-utils'
+import { waitFor, retry } from 'next-test-utils'
 import { Readable } from 'stream'
 
 import {
@@ -63,15 +63,14 @@ describe('app-custom-routes', () => {
         now: expect.any(Number),
       })
       if (isNextStart) {
-        await check(async () => {
+        await retry(async () => {
           expect(
             await next.readFile(`.next/server/app/${path}.body`)
           ).toBeTruthy()
           expect(
             await next.readFile(`.next/server/app/${path}.meta`)
           ).toBeTruthy()
-          return 'success'
-        }, 'success')
+        })
       }
     })
 
@@ -86,21 +85,19 @@ describe('app-custom-routes', () => {
         now: expect.any(Number),
       })
 
-      await check(async () => {
+      await retry(async () => {
         expect(data).not.toEqual(JSON.parse(await next.render(basePath + path)))
-        return 'success'
-      }, 'success')
+      })
 
       if (isNextStart) {
-        await check(async () => {
+        await retry(async () => {
           expect(
             await next.readFile(`.next/server/app/${path}.body`)
           ).toBeTruthy()
           expect(
             await next.readFile(`.next/server/app/${path}.meta`)
           ).toBeTruthy()
-          return 'success'
-        }, 'success')
+        })
       }
     })
   })
@@ -558,10 +555,9 @@ describe('app-custom-routes', () => {
       expect(await res.text()).toBeEmpty()
 
       if (!isNextDeploy) {
-        await check(() => {
+        await retry(() => {
           expect(next.cliOutput).toContain(error)
-          return 'yes'
-        }, 'yes')
+        })
       }
     })
   })
@@ -661,7 +657,7 @@ describe('app-custom-routes', () => {
         await next.deleteFile('app/default/route.ts')
       })
       it('should print an error when exporting a default handler in dev', async () => {
-        await check(async () => {
+        await retry(async () => {
           const res = await next.fetch(basePath + '/default')
 
           // Ensure we get a 405 (Method Not Allowed) response when there is no
@@ -673,8 +669,7 @@ describe('app-custom-routes', () => {
           expect(next.cliOutput).toMatch(
             /No HTTP methods exported in '.+\/route\.ts'\. Export a named export for each HTTP method\./
           )
-          return 'yes'
-        }, 'yes')
+        })
       })
     })
   }
@@ -683,12 +678,11 @@ describe('app-custom-routes', () => {
     it('should print an error when no response is returned', async () => {
       await next.fetch(basePath + '/no-response', { method: 'POST' })
 
-      await check(() => {
+      await retry(() => {
         expect(next.cliOutput).toMatch(
           /No response is returned from route handler '.+\/route\.ts'\. Ensure you return a `Response` or a `NextResponse` in all branches of your handler\./
         )
-        return 'yes'
-      }, 'yes')
+      })
     })
   })
 

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -3,13 +3,7 @@ import cheerio from 'cheerio'
 import { promisify } from 'node:util'
 import { join } from 'node:path'
 import { nextTestSetup } from 'e2e-utils'
-import {
-  check,
-  fetchViaHTTP,
-  normalizeRegEx,
-  retry,
-  waitFor,
-} from 'next-test-utils'
+import { fetchViaHTTP, normalizeRegEx, retry, waitFor } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
 const glob = promisify(globOrig)
@@ -266,9 +260,11 @@ describe('app-dir static/dynamic handling', () => {
       )
 
       // The page may take a moment to compile, so try it a few times.
-      await check(async () => {
-        return next.render('/invalid/first')
-      }, /A required parameter \(slug\) was not provided as a string received object/)
+      await retry(async () => {
+        expect(await next.render('/invalid/first')).toMatch(
+          /A required parameter \(slug\) was not provided as a string received object/
+        )
+      })
 
       await next.deleteFile('app/invalid/[slug]/page.js')
     })
@@ -278,9 +274,9 @@ describe('app-dir static/dynamic handling', () => {
       const v = ~~(Math.random() * 1000)
       await browser.eval(`document.cookie = "test-cookie=${v}"`)
       await browser.elementByCss('button').click()
-      await check(async () => {
-        return await browser.elementByCss('h1').text()
-      }, v.toString())
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toMatch(v.toString())
+      })
     })
   }
 
@@ -364,7 +360,7 @@ describe('app-dir static/dynamic handling', () => {
         expect(initLayoutData).toBeTruthy()
         expect(initPageData).toBeTruthy()
 
-        await check(async () => {
+        await retry(async () => {
           const revalidateRes = await next.fetch(
             `${revalidateApi}?tag=thankyounext`
           )
@@ -401,8 +397,7 @@ describe('app-dir static/dynamic handling', () => {
           expect(newNestedCacheData).not.toBe(initNestedCacheData)
           expect(newRouteHandlerData).not.toEqual(initRouteHandlerData)
           expect(newEdgeRouteHandlerData).not.toEqual(initEdgeRouteHandlerRes)
-          return 'success'
-        }, 'success')
+        })
       }
     )
   }
@@ -458,7 +453,7 @@ describe('app-dir static/dynamic handling', () => {
         expect(initLayoutData).toBeTruthy()
         expect(initPageData).toBeTruthy()
 
-        await check(async () => {
+        await retry(async () => {
           const revalidateRes = await next.fetch(
             `${revalidateApi}?path=/variable-revalidate/revalidate-360-isr`
           )
@@ -476,8 +471,7 @@ describe('app-dir static/dynamic handling', () => {
           expect(newPageData).toBeTruthy()
           expect(newLayoutData).not.toBe(initLayoutData)
           expect(newPageData).not.toBe(initPageData)
-          return 'success'
-        }, 'success')
+        })
       }
     )
   }
@@ -496,7 +490,7 @@ describe('app-dir static/dynamic handling', () => {
       expect(initLayoutData).toBeTruthy()
       expect(initPageData).toBeTruthy()
 
-      await check(async () => {
+      await retry(async () => {
         const revalidateRes = await next.fetch(
           '/api/revalidate-path-node?path=/variable-revalidate/revalidate-360-isr'
         )
@@ -514,8 +508,7 @@ describe('app-dir static/dynamic handling', () => {
         expect(newPageData).toBeTruthy()
         expect(newLayoutData).not.toBe(initLayoutData)
         expect(newPageData).not.toBe(initPageData)
-        return 'success'
-      }, 'success')
+      })
     })
   }
 
@@ -550,19 +543,18 @@ describe('app-dir static/dynamic handling', () => {
       let prevInitialRandomData
 
       // wait for a fresh revalidation
-      await check(async () => {
+      await retry(async () => {
         const $ = await next.render$('/variable-config-revalidate/revalidate-3')
         prevInitialDate = $('#date').text()
         prevInitialRandomData = $('#random-data').text()
 
         expect(prevInitialDate).not.toBe(initialDate)
         expect(prevInitialRandomData).not.toBe(initialRandomData)
-        return 'success'
-      }, 'success')
+      })
 
       // the date should revalidate first after 3 seconds
       // while the fetch data stays in place for 9 seconds
-      await check(async () => {
+      await retry(async () => {
         const $ = await next.render$('/variable-config-revalidate/revalidate-3')
         const curDate = $('#date').text()
         const curRandomData = $('#random-data').text()
@@ -572,13 +564,12 @@ describe('app-dir static/dynamic handling', () => {
 
         prevInitialDate = curDate
         prevInitialRandomData = curRandomData
-        return 'success'
-      }, 'success')
+      })
     })
   }
 
   it('should not cache non-ok statusCode', async () => {
-    await check(async () => {
+    await retry(async () => {
       const $ = await next.render$('/variable-revalidate/status-code')
       const origData = JSON.parse($('#page-data').text())
 
@@ -588,8 +579,7 @@ describe('app-dir static/dynamic handling', () => {
       const newData = JSON.parse(new$('#page-data').text())
       expect(newData.status).toBe(origData.status)
       expect(newData.text).not.toBe(origData.text)
-      return 'success'
-    }, 'success')
+    })
   })
 
   if (isNextStart) {
@@ -1994,7 +1984,7 @@ describe('app-dir static/dynamic handling', () => {
     let prevHtml = await res.text()
     let prev$ = cheerio.load(prevHtml)
 
-    await check(async () => {
+    await retry(async () => {
       const curRes = await next.fetch('/default-cache')
       expect(curRes.status).toBe(200)
 
@@ -2021,8 +2011,7 @@ describe('app-dir static/dynamic handling', () => {
         prevHtml = curHtml
         prev$ = cur$
       }
-      return 'success'
-    }, 'success')
+    })
   })
 
   it('should cache correctly for fetchCache = force-cache', async () => {
@@ -2032,7 +2021,7 @@ describe('app-dir static/dynamic handling', () => {
     let prevHtml = await res.text()
     let prev$ = cheerio.load(prevHtml)
 
-    await check(async () => {
+    await retry(async () => {
       const curRes = await next.fetch('/force-cache')
       expect(curRes.status).toBe(200)
 
@@ -2052,9 +2041,7 @@ describe('app-dir static/dynamic handling', () => {
       expect(cur$('#data-auto-cache').text()).toBe(
         prev$('#data-auto-cache').text()
       )
-
-      return 'success'
-    }, 'success')
+    })
 
     if (!isNextDeploy) {
       expect(next.cliOutput).toContain(
@@ -2070,7 +2057,7 @@ describe('app-dir static/dynamic handling', () => {
     let prevHtml = await res.text()
     let prev$ = cheerio.load(prevHtml)
 
-    await check(async () => {
+    await retry(async () => {
       const curRes = await next.fetch('/fetch-no-cache')
       expect(curRes.status).toBe(200)
 
@@ -2097,8 +2084,7 @@ describe('app-dir static/dynamic handling', () => {
         prevHtml = curHtml
         prev$ = cur$
       }
-      return 'success'
-    }, 'success')
+    })
   })
 
   if (isNextDev) {
@@ -2316,7 +2302,7 @@ describe('app-dir static/dynamic handling', () => {
       let slugFetchSlug
 
       if (isNextDev) {
-        await check(() => {
+        await retry(() => {
           const matches = stripAnsi(next.cliOutput).match(
             /partial-gen-params fetch ([\d]{1,})/
           )
@@ -2325,8 +2311,8 @@ describe('app-dir static/dynamic handling', () => {
             langFetchSlug = matches[1]
             slugFetchSlug = langFetchSlug
           }
-          return langFetchSlug ? 'success' : next.cliOutput
-        }, 'success')
+          expect(langFetchSlug).toBeTruthy()
+        })
       } else {
         // the fetch cache can potentially be a miss since
         // the generateStaticParams are executed parallel
@@ -2378,7 +2364,7 @@ describe('app-dir static/dynamic handling', () => {
   }
 
   it('should honor fetch cache correctly', async () => {
-    await check(async () => {
+    await retry(async () => {
       const res = await fetchViaHTTP(
         next.url,
         '/variable-revalidate/revalidate-3'
@@ -2403,8 +2389,7 @@ describe('app-dir static/dynamic handling', () => {
       expect($2('#page-data').text()).toBe(pageData)
       expect($2('#page-data-2').text()).toBe(pageData2)
       expect(pageData).toBe(pageData2)
-      return 'success'
-    }, 'success')
+    })
 
     if (isNextStart) {
       expect(next.cliOutput).toContain(
@@ -2414,7 +2399,7 @@ describe('app-dir static/dynamic handling', () => {
   })
 
   it('should honor fetch cache correctly (edge)', async () => {
-    await check(async () => {
+    await retry(async () => {
       const res = await fetchViaHTTP(
         next.url,
         '/variable-revalidate-edge/revalidate-3'
@@ -2440,12 +2425,11 @@ describe('app-dir static/dynamic handling', () => {
         expect($2('#layout-data').text()).toBe(layoutData)
         expect($2('#page-data').text()).toBe(pageData)
       }
-      return 'success'
-    }, 'success')
+    })
   })
 
   it('should cache correctly with authorization header and revalidate', async () => {
-    await check(async () => {
+    await retry(async () => {
       const res = await fetchViaHTTP(
         next.url,
         '/variable-revalidate/authorization'
@@ -2467,8 +2451,7 @@ describe('app-dir static/dynamic handling', () => {
 
       expect($2('#layout-data').text()).toBe(layoutData)
       expect($2('#page-data').text()).toBe(pageData)
-      return 'success'
-    }, 'success')
+    })
   })
 
   it('should not cache correctly with POST method request init', async () => {
@@ -2496,7 +2479,7 @@ describe('app-dir static/dynamic handling', () => {
   })
 
   it('should cache correctly with post method and revalidate', async () => {
-    await check(async () => {
+    await retry(async () => {
       const res = await fetchViaHTTP(
         next.url,
         '/variable-revalidate/post-method'
@@ -2529,12 +2512,11 @@ describe('app-dir static/dynamic handling', () => {
       expect($2('#data-body1').text()).toBe(dataBody1)
       expect($2('#data-body2').text()).toBe(dataBody2)
       expect($2('#data-body3').text()).toBe(dataBody3)
-      return 'success'
-    }, 'success')
+    })
   })
 
   it('should cache correctly with post method and revalidate edge', async () => {
-    await check(async () => {
+    await retry(async () => {
       const res = await fetchViaHTTP(
         next.url,
         '/variable-revalidate-edge/post-method'
@@ -2564,12 +2546,11 @@ describe('app-dir static/dynamic handling', () => {
       expect($2('#data-body2').text()).toBe(dataBody2)
       expect($2('#data-body3').text()).toBe(dataBody3)
       expect($2('#data-body4').text()).toBe(dataBody4)
-      return 'success'
-    }, 'success')
+    })
   })
 
   it('should cache correctly with POST method and revalidate', async () => {
-    await check(async () => {
+    await retry(async () => {
       const res = await fetchViaHTTP(
         next.url,
         '/variable-revalidate/post-method'
@@ -2591,12 +2572,11 @@ describe('app-dir static/dynamic handling', () => {
 
       expect($2('#layout-data').text()).toBe(layoutData)
       expect($2('#page-data').text()).toBe(pageData)
-      return 'success'
-    }, 'success')
+    })
   })
 
   it('should cache correctly with cookie header and revalidate', async () => {
-    await check(async () => {
+    await retry(async () => {
       const res = await fetchViaHTTP(next.url, '/variable-revalidate/cookie')
       expect(res.status).toBe(200)
       const html = await res.text()
@@ -2612,12 +2592,11 @@ describe('app-dir static/dynamic handling', () => {
 
       expect($2('#layout-data').text()).toBe(layoutData)
       expect($2('#page-data').text()).toBe(pageData)
-      return 'success'
-    }, 'success')
+    })
   })
 
   it('should cache correctly with utf8 encoding', async () => {
-    await check(async () => {
+    await retry(async () => {
       const res = await fetchViaHTTP(next.url, '/variable-revalidate/encoding')
       expect(res.status).toBe(200)
       const html = await res.text()
@@ -2637,12 +2616,11 @@ describe('app-dir static/dynamic handling', () => {
 
       expect($2('#layout-data').text()).toBe(layoutData)
       expect($2('#page-data').text()).toBe(pageData)
-      return 'success'
-    }, 'success')
+    })
   })
 
   it('should cache correctly with utf8 encoding edge', async () => {
-    await check(async () => {
+    await retry(async () => {
       const res = await fetchViaHTTP(
         next.url,
         '/variable-revalidate-edge/encoding'
@@ -2668,12 +2646,11 @@ describe('app-dir static/dynamic handling', () => {
 
       expect($2('#layout-data').text()).toBe(layoutData)
       expect($2('#page-data').text()).toBe(pageData)
-      return 'success'
-    }, 'success')
+    })
   })
 
   it('should cache correctly handle JSON body', async () => {
-    await check(async () => {
+    await retry(async () => {
       const res = await fetchViaHTTP(next.url, '/variable-revalidate-edge/body')
       expect(res.status).toBe(200)
       const html = await res.text()
@@ -2694,8 +2671,7 @@ describe('app-dir static/dynamic handling', () => {
 
       expect($2('#layout-data').text()).toBe(layoutData)
       expect($2('#page-data').text()).toBe(pageData)
-      return 'success'
-    }, 'success')
+    })
   })
 
   it('should not throw Dynamic Server Usage error when using generateStaticParams with draftMode', async () => {
@@ -2796,7 +2772,7 @@ describe('app-dir static/dynamic handling', () => {
     expect(html).toContain('one')
     const initData = cheerio.load(html)('#data').text()
 
-    await check(async () => {
+    await retry(async () => {
       const res2 = await next.fetch('/gen-params-dynamic-revalidate/one')
 
       expect(res2.status).toBe(200)
@@ -2804,8 +2780,7 @@ describe('app-dir static/dynamic handling', () => {
       const $ = cheerio.load(await res2.text())
       expect($('#data').text()).toBeTruthy()
       expect($('#data').text()).not.toBe(initData)
-      return 'success'
-    }, 'success')
+    })
   })
 
   if (!process.env.CUSTOM_CACHE_HANDLER) {
@@ -2950,28 +2925,28 @@ describe('app-dir static/dynamic handling', () => {
       ).toContain('/blog/[author]')
       await browser.elementByCss('#author-2').click()
 
-      await check(async () => {
+      await retry(async () => {
         const params = JSON.parse(await browser.elementByCss('#params').text())
-        return params.author === 'seb' ? 'found' : params
-      }, 'found')
+        expect(params.author === 'seb').toBeTruthy()
+      })
 
       expect(await browser.eval('window.beforeNav')).toBe(1)
       await browser.elementByCss('#author-1-post-1').click()
 
-      await check(async () => {
+      await retry(async () => {
         const params = JSON.parse(await browser.elementByCss('#params').text())
-        return params.author === 'tim' && params.slug === 'first-post'
-          ? 'found'
-          : params
-      }, 'found')
+        expect(
+          params.author === 'tim' && params.slug === 'first-post'
+        ).toBeTruthy()
+      })
 
       expect(await browser.eval('window.beforeNav')).toBe(1)
       await browser.back()
 
-      await check(async () => {
+      await retry(async () => {
         const params = JSON.parse(await browser.elementByCss('#params').text())
-        return params.author === 'seb' ? 'found' : params
-      }, 'found')
+        expect(params.author === 'seb').toBeTruthy()
+      })
 
       expect(await browser.eval('window.beforeNav')).toBe(1)
     })
@@ -3329,15 +3304,14 @@ describe('app-dir static/dynamic handling', () => {
         expect(data1 && data2).toBeTruthy()
         expect(data1).not.toEqual(data2)
 
-        await check(async () => {
+        await retry(() => {
           expect(
             next.cliOutput.substring(cliOutputStart).match(/Load data/g).length
           ).toBe(2)
           expect(next.cliOutput.substring(cliOutputStart)).toContain(
             'Error: Failed to set Next.js data cache, items over 2MB can not be cached'
           )
-          return 'success'
-        }, 'success')
+        })
       })
     }
     if (process.env.CUSTOM_CACHE_HANDLER && isNextDev) {
@@ -3356,12 +3330,11 @@ describe('app-dir static/dynamic handling', () => {
         expect(data1 && data2).toBeTruthy()
         expect(data1).toEqual(data2)
 
-        await check(async () => {
+        await retry(() => {
           expect(
             next.cliOutput.substring(cliOutputStart).match(/Load data/g).length
           ).toBe(1)
-          return 'success'
-        }, 'success')
+        })
 
         expect(next.cliOutput.substring(cliOutputStart)).not.toContain(
           'Error: Failed to set Next.js data cache, items over 2MB can not be cached'

--- a/test/e2e/app-dir/app/useReportWebVitals.test.ts
+++ b/test/e2e/app-dir/app/useReportWebVitals.test.ts
@@ -1,6 +1,6 @@
 import { createNext } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('useReportWebVitals hook', () => {
   let next: NextInstance
@@ -37,9 +37,8 @@ describe('useReportWebVitals hook', () => {
     await browser.elementById('btn').click()
 
     // Make sure all registered events in performance-relayer has fired
-    await check(async () => {
+    await retry(() => {
       expect(eventsCount).toBeGreaterThanOrEqual(6)
-      return 'success'
-    }, 'success')
+    })
   })
 })

--- a/test/e2e/app-dir/autoscroll-with-css-modules/index.test.ts
+++ b/test/e2e/app-dir/autoscroll-with-css-modules/index.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('router autoscrolling on navigation with css modules', () => {
   const { next } = nextTestSetup({
@@ -18,13 +18,11 @@ describe('router autoscrolling on navigation with css modules', () => {
     browser,
     options: { x: number; y: number }
   ) =>
-    check(async () => {
+    retry(async () => {
       const top = await getTopScroll(browser)
       const left = await getLeftScroll(browser)
-      return top === options.y && left === options.x
-        ? 'success'
-        : JSON.stringify({ top, left })
-    }, 'success')
+      expect(top === options.y && left === options.x).toBeTruthy()
+    })
 
   const scrollTo = async (
     browser: BrowserInterface,

--- a/test/e2e/app-dir/binary/rsc-binary.test.ts
+++ b/test/e2e/app-dir/binary/rsc-binary.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('RSC binary serialization', () => {
   const { next, skipped } = nextTestSetup({
@@ -19,14 +19,14 @@ describe('RSC binary serialization', () => {
 
   it('should correctly encode/decode binaries and hydrate', async function () {
     const browser = await next.browser('/')
-    await check(async () => {
+    await retry(async () => {
       const content = await browser.elementByCss('body').text()
 
-      return content.includes('utf8 binary: hello') &&
-        content.includes('arbitrary binary: 255,0,1,2,3') &&
-        content.includes('hydrated: true')
-        ? 'success'
-        : 'fail'
-    }, 'success')
+      expect(
+        content.includes('utf8 binary: hello') &&
+          content.includes('arbitrary binary: 255,0,1,2,3') &&
+          content.includes('hydrated: true')
+      ).toBeTruthy()
+    })
   })
 })

--- a/test/e2e/app-dir/conflicting-page-segments/conflicting-page-segments.test.ts
+++ b/test/e2e/app-dir/conflicting-page-segments/conflicting-page-segments.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('conflicting-page-segments', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
@@ -24,10 +24,11 @@ describe('conflicting-page-segments', () => {
     } else {
       await expect(next.start()).rejects.toThrow('next build failed')
 
-      await check(
-        () => next.cliOutput,
-        /You cannot have two parallel pages that resolve to the same path\. Please check \/\(group-a\)\/page and \/\(group-b\)\/page\./i
-      )
+      await retry(async () => {
+        expect(await next.cliOutput).toMatch(
+          /You cannot have two parallel pages that resolve to the same path\. Please check \/\(group-a\)\/page and \/\(group-b\)\/page\./i
+        )
+      })
     }
   })
 })

--- a/test/e2e/app-dir/create-root-layout/create-root-layout.test.ts
+++ b/test/e2e/app-dir/create-root-layout/create-root-layout.test.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 ;(process.env.TURBOPACK ? describe.skip : describe)(
   'app-dir create root layout',
@@ -38,10 +38,11 @@ import stripAnsi from 'strip-ansi'
               'Hello world!'
             )
 
-            await check(
-              () => stripAnsi(next.cliOutput.slice(outputIndex)),
-              /did not have a root layout/
-            )
+            await retry(async () => {
+              expect(
+                await stripAnsi(next.cliOutput.slice(outputIndex))
+              ).toMatch(/did not have a root layout/)
+            })
             expect(stripAnsi(next.cliOutput.slice(outputIndex))).toMatch(
               'Your page app/route/page.js did not have a root layout. We created app/layout.js for you.'
             )
@@ -89,10 +90,11 @@ import stripAnsi from 'strip-ansi'
               'Hello world'
             )
 
-            await check(
-              () => stripAnsi(next.cliOutput.slice(outputIndex)),
-              /did not have a root layout/
-            )
+            await retry(async () => {
+              expect(
+                await stripAnsi(next.cliOutput.slice(outputIndex))
+              ).toMatch(/did not have a root layout/)
+            })
             expect(stripAnsi(next.cliOutput.slice(outputIndex))).toInclude(
               'Your page app/(group)/page.js did not have a root layout. We created app/(group)/layout.js for you.'
             )
@@ -143,10 +145,11 @@ import stripAnsi from 'strip-ansi'
               'Hello world'
             )
 
-            await check(
-              () => stripAnsi(next.cliOutput.slice(outputIndex)),
-              /did not have a root layout/
-            )
+            await retry(async () => {
+              expect(
+                await stripAnsi(next.cliOutput.slice(outputIndex))
+              ).toMatch(/did not have a root layout/)
+            })
             expect(stripAnsi(next.cliOutput.slice(outputIndex))).toInclude(
               'Your page app/(group)/route/second/inner/page.js did not have a root layout. We created app/(group)/route/second/layout.js for you.'
             )
@@ -194,10 +197,11 @@ import stripAnsi from 'strip-ansi'
             'Hello world!'
           )
 
-          await check(
-            () => stripAnsi(next.cliOutput.slice(outputIndex)),
-            /did not have a root layout/
-          )
+          await retry(async () => {
+            expect(await stripAnsi(next.cliOutput.slice(outputIndex))).toMatch(
+              /did not have a root layout/
+            )
+          })
           expect(stripAnsi(next.cliOutput.slice(outputIndex))).toInclude(
             'Your page app/page.tsx did not have a root layout. We created app/layout.tsx for you.'
           )

--- a/test/e2e/app-dir/emotion-js/index.test.ts
+++ b/test/e2e/app-dir/emotion-js/index.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('app dir - emotion-js', () => {
   const { next, skipped } = nextTestSetup({
@@ -19,12 +19,12 @@ describe('app dir - emotion-js', () => {
     const browser = await next.browser('/')
     const el = browser.elementByCss('h1')
     expect(await el.text()).toBe('Blue')
-    await check(
-      async () =>
+    await retry(async () => {
+      expect(
         await browser.eval(
           `window.getComputedStyle(document.querySelector('h1')).color`
-        ),
-      'rgb(0, 0, 255)'
-    )
+        )
+      ).toEqual('rgb(0, 0, 255)')
+    })
   })
 })

--- a/test/e2e/app-dir/interception-dynamic-segment-middleware/interception-dynamic-segment-middleware.test.ts
+++ b/test/e2e/app-dir/interception-dynamic-segment-middleware/interception-dynamic-segment-middleware.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('interception-dynamic-segment-middleware', () => {
   const { next } = nextTestSetup({
@@ -10,9 +10,17 @@ describe('interception-dynamic-segment-middleware', () => {
     const browser = await next.browser('/')
 
     await browser.elementByCss('[href="/foo/p/1"]').click()
-    await check(() => browser.elementById('modal').text(), /intercepted/)
+    await retry(async () => {
+      expect(await browser.elementById('modal').text()).toMatch(/intercepted/)
+    })
     await browser.refresh()
-    await check(() => browser.elementById('modal').text(), '')
-    await check(() => browser.elementById('children').text(), /not intercepted/)
+    await retry(async () => {
+      expect(await browser.elementById('modal').text()).toEqual('')
+    })
+    await retry(async () => {
+      expect(await browser.elementById('children').text()).toMatch(
+        /not intercepted/
+      )
+    })
   })
 })

--- a/test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
+++ b/test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('interception-dynamic-segment', () => {
   const { next } = nextTestSetup({
@@ -10,9 +10,17 @@ describe('interception-dynamic-segment', () => {
     const browser = await next.browser('/')
 
     await browser.elementByCss('[href="/foo/1"]').click()
-    await check(() => browser.elementById('modal').text(), /intercepted/)
+    await retry(async () => {
+      expect(await browser.elementById('modal').text()).toMatch(/intercepted/)
+    })
     await browser.refresh()
-    await check(() => browser.elementById('modal').text(), '')
-    await check(() => browser.elementById('children').text(), /not intercepted/)
+    await retry(async () => {
+      expect(await browser.elementById('modal').text()).toEqual('')
+    })
+    await retry(async () => {
+      expect(await browser.elementById('children').text()).toMatch(
+        /not intercepted/
+      )
+    })
   })
 })

--- a/test/e2e/app-dir/interception-middleware-rewrite/interception-middleware-rewrite.test.ts
+++ b/test/e2e/app-dir/interception-middleware-rewrite/interception-middleware-rewrite.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('interception-middleware-rewrite', () => {
   const { next, skipped } = nextTestSetup({
@@ -15,65 +15,82 @@ describe('interception-middleware-rewrite', () => {
   it('should support intercepting routes with a middleware rewrite', async () => {
     const browser = await next.browser('/')
 
-    await check(() => browser.waitForElementByCss('#children').text(), 'root')
+    await retry(async () => {
+      expect(await browser.waitForElementByCss('#children').text()).toEqual(
+        'root'
+      )
+    })
 
-    await check(
-      () =>
-        browser
+    await retry(async () => {
+      expect(
+        await browser
           .elementByCss('[href="/feed"]')
           .click()
           .waitForElementByCss('#modal')
-          .text(),
-      'intercepted'
-    )
+          .text()
+      ).toEqual('intercepted')
+    })
 
-    await check(
-      () => browser.refresh().waitForElementByCss('#children').text(),
-      'not intercepted'
-    )
+    await retry(async () => {
+      expect(
+        await browser.refresh().waitForElementByCss('#children').text()
+      ).toEqual('not intercepted')
+    })
 
-    await check(() => browser.waitForElementByCss('#modal').text(), '')
+    await retry(async () => {
+      expect(await browser.waitForElementByCss('#modal').text()).toEqual('')
+    })
   })
 
   it('should continue to work after using browser back button and following another intercepting route', async () => {
     const browser = await next.browser('/')
-    await check(() => browser.elementById('children').text(), 'root')
+    await retry(async () => {
+      expect(await browser.elementById('children').text()).toEqual('root')
+    })
 
     await browser.elementByCss('[href="/photos/1"]').click()
-    await check(
-      () => browser.elementById('modal').text(),
-      'Intercepted Photo ID: 1'
-    )
+    await retry(async () => {
+      expect(await browser.elementById('modal').text()).toEqual(
+        'Intercepted Photo ID: 1'
+      )
+    })
     await browser.back()
     await browser.elementByCss('[href="/photos/2"]').click()
-    await check(
-      () => browser.elementById('modal').text(),
-      'Intercepted Photo ID: 2'
-    )
+    await retry(async () => {
+      expect(await browser.elementById('modal').text()).toEqual(
+        'Intercepted Photo ID: 2'
+      )
+    })
   })
 
   it('should continue to show the intercepted page when revisiting it', async () => {
     const browser = await next.browser('/')
-    await check(() => browser.elementById('children').text(), 'root')
+    await retry(async () => {
+      expect(await browser.elementById('children').text()).toEqual('root')
+    })
 
     await browser.elementByCss('[href="/photos/1"]').click()
 
     // we should be showing the modal and not the page
-    await check(
-      () => browser.elementById('modal').text(),
-      'Intercepted Photo ID: 1'
-    )
+    await retry(async () => {
+      expect(await browser.elementById('modal').text()).toEqual(
+        'Intercepted Photo ID: 1'
+      )
+    })
 
     await browser.refresh()
 
     // page should show after reloading the browser
-    await check(
-      () => browser.elementById('children').text(),
-      'Page Photo ID: 1'
-    )
+    await retry(async () => {
+      expect(await browser.elementById('children').text()).toEqual(
+        'Page Photo ID: 1'
+      )
+    })
 
     // modal should no longer be showing
-    await check(() => browser.elementById('modal').text(), '')
+    await retry(async () => {
+      expect(await browser.elementById('modal').text()).toEqual('')
+    })
 
     await browser.back()
 
@@ -81,12 +98,15 @@ describe('interception-middleware-rewrite', () => {
     await browser.elementByCss('[href="/photos/1"]').click()
 
     // ensure that we're still showing the modal and not the page
-    await check(
-      () => browser.elementById('modal').text(),
-      'Intercepted Photo ID: 1'
-    )
+    await retry(async () => {
+      expect(await browser.elementById('modal').text()).toEqual(
+        'Intercepted Photo ID: 1'
+      )
+    })
 
     // page content should not have changed
-    await check(() => browser.elementById('children').text(), 'root')
+    await retry(async () => {
+      expect(await browser.elementById('children').text()).toEqual('root')
+    })
   })
 })

--- a/test/e2e/app-dir/interception-route-prefetch-cache/interception-route-prefetch-cache.test.ts
+++ b/test/e2e/app-dir/interception-route-prefetch-cache/interception-route-prefetch-cache.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup, FileRef } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { join } from 'path'
 import { Response } from 'playwright'
 
@@ -10,34 +10,44 @@ describe('interception-route-prefetch-cache', () => {
 
       await browser.elementByCss('[href="/foo"]').click()
 
-      await check(() => browser.elementById('children').text(), /Foo Page/)
+      await retry(async () => {
+        expect(await browser.elementById('children').text()).toMatch(/Foo Page/)
+      })
 
       await browser.elementByCss('[href="/post/1"]').click()
 
       // Ensure the existing page content is still the same
-      await check(() => browser.elementById('children').text(), /Foo Page/)
+      await retry(async () => {
+        expect(await browser.elementById('children').text()).toMatch(/Foo Page/)
+      })
 
       // Verify we got the right interception
-      await check(
-        () => browser.elementById('slot').text(),
-        /Intercepted on Foo Page/
-      )
+      await retry(async () => {
+        expect(await browser.elementById('slot').text()).toMatch(
+          /Intercepted on Foo Page/
+        )
+      })
 
       // Go back home. At this point, the router cache should have content from /foo
       // Now we want to ensure that /bar doesn't share that same prefetch cache entry
       await browser.elementByCss('[href="/"]').click()
       await browser.elementByCss('[href="/bar"]').click()
 
-      await check(() => browser.elementById('children').text(), /Bar Page/)
+      await retry(async () => {
+        expect(await browser.elementById('children').text()).toMatch(/Bar Page/)
+      })
       await browser.elementByCss('[href="/post/1"]').click()
 
       // Ensure the existing page content is still the same. If the prefetch cache resolved the wrong cache node
       // then we'd see the content from /foo
-      await check(() => browser.elementById('children').text(), /Bar Page/)
-      await check(
-        () => browser.elementById('slot').text(),
-        /Intercepted on Bar Page/
-      )
+      await retry(async () => {
+        expect(await browser.elementById('children').text()).toMatch(/Bar Page/)
+      })
+      await retry(async () => {
+        expect(await browser.elementById('slot').text()).toMatch(
+          /Intercepted on Bar Page/
+        )
+      })
     })
   }
 

--- a/test/e2e/app-dir/interception-routes-root-catchall/interception-routes-root-catchall.test.ts
+++ b/test/e2e/app-dir/interception-routes-root-catchall/interception-routes-root-catchall.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('interception-routes-root-catchall', () => {
   const { next } = nextTestSetup({
@@ -11,18 +11,22 @@ describe('interception-routes-root-catchall', () => {
     await browser.elementByCss('[href="/items/1"]').click()
 
     // this triggers the /items route interception handling
-    await check(
-      () => browser.elementById('slot').text(),
-      /Intercepted Modal Page. Id: 1/
-    )
+    await retry(async () => {
+      expect(await browser.elementById('slot').text()).toMatch(
+        /Intercepted Modal Page. Id: 1/
+      )
+    })
     await browser.refresh()
 
     // no longer intercepted, using the page
-    await check(() => browser.elementById('slot').text(), /default @modal/)
-    await check(
-      () => browser.elementById('children').text(),
-      /Regular Item Page. Id: 1/
-    )
+    await retry(async () => {
+      expect(await browser.elementById('slot').text()).toMatch(/default @modal/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('children').text()).toMatch(
+        /Regular Item Page. Id: 1/
+      )
+    })
   })
 
   it('should handle non-intercepted catch-all pages', async () => {
@@ -30,10 +34,13 @@ describe('interception-routes-root-catchall', () => {
 
     // there's no explicit page for /foobar. This will trigger the catchall [...slug] page
     await browser.elementByCss('[href="/foobar"]').click()
-    await check(() => browser.elementById('slot').text(), /default @modal/)
-    await check(
-      () => browser.elementById('children').text(),
-      /Root Catch-All Page/
-    )
+    await retry(async () => {
+      expect(await browser.elementById('slot').text()).toMatch(/default @modal/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('children').text()).toMatch(
+        /Root Catch-All Page/
+      )
+    })
   })
 })

--- a/test/e2e/app-dir/logging/fetch-warning.test.ts
+++ b/test/e2e/app-dir/logging/fetch-warning.test.ts
@@ -1,4 +1,4 @@
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 
 describe('app-dir - fetch warnings', () => {
@@ -21,32 +21,32 @@ describe('app-dir - fetch warnings', () => {
   })
 
   it('should log when request input is a string', async () => {
-    await check(() => {
-      return next.cliOutput.includes(
-        'fetch for https://next-data-api-endpoint.vercel.app/api/random?request-string on /cache-revalidate specified "cache: force-cache" and "revalidate: 3", only one should be specified'
-      )
-        ? 'success'
-        : 'fail'
-    }, 'success')
+    await retry(() => {
+      expect(
+        next.cliOutput.includes(
+          'fetch for https://next-data-api-endpoint.vercel.app/api/random?request-string on /cache-revalidate specified "cache: force-cache" and "revalidate: 3", only one should be specified'
+        )
+      ).toBeTruthy()
+    })
   })
 
   it('should log when request input is a Request instance', async () => {
-    await check(() => {
-      return next.cliOutput.includes(
-        'fetch for https://next-data-api-endpoint.vercel.app/api/random?request-input-cache-override on /cache-revalidate specified "cache: force-cache" and "revalidate: 3", only one should be specified.'
-      )
-        ? 'success'
-        : 'fail'
-    }, 'success')
+    await retry(() => {
+      expect(
+        next.cliOutput.includes(
+          'fetch for https://next-data-api-endpoint.vercel.app/api/random?request-input-cache-override on /cache-revalidate specified "cache: force-cache" and "revalidate: 3", only one should be specified.'
+        )
+      ).toBeTruthy()
+    })
   })
 
   it('should not log when overriding cache within the Request object', async () => {
-    await check(() => {
-      return next.cliOutput.includes(
-        `fetch for https://next-data-api-endpoint.vercel.app/api/random?request-input on /cache-revalidate specified "cache: default" and "revalidate: 3", only one should be specified.`
-      )
-        ? 'fail'
-        : 'success'
-    }, 'success')
+    await retry(() => {
+      expect(
+        next.cliOutput.includes(
+          `fetch for https://next-data-api-endpoint.vercel.app/api/random?request-input on /cache-revalidate specified "cache: default" and "revalidate: 3", only one should be specified.`
+        )
+      ).toBeFalsy()
+    })
   })
 })

--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -1,6 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 import imageSize from 'image-size'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 const CACHE_HEADERS = {
   NONE: 'no-cache, no-store',
@@ -172,10 +172,9 @@ describe('app dir - metadata dynamic routes', () => {
       )
 
       if (isNextDev) {
-        await check(async () => {
+        await retry(() => {
           next.hasFile('.next/server/app-paths-manifest.json')
-          return 'success'
-        }, /success/)
+        })
 
         const appPathsManifest = JSON.parse(
           await next.readFile('.next/server/app-paths-manifest.json')
@@ -472,12 +471,11 @@ describe('app dir - metadata dynamic routes', () => {
       const output = outputAfterFetch.replace(outputBeforeFetch, '')
 
       try {
-        await check(async () => {
+        await retry(() => {
           expect(output).toContain(
             `id property is required for every item returned from generateImageMetadata`
           )
-          return 'success'
-        }, /success/)
+        })
       } finally {
         await next.deleteFile(iconFilePath)
         await next.fetch('/metadata-base/unset/icon/100')
@@ -513,12 +511,11 @@ describe('app dir - metadata dynamic routes', () => {
       const output = outputAfterFetch.replace(outputBeforeFetch, '')
 
       try {
-        await check(async () => {
+        await retry(() => {
           expect(output).toContain(
             `id property is required for every item returned from generateSitemaps`
           )
-          return 'success'
-        }, /success/)
+        })
       } finally {
         await next.deleteFile(sitemapFilePath)
         await next.fetch('/metadata-base/unset/sitemap/0')
@@ -540,12 +537,11 @@ describe('app dir - metadata dynamic routes', () => {
         )
         const currentNextCliOutputLength = next.cliOutput.length
 
-        await check(async () => {
+        await retry(async () => {
           await next.fetch('/opengraph-image')
           const output = next.cliOutput.slice(currentNextCliOutputLength)
           expect(output).toContain(`Default export is missing in`)
-          return 'success'
-        }, /success/)
+        })
       } finally {
         await next.patchFile(ogImageFilePath, ogImageFileContent)
       }

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -1,6 +1,6 @@
 import type { BrowserInterface } from 'next-webdriver'
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import fs from 'fs/promises'
 import path from 'path'
 import cheerio from 'cheerio'
@@ -431,10 +431,11 @@ describe('app dir - metadata', () => {
       await checkMetaNameContentPair(browser, 'keywords', 'parent,child')
 
       await browser.loadPage(next.url + '/async/blog?q=xxx')
-      await check(
-        () => browser.elementByCss('p').text(),
-        /params - blog query - xxx/
-      )
+      await retry(async () => {
+        expect(await browser.elementByCss('p').text()).toMatch(
+          /params - blog query - xxx/
+        )
+      })
     })
 
     it('should handle metadataBase for urls resolved as only URL type', async () => {
@@ -766,11 +767,11 @@ describe('app dir - metadata', () => {
           'app/icons/static/icon2.png'
         )
 
-        await check(async () => {
+        await retry(async () => {
           const $ = await next.render$('/icons/static')
           const $icon = $('head > link[rel="icon"][type!="image/x-icon"]')
-          return $icon.attr('href')
-        }, /\/icons\/static\/icon2/)
+          expect(await $icon.attr('href')).toMatch(/\/icons\/static\/icon2/)
+        })
 
         await next.renameFile(
           'app/icons/static/icon2.png',

--- a/test/e2e/app-dir/next-image/next-image-proxy.test.ts
+++ b/test/e2e/app-dir/next-image/next-image-proxy.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'path'
-import { findPort, check } from 'next-test-utils'
+import { findPort, retry } from 'next-test-utils'
 import https from 'https'
 import httpProxy from 'http-proxy'
 import fs from 'fs'
@@ -98,7 +98,11 @@ describe('next-image-proxy', () => {
     }
 
     const expected = JSON.stringify({ fulfilledCount: 4, failCount: 0 })
-    await check(() => JSON.stringify({ fulfilledCount, failCount }), expected)
+    await retry(async () => {
+      expect(await JSON.stringify({ fulfilledCount, failCount })).toMatch(
+        expected
+      )
+    })
   })
 
   it('should work with connection upgrade by removing it via filterReqHeaders()', async () => {

--- a/test/e2e/app-dir/not-found-default/index.test.ts
+++ b/test/e2e/app-dir/not-found-default/index.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check, getRedboxDescription, hasRedbox } from 'next-test-utils'
+import { getRedboxDescription, hasRedbox, retry } from 'next-test-utils'
 
 describe('app dir - not found with default 404 page', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
@@ -17,13 +17,12 @@ describe('app dir - not found with default 404 page', () => {
     await browser.elementByCss('#trigger-not-found').click()
 
     if (isNextDev) {
-      await check(async () => {
+      await retry(async () => {
         expect(await hasRedbox(browser)).toBe(true)
         expect(await getRedboxDescription(browser)).toMatch(
           /notFound\(\) is not allowed to use in root layout/
         )
-        return 'success'
-      }, /success/)
+      })
     }
   })
 

--- a/test/e2e/app-dir/not-found/basic/index.test.ts
+++ b/test/e2e/app-dir/not-found/basic/index.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('app dir - not-found - basic', () => {
   const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
@@ -118,10 +118,10 @@ describe('app dir - not-found - basic', () => {
           setTimeout(resolve, 3000)
         })
 
-        await check(async () => {
+        await retry(async () => {
           const newTimestamp = await browser.elementByCss('#timestamp').text()
-          return newTimestamp !== timestamp ? 'failure' : 'success'
-        }, 'success')
+          expect(newTimestamp !== timestamp).toBeFalsy()
+        })
       })
 
       // Disabling for Edge because it is too flakey.
@@ -129,11 +129,19 @@ describe('app dir - not-found - basic', () => {
       if (!isEdge) {
         it('should render the 404 page when the file is removed, and restore the page when re-added', async () => {
           const browser = await next.browser('/')
-          await check(() => browser.elementByCss('h1').text(), 'My page')
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toEqual('My page')
+          })
           await next.renameFile('./app/page.js', './app/foo.js')
-          await check(() => browser.elementByCss('h1').text(), 'Root Not Found')
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toEqual(
+              'Root Not Found'
+            )
+          })
           await next.renameFile('./app/foo.js', './app/page.js')
-          await check(() => browser.elementByCss('h1').text(), 'My page')
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toEqual('My page')
+          })
         })
       }
     }

--- a/test/e2e/app-dir/not-found/css-precedence/index.test.ts
+++ b/test/e2e/app-dir/not-found/css-precedence/index.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('not-found app dir css', () => {
   const { next, skipped } = nextTestSetup({
@@ -16,30 +16,30 @@ describe('not-found app dir css', () => {
 
   it('should load css while navigation between not-found and page', async () => {
     const browser = await next.browser('/')
-    await check(
-      async () =>
+    await retry(async () => {
+      expect(
         await browser.eval(
           `window.getComputedStyle(document.querySelector('#go-to-404')).backgroundColor`
-        ),
-      'rgb(0, 128, 0)'
-    )
+        )
+      ).toEqual('rgb(0, 128, 0)')
+    })
     await browser.elementByCss('#go-to-404').click()
     await browser.waitForElementByCss('#go-to-index')
-    await check(
-      async () =>
+    await retry(async () => {
+      expect(
         await browser.eval(
           `window.getComputedStyle(document.querySelector('#go-to-index')).backgroundColor`
-        ),
-      'rgb(0, 128, 0)'
-    )
+        )
+      ).toEqual('rgb(0, 128, 0)')
+    })
     await browser.elementByCss('#go-to-index').click()
     await browser.waitForElementByCss('#go-to-404')
-    await check(
-      async () =>
+    await retry(async () => {
+      expect(
         await browser.eval(
           `window.getComputedStyle(document.querySelector('#go-to-404')).backgroundColor`
-        ),
-      'rgb(0, 128, 0)'
-    )
+        )
+      ).toEqual('rgb(0, 128, 0)')
+    })
   })
 })

--- a/test/e2e/app-dir/parallel-route-not-found-params/parallel-route-not-found-params.test.ts
+++ b/test/e2e/app-dir/parallel-route-not-found-params/parallel-route-not-found-params.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('parallel-route-not-found', () => {
   const { next } = nextTestSetup({
@@ -8,16 +8,12 @@ describe('parallel-route-not-found', () => {
 
   it('should behave correctly without any errors', async () => {
     const browser = await next.browser('/en')
-    await check(() => {
-      if (
+    await retry(() => {
+      expect(
         next.cliOutput.includes('TypeError') ||
-        next.cliOutput.includes('Warning')
-      ) {
-        return 'has-errors'
-      }
-
-      return 'success'
-    }, 'success')
+          next.cliOutput.includes('Warning')
+      ).toBeTruthy()
+    })
 
     expect(await browser.elementByCss('body').text()).not.toContain(
       'Interception Modal'
@@ -26,37 +22,41 @@ describe('parallel-route-not-found', () => {
 
     await browser.elementByCss("[href='/en/show']").click()
 
-    await check(() => {
-      if (
+    await retry(() => {
+      expect(
         next.cliOutput.includes('TypeError') ||
-        next.cliOutput.includes('Warning')
-      ) {
-        return 'has-errors'
-      }
+          next.cliOutput.includes('Warning')
+      ).toBeTruthy()
+    })
 
-      return 'success'
-    }, 'success')
-
-    await check(() => browser.elementByCss('body').text(), /Interception Modal/)
-    await check(() => browser.elementByCss('body').text(), /Locale: en/)
+    await retry(async () => {
+      expect(await browser.elementByCss('body').text()).toMatch(
+        /Interception Modal/
+      )
+    })
+    await retry(async () => {
+      expect(await browser.elementByCss('body').text()).toMatch(/Locale: en/)
+    })
 
     await browser.refresh()
-    await check(() => browser.elementByCss('body').text(), /Regular Modal Page/)
-    await check(() => browser.elementByCss('body').text(), /Locale: en/)
+    await retry(async () => {
+      expect(await browser.elementByCss('body').text()).toMatch(
+        /Regular Modal Page/
+      )
+    })
+    await retry(async () => {
+      expect(await browser.elementByCss('body').text()).toMatch(/Locale: en/)
+    })
   })
 
   it('should handle the not found case correctly without any errors', async () => {
     const browser = await next.browser('/de/show')
-    await check(() => {
-      if (
+    await retry(() => {
+      expect(
         next.cliOutput.includes('TypeError') ||
-        next.cliOutput.includes('Warning')
-      ) {
-        return 'has-errors'
-      }
-
-      return 'success'
-    }, 'success')
+          next.cliOutput.includes('Warning')
+      ).toBeTruthy()
+    })
 
     expect(await browser.elementByCss('body').text()).toContain(
       'Custom Not Found'

--- a/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check, retry } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { outdent } from 'outdent'
 
 describe('parallel-routes-and-interception', () => {
@@ -12,49 +12,60 @@ describe('parallel-routes-and-interception', () => {
       const browser = await next.browser('/parallel-tab-bar')
 
       const hasHome = async () => {
-        await check(
-          () => browser.waitForElementByCss('#home').text(),
-          'Tab bar page (@children)'
-        )
+        await retry(async () => {
+          expect(await browser.waitForElementByCss('#home').text()).toEqual(
+            'Tab bar page (@children)'
+          )
+        })
       }
       const hasViewsHome = async () => {
-        await check(
-          () => browser.waitForElementByCss('#views-home').text(),
-          'Views home'
-        )
+        await retry(async () => {
+          expect(
+            await browser.waitForElementByCss('#views-home').text()
+          ).toEqual('Views home')
+        })
       }
       const hasViewDuration = async () => {
-        await check(
-          () => browser.waitForElementByCss('#view-duration').text(),
-          'View duration'
-        )
+        await retry(async () => {
+          expect(
+            await browser.waitForElementByCss('#view-duration').text()
+          ).toEqual('View duration')
+        })
       }
       const hasImpressions = async () => {
-        await check(
-          () => browser.waitForElementByCss('#impressions').text(),
-          'Impressions'
-        )
+        await retry(async () => {
+          expect(
+            await browser.waitForElementByCss('#impressions').text()
+          ).toEqual('Impressions')
+        })
       }
       const hasAudienceHome = async () => {
-        await check(
-          () => browser.waitForElementByCss('#audience-home').text(),
-          'Audience home'
-        )
+        await retry(async () => {
+          expect(
+            await browser.waitForElementByCss('#audience-home').text()
+          ).toEqual('Audience home')
+        })
       }
       const hasDemographics = async () => {
-        await check(
-          () => browser.waitForElementByCss('#demographics').text(),
-          'Demographics'
-        )
+        await retry(async () => {
+          expect(
+            await browser.waitForElementByCss('#demographics').text()
+          ).toEqual('Demographics')
+        })
       }
       const hasSubscribers = async () => {
-        await check(
-          () => browser.waitForElementByCss('#subscribers').text(),
-          'Subscribers'
-        )
+        await retry(async () => {
+          expect(
+            await browser.waitForElementByCss('#subscribers').text()
+          ).toEqual('Subscribers')
+        })
       }
       const checkUrlPath = async (path: string) => {
-        await check(() => browser.url(), `${next.url}/parallel-tab-bar${path}`)
+        await retry(async () => {
+          expect(await browser.url()).toMatch(
+            `${next.url}/parallel-tab-bar${path}`
+          )
+        })
       }
 
       // Initial page
@@ -186,15 +197,17 @@ describe('parallel-routes-and-interception', () => {
     it('should throw a 404 when no matching parallel route is found', async () => {
       const browser = await next.browser('/parallel-tab-bar')
       // we make sure the page is available through navigating
-      await check(
-        () => browser.waitForElementByCss('#home').text(),
-        'Tab bar page (@children)'
-      )
+      await retry(async () => {
+        expect(await browser.waitForElementByCss('#home').text()).toEqual(
+          'Tab bar page (@children)'
+        )
+      })
       await browser.elementByCss('#view-duration-link').click()
-      await check(
-        () => browser.waitForElementByCss('#view-duration').text(),
-        'View duration'
-      )
+      await retry(async () => {
+        expect(
+          await browser.waitForElementByCss('#view-duration').text()
+        ).toEqual('View duration')
+      })
 
       // fetch /parallel-tab-bar/view-duration
       const res = await next.fetch(`${next.url}/parallel-tab-bar/view-duration`)
@@ -204,55 +217,67 @@ describe('parallel-routes-and-interception', () => {
 
     it('should render nested parallel routes', async () => {
       const browser = await next.browser('/parallel-side-bar/nested/deeper')
-      await check(
-        () => browser.waitForElementByCss('#nested-deeper-main').text(),
-        'Nested deeper page'
-      )
+      await retry(async () => {
+        expect(
+          await browser.waitForElementByCss('#nested-deeper-main').text()
+        ).toEqual('Nested deeper page')
+      })
 
-      await check(
-        () => browser.waitForElementByCss('#nested-deeper-sidebar').text(),
-        'Nested deeper sidebar here'
-      )
+      await retry(async () => {
+        expect(
+          await browser.waitForElementByCss('#nested-deeper-sidebar').text()
+        ).toEqual('Nested deeper sidebar here')
+      })
 
       await browser.elementByCss('[href="/parallel-side-bar/nested"]').click()
 
-      await check(
-        () => browser.waitForElementByCss('#nested-main').text(),
-        'Nested page'
-      )
+      await retry(async () => {
+        expect(
+          await browser.waitForElementByCss('#nested-main').text()
+        ).toEqual('Nested page')
+      })
 
-      await check(
-        () => browser.waitForElementByCss('#nested-sidebar').text(),
-        'Nested sidebar here'
-      )
+      await retry(async () => {
+        expect(
+          await browser.waitForElementByCss('#nested-sidebar').text()
+        ).toEqual('Nested sidebar here')
+      })
 
       await browser.elementByCss('[href="/parallel-side-bar"]').click()
 
-      await check(() => browser.waitForElementByCss('#main').text(), 'homepage')
+      await retry(async () => {
+        expect(await browser.waitForElementByCss('#main').text()).toEqual(
+          'homepage'
+        )
+      })
 
-      await check(
-        () => browser.waitForElementByCss('#sidebar-main').text(),
-        'root sidebar here'
-      )
+      await retry(async () => {
+        expect(
+          await browser.waitForElementByCss('#sidebar-main').text()
+        ).toEqual('root sidebar here')
+      })
     })
 
     it('should support layout files in parallel routes', async () => {
       const browser = await next.browser('/parallel-layout')
-      await check(
-        () => browser.waitForElementByCss('#parallel-layout').text(),
-        'parallel layout'
-      )
+      await retry(async () => {
+        expect(
+          await browser.waitForElementByCss('#parallel-layout').text()
+        ).toEqual('parallel layout')
+      })
 
       // navigate to /parallel-layout/subroute
       await browser.elementByCss('[href="/parallel-layout/subroute"]').click()
-      await check(
-        () => browser.waitForElementByCss('#parallel-layout').text(),
-        'parallel layout'
-      )
-      await check(
-        () => browser.waitForElementByCss('#parallel-subroute').text(),
-        'parallel subroute layout'
-      )
+      await retry(async () => {
+        expect(
+          await browser.waitForElementByCss('#parallel-layout').text()
+        ).toEqual('parallel layout')
+      })
+      await retry(async () => {
+        expect(
+          await browser.waitForElementByCss('#parallel-subroute').text()
+        ).toEqual('parallel subroute layout')
+      })
     })
 
     it('should only scroll to the parallel route that was navigated to', async () => {
@@ -264,39 +289,52 @@ describe('parallel-routes-and-interception', () => {
       await browser.elementByCss('[href="/parallel-scroll/nav"]').click()
       await browser.waitForElementByCss('#modal')
       // check that we didn't scroll back to the top
-      await check(() => browser.eval('window.scrollY'), position)
+      await retry(async () => {
+        expect(await browser.eval('window.scrollY')).toMatch(position)
+      })
     })
 
     it('should apply the catch-all route to the parallel route if no matching route is found', async () => {
       const browser = await next.browser('/parallel-catchall')
 
       await browser.elementByCss('[href="/parallel-catchall/bar"]').click()
-      await check(() => browser.waitForElementByCss('#main').text(), 'bar slot')
-      await check(
-        () => browser.waitForElementByCss('#slot-content').text(),
-        'slot catchall'
-      )
+      await retry(async () => {
+        expect(await browser.waitForElementByCss('#main').text()).toEqual(
+          'bar slot'
+        )
+      })
+      await retry(async () => {
+        expect(
+          await browser.waitForElementByCss('#slot-content').text()
+        ).toEqual('slot catchall')
+      })
 
       await browser.elementByCss('[href="/parallel-catchall/foo"]').click()
-      await check(() => browser.waitForElementByCss('#main').text(), 'foo')
-      await check(
-        () => browser.waitForElementByCss('#slot-content').text(),
-        'foo slot'
-      )
+      await retry(async () => {
+        expect(await browser.waitForElementByCss('#main').text()).toEqual('foo')
+      })
+      await retry(async () => {
+        expect(
+          await browser.waitForElementByCss('#slot-content').text()
+        ).toEqual('foo slot')
+      })
 
       await browser.elementByCss('[href="/parallel-catchall/baz"]').click()
-      await check(
-        () => browser.waitForElementByCss('#main').text(),
-        /main catchall/
-      )
-      await check(
-        () => browser.waitForElementByCss('#main').text(),
-        /catchall page client component/
-      )
-      await check(
-        () => browser.waitForElementByCss('#slot-content').text(),
-        'baz slot'
-      )
+      await retry(async () => {
+        expect(await browser.waitForElementByCss('#main').text()).toMatch(
+          /main catchall/
+        )
+      })
+      await retry(async () => {
+        expect(await browser.waitForElementByCss('#main').text()).toMatch(
+          /catchall page client component/
+        )
+      })
+      await retry(async () => {
+        expect(
+          await browser.waitForElementByCss('#slot-content').text()
+        ).toEqual('baz slot')
+      })
     })
 
     it('should match the catch-all routes of the more specific path, if there is more than one catch-all route', async () => {
@@ -305,64 +343,78 @@ describe('parallel-routes-and-interception', () => {
       await browser
         .elementByCss('[href="/parallel-nested-catchall/foo"]')
         .click()
-      await check(() => browser.waitForElementByCss('#main').text(), 'foo')
-      await check(
-        () => browser.waitForElementByCss('#slot-content').text(),
-        'foo slot'
-      )
+      await retry(async () => {
+        expect(await browser.waitForElementByCss('#main').text()).toEqual('foo')
+      })
+      await retry(async () => {
+        expect(
+          await browser.waitForElementByCss('#slot-content').text()
+        ).toEqual('foo slot')
+      })
 
       await browser
         .elementByCss('[href="/parallel-nested-catchall/bar"]')
         .click()
-      await check(() => browser.waitForElementByCss('#main').text(), 'bar')
-      await check(
-        () => browser.waitForElementByCss('#slot-content').text(),
-        'slot catchall'
-      )
+      await retry(async () => {
+        expect(await browser.waitForElementByCss('#main').text()).toEqual('bar')
+      })
+      await retry(async () => {
+        expect(
+          await browser.waitForElementByCss('#slot-content').text()
+        ).toEqual('slot catchall')
+      })
 
       await browser
         .elementByCss('[href="/parallel-nested-catchall/foo/123"]')
         .click()
-      await check(() => browser.waitForElementByCss('#main').text(), 'foo id')
-      await check(
-        () => browser.waitForElementByCss('#slot-content').text(),
-        'foo id catchAll'
-      )
+      await retry(async () => {
+        expect(await browser.waitForElementByCss('#main').text()).toEqual(
+          'foo id'
+        )
+      })
+      await retry(async () => {
+        expect(
+          await browser.waitForElementByCss('#slot-content').text()
+        ).toEqual('foo id catchAll')
+      })
     })
 
     it('should navigate with a link with prefetch=false', async () => {
       const browser = await next.browser('/parallel-prefetch-false')
 
       // check if the default view loads
-      await check(
-        () => browser.waitForElementByCss('#default-parallel').text(),
-        'default view for parallel'
-      )
+      await retry(async () => {
+        expect(
+          await browser.waitForElementByCss('#default-parallel').text()
+        ).toEqual('default view for parallel')
+      })
 
       // check that navigating to /foo re-renders the layout to display @parallel/foo
-      await check(
-        () =>
-          browser
+      await retry(async () => {
+        expect(
+          await browser
             .elementByCss('[href="/parallel-prefetch-false/foo"]')
             .click()
             .waitForElementByCss('#parallel-foo')
-            .text(),
-        'parallel for foo'
-      )
+            .text()
+        ).toEqual('parallel for foo')
+      })
     })
 
     it('should display all parallel route params with useParams', async () => {
       const browser = await next.browser('/parallel-dynamic/foo/bar')
 
-      await check(
-        () => browser.waitForElementByCss('#foo').text(),
-        `{"slug":"foo","id":"bar"}`
-      )
+      await retry(async () => {
+        expect(await browser.waitForElementByCss('#foo').text()).toMatch(
+          `{"slug":"foo","id":"bar"}`
+        )
+      })
 
-      await check(
-        () => browser.waitForElementByCss('#bar').text(),
-        `{"slug":"foo","id":"bar"}`
-      )
+      await retry(async () => {
+        expect(await browser.waitForElementByCss('#bar').text()).toMatch(
+          `{"slug":"foo","id":"bar"}`
+        )
+      })
     })
 
     it('should load CSS for a default page that exports another page', async () => {
@@ -425,11 +477,11 @@ describe('parallel-routes-and-interception', () => {
           setTimeout(resolve, 3000)
         })
 
-        await check(async () => {
+        await retry(async () => {
           // an invalid response triggers a fast refresh, so if the timestamp doesn't update, this behaved correctly
           const newTimestamp = await browser.elementByCss('#timestamp').text()
-          return newTimestamp !== timestamp ? 'failure' : 'success'
-        }, 'success')
+          expect(newTimestamp !== timestamp).toBeFalsy()
+        })
       })
 
       it('should support nested parallel routes', async () => {
@@ -440,11 +492,11 @@ describe('parallel-routes-and-interception', () => {
           setTimeout(resolve, 3000)
         })
 
-        await check(async () => {
+        await retry(async () => {
           // an invalid response triggers a fast refresh, so if the timestamp doesn't update, this behaved correctly
           const newTimestamp = await browser.elementByCss('#timestamp').text()
-          return newTimestamp !== timestamp ? 'failure' : 'success'
-        }, 'success')
+          expect(newTimestamp !== timestamp).toBeFalsy()
+        })
       })
     }
   })
@@ -454,36 +506,41 @@ describe('parallel-routes-and-interception', () => {
       const browser = await next.browser('/intercepting-routes-dynamic/photos')
 
       // Check if navigation to modal route works
-      await check(
-        () =>
-          browser
+      await retry(async () => {
+        expect(
+          await browser
             .elementByCss(
               '[href="/intercepting-routes-dynamic/photos/next/123"]'
             )
             .click()
             .waitForElementByCss('#user-intercept-page')
-            .text(),
-        'Intercepted Page'
-      )
+            .text()
+        ).toEqual('Intercepted Page')
+      })
 
       // Check if url matches even though it was intercepted.
-      await check(
-        () => browser.url(),
-        next.url + '/intercepting-routes-dynamic/photos/next/123'
-      )
+      await retry(async () => {
+        expect(await browser.url()).toMatch(
+          next.url + '/intercepting-routes-dynamic/photos/next/123'
+        )
+      })
 
       // Trigger a refresh, this should load the normal page, not the modal.
-      await check(
-        () =>
-          browser.refresh().waitForElementByCss('#user-regular-page').text(),
-        'Regular Page'
-      )
+      await retry(async () => {
+        expect(
+          await browser
+            .refresh()
+            .waitForElementByCss('#user-regular-page')
+            .text()
+        ).toEqual('Regular Page')
+      })
 
       // Check if the url matches still.
-      await check(
-        () => browser.url(),
-        next.url + '/intercepting-routes-dynamic/photos/next/123'
-      )
+      await retry(async () => {
+        expect(await browser.url()).toMatch(
+          next.url + '/intercepting-routes-dynamic/photos/next/123'
+        )
+      })
     })
   })
 
@@ -494,41 +551,43 @@ describe('parallel-routes-and-interception', () => {
       )
 
       // Check if navigation to modal route works
-      await check(
-        () =>
-          browser
+      await retry(async () => {
+        expect(
+          await browser
             .elementByCss(
               '[href="/intercepting-routes-dynamic-catchall/photos/optional-catchall/123"]'
             )
             .click()
             .waitForElementByCss('#optional-catchall-intercept-page')
-            .text(),
-        'Intercepted Page'
-      )
+            .text()
+        ).toEqual('Intercepted Page')
+      })
 
       // Check if url matches even though it was intercepted.
-      await check(
-        () => browser.url(),
-        next.url +
-          '/intercepting-routes-dynamic-catchall/photos/optional-catchall/123'
-      )
+      await retry(async () => {
+        expect(await browser.url()).toMatch(
+          next.url +
+            '/intercepting-routes-dynamic-catchall/photos/optional-catchall/123'
+        )
+      })
 
       // Trigger a refresh, this should load the normal page, not the modal.
-      await check(
-        () =>
-          browser
+      await retry(async () => {
+        expect(
+          await browser
             .refresh()
             .waitForElementByCss('#optional-catchall-regular-page')
-            .text(),
-        'Regular Page'
-      )
+            .text()
+        ).toEqual('Regular Page')
+      })
 
       // Check if the url matches still.
-      await check(
-        () => browser.url(),
-        next.url +
-          '/intercepting-routes-dynamic-catchall/photos/optional-catchall/123'
-      )
+      await retry(async () => {
+        expect(await browser.url()).toMatch(
+          next.url +
+            '/intercepting-routes-dynamic-catchall/photos/optional-catchall/123'
+        )
+      })
     })
   })
 
@@ -539,39 +598,41 @@ describe('parallel-routes-and-interception', () => {
       )
 
       // Check if navigation to modal route works
-      await check(
-        () =>
-          browser
+      await retry(async () => {
+        expect(
+          await browser
             .elementByCss(
               '[href="/intercepting-routes-dynamic-catchall/photos/catchall/123"]'
             )
             .click()
             .waitForElementByCss('#catchall-intercept-page')
-            .text(),
-        'Intercepted Page'
-      )
+            .text()
+        ).toEqual('Intercepted Page')
+      })
 
       // Check if url matches even though it was intercepted.
-      await check(
-        () => browser.url(),
-        next.url + '/intercepting-routes-dynamic-catchall/photos/catchall/123'
-      )
+      await retry(async () => {
+        expect(await browser.url()).toMatch(
+          next.url + '/intercepting-routes-dynamic-catchall/photos/catchall/123'
+        )
+      })
 
       // Trigger a refresh, this should load the normal page, not the modal.
-      await check(
-        () =>
-          browser
+      await retry(async () => {
+        expect(
+          await browser
             .refresh()
             .waitForElementByCss('#catchall-regular-page')
-            .text(),
-        'Regular Page'
-      )
+            .text()
+        ).toEqual('Regular Page')
+      })
 
       // Check if the url matches still.
-      await check(
-        () => browser.url(),
-        next.url + '/intercepting-routes-dynamic-catchall/photos/catchall/123'
-      )
+      await retry(async () => {
+        expect(await browser.url()).toMatch(
+          next.url + '/intercepting-routes-dynamic-catchall/photos/catchall/123'
+        )
+      })
     })
   })
 
@@ -580,250 +641,274 @@ describe('parallel-routes-and-interception', () => {
       const browser = await next.browser('/intercepting-routes/feed')
 
       // Check if navigation to modal route works.
-      await check(
-        () =>
-          browser
+      await retry(async () => {
+        expect(
+          await browser
             .elementByCss('[href="/intercepting-routes/feed/photos/1"]')
             .click()
             .waitForElementByCss('#photo-intercepted-1')
-            .text(),
-        'Photo INTERCEPTED 1'
-      )
+            .text()
+        ).toEqual('Photo INTERCEPTED 1')
+      })
 
       // Check if intercepted route was rendered while existing page content was removed.
       // Content would only be preserved when combined with parallel routes.
       // await check(() => browser.elementByCss('#feed-page').text()).not.toBe('Feed')
 
       // Check if url matches even though it was intercepted.
-      await check(
-        () => browser.url(),
-        next.url + '/intercepting-routes/feed/photos/1'
-      )
+      await retry(async () => {
+        expect(await browser.url()).toMatch(
+          next.url + '/intercepting-routes/feed/photos/1'
+        )
+      })
 
       // Trigger a refresh, this should load the normal page, not the modal.
-      await check(
-        () => browser.refresh().waitForElementByCss('#photo-page-1').text(),
-        'Photo PAGE 1'
-      )
+      await retry(async () => {
+        expect(
+          await browser.refresh().waitForElementByCss('#photo-page-1').text()
+        ).toEqual('Photo PAGE 1')
+      })
 
       // Check if the url matches still.
-      await check(
-        () => browser.url(),
-        next.url + '/intercepting-routes/feed/photos/1'
-      )
+      await retry(async () => {
+        expect(await browser.url()).toMatch(
+          next.url + '/intercepting-routes/feed/photos/1'
+        )
+      })
     })
 
     it('should render an intercepted route from a slot', async () => {
       const browser = await next.browser('/')
 
-      await check(
-        () => browser.waitForElementByCss('#default-slot').text(),
-        'default from @slot'
-      )
+      await retry(async () => {
+        expect(
+          await browser.waitForElementByCss('#default-slot').text()
+        ).toEqual('default from @slot')
+      })
 
-      await check(
-        () =>
-          browser
+      await retry(async () => {
+        expect(
+          await browser
             .elementByCss('[href="/nested"]')
             .click()
             .waitForElementByCss('#interception-slot')
-            .text(),
-        'interception from @slot/nested'
-      )
+            .text()
+        ).toEqual('interception from @slot/nested')
+      })
 
       // Check if the client component is rendered
-      await check(
-        () => browser.waitForElementByCss('#interception-slot-client').text(),
-        'client component'
-      )
+      await retry(async () => {
+        expect(
+          await browser.waitForElementByCss('#interception-slot-client').text()
+        ).toEqual('client component')
+      })
 
-      await check(
-        () => browser.refresh().waitForElementByCss('#nested').text(),
-        'hello world from /nested'
-      )
+      await retry(async () => {
+        expect(
+          await browser.refresh().waitForElementByCss('#nested').text()
+        ).toEqual('hello world from /nested')
+      })
     })
 
     it('should render an intercepted route at the top level from a nested path', async () => {
       const browser = await next.browser('/nested-link')
 
-      await check(
-        () => browser.waitForElementByCss('#default-slot').text(),
-        'default from @slot'
-      )
+      await retry(async () => {
+        expect(
+          await browser.waitForElementByCss('#default-slot').text()
+        ).toEqual('default from @slot')
+      })
 
-      await check(
-        () =>
-          browser
+      await retry(async () => {
+        expect(
+          await browser
             .elementByCss('[href="/nested"]')
             .click()
             .waitForElementByCss('#interception-slot')
-            .text(),
-        'interception from @slot/nested'
-      )
+            .text()
+        ).toEqual('interception from @slot/nested')
+      })
 
-      await check(
-        () => browser.refresh().waitForElementByCss('#nested').text(),
-        'hello world from /nested'
-      )
+      await retry(async () => {
+        expect(
+          await browser.refresh().waitForElementByCss('#nested').text()
+        ).toEqual('hello world from /nested')
+      })
     })
 
     it('should render intercepted route from a nested route', async () => {
       const browser = await next.browser('/intercepting-routes/feed/nested')
 
       // Check if navigation to modal route works.
-      await check(
-        () =>
-          browser
+      await retry(async () => {
+        expect(
+          await browser
             .elementByCss('[href="/intercepting-routes/feed/photos/1"]')
             .click()
             .waitForElementByCss('#photo-intercepted-1')
-            .text(),
-        'Photo INTERCEPTED 1'
-      )
+            .text()
+        ).toEqual('Photo INTERCEPTED 1')
+      })
 
       // Check if intercepted route was rendered while existing page content was removed.
       // Content would only be preserved when combined with parallel routes.
       // await check(() => browser.elementByCss('#feed-page').text()).not.toBe('Feed')
 
       // Check if url matches even though it was intercepted.
-      await check(
-        () => browser.url(),
-        next.url + '/intercepting-routes/feed/photos/1'
-      )
+      await retry(async () => {
+        expect(await browser.url()).toMatch(
+          next.url + '/intercepting-routes/feed/photos/1'
+        )
+      })
 
       // Trigger a refresh, this should load the normal page, not the modal.
-      await check(
-        () => browser.refresh().waitForElementByCss('#photo-page-1').text(),
-        'Photo PAGE 1'
-      )
+      await retry(async () => {
+        expect(
+          await browser.refresh().waitForElementByCss('#photo-page-1').text()
+        ).toEqual('Photo PAGE 1')
+      })
 
       // Check if the url matches still.
-      await check(
-        () => browser.url(),
-        next.url + '/intercepting-routes/feed/photos/1'
-      )
+      await retry(async () => {
+        expect(await browser.url()).toMatch(
+          next.url + '/intercepting-routes/feed/photos/1'
+        )
+      })
     })
 
     it('should re-render the layout on the server when it had a default child route', async () => {
       const browser = await next.browser('/parallel-non-intercepting')
 
       // check if the default view loads
-      await check(
-        () => browser.waitForElementByCss('#default-parallel').text(),
-        'default view for parallel'
-      )
+      await retry(async () => {
+        expect(
+          await browser.waitForElementByCss('#default-parallel').text()
+        ).toEqual('default view for parallel')
+      })
 
       // check that navigating to /foo re-renders the layout to display @parallel/foo
-      await check(
-        () =>
-          browser
+      await retry(async () => {
+        expect(
+          await browser
             .elementByCss('[href="/parallel-non-intercepting/foo"]')
             .click()
             .waitForElementByCss('#parallel-foo')
-            .text(),
-        'parallel for foo'
-      )
+            .text()
+        ).toEqual('parallel for foo')
+      })
 
       // check that navigating to /foo also re-renders the base children
-      await check(() => browser.elementByCss('#children-foo').text(), 'foo')
+      await retry(async () => {
+        expect(await browser.elementByCss('#children-foo').text()).toEqual(
+          'foo'
+        )
+      })
     })
 
     it('should render modal when paired with parallel routes', async () => {
       const browser = await next.browser('/intercepting-parallel-modal/vercel')
       // Check if navigation to modal route works.
-      await check(
-        () =>
-          browser
+      await retry(async () => {
+        expect(
+          await browser
             .elementByCss('[href="/intercepting-parallel-modal/photo/1"]')
             .click()
             .waitForElementByCss('#photo-modal-1')
-            .text(),
-        'Photo MODAL 1'
-      )
+            .text()
+        ).toEqual('Photo MODAL 1')
+      })
 
-      await check(
-        () =>
-          browser
+      await retry(async () => {
+        expect(
+          await browser
             .elementByCss('[href="/intercepting-parallel-modal/photo/2"]')
             .click()
             .waitForElementByCss('#photo-modal-2')
-            .text(),
-        'Photo MODAL 2'
-      )
+            .text()
+        ).toEqual('Photo MODAL 2')
+      })
 
       // Check if modal was rendered while existing page content is preserved.
-      await check(
-        () => browser.elementByCss('#user-page').text(),
-        'Feed for vercel'
-      )
+      await retry(async () => {
+        expect(await browser.elementByCss('#user-page').text()).toEqual(
+          'Feed for vercel'
+        )
+      })
 
       // Check if url matches even though it was intercepted.
-      await check(
-        () => browser.url(),
-        next.url + '/intercepting-parallel-modal/photo/2'
-      )
+      await retry(async () => {
+        expect(await browser.url()).toMatch(
+          next.url + '/intercepting-parallel-modal/photo/2'
+        )
+      })
 
       // Trigger a refresh, this should load the normal page, not the modal.
-      await check(
-        () => browser.refresh().waitForElementByCss('#photo-page-2').text(),
-        'Photo PAGE 2'
-      )
+      await retry(async () => {
+        expect(
+          await browser.refresh().waitForElementByCss('#photo-page-2').text()
+        ).toEqual('Photo PAGE 2')
+      })
 
       // Check if the url matches still.
-      await check(
-        () => browser.url(),
-        next.url + '/intercepting-parallel-modal/photo/2'
-      )
+      await retry(async () => {
+        expect(await browser.url()).toMatch(
+          next.url + '/intercepting-parallel-modal/photo/2'
+        )
+      })
     })
 
     it('should support intercepting with beforeFiles rewrites', async () => {
       const browser = await next.browser('/foo')
 
-      await check(
-        () =>
-          browser
+      await retry(async () => {
+        expect(
+          await browser
             .elementByCss('[href="/photos"]')
             .click()
             .waitForElementByCss('#intercepted')
-            .text(),
-        'intercepted'
-      )
+            .text()
+        ).toEqual('intercepted')
+      })
     })
 
     it('should support intercepting local dynamic sibling routes', async () => {
       const browser = await next.browser('/intercepting-siblings')
 
-      await check(
-        () =>
-          browser
+      await retry(async () => {
+        expect(
+          await browser
             .elementByCss('[href="/intercepting-siblings/1"]')
             .click()
             .waitForElementByCss('#intercepted-sibling')
-            .text(),
-        '1'
-      )
-      await check(
-        () =>
-          browser
+            .text()
+        ).toEqual('1')
+      })
+      await retry(async () => {
+        expect(
+          await browser
             .elementByCss('[href="/intercepting-siblings/2"]')
             .click()
             .waitForElementByCss('#intercepted-sibling')
-            .text(),
-        '2'
-      )
-      await check(
-        () =>
-          browser
+            .text()
+        ).toEqual('2')
+      })
+      await retry(async () => {
+        expect(
+          await browser
             .elementByCss('[href="/intercepting-siblings/3"]')
             .click()
             .waitForElementByCss('#intercepted-sibling')
-            .text(),
-        '3'
-      )
+            .text()
+        ).toEqual('3')
+      })
 
       await next.browser('/intercepting-siblings/1')
 
-      await check(() => browser.waitForElementByCss('#main-slot').text(), '1')
+      await retry(async () => {
+        expect(await browser.waitForElementByCss('#main-slot').text()).toEqual(
+          '1'
+        )
+      })
     })
 
     it('should intercept on routes that contain hyphenated/special dynamic params', async () => {

--- a/test/e2e/app-dir/parallel-routes-catchall-groups/parallel-routes-catchall-groups.test.ts
+++ b/test/e2e/app-dir/parallel-routes-catchall-groups/parallel-routes-catchall-groups.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('parallel-routes-catchall-groups', () => {
   const { next } = nextTestSetup({
@@ -9,15 +9,21 @@ describe('parallel-routes-catchall-groups', () => {
   it('should work without throwing any errors about conflicting paths', async () => {
     const browser = await next.browser('/')
 
-    await check(() => browser.elementByCss('body').text(), /Home/)
+    await retry(async () => {
+      expect(await browser.elementByCss('body').text()).toMatch(/Home/)
+    })
     await browser.elementByCss('[href="/foo"]').click()
     // Foo has a page route defined, so we'd expect to see the page content
-    await check(() => browser.elementByCss('body').text(), /Foo Page/)
+    await retry(async () => {
+      expect(await browser.elementByCss('body').text()).toMatch(/Foo Page/)
+    })
     await browser.back()
 
     // /bar doesn't have an explicit page path. (group-a) defines a catch-all slot with a separate root layout
     // that only renders a slot (ie no children). So we'd expect to see the fallback slot content
     await browser.elementByCss('[href="/bar"]').click()
-    await check(() => browser.elementByCss('body').text(), /Catcher/)
+    await retry(async () => {
+      expect(await browser.elementByCss('body').text()).toMatch(/Catcher/)
+    })
   })
 })

--- a/test/e2e/app-dir/parallel-routes-catchall/parallel-routes-catchall.test.ts
+++ b/test/e2e/app-dir/parallel-routes-catchall/parallel-routes-catchall.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('parallel-routes-catchall', () => {
   const { next } = nextTestSetup({
@@ -8,56 +8,86 @@ describe('parallel-routes-catchall', () => {
 
   it('should match correctly when defining an explicit page & slot', async () => {
     const browser = await next.browser('/')
-    await check(() => browser.elementById('slot').text(), /@slot default/)
+    await retry(async () => {
+      expect(await browser.elementById('slot').text()).toMatch(/@slot default/)
+    })
 
     await browser.elementByCss('[href="/foo"]').click()
 
     // foo has defined a page route and a corresponding parallel slot
     // so we'd expect to see the custom slot content & the page content
-    await check(() => browser.elementById('children').text(), /foo/)
-    await check(() => browser.elementById('slot').text(), /foo slot/)
+    await retry(async () => {
+      expect(await browser.elementById('children').text()).toMatch(/foo/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('slot').text()).toMatch(/foo slot/)
+    })
   })
 
   it('should match correctly when defining an explicit page but no slot', async () => {
     const browser = await next.browser('/')
-    await check(() => browser.elementById('slot').text(), /@slot default/)
+    await retry(async () => {
+      expect(await browser.elementById('slot').text()).toMatch(/@slot default/)
+    })
 
     await browser.elementByCss('[href="/bar"]').click()
 
     // bar has defined a slot but no page route
     // so we'd expect to see the catch-all slot & the page content
-    await check(() => browser.elementById('children').text(), /bar/)
-    await check(() => browser.elementById('slot').text(), /slot catchall/)
-    await check(
-      () => browser.elementById('slot').text(),
-      /catchall slot client component/
-    )
+    await retry(async () => {
+      expect(await browser.elementById('children').text()).toMatch(/bar/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('slot').text()).toMatch(/slot catchall/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('slot').text()).toMatch(
+        /catchall slot client component/
+      )
+    })
   })
 
   it('should match correctly when defining an explicit slot but no page', async () => {
     const browser = await next.browser('/')
-    await check(() => browser.elementById('slot').text(), /@slot default/)
+    await retry(async () => {
+      expect(await browser.elementById('slot').text()).toMatch(/@slot default/)
+    })
 
     await browser.elementByCss('[href="/baz"]').click()
 
     // baz has defined a page route and a corresponding parallel slot
     // so we'd expect to see the custom slot content & the page content
-    await check(() => browser.elementById('children').text(), /main catchall/)
-    await check(() => browser.elementById('slot').text(), /baz slot/)
+    await retry(async () => {
+      expect(await browser.elementById('children').text()).toMatch(
+        /main catchall/
+      )
+    })
+    await retry(async () => {
+      expect(await browser.elementById('slot').text()).toMatch(/baz slot/)
+    })
   })
 
   it('should match both the catch-all page & slot', async () => {
     const browser = await next.browser('/')
-    await check(() => browser.elementById('slot').text(), /@slot default/)
+    await retry(async () => {
+      expect(await browser.elementById('slot').text()).toMatch(/@slot default/)
+    })
 
     await browser.elementByCss('[href="/quux"]').click()
 
     // quux doesn't have a page or slot defined. It should use the catch-all for both
-    await check(() => browser.elementById('children').text(), /main catchall/)
-    await check(() => browser.elementById('slot').text(), /slot catchall/)
-    await check(
-      () => browser.elementById('slot').text(),
-      /catchall slot client component/
-    )
+    await retry(async () => {
+      expect(await browser.elementById('children').text()).toMatch(
+        /main catchall/
+      )
+    })
+    await retry(async () => {
+      expect(await browser.elementById('slot').text()).toMatch(/slot catchall/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('slot').text()).toMatch(
+        /catchall slot client component/
+      )
+    })
   })
 })

--- a/test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts
+++ b/test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check, retry } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('parallel-routes-revalidation', () => {
   const { next } = nextTestSetup({
@@ -8,69 +8,103 @@ describe('parallel-routes-revalidation', () => {
 
   it('should submit the action and revalidate the page data', async () => {
     const browser = await next.browser('/')
-    await check(() => browser.hasElementByCssSelector('#create-entry'), false)
+    await retry(async () => {
+      expect(await browser.hasElementByCssSelector('#create-entry')).toMatch(
+        false
+      )
+    })
 
     // there shouldn't be any data yet
     expect((await browser.elementsByCss('#entries li')).length).toBe(0)
 
     await browser.elementByCss("[href='/revalidate-modal']").click()
 
-    await check(() => browser.hasElementByCssSelector('#create-entry'), true)
+    await retry(async () => {
+      expect(await browser.hasElementByCssSelector('#create-entry')).toMatch(
+        true
+      )
+    })
 
     await browser.elementById('create-entry').click()
 
     // we created an entry and called revalidate, so we should have 1 entry
-    await check(
-      async () => (await browser.elementsByCss('#entries li')).length,
-      1
-    )
+    await retry(async () => {
+      expect((await browser.elementsByCss('#entries li')).length).toBe(1)
+    })
 
     await browser.elementById('create-entry').click()
 
     // we created an entry and called revalidate, so we should have 2 entries
-    await check(
-      async () => (await browser.elementsByCss('#entries li')).length,
-      2
-    )
+    await retry(async () => {
+      expect((await browser.elementsByCss('#entries li')).length).toBe(2)
+    })
 
     await browser.elementByCss("[href='/']").click()
 
     // following a link back to `/` should close the modal
-    await check(() => browser.hasElementByCssSelector('#create-entry'), false)
-    await check(() => browser.elementByCss('body').text(), /Current Data/)
+    await retry(async () => {
+      expect(await browser.hasElementByCssSelector('#create-entry')).toMatch(
+        false
+      )
+    })
+    await retry(async () => {
+      expect(await browser.elementByCss('body').text()).toMatch(/Current Data/)
+    })
   })
 
   it('should handle router.refresh() when called in a slot', async () => {
     const browser = await next.browser('/')
-    await check(() => browser.hasElementByCssSelector('#refresh-router'), false)
+    await retry(async () => {
+      expect(await browser.hasElementByCssSelector('#refresh-router')).toMatch(
+        false
+      )
+    })
     const currentRandomNumber = (
       await browser.elementById('random-number')
     ).text()
     await browser.elementByCss("[href='/refresh-modal']").click()
-    await check(() => browser.hasElementByCssSelector('#refresh-router'), true)
+    await retry(async () => {
+      expect(await browser.hasElementByCssSelector('#refresh-router')).toMatch(
+        true
+      )
+    })
     await browser.elementById('refresh-router').click()
 
-    await check(async () => {
+    await retry(async () => {
       const randomNumber = (await browser.elementById('random-number')).text()
-      return randomNumber !== currentRandomNumber
-    }, true)
+      expect((await randomNumber) !== currentRandomNumber).toMatch(true)
+    })
 
     await browser.elementByCss("[href='/']").click()
 
     // following a link back to `/` should close the modal
-    await check(() => browser.hasElementByCssSelector('#create-entry'), false)
-    await check(() => browser.elementByCss('body').text(), /Current Data/)
+    await retry(async () => {
+      expect(await browser.hasElementByCssSelector('#create-entry')).toMatch(
+        false
+      )
+    })
+    await retry(async () => {
+      expect(await browser.elementByCss('body').text()).toMatch(/Current Data/)
+    })
   })
 
   it('should handle a redirect action when called in a slot', async () => {
     const browser = await next.browser('/')
-    await check(() => browser.hasElementByCssSelector('#redirect'), false)
+    await retry(async () => {
+      expect(await browser.hasElementByCssSelector('#redirect')).toMatch(false)
+    })
     await browser.elementByCss("[href='/redirect-modal']").click()
-    await check(() => browser.hasElementByCssSelector('#redirect'), true)
+    await retry(async () => {
+      expect(await browser.hasElementByCssSelector('#redirect')).toMatch(true)
+    })
     await browser.elementById('redirect').click()
 
-    await check(() => browser.hasElementByCssSelector('#redirect'), false)
-    await check(() => browser.elementByCss('body').text(), /Current Data/)
+    await retry(async () => {
+      expect(await browser.hasElementByCssSelector('#redirect')).toMatch(false)
+    })
+    await retry(async () => {
+      expect(await browser.elementByCss('body').text()).toMatch(/Current Data/)
+    })
   })
 
   it.each([
@@ -188,7 +222,11 @@ describe('parallel-routes-revalidation', () => {
 
     await browser.elementByCss("[href='/revalidate-modal']").click()
 
-    await check(() => browser.hasElementByCssSelector('#create-entry'), true)
+    await retry(async () => {
+      expect(await browser.hasElementByCssSelector('#create-entry')).toMatch(
+        true
+      )
+    })
 
     await browser.elementById('clear-entries').click()
 

--- a/test/e2e/app-dir/parallel-routes-use-selected-layout-segment/parallel-routes-use-selected-layout-segment.test.ts
+++ b/test/e2e/app-dir/parallel-routes-use-selected-layout-segment/parallel-routes-use-selected-layout-segment.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('parallel-routes-use-selected-layout-segment', () => {
   const { next } = nextTestSetup({
@@ -8,66 +8,130 @@ describe('parallel-routes-use-selected-layout-segment', () => {
 
   it('hard nav to router page and soft nav around other router pages', async () => {
     const browser = await next.browser('/')
-    await check(() => browser.elementById('navSegment').text(), /^$/)
-    await check(() => browser.elementById('authSegment').text(), /^$/)
-    await check(() => browser.elementById('routeSegment').text(), /^$/)
+    await retry(async () => {
+      expect(await browser.elementById('navSegment').text()).toMatch(/^$/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('authSegment').text()).toMatch(/^$/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('routeSegment').text()).toMatch(/^$/)
+    })
 
     await browser.elementByCss('[href="/foo"]').click()
-    await check(() => browser.elementById('navSegment').text(), /^$/)
-    await check(() => browser.elementById('authSegment').text(), /^$/)
-    await check(() => browser.elementById('routeSegment').text(), /foo/)
+    await retry(async () => {
+      expect(await browser.elementById('navSegment').text()).toMatch(/^$/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('authSegment').text()).toMatch(/^$/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('routeSegment').text()).toMatch(/foo/)
+    })
   })
 
   it('hard nav to router page and soft nav to parallel routes', async () => {
     const browser = await next.browser('/')
-    await check(() => browser.elementById('navSegment').text(), /^$/)
-    await check(() => browser.elementById('authSegment').text(), /^$/)
-    await check(() => browser.elementById('routeSegment').text(), /^$/)
+    await retry(async () => {
+      expect(await browser.elementById('navSegment').text()).toMatch(/^$/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('authSegment').text()).toMatch(/^$/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('routeSegment').text()).toMatch(/^$/)
+    })
 
     // soft nav to /login, since both @nav and @auth has /login defined, we expect both navSegment and authSegment to be 'login'
     await browser.elementByCss('[href="/login"]').click()
-    await check(() => browser.elementById('navSegment').text(), /login/)
-    await check(() => browser.elementById('authSegment').text(), /login/)
-    await check(() => browser.elementById('routeSegment').text(), /^$/)
+    await retry(async () => {
+      expect(await browser.elementById('navSegment').text()).toMatch(/login/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('authSegment').text()).toMatch(/login/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('routeSegment').text()).toMatch(/^$/)
+    })
 
     // when navigating to /reset, the @auth slot will render the /reset page ('reset') while maintaining the currently active page for the @nav slot ('login') since /reset is only defined in @auth
     await browser.elementByCss('[href="/reset"]').click()
-    await check(() => browser.elementById('navSegment').text(), /login/)
-    await check(() => browser.elementById('authSegment').text(), /reset/)
-    await check(() => browser.elementById('routeSegment').text(), /^$/)
+    await retry(async () => {
+      expect(await browser.elementById('navSegment').text()).toMatch(/login/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('authSegment').text()).toMatch(/reset/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('routeSegment').text()).toMatch(/^$/)
+    })
 
     // when navigating to nested path /reset/withEmail, the @auth slot will render the nested /reset/withEmail page ('reset') while maintaining the currently active page for the @nav slot ('login') since /reset/withEmail is only defined in @auth
     await browser.elementByCss('[href="/reset/withEmail"]').click()
-    await check(() => browser.elementById('navSegment').text(), /login/)
-    await check(() => browser.elementById('authSegment').text(), /withEmail/)
-    await check(() => browser.elementById('routeSegment').text(), /^$/)
+    await retry(async () => {
+      expect(await browser.elementById('navSegment').text()).toMatch(/login/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('authSegment').text()).toMatch(
+        /withEmail/
+      )
+    })
+    await retry(async () => {
+      expect(await browser.elementById('routeSegment').text()).toMatch(/^$/)
+    })
   })
 
   it('hard nav to router page and soft nav to parallel route and soft nav back to another router page', async () => {
     const browser = await next.browser('/')
-    await check(() => browser.elementById('navSegment').text(), /^$/)
-    await check(() => browser.elementById('authSegment').text(), /^$/)
-    await check(() => browser.elementById('routeSegment').text(), /^$/)
+    await retry(async () => {
+      expect(await browser.elementById('navSegment').text()).toMatch(/^$/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('authSegment').text()).toMatch(/^$/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('routeSegment').text()).toMatch(/^$/)
+    })
 
     // when navigating to /reset, the @auth slot will render the /reset page ('reset') while maintaining the currently active page for the @nav slot ('null') since /reset is only defined in @auth
     await browser.elementByCss('[href="/reset"]').click()
-    await check(() => browser.elementById('navSegment').text(), /^$/)
-    await check(() => browser.elementById('authSegment').text(), /reset/)
-    await check(() => browser.elementById('routeSegment').text(), /^$/)
+    await retry(async () => {
+      expect(await browser.elementById('navSegment').text()).toMatch(/^$/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('authSegment').text()).toMatch(/reset/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('routeSegment').text()).toMatch(/^$/)
+    })
 
     // when soft navigate to /foo, the @auth and @nav slot will maintain their the currently active states since they do not have /foo defined
     await browser.elementByCss('[href="/foo"]').click()
-    await check(() => browser.elementById('navSegment').text(), /^$/)
-    await check(() => browser.elementById('authSegment').text(), /reset/)
-    await check(() => browser.elementById('routeSegment').text(), /foo/)
+    await retry(async () => {
+      expect(await browser.elementById('navSegment').text()).toMatch(/^$/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('authSegment').text()).toMatch(/reset/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('routeSegment').text()).toMatch(/foo/)
+    })
   })
 
   it('hard nav to parallel route', async () => {
     const browser = await next.browser('/reset/withMobile')
-    await check(() => browser.elementById('navSegment').text(), /^$/)
-    await check(() => browser.elementById('authSegment').text(), /withMobile/)
+    await retry(async () => {
+      expect(await browser.elementById('navSegment').text()).toMatch(/^$/)
+    })
+    await retry(async () => {
+      expect(await browser.elementById('authSegment').text()).toMatch(
+        /withMobile/
+      )
+    })
 
     // the /app/default.tsx is rendered since /reset/withMobile is only defined in @auth
-    await check(() => browser.elementById('routeSegment').text(), /^$/)
+    await retry(async () => {
+      expect(await browser.elementById('routeSegment').text()).toMatch(/^$/)
+    })
   })
 })

--- a/test/e2e/app-dir/ppr/ppr.test.ts
+++ b/test/e2e/app-dir/ppr/ppr.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check, findAllTelemetryEvents } from 'next-test-utils'
+import { findAllTelemetryEvents, retry } from 'next-test-utils'
 
 describe('ppr', () => {
   const { next, isNextDev, isNextStart } = nextTestSetup({
@@ -10,12 +10,12 @@ describe('ppr', () => {
   })
 
   it('should indicate the feature is experimental', async () => {
-    await check(() => {
-      return next.cliOutput.includes('Experiments (use with caution)') &&
-        next.cliOutput.includes('ppr')
-        ? 'success'
-        : 'fail'
-    }, 'success')
+    await retry(() => {
+      expect(
+        next.cliOutput.includes('Experiments (use with caution)') &&
+          next.cliOutput.includes('ppr')
+      ).toBeTruthy()
+    })
   })
   if (isNextStart) {
     describe('build output', () => {

--- a/test/e2e/app-dir/root-layout/root-layout.test.ts
+++ b/test/e2e/app-dir/root-layout/root-layout.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check, getRedboxSource, hasRedbox } from 'next-test-utils'
+import { getRedboxSource, hasRedbox, retry } from 'next-test-utils'
 
 describe('app-dir root layout', () => {
   const {
@@ -118,23 +118,21 @@ describe('app-dir root layout', () => {
       await browser.eval('window.__TEST_NO_RELOAD = true')
 
       // Navigate to page with same root layout
-      await check(async () => {
+      await retry(async () => {
         await browser.elementByCss('a').click()
         expect(
           await browser.waitForElementByCss('#parallel-one-inner').text()
         ).toBe('One inner')
         expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeTrue()
-        return 'success'
-      }, 'success')
+      })
 
       // Navigate to page with different root layout
-      await check(async () => {
+      await retry(async () => {
         await browser.elementByCss('a').click()
         expect(await browser.waitForElementByCss('#dynamic-hello').text()).toBe(
           'dynamic hello'
         )
-        return 'success'
-      }, 'success')
+      })
       expect(await browser.eval('window.__TEST_NO_RELOAD')).toBeUndefined()
     })
 

--- a/test/e2e/app-dir/route-page-manifest-bug/route-page-manifest-bug.test.ts
+++ b/test/e2e/app-dir/route-page-manifest-bug/route-page-manifest-bug.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('route-page-manifest-bug', () => {
   const { next } = nextTestSetup({
@@ -13,25 +13,29 @@ describe('route-page-manifest-bug', () => {
       'Page that would break'
     )
     await browser.eval('window.location.href = "/abc"')
-    await check(
-      () => browser.eval('document.body.textContent'),
-      '{"url":"https://www.example.com"}'
-    )
+    await retry(async () => {
+      expect(await browser.eval('document.body.textContent')).toEqual(
+        '{"url":"https://www.example.com"}'
+      )
+    })
     await browser.refresh()
-    await check(
-      () => browser.eval('document.body.textContent'),
-      '{"url":"https://www.example.com"}'
-    )
+    await retry(async () => {
+      expect(await browser.eval('document.body.textContent')).toEqual(
+        '{"url":"https://www.example.com"}'
+      )
+    })
     await browser.refresh()
-    await check(
-      () => browser.eval('document.body.textContent'),
-      '{"url":"https://www.example.com"}'
-    )
+    await retry(async () => {
+      expect(await browser.eval('document.body.textContent')).toEqual(
+        '{"url":"https://www.example.com"}'
+      )
+    })
     await browser.refresh()
-    await check(
-      () => browser.eval('document.body.textContent'),
-      '{"url":"https://www.example.com"}'
-    )
+    await retry(async () => {
+      expect(await browser.eval('document.body.textContent')).toEqual(
+        '{"url":"https://www.example.com"}'
+      )
+    })
 
     await browser.back()
     expect(await browser.waitForElementByCss('#page-title').text()).toBe(

--- a/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+++ b/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
@@ -1,6 +1,6 @@
 import webdriver from 'next-webdriver'
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('router autoscrolling on navigation', () => {
   const { next, isNextDev } = nextTestSetup({
@@ -19,13 +19,11 @@ describe('router autoscrolling on navigation', () => {
     browser,
     options: { x: number; y: number }
   ) =>
-    check(async () => {
+    retry(async () => {
       const top = await getTopScroll(browser)
       const left = await getLeftScroll(browser)
-      return top === options.y && left === options.x
-        ? 'success'
-        : JSON.stringify({ top, left })
-    }, 'success')
+      expect(top === options.y && left === options.x).toBeTruthy()
+    })
 
   const scrollTo = async (
     browser: BrowserInterface,
@@ -171,7 +169,9 @@ describe('router autoscrolling on navigation', () => {
         .elementByCss('#to-invisible-first-element')
         .click()
         .waitForElementByCss('#content-that-is-visible')
-      await check(() => browser.eval('window.scrollY'), 0)
+      await retry(() => {
+        expect(browser.eval('window.scrollY')).toBe(0)
+      })
     })
 
     it('Should scroll to the top of the layout when the first child is position fixed', async () => {
@@ -181,20 +181,23 @@ describe('router autoscrolling on navigation', () => {
         .elementByCss('#to-fixed-first-element')
         .click()
         .waitForElementByCss('#content-that-is-visible')
-      await check(() => browser.eval('window.scrollY'), 0)
+      await retry(() => {
+        expect(browser.eval('window.scrollY')).toBe(0)
+      })
 
       if (isNextDev) {
         // Check that we've logged a warning
-        await check(async () => {
+        await retry(async () => {
           const logs = await browser.log()
-          return logs.some((log) =>
-            log.message.includes(
-              'Skipping auto-scroll behavior due to `position: sticky` or `position: fixed` on element:'
+
+          expect(
+            logs.some((log) =>
+              log.message.includes(
+                'Skipping auto-scroll behavior due to `position: sticky` or `position: fixed` on element:'
+              )
             )
-          )
-            ? 'success'
-            : undefined
-        }, 'success')
+          ).toBeTruthy()
+        })
       }
     })
 
@@ -205,20 +208,23 @@ describe('router autoscrolling on navigation', () => {
         .elementByCss('#to-sticky-first-element')
         .click()
         .waitForElementByCss('#content-that-is-visible')
-      await check(() => browser.eval('window.scrollY'), 0)
+      await retry(() => {
+        expect(browser.eval('window.scrollY')).toBe(0)
+      })
 
       if (isNextDev) {
         // Check that we've logged a warning
-        await check(async () => {
+        await retry(async () => {
           const logs = await browser.log()
-          return logs.some((log) =>
-            log.message.includes(
-              'Skipping auto-scroll behavior due to `position: sticky` or `position: fixed` on element:'
+
+          expect(
+            logs.some((log) =>
+              log.message.includes(
+                'Skipping auto-scroll behavior due to `position: sticky` or `position: fixed` on element:'
+              )
             )
-          )
-            ? 'success'
-            : undefined
-        }, 'success')
+          ).toBeTruthy()
+        })
       }
     })
 
@@ -229,9 +235,13 @@ describe('router autoscrolling on navigation', () => {
         .elementByCss('#to-loading-scroll')
         .click()
         .waitForElementByCss('#loading-component')
-      await check(() => browser.eval('window.scrollY'), 0)
+      await retry(() => {
+        expect(browser.eval('window.scrollY')).toBe(0)
+      })
       await browser.waitForElementByCss('#content-that-is-visible')
-      await check(() => browser.eval('window.scrollY'), 0)
+      await retry(() => {
+        expect(browser.eval('window.scrollY')).toBe(0)
+      })
     })
   })
 })

--- a/test/e2e/app-dir/search-params-react-key/layout-params.test.ts
+++ b/test/e2e/app-dir/search-params-react-key/layout-params.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('app dir - search params keys', () => {
   const { next } = nextTestSetup({
@@ -15,32 +15,28 @@ describe('app dir - search params keys', () => {
 
     await browser.elementByCss('#push').click()
 
-    await check(async () => {
+    await retry(async () => {
       const newSearchParams = await browser
         .waitForElementByCss('#search-params')
         .text()
 
       const count = await browser.waitForElementByCss('#count').text()
 
-      return newSearchParams !== searchParams && count === '2'
-        ? 'success'
-        : 'retry'
-    }, 'success')
+      expect(newSearchParams !== searchParams && count === '2').toBeTruthy()
+    })
 
     await browser.elementByCss('#increment').click()
     await browser.elementByCss('#increment').click()
 
     await browser.elementByCss('#replace').click()
 
-    await check(async () => {
+    await retry(async () => {
       const newSearchParams = await browser
         .waitForElementByCss('#search-params')
         .text()
       const count = await browser.waitForElementByCss('#count').text()
 
-      return newSearchParams !== searchParams && count === '4'
-        ? 'success'
-        : 'retry'
-    }, 'success')
+      expect(newSearchParams !== searchParams && count === '4').toBeTruthy()
+    })
   })
 })

--- a/test/e2e/app-dir/server-actions-relative-redirect/server-actions-relative-redirect.test.ts
+++ b/test/e2e/app-dir/server-actions-relative-redirect/server-actions-relative-redirect.test.ts
@@ -1,6 +1,6 @@
 // @ts-check
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('server-actions-relative-redirect', () => {
   const { next } = nextTestSetup({
@@ -11,25 +11,21 @@ describe('server-actions-relative-redirect', () => {
     const browser = await next.browser('/')
     await browser.waitForElementByCss('#relative-redirect').click()
 
-    await check(async () => {
+    await retry(async () => {
       expect(await browser.waitForElementByCss('#page-loaded').text()).toBe(
         'hello nested page'
       )
-
-      return 'success'
-    }, 'success')
+    })
   })
 
   it('should work with absolute redirect', async () => {
     const browser = await next.browser('/')
     await browser.waitForElementByCss('#absolute-redirect').click()
 
-    await check(async () => {
+    await retry(async () => {
       expect(await browser.waitForElementByCss('#page-loaded').text()).toBe(
         'hello nested page'
       )
-
-      return 'success'
-    }, 'success')
+    })
   })
 })

--- a/test/e2e/app-dir/shallow-routing/shallow-routing.test.ts
+++ b/test/e2e/app-dir/shallow-routing/shallow-routing.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('shallow-routing', () => {
   const { next } = nextTestSetup({
@@ -22,10 +22,11 @@ describe('shallow-routing', () => {
         .waitForElementByCss('#state-updated')
         .elementByCss('#get-latest')
         .click()
-      await check(
-        () => browser.elementByCss('#my-data').text(),
-        `{"foo":"bar"}`
-      )
+      await retry(async () => {
+        expect(await browser.elementByCss('#my-data').text()).toMatch(
+          `{"foo":"bar"}`
+        )
+      })
     })
 
     it('should support setting a different pathname reflected on usePathname', async () => {
@@ -41,10 +42,11 @@ describe('shallow-routing', () => {
       await browser.elementByCss('#push-pathname').click()
 
       // Check usePathname value is the new pathname
-      await check(
-        () => browser.elementByCss('#my-data').text(),
-        '/my-non-existent-path'
-      )
+      await retry(async () => {
+        expect(await browser.elementByCss('#my-data').text()).toEqual(
+          '/my-non-existent-path'
+        )
+      })
 
       // Check current url is the new pathname
       expect(await browser.url()).toBe(`${next.url}/my-non-existent-path`)
@@ -63,7 +65,9 @@ describe('shallow-routing', () => {
       await browser.elementByCss('#push-searchparams').click()
 
       // Check useSearchParams value is the new searchparam
-      await check(() => browser.elementByCss('#my-data').text(), 'foo')
+      await retry(async () => {
+        expect(await browser.elementByCss('#my-data').text()).toEqual('foo')
+      })
 
       // Check current url is the new searchparams
       expect(await browser.url()).toBe(
@@ -74,7 +78,11 @@ describe('shallow-routing', () => {
       await browser.elementByCss('#push-searchparams').click()
 
       // Check useSearchParams value is the new searchparam
-      await check(() => browser.elementByCss('#my-data').text(), 'foo-added')
+      await retry(async () => {
+        expect(await browser.elementByCss('#my-data').text()).toEqual(
+          'foo-added'
+        )
+      })
 
       // Check current url is the new searchparams
       expect(await browser.url()).toBe(
@@ -95,7 +103,9 @@ describe('shallow-routing', () => {
       await browser.elementByCss('#push-string-url').click()
 
       // Check useSearchParams value is the new searchparam
-      await check(() => browser.elementByCss('#my-data').text(), 'foo')
+      await retry(async () => {
+        expect(await browser.elementByCss('#my-data').text()).toEqual('foo')
+      })
 
       // Check current url is the new searchparams
       expect(await browser.url()).toBe(
@@ -106,7 +116,11 @@ describe('shallow-routing', () => {
       await browser.elementByCss('#push-string-url').click()
 
       // Check useSearchParams value is the new searchparam
-      await check(() => browser.elementByCss('#my-data').text(), 'foo-added')
+      await retry(async () => {
+        expect(await browser.elementByCss('#my-data').text()).toEqual(
+          'foo-added'
+        )
+      })
 
       // Check current url is the new searchparams
       expect(await browser.url()).toBe(
@@ -127,7 +141,9 @@ describe('shallow-routing', () => {
       await browser.elementByCss('#push-string-url-null').click()
 
       // Check useSearchParams value is the new searchparam
-      await check(() => browser.elementByCss('#my-data').text(), 'foo')
+      await retry(async () => {
+        expect(await browser.elementByCss('#my-data').text()).toEqual('foo')
+      })
 
       // Check current url is the new searchparams
       expect(await browser.url()).toBe(
@@ -138,7 +154,11 @@ describe('shallow-routing', () => {
       await browser.elementByCss('#push-string-url-null').click()
 
       // Check useSearchParams value is the new searchparam
-      await check(() => browser.elementByCss('#my-data').text(), 'foo-added')
+      await retry(async () => {
+        expect(await browser.elementByCss('#my-data').text()).toEqual(
+          'foo-added'
+        )
+      })
 
       // Check current url is the new searchparams
       expect(await browser.url()).toBe(
@@ -160,7 +180,9 @@ describe('shallow-routing', () => {
     await browser.elementByCss('#push-string-url-undefined').click()
 
     // Check useSearchParams value is the new searchparam
-    await check(() => browser.elementByCss('#my-data').text(), 'foo')
+    await retry(async () => {
+      expect(await browser.elementByCss('#my-data').text()).toEqual('foo')
+    })
 
     // Check current url is the new searchparams
     expect(await browser.url()).toBe(
@@ -171,7 +193,9 @@ describe('shallow-routing', () => {
     await browser.elementByCss('#push-string-url-undefined').click()
 
     // Check useSearchParams value is the new searchparam
-    await check(() => browser.elementByCss('#my-data').text(), 'foo-added')
+    await retry(async () => {
+      expect(await browser.elementByCss('#my-data').text()).toEqual('foo-added')
+    })
 
     // Check current url is the new searchparams
     expect(await browser.url()).toBe(
@@ -195,10 +219,11 @@ describe('shallow-routing', () => {
         .waitForElementByCss('#state-updated')
         .elementByCss('#get-latest')
         .click()
-      await check(
-        () => browser.elementByCss('#my-data').text(),
-        `{"foo":"bar"}`
-      )
+      await retry(async () => {
+        expect(await browser.elementByCss('#my-data').text()).toMatch(
+          `{"foo":"bar"}`
+        )
+      })
     })
 
     it('should support setting a different pathname reflected on usePathname', async () => {
@@ -214,10 +239,11 @@ describe('shallow-routing', () => {
       await browser.elementByCss('#replace-pathname').click()
 
       // Check usePathname value is the new pathname
-      await check(
-        () => browser.elementByCss('#my-data').text(),
-        '/my-non-existent-path'
-      )
+      await retry(async () => {
+        expect(await browser.elementByCss('#my-data').text()).toEqual(
+          '/my-non-existent-path'
+        )
+      })
 
       // Check current url is the new pathname
       expect(await browser.url()).toBe(`${next.url}/my-non-existent-path`)
@@ -236,7 +262,9 @@ describe('shallow-routing', () => {
       await browser.elementByCss('#replace-searchparams').click()
 
       // Check useSearchParams value is the new searchparam
-      await check(() => browser.elementByCss('#my-data').text(), 'foo')
+      await retry(async () => {
+        expect(await browser.elementByCss('#my-data').text()).toEqual('foo')
+      })
 
       // Check current url is the new searchparams
       expect(await browser.url()).toBe(
@@ -247,7 +275,11 @@ describe('shallow-routing', () => {
       await browser.elementByCss('#replace-searchparams').click()
 
       // Check useSearchParams value is the new searchparam
-      await check(() => browser.elementByCss('#my-data').text(), 'foo-added')
+      await retry(async () => {
+        expect(await browser.elementByCss('#my-data').text()).toEqual(
+          'foo-added'
+        )
+      })
 
       // Check current url is the new searchparams
       expect(await browser.url()).toBe(
@@ -268,7 +300,9 @@ describe('shallow-routing', () => {
       await browser.elementByCss('#replace-string-url').click()
 
       // Check useSearchParams value is the new searchparam
-      await check(() => browser.elementByCss('#my-data').text(), 'foo')
+      await retry(async () => {
+        expect(await browser.elementByCss('#my-data').text()).toEqual('foo')
+      })
 
       // Check current url is the new searchparams
       expect(await browser.url()).toBe(
@@ -279,7 +313,11 @@ describe('shallow-routing', () => {
       await browser.elementByCss('#replace-string-url').click()
 
       // Check useSearchParams value is the new searchparam
-      await check(() => browser.elementByCss('#my-data').text(), 'foo-added')
+      await retry(async () => {
+        expect(await browser.elementByCss('#my-data').text()).toEqual(
+          'foo-added'
+        )
+      })
 
       // Check current url is the new searchparams
       expect(await browser.url()).toBe(
@@ -300,7 +338,9 @@ describe('shallow-routing', () => {
       await browser.elementByCss('#replace-string-url-null').click()
 
       // Check useSearchParams value is the new searchparam
-      await check(() => browser.elementByCss('#my-data').text(), 'foo')
+      await retry(async () => {
+        expect(await browser.elementByCss('#my-data').text()).toEqual('foo')
+      })
 
       // Check current url is the new searchparams
       expect(await browser.url()).toBe(
@@ -311,7 +351,11 @@ describe('shallow-routing', () => {
       await browser.elementByCss('#replace-string-url-null').click()
 
       // Check useSearchParams value is the new searchparam
-      await check(() => browser.elementByCss('#my-data').text(), 'foo-added')
+      await retry(async () => {
+        expect(await browser.elementByCss('#my-data').text()).toEqual(
+          'foo-added'
+        )
+      })
 
       // Check current url is the new searchparams
       expect(await browser.url()).toBe(
@@ -332,7 +376,9 @@ describe('shallow-routing', () => {
       await browser.elementByCss('#replace-string-url-undefined').click()
 
       // Check useSearchParams value is the new searchparam
-      await check(() => browser.elementByCss('#my-data').text(), 'foo')
+      await retry(async () => {
+        expect(await browser.elementByCss('#my-data').text()).toEqual('foo')
+      })
 
       // Check current url is the new searchparams
       expect(await browser.url()).toBe(
@@ -343,7 +389,11 @@ describe('shallow-routing', () => {
       await browser.elementByCss('#replace-string-url-undefined').click()
 
       // Check useSearchParams value is the new searchparam
-      await check(() => browser.elementByCss('#my-data').text(), 'foo-added')
+      await retry(async () => {
+        expect(await browser.elementByCss('#my-data').text()).toEqual(
+          'foo-added'
+        )
+      })
 
       // Check current url is the new searchparams
       expect(await browser.url()).toBe(
@@ -367,10 +417,11 @@ describe('shallow-routing', () => {
         await browser.elementByCss('#push-pathname').click()
 
         // Check usePathname value is the new pathname
-        await check(
-          () => browser.elementByCss('#my-data').text(),
-          '/my-non-existent-path'
-        )
+        await retry(async () => {
+          expect(await browser.elementByCss('#my-data').text()).toEqual(
+            '/my-non-existent-path'
+          )
+        })
 
         // Check current url is the new pathname
         expect(await browser.url()).toBe(`${next.url}/my-non-existent-path`)
@@ -379,18 +430,20 @@ describe('shallow-routing', () => {
         await browser.back()
 
         // Check usePathname value is the old pathname
-        await check(
-          () => browser.elementByCss('#my-data').text(),
-          '/pushstate-new-pathname'
-        )
+        await retry(async () => {
+          expect(await browser.elementByCss('#my-data').text()).toEqual(
+            '/pushstate-new-pathname'
+          )
+        })
 
         await browser.forward()
 
         // Check usePathname value is the old pathname
-        await check(
-          () => browser.elementByCss('#my-data').text(),
-          '/my-non-existent-path'
-        )
+        await retry(async () => {
+          expect(await browser.elementByCss('#my-data').text()).toEqual(
+            '/my-non-existent-path'
+          )
+        })
       })
     })
 
@@ -412,10 +465,11 @@ describe('shallow-routing', () => {
           .elementByCss('#get-latest')
           .click()
 
-        await check(
-          () => browser.elementByCss('#my-data').text(),
-          `{"foo":"bar"}`
-        )
+        await retry(async () => {
+          expect(await browser.elementByCss('#my-data').text()).toMatch(
+            `{"foo":"bar"}`
+          )
+        })
 
         expect(
           await browser
@@ -429,22 +483,23 @@ describe('shallow-routing', () => {
         await browser.back()
 
         // Check usePathname value is the old pathname
-        await check(
-          () => browser.elementByCss('#my-data').text(),
-          `{"foo":"bar"}`
-        )
+        await retry(async () => {
+          expect(await browser.elementByCss('#my-data').text()).toMatch(
+            `{"foo":"bar"}`
+          )
+        })
 
         await browser.forward()
 
-        await check(
-          () =>
-            browser
+        await retry(async () => {
+          expect(
+            await browser
               .elementByCss('#to-a-mpa')
               .click()
               .waitForElementByCss('#page-a')
-              .text(),
-          'Page A'
-        )
+              .text()
+          ).toEqual('Page A')
+        })
       })
 
       it('should support hash navigations while continuing to work for pushState/replaceState APIs', async () => {
@@ -467,7 +522,9 @@ describe('shallow-routing', () => {
         await browser.elementByCss('#push-string-url').click()
 
         // Check useSearchParams value is the new searchparam
-        await check(() => browser.elementByCss('#my-data').text(), 'foo')
+        await retry(async () => {
+          expect(await browser.elementByCss('#my-data').text()).toEqual('foo')
+        })
 
         // Check current url is the new searchparams
         expect(await browser.url()).toBe(
@@ -478,7 +535,11 @@ describe('shallow-routing', () => {
         await browser.elementByCss('#push-string-url').click()
 
         // Check useSearchParams value is the new searchparam
-        await check(() => browser.elementByCss('#my-data').text(), 'foo-added')
+        await retry(async () => {
+          expect(await browser.elementByCss('#my-data').text()).toEqual(
+            'foo-added'
+          )
+        })
 
         // Check current url is the new searchparams
         expect(await browser.url()).toBe(

--- a/test/e2e/app-dir/use-selected-layout-segment-s/use-selected-layout-segment-s.test.ts
+++ b/test/e2e/app-dir/use-selected-layout-segment-s/use-selected-layout-segment-s.test.ts
@@ -1,7 +1,7 @@
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
 import webdriver from 'next-webdriver'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('useSelectedLayoutSegment(s)', () => {
   let next: NextInstance
@@ -76,10 +76,11 @@ describe('useSelectedLayoutSegment(s)', () => {
   it('should correctly update when changing static segment', async () => {
     browser.elementById('change-static').click()
 
-    await check(
-      () => browser.eval('window.location.pathname'),
-      '/segment-name/param1/different-segment'
-    )
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toEqual(
+        '/segment-name/param1/different-segment'
+      )
+    })
 
     expect(
       await browser.elementByCss('#root > .segments').text()
@@ -97,10 +98,11 @@ describe('useSelectedLayoutSegment(s)', () => {
   it('should correctly update when changing param segment', async () => {
     browser.elementById('change-param').click()
 
-    await check(
-      () => browser.eval('window.location.pathname'),
-      '/segment-name/param1/segment-name2/different-value/value3/value4'
-    )
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toEqual(
+        '/segment-name/param1/segment-name2/different-value/value3/value4'
+      )
+    })
 
     expect(
       await browser.elementByCss('#root > .segments').text()
@@ -120,10 +122,11 @@ describe('useSelectedLayoutSegment(s)', () => {
   it('should correctly update when changing catchall segment', async () => {
     browser.elementById('change-catchall').click()
 
-    await check(
-      () => browser.eval('window.location.pathname'),
-      '/segment-name/param1/segment-name2/value2/different/random/paths'
-    )
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toEqual(
+        '/segment-name/param1/segment-name2/value2/different/random/paths'
+      )
+    })
 
     expect(
       await browser.elementByCss('#root > .segments').text()

--- a/test/e2e/async-modules/index.test.ts
+++ b/test/e2e/async-modules/index.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('Async modules', () => {
   const { next, isNextDev: dev } = nextTestSetup({
@@ -45,11 +45,11 @@ describe('Async modules', () => {
   // TODO: investigate this test flaking
   it.skip('can render async AMP pages', async () => {
     const browser = await next.browser('/config')
-    await check(
-      () => browser.elementByCss('#amp-timeago').text(),
-      'just now',
-      true
-    )
+    await retry(async () => {
+      expect(await browser.elementByCss('#amp-timeago').text()).toEqual(
+        'just now'
+      )
+    })
   })
   ;(dev ? it.skip : it)('can render async error page', async () => {
     const browser = await next.browser('/make-error')

--- a/test/e2e/config-schema-check/index.test.ts
+++ b/test/e2e/config-schema-check/index.test.ts
@@ -1,6 +1,6 @@
 import stripAnsi from 'strip-ansi'
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('next.config.js schema validating - defaultConfig', () => {
   const { next, skipped } = nextTestSetup({
@@ -52,7 +52,7 @@ describe('next.config.js schema validating - invalid config', () => {
   }
 
   it('should warn the invalid next config', async () => {
-    await check(() => {
+    await retry(() => {
       const output = stripAnsi(next.cliOutput)
       const warningTimes = output.split('badKey').length - 1
 
@@ -60,8 +60,6 @@ describe('next.config.js schema validating - invalid config', () => {
       expect(output).toContain('badKey')
       // for next start and next build we both display the warnings
       expect(warningTimes).toBe(isNextStart ? 2 : 1)
-
-      return 'success'
-    }, 'success')
+    })
   })
 })

--- a/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
+++ b/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
@@ -4,7 +4,7 @@ import {
   hasRedbox,
   getRedboxSource,
   getRedboxDescription,
-  check,
+  retry,
 } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
@@ -43,16 +43,18 @@ describe('fetch failures have good stack traces in edge runtime', () => {
 
     if (process.env.TURBOPACK) {
       // pages_api_unknown-domain-no-await_d8c7f5.js:14:5
-      await check(
-        () => stripAnsi(next.cliOutput),
-        /pages_api_unknown-domain-no-await_.*?\.js/
-      )
+      await retry(async () => {
+        expect(await stripAnsi(next.cliOutput)).toMatch(
+          /pages_api_unknown-domain-no-await_.*?\.js/
+        )
+      })
     } else {
       // webpack-internal:///(middleware)/./pages/api/unknown-domain-no-await.js:10:5
-      await check(
-        () => stripAnsi(next.cliOutput),
-        /at.+\/pages\/api\/unknown-domain-no-await.js/
-      )
+      await retry(async () => {
+        expect(await stripAnsi(next.cliOutput)).toMatch(
+          /at.+\/pages\/api\/unknown-domain-no-await.js/
+        )
+      })
     }
   })
 })

--- a/test/e2e/i18n-data-fetching-redirect/index.test.ts
+++ b/test/e2e/i18n-data-fetching-redirect/index.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 
 describe('i18n-data-fetching-redirect', () => {
@@ -41,10 +41,11 @@ describe('i18n-data-fetching-redirect', () => {
           `/${fromLocale}/${path}/${toLocale}`
         )
 
-        await check(
-          () => browser.eval('window.location.pathname'),
-          `/${toLocale}/home`
-        )
+        await retry(async () => {
+          expect(await browser.eval('window.location.pathname')).toMatch(
+            `/${toLocale}/home`
+          )
+        })
         expect(await browser.elementByCss('#router-locale').text()).toBe(
           toLocale
         )
@@ -73,10 +74,11 @@ describe('i18n-data-fetching-redirect', () => {
 
         await browser.elementByCss(`#to-${path}-${toLocale}`).click()
 
-        await check(
-          () => browser.eval('window.location.pathname'),
-          `/${toLocale}/home`
-        )
+        await retry(async () => {
+          expect(await browser.eval('window.location.pathname')).toMatch(
+            `/${toLocale}/home`
+          )
+        })
 
         expect(await browser.eval('window.beforeNav')).toBe(1)
         expect(await browser.elementByCss('#router-locale').text()).toBe(
@@ -104,10 +106,11 @@ describe('i18n-data-fetching-redirect', () => {
     `('$path $locale', async ({ path, locale }) => {
       const browser = await webdriver(next.url, `/${locale}/${path}/from-ctx`)
 
-      await check(
-        () => browser.eval('window.location.pathname'),
-        `/${locale}/home`
-      )
+      await retry(async () => {
+        expect(await browser.eval('window.location.pathname')).toMatch(
+          `/${locale}/home`
+        )
+      })
       expect(await browser.elementByCss('#router-locale').text()).toBe(locale)
       expect(await browser.elementByCss('#router-pathname').text()).toBe(
         '/home'
@@ -129,10 +132,11 @@ describe('i18n-data-fetching-redirect', () => {
 
       await browser.elementByCss(`#to-${path}-from-ctx`).click()
 
-      await check(
-        () => browser.eval('window.location.pathname'),
-        `/${locale}/home`
-      )
+      await retry(async () => {
+        expect(await browser.eval('window.location.pathname')).toMatch(
+          `/${locale}/home`
+        )
+      })
 
       expect(await browser.eval('window.beforeNav')).toBe(1)
       expect(await browser.elementByCss('#router-locale').text()).toBe(locale)

--- a/test/e2e/i18n-ignore-redirect-source-locale/redirects-with-basepath.test.ts
+++ b/test/e2e/i18n-ignore-redirect-source-locale/redirects-with-basepath.test.ts
@@ -1,6 +1,6 @@
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 
@@ -58,7 +58,9 @@ describe('i18n-ignore-redirect-source-locale with basepath', () => {
     'get redirected to the new page, from: %s to: sv',
     async (locale) => {
       const browser = await webdriver(next.url, `basepath/${locale}/to-sv`)
-      await check(() => browser.elementById('current-locale').text(), 'sv')
+      await retry(async () => {
+        expect(await browser.elementById('current-locale').text()).toEqual('sv')
+      })
     }
   )
 
@@ -66,7 +68,9 @@ describe('i18n-ignore-redirect-source-locale with basepath', () => {
     'get redirected to the new page, from: %s to: en',
     async (locale) => {
       const browser = await webdriver(next.url, `basepath/${locale}/to-en`)
-      await check(() => browser.elementById('current-locale').text(), 'en')
+      await retry(async () => {
+        expect(await browser.elementById('current-locale').text()).toEqual('en')
+      })
     }
   )
 
@@ -74,7 +78,9 @@ describe('i18n-ignore-redirect-source-locale with basepath', () => {
     'get redirected to the new page, from: %s to: /',
     async (locale) => {
       const browser = await webdriver(next.url, `basepath/${locale}/to-slash`)
-      await check(() => browser.elementById('current-locale').text(), 'en')
+      await retry(async () => {
+        expect(await browser.elementById('current-locale').text()).toEqual('en')
+      })
     }
   )
 
@@ -82,10 +88,11 @@ describe('i18n-ignore-redirect-source-locale with basepath', () => {
     'get redirected to the new page, from and to: %s',
     async (locale) => {
       const browser = await webdriver(next.url, `basepath/${locale}/to-same`)
-      await check(
-        () => browser.elementById('current-locale').text(),
-        locale === '' ? 'en' : locale.slice(1)
-      )
+      await retry(async () => {
+        expect(await browser.elementById('current-locale').text()).toMatch(
+          locale === '' ? 'en' : locale.slice(1)
+        )
+      })
     }
   )
 })

--- a/test/e2e/i18n-ignore-redirect-source-locale/redirects.test.ts
+++ b/test/e2e/i18n-ignore-redirect-source-locale/redirects.test.ts
@@ -1,6 +1,6 @@
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 
@@ -57,7 +57,9 @@ describe('i18n-ignore-redirect-source-locale', () => {
     'get redirected to the new page, from: %s to: sv',
     async (locale) => {
       const browser = await webdriver(next.url, `${locale}/to-sv`)
-      await check(() => browser.elementById('current-locale').text(), 'sv')
+      await retry(async () => {
+        expect(await browser.elementById('current-locale').text()).toEqual('sv')
+      })
     }
   )
 
@@ -65,7 +67,9 @@ describe('i18n-ignore-redirect-source-locale', () => {
     'get redirected to the new page, from: %s to: en',
     async (locale) => {
       const browser = await webdriver(next.url, `${locale}/to-en`)
-      await check(() => browser.elementById('current-locale').text(), 'en')
+      await retry(async () => {
+        expect(await browser.elementById('current-locale').text()).toEqual('en')
+      })
     }
   )
 
@@ -73,7 +77,9 @@ describe('i18n-ignore-redirect-source-locale', () => {
     'get redirected to the new page, from: %s to: /',
     async (locale) => {
       const browser = await webdriver(next.url, `${locale}/to-slash`)
-      await check(() => browser.elementById('current-locale').text(), 'en')
+      await retry(async () => {
+        expect(await browser.elementById('current-locale').text()).toEqual('en')
+      })
     }
   )
 
@@ -81,10 +87,11 @@ describe('i18n-ignore-redirect-source-locale', () => {
     'get redirected to the new page, from and to: %s',
     async (locale) => {
       const browser = await webdriver(next.url, `${locale}/to-same`)
-      await check(
-        () => browser.elementById('current-locale').text(),
-        locale === '' ? 'en' : locale.slice(1)
-      )
+      await retry(async () => {
+        expect(await browser.elementById('current-locale').text()).toMatch(
+          locale === '' ? 'en' : locale.slice(1)
+        )
+      })
     }
   )
 })

--- a/test/e2e/ignore-invalid-popstateevent/with-i18n.test.ts
+++ b/test/e2e/ignore-invalid-popstateevent/with-i18n.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check, waitFor } from 'next-test-utils'
+import { waitFor, retry } from 'next-test-utils'
 import webdriver, { BrowserInterface } from 'next-webdriver'
 
 import type { HistoryState } from 'next/dist/shared/lib/router/router'
@@ -47,7 +47,9 @@ describe('i18n: Event with stale state - static route previously was dynamic', (
 
     // 2nd event isn't ignored
     await emitPopsStateEvent(browser, state)
-    await check(() => browser.elementByCss('#page-type').text(), 'dynamic')
+    await retry(async () => {
+      expect(await browser.elementByCss('#page-type').text()).toEqual('dynamic')
+    })
   })
 
   test('Ignore event with query param', async () => {
@@ -70,7 +72,9 @@ describe('i18n: Event with stale state - static route previously was dynamic', (
 
     // 2nd event isn't ignored
     await emitPopsStateEvent(browser, state)
-    await check(() => browser.elementByCss('#page-type').text(), 'dynamic')
+    await retry(async () => {
+      expect(await browser.elementByCss('#page-type').text()).toEqual('dynamic')
+    })
   })
 
   test("Don't ignore event with different locale", async () => {
@@ -87,6 +91,8 @@ describe('i18n: Event with stale state - static route previously was dynamic', (
     expect(await browser.elementByCss('#page-type').text()).toBe('static')
 
     await emitPopsStateEvent(browser, state)
-    await check(() => browser.elementByCss('#page-type').text(), 'dynamic')
+    await retry(async () => {
+      expect(await browser.elementByCss('#page-type').text()).toEqual('dynamic')
+    })
   })
 })

--- a/test/e2e/ignore-invalid-popstateevent/without-i18n.test.ts
+++ b/test/e2e/ignore-invalid-popstateevent/without-i18n.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check, waitFor } from 'next-test-utils'
+import { waitFor, retry } from 'next-test-utils'
 import webdriver, { BrowserInterface } from 'next-webdriver'
 
 import type { HistoryState } from 'next/dist/shared/lib/router/router'
@@ -47,7 +47,9 @@ describe('Event with stale state - static route previously was dynamic', () => {
 
     // 2nd event isn't ignored
     await emitPopsStateEvent(browser, state)
-    await check(() => browser.elementByCss('#page-type').text(), 'dynamic')
+    await retry(async () => {
+      expect(await browser.elementByCss('#page-type').text()).toEqual('dynamic')
+    })
   })
 
   test('Ignore event with query param', async () => {
@@ -70,6 +72,8 @@ describe('Event with stale state - static route previously was dynamic', () => {
 
     // 2nd event isn't ignored
     await emitPopsStateEvent(browser, state)
-    await check(() => browser.elementByCss('#page-type').text(), 'dynamic')
+    await retry(async () => {
+      expect(await browser.elementByCss('#page-type').text()).toEqual('dynamic')
+    })
   })
 })

--- a/test/e2e/instrumentation-hook-src/instrumentation-hook-src.test.ts
+++ b/test/e2e/instrumentation-hook-src/instrumentation-hook-src.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 describe('instrumentation-hook-rsc', () => {
   describe('instrumentation', () => {
     const { next, isNextDev, skipped } = nextTestSetup({
@@ -18,7 +18,9 @@ describe('instrumentation-hook-rsc', () => {
 
     it('should run the instrumentation hook', async () => {
       await next.render('/')
-      await check(() => next.cliOutput, /instrumentation hook/)
+      await retry(async () => {
+        expect(await next.cliOutput).toMatch(/instrumentation hook/)
+      })
     })
     it('should not overlap with a instrumentation page', async () => {
       const page = await next.render('/instrumentation')
@@ -26,7 +28,9 @@ describe('instrumentation-hook-rsc', () => {
     })
     it('should run the edge instrumentation compiled version with the edge runtime', async () => {
       await next.render('/edge')
-      await check(() => next.cliOutput, /instrumentation hook on the edge/)
+      await retry(async () => {
+        expect(await next.cliOutput).toMatch(/instrumentation hook on the edge/)
+      })
     })
     if (isNextDev) {
       // TODO: Implement handling for changing the instrument file.
@@ -36,15 +40,18 @@ describe('instrumentation-hook-rsc', () => {
           './src/instrumentation.js',
           `export function register() {console.log('toast')}`
         )
-        await check(() => next.cliOutput, /toast/)
+        await retry(async () => {
+          expect(await next.cliOutput).toMatch(/toast/)
+        })
         await next.renameFile(
           './src/instrumentation.js',
           './src/instrumentation.js.bak'
         )
-        await check(
-          () => next.cliOutput,
-          /The instrumentation file has been removed/
-        )
+        await retry(async () => {
+          expect(await next.cliOutput).toMatch(
+            /The instrumentation file has been removed/
+          )
+        })
         await next.patchFile(
           './src/instrumentation.js.bak',
           `export function register() {console.log('bread')}`
@@ -53,8 +60,14 @@ describe('instrumentation-hook-rsc', () => {
           './src/instrumentation.js.bak',
           './src/instrumentation.js'
         )
-        await check(() => next.cliOutput, /The instrumentation file was added/)
-        await check(() => next.cliOutput, /bread/)
+        await retry(async () => {
+          expect(await next.cliOutput).toMatch(
+            /The instrumentation file was added/
+          )
+        })
+        await retry(async () => {
+          expect(await next.cliOutput).toMatch(/bread/)
+        })
       })
     }
   })

--- a/test/e2e/instrumentation-hook/instrumentation-hook.test.ts
+++ b/test/e2e/instrumentation-hook/instrumentation-hook.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import path from 'path'
 
 const describeCase = (
@@ -48,33 +48,43 @@ describe('Instrumentation Hook', () => {
   describeCase('with-middleware', ({ next }) => {
     it('with-middleware should run the instrumentation hook', async () => {
       await next.render('/')
-      await check(() => next.cliOutput, /instrumentation hook on the edge/)
+      await retry(async () => {
+        expect(await next.cliOutput).toMatch(/instrumentation hook on the edge/)
+      })
     })
   })
 
   describeCase('with-edge-api', ({ next }) => {
     it('with-edge-api should run the instrumentation hook', async () => {
       await next.render('/api')
-      await check(() => next.cliOutput, /instrumentation hook on the edge/)
+      await retry(async () => {
+        expect(await next.cliOutput).toMatch(/instrumentation hook on the edge/)
+      })
     })
   })
 
   describeCase('with-edge-page', ({ next }) => {
     it('with-edge-page should run the instrumentation hook', async () => {
       await next.render('/')
-      await check(() => next.cliOutput, /instrumentation hook on the edge/)
+      await retry(async () => {
+        expect(await next.cliOutput).toMatch(/instrumentation hook on the edge/)
+      })
     })
   })
 
   describeCase('with-node-api', ({ next }) => {
     it('with-node-api should run the instrumentation hook', async () => {
-      await check(() => next.cliOutput, /instrumentation hook on nodejs/)
+      await retry(async () => {
+        expect(await next.cliOutput).toMatch(/instrumentation hook on nodejs/)
+      })
     })
   })
 
   describeCase('with-node-page', ({ next }) => {
     it('with-node-page should run the instrumentation hook', async () => {
-      await check(() => next.cliOutput, /instrumentation hook on nodejs/)
+      await retry(async () => {
+        expect(await next.cliOutput).toMatch(/instrumentation hook on nodejs/)
+      })
     })
   })
 
@@ -105,15 +115,18 @@ describe('Instrumentation Hook', () => {
           './instrumentation.js',
           `export function register() {console.log('toast')}`
         )
-        await check(() => next.cliOutput, /toast/)
+        await retry(async () => {
+          expect(await next.cliOutput).toMatch(/toast/)
+        })
         await next.renameFile(
           './instrumentation.js',
           './instrumentation.js.bak'
         )
-        await check(
-          () => next.cliOutput,
-          /The instrumentation file has been removed/
-        )
+        await retry(async () => {
+          expect(await next.cliOutput).toMatch(
+            /The instrumentation file has been removed/
+          )
+        })
         await next.patchFile(
           './instrumentation.js.bak',
           `export function register() {console.log('bread')}`
@@ -122,8 +135,14 @@ describe('Instrumentation Hook', () => {
           './instrumentation.js.bak',
           './instrumentation.js'
         )
-        await check(() => next.cliOutput, /The instrumentation file was added/)
-        await check(() => next.cliOutput, /bread/)
+        await retry(async () => {
+          expect(await next.cliOutput).toMatch(
+            /The instrumentation file was added/
+          )
+        })
+        await retry(async () => {
+          expect(await next.cliOutput).toMatch(/bread/)
+        })
       })
     }
   })

--- a/test/e2e/link-with-api-rewrite/index.test.ts
+++ b/test/e2e/link-with-api-rewrite/index.test.ts
@@ -1,6 +1,6 @@
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 
@@ -27,8 +27,10 @@ describe('link-with-api-rewrite', () => {
       // unset).
       await browser.eval('window.beforeNav = "hi"')
       await browser.elementById('rewrite').click()
-      await check(() => browser.eval('window.beforeNav'), {
-        test: (content) => content !== 'hi',
+      await retry(async () => {
+        expect(await browser.eval('window.beforeNav')).toMatch({
+          test: (content) => content !== 'hi',
+        })
       })
 
       // Check to see that we were in fact navigated to the correct page.
@@ -54,8 +56,10 @@ describe('link-with-api-rewrite', () => {
       // unset).
       await browser.eval('window.beforeNav = "hi"')
       await browser.elementById('direct').click()
-      await check(() => browser.eval('window.beforeNav'), {
-        test: (content) => content !== 'hi',
+      await retry(async () => {
+        expect(await browser.eval('window.beforeNav')).toMatch({
+          test: (content) => content !== 'hi',
+        })
       })
 
       // Check to see that we were in fact navigated to the correct page.

--- a/test/e2e/manual-client-base-path/index.test.ts
+++ b/test/e2e/manual-client-base-path/index.test.ts
@@ -5,7 +5,7 @@ import { join } from 'path'
 import http from 'http'
 import webdriver from 'next-webdriver'
 import assert from 'assert'
-import { check, renderViaHTTP, waitFor } from 'next-test-utils'
+import { renderViaHTTP, waitFor, retry } from 'next-test-utils'
 
 describe('manual-client-base-path', () => {
   if ((global as any).isNextDeploy) {
@@ -118,7 +118,7 @@ describe('manual-client-base-path', () => {
       expect(await browser.eval('window.location.pathname')).toBe(asPath)
       expect(await browser.eval('window.location.search')).toBe('?update=1')
 
-      await check(async () => {
+      await retry(async () => {
         assert.deepEqual(
           JSON.parse(await browser.elementByCss('#router').text()),
           {
@@ -131,8 +131,7 @@ describe('manual-client-base-path', () => {
             basePath,
           }
         )
-        return 'success'
-      }, 'success')
+      })
 
       await waitFor(5 * 1000)
       expect(await browser.eval('window.beforeNav')).toBe(1)
@@ -144,41 +143,59 @@ describe('manual-client-base-path', () => {
     await browser.eval('window.beforeNav = 1')
 
     await browser.elementByCss('#to-another').click()
-    await check(() => browser.elementByCss('#page').text(), 'another page')
+    await retry(async () => {
+      expect(await browser.elementByCss('#page').text()).toEqual('another page')
+    })
     expect(await browser.eval('window.location.pathname')).toBe('/another')
 
     await browser.back()
-    await check(() => browser.elementByCss('#page').text(), 'index page')
+    await retry(async () => {
+      expect(await browser.elementByCss('#page').text()).toEqual('index page')
+    })
     expect(await browser.eval('window.location.pathname')).toBe('/')
 
     await browser.forward()
-    await check(() => browser.elementByCss('#page').text(), 'another page')
+    await retry(async () => {
+      expect(await browser.elementByCss('#page').text()).toEqual('another page')
+    })
     expect(await browser.eval('window.location.pathname')).toBe('/another')
 
     await browser.back()
-    await check(() => browser.elementByCss('#page').text(), 'index page')
+    await retry(async () => {
+      expect(await browser.elementByCss('#page').text()).toEqual('index page')
+    })
     expect(await browser.eval('window.location.pathname')).toBe('/')
 
     await browser.elementByCss('#to-another-slash').click()
-    await check(() => browser.elementByCss('#page').text(), 'another page')
+    await retry(async () => {
+      expect(await browser.elementByCss('#page').text()).toEqual('another page')
+    })
     expect(await browser.eval('window.location.pathname')).toBe('/another')
 
     await browser.back()
-    await check(() => browser.elementByCss('#page').text(), 'index page')
+    await retry(async () => {
+      expect(await browser.elementByCss('#page').text()).toEqual('index page')
+    })
     expect(await browser.eval('window.location.pathname')).toBe('/')
 
     await browser.elementByCss('#to-dynamic').click()
-    await check(() => browser.elementByCss('#page').text(), 'dynamic page')
+    await retry(async () => {
+      expect(await browser.elementByCss('#page').text()).toEqual('dynamic page')
+    })
     expect(await browser.eval('window.location.pathname')).toBe(
       '/dynamic/first'
     )
 
     await browser.back()
-    await check(() => browser.elementByCss('#page').text(), 'index page')
+    await retry(async () => {
+      expect(await browser.elementByCss('#page').text()).toEqual('index page')
+    })
     expect(await browser.eval('window.location.pathname')).toBe('/')
 
     await browser.forward()
-    await check(() => browser.elementByCss('#page').text(), 'dynamic page')
+    await retry(async () => {
+      expect(await browser.elementByCss('#page').text()).toEqual('dynamic page')
+    })
     expect(await browser.eval('window.location.pathname')).toBe(
       '/dynamic/first'
     )
@@ -191,20 +208,25 @@ describe('manual-client-base-path', () => {
     await browser.eval('window.beforeNav = 1')
 
     await browser.elementByCss('#to-index').click()
-    await check(() => browser.elementByCss('#page').text(), 'index page')
+    await retry(async () => {
+      expect(await browser.elementByCss('#page').text()).toEqual('index page')
+    })
     expect(await browser.eval('window.location.pathname')).toBe('/')
 
     await browser.elementByCss('#to-dynamic').click()
-    await check(() => browser.elementByCss('#page').text(), 'dynamic page')
+    await retry(async () => {
+      expect(await browser.elementByCss('#page').text()).toEqual('dynamic page')
+    })
     expect(await browser.eval('window.location.pathname')).toBe(
       '/dynamic/first'
     )
 
     await browser.elementByCss('#to-dynamic').click()
-    await check(
-      () => browser.eval('window.location.pathname'),
-      '/dynamic/second'
-    )
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toEqual(
+        '/dynamic/second'
+      )
+    })
 
     expect(await browser.eval('window.beforeNav')).toBe(1)
   })

--- a/test/e2e/middleware-dynamic-basepath-matcher/test/index.test.ts
+++ b/test/e2e/middleware-dynamic-basepath-matcher/test/index.test.ts
@@ -3,7 +3,7 @@
 
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { check, fetchViaHTTP } from 'next-test-utils'
+import { fetchViaHTTP, retry } from 'next-test-utils'
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
 
@@ -46,8 +46,14 @@ describe('Middleware custom matchers basePath', () => {
   // See https://linear.app/vercel/issue/EC-160/header-value-set-on-middleware-is-not-propagated-on-client-request-of
   itif(!isModeDeploy)('should match query path', async () => {
     const browser = await webdriver(next.url, '/base/random')
-    await check(() => browser.elementById('router-path').text(), 'random')
+    await retry(async () => {
+      expect(await browser.elementById('router-path').text()).toEqual('random')
+    })
     await browser.elementById('linkelement').click()
-    await check(() => browser.elementById('router-path').text(), 'another-page')
+    await retry(async () => {
+      expect(await browser.elementById('router-path').text()).toEqual(
+        'another-page'
+      )
+    })
   })
 })

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -5,10 +5,10 @@ import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { NextInstance } from 'e2e-utils'
 import {
-  check,
   fetchViaHTTP,
   shouldRunTurboDevTest,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import { createNext, FileRef } from 'e2e-utils'
 
@@ -106,16 +106,18 @@ describe('Middleware Runtime', () => {
       const browser = await next.browser('/ssr-page')
       await browser.eval('window.next.router.push("/ssg/not-found-1")')
 
-      await check(
-        () => browser.eval('document.documentElement.innerHTML'),
-        /This page could not be found/
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval('document.documentElement.innerHTML')
+        ).toMatch(/This page could not be found/)
+      })
 
       await browser.refresh()
-      await check(
-        () => browser.eval('document.documentElement.innerHTML'),
-        /This page could not be found/
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval('document.documentElement.innerHTML')
+        ).toMatch(/This page could not be found/)
+      })
     })
 
     it('should be able to rewrite on _next/static/chunks/pages/ 404', async () => {
@@ -277,22 +279,26 @@ describe('Middleware Runtime', () => {
       })
       await browser.eval('window.beforeNav = 1')
 
-      await check(async () => {
+      await retry(async () => {
         const didReq = await browser.eval('next.router.isReady')
-        return didReq ||
-          requests.some((req) =>
-            new URL(req, 'http://n').pathname.endsWith('/to-ssg.json')
-          )
-          ? 'found'
-          : JSON.stringify(requests)
-      }, 'found')
 
-      await check(
-        () => browser.eval('document.documentElement.innerHTML'),
-        /"slug":"hello"/
-      )
+        expect(
+          didReq ||
+            requests.some((req) =>
+              new URL(req, 'http://n').pathname.endsWith('/to-ssg.json')
+            )
+        ).toBeTruthy()
+      })
 
-      await check(() => browser.elementByCss('body').text(), /\/to-ssg/)
+      await retry(async () => {
+        expect(
+          await browser.eval('document.documentElement.innerHTML')
+        ).toMatch(/"slug":"hello"/)
+      })
+
+      await retry(async () => {
+        expect(await browser.elementByCss('body').text()).toMatch(/\/to-ssg/)
+      })
 
       expect(JSON.parse(await browser.elementByCss('#query').text())).toEqual({
         from: 'middleware',
@@ -309,10 +315,11 @@ describe('Middleware Runtime', () => {
 
     it('should have correct dynamic route params on client-transition to dynamic route', async () => {
       const browser = await webdriver(next.url, '/404')
-      await check(
-        () => browser.eval('next.router.isReady ? "yes" : "nope"'),
-        'yes'
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval('next.router.isReady ? "yes" : "nope"')
+        ).toEqual('yes')
+      })
       await browser.eval('window.beforeNav = 1')
       await browser.eval('window.next.router.push("/blog/first")')
       await browser.waitForElementByCss('#blog')
@@ -331,7 +338,11 @@ describe('Middleware Runtime', () => {
       expect(await browser.elementByCss('#as-path').text()).toBe('/blog/first')
 
       await browser.eval('window.next.router.push("/blog/second")')
-      await check(() => browser.elementByCss('body').text(), /"slug":"second"/)
+      await retry(async () => {
+        expect(await browser.elementByCss('body').text()).toMatch(
+          /"slug":"second"/
+        )
+      })
 
       expect(JSON.parse(await browser.elementByCss('#query').text())).toEqual({
         slug: 'second',
@@ -349,10 +360,11 @@ describe('Middleware Runtime', () => {
 
     it('should have correct dynamic route params for middleware rewrite to dynamic route', async () => {
       const browser = await webdriver(next.url, '/404')
-      await check(
-        () => browser.eval('next.router.isReady ? "yes" : "no"'),
-        'yes'
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval('next.router.isReady ? "yes" : "no"')
+        ).toEqual('yes')
+      })
       await browser.eval('window.beforeNav = 1')
       await browser.eval('window.next.router.push("/rewrite-to-dynamic")')
       await browser.waitForElementByCss('#blog')
@@ -376,10 +388,11 @@ describe('Middleware Runtime', () => {
 
     it('should have correct route params for chained rewrite from middleware to config rewrite', async () => {
       const browser = await webdriver(next.url, '/404')
-      await check(
-        () => browser.eval('next.router.isReady ? "yes" : "no"'),
-        'yes'
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval('next.router.isReady ? "yes" : "no"')
+        ).toEqual('yes')
+      })
       await browser.eval('window.beforeNav = 1')
       await browser.eval(
         'window.next.router.push("/rewrite-to-config-rewrite")'
@@ -427,17 +440,19 @@ describe('Middleware Runtime', () => {
 
     it('should have correct route params for rewrite from config non-dynamic route', async () => {
       const browser = await webdriver(next.url, '/404')
-      await check(
-        () => browser.eval('next.router.isReady ? "yes" : "nope"'),
-        'yes'
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval('next.router.isReady ? "yes" : "nope"')
+        ).toEqual('yes')
+      })
       await browser.eval('window.beforeNav = 1')
       await browser.eval('window.next.router.push("/rewrite-1")')
 
-      await check(
-        () => browser.eval('document.documentElement.innerHTML'),
-        /Hello World/
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval('document.documentElement.innerHTML')
+        ).toMatch(/Hello World/)
+      })
 
       expect(await browser.eval('window.next.router.query')).toEqual({
         from: 'config',
@@ -455,10 +470,10 @@ describe('Middleware Runtime', () => {
 
       const browser = await webdriver(next.url, `/`)
       await browser.eval(`next.router.push('/redirect-1')`)
-      await check(async () => {
+      await retry(async () => {
         const pathname = await browser.eval('location.pathname')
-        return pathname === '/somewhere/else' ? 'success' : pathname
-      }, 'success')
+        expect(pathname === '/somewhere/else').toBeTruthy()
+      })
     })
 
     it('should rewrite the same for direct visit and client-transition', async () => {
@@ -467,16 +482,17 @@ describe('Middleware Runtime', () => {
       expect(await res.text()).toContain('Hello World')
 
       const browser = await webdriver(next.url, `/404`)
-      await check(
-        () => browser.eval('next.router.isReady ? "yes" : "nope"'),
-        'yes'
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval('next.router.isReady ? "yes" : "nope"')
+        ).toEqual('yes')
+      })
       await browser.eval('window.beforeNav = 1')
       await browser.eval(`next.router.push('/rewrite-1')`)
-      await check(async () => {
+      await retry(async () => {
         const content = await browser.eval('document.documentElement.innerHTML')
-        return content.includes('Hello World') ? 'success' : content
-      }, 'success')
+        expect(content.includes('Hello World')).toBeTruthy()
+      })
       expect(await browser.eval('window.beforeNav')).toBe(1)
     })
 
@@ -487,10 +503,10 @@ describe('Middleware Runtime', () => {
 
       const browser = await webdriver(next.url, `/404`)
       await browser.eval(`next.router.push('/rewrite-2')`)
-      await check(async () => {
+      await retry(async () => {
         const content = await browser.eval('document.documentElement.innerHTML')
-        return content.includes('AboutA') ? 'success' : content
-      }, 'success')
+        expect(content.includes('AboutA')).toBeTruthy()
+      })
     })
 
     it('should respond with 400 on decode failure', async () => {

--- a/test/e2e/middleware-redirects/test/index.test.ts
+++ b/test/e2e/middleware-redirects/test/index.test.ts
@@ -3,7 +3,7 @@
 import { join } from 'path'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
-import { check, fetchViaHTTP } from 'next-test-utils'
+import { fetchViaHTTP, retry } from 'next-test-utils'
 import { NextInstance } from 'e2e-utils'
 import { createNext, FileRef } from 'e2e-utils'
 
@@ -70,12 +70,11 @@ describe('Middleware Redirect', () => {
 
       const browser = await webdriver(next.url, '/')
       await browser.elementByCss('#old-home-external').click()
-      await check(async () => {
+      await retry(async () => {
         expect(await browser.elementByCss('h1').text()).toEqual(
           'Example Domain'
         )
-        return 'yes'
-      }, 'yes')
+      })
     })
   }
 
@@ -150,7 +149,9 @@ describe('Middleware Redirect', () => {
       const browser = await webdriver(next.url, `${locale}`)
       await browser.elementByCss('#link-to-api-with-locale').click()
       await browser.waitForCondition('window.location.pathname === "/api/ok"')
-      await check(() => browser.elementByCss('body').text(), 'ok')
+      await retry(async () => {
+        expect(await browser.elementByCss('body').text()).toEqual('ok')
+      })
       const logs = await browser.log()
       const errors = logs
         .filter((x) => x.source === 'error')

--- a/test/e2e/middleware-shallow-link/index.test.ts
+++ b/test/e2e/middleware-shallow-link/index.test.ts
@@ -2,7 +2,7 @@ import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('browser-shallow-navigation', () => {
   let next: NextInstance
@@ -37,6 +37,10 @@ describe('browser-shallow-navigation', () => {
     await browser.elementByCss('[data-go-back]').click()
 
     // get page h1
-    await check(() => browser.elementByCss('h1').text(), /Content for page 1/)
+    await retry(async () => {
+      expect(await browser.elementByCss('h1').text()).toMatch(
+        /Content for page 1/
+      )
+    })
   })
 })

--- a/test/e2e/multi-zone/multi-zone.test.ts
+++ b/test/e2e/multi-zone/multi-zone.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check, waitFor } from 'next-test-utils'
+import { waitFor, retry } from 'next-test-utils'
 import path from 'path'
 
 describe('multi-zone', () => {
@@ -83,7 +83,9 @@ describe('multi-zone', () => {
       )
       await next.patchFile(filePath, patchedContent)
 
-      await check(() => browser.elementByCss('body').text(), /hmr content/)
+      await retry(async () => {
+        expect(await browser.elementByCss('body').text()).toMatch(/hmr content/)
+      })
 
       // restore original content
       await next.patchFile(filePath, content)

--- a/test/e2e/next-script/index.test.ts
+++ b/test/e2e/next-script/index.test.ts
@@ -1,7 +1,7 @@
 import webdriver, { BrowserInterface } from 'next-webdriver'
 import { createNext } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('beforeInteractive in document Head', () => {
   let next: NextInstance
@@ -360,14 +360,12 @@ describe('empty strategy in document body', () => {
           browser = await webdriver(next.url, '/')
 
           // Partytown modifies type to "text/partytown-x" after it has been executed in the web worker
-          await check(async () => {
+          await retry(async () => {
             const processedWorkerScripts = await browser.eval(
               `document.querySelectorAll('script[type="text/partytown-x"]').length`
             )
-            return processedWorkerScripts > 0
-              ? 'success'
-              : processedWorkerScripts
-          }, 'success')
+            expect(processedWorkerScripts > 0).toBeTruthy()
+          })
         } finally {
           if (browser) await browser.close()
         }
@@ -426,12 +424,12 @@ describe('empty strategy in document body', () => {
           browser = await webdriver(next.url, '/')
 
           // Partytown modifies type to "text/partytown-x" after it has been executed in the web worker
-          await check(async () => {
+          await retry(async () => {
             const processedWorkerScripts = await browser.eval(
               `document.querySelectorAll('script[type="text/partytown-x"]').length`
             )
-            return processedWorkerScripts + ''
-          }, '1')
+            expect((await processedWorkerScripts) + '').toEqual('1')
+          })
 
           const text = await browser.elementById('text').text()
           expect(text).toBe('abc')
@@ -451,12 +449,12 @@ describe('empty strategy in document body', () => {
           browser = await webdriver(next.url, '/')
 
           // Partytown modifies type to "text/partytown-x" after it has been executed in the web worker
-          await check(async () => {
+          await retry(async () => {
             const processedWorkerScripts = await browser.eval(
               `document.querySelectorAll('script[type="text/partytown-x"]').length`
             )
-            return processedWorkerScripts + ''
-          }, '1')
+            expect((await processedWorkerScripts) + '').toEqual('1')
+          })
 
           const text = await browser.elementById('text').text()
           expect(text).toBe('abcd')

--- a/test/e2e/nonce-head-manager/index.test.ts
+++ b/test/e2e/nonce-head-manager/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext, FileRef } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { NextInstance } from 'e2e-utils'
 import { join } from 'path'
@@ -20,37 +20,37 @@ describe('nonce head manager', () => {
 
   async function runTests(url) {
     const browser = await webdriver(next.url, url)
-    await check(
-      async () =>
-        await browser.eval(`JSON.stringify(window.scriptExecutionIds)`),
-      '["src-1.js"]'
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`JSON.stringify(window.scriptExecutionIds)`)
+      ).toEqual('["src-1.js"]')
+    })
 
     await browser.elementByCss('#force-rerender').click()
-    await check(
-      async () =>
-        await browser.eval(`document.getElementById('h1').textContent`),
-      'Count 1'
-    )
-    await check(
-      async () =>
-        await browser.eval(`JSON.stringify(window.scriptExecutionIds)`),
-      '["src-1.js"]'
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById('h1').textContent`)
+      ).toEqual('Count 1')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`JSON.stringify(window.scriptExecutionIds)`)
+      ).toEqual('["src-1.js"]')
+    })
 
     await browser.elementByCss('#change-script').click()
-    await check(
-      async () =>
-        await browser.eval(`JSON.stringify(window.scriptExecutionIds)`),
-      '["src-1.js","src-2.js"]'
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`JSON.stringify(window.scriptExecutionIds)`)
+      ).toEqual('["src-1.js","src-2.js"]')
+    })
 
     await browser.elementByCss('#change-script').click()
-    await check(
-      async () =>
-        await browser.eval(`JSON.stringify(window.scriptExecutionIds)`),
-      '["src-1.js","src-2.js","src-1.js"]'
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`JSON.stringify(window.scriptExecutionIds)`)
+      ).toEqual('["src-1.js","src-2.js","src-1.js"]')
+    })
   }
 
   it('should not re-execute the script when re-rendering', async () => {

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 import { SavedSpan } from './constants'
 import { type Collector, connectCollector } from './collector'
@@ -893,7 +893,7 @@ type HierSavedSpan = SavedSpan & { spans?: HierSavedSpan[] }
 type SpanMatch = Omit<Partial<HierSavedSpan>, 'spans'> & { spans?: SpanMatch[] }
 
 async function expectTrace(collector: Collector, match: SpanMatch[]) {
-  await check(async () => {
+  await retry(() => {
     const traces = collector.getSpans()
 
     const tree: HierSavedSpan[] = []
@@ -942,6 +942,5 @@ async function expectTrace(collector: Collector, match: SpanMatch[]) {
     })
 
     expect(tree).toMatchObject(match)
-    return 'success'
-  }, 'success')
+  })
 }

--- a/test/e2e/reload-scroll-backforward-restoration/index.test.ts
+++ b/test/e2e/reload-scroll-backforward-restoration/index.test.ts
@@ -1,6 +1,6 @@
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import assert from 'assert'
@@ -49,12 +49,13 @@ describe('reload-scroll-back-restoration', () => {
 
     // check restore value on history index: 1
     await browser.back()
-    await check(
-      () => browser.eval(() => document.documentElement.innerHTML),
-      /routeChangeComplete/
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(() => document.documentElement.innerHTML)
+      ).toMatch(/routeChangeComplete/)
+    })
 
-    await check(async () => {
+    await retry(async () => {
       assert.equal(
         scrollPositionMemories[1].x,
         Math.floor(await browser.eval(() => window.scrollX))
@@ -63,24 +64,24 @@ describe('reload-scroll-back-restoration', () => {
         scrollPositionMemories[1].y,
         Math.floor(await browser.eval(() => window.scrollY))
       )
-      return 'success'
-    }, 'success')
+    })
 
     await browser.refresh()
 
-    await check(async () => {
+    await retry(async () => {
       const isReady = await browser.eval('next.router.isReady')
-      return isReady ? 'success' : isReady
-    }, 'success')
+      expect(isReady).toBeTruthy()
+    })
 
     // check restore value on history index: 0
     await browser.back()
-    await check(
-      () => browser.eval(() => document.documentElement.innerHTML),
-      /routeChangeComplete/
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(() => document.documentElement.innerHTML)
+      ).toMatch(/routeChangeComplete/)
+    })
 
-    await check(async () => {
+    await retry(async () => {
       assert.equal(
         scrollPositionMemories[0].x,
         Math.floor(await browser.eval(() => window.scrollX))
@@ -89,8 +90,7 @@ describe('reload-scroll-back-restoration', () => {
         scrollPositionMemories[0].y,
         Math.floor(await browser.eval(() => window.scrollY))
       )
-      return 'success'
-    }, 'success')
+    })
   })
 
   it('should restore the scroll position on navigating forward', async () => {
@@ -130,12 +130,13 @@ describe('reload-scroll-back-restoration', () => {
     await browser.back()
     await browser.back()
     await browser.forward()
-    await check(
-      () => browser.eval(() => document.documentElement.innerHTML),
-      /routeChangeComplete/
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(() => document.documentElement.innerHTML)
+      ).toMatch(/routeChangeComplete/)
+    })
 
-    await check(async () => {
+    await retry(async () => {
       assert.equal(
         scrollPositionMemories[1].x,
         Math.floor(await browser.eval(() => window.scrollX))
@@ -144,24 +145,24 @@ describe('reload-scroll-back-restoration', () => {
         scrollPositionMemories[1].y,
         Math.floor(await browser.eval(() => window.scrollY))
       )
-      return 'success'
-    }, 'success')
+    })
 
     await browser.refresh()
 
-    await check(async () => {
+    await retry(async () => {
       const isReady = await browser.eval('next.router.isReady')
-      return isReady ? 'success' : isReady
-    }, 'success')
+      expect(isReady).toBeTruthy()
+    })
 
     // check restore value on history index: 2
     await browser.forward()
-    await check(
-      () => browser.eval(() => document.documentElement.innerHTML),
-      /routeChangeComplete/
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(() => document.documentElement.innerHTML)
+      ).toMatch(/routeChangeComplete/)
+    })
 
-    await check(async () => {
+    await retry(async () => {
       assert.equal(
         scrollPositionMemories[2].x,
         Math.floor(await browser.eval(() => window.scrollX))
@@ -170,7 +171,6 @@ describe('reload-scroll-back-restoration', () => {
         scrollPositionMemories[2].y,
         Math.floor(await browser.eval(() => window.scrollY))
       )
-      return 'success'
-    }, 'success')
+    })
   })
 })

--- a/test/e2e/repeated-forward-slashes-error/repeated-forward-slashes-error.test.ts
+++ b/test/e2e/repeated-forward-slashes-error/repeated-forward-slashes-error.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('repeated-forward-slashes-error', () => {
   const { next } = nextTestSetup({
@@ -8,7 +8,9 @@ describe('repeated-forward-slashes-error', () => {
 
   it('should log error when href has repeated forward-slashes', async () => {
     await next.render$('/my/path/name')
-    await check(() => next.cliOutput, /Invalid href/)
+    await retry(async () => {
+      expect(await next.cliOutput).toMatch(/Invalid href/)
+    })
     expect(next.cliOutput).toContain(
       "Invalid href '/hello//world' passed to next/router in page: '/my/path/[name]'. Repeated forward-slashes (//) or backslashes \\ are not valid in the href."
     )

--- a/test/e2e/socket-io/index.test.js
+++ b/test/e2e/socket-io/index.test.js
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('socket-io', () => {
   const { next } = nextTestSetup({
@@ -28,12 +28,16 @@ describe('socket-io', () => {
     const input2 = await browser2.elementByCss('input')
 
     await input1.fill('hello world')
-    await check(() => input2.inputValue(), /hello world/)
+    await retry(async () => {
+      expect(await input2.inputValue()).toMatch(/hello world/)
+    })
 
     const currentRequestsCount = requestsCount
 
     await input1.fill('123456')
-    await check(() => input2.inputValue(), /123456/)
+    await retry(async () => {
+      expect(await input2.inputValue()).toMatch(/123456/)
+    })
 
     // There should be no new requests (polling) and using the existing WS connection
     expect(requestsCount).toBe(currentRequestsCount)

--- a/test/e2e/ssr-react-context/index.test.ts
+++ b/test/e2e/ssr-react-context/index.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'path'
-import { renderViaHTTP, check } from 'next-test-utils'
+import { renderViaHTTP, retry } from 'next-test-utils'
 import { NextInstance } from 'e2e-utils'
 import { createNext, FileRef } from 'e2e-utils'
 
@@ -36,11 +36,19 @@ describe('React Context', () => {
       )
 
       try {
-        await check(() => renderViaHTTP(next.url, '/'), /Value: .*?new value/)
+        await retry(async () => {
+          expect(await renderViaHTTP(next.url, '/')).toMatch(
+            /Value: .*?new value/
+          )
+        })
       } finally {
         await next.patchFile(aboutAppPagePath, originalContent)
       }
-      await check(() => renderViaHTTP(next.url, '/'), /Value: .*?hello world/)
+      await retry(async () => {
+        expect(await renderViaHTTP(next.url, '/')).toMatch(
+          /Value: .*?hello world/
+        )
+      })
     })
   }
 })

--- a/test/e2e/streaming-ssr/index.test.ts
+++ b/test/e2e/streaming-ssr/index.test.ts
@@ -2,12 +2,12 @@ import { join } from 'path'
 import { createNext, nextTestSetup } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
 import {
-  check,
   fetchViaHTTP,
   findPort,
   initNextServerScript,
   killApp,
   renderViaHTTP,
+  retry,
 } from 'next-test-utils'
 
 const isNextProd = !(global as any).isNextDev && !(global as any).isNextDeploy
@@ -76,9 +76,9 @@ describe('streaming SSR with custom next configs', () => {
       }
     `
       )
-      await check(async () => {
-        return await renderViaHTTP(next.url, '/')
-      }, /index/)
+      await retry(async () => {
+        expect(await renderViaHTTP(next.url, '/')).toMatch(/index/)
+      })
       await next.deleteFile('pages/_document.js')
     })
   }

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -2,7 +2,7 @@
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check, fetchViaHTTP, renderViaHTTP, waitFor } from 'next-test-utils'
+import { fetchViaHTTP, renderViaHTTP, waitFor, retry } from 'next-test-utils'
 
 function splitLines(text) {
   return text
@@ -88,18 +88,20 @@ describe('Switchable runtime', () => {
         await browser.waitForElementByCss('a').click()
 
         // on /edge/[id]
-        await check(
-          () => browser.eval('document.documentElement.innerHTML'),
-          /to \/edge\/foo/
-        )
+        await retry(async () => {
+          expect(
+            await browser.eval('document.documentElement.innerHTML')
+          ).toMatch(/to \/edge\/foo/)
+        })
 
         await browser.waitForElementByCss('a').click()
 
         // on /edge/foo
-        await check(
-          () => browser.eval('document.documentElement.innerHTML'),
-          /to \/edge\/\[id\]/
-        )
+        await retry(async () => {
+          expect(
+            await browser.eval('document.documentElement.innerHTML')
+          ).toMatch(/to \/edge\/\[id\]/)
+        })
 
         expect(context.stdout).not.toContain('self is not defined')
         expect(context.stderr).not.toContain('self is not defined')
@@ -125,10 +127,11 @@ describe('Switchable runtime', () => {
           .click()
           .waitForElementByCss('.node-rsc-ssr')
 
-        await check(
-          () => browser.eval('document.documentElement.innerHTML'),
-          /This is a SSR RSC page/
-        )
+        await retry(async () => {
+          expect(
+            await browser.eval('document.documentElement.innerHTML')
+          ).toMatch(/This is a SSR RSC page/)
+        })
         expect(flightRequest).toContain('/node-rsc-ssr')
       })
 
@@ -140,10 +143,11 @@ describe('Switchable runtime', () => {
           .click()
           .waitForElementByCss('.node-rsc-ssg')
 
-        await check(
-          () => browser.eval('document.documentElement.innerHTML'),
-          /This is a SSG RSC page/
-        )
+        await retry(async () => {
+          expect(
+            await browser.eval('document.documentElement.innerHTML')
+          ).toMatch(/This is a SSG RSC page/)
+        })
       })
 
       it.skip('should support client side navigation to static rsc pages', async () => {
@@ -154,10 +158,11 @@ describe('Switchable runtime', () => {
           .click()
           .waitForElementByCss('.node-rsc')
 
-        await check(
-          () => browser.eval('document.documentElement.innerHTML'),
-          /This is a static RSC page/
-        )
+        await retry(async () => {
+          expect(
+            await browser.eval('document.documentElement.innerHTML')
+          ).toMatch(/This is a static RSC page/)
+        })
       })
 
       it('should not consume server.js file extension', async () => {
@@ -179,10 +184,11 @@ describe('Switchable runtime', () => {
       })
 
       it('should be possible to switch between runtimes in API routes', async () => {
-        await check(
-          () => renderViaHTTP(next.url, '/api/switch-in-dev'),
-          'server response'
-        )
+        await retry(async () => {
+          expect(await renderViaHTTP(next.url, '/api/switch-in-dev')).toEqual(
+            'server response'
+          )
+        })
 
         // Edge
         await next.patchFile(
@@ -195,10 +201,11 @@ describe('Switchable runtime', () => {
           export default () => new Response('edge response')
           `
         )
-        await check(
-          () => renderViaHTTP(next.url, '/api/switch-in-dev'),
-          'edge response'
-        )
+        await retry(async () => {
+          expect(await renderViaHTTP(next.url, '/api/switch-in-dev')).toEqual(
+            'edge response'
+          )
+        })
 
         // Server
         await next.patchFile(
@@ -209,10 +216,11 @@ describe('Switchable runtime', () => {
           }
           `
         )
-        await check(
-          () => renderViaHTTP(next.url, '/api/switch-in-dev'),
-          'server response again'
-        )
+        await retry(async () => {
+          expect(await renderViaHTTP(next.url, '/api/switch-in-dev')).toEqual(
+            'server response again'
+          )
+        })
 
         // Edge
         await next.patchFile(
@@ -225,17 +233,19 @@ describe('Switchable runtime', () => {
           export default () => new Response('edge response again')
           `
         )
-        await check(
-          () => renderViaHTTP(next.url, '/api/switch-in-dev'),
-          'edge response again'
-        )
+        await retry(async () => {
+          expect(await renderViaHTTP(next.url, '/api/switch-in-dev')).toEqual(
+            'edge response again'
+          )
+        })
       })
 
       it('should be possible to switch between runtimes in pages', async () => {
-        await check(
-          () => renderViaHTTP(next.url, '/switch-in-dev'),
-          /Hello from edge page/
-        )
+        await retry(async () => {
+          expect(await renderViaHTTP(next.url, '/switch-in-dev')).toMatch(
+            /Hello from edge page/
+          )
+        })
 
         // Server
         await next.patchFile(
@@ -246,10 +256,11 @@ describe('Switchable runtime', () => {
           }
           `
         )
-        await check(
-          () => renderViaHTTP(next.url, '/switch-in-dev'),
-          /Hello from server page/
-        )
+        await retry(async () => {
+          expect(await renderViaHTTP(next.url, '/switch-in-dev')).toMatch(
+            /Hello from server page/
+          )
+        })
 
         // Edge
         await next.patchFile(
@@ -264,10 +275,11 @@ describe('Switchable runtime', () => {
       }
       `
         )
-        await check(
-          () => renderViaHTTP(next.url, '/switch-in-dev'),
-          /Hello from edge page again/
-        )
+        await retry(async () => {
+          expect(await renderViaHTTP(next.url, '/switch-in-dev')).toMatch(
+            /Hello from edge page again/
+          )
+        })
 
         // Server
         await next.patchFile(
@@ -278,10 +290,11 @@ describe('Switchable runtime', () => {
             }
             `
         )
-        await check(
-          () => renderViaHTTP(next.url, '/switch-in-dev'),
-          /Hello from server page again/
-        )
+        await retry(async () => {
+          expect(await renderViaHTTP(next.url, '/switch-in-dev')).toMatch(
+            /Hello from server page again/
+          )
+        })
       })
 
       // Doesn't work, see https://github.com/vercel/next.js/pull/39327
@@ -290,10 +303,11 @@ describe('Switchable runtime', () => {
           'pages/api/switch-in-dev-same-content.js'
         )
         console.log({ fileContent })
-        await check(
-          () => renderViaHTTP(next.url, '/api/switch-in-dev-same-content'),
-          'server response'
-        )
+        await retry(async () => {
+          expect(
+            await renderViaHTTP(next.url, '/api/switch-in-dev-same-content')
+          ).toEqual('server response')
+        })
 
         // Edge
         await next.patchFile(
@@ -306,28 +320,31 @@ describe('Switchable runtime', () => {
           export default () => new Response('edge response')
           `
         )
-        await check(
-          () => renderViaHTTP(next.url, '/api/switch-in-dev-same-content'),
-          'edge response'
-        )
+        await retry(async () => {
+          expect(
+            await renderViaHTTP(next.url, '/api/switch-in-dev-same-content')
+          ).toEqual('edge response')
+        })
 
         // Server - same content as first compilation of the server runtime version
         await next.patchFile(
           'pages/api/switch-in-dev-same-content.js',
           fileContent
         )
-        await check(
-          () => renderViaHTTP(next.url, '/api/switch-in-dev-same-content'),
-          'server response'
-        )
+        await retry(async () => {
+          expect(
+            await renderViaHTTP(next.url, '/api/switch-in-dev-same-content')
+          ).toEqual('server response')
+        })
       })
 
       // TODO: investigate these failures
       it.skip('should recover from syntax error when using edge runtime', async () => {
-        await check(
-          () => renderViaHTTP(next.url, '/api/syntax-error-in-dev'),
-          'edge response'
-        )
+        await retry(async () => {
+          expect(
+            await renderViaHTTP(next.url, '/api/syntax-error-in-dev')
+          ).toEqual('edge response')
+        })
 
         // Syntax error
         await next.patchFile(
@@ -340,10 +357,11 @@ describe('Switchable runtime', () => {
         export default  => new Response('edge response')
         `
         )
-        await check(
-          () => renderViaHTTP(next.url, '/api/syntax-error-in-dev'),
-          /Unexpected token/
-        )
+        await retry(async () => {
+          expect(
+            await renderViaHTTP(next.url, '/api/syntax-error-in-dev')
+          ).toMatch(/Unexpected token/)
+        })
 
         // Fix syntax error
         await next.patchFile(
@@ -357,17 +375,19 @@ describe('Switchable runtime', () => {
 
         `
         )
-        await check(
-          () => renderViaHTTP(next.url, '/api/syntax-error-in-dev'),
-          'edge response again'
-        )
+        await retry(async () => {
+          expect(
+            await renderViaHTTP(next.url, '/api/syntax-error-in-dev')
+          ).toEqual('edge response again')
+        })
       })
 
       it.skip('should not crash the dev server when invalid runtime is configured', async () => {
-        await check(
-          () => renderViaHTTP(next.url, '/invalid-runtime'),
-          /Hello from page without errors/
-        )
+        await retry(async () => {
+          expect(await renderViaHTTP(next.url, '/invalid-runtime')).toMatch(
+            /Hello from page without errors/
+          )
+        })
 
         // Invalid runtime type
         await next.patchFile(
@@ -382,10 +402,11 @@ describe('Switchable runtime', () => {
           }
             `
         )
-        await check(
-          () => renderViaHTTP(next.url, '/invalid-runtime'),
-          /Hello from page with invalid type/
-        )
+        await retry(async () => {
+          expect(await renderViaHTTP(next.url, '/invalid-runtime')).toMatch(
+            /Hello from page with invalid type/
+          )
+        })
         expect(next.cliOutput).toInclude(
           'The `runtime` config must be a string. Please leave it empty or choose one of:'
         )
@@ -403,10 +424,11 @@ describe('Switchable runtime', () => {
             }
               `
         )
-        await check(
-          () => renderViaHTTP(next.url, '/invalid-runtime'),
-          /Hello from page with invalid runtime/
-        )
+        await retry(async () => {
+          expect(await renderViaHTTP(next.url, '/invalid-runtime')).toMatch(
+            /Hello from page with invalid runtime/
+          )
+        })
         expect(next.cliOutput).toInclude(
           'Provided runtime "asd" is not supported. Please leave it empty or choose one of:'
         )
@@ -425,10 +447,11 @@ describe('Switchable runtime', () => {
 
         `
         )
-        await check(
-          () => renderViaHTTP(next.url, '/invalid-runtime'),
-          /Hello from page without errors/
-        )
+        await retry(async () => {
+          expect(await renderViaHTTP(next.url, '/invalid-runtime')).toMatch(
+            /Hello from page without errors/
+          )
+        })
       })
 
       it.skip('should give proper errors for invalid runtime in app dir', async () => {
@@ -442,10 +465,11 @@ describe('Switchable runtime', () => {
           export const runtime = 'invalid-runtime'
           `
         )
-        await check(
-          () => renderViaHTTP(next.url, '/app-invalid-runtime'),
-          /Hello from app/
-        )
+        await retry(async () => {
+          expect(await renderViaHTTP(next.url, '/app-invalid-runtime')).toMatch(
+            /Hello from app/
+          )
+        })
         expect(next.cliOutput).toInclude(
           'Provided runtime "invalid-runtime" is not supported. Please leave it empty or choose one of:'
         )
@@ -535,13 +559,11 @@ describe('Switchable runtime', () => {
         await waitFor(4000)
         await renderViaHTTP(context.appPort, '/node-rsc-isr')
 
-        await check(async () => {
+        await retry(async () => {
           const html3 = await renderViaHTTP(context.appPort, '/node-rsc-isr')
           const renderedAt3 = +html3.match(/Time: (\d+)/)[1]
-          return renderedAt2 < renderedAt3
-            ? 'success'
-            : `${renderedAt2} should be less than ${renderedAt3}`
-        }, 'success')
+          expect(renderedAt2 < renderedAt3).toBeTruthy()
+        })
       })
 
       it('should build /edge as a dynamic page with the edge runtime', async () => {

--- a/test/integration/404-page/test/index.test.js
+++ b/test/integration/404-page/test/index.test.js
@@ -12,7 +12,7 @@ import {
   fetchViaHTTP,
   waitFor,
   getPageFileFromPagesManifest,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '../')
@@ -116,7 +116,9 @@ describe('404 Page Support', () => {
       })
       await renderViaHTTP(appPort, '/abc')
       try {
-        await check(() => stderr, gip404Err)
+        await retry(async () => {
+          expect(await stderr).toMatch(gip404Err)
+        })
       } finally {
         await killApp(app)
 

--- a/test/integration/amphtml/test/index.test.js
+++ b/test/integration/amphtml/test/index.test.js
@@ -4,7 +4,6 @@ import { validateAMP } from 'amp-test-utils'
 import cheerio from 'cheerio'
 import { readFileSync, writeFileSync, rename } from 'fs-extra'
 import {
-  check,
   findPort,
   getBrowserBodyText,
   killApp,
@@ -13,6 +12,7 @@ import {
   nextStart,
   renderViaHTTP,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -344,18 +344,20 @@ describe('AMP Usage', () => {
         // change the content
         writeFileSync(hmrTestPagePath, editedContent, 'utf8')
 
-        await check(
-          () => getBrowserBodyText(browser),
-          /This is a cold AMP page/
-        )
+        await retry(async () => {
+          expect(await getBrowserBodyText(browser)).toMatch(
+            /This is a cold AMP page/
+          )
+        })
 
         // add the original content
         writeFileSync(hmrTestPagePath, originalContent, 'utf8')
 
-        await check(
-          () => getBrowserBodyText(browser),
-          /This is the hot AMP page/
-        )
+        await retry(async () => {
+          expect(await getBrowserBodyText(browser)).toMatch(
+            /This is the hot AMP page/
+          )
+        })
       } finally {
         await browser.close()
       }
@@ -379,12 +381,16 @@ describe('AMP Usage', () => {
         // change the content
         writeFileSync(hmrTestPagePath, editedContent, 'utf8')
 
-        await check(() => getBrowserBodyText(browser), /replaced it!/)
+        await retry(async () => {
+          expect(await getBrowserBodyText(browser)).toMatch(/replaced it!/)
+        })
 
         // add the original content
         writeFileSync(hmrTestPagePath, originalContent, 'utf8')
 
-        await check(() => getBrowserBodyText(browser), /I'm an AMP page!/)
+        await retry(async () => {
+          expect(await getBrowserBodyText(browser)).toMatch(/I'm an AMP page!/)
+        })
       } finally {
         await browser.close()
       }
@@ -392,7 +398,11 @@ describe('AMP Usage', () => {
 
     it.skip('should detect changes to component and refresh an AMP page', async () => {
       const browser = await webdriver(dynamicAppPort, '/hmr/comp')
-      await check(() => browser.elementByCss('#hello-comp').text(), /hello/)
+      await retry(async () => {
+        expect(await browser.elementByCss('#hello-comp').text()).toMatch(
+          /hello/
+        )
+      })
 
       const testComp = join(__dirname, '../components/hello.js')
 
@@ -400,10 +410,16 @@ describe('AMP Usage', () => {
       const newContent = origContent.replace('>hello<', '>hi<')
 
       writeFileSync(testComp, newContent, 'utf8')
-      await check(() => browser.elementByCss('#hello-comp').text(), /hi/)
+      await retry(async () => {
+        expect(await browser.elementByCss('#hello-comp').text()).toMatch(/hi/)
+      })
 
       writeFileSync(testComp, origContent, 'utf8')
-      await check(() => browser.elementByCss('#hello-comp').text(), /hello/)
+      await retry(async () => {
+        expect(await browser.elementByCss('#hello-comp').text()).toMatch(
+          /hello/
+        )
+      })
     })
 
     it.skip('should not reload unless the page is edited for an AMP page', async () => {
@@ -414,7 +430,11 @@ describe('AMP Usage', () => {
         await renderViaHTTP(dynamicAppPort, '/hmr/test')
 
         browser = await webdriver(dynamicAppPort, '/hmr/amp')
-        await check(() => browser.elementByCss('p').text(), /I'm an AMP page!/)
+        await retry(async () => {
+          expect(await browser.elementByCss('p').text()).toMatch(
+            /I'm an AMP page!/
+          )
+        })
 
         const origDate = await browser.elementByCss('span').text()
 
@@ -449,12 +469,16 @@ describe('AMP Usage', () => {
         // change the content
         writeFileSync(otherHmrTestPage, otherEditedContent, 'utf8')
 
-        await check(() => getBrowserBodyText(browser), /replaced it!/)
+        await retry(async () => {
+          expect(await getBrowserBodyText(browser)).toMatch(/replaced it!/)
+        })
 
         // restore original content
         writeFileSync(otherHmrTestPage, otherOrigContent, 'utf8')
 
-        await check(() => getBrowserBodyText(browser), /I'm an AMP page!/)
+        await retry(async () => {
+          expect(await getBrowserBodyText(browser)).toMatch(/I'm an AMP page!/)
+        })
       } finally {
         writeFileSync(hmrTestPagePath, originalContent, 'utf8')
         await browser.close()
@@ -485,12 +509,18 @@ describe('AMP Usage', () => {
         // change the content
         writeFileSync(hmrTestPagePath, editedContent, 'utf8')
 
-        await check(() => getBrowserBodyText(browser), /replaced it!/)
+        await retry(async () => {
+          expect(await getBrowserBodyText(browser)).toMatch(/replaced it!/)
+        })
 
         // add the original content
         writeFileSync(hmrTestPagePath, originalContent, 'utf8')
 
-        await check(() => getBrowserBodyText(browser), /I'm a hybrid AMP page!/)
+        await retry(async () => {
+          expect(await getBrowserBodyText(browser)).toMatch(
+            /I'm a hybrid AMP page!/
+          )
+        })
       } finally {
         await browser.close()
       }
@@ -514,12 +544,16 @@ describe('AMP Usage', () => {
         // change the content
         writeFileSync(hmrTestPagePath, editedContent, 'utf8')
 
-        await check(() => getBrowserBodyText(browser), /replaced it!/)
+        await retry(async () => {
+          expect(await getBrowserBodyText(browser)).toMatch(/replaced it!/)
+        })
 
         // add the original content
         writeFileSync(hmrTestPagePath, originalContent, 'utf8')
 
-        await check(() => getBrowserBodyText(browser), /I'm an AMP page!/)
+        await retry(async () => {
+          expect(await getBrowserBodyText(browser)).toMatch(/I'm an AMP page!/)
+        })
       } finally {
         await browser.close()
       }

--- a/test/integration/app-dir-export/test/start.test.ts
+++ b/test/integration/app-dir-export/test/start.test.ts
@@ -3,12 +3,12 @@
 import { join } from 'path'
 import fs from 'fs-extra'
 import {
-  check,
   File,
   findPort,
   killApp,
   nextBuild,
   nextStart,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -38,7 +38,9 @@ describe('app dir - with output export (next start)', () => {
             stderr += msg || ''
           },
         })
-        await check(() => stderr, /error/i)
+        await retry(async () => {
+          expect(await stderr).toMatch(/error/i)
+        })
         expect(stderr).toContain(
           '"next start" does not work with "output: export" configuration. Use "npx serve@latest out" instead.'
         )
@@ -59,7 +61,10 @@ describe('app dir - with output export (next start)', () => {
               stderr += msg || ''
             },
           })
-          await check(() => stderr, /⚠/i)
+          await retry(async () => {
+            // eslint-disable-next-line jest/no-standalone-expect
+            expect(await stderr).toMatch(/⚠/i)
+          })
           // eslint-disable-next-line jest/no-standalone-expect
           expect(stderr).toContain(
             `"next start" does not work with "output: standalone" configuration. Use "node .next/standalone/server.js" instead.`

--- a/test/integration/app-dir-export/test/utils.ts
+++ b/test/integration/app-dir-export/test/utils.ts
@@ -6,7 +6,6 @@ import fs from 'fs-extra'
 import webdriver from 'next-webdriver'
 import globOrig from 'glob'
 import {
-  check,
   fetchViaHTTP,
   File,
   findPort,
@@ -18,6 +17,7 @@ import {
   nextBuild,
   startStaticServer,
   stopApp,
+  retry,
 } from 'next-test-utils'
 
 const glob = promisify(globOrig)
@@ -159,58 +159,80 @@ export async function runTests({
         const source = await getRedboxSource(browser)
         expect(`${header}\n${source}`).toContain(expectedErrMsg)
       } else {
-        await check(() => result.stderr, /error/i)
+        await retry(async () => {
+          expect(await result.stderr).toMatch(/error/i)
+        })
       }
       expect(result.stderr).toMatch(expectedErrMsg)
     } else {
       const a = (n: number) => `li:nth-child(${n}) a`
       const browser = await webdriver(port, '/')
-      await check(() => browser.elementByCss('h1').text(), 'Home')
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toEqual('Home')
+      })
       expect(await browser.elementByCss(a(1)).text()).toBe(
         'another no trailingslash'
       )
       await browser.elementByCss(a(1)).click()
 
-      await check(() => browser.elementByCss('h1').text(), 'Another')
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toEqual('Another')
+      })
       expect(await browser.elementByCss(a(1)).text()).toBe(
         'Visit the home page'
       )
       await browser.elementByCss(a(1)).click()
 
-      await check(() => browser.elementByCss('h1').text(), 'Home')
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toEqual('Home')
+      })
       expect(await browser.elementByCss(a(2)).text()).toBe(
         'another has trailingslash'
       )
       await browser.elementByCss(a(2)).click()
 
-      await check(() => browser.elementByCss('h1').text(), 'Another')
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toEqual('Another')
+      })
       expect(await browser.elementByCss(a(1)).text()).toBe(
         'Visit the home page'
       )
       await browser.elementByCss(a(1)).click()
 
-      await check(() => browser.elementByCss('h1').text(), 'Home')
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toEqual('Home')
+      })
       expect(await browser.elementByCss(a(3)).text()).toBe('another first page')
       await browser.elementByCss(a(3)).click()
-      await check(() => browser.elementByCss('h1').text(), 'first')
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toEqual('first')
+      })
       expect(await browser.elementByCss(a(1)).text()).toBe('Visit another page')
       await browser.elementByCss(a(1)).click()
 
-      await check(() => browser.elementByCss('h1').text(), 'Another')
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toEqual('Another')
+      })
       expect(await browser.elementByCss(a(4)).text()).toBe(
         'another second page'
       )
       await browser.elementByCss(a(4)).click()
 
-      await check(() => browser.elementByCss('h1').text(), 'second')
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toEqual('second')
+      })
       expect(await browser.elementByCss(a(1)).text()).toBe('Visit another page')
       await browser.elementByCss(a(1)).click()
 
-      await check(() => browser.elementByCss('h1').text(), 'Another')
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toEqual('Another')
+      })
       expect(await browser.elementByCss(a(5)).text()).toBe('image import page')
       await browser.elementByCss(a(5)).click()
 
-      await check(() => browser.elementByCss('h1').text(), 'Image Import')
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toEqual('Image Import')
+      })
       expect(await browser.elementByCss(a(2)).text()).toBe('View the image')
       expect(await browser.elementByCss(a(2)).getAttribute('href')).toMatch(
         /\/test\.(.*)\.png/

--- a/test/integration/app-document-add-hmr/test/index.test.js
+++ b/test/integration/app-document-add-hmr/test/index.test.js
@@ -3,7 +3,7 @@
 import fs from 'fs-extra'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { killApp, findPort, launchApp, check } from 'next-test-utils'
+import { killApp, findPort, launchApp, retry } from 'next-test-utils'
 
 const appDir = join(__dirname, '../')
 const appPage = join(appDir, 'pages/_app.js')
@@ -41,20 +41,20 @@ describe('_app/_document add HMR', () => {
       `
       )
 
-      await check(async () => {
+      await retry(async () => {
         const html = await browser.eval('document.documentElement.innerHTML')
-        return html.includes('custom _app') && html.includes('index page')
-          ? 'success'
-          : html
-      }, 'success')
+        expect(
+          html.includes('custom _app') && html.includes('index page')
+        ).toBeTruthy()
+      })
     } finally {
       await fs.remove(appPage)
-      await check(async () => {
+      await retry(async () => {
         const html = await browser.eval('document.documentElement.innerHTML')
-        return !html.includes('custom _app') && html.includes('index page')
-          ? 'restored'
-          : html
-      }, 'restored')
+        expect(
+          !html.includes('custom _app') && html.includes('index page')
+        ).toBeTruthy()
+      })
     }
   })
 
@@ -96,20 +96,20 @@ describe('_app/_document add HMR', () => {
       `
       )
 
-      await check(async () => {
+      await retry(async () => {
         const html = await browser.eval('document.documentElement.innerHTML')
-        return html.includes('custom _document') && html.includes('index page')
-          ? 'success'
-          : html
-      }, 'success')
+        expect(
+          html.includes('custom _document') && html.includes('index page')
+        ).toBeTruthy()
+      })
     } finally {
       await fs.remove(documentPage)
-      await check(async () => {
+      await retry(async () => {
         const html = await browser.eval('document.documentElement.innerHTML')
-        return !html.includes('custom _document') && html.includes('index page')
-          ? 'restored'
-          : html
-      }, 'restored')
+        expect(
+          !html.includes('custom _document') && html.includes('index page')
+        ).toBeTruthy()
+      })
     }
   })
 })

--- a/test/integration/app-document-remove-hmr/test/index.test.js
+++ b/test/integration/app-document-remove-hmr/test/index.test.js
@@ -3,7 +3,7 @@
 import fs from 'fs-extra'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { killApp, findPort, launchApp, check } from 'next-test-utils'
+import { killApp, findPort, launchApp, retry } from 'next-test-utils'
 
 const appDir = join(__dirname, '../')
 const appPage = join(appDir, 'pages/_app.js')
@@ -30,12 +30,12 @@ describe('_app removal HMR', () => {
 
       await fs.rename(appPage, appPage + '.bak')
 
-      await check(async () => {
+      await retry(async () => {
         const html = await browser.eval('document.documentElement.innerHTML')
-        return html.includes('index page') && !html.includes('custom _app')
-          ? 'success'
-          : html
-      }, 'success')
+        expect(
+          html.includes('index page') && !html.includes('custom _app')
+        ).toBeTruthy()
+      })
 
       await fs.writeFile(
         indexPage,
@@ -46,23 +46,23 @@ describe('_app removal HMR', () => {
       `
       )
 
-      await check(async () => {
+      await retry(async () => {
         const html = await browser.eval('document.documentElement.innerHTML')
-        return html.includes('index page updated') &&
-          !html.includes('custom _app')
-          ? 'success'
-          : html
-      }, 'success')
+
+        expect(
+          html.includes('index page updated') && !html.includes('custom _app')
+        ).toBeTruthy()
+      })
 
       await fs.rename(appPage + '.bak', appPage)
 
-      await check(async () => {
+      await retry(async () => {
         const html = await browser.eval('document.documentElement.innerHTML')
-        return html.includes('index page updated') &&
-          html.includes('custom _app')
-          ? 'success'
-          : html
-      }, 'success')
+
+        expect(
+          html.includes('index page updated') && html.includes('custom _app')
+        ).toBeTruthy()
+      })
     } finally {
       await fs.writeFile(indexPage, indexContent)
 
@@ -82,12 +82,12 @@ describe('_app removal HMR', () => {
 
       await fs.rename(documentPage, documentPage + '.bak')
 
-      await check(async () => {
+      await retry(async () => {
         const html = await browser.eval('document.documentElement.innerHTML')
-        return html.includes('index page') && !html.includes('custom _document')
-          ? 'success'
-          : html
-      }, 'success')
+        expect(
+          html.includes('index page') && !html.includes('custom _document')
+        ).toBeTruthy()
+      })
 
       await fs.writeFile(
         indexPage,
@@ -98,23 +98,25 @@ describe('_app removal HMR', () => {
       `
       )
 
-      await check(async () => {
+      await retry(async () => {
         const html = await browser.eval('document.documentElement.innerHTML')
-        return html.includes('index page updated') &&
-          !html.includes('custom _document')
-          ? 'success'
-          : html
-      }, 'success')
+
+        expect(
+          html.includes('index page updated') &&
+            !html.includes('custom _document')
+        ).toBeTruthy()
+      })
 
       await fs.rename(documentPage + '.bak', documentPage)
 
-      await check(async () => {
+      await retry(async () => {
         const html = await browser.eval('document.documentElement.innerHTML')
-        return html.includes('index page updated') &&
-          html.includes('custom _document')
-          ? 'success'
-          : html
-      }, 'success')
+
+        expect(
+          html.includes('index page updated') &&
+            html.includes('custom _document')
+        ).toBeTruthy()
+      })
     } finally {
       await fs.writeFile(indexPage, indexContent)
 

--- a/test/integration/auto-export/test/index.test.js
+++ b/test/integration/auto-export/test/index.test.js
@@ -8,7 +8,7 @@ import {
   findPort,
   killApp,
   launchApp,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = path.join(__dirname, '..')
@@ -34,17 +34,22 @@ const runTests = () => {
 
   it('Refreshes query on mount', async () => {
     const browser = await webdriver(appPort, '/post-1')
-    await check(() => browser.eval('document.body.innerHTML'), /post.*post-1/)
+    await retry(async () => {
+      expect(await browser.eval('document.body.innerHTML')).toMatch(
+        /post.*post-1/
+      )
+    })
     const html = await browser.eval('document.body.innerHTML')
     expect(html).toMatch(/nextExport/)
   })
 
   it('should update asPath after mount', async () => {
     const browser = await webdriver(appPort, '/zeit/cmnt-2')
-    await check(
-      () => browser.eval(`document.documentElement.innerHTML`),
-      /\/zeit\/cmnt-2/
-    )
+    await retry(async () => {
+      expect(await browser.eval(`document.documentElement.innerHTML`)).toMatch(
+        /\/zeit\/cmnt-2/
+      )
+    })
   })
 
   it('should not replace URL with page name while asPath is delayed', async () => {

--- a/test/integration/build-indicator/test/index.test.js
+++ b/test/integration/build-indicator/test/index.test.js
@@ -3,7 +3,7 @@
 import fs from 'fs-extra'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { findPort, launchApp, killApp, waitFor, check } from 'next-test-utils'
+import { findPort, launchApp, killApp, waitFor, retry } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
 const appDir = join(__dirname, '..')
@@ -47,12 +47,13 @@ describe('Build Activity Indicator', () => {
     })
     await fs.remove(configPath)
 
-    await check(
-      () => stripAnsi(stderr),
-      new RegExp(
-        `Invalid "devIndicator.buildActivityPosition" provided, expected one of top-left, top-right, bottom-left, bottom-right, received ttop-leff`
+    await retry(async () => {
+      expect(await stripAnsi(stderr)).toMatch(
+        new RegExp(
+          `Invalid "devIndicator.buildActivityPosition" provided, expected one of top-left, top-right, bottom-left, bottom-right, received ttop-leff`
+        )
       )
-    )
+    })
 
     if (app) {
       await killApp(app)

--- a/test/integration/client-shallow-routing/test/index.test.js
+++ b/test/integration/client-shallow-routing/test/index.test.js
@@ -8,8 +8,8 @@ import {
   killApp,
   nextBuild,
   nextStart,
-  check,
   waitFor,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '../')
@@ -38,7 +38,9 @@ const runTests = () => {
     await browser.elementByCss('#to-another').click()
     await waitFor(1000)
 
-    await check(() => browser.elementByCss('#props').text(), /another/)
+    await retry(async () => {
+      expect(await browser.elementByCss('#props').text()).toMatch(/another/)
+    })
 
     const props4 = JSON.parse(await browser.elementByCss('#props').text())
     expect(props4.params).toEqual({ slug: 'another' })

--- a/test/integration/config-devtool-dev/test/index.test.js
+++ b/test/integration/config-devtool-dev/test/index.test.js
@@ -1,12 +1,12 @@
 /* eslint-env jest */
 
 import {
-  check,
   findPort,
   getRedboxSource,
   hasRedbox,
   killApp,
   launchApp,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -28,11 +28,9 @@ const appDir = join(__dirname, '../')
         },
       })
 
-      const found = await check(
-        () => stderr,
-        /Reverting webpack devtool to /,
-        false
-      )
+      const found = await retry(async () => {
+        expect(await stderr).toMatch(/Reverting webpack devtool to /)
+      })
 
       const browser = await webdriver(appPort, '/')
       expect(await hasRedbox(browser)).toBe(true)

--- a/test/integration/config-experimental-warning/test/index.test.js
+++ b/test/integration/config-experimental-warning/test/index.test.js
@@ -8,7 +8,7 @@ import {
   File,
   nextBuild,
   nextStart,
-  check,
+  retry,
 } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
@@ -197,7 +197,7 @@ describe('Config Experimental Warning', () => {
           },
         })
 
-        await check(() => {
+        await retry(() => {
           const cliOutput = stripAnsi(stdout)
           const cliOutputErr = stripAnsi(stderr)
           expect(cliOutput).not.toContain(experimentalHeader)

--- a/test/integration/create-next-app/prompts.test.ts
+++ b/test/integration/create-next-app/prompts.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'path'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { createNextApp, projectFilesShouldExist, useTempDir } from './utils'
 
 let testVersion
@@ -152,7 +152,11 @@ describe.skip('create-next-app prompts', () => {
         // cursor forward, choose 'Yes' for custom import alias
         childProcess.stdin.write('\u001b[C\n')
         // used check here since it needs to wait for the prompt
-        await check(() => output, /What import alias would you like configured/)
+        await retry(async () => {
+          expect(await output).toMatch(
+            /What import alias would you like configured/
+          )
+        })
         childProcess.stdin.write('@/something/*\n')
       })
 

--- a/test/integration/css/test/css-modules.test.js
+++ b/test/integration/css/test/css-modules.test.js
@@ -2,7 +2,6 @@
 import cheerio from 'cheerio'
 import { readdir, readFile, remove } from 'fs-extra'
 import {
-  check,
   File,
   findPort,
   killApp,
@@ -11,6 +10,7 @@ import {
   nextStart,
   renderViaHTTP,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -271,20 +271,20 @@ useLightningcss: ${useLightningcss}
         const cssFile = new File(join(appDir, 'pages/index.module.css'))
         try {
           cssFile.replace('color: yellow;', 'color: rgb(1, 1, 1);')
-          await check(
-            () =>
-              browser.eval(
+          await retry(async () => {
+            expect(
+              await browser.eval(
                 `window.getComputedStyle(document.querySelector('#yellowText')).color`
-              ),
-            'rgb(1, 1, 1)'
-          )
-          await check(
-            () =>
-              browser.eval(
+              )
+            ).toEqual('rgb(1, 1, 1)')
+          })
+          await retry(async () => {
+            expect(
+              await browser.eval(
                 `window.getComputedStyle(document.querySelector('#blueText')).color`
-              ),
-            'rgb(0, 0, 255)'
-          )
+              )
+            ).toEqual('rgb(0, 0, 255)')
+          })
         } finally {
           cssFile.restore()
         }

--- a/test/integration/css/test/css-rendering.test.js
+++ b/test/integration/css/test/css-rendering.test.js
@@ -1,13 +1,13 @@
 /* eslint-env jest */
 import { pathExists, readFile, readJSON, remove } from 'fs-extra'
 import {
-  check,
   findPort,
   File,
   killApp,
   nextBuild,
   nextStart,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -256,11 +256,11 @@ module.exports = {
 
             // Navigate to other:
             await browser.waitForElementByCss('#link-other').click()
-            await check(
-              () => browser.eval(`document.body.innerText`),
-              'Application error: a client-side exception has occurred (see the browser console for more information).',
-              true
-            )
+            await retry(async () => {
+              expect(await browser.eval(`document.body.innerText`)).toEqual(
+                'Application error: a client-side exception has occurred (see the browser console for more information).'
+              )
+            })
 
             const newPageStyles = await browser.eval(
               `document.querySelector('link[rel=stylesheet][data-n-p]')`
@@ -418,10 +418,11 @@ module.exports = {
           const browser = await webdriver(appPort, '/')
           try {
             await checkBlackTitle(browser)
-            await check(
-              () => browser.eval(`document.querySelector('p').innerText`),
-              'mounted'
-            )
+            await retry(async () => {
+              expect(
+                await browser.eval(`document.querySelector('p').innerText`)
+              ).toEqual('mounted')
+            })
           } finally {
             await browser.close()
           }
@@ -431,10 +432,11 @@ module.exports = {
           const browser = await webdriver(appPort, '/client')
           try {
             await checkRedTitle(browser)
-            await check(
-              () => browser.eval(`document.querySelector('p').innerText`),
-              'mounted'
-            )
+            await retry(async () => {
+              expect(
+                await browser.eval(`document.querySelector('p').innerText`)
+              ).toEqual('mounted')
+            })
           } finally {
             await browser.close()
           }
@@ -444,16 +446,18 @@ module.exports = {
           const browser = await webdriver(appPort, '/')
           try {
             await checkBlackTitle(browser)
-            await check(
-              () => browser.eval(`document.querySelector('p').innerText`),
-              'mounted'
-            )
+            await retry(async () => {
+              expect(
+                await browser.eval(`document.querySelector('p').innerText`)
+              ).toEqual('mounted')
+            })
             await browser.eval(`document.querySelector('#link-client').click()`)
             await checkRedTitle(browser)
-            await check(
-              () => browser.eval(`document.querySelector('p').innerText`),
-              'mounted'
-            )
+            await retry(async () => {
+              expect(
+                await browser.eval(`document.querySelector('p').innerText`)
+              ).toEqual('mounted')
+            })
           } finally {
             await browser.close()
           }

--- a/test/integration/css/test/dev-css-handling.test.js
+++ b/test/integration/css/test/dev-css-handling.test.js
@@ -1,12 +1,12 @@
 /* eslint-env jest */
 import { remove } from 'fs-extra'
 import {
-  check,
   File,
   findPort,
   killApp,
   launchApp,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -50,13 +50,13 @@ describe('Can hot reload CSS without losing state', () => {
       try {
         cssFile.replace('color: red', 'color: purple')
 
-        await check(
-          () =>
-            browser.eval(
+        await retry(async () => {
+          expect(
+            await browser.eval(
               `window.getComputedStyle(document.querySelector('.red-text')).color`
-            ),
-          'rgb(128, 0, 128)'
-        )
+            )
+          ).toEqual('rgb(128, 0, 128)')
+        })
 
         // ensure text remained
         expect(await browser.elementById('text-input').getValue()).toBe(

--- a/test/integration/custom-error-page-exception/test/index.test.js
+++ b/test/integration/custom-error-page-exception/test/index.test.js
@@ -2,7 +2,7 @@
 
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { nextBuild, nextStart, findPort, killApp, check } from 'next-test-utils'
+import { nextBuild, nextStart, findPort, killApp, retry } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
 const nodeArgs = ['-r', join(appDir, '../../lib/react-channel-require-hook.js')]
@@ -29,10 +29,11 @@ describe.skip('Custom error page exception', () => {
         const browser = await webdriver(appPort, '/')
         await browser.waitForElementByCss(navSel).elementByCss(navSel).click()
 
-        await check(
-          () => browser.eval('document.documentElement.innerHTML'),
-          /Application error: a client-side exception has occurred/
-        )
+        await retry(async () => {
+          expect(
+            await browser.eval('document.documentElement.innerHTML')
+          ).toMatch(/Application error: a client-side exception has occurred/)
+        })
       })
     }
   )

--- a/test/integration/custom-routes-i18n/test/index.test.js
+++ b/test/integration/custom-routes-i18n/test/index.test.js
@@ -13,7 +13,7 @@ import {
   nextStart,
   File,
   fetchViaHTTP,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -93,7 +93,7 @@ const runTests = () => {
 
       await browser.elementByCss('#to-about').click()
 
-      await check(async () => {
+      await retry(async () => {
         const data = JSON.parse(
           cheerio
             .load(await browser.eval('document.documentElement.innerHTML'))(
@@ -102,10 +102,8 @@ const runTests = () => {
             .text()
         )
         console.log(data)
-        return data.url === `${expectedIndex ? '/fr' : ''}/about`
-          ? 'success'
-          : 'fail'
-      }, 'success')
+        expect(data.url === `${expectedIndex ? '/fr' : ''}/about`).toBeTruthy()
+      })
 
       await browser
         .back()
@@ -113,7 +111,7 @@ const runTests = () => {
         .elementByCss('#to-catch-all')
         .click()
 
-      await check(async () => {
+      await retry(async () => {
         const data = JSON.parse(
           cheerio
             .load(await browser.eval('document.documentElement.innerHTML'))(
@@ -122,10 +120,8 @@ const runTests = () => {
             .text()
         )
         console.log(data)
-        return data.url === `${expectedIndex ? '/fr' : ''}/hello`
-          ? 'success'
-          : 'fail'
-      }, 'success')
+        expect(data.url === `${expectedIndex ? '/fr' : ''}/hello`).toBeTruthy()
+      })
 
       await browser.back().waitForElementByCss('#links')
 
@@ -133,15 +129,20 @@ const runTests = () => {
 
       await browser.elementByCss('#to-index').click()
 
-      await check(() => browser.eval('window.location.pathname'), locale || '/')
+      await retry(async () => {
+        expect(await browser.eval('window.location.pathname')).toMatch(
+          locale || '/'
+        )
+      })
       expect(await browser.eval('window.beforeNav')).toBe(1)
 
       await browser.elementByCss('#to-links').click()
 
-      await check(
-        () => browser.eval('window.location.pathname'),
-        `${locale}/links`
-      )
+      await retry(async () => {
+        expect(await browser.eval('window.location.pathname')).toMatch(
+          `${locale}/links`
+        )
+      })
       expect(await browser.eval('window.beforeNav')).toBe(1)
     }
   })

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -22,7 +22,7 @@ import {
   waitFor,
   normalizeRegEx,
   hasRedbox,
-  check,
+  retry,
 } from 'next-test-utils'
 
 let appDir = join(__dirname, '..')
@@ -93,10 +93,9 @@ const runTests = (isDev = false) => {
       })
     })
 
-    await check(
-      () => (messages.length > 0 ? 'success' : JSON.stringify(messages)),
-      'success'
-    )
+    await retry(() => {
+      expect(messages.length > 0).toBeTruthy()
+    })
     ws.close()
     expect([...externalServerHits]).toEqual(['/_next/webpack-hmr?page=/about'])
   })
@@ -195,10 +194,11 @@ const runTests = (isDev = false) => {
 
     const browser = await webdriver(appPort, '/nav')
     await browser.elementByCss('#to-before-files-overridden').click()
-    await check(
-      () => browser.eval('document.documentElement.innerHTML'),
-      /Example Domain/
-    )
+    await retry(async () => {
+      expect(await browser.eval('document.documentElement.innerHTML')).toMatch(
+        /Example Domain/
+      )
+    })
   })
 
   it('should handle beforeFiles rewrite to dynamic route correctly', async () => {
@@ -214,10 +214,11 @@ const runTests = (isDev = false) => {
     const browser = await webdriver(appPort, '/nav')
     await browser.eval('window.beforeNav = 1')
     await browser.elementByCss('#to-before-files-dynamic').click()
-    await check(
-      () => browser.eval('document.documentElement.innerHTML'),
-      /_sport\/\[slug\]/
-    )
+    await retry(async () => {
+      expect(await browser.eval('document.documentElement.innerHTML')).toMatch(
+        /_sport\/\[slug\]/
+      )
+    })
     expect(JSON.parse(await browser.elementByCss('#query').text())).toEqual({
       slug: 'nfl',
     })
@@ -240,10 +241,11 @@ const runTests = (isDev = false) => {
     const browser = await webdriver(appPort, '/nav')
     await browser.eval('window.beforeNav = 1')
     await browser.elementByCss('#to-before-files-dynamic-again').click()
-    await check(
-      () => browser.eval('document.documentElement.innerHTML'),
-      /_sport\/\[slug\]\/test/
-    )
+    await retry(async () => {
+      expect(await browser.eval('document.documentElement.innerHTML')).toMatch(
+        /_sport\/\[slug\]\/test/
+      )
+    })
     expect(JSON.parse(await browser.elementByCss('#query').text())).toEqual({
       slug: 'nfl',
     })
@@ -329,10 +331,11 @@ const runTests = (isDev = false) => {
 
   it('should parse params correctly for rewrite to auto-export dynamic page', async () => {
     const browser = await webdriver(appPort, '/rewriting-to-auto-export')
-    await check(
-      () => browser.eval(() => document.documentElement.innerHTML),
-      /auto-export.*?hello/
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(() => document.documentElement.innerHTML)
+      ).toMatch(/auto-export.*?hello/)
+    })
     expect(JSON.parse(await browser.elementByCss('#query').text())).toEqual({
       rewrite: '1',
       slug: 'hello',
@@ -2682,10 +2685,11 @@ describe('Custom routes', () => {
 
     it('should not error for no-op rewrite and auto export dynamic route', async () => {
       const browser = await webdriver(appPort, '/auto-export/my-slug')
-      await check(
-        () => browser.eval(() => document.documentElement.innerHTML),
-        /auto-export.*?my-slug/
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval(() => document.documentElement.innerHTML)
+        ).toMatch(/auto-export.*?my-slug/)
+      })
     })
   })
   ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(

--- a/test/integration/custom-server/test/index.test.js
+++ b/test/integration/custom-server/test/index.test.js
@@ -10,9 +10,9 @@ import {
   killApp,
   renderViaHTTP,
   fetchViaHTTP,
-  check,
   File,
   nextBuild,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '../')
@@ -198,7 +198,11 @@ describe.each([
 
           indexPg.replace('Asset', 'Asset!!')
 
-          await check(() => browser.elementByCss('#go-asset').text(), /Asset!!/)
+          await retry(async () => {
+            expect(await browser.elementByCss('#go-asset').text()).toMatch(
+              /Asset!!/
+            )
+          })
         } finally {
           if (browser) {
             await browser.close()
@@ -299,7 +303,9 @@ describe.each([
         }
       )
       await fetchViaHTTP(nextUrl, '/unhandled-rejection', undefined, { agent })
-      await check(() => stderr, /unhandledRejection/)
+      await retry(async () => {
+        expect(await stderr).toMatch(/unhandledRejection/)
+      })
       expect(stderr).toContain('unhandledRejection: Error: unhandled rejection')
       expect(stderr).toContain('server.js:38:22')
     })

--- a/test/integration/data-fetching-errors/test/index.test.js
+++ b/test/integration/data-fetching-errors/test/index.test.js
@@ -8,7 +8,7 @@ import {
   nextBuild,
   renderViaHTTP,
   nextStart,
-  check,
+  retry,
 } from 'next-test-utils'
 import { join } from 'path'
 import {
@@ -167,10 +167,10 @@ describe('GS(S)P Page Errors', () => {
               stderr += msg || ''
             },
           })
-          await check(async () => {
+          await retry(async () => {
             await renderViaHTTP(appPort, '/')
-            return stderr
-          }, /error: oops/i)
+            expect(await stderr).toMatch(/error: oops/i)
+          })
 
           expect(stderr).toContain('Error: Oops')
         } finally {

--- a/test/integration/dynamic-optional-routing-root-fallback/test/index.test.js
+++ b/test/integration/dynamic-optional-routing-root-fallback/test/index.test.js
@@ -2,12 +2,12 @@
 
 import fs from 'fs-extra'
 import {
-  check,
   findPort,
   killApp,
   launchApp,
   nextBuild,
   nextStart,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -21,7 +21,9 @@ function runTests() {
     const browser = await webdriver(appPort, '/')
     try {
       await browser.waitForElementByCss('#success')
-      await check(() => browser.elementByCss('#success').text(), /yay/)
+      await retry(async () => {
+        expect(await browser.elementByCss('#success').text()).toMatch(/yay/)
+      })
     } finally {
       await browser.close()
     }
@@ -31,7 +33,9 @@ function runTests() {
     const browser = await webdriver(appPort, '/one')
     try {
       await browser.waitForElementByCss('#success')
-      await check(() => browser.elementByCss('#success').text(), /one/)
+      await retry(async () => {
+        expect(await browser.elementByCss('#success').text()).toMatch(/one/)
+      })
     } finally {
       await browser.close()
     }
@@ -41,7 +45,9 @@ function runTests() {
     const browser = await webdriver(appPort, '/one/two')
     try {
       await browser.waitForElementByCss('#success')
-      await check(() => browser.elementByCss('#success').text(), /one,two/)
+      await retry(async () => {
+        expect(await browser.elementByCss('#success').text()).toMatch(/one,two/)
+      })
     } finally {
       await browser.close()
     }

--- a/test/integration/dynamic-optional-routing/test/index.test.js
+++ b/test/integration/dynamic-optional-routing/test/index.test.js
@@ -10,7 +10,7 @@ import {
   nextBuild,
   nextStart,
   renderViaHTTP,
-  check,
+  retry,
 } from 'next-test-utils'
 import { join } from 'path'
 
@@ -187,10 +187,11 @@ function runInvalidPagesTests(buildFn) {
     try {
       await fs.outputFile(invalidRoute, DUMMY_PAGE, 'utf-8')
       await buildFn(appDir)
-      await check(
-        () => stderr,
-        /You cannot define a route with the same specificity as a optional catch-all route/
-      )
+      await retry(async () => {
+        expect(await stderr).toMatch(
+          /You cannot define a route with the same specificity as a optional catch-all route/
+        )
+      })
     } finally {
       await fs.unlink(invalidRoute)
     }
@@ -201,10 +202,11 @@ function runInvalidPagesTests(buildFn) {
     try {
       await fs.outputFile(invalidRoute, DUMMY_PAGE, 'utf-8')
       await buildFn(appDir)
-      await check(
-        () => stderr,
-        /You cannot define a route with the same specificity as a optional catch-all route/
-      )
+      await retry(async () => {
+        expect(await stderr).toMatch(
+          /You cannot define a route with the same specificity as a optional catch-all route/
+        )
+      })
     } finally {
       await fs.unlink(invalidRoute)
     }
@@ -215,7 +217,9 @@ function runInvalidPagesTests(buildFn) {
     try {
       await fs.outputFile(invalidRoute, DUMMY_PAGE, 'utf-8')
       await buildFn(appDir)
-      await check(() => stderr, /You cannot use both .+ at the same level/)
+      await retry(async () => {
+        expect(await stderr).toMatch(/You cannot use both .+ at the same level/)
+      })
     } finally {
       await fs.unlink(invalidRoute)
     }
@@ -226,10 +230,11 @@ function runInvalidPagesTests(buildFn) {
     try {
       await fs.outputFile(invalidRoute, DUMMY_PAGE, 'utf-8')
       await buildFn(appDir)
-      await check(
-        () => stderr,
-        /Optional route parameters are not yet supported/
-      )
+      await retry(async () => {
+        expect(await stderr).toMatch(
+          /Optional route parameters are not yet supported/
+        )
+      })
     } finally {
       await fs.unlink(invalidRoute)
     }

--- a/test/integration/edge-runtime-module-errors/test/index.test.js
+++ b/test/integration/edge-runtime-module-errors/test/index.test.js
@@ -4,7 +4,6 @@
 import { remove } from 'fs-extra'
 import { join } from 'path'
 import {
-  check,
   fetchViaHTTP,
   findPort,
   killApp,
@@ -180,14 +179,13 @@ describe('Edge runtime code with imports', () => {
             )
             const res = await fetchViaHTTP(context.appPort, url)
             expect(res.status).toBe(500)
-            await check(async () => {
+            await retry(async () => {
               expectUnsupportedModuleDevError(
                 moduleName,
                 importStatement,
                 await res.text()
               )
-              return 'success'
-            }, 'success')
+            })
           })
         }
       )
@@ -257,10 +255,9 @@ describe('Edge runtime code with imports', () => {
       expect(res.status).toBe(500)
 
       const text = await res.text()
-      await check(async () => {
+      await retry(() => {
         expectModuleNotFoundDevError(moduleName, importStatement, text)
-        return 'success'
-      }, 'success')
+      })
     })
     ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
       'production mode',

--- a/test/integration/edge-runtime-module-errors/test/module-imports.test.js
+++ b/test/integration/edge-runtime-module-errors/test/module-imports.test.js
@@ -4,13 +4,13 @@
 import { remove } from 'fs-extra'
 import { join } from 'path'
 import {
-  check,
   fetchViaHTTP,
   findPort,
   killApp,
   launchApp,
   nextBuild,
   nextStart,
+  retry,
 } from 'next-test-utils'
 import {
   context,
@@ -88,10 +88,9 @@ describe('Edge runtime code with imports', () => {
       expect(res.status).toBe(500)
 
       const text = await res.text()
-      await check(async () => {
+      await retry(() => {
         expectUnsupportedModuleDevError(moduleName, importStatement, text)
-        return 'success'
-      }, 'success')
+      })
     })
     ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
       'production mode',
@@ -155,10 +154,9 @@ describe('Edge runtime code with imports', () => {
       expect(res.status).toBe(500)
 
       const text = await res.text()
-      await check(async () => {
+      await retry(() => {
         expectModuleNotFoundDevError(moduleName, importStatement, text)
-        return 'success'
-      }, 'success')
+      })
     })
     ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
       'production mode',
@@ -221,10 +219,9 @@ describe('Edge runtime code with imports', () => {
       expect(res.status).toBe(500)
 
       const text = await res.text()
-      await check(async () => {
+      await retry(() => {
         expectModuleNotFoundDevError(moduleName, importStatement, text)
-        return 'success'
-      }, 'success')
+      })
     })
     ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
       'production mode',

--- a/test/integration/edge-runtime-streaming-error/test/index.test.ts
+++ b/test/integration/edge-runtime-streaming-error/test/index.test.ts
@@ -1,6 +1,5 @@
 import stripAnsi from 'next/dist/compiled/strip-ansi'
 import {
-  check,
   fetchViaHTTP,
   findPort,
   killApp,
@@ -8,6 +7,7 @@ import {
   nextBuild,
   nextStart,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import path from 'path'
 import { remove } from 'fs-extra'
@@ -20,13 +20,14 @@ function test(context: ReturnType<typeof createContext>) {
     expect(await res.text()).toEqual('hello')
     expect(res.status).toBe(200)
     await waitFor(200)
-    await check(
-      () => stripAnsi(context.output),
-      new RegExp(
-        `The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received type boolean`,
-        'm'
+    await retry(async () => {
+      expect(await stripAnsi(context.output)).toMatch(
+        new RegExp(
+          `The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received type boolean`,
+          'm'
+        )
       )
-    )
+    })
     expect(stripAnsi(context.output)).not.toContain('webpack-internal:')
   }
 }

--- a/test/integration/empty-object-getInitialProps/test/index.test.js
+++ b/test/integration/empty-object-getInitialProps/test/index.test.js
@@ -8,7 +8,7 @@ import {
   launchApp,
   killApp,
   waitFor,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -60,10 +60,10 @@ describe('Empty Project', () => {
         }
         window.next.router.replace('/another')
       })()`)
-      await check(async () => {
+      await retry(async () => {
         const gotWarn = await browser.eval(`window.gotWarn`)
-        return gotWarn ? 'pass' : 'fail'
-      }, 'pass')
+        expect(gotWarn).toBeTruthy()
+      })
     } finally {
       await browser.close()
     }

--- a/test/integration/gssp-redirect-base-path/test/index.test.js
+++ b/test/integration/gssp-redirect-base-path/test/index.test.js
@@ -10,7 +10,7 @@ import {
   nextBuild,
   nextStart,
   fetchViaHTTP,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -56,10 +56,11 @@ const runTests = (isDev) => {
 
     const browser = await webdriver(appPort, `${basePath}`)
     await browser.eval(`next.router.push('/gssp-blog/redirect-1-no-basepath-')`)
-    await check(
-      () => browser.eval('document.documentElement.innerHTML'),
-      /oops not found/
-    )
+    await retry(async () => {
+      expect(await browser.eval('document.documentElement.innerHTML')).toMatch(
+        /oops not found/
+      )
+    })
 
     const parsedUrl2 = url.parse(await browser.eval('window.location.href'))
     expect(parsedUrl2.pathname).toBe('/404')
@@ -216,10 +217,11 @@ const runTests = (isDev) => {
       }
     )
 
-    await check(
-      () => browser.eval(() => document.documentElement.innerHTML),
-      /oops not found/
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(() => document.documentElement.innerHTML)
+      ).toMatch(/oops not found/)
+    })
 
     const initialHref = await browser.eval(() => window.initialHref)
     expect(initialHref).toBeFalsy()
@@ -238,10 +240,11 @@ const runTests = (isDev) => {
       }
     )
 
-    await check(
-      () => browser.eval(() => document.location.hostname),
-      'example.vercel.sh'
-    )
+    await retry(async () => {
+      expect(await browser.eval(() => document.location.hostname)).toEqual(
+        'example.vercel.sh'
+      )
+    })
 
     const initialHref = await browser.eval(() => window.initialHref)
     expect(initialHref).toBeFalsy()
@@ -256,10 +259,11 @@ const runTests = (isDev) => {
       }
     )
 
-    await check(
-      () => browser.eval(() => document.location.hostname),
-      'example.vercel.sh'
-    )
+    await retry(async () => {
+      expect(await browser.eval(() => document.location.hostname)).toEqual(
+        'example.vercel.sh'
+      )
+    })
 
     const initialHref = await browser.eval(() => window.initialHref)
     expect(initialHref).toBeFalsy()

--- a/test/integration/gssp-redirect-with-rewrites/test/index.test.js
+++ b/test/integration/gssp-redirect-with-rewrites/test/index.test.js
@@ -6,7 +6,7 @@ import {
   findPort,
   launchApp,
   killApp,
-  check,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 
@@ -53,9 +53,9 @@ describe('getServerSideProps redirects', () => {
     await browser.elementByCss('#link-unknown-url').click()
 
     // Wait until the page has be reloaded
-    await check(async () => {
+    await retry(async () => {
       const val = await browser.eval('window.__SAME_PAGE')
-      return val ? 'fail' : 'success'
-    }, 'success')
+      expect(val).toBeFalsy()
+    })
   })
 })

--- a/test/integration/gssp-redirect/test/index.test.js
+++ b/test/integration/gssp-redirect/test/index.test.js
@@ -10,7 +10,7 @@ import {
   nextBuild,
   nextStart,
   fetchViaHTTP,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -257,10 +257,11 @@ const runTests = (isDev) => {
       }
     )
 
-    await check(
-      () => browser.eval(() => document.documentElement.innerHTML),
-      /oops not found/
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(() => document.documentElement.innerHTML)
+      ).toMatch(/oops not found/)
+    })
 
     const initialHref = await browser.eval(() => window.initialHref)
     expect(initialHref).toBeFalsy()
@@ -279,10 +280,11 @@ const runTests = (isDev) => {
       }
     )
 
-    await check(
-      () => browser.eval(() => document.location.hostname),
-      'example.vercel.sh'
-    )
+    await retry(async () => {
+      expect(await browser.eval(() => document.location.hostname)).toEqual(
+        'example.vercel.sh'
+      )
+    })
 
     const initialHref = await browser.eval(() => window.initialHref)
     expect(initialHref).toBeFalsy()
@@ -297,10 +299,11 @@ const runTests = (isDev) => {
       }
     )
 
-    await check(
-      () => browser.eval(() => document.location.hostname),
-      'example.vercel.sh'
-    )
+    await retry(async () => {
+      expect(await browser.eval(() => document.location.hostname)).toEqual(
+        'example.vercel.sh'
+      )
+    })
 
     const initialHref = await browser.eval(() => window.initialHref)
     expect(initialHref).toBeFalsy()

--- a/test/integration/hydration/test/index.test.js
+++ b/test/integration/hydration/test/index.test.js
@@ -9,7 +9,7 @@ import {
   findPort,
   killApp,
   launchApp,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = path.join(__dirname, '..')
@@ -31,10 +31,11 @@ const runTests = () => {
     const browser = await webdriver(appPort, '//')
     await browser.eval('window.beforeNav = true')
     await browser.eval('window.next.router.push("/details")')
-    await check(
-      () => browser.eval('document.documentElement.innerHTML'),
-      /details/
-    )
+    await retry(async () => {
+      expect(await browser.eval('document.documentElement.innerHTML')).toMatch(
+        /details/
+      )
+    })
     expect(await browser.eval('window.beforeNav')).toBe(true)
   })
 }

--- a/test/integration/i18n-support-catchall/test/index.test.js
+++ b/test/integration/i18n-support-catchall/test/index.test.js
@@ -11,7 +11,7 @@ import {
   launchApp,
   nextBuild,
   nextStart,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '../')
@@ -84,7 +84,9 @@ function runTests(isDev) {
 
     await browser.elementByCss('#to-locale-index').click()
 
-    await check(() => browser.eval('window.location.pathname'), '/nl-NL')
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toEqual('/nl-NL')
+    })
 
     expect(await browser.elementByCss('#router-locale').text()).toBe('nl-NL')
     expect(await browser.elementByCss('#router-default-locale').text()).toBe(
@@ -106,7 +108,11 @@ function runTests(isDev) {
 
     await browser.back()
 
-    await check(() => browser.elementByCss('#router-locale').text(), 'en-US')
+    await retry(async () => {
+      expect(await browser.elementByCss('#router-locale').text()).toEqual(
+        'en-US'
+      )
+    })
 
     expect(await browser.elementByCss('#router-locale').text()).toBe('en-US')
     expect(await browser.elementByCss('#router-default-locale').text()).toBe(
@@ -132,10 +138,11 @@ function runTests(isDev) {
 
     await browser.elementByCss('#to-locale-another').click()
 
-    await check(
-      () => browser.eval('window.location.pathname'),
-      '/nl-NL/another'
-    )
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toEqual(
+        '/nl-NL/another'
+      )
+    })
 
     expect(await browser.elementByCss('#router-locale').text()).toBe('nl-NL')
     expect(await browser.elementByCss('#router-default-locale').text()).toBe(
@@ -161,7 +168,11 @@ function runTests(isDev) {
 
     await browser.back()
 
-    await check(() => browser.elementByCss('#router-locale').text(), 'en-US')
+    await retry(async () => {
+      expect(await browser.elementByCss('#router-locale').text()).toEqual(
+        'en-US'
+      )
+    })
 
     expect(await browser.elementByCss('#router-locale').text()).toBe('en-US')
     expect(await browser.elementByCss('#router-default-locale').text()).toBe(
@@ -195,7 +206,7 @@ function runTests(isDev) {
         document.querySelector('#to-fr-locale-index').scrollIntoView()
       })()`)
 
-      await check(async () => {
+      await retry(async () => {
         const hrefs = await browser.eval(`Object.keys(window.next.router.sdc)`)
         hrefs.sort()
 
@@ -214,8 +225,7 @@ function runTests(isDev) {
             '/nl-NL/another.json',
           ]
         )
-        return 'yes'
-      }, 'yes')
+      })
     })
   }
 }

--- a/test/integration/i18n-support-index-rewrite/test/index.test.js
+++ b/test/integration/i18n-support-index-rewrite/test/index.test.js
@@ -11,7 +11,7 @@ import {
   nextBuild,
   nextStart,
   renderViaHTTP,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -57,7 +57,7 @@ const runTests = () => {
         window.next.router.push('/')
       })()`)
 
-      await check(async () => {
+      await retry(async () => {
         const html = await browser.eval('document.documentElement.innerHTML')
         const props = JSON.parse(cheerio.load(html)('#props').text())
         assert.deepEqual(props, {
@@ -67,8 +67,7 @@ const runTests = () => {
           locale,
           hello: 'world',
         })
-        return 'success'
-      }, 'success')
+      })
 
       expect(await browser.eval('window.beforeNav')).toBe(1)
     }

--- a/test/integration/i18n-support-same-page-hash-change/test/index.test.js
+++ b/test/integration/i18n-support-same-page-hash-change/test/index.test.js
@@ -8,7 +8,7 @@ import {
   findPort,
   nextBuild,
   nextStart,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -21,16 +21,26 @@ const runTests = () => {
 
     await browser.elementByCss('#change-locale').click()
 
-    await check(() => browser.eval('window.location.pathname'), '/fr/about')
-    await check(() => browser.eval('window.location.hash'), '#hash')
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toEqual(
+        '/fr/about'
+      )
+    })
+    await retry(async () => {
+      expect(await browser.eval('window.location.hash')).toEqual('#hash')
+    })
 
     expect(await browser.elementByCss('#router-locale').text()).toBe('fr')
     expect(await browser.elementByCss('#props-locale').text()).toBe('fr')
 
     await browser.elementByCss('#change-locale').click()
 
-    await check(() => browser.eval('window.location.pathname'), '/about')
-    await check(() => browser.eval('window.location.hash'), '#hash')
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toEqual('/about')
+    })
+    await retry(async () => {
+      expect(await browser.eval('window.location.hash')).toEqual('#hash')
+    })
 
     expect(await browser.elementByCss('#router-locale').text()).toBe('en')
     expect(await browser.elementByCss('#props-locale').text()).toBe('en')
@@ -41,16 +51,26 @@ const runTests = () => {
 
     await browser.elementByCss('#change-locale').click()
 
-    await check(() => browser.eval('window.location.pathname'), '/fr/posts/a')
-    await check(() => browser.eval('window.location.hash'), '#hash')
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toEqual(
+        '/fr/posts/a'
+      )
+    })
+    await retry(async () => {
+      expect(await browser.eval('window.location.hash')).toEqual('#hash')
+    })
 
     expect(await browser.elementByCss('#router-locale').text()).toBe('fr')
     expect(await browser.elementByCss('#props-locale').text()).toBe('fr')
 
     await browser.elementByCss('#change-locale').click()
 
-    await check(() => browser.eval('window.location.pathname'), '/posts/a')
-    await check(() => browser.eval('window.location.hash'), '#hash')
+    await retry(async () => {
+      expect(await browser.eval('window.location.pathname')).toEqual('/posts/a')
+    })
+    await retry(async () => {
+      expect(await browser.eval('window.location.hash')).toEqual('#hash')
+    })
 
     expect(await browser.elementByCss('#router-locale').text()).toBe('en')
     expect(await browser.elementByCss('#props-locale').text()).toBe('en')
@@ -59,14 +79,22 @@ const runTests = () => {
   it('should trigger hash change events', async () => {
     const browser = await webdriver(appPort, `/about#hash`)
 
-    await check(() => browser.eval('window.location.hash'), '#hash')
+    await retry(async () => {
+      expect(await browser.eval('window.location.hash')).toEqual('#hash')
+    })
 
     await browser.elementByCss('#hash-change').click()
 
-    await check(() => browser.eval('window.hashChangeStart'), 'yes')
-    await check(() => browser.eval('window.hashChangeComplete'), 'yes')
+    await retry(async () => {
+      expect(await browser.eval('window.hashChangeStart')).toEqual('yes')
+    })
+    await retry(async () => {
+      expect(await browser.eval('window.hashChangeComplete')).toEqual('yes')
+    })
 
-    await check(() => browser.eval('window.location.hash'), '#newhash')
+    await retry(async () => {
+      expect(await browser.eval('window.location.hash')).toEqual('#newhash')
+    })
   })
 }
 

--- a/test/integration/i18n-support/test/index.test.js
+++ b/test/integration/i18n-support/test/index.test.js
@@ -13,7 +13,7 @@ import {
   fetchViaHTTP,
   File,
   launchApp,
-  check,
+  retry,
 } from 'next-test-utils'
 import assert from 'assert'
 
@@ -232,7 +232,7 @@ describe('i18n Support', () => {
             document.querySelector('#to-gsp-fr').scrollIntoView()
           })()`)
 
-          await check(async () => {
+          await retry(async () => {
             const hrefs = await browser.eval(
               `Object.keys(window.next.router.sdc)`
             )
@@ -246,8 +246,7 @@ describe('i18n Support', () => {
               ),
               ['/en-US/gsp.json', '/fr.json', '/fr/gsp.json', '/nl-NL/gsp.json']
             )
-            return 'yes'
-          }, 'yes')
+          })
         })
 
         it('should have correct locale domain hrefs', async () => {

--- a/test/integration/image-optimizer/test/index.test.ts
+++ b/test/integration/image-optimizer/test/index.test.ts
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 import {
-  check,
   fetchViaHTTP,
   File,
   findPort,
@@ -588,7 +587,7 @@ describe('Image Optimizer', () => {
             `attachment; filename="test.webp"`
           )
 
-          await check(async () => {
+          await retry(async () => {
             const files = await fsToJson(imagesDir)
 
             let found = false
@@ -603,8 +602,8 @@ describe('Image Optimizer', () => {
                 found = true
               }
             })
-            return found ? 'success' : 'failed'
-          }, 'success')
+            expect(found).toBeTruthy()
+          })
         })
 
         it('should not set max-age header when not matching next.config.js', async () => {
@@ -727,7 +726,7 @@ describe('Image Optimizer', () => {
             `attachment; filename="next-js-bg.webp"`
           )
 
-          await check(async () => {
+          await retry(async () => {
             const files = await fsToJson(imagesDir)
 
             let found = false
@@ -742,8 +741,8 @@ describe('Image Optimizer', () => {
                 found = true
               }
             })
-            return found ? 'success' : 'failed'
-          }, 'success')
+            expect(found).toBeTruthy()
+          })
           await expectWidth(res, 64)
         })
       }

--- a/test/integration/index-index/test/index.test.js
+++ b/test/integration/index-index/test/index.test.js
@@ -10,8 +10,8 @@ import {
   nextBuild,
   nextStart,
   renderViaHTTP,
-  check,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -42,7 +42,9 @@ function runTests() {
     try {
       await browser.elementByCss('#link1').click()
       await waitFor(1000)
-      await check(() => browser.elementByCss('#page').text(), /^index$/)
+      await retry(async () => {
+        expect(await browser.elementByCss('#page').text()).toMatch(/^index$/)
+      })
     } finally {
       await browser.close()
     }
@@ -69,7 +71,11 @@ function runTests() {
     try {
       await browser.elementByCss('#link2').click()
       await waitFor(1000)
-      await check(() => browser.elementByCss('#page').text(), /^index > index$/)
+      await retry(async () => {
+        expect(await browser.elementByCss('#page').text()).toMatch(
+          /^index > index$/
+        )
+      })
     } finally {
       await browser.close()
     }
@@ -96,7 +102,11 @@ function runTests() {
     try {
       await browser.elementByCss('#link5').click()
       await waitFor(1000)
-      await check(() => browser.elementByCss('#page').text(), /^index > user$/)
+      await retry(async () => {
+        expect(await browser.elementByCss('#page').text()).toMatch(
+          /^index > user$/
+        )
+      })
     } finally {
       await browser.close()
     }
@@ -123,10 +133,11 @@ function runTests() {
     try {
       await browser.elementByCss('#link6').click()
       await waitFor(1000)
-      await check(
-        () => browser.elementByCss('#page').text(),
-        /^index > project$/
-      )
+      await retry(async () => {
+        expect(await browser.elementByCss('#page').text()).toMatch(
+          /^index > project$/
+        )
+      })
     } finally {
       await browser.close()
     }
@@ -153,10 +164,11 @@ function runTests() {
     try {
       await browser.elementByCss('#link3').click()
       await waitFor(1000)
-      await check(
-        () => browser.elementByCss('#page').text(),
-        /^index > index > index$/
-      )
+      await retry(async () => {
+        expect(await browser.elementByCss('#page').text()).toMatch(
+          /^index > index > index$/
+        )
+      })
     } finally {
       await browser.close()
     }
@@ -172,7 +184,9 @@ function runTests() {
     try {
       await browser.elementByCss('#link4').click()
       await waitFor(1000)
-      await check(() => browser.elementByCss('h1').text(), /404/)
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toMatch(/404/)
+      })
     } finally {
       await browser.close()
     }

--- a/test/integration/invalid-href/test/index.test.js
+++ b/test/integration/invalid-href/test/index.test.js
@@ -9,8 +9,8 @@ import {
   nextBuild,
   nextStart,
   waitFor,
-  check,
   fetchViaHTTP,
+  retry,
 } from 'next-test-utils'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
@@ -44,10 +44,10 @@ const showsError = async (pathname, regex, click = false, isWarn = false) => {
       await waitFor(500)
     }
     if (isWarn) {
-      await check(async () => {
+      await retry(async () => {
         const warnLogs = await browser.eval('window.warnLogs')
-        return warnLogs.join('\n')
-      }, regex)
+        expect(await warnLogs.join('\n')).toMatch(regex)
+      })
     } else {
       expect(await hasRedbox(browser)).toBe(true)
       const errorContent = await getRedboxHeader(browser)

--- a/test/integration/invalid-revalidate-values/test/index.test.js
+++ b/test/integration/invalid-revalidate-values/test/index.test.js
@@ -7,8 +7,8 @@ import {
   File,
   launchApp,
   renderViaHTTP,
-  check,
   waitFor,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -64,10 +64,11 @@ describe('Invalid revalidate values', () => {
     pageFile.replace('revalidate: 1', 'revalidate: "1"')
 
     try {
-      await check(
-        () => renderViaHTTP(appPort, '/ssg'),
-        /A page's revalidate option must be seconds expressed as a natural number. Mixed numbers and strings cannot be used. Received/
-      )
+      await retry(async () => {
+        expect(await renderViaHTTP(appPort, '/ssg')).toMatch(
+          /A page's revalidate option must be seconds expressed as a natural number. Mixed numbers and strings cannot be used. Received/
+        )
+      })
     } finally {
       pageFile.restore()
     }
@@ -77,10 +78,11 @@ describe('Invalid revalidate values', () => {
     pageFile.replace('revalidate: 1', 'revalidate: null')
 
     try {
-      await check(
-        () => renderViaHTTP(appPort, '/ssg'),
-        /A page's revalidate option must be seconds expressed as a natural number. Mixed numbers and strings cannot be used. Received/
-      )
+      await retry(async () => {
+        expect(await renderViaHTTP(appPort, '/ssg')).toMatch(
+          /A page's revalidate option must be seconds expressed as a natural number. Mixed numbers and strings cannot be used. Received/
+        )
+      })
     } finally {
       pageFile.restore()
     }
@@ -90,10 +92,11 @@ describe('Invalid revalidate values', () => {
     pageFile.replace('revalidate: 1', 'revalidate: 1.1')
 
     try {
-      await check(
-        () => renderViaHTTP(appPort, '/ssg'),
-        /A page's revalidate option must be seconds expressed as a natural number for \/ssg. Mixed numbers, such as/
-      )
+      await retry(async () => {
+        expect(await renderViaHTTP(appPort, '/ssg')).toMatch(
+          /A page's revalidate option must be seconds expressed as a natural number for \/ssg. Mixed numbers, such as/
+        )
+      })
     } finally {
       pageFile.restore()
     }

--- a/test/integration/jsconfig-baseurl/test/index.test.js
+++ b/test/integration/jsconfig-baseurl/test/index.test.js
@@ -10,7 +10,7 @@ import {
   launchApp,
   killApp,
   nextBuild,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -54,14 +54,12 @@ describe('jsconfig.json baseurl', () => {
           contents.replace('components/world', 'components/worldd')
         )
 
-        const found = await check(
-          async () => {
-            await renderViaHTTP(appPort, '/hello')
-            return stripAnsi(output)
-          },
-          /Module not found: Can't resolve 'components\/worldd'/,
-          false
-        )
+        const found = await retry(async () => {
+          await renderViaHTTP(appPort, '/hello')
+          expect(await stripAnsi(output)).toMatch(
+            /Module not found: Can't resolve 'components\/worldd'/
+          )
+        })
         expect(found).toBe(true)
       } finally {
         await fs.writeFile(basicPage, contents)

--- a/test/integration/jsconfig-paths/test/index.test.js
+++ b/test/integration/jsconfig-paths/test/index.test.js
@@ -11,8 +11,8 @@ import {
   launchApp,
   nextBuild,
   killApp,
-  check,
   File,
+  retry,
 } from 'next-test-utils'
 import * as JSON5 from 'json5'
 
@@ -69,14 +69,12 @@ function runTests() {
       try {
         await fs.writeFile(basicPage, contents.replace('@c/world', '@c/worldd'))
 
-        const found = await check(
-          async () => {
-            await renderViaHTTP(appPort, '/basic-alias')
-            return stripAnsi(output)
-          },
-          /Module not found: Can't resolve '@c\/worldd'/,
-          false
-        )
+        const found = await retry(async () => {
+          await renderViaHTTP(appPort, '/basic-alias')
+          expect(await stripAnsi(output)).toMatch(
+            /Module not found: Can't resolve '@c\/worldd'/
+          )
+        })
         expect(found).toBe(true)
       } finally {
         await fs.writeFile(basicPage, contents)

--- a/test/integration/link-with-encoding/test/index.test.js
+++ b/test/integration/link-with-encoding/test/index.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import { findPort, killApp, launchApp, waitFor, check } from 'next-test-utils'
+import { findPort, killApp, launchApp, waitFor, retry } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
 
@@ -40,10 +40,14 @@ describe('Link Component with Encoding', () => {
             { pathname: encodeURI('/single/hello world ') }
           )`
         )
-        await check(() => browser.hasElementByCssSelector('#query-content'), {
-          test(val) {
-            return Boolean(val)
-          },
+        await retry(async () => {
+          expect(
+            await browser.hasElementByCssSelector('#query-content')
+          ).toMatch({
+            test(val) {
+              return Boolean(val)
+            },
+          })
         })
         const text = await browser.elementByCss('#query-content').text()
         expect(text).toMatchInlineSnapshot(`"{"slug":"hello world "}"`)
@@ -57,10 +61,14 @@ describe('Link Component with Encoding', () => {
       try {
         await waitFor(2000)
         await browser.elementByCss('#single-spaces').click()
-        await check(() => browser.hasElementByCssSelector('#query-content'), {
-          test(val) {
-            return Boolean(val)
-          },
+        await retry(async () => {
+          expect(
+            await browser.hasElementByCssSelector('#query-content')
+          ).toMatch({
+            test(val) {
+              return Boolean(val)
+            },
+          })
         })
         const text = await browser.elementByCss('#query-content').text()
         expect(text).toMatchInlineSnapshot(`"{"slug":"hello world "}"`)
@@ -91,10 +99,14 @@ describe('Link Component with Encoding', () => {
             { pathname: encodeURI('/single/hello%world') }
           )`
         )
-        await check(() => browser.hasElementByCssSelector('#query-content'), {
-          test(val) {
-            return Boolean(val)
-          },
+        await retry(async () => {
+          expect(
+            await browser.hasElementByCssSelector('#query-content')
+          ).toMatch({
+            test(val) {
+              return Boolean(val)
+            },
+          })
         })
         const text = await browser.elementByCss('#query-content').text()
         expect(text).toMatchInlineSnapshot(`"{"slug":"hello%world"}"`)
@@ -108,10 +120,14 @@ describe('Link Component with Encoding', () => {
       try {
         await waitFor(2000)
         await browser.elementByCss('#single-percent').click()
-        await check(() => browser.hasElementByCssSelector('#query-content'), {
-          test(val) {
-            return Boolean(val)
-          },
+        await retry(async () => {
+          expect(
+            await browser.hasElementByCssSelector('#query-content')
+          ).toMatch({
+            test(val) {
+              return Boolean(val)
+            },
+          })
         })
         const text = await browser.elementByCss('#query-content').text()
         expect(text).toMatchInlineSnapshot(`"{"slug":"hello%world"}"`)
@@ -145,10 +161,14 @@ describe('Link Component with Encoding', () => {
             { pathname: '/single/hello${encodeURIComponent('/')}world' }
           )`
         )
-        await check(() => browser.hasElementByCssSelector('#query-content'), {
-          test(val) {
-            return Boolean(val)
-          },
+        await retry(async () => {
+          expect(
+            await browser.hasElementByCssSelector('#query-content')
+          ).toMatch({
+            test(val) {
+              return Boolean(val)
+            },
+          })
         })
         const text = await browser.elementByCss('#query-content').text()
         expect(text).toMatchInlineSnapshot(`"{"slug":"hello/world"}"`)
@@ -162,10 +182,14 @@ describe('Link Component with Encoding', () => {
       try {
         await waitFor(2000)
         await browser.elementByCss('#single-slash').click()
-        await check(() => browser.hasElementByCssSelector('#query-content'), {
-          test(val) {
-            return Boolean(val)
-          },
+        await retry(async () => {
+          expect(
+            await browser.hasElementByCssSelector('#query-content')
+          ).toMatch({
+            test(val) {
+              return Boolean(val)
+            },
+          })
         })
         const text = await browser.elementByCss('#query-content').text()
         expect(text).toMatchInlineSnapshot(`"{"slug":"hello/world"}"`)
@@ -203,10 +227,14 @@ describe('Link Component with Encoding', () => {
             { pathname: '/single/hello${encodeURIComponent('"')}world' }
           )`
         )
-        await check(() => browser.hasElementByCssSelector('#query-content'), {
-          test(val) {
-            return Boolean(val)
-          },
+        await retry(async () => {
+          expect(
+            await browser.hasElementByCssSelector('#query-content')
+          ).toMatch({
+            test(val) {
+              return Boolean(val)
+            },
+          })
         })
         const text = await browser.elementByCss('#query-content').text()
         expect(JSON.parse(text)).toMatchInlineSnapshot(`
@@ -224,10 +252,14 @@ describe('Link Component with Encoding', () => {
       try {
         await waitFor(2000)
         await browser.elementByCss('#single-double-quote').click()
-        await check(() => browser.hasElementByCssSelector('#query-content'), {
-          test(val) {
-            return Boolean(val)
-          },
+        await retry(async () => {
+          expect(
+            await browser.hasElementByCssSelector('#query-content')
+          ).toMatch({
+            test(val) {
+              return Boolean(val)
+            },
+          })
         })
         const text = await browser.elementByCss('#query-content').text()
         expect(JSON.parse(text)).toMatchInlineSnapshot(`
@@ -265,10 +297,14 @@ describe('Link Component with Encoding', () => {
             { pathname: '/single/hello${encodeURIComponent(':')}world' }
           )`
         )
-        await check(() => browser.hasElementByCssSelector('#query-content'), {
-          test(val) {
-            return Boolean(val)
-          },
+        await retry(async () => {
+          expect(
+            await browser.hasElementByCssSelector('#query-content')
+          ).toMatch({
+            test(val) {
+              return Boolean(val)
+            },
+          })
         })
         const text = await browser.elementByCss('#query-content').text()
         expect(text).toMatchInlineSnapshot(`"{"slug":"hello:world"}"`)
@@ -282,10 +318,14 @@ describe('Link Component with Encoding', () => {
       try {
         await waitFor(2000)
         await browser.elementByCss('#single-colon').click()
-        await check(() => browser.hasElementByCssSelector('#query-content'), {
-          test(val) {
-            return Boolean(val)
-          },
+        await retry(async () => {
+          expect(
+            await browser.hasElementByCssSelector('#query-content')
+          ).toMatch({
+            test(val) {
+              return Boolean(val)
+            },
+          })
         })
         const text = await browser.elementByCss('#query-content').text()
         expect(text).toMatchInlineSnapshot(`"{"slug":"hello:world"}"`)

--- a/test/integration/middleware-dev-update/test/index.test.js
+++ b/test/integration/middleware-dev-update/test/index.test.js
@@ -1,5 +1,4 @@
 import {
-  check,
   fetchViaHTTP,
   File,
   findPort,
@@ -40,14 +39,13 @@ describe('Middleware development errors', () => {
   })
 
   async function assertMiddlewareFetch(hasMiddleware, path = '/') {
-    await check(async () => {
+    await retry(async () => {
       const res = await fetchViaHTTP(context.appPort, path)
       expect(res.status).toBe(200)
       expect(res.headers.get('x-from-middleware')).toBe(
         hasMiddleware ? 'true' : null
       )
-      return 'success'
-    }, 'success')
+    })
   }
 
   async function assertMiddlewareRender(hasMiddleware, path = '/') {

--- a/test/integration/missing-document-component-error/test/index.test.js
+++ b/test/integration/missing-document-component-error/test/index.test.js
@@ -6,8 +6,8 @@ import {
   findPort,
   killApp,
   launchApp,
-  check,
   renderViaHTTP,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -28,8 +28,12 @@ const checkMissing = async (missing = [], docContent) => {
 
   await renderViaHTTP(appPort, '/')
 
-  await check(() => stderr, new RegExp(`missing-document-component`))
-  await check(() => stderr, new RegExp(`${missing.join(', ')}`))
+  await retry(async () => {
+    expect(await stderr).toMatch(new RegExp(`missing-document-component`))
+  })
+  await retry(async () => {
+    expect(await stderr).toMatch(new RegExp(`${missing.join(', ')}`))
+  })
 
   await killApp(app)
   await fs.remove(docPath)

--- a/test/integration/next-image-legacy/base-path/test/index.test.ts
+++ b/test/integration/next-image-legacy/base-path/test/index.test.ts
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 
 import {
-  check,
   findPort,
   getRedboxHeader,
   hasRedbox,
@@ -10,6 +9,7 @@ import {
   nextBuild,
   nextStart,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -63,7 +63,7 @@ function runTests(mode) {
   it('should load the images', async () => {
     let browser = await webdriver(appPort, '/docs')
     try {
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById('basic-image').naturalWidth`
         )
@@ -71,9 +71,7 @@ function runTests(mode) {
         if (result === 0) {
           throw new Error('Incorrectly loaded image')
         }
-
-        return 'result-correct'
-      }, /result-correct/)
+      })
 
       expect(
         await hasImageMatchingUrl(
@@ -89,17 +87,19 @@ function runTests(mode) {
   it('should update the image on src change', async () => {
     let browser = await webdriver(appPort, '/docs/update')
     try {
-      await check(
-        () => browser.eval(`document.getElementById("update-image").src`),
-        /test\.jpg/
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("update-image").src`)
+        ).toMatch(/test\.jpg/)
+      })
 
       await browser.eval(`document.getElementById("toggle").click()`)
 
-      await check(
-        () => browser.eval(`document.getElementById("update-image").src`),
-        /test\.png/
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("update-image").src`)
+        ).toMatch(/test\.png/)
+      })
     } finally {
       await browser.close()
     }
@@ -108,16 +108,14 @@ function runTests(mode) {
   it('should work when using flexbox', async () => {
     let browser = await webdriver(appPort, '/docs/flex')
     try {
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById('basic-image').width`
         )
         if (result === 0) {
           throw new Error('Incorrectly loaded image')
         }
-
-        return 'result-correct'
-      }, /result-correct/)
+      })
     } finally {
       await browser.close()
     }
@@ -162,12 +160,11 @@ function runTests(mode) {
       const delta = 250
       const id = 'intrinsic1'
 
-      await check(async () => {
+      await retry(async () => {
         expect(await getSrc(browser, id)).toBe(
           '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75'
         )
-        return 'success'
-      }, 'success')
+      })
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
         '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=1200&q=75 1x, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75 2x'
       )
@@ -203,12 +200,11 @@ function runTests(mode) {
       const delta = 250
       const id = 'responsive1'
 
-      await check(async () => {
+      await retry(async () => {
         expect(await getSrc(browser, id)).toBe(
           '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75'
         )
-        return 'success'
-      }, 'success')
+      })
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
         '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=640&q=75 640w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=750&q=75 750w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=828&q=75 828w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1080&q=75 1080w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1200&q=75 1200w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1920&q=75 1920w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=2048&q=75 2048w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75 3840w'
       )
@@ -244,12 +240,11 @@ function runTests(mode) {
       const delta = 150
       const id = 'fill1'
 
-      await check(async () => {
+      await retry(async () => {
         expect(await getSrc(browser, id)).toBe(
           '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75'
         )
-        return 'success'
-      }, 'success')
+      })
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
         '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=640&q=75 640w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=750&q=75 750w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=828&q=75 828w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1080&q=75 1080w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1200&q=75 1200w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1920&q=75 1920w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=2048&q=75 2048w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75 3840w'
       )
@@ -285,12 +280,11 @@ function runTests(mode) {
       const height = await getComputed(browser, id, 'height')
       await browser.eval(`document.getElementById("${id}").scrollIntoView()`)
 
-      await check(async () => {
+      await retry(async () => {
         expect(await getSrc(browser, id)).toBe(
           '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75'
         )
-        return 'success'
-      }, 'success')
+      })
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
         '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=640&q=75 640w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=750&q=75 750w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=828&q=75 828w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1080&q=75 1080w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1200&q=75 1200w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1920&q=75 1920w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=2048&q=75 2048w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75 3840w'
       )
@@ -336,12 +330,11 @@ function runTests(mode) {
       const delta = 250
       const id = 'sizes1'
 
-      await check(async () => {
+      await retry(async () => {
         expect(await getSrc(browser, id)).toBe(
           '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75'
         )
-        return 'success'
-      }, 'success')
+      })
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
         '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=16&q=75 16w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=32&q=75 32w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=48&q=75 48w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=64&q=75 64w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=96&q=75 96w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=128&q=75 128w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=256&q=75 256w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=384&q=75 384w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=640&q=75 640w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=750&q=75 750w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=828&q=75 828w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1080&q=75 1080w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1200&q=75 1200w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1920&q=75 1920w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=2048&q=75 2048w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75 3840w'
       )
@@ -377,9 +370,11 @@ function runTests(mode) {
 
       expect(await hasRedbox(browser)).toBe(false)
 
-      await check(async () => {
-        return (await browser.log()).map((log) => log.message).join('\n')
-      }, /Image is missing required "src" property/gm)
+      await retry(async () => {
+        expect(
+          await (await browser.log()).map((log) => log.message).join('\n')
+        ).toMatch(/Image is missing required "src" property/gm)
+      })
     })
 
     it('should show invalid src error', async () => {
@@ -410,7 +405,7 @@ function runTests(mode) {
       const id = 'prose-image'
 
       // Wait for image to load:
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById(${JSON.stringify(id)}).naturalWidth`
         )
@@ -418,9 +413,7 @@ function runTests(mode) {
         if (result < 1) {
           throw new Error('Image not ready')
         }
-
-        return 'result-correct'
-      }, /result-correct/)
+      })
 
       await waitFor(1000)
 
@@ -440,7 +433,7 @@ function runTests(mode) {
         const id = 'exif-rotation-image'
 
         // Wait for image to load:
-        await check(async () => {
+        await retry(async () => {
           const result = await browser.eval(
             `document.getElementById(${JSON.stringify(id)}).naturalWidth`
           )
@@ -448,9 +441,7 @@ function runTests(mode) {
           if (result < 1) {
             throw new Error('Image not ready')
           }
-
-          return 'result-correct'
-        }, /result-correct/)
+        })
 
         await waitFor(1000)
 

--- a/test/integration/next-image-legacy/basic/test/index.test.ts
+++ b/test/integration/next-image-legacy/basic/test/index.test.ts
@@ -1,12 +1,12 @@
 /* eslint-env jest */
 
 import {
-  check,
   findPort,
   killApp,
   nextBuild,
   nextStart,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -136,13 +136,19 @@ function lazyLoadingTests() {
       `window.scrollTo(0, ${topOfMidImage - (viewportHeight + buffer)})`
     )
 
-    await check(() => {
-      return browser.elementById('lazy-mid').getAttribute('src')
-    }, 'https://example.com/myaccount/lazy2.jpg?auto=format&fit=max&w=1024')
+    await retry(async () => {
+      expect(await browser.elementById('lazy-mid').getAttribute('src')).toEqual(
+        'https://example.com/myaccount/lazy2.jpg?auto=format&fit=max&w=1024'
+      )
+    })
 
-    await check(() => {
-      return browser.elementById('lazy-mid').getAttribute('srcset')
-    }, 'https://example.com/myaccount/lazy2.jpg?auto=format&fit=max&w=480 1x, https://example.com/myaccount/lazy2.jpg?auto=format&fit=max&w=1024 2x')
+    await retry(async () => {
+      expect(
+        await browser.elementById('lazy-mid').getAttribute('srcset')
+      ).toEqual(
+        'https://example.com/myaccount/lazy2.jpg?auto=format&fit=max&w=480 1x, https://example.com/myaccount/lazy2.jpg?auto=format&fit=max&w=1024 2x'
+      )
+    })
   })
   it('should not have loaded the third image after scrolling down', async () => {
     expect(await browser.elementById('lazy-bottom').getAttribute('src')).toBe(
@@ -220,17 +226,25 @@ function lazyLoadingTests() {
       `window.scrollTo(0, ${topOfBottomImage - (viewportHeight + buffer)})`
     )
 
-    await check(() => {
-      return browser.eval(
-        'document.querySelector("#lazy-boundary").getAttribute("src")'
+    await retry(async () => {
+      expect(
+        await browser.eval(
+          'document.querySelector("#lazy-boundary").getAttribute("src")'
+        )
+      ).toEqual(
+        'https://example.com/myaccount/lazy6.jpg?auto=format&fit=max&w=1600'
       )
-    }, 'https://example.com/myaccount/lazy6.jpg?auto=format&fit=max&w=1600')
+    })
 
-    await check(() => {
-      return browser.eval(
-        'document.querySelector("#lazy-boundary").getAttribute("srcset")'
+    await retry(async () => {
+      expect(
+        await browser.eval(
+          'document.querySelector("#lazy-boundary").getAttribute("srcset")'
+        )
+      ).toEqual(
+        'https://example.com/myaccount/lazy6.jpg?auto=format&fit=max&w=1024 1x, https://example.com/myaccount/lazy6.jpg?auto=format&fit=max&w=1600 2x'
       )
-    }, 'https://example.com/myaccount/lazy6.jpg?auto=format&fit=max&w=1024 1x, https://example.com/myaccount/lazy6.jpg?auto=format&fit=max&w=1600 2x')
+    })
   })
 }
 

--- a/test/integration/next-image-legacy/default/test/index.test.ts
+++ b/test/integration/next-image-legacy/default/test/index.test.ts
@@ -3,7 +3,6 @@
 import cheerio from 'cheerio'
 import validateHTML from 'html-validator'
 import {
-  check,
   fetchViaHTTP,
   findPort,
   getRedboxHeader,
@@ -14,6 +13,7 @@ import {
   nextStart,
   renderViaHTTP,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -76,7 +76,7 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/')
 
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById('basic-image').naturalWidth`
         )
@@ -84,9 +84,7 @@ function runTests(mode) {
         if (result === 0) {
           throw new Error('Incorrectly loaded image')
         }
-
-        return 'result-correct'
-      }, /result-correct/)
+      })
 
       expect(
         await hasImageMatchingUrl(
@@ -106,7 +104,7 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/priority')
 
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById('basic-image').naturalWidth`
         )
@@ -114,9 +112,7 @@ function runTests(mode) {
         if (result === 0) {
           throw new Error('Incorrectly loaded image')
         }
-
-        return 'result-correct'
-      }, /result-correct/)
+      })
 
       const links = await browser.elementsByCss('link[rel=preload][as=image]')
       const entries = []
@@ -228,17 +224,19 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/update')
 
-      await check(
-        () => browser.eval(`document.getElementById("update-image").src`),
-        /test\.jpg/
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("update-image").src`)
+        ).toMatch(/test\.jpg/)
+      })
 
       await browser.eval(`document.getElementById("toggle").click()`)
 
-      await check(
-        () => browser.eval(`document.getElementById("update-image").src`),
-        /test\.png/
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("update-image").src`)
+        ).toMatch(/test\.png/)
+      })
     } finally {
       if (browser) {
         await browser.close()
@@ -255,81 +253,96 @@ function runTests(mode) {
         `document.getElementById("footer").scrollIntoView({behavior: "smooth"})`
       )
 
-      await check(
-        () => browser.eval(`document.getElementById("img1").currentSrc`),
-        /test(.*)jpg/
-      )
-      await check(
-        () => browser.eval(`document.getElementById("img2").currentSrc`),
-        /test(.*).png/
-      )
-      await check(
-        () => browser.eval(`document.getElementById("img3").currentSrc`),
-        /test\.svg/
-      )
-      await check(
-        () => browser.eval(`document.getElementById("img4").currentSrc`),
-        /test(.*)ico/
-      )
-      await check(
-        () => browser.eval(`document.getElementById("msg1").textContent`),
-        'loaded 1 img1 with dimensions 128x128'
-      )
-      await check(
-        () => browser.eval(`document.getElementById("msg2").textContent`),
-        'loaded 1 img2 with dimensions 400x400'
-      )
-      await check(
-        () => browser.eval(`document.getElementById("msg3").textContent`),
-        'loaded 1 img3 with dimensions 266x266'
-      )
-      await check(
-        () => browser.eval(`document.getElementById("msg4").textContent`),
-        'loaded 1 img4 with dimensions 21x21'
-      )
-      await check(
-        () => browser.eval(`document.getElementById("msg5").textContent`),
-        'loaded 1 img5 with dimensions 3x5'
-      )
-      await check(
-        () => browser.eval(`document.getElementById("msg6").textContent`),
-        'loaded 1 img6 with dimensions 3x5'
-      )
-      await check(
-        () => browser.eval(`document.getElementById("msg7").textContent`),
-        'loaded 1 img7 with dimensions 400x400'
-      )
-      await check(
-        () => browser.eval(`document.getElementById("msg8").textContent`),
-        'loaded 1 img8 with dimensions 640x373'
-      )
-      await check(
-        () =>
-          browser.eval(
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("img1").currentSrc`)
+        ).toMatch(/test(.*)jpg/)
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("img2").currentSrc`)
+        ).toMatch(/test(.*).png/)
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("img3").currentSrc`)
+        ).toMatch(/test\.svg/)
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("img4").currentSrc`)
+        ).toMatch(/test(.*)ico/)
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg1").textContent`)
+        ).toEqual('loaded 1 img1 with dimensions 128x128')
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg2").textContent`)
+        ).toEqual('loaded 1 img2 with dimensions 400x400')
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg3").textContent`)
+        ).toEqual('loaded 1 img3 with dimensions 266x266')
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg4").textContent`)
+        ).toEqual('loaded 1 img4 with dimensions 21x21')
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg5").textContent`)
+        ).toEqual('loaded 1 img5 with dimensions 3x5')
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg6").textContent`)
+        ).toEqual('loaded 1 img6 with dimensions 3x5')
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg7").textContent`)
+        ).toEqual('loaded 1 img7 with dimensions 400x400')
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg8").textContent`)
+        ).toEqual('loaded 1 img8 with dimensions 640x373')
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(
             `document.getElementById("img8").getAttribute("data-nimg")`
-          ),
-        'intrinsic'
-      )
-      await check(
-        () => browser.eval(`document.getElementById("img8").currentSrc`),
-        /wide.png/
-      )
+          )
+        ).toEqual('intrinsic')
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("img8").currentSrc`)
+        ).toMatch(/wide.png/)
+      })
       await browser.eval('document.getElementById("toggle").click()')
-      await check(
-        () => browser.eval(`document.getElementById("msg8").textContent`),
-        'loaded 2 img8 with dimensions 400x300'
-      )
-      await check(
-        () =>
-          browser.eval(
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg8").textContent`)
+        ).toEqual('loaded 2 img8 with dimensions 400x300')
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(
             `document.getElementById("img8").getAttribute("data-nimg")`
-          ),
-        'fixed'
-      )
-      await check(
-        () => browser.eval(`document.getElementById("img8").currentSrc`),
-        /test-rect.jpg/
-      )
+          )
+        ).toEqual('fixed')
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("img8").currentSrc`)
+        ).toMatch(/test-rect.jpg/)
+      })
     } finally {
       if (browser) {
         await browser.close()
@@ -344,93 +357,111 @@ function runTests(mode) {
       `document.getElementById("footer").scrollIntoView({behavior: "smooth"})`
     )
 
-    await check(
-      () => browser.eval(`document.getElementById("img1").currentSrc`),
-      /test(.*)jpg/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img2").currentSrc`),
-      /test(.*).png/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img3").currentSrc`),
-      /test\.svg/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img4").currentSrc`),
-      /test(.*)ico/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg1").textContent`),
-      'loaded 1 img1 with native onLoad'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'loaded 1 img2 with native onLoad'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg3").textContent`),
-      'loaded 1 img3 with native onLoad'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg4").textContent`),
-      'loaded 1 img4 with native onLoad'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg8").textContent`),
-      'loaded 1 img8 with native onLoad'
-    )
-    await check(
-      () =>
-        browser.eval(
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img1").currentSrc`)
+      ).toMatch(/test(.*)jpg/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img2").currentSrc`)
+      ).toMatch(/test(.*).png/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img3").currentSrc`)
+      ).toMatch(/test\.svg/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img4").currentSrc`)
+      ).toMatch(/test(.*)ico/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg1").textContent`)
+      ).toEqual('loaded 1 img1 with native onLoad')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg2").textContent`)
+      ).toEqual('loaded 1 img2 with native onLoad')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg3").textContent`)
+      ).toEqual('loaded 1 img3 with native onLoad')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg4").textContent`)
+      ).toEqual('loaded 1 img4 with native onLoad')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg8").textContent`)
+      ).toEqual('loaded 1 img8 with native onLoad')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(
           `document.getElementById("img8").getAttribute("data-nimg")`
-        ),
-      'intrinsic'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img8").currentSrc`),
-      /wide.png/
-    )
+        )
+      ).toEqual('intrinsic')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img8").currentSrc`)
+      ).toMatch(/wide.png/)
+    })
     await browser.eval('document.getElementById("toggle").click()')
     // The normal `onLoad()` is triggered by lazy placeholder image
     // so ideally this would be "2" instead of "3" count
-    await check(
-      () => browser.eval(`document.getElementById("msg8").textContent`),
-      'loaded 3 img8 with native onLoad'
-    )
-    await check(
-      () =>
-        browser.eval(
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg8").textContent`)
+      ).toEqual('loaded 3 img8 with native onLoad')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(
           `document.getElementById("img8").getAttribute("data-nimg")`
-        ),
-      'fixed'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img8").currentSrc`),
-      /test-rect.jpg/
-    )
+        )
+      ).toEqual('fixed')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img8").currentSrc`)
+      ).toMatch(/test-rect.jpg/)
+    })
   })
 
   it('should callback native onError when error occurred while loading image', async () => {
     let browser = await webdriver(appPort, '/on-error')
 
-    await check(
-      () => browser.eval(`document.getElementById("img1").currentSrc`),
-      /test\.png/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img2").currentSrc`),
-      //This is an empty data url
-      /nonexistent-img\.png/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg1").textContent`),
-      'no error occurred'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'error occurred while loading img2'
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img1").currentSrc`)
+      ).toMatch(/test\.png/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img2").currentSrc`)
+      ).toMatch(
+        //This is an empty data url
+        /nonexistent-img\.png/
+      )
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg1").textContent`)
+      ).toEqual('no error occurred')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg2").textContent`)
+      ).toEqual('error occurred while loading img2')
+    })
   })
 
   it('should work with image with blob src', async () => {
@@ -438,14 +469,16 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/blob')
 
-      await check(
-        () => browser.eval(`document.getElementById("blob-image").src`),
-        /^blob:/
-      )
-      await check(
-        () => browser.eval(`document.getElementById("blob-image").srcset`),
-        ''
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("blob-image").src`)
+        ).toMatch(/^blob:/)
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("blob-image").srcset`)
+        ).toEqual('')
+      })
     } finally {
       if (browser) {
         await browser.close()
@@ -457,16 +490,14 @@ function runTests(mode) {
     let browser
     try {
       browser = await webdriver(appPort, '/flex')
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById('basic-image').width`
         )
         if (result === 0) {
           throw new Error('Incorrectly loaded image')
         }
-
-        return 'result-correct'
-      }, /result-correct/)
+      })
     } finally {
       if (browser) {
         await browser.close()
@@ -483,12 +514,11 @@ function runTests(mode) {
       const delta = 250
       const id = 'fixed1'
 
-      await check(async () => {
+      await retry(async () => {
         expect(await getSrc(browser, id)).toBe(
           '/_next/image?url=%2Fwide.png&w=3840&q=75'
         )
-        return 'success'
-      }, 'success')
+      })
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
         '/_next/image?url=%2Fwide.png&w=1200&q=75 1x, /_next/image?url=%2Fwide.png&w=3840&q=75 2x'
       )
@@ -521,12 +551,11 @@ function runTests(mode) {
       const delta = 250
       const id = 'intrinsic1'
 
-      await check(async () => {
+      await retry(async () => {
         expect(await getSrc(browser, id)).toBe(
           '/_next/image?url=%2Fwide.png&w=3840&q=75'
         )
-        return 'success'
-      }, 'success')
+      })
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
         '/_next/image?url=%2Fwide.png&w=1200&q=75 1x, /_next/image?url=%2Fwide.png&w=3840&q=75 2x'
       )
@@ -565,12 +594,11 @@ function runTests(mode) {
       const delta = 250
       const id = 'responsive1'
 
-      await check(async () => {
+      await retry(async () => {
         expect(await getSrc(browser, id)).toBe(
           '/_next/image?url=%2Fwide.png&w=3840&q=75'
         )
-        return 'success'
-      }, 'success')
+      })
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
         '/_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w'
       )
@@ -609,12 +637,11 @@ function runTests(mode) {
       const delta = 150
       const id = 'fill1'
 
-      await check(async () => {
+      await retry(async () => {
         expect(await getSrc(browser, id)).toBe(
           '/_next/image?url=%2Fwide.png&w=3840&q=75'
         )
-        return 'success'
-      }, 'success')
+      })
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
         '/_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w'
       )
@@ -653,18 +680,21 @@ function runTests(mode) {
       const height = await getComputed(browser, id, 'height')
       await browser.eval(`document.getElementById("${id}").scrollIntoView()`)
 
-      await check(async () => {
+      await retry(async () => {
         expect(await getSrc(browser, id)).toBe(
           '/_next/image?url=%2Fwide.png&w=3840&q=75'
         )
-        return 'success'
-      }, 'success')
+      })
 
-      await check(() => {
-        return browser.eval(
-          `document.querySelector('#${id}').getAttribute('srcset')`
+      await retry(async () => {
+        expect(
+          await browser.eval(
+            `document.querySelector('#${id}').getAttribute('srcset')`
+          )
+        ).toEqual(
+          '/_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w'
         )
-      }, '/_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w')
+      })
 
       expect(await browser.elementById(id).getAttribute('sizes')).toBe('100vw')
       expect(await getComputed(browser, id, 'width')).toBe(width)
@@ -696,18 +726,26 @@ function runTests(mode) {
       expect(objectFit).toBe('cover')
       expect(objectPosition).toBe('left center')
       await browser.eval(`document.getElementById("fill3").scrollIntoView()`)
-      await check(() => {
-        return browser.eval(
-          `document.querySelector('#fill3').getAttribute('srcset')`
+      await retry(async () => {
+        expect(
+          await browser.eval(
+            `document.querySelector('#fill3').getAttribute('srcset')`
+          )
+        ).toEqual(
+          '/_next/image?url=%2Fwide.png&w=256&q=75 256w, /_next/image?url=%2Fwide.png&w=384&q=75 384w, /_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w'
         )
-      }, '/_next/image?url=%2Fwide.png&w=256&q=75 256w, /_next/image?url=%2Fwide.png&w=384&q=75 384w, /_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w')
+      })
 
       await browser.eval(`document.getElementById("fill4").scrollIntoView()`)
-      await check(() => {
-        return browser.eval(
-          `document.querySelector('#fill4').getAttribute('srcset')`
+      await retry(async () => {
+        expect(
+          await browser.eval(
+            `document.querySelector('#fill4').getAttribute('srcset')`
+          )
+        ).toEqual(
+          '/_next/image?url=%2Fwide.png&w=16&q=75 16w, /_next/image?url=%2Fwide.png&w=32&q=75 32w, /_next/image?url=%2Fwide.png&w=48&q=75 48w, /_next/image?url=%2Fwide.png&w=64&q=75 64w, /_next/image?url=%2Fwide.png&w=96&q=75 96w, /_next/image?url=%2Fwide.png&w=128&q=75 128w, /_next/image?url=%2Fwide.png&w=256&q=75 256w, /_next/image?url=%2Fwide.png&w=384&q=75 384w, /_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w'
         )
-      }, '/_next/image?url=%2Fwide.png&w=16&q=75 16w, /_next/image?url=%2Fwide.png&w=32&q=75 32w, /_next/image?url=%2Fwide.png&w=48&q=75 48w, /_next/image?url=%2Fwide.png&w=64&q=75 64w, /_next/image?url=%2Fwide.png&w=96&q=75 96w, /_next/image?url=%2Fwide.png&w=128&q=75 128w, /_next/image?url=%2Fwide.png&w=256&q=75 256w, /_next/image?url=%2Fwide.png&w=384&q=75 384w, /_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w')
+      })
     } finally {
       if (browser) {
         await browser.close()
@@ -724,12 +762,11 @@ function runTests(mode) {
       const delta = 250
       const id = 'sizes1'
 
-      await check(async () => {
+      await retry(async () => {
         expect(await getSrc(browser, id)).toBe(
           '/_next/image?url=%2Fwide.png&w=3840&q=75'
         )
-        return 'success'
-      }, 'success')
+      })
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
         '/_next/image?url=%2Fwide.png&w=16&q=75 16w, /_next/image?url=%2Fwide.png&w=32&q=75 32w, /_next/image?url=%2Fwide.png&w=48&q=75 48w, /_next/image?url=%2Fwide.png&w=64&q=75 64w, /_next/image?url=%2Fwide.png&w=96&q=75 96w, /_next/image?url=%2Fwide.png&w=128&q=75 128w, /_next/image?url=%2Fwide.png&w=256&q=75 256w, /_next/image?url=%2Fwide.png&w=384&q=75 384w, /_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w'
       )
@@ -815,9 +852,11 @@ function runTests(mode) {
 
       expect(await hasRedbox(browser)).toBe(false)
 
-      await check(async () => {
-        return (await browser.log()).map((log) => log.message).join('\n')
-      }, /Image is missing required "src" property/gm)
+      await retry(async () => {
+        expect(
+          await (await browser.log()).map((log) => log.message).join('\n')
+        ).toMatch(/Image is missing required "src" property/gm)
+      })
     })
 
     it('should show invalid src error', async () => {
@@ -871,9 +910,13 @@ function runTests(mode) {
     it('should warn when img with layout=responsive is inside flex container', async () => {
       const browser = await webdriver(appPort, '/layout-responsive-inside-flex')
       await browser.eval(`document.getElementById("img").scrollIntoView()`)
-      await check(async () => {
-        return (await browser.log()).map((log) => log.message).join('\n')
-      }, /Image with src (.*)jpg(.*) may not render properly as a child of a flex container. Consider wrapping the image with a div to configure the width/gm)
+      await retry(async () => {
+        expect(
+          await (await browser.log()).map((log) => log.message).join('\n')
+        ).toMatch(
+          /Image with src (.*)jpg(.*) may not render properly as a child of a flex container. Consider wrapping the image with a div to configure the width/gm
+        )
+      })
       expect(await hasRedbox(browser)).toBe(false)
     })
 
@@ -931,15 +974,14 @@ function runTests(mode) {
       let browser = await webdriver(appPort, '/priority-missing-warning')
       try {
         // Wait for image to load:
-        await check(async () => {
+        await retry(async () => {
           const result = await browser.eval(
             `document.getElementById('responsive').naturalWidth`
           )
           if (result < 1) {
             throw new Error('Image not ready')
           }
-          return 'done'
-        }, 'done')
+        })
         await waitFor(1000)
         const warnings = (await browser.log())
           .map((log) => log.message)
@@ -1031,15 +1073,14 @@ function runTests(mode) {
         `document.querySelector("button").textContent`
       )
       expect(count).toBe('Count: 2')
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           'document.getElementById("w").naturalWidth'
         )
         if (result < 1) {
           throw new Error('Image not loaded')
         }
-        return 'done'
-      }, 'done')
+      })
       await waitFor(1000)
       const warnings = (await browser.log())
         .map((log) => log.message)
@@ -1069,7 +1110,7 @@ function runTests(mode) {
       const id = 'prose-image'
 
       // Wait for image to load:
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById(${JSON.stringify(id)}).naturalWidth`
         )
@@ -1077,9 +1118,7 @@ function runTests(mode) {
         if (result < 1) {
           throw new Error('Image not ready')
         }
-
-        return 'result-correct'
-      }, /result-correct/)
+      })
 
       await waitFor(1000)
 
@@ -1135,8 +1174,12 @@ function runTests(mode) {
 
   it('should apply filter style after image loads', async () => {
     const browser = await webdriver(appPort, '/style-filter')
-    await check(() => getSrc(browser, 'img-plain'), /^\/_next\/image/)
-    await check(() => getSrc(browser, 'img-blur'), /^\/_next\/image/)
+    await retry(async () => {
+      expect(await getSrc(browser, 'img-plain')).toMatch(/^\/_next\/image/)
+    })
+    await retry(async () => {
+      expect(await getSrc(browser, 'img-blur')).toMatch(/^\/_next\/image/)
+    })
     await waitFor(1000)
 
     expect(await getComputedStyle(browser, 'img-plain', 'filter')).toBe(
@@ -1184,7 +1227,7 @@ function runTests(mode) {
         const id = 'exif-rotation-image'
 
         // Wait for image to load:
-        await check(async () => {
+        await retry(async () => {
           const result = await browser.eval(
             `document.getElementById(${JSON.stringify(id)}).naturalWidth`
           )
@@ -1192,9 +1235,7 @@ function runTests(mode) {
           if (result < 1) {
             throw new Error('Image not ready')
           }
-
-          return 'result-correct'
-        }, /result-correct/)
+        })
 
         await waitFor(1000)
 
@@ -1248,15 +1289,15 @@ function runTests(mode) {
     let browser
     try {
       browser = await webdriver(appPort, '/blurry-placeholder')
-      await check(
-        async () =>
+      await retry(async () => {
+        expect(
           await getComputedStyle(
             browser,
             'blurry-placeholder',
             'background-image'
-          ),
-        'none'
-      )
+          )
+        ).toEqual('none')
+      })
 
       expect(
         await getComputedStyle(
@@ -1270,15 +1311,15 @@ function runTests(mode) {
 
       await browser.eval('document.getElementById("spacer").remove()')
 
-      await check(
-        async () =>
+      await retry(async () => {
+        expect(
           await getComputedStyle(
             browser,
             'blurry-placeholder-with-lazy',
             'background-image'
-          ),
-        'none'
-      )
+          )
+        ).toEqual('none')
+      })
     } finally {
       if (browser) {
         await browser.close()
@@ -1291,7 +1332,7 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/lazy-src-change')
       // image should not be loaded as it is out of viewport
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById('basic-image').naturalWidth`
         )
@@ -1299,9 +1340,7 @@ function runTests(mode) {
         if (result >= 400) {
           throw new Error('Incorrectly loaded image')
         }
-
-        return 'result-correct'
-      }, /result-correct/)
+      })
 
       // Move image into viewport
       await browser.eval(
@@ -1309,7 +1348,7 @@ function runTests(mode) {
       )
 
       // image should be loaded by now
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById('basic-image').naturalWidth`
         )
@@ -1317,14 +1356,15 @@ function runTests(mode) {
         if (result < 400) {
           throw new Error('Incorrectly loaded image')
         }
+      })
 
-        return 'result-correct'
-      }, /result-correct/)
-
-      await check(
-        () => browser.eval(`document.getElementById("basic-image").currentSrc`),
-        /test\.jpg/
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval(
+            `document.getElementById("basic-image").currentSrc`
+          )
+        ).toMatch(/test\.jpg/)
+      })
 
       // Make image out of viewport again
       await browser.eval(
@@ -1335,7 +1375,7 @@ function runTests(mode) {
         'document.getElementById("button-change-image-src").click()'
       )
       // "new" image should be lazy loaded
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById('basic-image').naturalWidth`
         )
@@ -1343,16 +1383,14 @@ function runTests(mode) {
         if (result >= 400) {
           throw new Error('Incorrectly loaded image')
         }
-
-        return 'result-correct'
-      }, /result-correct/)
+      })
 
       // Move image into viewport again
       await browser.eval(
         'document.getElementById("spacer").style.display = "none"'
       )
       // "new" image should be loaded by now
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById('basic-image').naturalWidth`
         )
@@ -1360,14 +1398,15 @@ function runTests(mode) {
         if (result < 400) {
           throw new Error('Incorrectly loaded image')
         }
+      })
 
-        return 'result-correct'
-      }, /result-correct/)
-
-      await check(
-        () => browser.eval(`document.getElementById("basic-image").currentSrc`),
-        /test\.png/
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval(
+            `document.getElementById("basic-image").currentSrc`
+          )
+        ).toMatch(/test\.png/)
+      })
     } finally {
       if (browser) {
         await browser.close()
@@ -1379,7 +1418,7 @@ function runTests(mode) {
     let browser
     try {
       browser = await webdriver(appPort, '/lazy-withref')
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById('myImage1').naturalWidth`
         )
@@ -1387,11 +1426,9 @@ function runTests(mode) {
         if (result >= 400) {
           throw new Error('Incorrectly loaded image')
         }
+      })
 
-        return 'result-correct'
-      }, /result-correct/)
-
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById('myImage4').naturalWidth`
         )
@@ -1399,11 +1436,9 @@ function runTests(mode) {
         if (result >= 400) {
           throw new Error('Incorrectly loaded image')
         }
+      })
 
-        return 'result-correct'
-      }, /result-correct/)
-
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById('myImage2').naturalWidth`
         )
@@ -1411,11 +1446,9 @@ function runTests(mode) {
         if (result < 400) {
           throw new Error('Incorrectly loaded image')
         }
+      })
 
-        return 'result-correct'
-      }, /result-correct/)
-
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById('myImage3').naturalWidth`
         )
@@ -1423,9 +1456,7 @@ function runTests(mode) {
         if (result < 400) {
           throw new Error('Incorrectly loaded image')
         }
-
-        return 'result-correct'
-      }, /result-correct/)
+      })
 
       expect(
         await hasImageMatchingUrl(

--- a/test/integration/next-image-legacy/no-intersection-observer-fallback/test/index.test.ts
+++ b/test/integration/next-image-legacy/no-intersection-observer-fallback/test/index.test.ts
@@ -1,10 +1,10 @@
 import {
-  check,
   findPort,
   killApp,
   nextBuild,
   nextStart,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -30,9 +30,9 @@ describe('Image Component No IntersectionObserver test', () => {
           browser = await webdriver(appPort, '/no-observer')
 
           // Make sure the IntersectionObserver is mocked to null during the test
-          await check(() => {
-            return browser.eval('IntersectionObserver')
-          }, /null/)
+          await retry(async () => {
+            expect(await browser.eval('IntersectionObserver')).toMatch(/null/)
+          })
 
           expect(
             await browser.elementById('lazy-no-observer').getAttribute('src')
@@ -52,9 +52,9 @@ describe('Image Component No IntersectionObserver test', () => {
           browser = await webdriver(appPort, '/')
 
           // Make sure the IntersectionObserver is mocked to null during the test
-          await check(() => {
-            return browser.eval('IntersectionObserver')
-          }, /null/)
+          await retry(async () => {
+            expect(await browser.eval('IntersectionObserver')).toMatch(/null/)
+          })
 
           await browser.waitForElementByCss('#link-no-observer').click()
 

--- a/test/integration/next-image-legacy/trailing-slash/test/index.test.ts
+++ b/test/integration/next-image-legacy/trailing-slash/test/index.test.ts
@@ -1,12 +1,12 @@
 /* eslint-env jest */
 
 import {
-  check,
   findPort,
   killApp,
   launchApp,
   nextBuild,
   nextStart,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -62,15 +62,14 @@ describe('Image Component Trailing Slash Tests', () => {
         try {
           browser = await webdriver(appPort, '/')
           const id = 'test1'
-          await check(async () => {
+          await retry(async () => {
             const srcImage = await browser.eval(
               `document.getElementById('${id}').src`
             )
             expect(srcImage).toMatch(
               /\/_next\/image\/\?url=%2F_next%2Fstatic%2Fmedia%2Ftest(.+).jpg&w=828&q=75/
             )
-            return 'success'
-          }, 'success')
+          })
         } finally {
           if (browser) {
             await browser.close()

--- a/test/integration/next-image-legacy/unoptimized/test/index.test.ts
+++ b/test/integration/next-image-legacy/unoptimized/test/index.test.ts
@@ -2,12 +2,12 @@
 
 import { join } from 'path'
 import {
-  check,
   findPort,
   killApp,
   launchApp,
   nextBuild,
   nextStart,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 
@@ -45,42 +45,53 @@ function runTests() {
       await browser.elementById('eager-image').getAttribute('srcset')
     ).toBeNull()
 
-    await check(async () => {
+    await retry(async () => {
       await browser.eval(
         `window.scrollTo(0, 0); document.getElementById("external-image").scrollIntoView()`
       )
-      return browser.eval(
-        `document.getElementById("external-image").currentSrc`
-      )
-    }, 'https://image-optimization-test.vercel.app/test.jpg')
 
-    await check(async () => {
+      expect(
+        await browser.eval(
+          `document.getElementById("external-image").currentSrc`
+        )
+      ).toEqual('https://image-optimization-test.vercel.app/test.jpg')
+    })
+
+    await retry(async () => {
       await browser.eval(
         `window.scrollTo(0, 0); document.getElementById("internal-image").scrollIntoView()`
       )
-      return browser.elementById('internal-image').getAttribute('src')
-    }, '/test.png')
+      expect(
+        await browser.elementById('internal-image').getAttribute('src')
+      ).toEqual('/test.png')
+    })
 
-    await check(async () => {
+    await retry(async () => {
       await browser.eval(
         `window.scrollTo(0, 0); document.getElementById("static-image").scrollIntoView()`
       )
-      return browser.elementById('static-image').getAttribute('src')
-    }, /test(.*)jpg/)
+      expect(
+        await browser.elementById('static-image').getAttribute('src')
+      ).toMatch(/test(.*)jpg/)
+    })
 
-    await check(async () => {
+    await retry(async () => {
       await browser.eval(
         `window.scrollTo(0, 0); document.getElementById("external-image").scrollIntoView()`
       )
-      return browser.elementById('external-image').getAttribute('src')
-    }, 'https://image-optimization-test.vercel.app/test.jpg')
+      expect(
+        await browser.elementById('external-image').getAttribute('src')
+      ).toEqual('https://image-optimization-test.vercel.app/test.jpg')
+    })
 
-    await check(async () => {
+    await retry(async () => {
       await browser.eval(
         `window.scrollTo(0, 0); document.getElementById("eager-image").scrollIntoView()`
       )
-      return browser.elementById('eager-image').getAttribute('src')
-    }, '/test.webp')
+      expect(
+        await browser.elementById('eager-image').getAttribute('src')
+      ).toEqual('/test.webp')
+    })
 
     expect(
       await browser.elementById('internal-image').getAttribute('srcset')

--- a/test/integration/next-image-new/app-dir/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir/test/index.test.ts
@@ -3,7 +3,6 @@
 import cheerio from 'cheerio'
 import validateHTML from 'html-validator'
 import {
-  check,
   fetchViaHTTP,
   findPort,
   getRedboxHeader,
@@ -14,6 +13,7 @@ import {
   nextStart,
   renderViaHTTP,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -76,7 +76,7 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/')
 
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById('basic-image').naturalWidth`
         )
@@ -84,9 +84,7 @@ function runTests(mode) {
         if (result === 0) {
           throw new Error('Incorrectly loaded image')
         }
-
-        return 'result-correct'
-      }, /result-correct/)
+      })
 
       expect(
         await hasImageMatchingUrl(
@@ -106,7 +104,7 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/priority')
 
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById('basic-image').naturalWidth`
         )
@@ -114,9 +112,7 @@ function runTests(mode) {
         if (result === 0) {
           throw new Error('Incorrectly loaded image')
         }
-
-        return 'result-correct'
-      }, /result-correct/)
+      })
 
       const links = await browser.elementsByCss('link[rel=preload][as=image]')
       const entries = []
@@ -275,17 +271,19 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/update')
 
-      await check(
-        () => browser.eval(`document.getElementById("update-image").src`),
-        /test\.jpg/
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("update-image").src`)
+        ).toMatch(/test\.jpg/)
+      })
 
       await browser.eval(`document.getElementById("toggle").click()`)
 
-      await check(
-        () => browser.eval(`document.getElementById("update-image").src`),
-        /test\.png/
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("update-image").src`)
+        ).toMatch(/test\.png/)
+      })
     } finally {
       if (browser) {
         await browser.close()
@@ -300,85 +298,101 @@ function runTests(mode) {
       `document.getElementById("footer").scrollIntoView({behavior: "smooth"})`
     )
 
-    await check(
-      () => browser.eval(`document.getElementById("img1").currentSrc`),
-      /test(.*)jpg/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img2").currentSrc`),
-      /test(.*).png/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img3").currentSrc`),
-      /test\.svg/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img4").currentSrc`),
-      /test(.*)ico/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg1").textContent`),
-      'loaded 1 img1 with dimensions 128x128'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'loaded 1 img2 with dimensions 400x400'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg3").textContent`),
-      'loaded 1 img3 with dimensions 400x400'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg4").textContent`),
-      'loaded 1 img4 with dimensions 32x32'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg5").textContent`),
-      'loaded 1 img5 with dimensions 3x5'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg6").textContent`),
-      'loaded 1 img6 with dimensions 3x5'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg7").textContent`),
-      'loaded 1 img7 with dimensions 400x400'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg8").textContent`),
-      'loaded 1 img8 with dimensions 640x373'
-    )
-    await check(
-      () =>
-        browser.eval(
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img1").currentSrc`)
+      ).toMatch(/test(.*)jpg/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img2").currentSrc`)
+      ).toMatch(/test(.*).png/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img3").currentSrc`)
+      ).toMatch(/test\.svg/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img4").currentSrc`)
+      ).toMatch(/test(.*)ico/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg1").textContent`)
+      ).toEqual('loaded 1 img1 with dimensions 128x128')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg2").textContent`)
+      ).toEqual('loaded 1 img2 with dimensions 400x400')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg3").textContent`)
+      ).toEqual('loaded 1 img3 with dimensions 400x400')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg4").textContent`)
+      ).toEqual('loaded 1 img4 with dimensions 32x32')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg5").textContent`)
+      ).toEqual('loaded 1 img5 with dimensions 3x5')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg6").textContent`)
+      ).toEqual('loaded 1 img6 with dimensions 3x5')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg7").textContent`)
+      ).toEqual('loaded 1 img7 with dimensions 400x400')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg8").textContent`)
+      ).toEqual('loaded 1 img8 with dimensions 640x373')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(
           `document.getElementById("img8").getAttribute("data-nimg")`
-        ),
-      '1'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img8").currentSrc`),
-      /wide.png/
-    )
+        )
+      ).toEqual('1')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img8").currentSrc`)
+      ).toMatch(/wide.png/)
+    })
     await browser.eval('document.getElementById("toggle").click()')
-    await check(
-      () => browser.eval(`document.getElementById("msg8").textContent`),
-      'loaded 2 img8 with dimensions 400x300'
-    )
-    await check(
-      () =>
-        browser.eval(
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg8").textContent`)
+      ).toEqual('loaded 2 img8 with dimensions 400x300')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(
           `document.getElementById("img8").getAttribute("data-nimg")`
-        ),
-      '1'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img8").currentSrc`),
-      /test-rect.jpg/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg9").textContent`),
-      'loaded 1 img9 with dimensions 400x400'
-    )
+        )
+      ).toEqual('1')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img8").currentSrc`)
+      ).toMatch(/test-rect.jpg/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg9").textContent`)
+      ).toEqual('loaded 1 img9 with dimensions 400x400')
+    })
 
     if (mode === 'dev') {
       const warnings = (await browser.log('browser'))
@@ -397,89 +411,109 @@ function runTests(mode) {
       `document.getElementById("footer").scrollIntoView({behavior: "smooth"})`
     )
 
-    await check(
-      () => browser.eval(`document.getElementById("msg1").textContent`),
-      'loaded img1 with native onLoad, count 1'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'loaded img2 with native onLoad, count 1'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg3").textContent`),
-      'loaded img3 with native onLoad, count 1'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg4").textContent`),
-      'loaded img4 with native onLoad, count 1'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg5").textContent`),
-      'loaded img5 with native onLoad, count 1'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg6").textContent`),
-      'loaded img6 with native onLoad, count 1'
-    )
-    await check(
-      () =>
-        browser.eval(
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg1").textContent`)
+      ).toEqual('loaded img1 with native onLoad, count 1')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg2").textContent`)
+      ).toEqual('loaded img2 with native onLoad, count 1')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg3").textContent`)
+      ).toEqual('loaded img3 with native onLoad, count 1')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg4").textContent`)
+      ).toEqual('loaded img4 with native onLoad, count 1')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg5").textContent`)
+      ).toEqual('loaded img5 with native onLoad, count 1')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg6").textContent`)
+      ).toEqual('loaded img6 with native onLoad, count 1')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(
           `document.getElementById("img5").getAttribute("data-nimg")`
-        ),
-      '1'
-    )
+        )
+      ).toEqual('1')
+    })
 
     await browser.eval('document.getElementById("toggle").click()')
 
-    await check(
-      () => browser.eval(`document.getElementById("msg1").textContent`),
-      'loaded img1 with native onLoad, count 2'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'loaded img2 with native onLoad, count 2'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg3").textContent`),
-      'loaded img3 with native onLoad, count 2'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg4").textContent`),
-      'loaded img4 with native onLoad, count 2'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg5").textContent`),
-      'loaded img5 with native onLoad, count 1'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg6").textContent`),
-      'loaded img6 with native onLoad, count 1'
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg1").textContent`)
+      ).toEqual('loaded img1 with native onLoad, count 2')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg2").textContent`)
+      ).toEqual('loaded img2 with native onLoad, count 2')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg3").textContent`)
+      ).toEqual('loaded img3 with native onLoad, count 2')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg4").textContent`)
+      ).toEqual('loaded img4 with native onLoad, count 2')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg5").textContent`)
+      ).toEqual('loaded img5 with native onLoad, count 1')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg6").textContent`)
+      ).toEqual('loaded img6 with native onLoad, count 1')
+    })
 
-    await check(
-      () => browser.eval(`document.getElementById("img1").currentSrc`),
-      /test(.*)jpg/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img2").currentSrc`),
-      /test(.*).png/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img3").currentSrc`),
-      /test\.svg/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img4").currentSrc`),
-      /test(.*)ico/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img5").currentSrc`),
-      /wide.png/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img6").currentSrc`),
-      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mO8ysv7HwAEngHwC+JqOgAAAABJRU5ErkJggg=='
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img1").currentSrc`)
+      ).toMatch(/test(.*)jpg/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img2").currentSrc`)
+      ).toMatch(/test(.*).png/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img3").currentSrc`)
+      ).toMatch(/test\.svg/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img4").currentSrc`)
+      ).toMatch(/test(.*)ico/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img5").currentSrc`)
+      ).toMatch(/wide.png/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img6").currentSrc`)
+      ).toEqual(
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mO8ysv7HwAEngHwC+JqOgAAAABJRU5ErkJggg=='
+      )
+    })
   })
 
   it('should callback native onError when error occurred while loading image', async () => {
@@ -487,42 +521,49 @@ function runTests(mode) {
     await browser.eval(
       `document.getElementById("img1").scrollIntoView({behavior: "smooth"})`
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg1").textContent`),
-      'no error occurred for img1'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img1").style.color`),
-      'transparent'
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg1").textContent`)
+      ).toEqual('no error occurred for img1')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img1").style.color`)
+      ).toEqual('transparent')
+    })
     await browser.eval(
       `document.getElementById("img2").scrollIntoView({behavior: "smooth"})`
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'no error occurred for img2'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img2").style.color`),
-      'transparent'
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg2").textContent`)
+      ).toEqual('no error occurred for img2')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img2").style.color`)
+      ).toEqual('transparent')
+    })
     await browser.eval(`document.getElementById("toggle").click()`)
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'error occurred while loading img2'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img2").style.color`),
-      ''
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg2").textContent`)
+      ).toEqual('error occurred while loading img2')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img2").style.color`)
+      ).toEqual('')
+    })
   })
 
   it('should callback native onError even when error before hydration', async () => {
     let browser = await webdriver(appPort, '/on-error-before-hydration')
-    await check(
-      () => browser.eval(`document.getElementById("msg").textContent`),
-      'error state'
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg").textContent`)
+      ).toEqual('error state')
+    })
   })
 
   it('should work with image with blob src', async () => {
@@ -530,14 +571,16 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/blob')
 
-      await check(
-        () => browser.eval(`document.getElementById("blob-image").src`),
-        /^blob:/
-      )
-      await check(
-        () => browser.eval(`document.getElementById("blob-image").srcset`),
-        ''
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("blob-image").src`)
+        ).toMatch(/^blob:/)
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("blob-image").srcset`)
+        ).toEqual('')
+      })
     } finally {
       if (browser) {
         await browser.close()
@@ -549,16 +592,14 @@ function runTests(mode) {
     let browser
     try {
       browser = await webdriver(appPort, '/flex')
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById('basic-image').width`
         )
         if (result === 0) {
           throw new Error('Incorrectly loaded image')
         }
-
-        return 'result-correct'
-      }, /result-correct/)
+      })
     } finally {
       if (browser) {
         await browser.close()
@@ -568,25 +609,25 @@ function runTests(mode) {
 
   it('should work when using overrideSrc prop', async () => {
     const browser = await webdriver(appPort, '/override-src')
-    await check(async () => {
+    await retry(async () => {
       const result = await browser.eval(
         `document.getElementById('override-src').width`
       )
       if (result === 0) {
         throw new Error('Incorrectly loaded image')
       }
+    })
 
-      return 'result-correct'
-    }, /result-correct/)
-
-    await check(
-      () => browser.eval(`document.getElementById('override-src').currentSrc`),
-      /test(.*)jpg/
-    )
-    await check(
-      () => browser.eval(`document.getElementById('override-src').src`),
-      /myoverride/
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById('override-src').currentSrc`)
+      ).toMatch(/test(.*)jpg/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById('override-src').src`)
+      ).toMatch(/myoverride/)
+    })
   })
 
   it('should work with sizes and automatically use responsive srcset', async () => {
@@ -698,10 +739,11 @@ function runTests(mode) {
     await browser.eval(
       `document.getElementById("blur1").scrollIntoView({behavior: "smooth"})`
     )
-    await check(
-      () => browser.eval(`document.getElementById("blur1").currentSrc`),
-      /test(.*)jpg/
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("blur1").currentSrc`)
+      ).toMatch(/test(.*)jpg/)
+    })
     expect(await browser.elementById('blur1').getAttribute('src')).toMatch(
       /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.jpg&w=828&q=75/
     )
@@ -743,10 +785,11 @@ function runTests(mode) {
     await browser.eval(
       `document.getElementById("blur2").scrollIntoView({behavior: "smooth"})`
     )
-    await check(
-      () => browser.eval(`document.getElementById("blur2").currentSrc`),
-      /test(.*)png/
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("blur2").currentSrc`)
+      ).toMatch(/test(.*)png/)
+    })
     expect(await browser.elementById('blur2').getAttribute('src')).toMatch(
       /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=3840&q=75/
     )
@@ -843,7 +886,7 @@ function runTests(mode) {
   it('should render picture via getImageProps', async () => {
     const browser = await webdriver(appPort, '/picture')
     // Wait for image to load:
-    await check(async () => {
+    await retry(async () => {
       const naturalWidth = await browser.eval(
         `document.querySelector('img').naturalWidth`
       )
@@ -851,9 +894,7 @@ function runTests(mode) {
       if (naturalWidth === 0) {
         throw new Error('Image did not load')
       }
-
-      return 'ready'
-    }, 'ready')
+    })
     const img = await browser.elementByCss('img')
     expect(img).toBeDefined()
     expect(await img.getAttribute('alt')).toBe('Hero')
@@ -882,9 +923,11 @@ function runTests(mode) {
 
       expect(await hasRedbox(browser)).toBe(false)
 
-      await check(async () => {
-        return (await browser.log()).map((log) => log.message).join('\n')
-      }, /Image is missing required "src" property/gm)
+      await retry(async () => {
+        expect(
+          await (await browser.log()).map((log) => log.message).join('\n')
+        ).toMatch(/Image is missing required "src" property/gm)
+      })
     })
 
     it('should show empty string src error', async () => {
@@ -892,9 +935,11 @@ function runTests(mode) {
 
       expect(await hasRedbox(browser)).toBe(false)
 
-      await check(async () => {
-        return (await browser.log()).map((log) => log.message).join('\n')
-      }, /Image is missing required "src" property/gm)
+      await retry(async () => {
+        expect(
+          await (await browser.log()).map((log) => log.message).join('\n')
+        ).toMatch(/Image is missing required "src" property/gm)
+      })
     })
 
     it('should show invalid src error', async () => {
@@ -972,9 +1017,11 @@ function runTests(mode) {
 
       expect(await hasRedbox(browser)).toBe(false)
 
-      await check(async () => {
-        return (await browser.log()).map((log) => log.message).join('\n')
-      }, /Image is missing required "alt" property/gm)
+      await retry(async () => {
+        expect(
+          await (await browser.log()).map((log) => log.message).join('\n')
+        ).toMatch(/Image is missing required "alt" property/gm)
+      })
     })
 
     it('should show error when missing width prop', async () => {
@@ -1054,15 +1101,14 @@ function runTests(mode) {
       let browser = await webdriver(appPort, '/priority-missing-warning')
       try {
         // Wait for image to load:
-        await check(async () => {
+        await retry(async () => {
           const result = await browser.eval(
             `document.getElementById('responsive').naturalWidth`
           )
           if (result < 1) {
             throw new Error('Image not ready')
           }
-          return 'done'
-        }, 'done')
+        })
         await waitFor(1000)
         const warnings = (await browser.log('browser'))
           .map((log) => log.message)
@@ -1144,15 +1190,14 @@ function runTests(mode) {
         `document.querySelector("button").textContent`
       )
       expect(count).toBe('Count: 2')
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           'document.getElementById("w").naturalWidth'
         )
         if (result < 1) {
           throw new Error('Image not loaded')
         }
-        return 'done'
-      }, 'done')
+      })
       await waitFor(1000)
       const warnings = (await browser.log())
         .map((log) => log.message)
@@ -1209,7 +1254,7 @@ function runTests(mode) {
       const id = 'prose-image'
 
       // Wait for image to load:
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById(${JSON.stringify(id)}).naturalWidth`
         )
@@ -1217,9 +1262,7 @@ function runTests(mode) {
         if (result < 1) {
           throw new Error('Image not ready')
         }
-
-        return 'result-correct'
-      }, /result-correct/)
+      })
 
       await waitFor(1000)
 
@@ -1275,8 +1318,12 @@ function runTests(mode) {
 
   it('should apply filter style after image loads', async () => {
     const browser = await webdriver(appPort, '/style-filter')
-    await check(() => getSrc(browser, 'img-plain'), /^\/_next\/image/)
-    await check(() => getSrc(browser, 'img-blur'), /^\/_next\/image/)
+    await retry(async () => {
+      expect(await getSrc(browser, 'img-plain')).toMatch(/^\/_next\/image/)
+    })
+    await retry(async () => {
+      expect(await getSrc(browser, 'img-blur')).toMatch(/^\/_next\/image/)
+    })
     await waitFor(1000)
 
     expect(await getComputedStyle(browser, 'img-plain', 'filter')).toBe(
@@ -1400,7 +1447,7 @@ function runTests(mode) {
       const id = 'exif-rotation-image'
 
       // Wait for image to load:
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById(${JSON.stringify(id)}).naturalWidth`
         )
@@ -1408,9 +1455,7 @@ function runTests(mode) {
         if (result === 0) {
           throw new Error('Image not ready')
         }
-
-        return 'result-correct'
-      }, /result-correct/)
+      })
 
       await waitFor(500)
 
@@ -1437,15 +1482,15 @@ function runTests(mode) {
 
   it('should remove data url placeholder after image loads', async () => {
     const browser = await webdriver(appPort, '/data-url-placeholder')
-    await check(
-      async () =>
+    await retry(async () => {
+      expect(
         await getComputedStyle(
           browser,
           'data-url-placeholder-raw',
           'background-image'
-        ),
-      'none'
-    )
+        )
+      ).toEqual('none')
+    })
     expect(
       await getComputedStyle(
         browser,
@@ -1458,15 +1503,15 @@ function runTests(mode) {
 
     await browser.eval('document.getElementById("spacer").remove()')
 
-    await check(
-      async () =>
+    await retry(async () => {
+      expect(
         await getComputedStyle(
           browser,
           'data-url-placeholder-with-lazy',
           'background-image'
-        ),
-      'none'
-    )
+        )
+      ).toEqual('none')
+    })
   })
 
   it('should render correct objectFit when data url placeholder and fill', async () => {
@@ -1503,15 +1548,15 @@ function runTests(mode) {
 
   it('should remove blurry placeholder after image loads', async () => {
     const browser = await webdriver(appPort, '/blurry-placeholder')
-    await check(
-      async () =>
+    await retry(async () => {
+      expect(
         await getComputedStyle(
           browser,
           'blurry-placeholder-raw',
           'background-image'
-        ),
-      'none'
-    )
+        )
+      ).toEqual('none')
+    })
     expect(
       await getComputedStyle(
         browser,
@@ -1524,15 +1569,15 @@ function runTests(mode) {
 
     await browser.eval('document.getElementById("spacer").remove()')
 
-    await check(
-      async () =>
+    await retry(async () => {
+      expect(
         await getComputedStyle(
           browser,
           'blurry-placeholder-with-lazy',
           'background-image'
-        ),
-      'none'
-    )
+        )
+      ).toEqual('none')
+    })
   })
 
   it('should render correct objectFit when blurDataURL and fill', async () => {

--- a/test/integration/next-image-new/default/test/index.test.ts
+++ b/test/integration/next-image-new/default/test/index.test.ts
@@ -3,7 +3,6 @@
 import cheerio from 'cheerio'
 import validateHTML from 'html-validator'
 import {
-  check,
   fetchViaHTTP,
   findPort,
   getRedboxHeader,
@@ -14,6 +13,7 @@ import {
   nextStart,
   renderViaHTTP,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -77,7 +77,7 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/')
 
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById('basic-image').naturalWidth`
         )
@@ -85,9 +85,7 @@ function runTests(mode) {
         if (result === 0) {
           throw new Error('Incorrectly loaded image')
         }
-
-        return 'result-correct'
-      }, /result-correct/)
+      })
 
       expect(
         await hasImageMatchingUrl(
@@ -107,7 +105,7 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/priority')
 
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById('basic-image').naturalWidth`
         )
@@ -115,9 +113,7 @@ function runTests(mode) {
         if (result === 0) {
           throw new Error('Incorrectly loaded image')
         }
-
-        return 'result-correct'
-      }, /result-correct/)
+      })
 
       const links = await browser.elementsByCss('link[rel=preload][as=image]')
       const entries = []
@@ -276,17 +272,19 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/update')
 
-      await check(
-        () => browser.eval(`document.getElementById("update-image").src`),
-        /test\.jpg/
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("update-image").src`)
+        ).toMatch(/test\.jpg/)
+      })
 
       await browser.eval(`document.getElementById("toggle").click()`)
 
-      await check(
-        () => browser.eval(`document.getElementById("update-image").src`),
-        /test\.png/
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("update-image").src`)
+        ).toMatch(/test\.png/)
+      })
     } finally {
       if (browser) {
         await browser.close()
@@ -301,85 +299,101 @@ function runTests(mode) {
       `document.getElementById("footer").scrollIntoView({behavior: "smooth"})`
     )
 
-    await check(
-      () => browser.eval(`document.getElementById("img1").currentSrc`),
-      /test(.*)jpg/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img2").currentSrc`),
-      /test(.*).png/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img3").currentSrc`),
-      /test\.svg/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img4").currentSrc`),
-      /test(.*)ico/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg1").textContent`),
-      'loaded 1 img1 with dimensions 128x128'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'loaded 1 img2 with dimensions 400x400'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg3").textContent`),
-      'loaded 1 img3 with dimensions 400x400'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg4").textContent`),
-      'loaded 1 img4 with dimensions 32x32'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg5").textContent`),
-      'loaded 1 img5 with dimensions 3x5'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg6").textContent`),
-      'loaded 1 img6 with dimensions 3x5'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg7").textContent`),
-      'loaded 1 img7 with dimensions 400x400'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg8").textContent`),
-      'loaded 1 img8 with dimensions 640x373'
-    )
-    await check(
-      () =>
-        browser.eval(
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img1").currentSrc`)
+      ).toMatch(/test(.*)jpg/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img2").currentSrc`)
+      ).toMatch(/test(.*).png/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img3").currentSrc`)
+      ).toMatch(/test\.svg/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img4").currentSrc`)
+      ).toMatch(/test(.*)ico/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg1").textContent`)
+      ).toEqual('loaded 1 img1 with dimensions 128x128')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg2").textContent`)
+      ).toEqual('loaded 1 img2 with dimensions 400x400')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg3").textContent`)
+      ).toEqual('loaded 1 img3 with dimensions 400x400')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg4").textContent`)
+      ).toEqual('loaded 1 img4 with dimensions 32x32')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg5").textContent`)
+      ).toEqual('loaded 1 img5 with dimensions 3x5')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg6").textContent`)
+      ).toEqual('loaded 1 img6 with dimensions 3x5')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg7").textContent`)
+      ).toEqual('loaded 1 img7 with dimensions 400x400')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg8").textContent`)
+      ).toEqual('loaded 1 img8 with dimensions 640x373')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(
           `document.getElementById("img8").getAttribute("data-nimg")`
-        ),
-      '1'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img8").currentSrc`),
-      /wide.png/
-    )
+        )
+      ).toEqual('1')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img8").currentSrc`)
+      ).toMatch(/wide.png/)
+    })
     await browser.eval('document.getElementById("toggle").click()')
-    await check(
-      () => browser.eval(`document.getElementById("msg8").textContent`),
-      'loaded 2 img8 with dimensions 400x300'
-    )
-    await check(
-      () =>
-        browser.eval(
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg8").textContent`)
+      ).toEqual('loaded 2 img8 with dimensions 400x300')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(
           `document.getElementById("img8").getAttribute("data-nimg")`
-        ),
-      '1'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img8").currentSrc`),
-      /test-rect.jpg/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg9").textContent`),
-      'loaded 1 img9 with dimensions 400x400'
-    )
+        )
+      ).toEqual('1')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img8").currentSrc`)
+      ).toMatch(/test-rect.jpg/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg9").textContent`)
+      ).toEqual('loaded 1 img9 with dimensions 400x400')
+    })
 
     if (mode === 'dev') {
       const warnings = (await browser.log('browser'))
@@ -398,89 +412,109 @@ function runTests(mode) {
       `document.getElementById("msg1").scrollIntoView({behavior: "smooth"})`
     )
 
-    await check(
-      () => browser.eval(`document.getElementById("msg1").textContent`),
-      'loaded img1 with native onLoad, count 1'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'loaded img2 with native onLoad, count 1'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg3").textContent`),
-      'loaded img3 with native onLoad, count 1'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg4").textContent`),
-      'loaded img4 with native onLoad, count 1'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg5").textContent`),
-      'loaded img5 with native onLoad, count 1'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg6").textContent`),
-      'loaded img6 with native onLoad, count 1'
-    )
-    await check(
-      () =>
-        browser.eval(
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg1").textContent`)
+      ).toEqual('loaded img1 with native onLoad, count 1')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg2").textContent`)
+      ).toEqual('loaded img2 with native onLoad, count 1')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg3").textContent`)
+      ).toEqual('loaded img3 with native onLoad, count 1')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg4").textContent`)
+      ).toEqual('loaded img4 with native onLoad, count 1')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg5").textContent`)
+      ).toEqual('loaded img5 with native onLoad, count 1')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg6").textContent`)
+      ).toEqual('loaded img6 with native onLoad, count 1')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(
           `document.getElementById("img5").getAttribute("data-nimg")`
-        ),
-      '1'
-    )
+        )
+      ).toEqual('1')
+    })
 
     await browser.eval('document.getElementById("toggle").click()')
 
-    await check(
-      () => browser.eval(`document.getElementById("msg1").textContent`),
-      'loaded img1 with native onLoad, count 2'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'loaded img2 with native onLoad, count 2'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg3").textContent`),
-      'loaded img3 with native onLoad, count 2'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg4").textContent`),
-      'loaded img4 with native onLoad, count 2'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg5").textContent`),
-      'loaded img5 with native onLoad, count 1'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("msg6").textContent`),
-      'loaded img6 with native onLoad, count 1'
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg1").textContent`)
+      ).toEqual('loaded img1 with native onLoad, count 2')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg2").textContent`)
+      ).toEqual('loaded img2 with native onLoad, count 2')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg3").textContent`)
+      ).toEqual('loaded img3 with native onLoad, count 2')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg4").textContent`)
+      ).toEqual('loaded img4 with native onLoad, count 2')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg5").textContent`)
+      ).toEqual('loaded img5 with native onLoad, count 1')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg6").textContent`)
+      ).toEqual('loaded img6 with native onLoad, count 1')
+    })
 
-    await check(
-      () => browser.eval(`document.getElementById("img1").currentSrc`),
-      /test(.*)jpg/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img2").currentSrc`),
-      /test(.*).png/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img3").currentSrc`),
-      /test\.svg/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img4").currentSrc`),
-      /test(.*)ico/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img5").currentSrc`),
-      /wide.png/
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img6").currentSrc`),
-      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mO8ysv7HwAEngHwC+JqOgAAAABJRU5ErkJggg=='
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img1").currentSrc`)
+      ).toMatch(/test(.*)jpg/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img2").currentSrc`)
+      ).toMatch(/test(.*).png/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img3").currentSrc`)
+      ).toMatch(/test\.svg/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img4").currentSrc`)
+      ).toMatch(/test(.*)ico/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img5").currentSrc`)
+      ).toMatch(/wide.png/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img6").currentSrc`)
+      ).toEqual(
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mO8ysv7HwAEngHwC+JqOgAAAABJRU5ErkJggg=='
+      )
+    })
   })
 
   it('should callback native onError when error occurred while loading image', async () => {
@@ -488,42 +522,49 @@ function runTests(mode) {
     await browser.eval(
       `document.getElementById("img1").scrollIntoView({behavior: "smooth"})`
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg1").textContent`),
-      'no error occurred for img1'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img1").style.color`),
-      'transparent'
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg1").textContent`)
+      ).toEqual('no error occurred for img1')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img1").style.color`)
+      ).toEqual('transparent')
+    })
     await browser.eval(
       `document.getElementById("img2").scrollIntoView({behavior: "smooth"})`
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'no error occurred for img2'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img2").style.color`),
-      'transparent'
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg2").textContent`)
+      ).toEqual('no error occurred for img2')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img2").style.color`)
+      ).toEqual('transparent')
+    })
     await browser.eval(`document.getElementById("toggle").click()`)
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'error occurred while loading img2'
-    )
-    await check(
-      () => browser.eval(`document.getElementById("img2").style.color`),
-      ''
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg2").textContent`)
+      ).toEqual('error occurred while loading img2')
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("img2").style.color`)
+      ).toEqual('')
+    })
   })
 
   it('should callback native onError even when error before hydration', async () => {
     let browser = await webdriver(appPort, '/on-error-before-hydration')
-    await check(
-      () => browser.eval(`document.getElementById("msg").textContent`),
-      'error state'
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("msg").textContent`)
+      ).toEqual('error state')
+    })
   })
 
   it('should work with image with blob src', async () => {
@@ -531,14 +572,16 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/blob')
 
-      await check(
-        () => browser.eval(`document.getElementById("blob-image").src`),
-        /^blob:/
-      )
-      await check(
-        () => browser.eval(`document.getElementById("blob-image").srcset`),
-        ''
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("blob-image").src`)
+        ).toMatch(/^blob:/)
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(`document.getElementById("blob-image").srcset`)
+        ).toEqual('')
+      })
     } finally {
       if (browser) {
         await browser.close()
@@ -550,16 +593,14 @@ function runTests(mode) {
     let browser
     try {
       browser = await webdriver(appPort, '/flex')
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById('basic-image').width`
         )
         if (result === 0) {
           throw new Error('Incorrectly loaded image')
         }
-
-        return 'result-correct'
-      }, /result-correct/)
+      })
     } finally {
       if (browser) {
         await browser.close()
@@ -569,25 +610,25 @@ function runTests(mode) {
 
   it('should work when using overrideSrc prop', async () => {
     const browser = await webdriver(appPort, '/override-src')
-    await check(async () => {
+    await retry(async () => {
       const result = await browser.eval(
         `document.getElementById('override-src').width`
       )
       if (result === 0) {
         throw new Error('Incorrectly loaded image')
       }
+    })
 
-      return 'result-correct'
-    }, /result-correct/)
-
-    await check(
-      () => browser.eval(`document.getElementById('override-src').currentSrc`),
-      /test(.*)jpg/
-    )
-    await check(
-      () => browser.eval(`document.getElementById('override-src').src`),
-      /myoverride/
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById('override-src').currentSrc`)
+      ).toMatch(/test(.*)jpg/)
+    })
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById('override-src').src`)
+      ).toMatch(/myoverride/)
+    })
   })
 
   it('should work with sizes and automatically use responsive srcset', async () => {
@@ -699,10 +740,11 @@ function runTests(mode) {
     await browser.eval(
       `document.getElementById("blur1").scrollIntoView({behavior: "smooth"})`
     )
-    await check(
-      () => browser.eval(`document.getElementById("blur1").currentSrc`),
-      /test(.*)jpg/
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("blur1").currentSrc`)
+      ).toMatch(/test(.*)jpg/)
+    })
     expect(await browser.elementById('blur1').getAttribute('src')).toMatch(
       /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.jpg&w=828&q=75/
     )
@@ -744,10 +786,11 @@ function runTests(mode) {
     await browser.eval(
       `document.getElementById("blur2").scrollIntoView({behavior: "smooth"})`
     )
-    await check(
-      () => browser.eval(`document.getElementById("blur2").currentSrc`),
-      /test(.*)png/
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(`document.getElementById("blur2").currentSrc`)
+      ).toMatch(/test(.*)png/)
+    })
     expect(await browser.elementById('blur2').getAttribute('src')).toMatch(
       /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=3840&q=75/
     )
@@ -844,7 +887,7 @@ function runTests(mode) {
   it('should render picture via getImageProps', async () => {
     const browser = await webdriver(appPort, '/picture')
     // Wait for image to load:
-    await check(async () => {
+    await retry(async () => {
       const naturalWidth = await browser.eval(
         `document.querySelector('img').naturalWidth`
       )
@@ -852,9 +895,7 @@ function runTests(mode) {
       if (naturalWidth === 0) {
         throw new Error('Image did not load')
       }
-
-      return 'ready'
-    }, 'ready')
+    })
     const img = await browser.elementByCss('img')
     expect(img).toBeDefined()
     expect(await img.getAttribute('alt')).toBe('Hero')
@@ -883,9 +924,11 @@ function runTests(mode) {
 
       expect(await hasRedbox(browser)).toBe(false)
 
-      await check(async () => {
-        return (await browser.log()).map((log) => log.message).join('\n')
-      }, /Image is missing required "src" property/gm)
+      await retry(async () => {
+        expect(
+          await (await browser.log()).map((log) => log.message).join('\n')
+        ).toMatch(/Image is missing required "src" property/gm)
+      })
     })
 
     it('should show empty string src error', async () => {
@@ -893,9 +936,11 @@ function runTests(mode) {
 
       expect(await hasRedbox(browser)).toBe(false)
 
-      await check(async () => {
-        return (await browser.log()).map((log) => log.message).join('\n')
-      }, /Image is missing required "src" property/gm)
+      await retry(async () => {
+        expect(
+          await (await browser.log()).map((log) => log.message).join('\n')
+        ).toMatch(/Image is missing required "src" property/gm)
+      })
     })
 
     it('should show invalid src error', async () => {
@@ -973,9 +1018,11 @@ function runTests(mode) {
 
       expect(await hasRedbox(browser)).toBe(false)
 
-      await check(async () => {
-        return (await browser.log()).map((log) => log.message).join('\n')
-      }, /Image is missing required "alt" property/gm)
+      await retry(async () => {
+        expect(
+          await (await browser.log()).map((log) => log.message).join('\n')
+        ).toMatch(/Image is missing required "alt" property/gm)
+      })
     })
 
     it('should show error when missing width prop', async () => {
@@ -1055,15 +1102,14 @@ function runTests(mode) {
       let browser = await webdriver(appPort, '/priority-missing-warning')
       try {
         // Wait for image to load:
-        await check(async () => {
+        await retry(async () => {
           const result = await browser.eval(
             `document.getElementById('responsive').naturalWidth`
           )
           if (result < 1) {
             throw new Error('Image not ready')
           }
-          return 'done'
-        }, 'done')
+        })
         await waitFor(1000)
         const warnings = (await browser.log())
           .map((log) => log.message)
@@ -1145,15 +1191,14 @@ function runTests(mode) {
         `document.querySelector("button").textContent`
       )
       expect(count).toBe('Count: 2')
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           'document.getElementById("w").naturalWidth'
         )
         if (result < 1) {
           throw new Error('Image not loaded')
         }
-        return 'done'
-      }, 'done')
+      })
       await waitFor(1000)
       const warnings = (await browser.log())
         .map((log) => log.message)
@@ -1211,7 +1256,7 @@ function runTests(mode) {
       const id = 'prose-image'
 
       // Wait for image to load:
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById(${JSON.stringify(id)}).naturalWidth`
         )
@@ -1219,9 +1264,7 @@ function runTests(mode) {
         if (result < 1) {
           throw new Error('Image not ready')
         }
-
-        return 'result-correct'
-      }, /result-correct/)
+      })
 
       await waitFor(1000)
 
@@ -1277,8 +1320,12 @@ function runTests(mode) {
 
   it('should apply filter style after image loads', async () => {
     const browser = await webdriver(appPort, '/style-filter')
-    await check(() => getSrc(browser, 'img-plain'), /^\/_next\/image/)
-    await check(() => getSrc(browser, 'img-blur'), /^\/_next\/image/)
+    await retry(async () => {
+      expect(await getSrc(browser, 'img-plain')).toMatch(/^\/_next\/image/)
+    })
+    await retry(async () => {
+      expect(await getSrc(browser, 'img-blur')).toMatch(/^\/_next\/image/)
+    })
     await waitFor(1000)
 
     expect(await getComputedStyle(browser, 'img-plain', 'filter')).toBe(
@@ -1402,7 +1449,7 @@ function runTests(mode) {
       const id = 'exif-rotation-image'
 
       // Wait for image to load:
-      await check(async () => {
+      await retry(async () => {
         const result = await browser.eval(
           `document.getElementById(${JSON.stringify(id)}).naturalWidth`
         )
@@ -1410,9 +1457,7 @@ function runTests(mode) {
         if (result === 0) {
           throw new Error('Image not ready')
         }
-
-        return 'result-correct'
-      }, /result-correct/)
+      })
 
       await waitFor(500)
 
@@ -1446,15 +1491,15 @@ function runTests(mode) {
 
   it('should remove data url placeholder after image loads', async () => {
     const browser = await webdriver(appPort, '/data-url-placeholder')
-    await check(
-      async () =>
+    await retry(async () => {
+      expect(
         await getComputedStyle(
           browser,
           'data-url-placeholder-raw',
           'background-image'
-        ),
-      'none'
-    )
+        )
+      ).toEqual('none')
+    })
     expect(
       await getComputedStyle(
         browser,
@@ -1467,15 +1512,15 @@ function runTests(mode) {
 
     await browser.eval('document.getElementById("spacer").remove()')
 
-    await check(
-      async () =>
+    await retry(async () => {
+      expect(
         await getComputedStyle(
           browser,
           'data-url-placeholder-with-lazy',
           'background-image'
-        ),
-      'none'
-    )
+        )
+      ).toEqual('none')
+    })
   })
 
   it('should render correct objectFit when data url placeholder and fill', async () => {
@@ -1512,15 +1557,15 @@ function runTests(mode) {
 
   it('should remove blurry placeholder after image loads', async () => {
     const browser = await webdriver(appPort, '/blurry-placeholder')
-    await check(
-      async () =>
+    await retry(async () => {
+      expect(
         await getComputedStyle(
           browser,
           'blurry-placeholder-raw',
           'background-image'
-        ),
-      'none'
-    )
+        )
+      ).toEqual('none')
+    })
     expect(
       await getComputedStyle(
         browser,
@@ -1533,15 +1578,15 @@ function runTests(mode) {
 
     await browser.eval('document.getElementById("spacer").remove()')
 
-    await check(
-      async () =>
+    await retry(async () => {
+      expect(
         await getComputedStyle(
           browser,
           'blurry-placeholder-with-lazy',
           'background-image'
-        ),
-      'none'
-    )
+        )
+      ).toEqual('none')
+    })
   })
 
   it('should render correct objectFit when blurDataURL and fill', async () => {

--- a/test/integration/next-image-new/middleware/test/index.test.ts
+++ b/test/integration/next-image-new/middleware/test/index.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 
 import { join } from 'path'
-import { check, findPort, killApp, launchApp } from 'next-test-utils'
+import { findPort, killApp, launchApp, retry } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 
 const appDir = join(__dirname, '../')
@@ -34,7 +34,9 @@ describe('Image with middleware in edge func', () => {
         Attempted import error: 'preload' is not exported from 'react-dom' (imported as 'preload').
        */
         await webdriver(appPort, '/')
-        await check(() => output, /compiled \//i)
+        await retry(async () => {
+          expect(await output).toMatch(/compiled \//i)
+        })
         expect(output).not.toContain(
           `'preload' is not exported from 'react-dom'`
         )

--- a/test/integration/next-image-new/trailing-slash/test/index.test.ts
+++ b/test/integration/next-image-new/trailing-slash/test/index.test.ts
@@ -1,12 +1,12 @@
 /* eslint-env jest */
 
 import {
-  check,
   findPort,
   killApp,
   launchApp,
   nextBuild,
   nextStart,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -62,15 +62,14 @@ describe('Image Component Trailing Slash Tests', () => {
         try {
           browser = await webdriver(appPort, '/')
           const id = 'test1'
-          await check(async () => {
+          await retry(async () => {
             const srcImage = await browser.eval(
               `document.getElementById('${id}').src`
             )
             expect(srcImage).toMatch(
               /\/_next\/image\/\?url=%2F_next%2Fstatic%2Fmedia%2Ftest(.+).jpg&w=828&q=75/
             )
-            return 'success'
-          }, 'success')
+          })
         } finally {
           if (browser) {
             await browser.close()

--- a/test/integration/next-image-new/unoptimized/test/index.test.ts
+++ b/test/integration/next-image-new/unoptimized/test/index.test.ts
@@ -2,12 +2,12 @@
 
 import { join } from 'path'
 import {
-  check,
   findPort,
   killApp,
   launchApp,
   nextBuild,
   nextStart,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 
@@ -57,11 +57,13 @@ function runTests(url: string) {
       `document.getElementById("eager-image").scrollIntoView({behavior: "smooth"})`
     )
 
-    await check(
-      () =>
-        browser.eval(`document.getElementById("external-image").currentSrc`),
-      'https://image-optimization-test.vercel.app/test.jpg'
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(
+          `document.getElementById("external-image").currentSrc`
+        )
+      ).toEqual('https://image-optimization-test.vercel.app/test.jpg')
+    })
 
     expect(
       await browser.elementById('internal-image').getAttribute('src')

--- a/test/integration/not-found-revalidate/test/index.test.js
+++ b/test/integration/not-found-revalidate/test/index.test.js
@@ -10,7 +10,7 @@ import {
   killApp,
   fetchViaHTTP,
   waitFor,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -46,32 +46,26 @@ const runTests = () => {
 
     // wait for revalidation to occur in background
     try {
-      await check(async () => {
+      await retry(async () => {
         res = await fetchViaHTTP(appPort, '/initial-not-found/first')
         $ = cheerio.load(await res.text())
 
-        return res.status === 200 && $('#data').text() === '200'
-          ? 'success'
-          : `${res.status} - ${$('#data').text()}`
-      }, 'success')
+        expect(res.status === 200 && $('#data').text() === '200').toBeTruthy()
+      })
 
-      await check(async () => {
+      await retry(async () => {
         res = await fetchViaHTTP(appPort, '/initial-not-found/second')
         $ = cheerio.load(await res.text())
 
-        return res.status === 200 && $('#data').text() === '200'
-          ? 'success'
-          : `${res.status} - ${$('#data').text()}`
-      }, 'success')
+        expect(res.status === 200 && $('#data').text() === '200').toBeTruthy()
+      })
 
-      await check(async () => {
+      await retry(async () => {
         res = await fetchViaHTTP(appPort, '/initial-not-found')
         $ = cheerio.load(await res.text())
 
-        return res.status === 200 && $('#data').text() === '200'
-          ? 'success'
-          : `${res.status} - ${$('#data').text()}`
-      }, 'success')
+        expect(res.status === 200 && $('#data').text() === '200').toBeTruthy()
+      })
     } finally {
       await fs.writeFile(dataFile, '404')
     }

--- a/test/integration/ondemand/test/index.test.js
+++ b/test/integration/ondemand/test/index.test.js
@@ -6,11 +6,11 @@ import {
   renderViaHTTP,
   killApp,
   waitFor,
-  check,
   getBrowserBodyText,
   getPageFileFromBuildManifest,
   getBuildManifest,
   initNextServerScript,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '../')
@@ -87,10 +87,10 @@ const startServer = async (optEnv = {}, opts) => {
 
       await browser.eval('document.getElementById("to-dynamic").click()')
 
-      await check(async () => {
+      await retry(async () => {
         const text = await getBrowserBodyText(browser)
-        return text
-      }, /Hello/)
+        expect(await text).toMatch(/Hello/)
+      })
     } finally {
       if (browser) {
         await browser.close()

--- a/test/integration/preload-viewport/test/index.test.js
+++ b/test/integration/preload-viewport/test/index.test.js
@@ -1,12 +1,12 @@
 /* eslint-env jest */
 
 import {
-  check,
   findPort,
   killApp,
   nextBuild,
   nextStart,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import http from 'http'
 import httpProxy from 'http-proxy'
@@ -101,7 +101,7 @@ describe('Prefetching Links in viewport', () => {
         try {
           browser = await webdriver(appPort, '/')
 
-          await check(async () => {
+          await retry(async () => {
             const links = await browser.elementsByCss('link[rel=prefetch]')
             let found = false
 
@@ -113,8 +113,7 @@ describe('Prefetching Links in viewport', () => {
               }
             }
             expect(found).toBe(true)
-            return 'success'
-          }, 'success')
+          })
         } finally {
           if (browser) await browser.close()
         }
@@ -157,7 +156,7 @@ describe('Prefetching Links in viewport', () => {
         try {
           browser = await webdriver(appPort, '/rewrite-prefetch')
 
-          await check(async () => {
+          await retry(async () => {
             const links = await browser.elementsByCss('link[rel=prefetch]')
             let found = false
 
@@ -169,8 +168,7 @@ describe('Prefetching Links in viewport', () => {
               }
             }
             expect(found).toBe(true)
-            return 'success'
-          }, 'success')
+          })
 
           const hrefs = await browser.eval(
             `Object.keys(window.next.router.sdc)`
@@ -462,7 +460,7 @@ describe('Prefetching Links in viewport', () => {
         // want to be re-fetched/re-observed.
         const browser = await webdriver(appPort, '/')
 
-        await check(async () => {
+        await retry(async () => {
           const links = await browser.elementsByCss('link[rel=prefetch]')
           let found = false
 
@@ -474,8 +472,7 @@ describe('Prefetching Links in viewport', () => {
             }
           }
           expect(found).toBe(true)
-          return 'success'
-        }, 'success')
+        })
 
         await browser.eval(`(function() {
       window.calledPrefetch = false
@@ -485,10 +482,11 @@ describe('Prefetching Links in viewport', () => {
       }
       window.next.router.push('/de-duped')
     })()`)
-        await check(
-          () => browser.eval('document.documentElement.innerHTML'),
-          /to \/first/
-        )
+        await retry(async () => {
+          expect(
+            await browser.eval('document.documentElement.innerHTML')
+          ).toMatch(/to \/first/)
+        })
         const calledPrefetch = await browser.eval(`window.calledPrefetch`)
         expect(calledPrefetch).toBe(false)
       })

--- a/test/integration/prerender-fallback-encoding/test/index.test.js
+++ b/test/integration/prerender-fallback-encoding/test/index.test.js
@@ -11,7 +11,7 @@ import {
   launchApp,
   nextStart,
   fetchViaHTTP,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -111,20 +111,20 @@ function runTests(isDev) {
             if (!isDev) {
               // we don't block on writing incremental data to the
               // disk so use check
-              await check(
-                () =>
-                  fs
+              await retry(async () => {
+                expect(
+                  await fs
                     .exists(join(pagesDir, mode, path + '.html'))
-                    .then((res) => (res ? 'yes' : 'no')),
-                'yes'
-              )
-              await check(
-                () =>
-                  fs
+                    .then((res) => (res ? 'yes' : 'no'))
+                ).toEqual('yes')
+              })
+              await retry(async () => {
+                expect(
+                  await fs
                     .exists(join(pagesDir, mode, path + '.json'))
-                    .then((res) => (res ? 'yes' : 'no')),
-                'yes'
-              )
+                    .then((res) => (res ? 'yes' : 'no'))
+                ).toEqual('yes')
+              })
             }
 
             const browser = await webdriver(appPort, `/${mode}/${testSlug}`)
@@ -265,14 +265,12 @@ function runTests(isDev) {
           })
         })()`)
 
-        await check(async () => {
+        await retry(async () => {
           const browserRouter = JSON.parse(
             await browser.elementByCss('#router').text()
           )
-          return browserRouter.asPath === `/${mode}/${nextSlug}`
-            ? 'success'
-            : 'fail'
-        }, 'success')
+          expect(browserRouter.asPath === `/${mode}/${nextSlug}`).toBeTruthy()
+        })
 
         expect(await browser.eval('window.beforeNav')).toBe(1)
       }
@@ -309,14 +307,12 @@ function runTests(isDev) {
           window.next.router.push('/${mode}/${nextSlug}')
         })()`)
 
-        await check(async () => {
+        await retry(async () => {
           const browserRouter = JSON.parse(
             await browser.elementByCss('#router').text()
           )
-          return browserRouter.asPath === `/${mode}/${nextSlug}`
-            ? 'success'
-            : 'fail'
-        }, 'success')
+          expect(browserRouter.asPath === `/${mode}/${nextSlug}`).toBeTruthy()
+        })
 
         expect(await browser.eval('window.beforeNav')).toBe(1)
       }

--- a/test/integration/preview-fallback/test/index.test.js
+++ b/test/integration/preview-fallback/test/index.test.js
@@ -13,7 +13,7 @@ import {
   nextBuild,
   nextStart,
   renderViaHTTP,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -211,10 +211,10 @@ function runTests(isDev) {
   it('should not write preview dynamic non-prerendered SSG page to cache with fallback', async () => {
     let browser = await webdriver(appPort, '/fallback/second')
 
-    await check(async () => {
+    await retry(async () => {
       const props = JSON.parse(await browser.elementByCss('#props').text())
-      return props.params ? 'pass' : 'fail'
-    }, 'pass')
+      expect(props.params).toBeTruthy()
+    })
 
     const props = JSON.parse(await browser.elementByCss('#props').text())
 
@@ -251,10 +251,10 @@ function runTests(isDev) {
 
     browser = await webdriver(appPort, '/fallback/second')
 
-    await check(async () => {
+    await retry(async () => {
       const props = JSON.parse(await browser.elementByCss('#props').text())
-      return props.params ? 'pass' : 'fail'
-    }, 'pass')
+      expect(props.params).toBeTruthy()
+    })
 
     const props2 = JSON.parse(await browser.elementByCss('#props').text())
 

--- a/test/integration/react-current-version/test/index.test.js
+++ b/test/integration/react-current-version/test/index.test.js
@@ -4,11 +4,11 @@ import { join } from 'path'
 
 import cheerio from 'cheerio'
 import {
-  check,
   File,
   renderViaHTTP,
   runDevSuite,
   runProdSuite,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 
@@ -96,14 +96,20 @@ function runTestsAgainstRuntime(runtime) {
         expect(stylesOccurrence.length).toBe(1)
 
         await withBrowser('/use-flush-effect/styled-jsx', async (browser) => {
-          await check(
-            () => browser.waitForElementByCss('#__jsx-900f996af369fc74').text(),
-            /(?:blue|#00f)/
-          )
-          await check(
-            () => browser.waitForElementByCss('#__jsx-8b0811664c4e575e').text(),
-            /red/
-          )
+          await retry(async () => {
+            expect(
+              await browser
+                .waitForElementByCss('#__jsx-900f996af369fc74')
+                .text()
+            ).toMatch(/(?:blue|#00f)/)
+          })
+          await retry(async () => {
+            expect(
+              await browser
+                .waitForElementByCss('#__jsx-8b0811664c4e575e')
+                .text()
+            ).toMatch(/red/)
+          })
         })
       })
 

--- a/test/integration/read-only-source-hmr/test/index.test.js
+++ b/test/integration/read-only-source-hmr/test/index.test.js
@@ -2,11 +2,11 @@
 
 import fs from 'fs-extra'
 import {
-  check,
   findPort,
   getBrowserBodyText,
   killApp,
   launchApp,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -60,7 +60,9 @@ describe('Read-only source HMR', () => {
 
     try {
       browser = await webdriver(appPort, '/hello')
-      await check(() => getBrowserBodyText(browser), /Hello World/)
+      await retry(async () => {
+        expect(await getBrowserBodyText(browser)).toMatch(/Hello World/)
+      })
 
       const originalContent = await fs.readFile(pagePath, 'utf8')
       const editedContent = originalContent.replace('Hello World', 'COOL page')
@@ -71,10 +73,14 @@ describe('Read-only source HMR', () => {
       }
 
       await writeReadOnlyFile(pagePath, editedContent)
-      await check(() => getBrowserBodyText(browser), /COOL page/)
+      await retry(async () => {
+        expect(await getBrowserBodyText(browser)).toMatch(/COOL page/)
+      })
 
       await writeReadOnlyFile(pagePath, originalContent)
-      await check(() => getBrowserBodyText(browser), /Hello World/)
+      await retry(async () => {
+        expect(await getBrowserBodyText(browser)).toMatch(/Hello World/)
+      })
     } finally {
       if (browser) {
         await browser.close()
@@ -87,7 +93,9 @@ describe('Read-only source HMR', () => {
 
     try {
       browser = await webdriver(appPort, '/hello')
-      await check(() => getBrowserBodyText(browser), /Hello World/)
+      await retry(async () => {
+        expect(await getBrowserBodyText(browser)).toMatch(/Hello World/)
+      })
 
       const originalContent = await fs.readFile(pagePath, 'utf8')
 
@@ -98,7 +106,9 @@ describe('Read-only source HMR', () => {
 
       await fs.remove(pagePath)
       await writeReadOnlyFile(pagePath, originalContent)
-      await check(() => getBrowserBodyText(browser), /Hello World/)
+      await retry(async () => {
+        expect(await getBrowserBodyText(browser)).toMatch(/Hello World/)
+      })
     } finally {
       if (browser) {
         await browser.close()
@@ -121,7 +131,9 @@ describe('Read-only source HMR', () => {
       )
 
       browser = await webdriver(appPort, '/new')
-      await check(() => getBrowserBodyText(browser), /New page/)
+      await retry(async () => {
+        expect(await getBrowserBodyText(browser)).toMatch(/New page/)
+      })
     } finally {
       if (browser) {
         await browser.close()

--- a/test/integration/revalidate-as-path/test/index.test.js
+++ b/test/integration/revalidate-as-path/test/index.test.js
@@ -10,7 +10,7 @@ import {
   renderViaHTTP,
   nextStart,
   waitFor,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '../')
@@ -39,7 +39,9 @@ const runTests = () => {
       hello: 'world',
     })
 
-    await check(() => stdout, /asPath/)
+    await retry(async () => {
+      expect(await stdout).toMatch(/asPath/)
+    })
     const asPath = stdout.split('asPath: ').pop().split('\n').shift()
     expect(asPath).toBe('/')
   })
@@ -63,7 +65,9 @@ const runTests = () => {
       hello: 'world',
     })
 
-    await check(() => stdout, /asPath/)
+    await retry(async () => {
+      expect(await stdout).toMatch(/asPath/)
+    })
     const asPath = stdout.split('asPath: ').pop().split('\n').shift()
     expect(asPath).toBe('/another/index')
   })

--- a/test/integration/rewrites-manual-href-as/test/index.test.js
+++ b/test/integration/rewrites-manual-href-as/test/index.test.js
@@ -2,12 +2,12 @@
 
 import { join } from 'path'
 import {
-  check,
   findPort,
   killApp,
   launchApp,
   nextBuild,
   nextStart,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 
@@ -108,13 +108,13 @@ const runTests = () => {
 
     expect(await browser.elementByCss('#preview').text()).toBe('preview page')
     expect(await browser.eval('window.beforeNav')).toBe(1)
-    await check(
-      async () =>
-        JSON.parse(
+    await retry(async () => {
+      expect(
+        await JSON.parse(
           await browser.eval('document.querySelector("#query").innerHTML')
-        ).slug,
-      '321'
-    )
+        ).slug
+      ).toEqual('321')
+    })
 
     await browser
       .elementByCss('#to-another')

--- a/test/integration/router-is-ready-app-gip/test/index.test.js
+++ b/test/integration/router-is-ready-app-gip/test/index.test.js
@@ -9,7 +9,7 @@ import {
   nextStart,
   nextBuild,
   File,
-  check,
+  retry,
 } from 'next-test-utils'
 
 let app
@@ -18,12 +18,12 @@ const appDir = join(__dirname, '../')
 const invalidPage = new File(join(appDir, 'pages/invalid.js'))
 
 const checkIsReadyValues = (browser, expected = []) => {
-  return check(async () => {
+  return retry(async () => {
     const values = JSON.stringify(
       (await browser.eval('window.isReadyValues')).sort()
     )
-    return JSON.stringify(expected.sort()) === values ? 'success' : values
-  }, 'success')
+    expect(JSON.stringify(expected.sort()) === values).toBeTruthy()
+  })
 }
 
 function runTests() {

--- a/test/integration/router-is-ready/test/index.test.js
+++ b/test/integration/router-is-ready/test/index.test.js
@@ -9,7 +9,7 @@ import {
   nextStart,
   nextBuild,
   File,
-  check,
+  retry,
 } from 'next-test-utils'
 
 let app
@@ -18,12 +18,12 @@ const appDir = join(__dirname, '../')
 const invalidPage = new File(join(appDir, 'pages/invalid.js'))
 
 const checkIsReadyValues = (browser, expected = []) => {
-  return check(async () => {
+  return retry(async () => {
     const values = JSON.stringify(
       (await browser.eval('window.isReadyValues')).sort()
     )
-    return JSON.stringify(expected.sort()) === values ? 'success' : values
-  }, 'success')
+    expect(JSON.stringify(expected.sort()) === values).toBeTruthy()
+  })
 }
 
 function runTests() {

--- a/test/integration/scroll-back-restoration/test/index.test.js
+++ b/test/integration/scroll-back-restoration/test/index.test.js
@@ -8,7 +8,7 @@ import {
   launchApp,
   nextStart,
   nextBuild,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '../')
@@ -35,17 +35,20 @@ const runTests = () => {
 
     await browser.eval(() => window.next.router.push('/another'))
 
-    await check(
-      () => browser.eval(() => document.documentElement.innerHTML),
-      /hi from another/
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(() => document.documentElement.innerHTML)
+      ).toMatch(/hi from another/)
+    })
     await browser.eval(() => (window.didHydrate = false))
 
     await browser.eval(() => window.history.back())
-    await check(() => browser.eval(() => window.didHydrate), {
-      test(content) {
-        return content
-      },
+    await retry(async () => {
+      expect(await browser.eval(() => window.didHydrate)).toMatch({
+        test(content) {
+          return content
+        },
+      })
     })
 
     const newScrollX = Math.floor(await browser.eval(() => window.scrollX))

--- a/test/integration/scroll-forward-restoration/test/index.test.js
+++ b/test/integration/scroll-forward-restoration/test/index.test.js
@@ -8,7 +8,7 @@ import {
   launchApp,
   nextStart,
   nextBuild,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '../')
@@ -20,10 +20,11 @@ const runTests = () => {
     const browser = await webdriver(appPort, '/another')
     await browser.elementByCss('#to-index').click()
 
-    await check(
-      () => browser.eval(() => document.documentElement.innerHTML),
-      /the end/
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(() => document.documentElement.innerHTML)
+      ).toMatch(/the end/)
+    })
 
     await browser.eval(() =>
       document.querySelector('#to-another').scrollIntoView()
@@ -42,18 +43,21 @@ const runTests = () => {
 
     await browser.eval(() => window.history.back())
 
-    await check(
-      () => browser.eval(() => document.documentElement.innerHTML),
-      /hi from another/
-    )
+    await retry(async () => {
+      expect(
+        await browser.eval(() => document.documentElement.innerHTML)
+      ).toMatch(/hi from another/)
+    })
 
     await browser.eval(() => (window.didHydrate = false))
     await browser.eval(() => window.history.forward())
 
-    await check(() => browser.eval(() => window.didHydrate), {
-      test(content) {
-        return content
-      },
+    await retry(async () => {
+      expect(await browser.eval(() => window.didHydrate)).toMatch({
+        test(content) {
+          return content
+        },
+      })
     })
 
     const newScrollX = Math.floor(await browser.eval(() => window.scrollX))

--- a/test/integration/server-side-dev-errors/test/index.test.js
+++ b/test/integration/server-side-dev-errors/test/index.test.js
@@ -7,9 +7,9 @@ import {
   killApp,
   findPort,
   launchApp,
-  check,
   hasRedbox,
   getRedboxSource,
+  retry,
 } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
@@ -49,16 +49,16 @@ describe('server-side dev errors', () => {
       )
       const browser = await webdriver(appPort, '/gsp')
 
-      await check(async () => {
+      await retry(() => {
         const err = stderr.slice(stderrIdx)
 
-        return err.includes('pages/gsp.js') &&
-          err.includes('6:2') &&
-          err.includes('getStaticProps') &&
-          err.includes('missingVar')
-          ? 'success'
-          : err
-      }, 'success')
+        expect(
+          err.includes('pages/gsp.js') &&
+            err.includes('6:2') &&
+            err.includes('getStaticProps') &&
+            err.includes('missingVar')
+        ).toBeTruthy()
+      })
 
       expect(await hasRedbox(browser)).toBe(true)
 
@@ -81,16 +81,16 @@ describe('server-side dev errors', () => {
       )
       const browser = await webdriver(appPort, '/gssp')
 
-      await check(async () => {
+      await retry(() => {
         const err = stderr.slice(stderrIdx)
 
-        return err.includes('pages/gssp.js') &&
-          err.includes('6:2') &&
-          err.includes('getServerSideProps') &&
-          err.includes('missingVar')
-          ? 'success'
-          : err
-      }, 'success')
+        expect(
+          err.includes('pages/gssp.js') &&
+            err.includes('6:2') &&
+            err.includes('getServerSideProps') &&
+            err.includes('missingVar')
+        ).toBeTruthy()
+      })
 
       expect(await hasRedbox(browser)).toBe(true)
 
@@ -113,16 +113,16 @@ describe('server-side dev errors', () => {
       )
       const browser = await webdriver(appPort, '/blog/first')
 
-      await check(async () => {
+      await retry(() => {
         const err = stderr.slice(stderrIdx)
 
-        return err.includes('pages/blog/[slug].js') &&
-          err.includes('6:2') &&
-          err.includes('getServerSideProps') &&
-          err.includes('missingVar')
-          ? 'success'
-          : err
-      }, 'success')
+        expect(
+          err.includes('pages/blog/[slug].js') &&
+            err.includes('6:2') &&
+            err.includes('getServerSideProps') &&
+            err.includes('missingVar')
+        ).toBeTruthy()
+      })
 
       expect(await hasRedbox(browser)).toBe(true)
 
@@ -145,16 +145,16 @@ describe('server-side dev errors', () => {
       )
       const browser = await webdriver(appPort, '/api/hello')
 
-      await check(async () => {
+      await retry(() => {
         const err = stderr.slice(stderrIdx)
 
-        return err.includes('pages/api/hello.js') &&
-          err.includes('2:3') &&
-          err.includes('default') &&
-          err.includes('missingVar')
-          ? 'success'
-          : err
-      }, 'success')
+        expect(
+          err.includes('pages/api/hello.js') &&
+            err.includes('2:3') &&
+            err.includes('default') &&
+            err.includes('missingVar')
+        ).toBeTruthy()
+      })
 
       expect(await hasRedbox(browser)).toBe(true)
 
@@ -177,16 +177,16 @@ describe('server-side dev errors', () => {
       )
       const browser = await webdriver(appPort, '/api/blog/first')
 
-      await check(async () => {
+      await retry(() => {
         const err = stderr.slice(stderrIdx)
 
-        return err.includes('pages/api/blog/[slug].js') &&
-          err.includes('2:3') &&
-          err.includes('default') &&
-          err.includes('missingVar')
-          ? 'success'
-          : err
-      }, 'success')
+        expect(
+          err.includes('pages/api/blog/[slug].js') &&
+            err.includes('2:3') &&
+            err.includes('default') &&
+            err.includes('missingVar')
+        ).toBeTruthy()
+      })
 
       expect(await hasRedbox(browser)).toBe(true)
 
@@ -202,63 +202,63 @@ describe('server-side dev errors', () => {
     const stderrIdx = stderr.length
     await webdriver(appPort, '/uncaught-rejection')
 
-    await check(async () => {
+    await retry(() => {
       const err = stderr.slice(stderrIdx)
 
-      return err.includes('pages/uncaught-rejection.js') &&
-        err.includes('7:20') &&
-        err.includes('getServerSideProps') &&
-        err.includes('catch this rejection')
-        ? 'success'
-        : err
-    }, 'success')
+      expect(
+        err.includes('pages/uncaught-rejection.js') &&
+          err.includes('7:20') &&
+          err.includes('getServerSideProps') &&
+          err.includes('catch this rejection')
+      ).toBeTruthy()
+    })
   })
 
   it('should show server-side error for uncaught empty rejection correctly', async () => {
     const stderrIdx = stderr.length
     await webdriver(appPort, '/uncaught-empty-rejection')
 
-    await check(async () => {
+    await retry(() => {
       const cleanStderr = stripAnsi(stderr.slice(stderrIdx))
 
-      return cleanStderr.includes('pages/uncaught-empty-rejection.js') &&
-        cleanStderr.includes('7:20') &&
-        cleanStderr.includes('getServerSideProps') &&
-        cleanStderr.includes('new Error()')
-        ? 'success'
-        : cleanStderr
-    }, 'success')
+      expect(
+        cleanStderr.includes('pages/uncaught-empty-rejection.js') &&
+          cleanStderr.includes('7:20') &&
+          cleanStderr.includes('getServerSideProps') &&
+          cleanStderr.includes('new Error()')
+      ).toBeTruthy()
+    })
   })
 
   it('should show server-side error for uncaught exception correctly', async () => {
     const stderrIdx = stderr.length
     await webdriver(appPort, '/uncaught-exception')
 
-    await check(async () => {
+    await retry(() => {
       const err = stderr.slice(stderrIdx)
 
-      return err.includes('pages/uncaught-exception.js') &&
-        err.includes('7:11') &&
-        err.includes('getServerSideProps') &&
-        err.includes('catch this exception')
-        ? 'success'
-        : err
-    }, 'success')
+      expect(
+        err.includes('pages/uncaught-exception.js') &&
+          err.includes('7:11') &&
+          err.includes('getServerSideProps') &&
+          err.includes('catch this exception')
+      ).toBeTruthy()
+    })
   })
 
   it('should show server-side error for uncaught empty exception correctly', async () => {
     const stderrIdx = stderr.length
     await webdriver(appPort, '/uncaught-empty-exception')
 
-    await check(async () => {
+    await retry(() => {
       const cleanStderr = stripAnsi(stderr.slice(stderrIdx))
 
-      return cleanStderr.includes('pages/uncaught-empty-exception.js') &&
-        cleanStderr.includes('7:11') &&
-        cleanStderr.includes('getServerSideProps') &&
-        cleanStderr.includes('new Error()')
-        ? 'success'
-        : cleanStderr
-    }, 'success')
+      expect(
+        cleanStderr.includes('pages/uncaught-empty-exception.js') &&
+          cleanStderr.includes('7:11') &&
+          cleanStderr.includes('getServerSideProps') &&
+          cleanStderr.includes('new Error()')
+      ).toBeTruthy()
+    })
   })
 })

--- a/test/integration/telemetry/test/config.test.js
+++ b/test/integration/telemetry/test/config.test.js
@@ -1,11 +1,11 @@
 import {
-  check,
   findAllTelemetryEvents,
   findPort,
   killApp,
   launchApp,
   nextBuild,
   nextLint,
+  retry,
 } from 'next-test-utils'
 import fs from 'fs-extra'
 import path from 'path'
@@ -103,7 +103,9 @@ describe('config telemetry', () => {
             NEXT_TELEMETRY_DEBUG: 1,
           },
         })
-        await check(() => stderr2, /NEXT_CLI_SESSION_STARTED/)
+        await retry(async () => {
+          expect(await stderr2).toMatch(/NEXT_CLI_SESSION_STARTED/)
+        })
         await killApp(app)
 
         await fs.rename(

--- a/test/integration/telemetry/test/page-features.test.js
+++ b/test/integration/telemetry/test/page-features.test.js
@@ -1,12 +1,12 @@
 import path from 'path'
 import fs from 'fs-extra'
 import {
-  check,
   findPort,
   killApp,
   launchApp,
   nextBuild,
   renderViaHTTP,
+  retry,
 } from 'next-test-utils'
 
 const appDir = path.join(__dirname, '..')
@@ -54,7 +54,9 @@ describe('page features telemetry', () => {
           },
           turbo: true,
         })
-        await check(() => stderr, /NEXT_CLI_SESSION_STARTED/)
+        await retry(async () => {
+          expect(await stderr).toMatch(/NEXT_CLI_SESSION_STARTED/)
+        })
         await renderViaHTTP(port, '/hello')
 
         if (app) {
@@ -96,13 +98,17 @@ describe('page features telemetry', () => {
           turbo: true,
         })
 
-        await check(() => stderr, /NEXT_CLI_SESSION_STARTED/)
+        await retry(async () => {
+          expect(await stderr).toMatch(/NEXT_CLI_SESSION_STARTED/)
+        })
         await renderViaHTTP(port, '/hello')
 
         if (app) {
           await killApp(app, 'SIGTERM')
         }
-        await check(() => stderr, /NEXT_CLI_SESSION_STOPPED/)
+        await retry(async () => {
+          expect(await stderr).toMatch(/NEXT_CLI_SESSION_STOPPED/)
+        })
 
         expect(stderr).toContain('NEXT_CLI_SESSION_STOPPED')
         const event1 = /NEXT_CLI_SESSION_STOPPED[\s\S]+?{([\s\S]+?)}/
@@ -137,14 +143,18 @@ describe('page features telemetry', () => {
           },
         })
 
-        await check(() => stderr, /NEXT_CLI_SESSION_STARTED/)
+        await retry(async () => {
+          expect(await stderr).toMatch(/NEXT_CLI_SESSION_STARTED/)
+        })
         await renderViaHTTP(port, '/hello')
 
         if (app) {
           await killApp(app, 'SIGTERM')
         }
 
-        await check(() => stderr, /NEXT_CLI_SESSION_STOPPED/)
+        await retry(async () => {
+          expect(await stderr).toMatch(/NEXT_CLI_SESSION_STOPPED/)
+        })
 
         expect(stderr).toContain('NEXT_CLI_SESSION_STOPPED')
         const event1 = /NEXT_CLI_SESSION_STOPPED[\s\S]+?{([\s\S]+?)}/

--- a/test/integration/trailing-slashes-href-resolving/test/index.test.js
+++ b/test/integration/trailing-slashes-href-resolving/test/index.test.js
@@ -3,12 +3,12 @@ import assert from 'assert'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import {
-  check,
   findPort,
   killApp,
   launchApp,
   nextBuild,
   nextStart,
+  retry,
 } from 'next-test-utils'
 
 let app
@@ -76,7 +76,7 @@ const runTests = (dev) => {
     it('should preload SSG routes correctly', async () => {
       const browser = await webdriver(appPort, '/')
 
-      await check(async () => {
+      await retry(async () => {
         const hrefs = await browser.eval(`Object.keys(window.next.router.sdc)`)
         hrefs.sort()
 
@@ -86,8 +86,7 @@ const runTests = (dev) => {
           ),
           ['/top-level-slug.json', '/world.json']
         )
-        return 'yes'
-      }, 'yes')
+      })
     })
   }
 }

--- a/test/integration/turbopack-unsupported-log/index.test.ts
+++ b/test/integration/turbopack-unsupported-log/index.test.ts
@@ -1,9 +1,9 @@
 import {
-  check,
   findPort,
   killApp,
   launchApp,
   renderViaHTTP,
+  retry,
 } from 'next-test-utils'
 import fs from 'fs-extra'
 import { join } from 'path'
@@ -83,13 +83,12 @@ describe('turbopack unsupported features log', () => {
       })
 
       try {
-        await check(() => {
+        await retry(() => {
           expect(output).toContain('(turbo)')
           expect(output).toContain(
             'You are using configuration and/or tools that are not yet'
           )
-          return 'success'
-        }, /success/)
+        })
       } finally {
         await killApp(app).catch(() => {})
         await fs.remove(nextConfigPath)

--- a/test/integration/url-imports/test/index.test.js
+++ b/test/integration/url-imports/test/index.test.js
@@ -12,9 +12,9 @@ import {
   fetchViaHTTP,
   launchApp,
   getBrowserBodyText,
-  check,
   startStaticServer,
   stopApp,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 
@@ -73,7 +73,11 @@ const appDir = join(__dirname, '../')
             let browser
             try {
               browser = await webdriver(appPort, page)
-              await check(() => getBrowserBodyText(browser), expectedClient)
+              await retry(async () => {
+                expect(await getBrowserBodyText(browser)).toMatch(
+                  expectedClient
+                )
+              })
             } finally {
               await browser.close()
             }
@@ -85,10 +89,13 @@ const appDir = join(__dirname, '../')
           try {
             browser = await webdriver(appPort, '/image')
             await browser.waitForElementByCss('#static-image')
-            await check(
-              () => browser.elementByCss('#static-image').getAttribute('src'),
-              /^\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Fvercel\.[0-9a-f]{8}\.png&/
-            )
+            await retry(async () => {
+              expect(
+                await browser.elementByCss('#static-image').getAttribute('src')
+              ).toMatch(
+                /^\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Fvercel\.[0-9a-f]{8}\.png&/
+              )
+            })
           } finally {
             await browser.close()
           }
@@ -99,13 +106,15 @@ const appDir = join(__dirname, '../')
           try {
             browser = await webdriver(appPort, '/css')
             await browser.waitForElementByCss('#static-css')
-            await check(
-              () =>
-                browser
+            await retry(async () => {
+              expect(
+                await browser
                   .elementByCss('#static-css')
-                  .getComputedCss('background-image'),
-              /^url\("http:\/\/localhost:\d+\/_next\/static\/media\/vercel\.[0-9a-f]{8}\.png"\)$/
-            )
+                  .getComputedCss('background-image')
+              ).toMatch(
+                /^url\("http:\/\/localhost:\d+\/_next\/static\/media\/vercel\.[0-9a-f]{8}\.png"\)$/
+              )
+            })
           } finally {
             await browser.close()
           }

--- a/test/integration/url/test/index.test.js
+++ b/test/integration/url/test/index.test.js
@@ -12,7 +12,7 @@ import {
   fetchViaHTTP,
   launchApp,
   getBrowserBodyText,
-  check,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 
@@ -54,7 +54,9 @@ for (const dev of [false, true]) {
           let browser
           try {
             browser = await webdriver(appPort, page)
-            await check(() => getBrowserBodyText(browser), expectedClient)
+            await retry(async () => {
+              expect(await getBrowserBodyText(browser)).toMatch(expectedClient)
+            })
           } finally {
             await browser.close()
           }

--- a/test/integration/worker-webpack5/test/index.test.js
+++ b/test/integration/worker-webpack5/test/index.test.js
@@ -1,11 +1,11 @@
 /* eslint-env jest */
 import {
-  check,
   findPort,
   killApp,
   launchApp,
   nextStart,
   nextBuild,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -21,9 +21,17 @@ const runTests = () => {
     try {
       browser = await webdriver(appPort, '/')
       await browser.waitForElementByCss('#web-status')
-      await check(() => browser.elementByCss('#web-status').text(), /PASS/i)
+      await retry(async () => {
+        expect(await browser.elementByCss('#web-status').text()).toMatch(
+          /PASS/i
+        )
+      })
       await browser.waitForElementByCss('#worker-status')
-      await check(() => browser.elementByCss('#worker-status').text(), /PASS/i)
+      await retry(async () => {
+        expect(await browser.elementByCss('#worker-status').text()).toMatch(
+          /PASS/i
+        )
+      })
     } finally {
       if (browser) {
         await browser.close()

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -647,49 +647,6 @@ export async function startCleanStaticServer(dir: string) {
   return server
 }
 
-/**
- * Check for content in 1 second intervals timing out after 30 seconds.
- *
- * @param {() => Promise<unknown> | unknown} contentFn
- * @param {RegExp | string | number} regex
- * @param {boolean} hardError
- * @param {number} maxRetries
- * @returns {Promise<boolean>}
- */
-export async function check(
-  contentFn: () => any | Promise<any>,
-  regex: any,
-  hardError = true,
-  maxRetries = 30
-) {
-  let content
-  let lastErr
-
-  for (let tries = 0; tries < maxRetries; tries++) {
-    try {
-      content = await contentFn()
-      if (typeof regex !== typeof /regex/) {
-        if (regex === content) {
-          return true
-        }
-      } else if (regex.test(content)) {
-        // found the content
-        return true
-      }
-      await waitFor(1000)
-    } catch (err) {
-      await waitFor(1000)
-      lastErr = err
-    }
-  }
-  console.error('TIMED OUT CHECK: ', { regex, content, lastErr })
-
-  if (hardError) {
-    throw new Error('TIMED OUT: ' + regex + '\n\n' + content + '\n\n' + lastErr)
-  }
-  return false
-}
-
 export class File {
   path: string
   originalContent: string

--- a/test/production/app-dir-prefetch-non-iso-url/index.test.ts
+++ b/test/production/app-dir-prefetch-non-iso-url/index.test.ts
@@ -3,7 +3,7 @@ import { NextInstance } from 'e2e-utils'
 import { join } from 'path'
 import { BrowserInterface } from '../../lib/browsers/base'
 import webdriver from 'next-webdriver'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('app-dir-prefetch-non-iso-url', () => {
   let next: NextInstance
@@ -24,7 +24,9 @@ describe('app-dir-prefetch-non-iso-url', () => {
     try {
       browser = await webdriver(next.url, '/')
       await browser.elementByCss('#to-iso').click()
-      await check(() => browser.elementByCss('#page').text(), '/[slug]')
+      await retry(async () => {
+        expect(await browser.elementByCss('#page').text()).toEqual('/[slug]')
+      })
     } finally {
       if (browser) {
         await browser.close()
@@ -38,7 +40,9 @@ describe('app-dir-prefetch-non-iso-url', () => {
     try {
       browser = await webdriver(next.url, '/')
       await browser.elementByCss('#to-non-iso').click()
-      await check(() => browser.elementByCss('#page').text(), '/[slug]')
+      await retry(async () => {
+        expect(await browser.elementByCss('#page').text()).toEqual('/[slug]')
+      })
     } finally {
       if (browser) {
         await browser.close()

--- a/test/production/custom-error-500/index.test.ts
+++ b/test/production/custom-error-500/index.test.ts
@@ -1,6 +1,6 @@
 import { createNext } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check, renderViaHTTP } from 'next-test-utils'
+import { renderViaHTTP, retry } from 'next-test-utils'
 
 describe('custom-error-500', () => {
   let next: NextInstance
@@ -54,7 +54,9 @@ describe('custom-error-500', () => {
     const html = await renderViaHTTP(next.url, '/')
     expect(html).toContain('pages/500')
 
-    await check(() => next.cliOutput, /called Error\.getInitialProps true/)
+    await retry(async () => {
+      expect(await next.cliOutput).toMatch(/called Error\.getInitialProps true/)
+    })
   })
 
   it('should work correctly with pages/404 present', async () => {
@@ -72,6 +74,8 @@ describe('custom-error-500', () => {
     const html = await renderViaHTTP(next.url, '/')
     expect(html).toContain('pages/500')
 
-    await check(() => next.cliOutput, /called Error\.getInitialProps true/)
+    await retry(async () => {
+      expect(await next.cliOutput).toMatch(/called Error\.getInitialProps true/)
+    })
   })
 })

--- a/test/production/deployment-id-handling/deployment-id-handling.test.ts
+++ b/test/production/deployment-id-handling/deployment-id-handling.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { join } from 'node:path'
 
 describe.each(['NEXT_DEPLOYMENT_ID', 'CUSTOM_DEPLOYMENT_ID'])(
@@ -56,10 +56,9 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'CUSTOM_DEPLOYMENT_ID'])(
 
         await browser.elementByCss('#dynamic-import').click()
 
-        await check(
-          () => (requests.length > 0 ? 'success' : JSON.stringify(requests)),
-          'success'
-        )
+        await retry(() => {
+          expect(requests.length > 0).toBeTruthy()
+        })
 
         try {
           expect(
@@ -131,10 +130,9 @@ describe('deployment-id-handling disabled', () => {
 
       await browser.elementByCss('#dynamic-import').click()
 
-      await check(
-        () => (requests.length > 0 ? 'success' : JSON.stringify(requests)),
-        'success'
-      )
+      await retry(() => {
+        expect(requests.length > 0).toBeTruthy()
+      })
 
       try {
         expect(

--- a/test/production/enoent-during-require/index.test.ts
+++ b/test/production/enoent-during-require/index.test.ts
@@ -1,6 +1,6 @@
 import { createNext } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check, renderViaHTTP } from 'next-test-utils'
+import { renderViaHTTP, retry } from 'next-test-utils'
 
 describe('ENOENT during require', () => {
   let next: NextInstance
@@ -41,14 +41,12 @@ describe('ENOENT during require', () => {
   afterAll(() => next.destroy())
 
   it('should show ENOENT error correctly', async () => {
-    await check(async () => {
+    await retry(async () => {
       await renderViaHTTP(next.url, '/')
       console.error(next.cliOutput)
 
-      return next.cliOutput.includes('non-existent-folder')
-        ? 'success'
-        : next.cliOutput
-    }, 'success')
+      expect(next.cliOutput.includes('non-existent-folder')).toBeTruthy()
+    })
 
     expect(next.cliOutput).not.toContain('Cannot destructure property')
   })

--- a/test/production/export/index.test.ts
+++ b/test/production/export/index.test.ts
@@ -3,8 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 import {
   renderViaHTTP,
   startStaticServer,
-  check,
   getBrowserBodyText,
+  retry,
 } from 'next-test-utils'
 import { AddressInfo, Server } from 'net'
 import cheerio from 'cheerio'
@@ -283,10 +283,11 @@ describe('static export', () => {
         .click()
         .waitForElementByCss('#dynamic-imports-page')
 
-      await check(
-        () => getBrowserBodyText(browser),
-        /Welcome to dynamic imports/
-      )
+      await retry(async () => {
+        expect(await getBrowserBodyText(browser)).toMatch(
+          /Welcome to dynamic imports/
+        )
+      })
 
       await browser.close()
     })
@@ -306,7 +307,9 @@ describe('static export', () => {
 
         expect(text).toBe('Vercel is awesome')
 
-        await check(() => browser.elementByCss('#hash').text(), /cool/)
+        await retry(async () => {
+          expect(await browser.elementByCss('#hash').text()).toMatch(/cool/)
+        })
       } finally {
         if (browser) {
           await browser.close()
@@ -363,10 +366,11 @@ describe('static export', () => {
           'document.getElementById("level1-home-page").click()'
         )
 
-        await check(
-          () => getBrowserBodyText(browser),
-          /This is the Level1 home page/
-        )
+        await retry(async () => {
+          expect(await getBrowserBodyText(browser)).toMatch(
+            /This is the Level1 home page/
+          )
+        })
 
         await browser.close()
       })
@@ -378,10 +382,11 @@ describe('static export', () => {
           'document.getElementById("level1-about-page").click()'
         )
 
-        await check(
-          () => getBrowserBodyText(browser),
-          /This is the Level1 about page/
-        )
+        await retry(async () => {
+          expect(await getBrowserBodyText(browser)).toMatch(
+            /This is the Level1 about page/
+          )
+        })
 
         await browser.close()
       })

--- a/test/production/fatal-render-errror/index.test.ts
+++ b/test/production/fatal-render-errror/index.test.ts
@@ -1,6 +1,6 @@
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check, renderViaHTTP, waitFor } from 'next-test-utils'
+import { renderViaHTTP, waitFor, retry } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
 
@@ -40,7 +40,9 @@ describe('fatal-render-errror', () => {
     await browser.eval('window.renderAttempts = 0')
 
     await browser.eval('window.next.router.push("/with-error")')
-    await check(() => browser.eval('location.pathname'), '/with-error')
+    await retry(async () => {
+      expect(await browser.eval('location.pathname')).toEqual('/with-error')
+    })
 
     // wait a bit to see if we are rendering multiple times unexpectedly
     await waitFor(500)

--- a/test/production/pages-dir/production/test/dynamic.ts
+++ b/test/production/pages-dir/production/test/dynamic.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import webdriver from 'next-webdriver'
 import cheerio from 'cheerio'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { NextInstance } from 'e2e-utils'
 
 // These tests are similar to ../../basic/test/dynamic.js
@@ -45,7 +45,11 @@ export default (next: NextInstance, render) => {
         let browser
         try {
           browser = await webdriver(next.appPort, '/dynamic/pagechange1')
-          await check(() => browser.elementByCss('body').text(), /PageChange1/)
+          await retry(async () => {
+            expect(await browser.elementByCss('body').text()).toMatch(
+              /PageChange1/
+            )
+          })
           const firstElement = await browser.elementById('with-css')
           const css1 = await firstElement.getComputedCss('display')
           expect(css1).toBe('flex')
@@ -53,7 +57,11 @@ export default (next: NextInstance, render) => {
             // @ts-expect-error window.next exists
             window.next.router.push('/dynamic/pagechange2')
           })
-          await check(() => browser.elementByCss('body').text(), /PageChange2/)
+          await retry(async () => {
+            expect(await browser.elementByCss('body').text()).toMatch(
+              /PageChange2/
+            )
+          })
           const secondElement = await browser.elementById('with-css')
           const css2 = await secondElement.getComputedCss('display')
           expect(css2).toBe(css1)
@@ -81,14 +89,16 @@ export default (next: NextInstance, render) => {
         let browser
         try {
           browser = await webdriver(next.appPort, '/dynamic/no-chunk')
-          await check(
-            () => browser.elementByCss('body').text(),
-            /Welcome, normal/
-          )
-          await check(
-            () => browser.elementByCss('body').text(),
-            /Welcome, dynamic/
-          )
+          await retry(async () => {
+            expect(await browser.elementByCss('body').text()).toMatch(
+              /Welcome, normal/
+            )
+          })
+          await retry(async () => {
+            expect(await browser.elementByCss('body').text()).toMatch(
+              /Welcome, dynamic/
+            )
+          })
         } finally {
           if (browser) {
             await browser.close()
@@ -106,10 +116,11 @@ export default (next: NextInstance, render) => {
         let browser
         try {
           browser = await webdriver(next.appPort, '/dynamic/no-ssr')
-          await check(
-            () => browser.elementByCss('body').text(),
-            /Hello World 1/
-          )
+          await retry(async () => {
+            expect(await browser.elementByCss('body').text()).toMatch(
+              /Hello World 1/
+            )
+          })
         } finally {
           if (browser) {
             await browser.close()
@@ -128,10 +139,11 @@ export default (next: NextInstance, render) => {
         let browser
         try {
           browser = await webdriver(next.appPort, '/dynamic/ssr-true')
-          await check(
-            () => browser.elementByCss('body').text(),
-            /Hello World 1/
-          )
+          await retry(async () => {
+            expect(await browser.elementByCss('body').text()).toMatch(
+              /Hello World 1/
+            )
+          })
         } finally {
           if (browser) {
             await browser.close()
@@ -153,10 +165,11 @@ export default (next: NextInstance, render) => {
             next.appPort,
             '/dynamic/no-ssr-custom-loading'
           )
-          await check(
-            () => browser.elementByCss('body').text(),
-            /Hello World 1/
-          )
+          await retry(async () => {
+            expect(await browser.elementByCss('body').text()).toMatch(
+              /Hello World 1/
+            )
+          })
         } finally {
           if (browser) {
             await browser.close()

--- a/test/production/pages-dir/production/test/index.test.ts
+++ b/test/production/pages-dir/production/test/index.test.ts
@@ -6,8 +6,8 @@ import {
   renderViaHTTP,
   waitFor,
   getPageFileFromPagesManifest,
-  check,
   fetchViaHTTP,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import {
@@ -78,11 +78,13 @@ describe('Production Usage', () => {
           `/${search || ''}${hash || ''}`
         )
 
-        await check(
-          () =>
-            browser.eval('window.next.router.isReady ? "ready" : "not ready"'),
-          'ready'
-        )
+        await retry(async () => {
+          expect(
+            await browser.eval(
+              'window.next.router.isReady ? "ready" : "not ready"'
+            )
+          ).toEqual('ready')
+        })
         expect(await browser.eval('window.location.pathname')).toBe('/')
         expect(await browser.eval('window.location.hash')).toBe(hash || '')
         expect(await browser.eval('window.location.search')).toBe(search || '')
@@ -1201,10 +1203,11 @@ describe('Production Usage', () => {
       })
     })()`)
 
-      await check(
-        () => browser.eval('document.documentElement.innerHTML'),
-        /page could not be found/
-      )
+      await retry(async () => {
+        expect(
+          await browser.eval('document.documentElement.innerHTML')
+        ).toMatch(/page could not be found/)
+      })
 
       expect(await browser.eval('window.beforeNav')).toBeFalsy()
       expect(await browser.eval('window.location.hash')).toBe('')
@@ -1226,10 +1229,11 @@ describe('Production Usage', () => {
 
     expect(await browser.eval('window.beforeNav')).toBe(1)
 
-    await check(
-      () => browser.elementByCss('img').getComputedCss('background-image'),
-      'none'
-    )
+    await retry(async () => {
+      expect(
+        await browser.elementByCss('img').getComputedCss('background-image')
+      ).toEqual('none')
+    })
 
     await browser.eval(`(function() {
       window.beforeNav = 1
@@ -1246,13 +1250,13 @@ describe('Production Usage', () => {
 
     expect(await browser.eval('window.beforeNav')).toBe(1)
 
-    await check(
-      () =>
-        browser
+    await retry(async () => {
+      expect(
+        await browser
           .elementByCss('#static-image')
-          .getComputedCss('background-image'),
-      'none'
-    )
+          .getComputedCss('background-image')
+      ).toEqual('none')
+    })
 
     for (let i = 0; i < 5; i++) {
       expect(

--- a/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
@@ -5,13 +5,13 @@ import { join } from 'path'
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
 import {
-  check,
   fetchViaHTTP,
   findPort,
   initNextServerScript,
   killApp,
   renderViaHTTP,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import nodeFetch from 'node-fetch'
 
@@ -593,39 +593,27 @@ describe('required server files i18n', () => {
     expect(res.status).toBe(500)
     expect(await res.text()).toBe('Internal Server Error')
 
-    await check(
-      () =>
-        errors.join('').includes('gip hit an oops')
-          ? 'success'
-          : errors.join('\n'),
-      'success'
-    )
+    await retry(() => {
+      expect(errors.join('').includes('gip hit an oops')).toBeTruthy()
+    })
   })
 
   it('should bubble error correctly for gssp page', async () => {
     const res = await fetchViaHTTP(appPort, '/errors/gssp', { crash: '1' })
     expect(res.status).toBe(500)
     expect(await res.text()).toBe('Internal Server Error')
-    await check(
-      () =>
-        errors.join('\n').includes('gssp hit an oops')
-          ? 'success'
-          : errors.join('\n'),
-      'success'
-    )
+    await retry(() => {
+      expect(errors.join('\n').includes('gssp hit an oops')).toBeTruthy()
+    })
   })
 
   it('should bubble error correctly for gsp page', async () => {
     const res = await fetchViaHTTP(appPort, '/errors/gsp/crash')
     expect(res.status).toBe(500)
     expect(await res.text()).toBe('Internal Server Error')
-    await check(
-      () =>
-        errors.join('\n').includes('gsp hit an oops')
-          ? 'success'
-          : errors.join('\n'),
-      'success'
-    )
+    await retry(() => {
+      expect(errors.join('\n').includes('gsp hit an oops')).toBeTruthy()
+    })
   })
 
   it('should bubble error correctly for API page', async () => {
@@ -633,13 +621,11 @@ describe('required server files i18n', () => {
     const res = await fetchViaHTTP(appPort, '/api/error')
     expect(res.status).toBe(500)
     expect(await res.text()).toBe('Internal Server Error')
-    await check(
-      () =>
+    await retry(() => {
+      expect(
         errors.join('\n').includes('some error from /api/error')
-          ? 'success'
-          : errors.join('\n'),
-      'success'
-    )
+      ).toBeTruthy()
+    })
   })
 
   it('should normalize optional values correctly for SSP page', async () => {


### PR DESCRIPTION
This deprecates the `check` test, replaced by using `retry`. This enhances the error messages presented during test failures, and brings us closer to a native jest testing experience.

The refactor was completed with the following codemod: https://github.com/wyattjoh/retry-codemod