### PR TITLE
Fix send-trace-to-jaeger boolean span values

### DIFF
--- a/scripts/send-trace-to-jaeger/src/main.rs
+++ b/scripts/send-trace-to-jaeger/src/main.rs
@@ -36,7 +36,9 @@ fn send_json_to_zipkin(zipkin_api: &str, value: String) {
         .send()
         .expect("Failed to send request");
 
-    println!("body = {:?}", res.text());
+    if !res.status().is_success() {
+        println!("body = {:?}", res.text());
+    }
 }
 
 // function to append zero to a number until 16 characters
@@ -83,6 +85,15 @@ fn main() {
                         if data["parentId"] != Value::Null {
                             data["parentId"] =
                                 Value::String(pad_zeros(data["parentId"].as_u64().unwrap()));
+                        }
+
+                        if let Some(tags) = data["tags"].as_object_mut() {
+                            for (_, value) in tags.iter_mut() {
+                                if value.is_boolean() {
+                                    let bool_val = value.as_bool().unwrap();
+                                    *value = serde_json::Value::String(bool_val.to_string());
+                                }
+                            }
                         }
 
                         data


### PR DESCRIPTION
Jaeger does not support booleans as span values and will throw an error. This ensures the boolean values are turned into strings.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
