### PR TITLE
Add Turbopack option to create-next-app

### DIFF
--- a/docs/02-app/02-api-reference/06-create-next-app.mdx
+++ b/docs/02-app/02-api-reference/06-create-next-app.mdx
@@ -39,6 +39,7 @@ Would you like to use Tailwind CSS?  No / Yes
 Would you like to use `src/` directory?  No / Yes
 Would you like to use App Router? (recommended)  No / Yes
 Would you like to customize the default import alias (@/*)?  No / Yes
+Would you like to use Turbopack for next dev? (RC)  No / Yes
 ```
 
 Once you've answered the prompts, a new project will be created with the correct configuration depending on your answers.
@@ -87,6 +88,10 @@ Options:
   --empty
 
     Initialize an empty project.
+
+  --turbo
+    
+    Would you like to use Turbopack for next dev? (RC)
 
   --use-npm
 


### PR DESCRIPTION
### Summary

This PR adds a new option to `create-next-app` to enable Turbopack for development. The option is presented during the setup process as:

```
Would you like to use Turbopack for next dev? (RC) … No / Yes
```

By default, the option is set to `No`. When set to `Yes`, the `package.json` script for `dev` is modified from `next dev` to `next dev --turbo`.

### Changes

1. Updated the interactive CLI prompt to include the Turbopack option.
2. Modified the `createApp` function to adjust the `dev` script in `package.json` based on the user's selection.
3. Updated the documentation to describe the new option and its use.

### Documentation

Updates were made to [create-next-app documentation](https://nextjs.org/docs/app/api-reference/create-next-app) to include the new Turbopack option.

### Why

This change provides developers an opportunity to opt-in to using Turbopack during development, offering potentially faster builds and improves developer experience. Given that Turbopack is currently in RC, the default is set to `No` to ensure stability for most users.

### Testing

Tested the implementation by running `create-next-app` and selecting different combinations of templates to ensure that the dev script updates appropriately.