### PR TITLE
Allow "edge" as a runtime for pages in the Pages Router

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2203,7 +2203,7 @@ export default async function build(
                         if (isEdgeRuntime(pageRuntime)) {
                           if (workerResult.hasStaticProps) {
                             console.warn(
-                              `"getStaticProps" is not yet supported fully with "experimental-edge", detected on ${page}`
+                              `"getStaticProps" is not yet supported fully with "edge" or "experimental-edge", detected on ${page}`
                             )
                           }
                           // TODO: add handling for statically rendering edge

--- a/test/e2e/edge-configurable-runtime/app/pages/index.jsx
+++ b/test/e2e/edge-configurable-runtime/app/pages/index.jsx
@@ -1,1 +1,2 @@
 export default () => <p>hello world</p>
+export const runtime = "edge"


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

Currently pages on the Pages Router only accept "experimental-edge", not "edge". If you use "edge", there will be a build error.

This is contrary to the documentation, which states

> You can explicitly set the runtime on a per-page basis by modifying the config, for example:
> 
> ```js
> // pages/index.js
> export const config = {
>   runtime: 'nodejs', // or "edge"
> }
>  
> export const getServerSideProps = async () => {}
> ```
>
> – [source](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props#edge-runtime)

This PR allows "edge" to be used as the runtime for Pages Router pages.

### Why?

Either the documentation is wrong, or the "edge" check should be removed. Since in #50701, the `// or "edge"` phrase was explicitly added to that part, I suppose the team decided already to fully stabilise the edge runtime everywhere, so I decided to make the PR to remove the "edge" check.

If the documentation is wrong and the edge runtime should still be marked as experimental, feel free to close this PR *but* please also update the documentation in that case.

### How?

I simply removed the "edge" checks. Using "experimental-edge" in pages should now result in a warning but things should still work (same as Edge API Routes).

Fixes #65945