### PR TITLE
Fix typo in JSDoc of `ppr` flag of `next.config.js`

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -383,7 +383,7 @@ export interface ExperimentalConfig {
   clientTraceMetadata?: string[]
 
   /**
-   * Enables experimental Partial Prerendering feature of Next.js
+   * Enables experimental Partial Prerendering feature of Next.js.
    * Using this feature will enable the `react@experimental` for the `app` directory.
    */
   ppr?: ExperimentalPPRConfig


### PR DESCRIPTION
### What?

There is a missing period (.) after the text: `Enables experimental Partial Prerendering feature of Next.js` in the JSDoc of `ppr` flag in `next.config.js`. This PR will add that.

<img width="784" alt="image" src="https://github.com/vercel/next.js/assets/36382069/8ba11d85-43bf-4f26-86d2-719fd0748ace">
