### PR TITLE
add pre-push hook to guard against accidental pushes directly to canary

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+main_branch="canary"
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ "$branch" = "$main_branch" ]; then
+  echo "You probably didn't intend to push directly to '$main_branch'." >&2
+  echo "If you're sure that that's what you want to do, bypass this check via" >&2
+  echo "" >&2
+  echo "  git push --no-verify" >&2
+  echo "" >&2
+  exit 1
+fi


### PR DESCRIPTION
We allow users in the Next.js team to push directly `canary` in order to allow emergency fixes (and, AFAIU, some other things in GH workflows). This PR adds a guardrail to prevent absentminded people from doing it by accident, requiring a `git push --no-verify` to bypass the hook.