### PR TITLE
Update 10-open-telemetry.mdx, missing packages.

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/10-open-telemetry.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/10-open-telemetry.mdx
@@ -27,10 +27,10 @@ That's why we prepared a package `@vercel/otel` that helps you get started quick
 
 ### Using `@vercel/otel`
 
-To get started, you must install `@vercel/otel`, `@opentelemetry/api`, and `@opentelemetry/api-logs`:
+To get started, install the following packages:
 
 ```bash filename="Terminal"
-npm install @vercel/otel @opentelemetry/api @opentelemetry/api-logs
+npm install @vercel/otel @opentelemetry/sdk-logs @opentelemetry/api-logs @opentelemetry/instrumentation
 ```
 
 <AppOnly>

--- a/docs/02-app/01-building-your-application/06-optimizing/10-open-telemetry.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/10-open-telemetry.mdx
@@ -27,10 +27,10 @@ That's why we prepared a package `@vercel/otel` that helps you get started quick
 
 ### Using `@vercel/otel`
 
-To get started, you must install `@vercel/otel`:
+To get started, you must install `@vercel/otel`, `@opentelemetry/api`, and `@opentelemetry/api-logs`:
 
 ```bash filename="Terminal"
-npm install @vercel/otel
+npm install @vercel/otel @opentelemetry/api @opentelemetry/api-logs
 ```
 
 <AppOnly>


### PR DESCRIPTION
It seems that some package installs are missing from the documentation, which leads to the following error:

```
Import trace for requested module:
./src/instrumentation.ts
Error [ERR_MODULE_NOT_FOUND]: An error occurred while loading instrumentation hook: Cannot find package <PACKAGE NAME> imported from <ROOT>/node_modules/@vercel/otel/dist/node/index.js
```

My instrumentation file looks like this:

```typescript
import { registerOTel } from "@vercel/otel";

export function register() {
  registerOTel({ serviceName: "NAME" });
}
```
