### PR TITLE
Revert "Set default stale-while-revalidate header value to 1 year"

### DIFF
--- a/packages/next/src/server/lib/revalidate.ts
+++ b/packages/next/src/server/lib/revalidate.ts
@@ -17,10 +17,9 @@ export function formatRevalidate({
   revalidate: Revalidate
   swrDelta?: SwrDelta
 }): string {
-  const swrHeader =
-    swrDelta === undefined
-      ? `stale-while-revalidate=${CACHE_ONE_YEAR}`
-      : `stale-while-revalidate=${swrDelta}`
+  const swrHeader = swrDelta
+    ? `stale-while-revalidate=${swrDelta}`
+    : 'stale-while-revalidate'
 
   if (revalidate === 0) {
     return 'private, no-cache, no-store, max-age=0, must-revalidate'


### PR DESCRIPTION
This PR was run without CI. Reverting so we can reland after it passes CI. 

Reverts vercel/next.js#65867