### PR TITLE
Add missing 'prerenderEarlyExit: false' in tests

### DIFF
--- a/test/e2e/app-dir/app-invalid-revalidate/next.config.js
+++ b/test/e2e/app-dir/app-invalid-revalidate/next.config.js
@@ -5,6 +5,9 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  experimental: {
+    prerenderEarlyExit: false,
+  },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
Since, https://github.com/vercel/next.js/pull/65830, I've been seeing weird flakes from `test/e2e/app-dir/app-invalid-revalidate/app-invalid-revalidate.test.ts`.
```
TIMED OUT: /Invalid revalidate value "1" on "\/", must be a non-negative number or "false"/
```

The build output looks like this:

```
  ▲ Next.js 14.3.0-canary.73

   Creating an optimized production build ...
   
[snip]

Error: Invalid revalidate value "1" on "/_not-found", must be a non-negative number or "false"

[snip]

     Generating static pages (2/4) 
  > Build error occurred
  Error: Export encountered an error on /_not-found, exiting due to prerenderEarlyExit: true being set
```
Note that there's no `Invalid revalidate value "1"` message for `/`, so the test will fail.

This looks like a race condition: the invalid `revalidate` value is set in a layout, so if `_not-found` happens to be prerendered before `/`, it'll abort the whole prerender (because of `prerenderEarlyExit: true`). so if the timing is right, the test -- which is looking for build errors for `/` -- will never see them and time out.

There might be more of these, but unfortunately they're basically race conditions, so I think we'll have to squash them as they come up.

CC @ijjk 