### PR TITLE
Switch from ld (the default linker) to using lld for GNU Linux targets

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -22,11 +22,18 @@ rustflags = ["-C", "target-feature=+crt-static"]
 [target.aarch64-pc-windows-msvc]
 linker = "rust-lld"
 
-[target.aarch64-apple-darwin]
+[target.'cfg(target_os = "macos")']
 linker = "rust-lld"
 
-[target.aarch64-unknown-linux-gnu]
-linker = "aarch64-linux-gnu-gcc"
+[target.'cfg(all(target_os = "linux", target_env = "gnu"))']
+rustflags = [
+  "--cfg",
+  "tokio_unstable",
+  "-Zshare-generics=y",
+  "-Zthreads=8",
+  "-Csymbol-mangling-version=v0",
+  "-Clink-arg=-fuse-ld=lld",
+]
 
 [target.aarch64-unknown-linux-musl]
 linker = "aarch64-linux-musl-gcc"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -31,8 +31,10 @@ rustflags = [
   "tokio_unstable",
   "-Zshare-generics=y",
   "-Zthreads=8",
+  "-Zunstable-options",
   "-Csymbol-mangling-version=v0",
-  "-Clink-arg=-fuse-ld=lld",
+  "-Clinker-flavor=gnu-lld-cc",
+  "-Clink-self-contained=+linker",
 ]
 
 [target.aarch64-unknown-linux-musl]

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -16,6 +16,11 @@ runs:
         rustflags: ''
         cache: false
 
+    - name: 'Install LLD (LLVM Linker) for Linux'
+      if: runner.os == 'Linux'
+      shell: bash
+      run: sudo apt-get -y update && sudo apt-get install -y lld
+
     - name: 'Add cargo problem matchers'
       shell: bash
       run: echo "::add-matcher::${{ github.action_path }}/matchers.json"

--- a/contributing/core/developing.md
+++ b/contributing/core/developing.md
@@ -4,10 +4,21 @@
 - All pull requests should be opened against `canary`.
 - The changes on the `canary` branch are published to the `@canary` tag on npm regularly.
 
-To develop locally:
+## Dependencies
 
-1. Install Rust and Cargo via [rustup](https://rustup.rs).
-1. Install the [GitHub CLI](https://github.com/cli/cli#installation).
+- Install Rust and Cargo via [rustup](https://rustup.rs).
+- Install the [GitHub CLI](https://github.com/cli/cli#installation).
+- Enable pnpm:
+  ```
+  corepack enable pnpm
+  ```
+- (Linux) Install LLD, the LLVM linker:
+  ```
+  sudo apt install lld
+  ```
+
+## Local Development
+
 1. Clone the Next.js repository (download only recent commits for faster clone):
    ```
    gh repo clone vercel/next.js -- --filter=blob:none --branch canary --single-branch
@@ -15,10 +26,6 @@ To develop locally:
 1. Create a new branch:
    ```
    git checkout -b MY_BRANCH_NAME origin/canary
-   ```
-1. Enable pnpm:
-   ```
-   corepack enable pnpm
    ```
 1. Install the dependencies with:
    ```


### PR DESCRIPTION
Copies changes from https://github.com/vercel/turbo/pull/8166, and updates contributing documentation to include the installation of lld.

> **What's wrong with `ld`?** It's very slow and uses a lot of memory.
>
> **Why `lld`?** It's fast, mature, and well-supported. Meta and Google use it for all their linking workloads. We're already using it for macos and x86-64 Windows. There is [ongoing work to make it the default for rustc](https://github.com/rust-lang/rust/issues/71515), and it already is default on a few platforms.
>
> **Why not `mold`?** Mold is generally faster, but the margin is slim enough for our workloads that it doesn't really matter. Mold only recently got support for LTO, doesn't support v0 rust symbol demanging, doesn't support BOLT (though we don't use that yet), etc. Mold is maturing quickly, but `lld` still seems like the "safer" choice.
