### PR TITLE
Fix router.refresh missing canonical url override

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -126,7 +126,10 @@ export function refreshReducer(
 
         mutable.cache = cache
         mutable.patchedTree = newTree
-        mutable.canonicalUrl = href
+
+        mutable.canonicalUrl = canonicalUrlOverride
+          ? createHrefFromUrl(canonicalUrlOverride)
+          : href
 
         currentTree = newTree
       }

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -127,10 +127,6 @@ export function refreshReducer(
         mutable.cache = cache
         mutable.patchedTree = newTree
 
-        mutable.canonicalUrl = canonicalUrlOverride
-          ? createHrefFromUrl(canonicalUrlOverride)
-          : href
-
         currentTree = newTree
       }
 

--- a/test/e2e/app-dir/navigation/app/api/set-token/route.ts
+++ b/test/e2e/app-dir/navigation/app/api/set-token/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server'
+
+export function POST() {
+  const res = NextResponse.json({ message: 'successful' })
+  res.cookies.set('token', 'this is a token')
+  return res
+}

--- a/test/e2e/app-dir/navigation/app/redirect-on-refresh/auth/Reload.js
+++ b/test/e2e/app-dir/navigation/app/redirect-on-refresh/auth/Reload.js
@@ -1,0 +1,19 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+
+export default function Reload() {
+  const router = useRouter()
+
+  useEffect(() => {
+    fetch(new URL('/api/set-token', location.origin), {
+      method: 'POST',
+      credentials: 'include',
+    }).then(() => {
+      router.refresh()
+    })
+  }, [router])
+
+  return null
+}

--- a/test/e2e/app-dir/navigation/app/redirect-on-refresh/auth/page.js
+++ b/test/e2e/app-dir/navigation/app/redirect-on-refresh/auth/page.js
@@ -1,0 +1,10 @@
+import Reload from './Reload'
+
+export default function Page() {
+  return (
+    <div>
+      Authenticated, now reloading...
+      <Reload />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/navigation/app/redirect-on-refresh/dashboard/page.js
+++ b/test/e2e/app-dir/navigation/app/redirect-on-refresh/dashboard/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Dashboard</p>
+}

--- a/test/e2e/app-dir/navigation/middleware.js
+++ b/test/e2e/app-dir/navigation/middleware.js
@@ -21,4 +21,13 @@ export function middleware(request) {
   if (request.nextUrl.pathname === '/redirect-middleware-to-dashboard') {
     return NextResponse.redirect(new URL('/redirect-dest', request.url))
   }
+
+  if (request.nextUrl.pathname === '/redirect-on-refresh/auth') {
+    const cookie = request.cookies.get('token')
+    if (cookie) {
+      return NextResponse.redirect(
+        new URL('/redirect-on-refresh/dashboard', request.url)
+      )
+    }
+  }
 }

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -909,4 +909,15 @@ describe('app dir - navigation', () => {
       })
     })
   })
+
+  describe('middleware redirect', () => {
+    it('should change browser location when router.refresh() gets a redirect response', async () => {
+      const browser = await next.browser('/redirect-on-refresh/auth')
+      await retry(async () =>
+        expect(await browser.url()).toBe(
+          next.url + '/redirect-on-refresh/dashboard'
+        )
+      )
+    })
+  })
 })


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/issues/65970

----

The browser update happens at https://github.com/vercel/next.js/blob/10d5c278bc0e9eab067df7b5f3943c12ab54a6a9/packages/next/src/client/components/app-router.tsx#L685, which sets the browser location to `canonicalUrl`. `canonicalUrl` was correctly set at https://github.com/vercel/next.js/blob/ab03c3261f53fcff1fb3387673cfd170a626564c/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts#L98, but then mistakenly overriden at https://github.com/vercel/next.js/blob/51549d92de3069b6dc5cd1f5fcdc04d5b1cbf37a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts#L129.

This PR fixes that and includes an E2E test to prevent future regression.