### PR TITLE
Mention Renaming of useFormState

### DIFF
--- a/docs/02-app/01-building-your-application/02-data-fetching/02-server-actions-and-mutations.mdx
+++ b/docs/02-app/01-building-your-application/02-data-fetching/02-server-actions-and-mutations.mdx
@@ -358,7 +358,7 @@ export default async function createsUser(formData) {
 }
 ```
 
-Once the fields have been validated on the server, you can return a serializable object in your action and use the React [`useActionState`](https://react.dev/reference/react/useActionState) hook (useActionState was previously known as useFormState, it was renamed in React 19) to show a message to the user.
+Once the fields have been validated on the server, you can return a serializable object in your action and use the React [`useActionState`](https://react.dev/reference/react/useActionState) hook to show a message to the user.
 
 - By passing the action to `useActionState`, the action's function signature changes to receive a new `prevState` or `initialState` parameter as its first argument.
 - `useActionState` is a React hook and therefore must be used in a Client Component.
@@ -444,6 +444,7 @@ export function Signup() {
 > **Good to know:**
 >
 > - Before mutating data, you should always ensure a user is also authorized to perform the action. See [Authentication and Authorization](#authentication-and-authorization).
+> - In earlier React Canary versions, this API was part of React DOM and called `useFormState`.
 
 #### Optimistic updates
 

--- a/docs/02-app/01-building-your-application/02-data-fetching/02-server-actions-and-mutations.mdx
+++ b/docs/02-app/01-building-your-application/02-data-fetching/02-server-actions-and-mutations.mdx
@@ -358,7 +358,7 @@ export default async function createsUser(formData) {
 }
 ```
 
-Once the fields have been validated on the server, you can return a serializable object in your action and use the React [`useActionState`](https://react.dev/reference/react/useActionState) hook to show a message to the user.
+Once the fields have been validated on the server, you can return a serializable object in your action and use the React [`useActionState`](https://react.dev/reference/react/useActionState) hook (useActionState was previously known as useFormState, it was renamed in React 19) to show a message to the user.
 
 - By passing the action to `useActionState`, the action's function signature changes to receive a new `prevState` or `initialState` parameter as its first argument.
 - `useActionState` is a React hook and therefore must be used in a Client Component.


### PR DESCRIPTION
The useFormState hook was renamed to useActionState in react 19. At this moment react 19 is still in Canary,  it would be hard for beginners to realise this. 

Mentioning the fact of it being renamed will ideally help new people. 