### PR TITLE
fix: race condition in CLI output in react-compiler test

### DIFF
--- a/test/e2e/react-compiler/react-compiler.test.ts
+++ b/test/e2e/react-compiler/react-compiler.test.ts
@@ -20,8 +20,10 @@ describe.each(
   })
 
   it('should show an experimental warning', async () => {
-    expect(next.cliOutput).toContain('Experiments (use with caution)')
-    expect(next.cliOutput).toContain('reactCompiler')
+    await retry(() => {
+      expect(next.cliOutput).toContain('Experiments (use with caution)')
+      expect(next.cliOutput).toContain('reactCompiler')
+    })
   })
 
   it('should render', async () => {


### PR DESCRIPTION
the 'should show an experimental warning' test in `react-compiler-test.ts` has been randomly flaking for me:

```
    Expected substring: "Experiments (use with caution)"
    Received string:    " ⚠ `experimental.ppr` has been defaulted to `true` because `__NEXT_EXPERIMENTAL_PPR` was set to `true` during testing.
     ⚠ `experimental.ppr` has been defaulted to `true` because `__NEXT_EXPERIMENTAL_PPR` was set to `true` during testing.
      ▲ Next.js 14.3.0-canary.69
      - Local:        http://localhost:40095
    "
```
when the actual CLI output is:
```
 ⚠ `experimental.ppr` has been defaulted to `true` because `__NEXT_EXPERIMENTAL_PPR` was set to `true` during testing.
 ⚠ `experimental.ppr` has been defaulted to `true` because `__NEXT_EXPERIMENTAL_PPR` was set to `true` during testing.
  ▲ Next.js 14.3.0-canary.69
  - Local:        http://localhost:40095
  - Experiments (use with caution):
    · reactCompiler
```
which indicates that we're reading the CLI output too early