### PR TITLE
feat: add copy button for runtime error

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/components/copy-button/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/components/copy-button/index.tsx
@@ -2,10 +2,9 @@ export function CopyButton({
   label,
   content,
   ...props
-}: {
+}: React.HTMLProps<HTMLSpanElement> & {
   label?: string
   content: string
-  [key: string]: any
 }) {
   return (
     <span

--- a/packages/next/src/client/components/react-dev-overlay/internal/components/copy-button/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/components/copy-button/index.tsx
@@ -13,6 +13,12 @@ export function CopyButton({
       aria-label={label}
       role="button"
       onClick={() => {
+        if (!navigator.clipboard) {
+          window.console.error(
+            'Next.js dev overlay: Clipboard API not available'
+          )
+          return
+        }
         navigator.clipboard.writeText(content)
       }}
     >

--- a/packages/next/src/client/components/react-dev-overlay/internal/components/copy-button/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/components/copy-button/index.tsx
@@ -1,0 +1,41 @@
+export function CopyButton({
+  label,
+  content,
+  ...props
+}: {
+  label?: string
+  content: string
+  [key: string]: any
+}) {
+  return (
+    <span
+      {...props}
+      role="button"
+      onClick={() => {
+        navigator.clipboard.writeText(content)
+      }}
+    >
+      <CopyIcon />
+      {label}
+    </span>
+  )
+}
+
+function CopyIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+      <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+    </svg>
+  )
+}

--- a/packages/next/src/client/components/react-dev-overlay/internal/components/copy-button/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/components/copy-button/index.tsx
@@ -10,13 +10,14 @@ export function CopyButton({
   return (
     <span
       {...props}
+      title={label}
+      aria-label={label}
       role="button"
       onClick={() => {
         navigator.clipboard.writeText(content)
       }}
     >
       <CopyIcon />
-      {label}
     </span>
   )
 }

--- a/packages/next/src/client/components/react-dev-overlay/internal/components/copy-button/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/components/copy-button/index.tsx
@@ -10,25 +10,27 @@ export function CopyButton({
   successLabel: string
   content: string
 }) {
-  const [copied, setCopied] = useState(false)
-  const title = copied ? successLabel : label
+  // copied: 0 = not copied, 1 = copied, 2 = error
+  const [copied, setCopied] = useState(0)
+  const isDisabled = copied === 2
+  const title = isDisabled ? '' : copied ? successLabel : label
   return (
     <span
       {...props}
       title={title}
       aria-label={title}
+      aria-disabled={isDisabled}
       role="button"
       onClick={() => {
+        if (isDisabled) return
         if (!navigator.clipboard) {
-          window.console.error(
-            'Next.js dev overlay: Clipboard API not available'
-          )
+          setCopied(2)
           return
         }
         navigator.clipboard.writeText(content).then(() => {
           if (copied) return
-          setCopied(true)
-          setTimeout(() => setCopied(false), 2000)
+          setCopied(1)
+          setTimeout(() => setCopied(0), 2000)
         })
       }}
     >

--- a/packages/next/src/client/components/react-dev-overlay/internal/components/copy-button/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/components/copy-button/index.tsx
@@ -1,16 +1,22 @@
+import { useState } from 'react'
+
 export function CopyButton({
   label,
+  successLabel,
   content,
   ...props
 }: React.HTMLProps<HTMLSpanElement> & {
-  label?: string
+  label: string
+  successLabel: string
   content: string
 }) {
+  const [copied, setCopied] = useState(false)
+  const title = copied ? successLabel : label
   return (
     <span
       {...props}
-      title={label}
-      aria-label={label}
+      title={title}
+      aria-label={title}
       role="button"
       onClick={() => {
         if (!navigator.clipboard) {
@@ -19,10 +25,14 @@ export function CopyButton({
           )
           return
         }
-        navigator.clipboard.writeText(content)
+        navigator.clipboard.writeText(content).then(() => {
+          if (copied) return
+          setCopied(true)
+          setTimeout(() => setCopied(false), 2000)
+        })
       }}
     >
-      <CopyIcon />
+      {copied ? <CopySuccessIcon /> : <CopyIcon />}
     </span>
   )
 }
@@ -30,11 +40,10 @@ export function CopyButton({
 function CopyIcon() {
   return (
     <svg
-      xmlns="http://www.w3.org/2000/svg"
       width="16"
       height="16"
       viewBox="0 0 24 24"
-      fill="none"
+      fill="transparent"
       stroke="currentColor"
       strokeWidth="1.5"
       strokeLinecap="round"
@@ -42,6 +51,22 @@ function CopyIcon() {
     >
       <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
       <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+    </svg>
+  )
+}
+
+function CopySuccessIcon() {
+  return (
+    <svg
+      height="16"
+      xlinkTitle="copied"
+      viewBox="0 0 16 16"
+      width="16"
+      stroke="currentColor"
+      fill="currentColor"
+      data-nextjs-data-runtime-error-copy-stack-success
+    >
+      <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z" />
     </svg>
   )
 }

--- a/packages/next/src/client/components/react-dev-overlay/internal/components/copy-button/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/components/copy-button/index.tsx
@@ -1,5 +1,11 @@
 import { useState } from 'react'
 
+enum CopyState {
+  Initial = 0,
+  Copied = 1,
+  Error = 2,
+}
+
 export function CopyButton({
   label,
   successLabel,
@@ -10,9 +16,8 @@ export function CopyButton({
   successLabel: string
   content: string
 }) {
-  // copied: 0 = not copied, 1 = copied, 2 = error
-  const [copied, setCopied] = useState(0)
-  const isDisabled = copied === 2
+  const [copied, setCopied] = useState(CopyState.Initial)
+  const isDisabled = copied === CopyState.Error
   const title = isDisabled ? '' : copied ? successLabel : label
   return (
     <span
@@ -24,13 +29,13 @@ export function CopyButton({
       onClick={() => {
         if (isDisabled) return
         if (!navigator.clipboard) {
-          setCopied(2)
+          setCopied(CopyState.Error)
           return
         }
         navigator.clipboard.writeText(content).then(() => {
           if (copied) return
-          setCopied(1)
-          setTimeout(() => setCopied(0), 2000)
+          setCopied(CopyState.Copied)
+          setTimeout(() => setCopied(CopyState.Initial), 2000)
         })
       }}
     >

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/GroupedStackFrames.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/GroupedStackFrames.tsx
@@ -27,12 +27,9 @@ function FrameworkGroup({
 
 export function GroupedStackFrames({
   groupedStackFrames,
-  show,
 }: {
   groupedStackFrames: StackFramesGroup[]
-  show: boolean
 }) {
-  if (!show) return
   return (
     <>
       {groupedStackFrames.map((stackFramesGroup, groupIndex) => {

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
@@ -125,14 +125,23 @@ export const styles = css`
   }
 
   [data-nextjs-data-runtime-error-copy-stack] {
+    position: relative;
     margin-left: var(--size-gap);
-    cursor: pointer;
+    transition:
+      transform 0.2s ease,
+      box-shadow 0.2s ease;
   }
   [data-nextjs-data-runtime-error-copy-stack] > svg {
     vertical-align: middle;
   }
   [data-nextjs-data-runtime-error-copy-stack]:hover {
     opacity: 0.8;
+    cursor: pointer;
+  }
+
+  /* Add button move effects when clicking */
+  [data-nextjs-data-runtime-error-copy-stack]:active {
+    top: 1px;
   }
 
   [data-nextjs-call-stack-frame] > h3,

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
@@ -67,7 +67,6 @@ export function RuntimeError({ error }: RuntimeErrorProps) {
           <h2>Source</h2>
           <GroupedStackFrames
             groupedStackFrames={leadingFramesGroupedByFramework}
-            show={all}
           />
           <CodeFrame
             stackFrame={firstFrame.originalStackFrame!}
@@ -81,7 +80,6 @@ export function RuntimeError({ error }: RuntimeErrorProps) {
           <h2>Call Stack</h2>
           <GroupedStackFrames
             groupedStackFrames={stackFramesGroupedByFramework}
-            show={all}
           />
         </React.Fragment>
       ) : undefined}

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
@@ -83,6 +83,7 @@ export function RuntimeError({ error }: RuntimeErrorProps) {
             {error.error.stack && (
               <CopyButton
                 data-nextjs-data-runtime-error-copy-stack
+                label="Copy error stack"
                 content={error.error.stack}
               />
             )}

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
@@ -4,6 +4,7 @@ import type { ReadyRuntimeError } from '../../helpers/getErrorByType'
 import { noop as css } from '../../helpers/noop-template'
 import { groupStackFramesByFramework } from '../../helpers/group-stack-frames-by-framework'
 import { GroupedStackFrames } from './GroupedStackFrames'
+import { CopyButton } from '../../components/copy-button'
 
 export type RuntimeErrorProps = { error: ReadyRuntimeError }
 
@@ -77,7 +78,16 @@ export function RuntimeError({ error }: RuntimeErrorProps) {
 
       {stackFramesGroupedByFramework.length ? (
         <React.Fragment>
-          <h2>Call Stack</h2>
+          <h2>
+            Call Stack
+            {error.error.stack && (
+              <CopyButton
+                data-nextjs-data-runtime-error-copy-stack
+                content={error.error.stack}
+              />
+            )}
+          </h2>
+
           <GroupedStackFrames
             groupedStackFrames={stackFramesGroupedByFramework}
           />
@@ -112,6 +122,17 @@ export const styles = css`
   [data-nextjs-call-stack-frame]:not(:last-child),
   [data-nextjs-component-stack-frame]:not(:last-child) {
     margin-bottom: var(--size-gap-double);
+  }
+
+  [data-nextjs-data-runtime-error-copy-stack] {
+    margin-left: var(--size-gap);
+    cursor: pointer;
+  }
+  [data-nextjs-data-runtime-error-copy-stack] > svg {
+    vertical-align: middle;
+  }
+  [data-nextjs-data-runtime-error-copy-stack]:hover {
+    opacity: 0.8;
   }
 
   [data-nextjs-call-stack-frame] > h3,

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
@@ -84,6 +84,7 @@ export function RuntimeError({ error }: RuntimeErrorProps) {
               <CopyButton
                 data-nextjs-data-runtime-error-copy-stack
                 label="Copy error stack"
+                successLabel="Copied"
                 content={error.error.stack}
               />
             )}
@@ -128,21 +129,15 @@ export const styles = css`
   [data-nextjs-data-runtime-error-copy-stack] {
     position: relative;
     margin-left: var(--size-gap);
-    transition:
-      transform 0.2s ease,
-      box-shadow 0.2s ease;
   }
   [data-nextjs-data-runtime-error-copy-stack] > svg {
     vertical-align: middle;
   }
-  [data-nextjs-data-runtime-error-copy-stack]:hover {
-    opacity: 0.8;
-    cursor: pointer;
+  [data-nextjs-data-runtime-error-copy-stack-success] {
+    color: var(--color-ansi-green);
   }
-
-  /* Add button move effects when clicking */
-  [data-nextjs-data-runtime-error-copy-stack]:active {
-    top: 1px;
+  [data-nextjs-data-runtime-error-copy-stack]:hover {
+    cursor: pointer;
   }
 
   [data-nextjs-call-stack-frame] > h3,

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
@@ -133,6 +133,13 @@ export const styles = css`
   [data-nextjs-data-runtime-error-copy-stack] > svg {
     vertical-align: middle;
   }
+  [data-nextjs-data-runtime-error-copy-stack][aria-disabled],
+  [data-nextjs-data-runtime-error-copy-stack][aria-disabled]:hover {
+    cursor: pointer;
+    color: var(--color-ansi-red);
+    opacity: 0.3;
+    cursor: not-allowed;
+  }
   [data-nextjs-data-runtime-error-copy-stack-success] {
     color: var(--color-ansi-green);
   }
@@ -165,7 +172,6 @@ export const styles = css`
     height: var(--size-font-small);
     margin-left: var(--size-gap);
     flex-shrink: 0;
-
     display: none;
   }
 


### PR DESCRIPTION
### What

Add copy stack trace button to copy the original stacktrace in error overlay.
It will be a dimmed red button with disallowed cursor when it's found not able to copy.

#### Video


https://github.com/vercel/next.js/assets/4800338/c44e0bf8-f340-41ba-8ee8-4b94fdc298e1


### Why

Makes error reporting easier, users can do one-click to copy the original text