### PR TITLE
chore(docs): remove suggestion of manually installing `sharp`

### DIFF
--- a/docs/02-app/01-building-your-application/10-deploying/index.mdx
+++ b/docs/02-app/01-building-your-application/10-deploying/index.mdx
@@ -80,7 +80,7 @@ Image Optimization can be used with a [static export](/docs/app/building-your-ap
 
 > **Good to know:**
 >
-> - When self-hosting, consider installing `sharp` for more performant [Image Optimization](/docs/pages/building-your-application/optimizing/images) in your production environment by running `npm install sharp` in your project directory. On Linux platforms, `sharp` may require [additional configuration](https://sharp.pixelplumbing.com/install#linux-memory-allocator) to prevent excessive memory usage.
+> - On glibc-based Linux systems, Image Optimization may require [additional configuration](https://sharp.pixelplumbing.com/install#linux-memory-allocator) to prevent excessive memory usage.
 > - Learn more about the [caching behavior of optimized images](/docs/app/api-reference/components/image#caching-behavior) and how to configure the TTL.
 > - You can also [disable Image Optimization](/docs/app/api-reference/components/image#unoptimized) and still retain other benefits of using `next/image` if you prefer. For example, if you are optimizing images yourself separately.
 

--- a/docs/02-app/02-api-reference/05-next-config-js/output.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/output.mdx
@@ -40,7 +40,6 @@ Additionally, a minimal `server.js` file is also output which can be used instea
 > **Good to know**:
 >
 > - If your project needs to listen to a specific port or hostname, you can define `PORT` or `HOSTNAME` environment variables before running `server.js`. For example, run `PORT=8080 HOSTNAME=0.0.0.0 node server.js` to start the server on `http://0.0.0.0:8080`.
-> - If your project uses [Image Optimization](/docs/app/building-your-application/optimizing/images) with the default `loader`, you must install `sharp` as a dependency:
 
 </AppOnly>
 
@@ -50,25 +49,8 @@ Additionally, a minimal `server.js` file is also output which can be used instea
 >
 > - `next.config.js` is read during `next build` and serialized into the `server.js` output file. If the legacy [`serverRuntimeConfig` or `publicRuntimeConfig` options](/docs/pages/api-reference/next-config-js/runtime-configuration) are being used, the values will be specific to values at build time.
 > - If your project needs to listen to a specific port or hostname, you can define `PORT` or `HOSTNAME` environment variables before running `server.js`. For example, run `PORT=8080 HOSTNAME=0.0.0.0 node server.js` to start the server on `http://0.0.0.0:8080`.
-> - If your project uses [Image Optimization](/docs/pages/building-your-application/optimizing/images) with the default `loader`, you must install `sharp` as a dependency:
 
 </PagesOnly>
-
-```bash filename="Terminal"
-npm i sharp
-```
-
-```bash filename="Terminal"
-yarn add sharp
-```
-
-```bash filename="Terminal"
-pnpm add sharp
-```
-
-```bash filename="Terminal"
-bun add sharp
-```
 
 ## Caveats
 

--- a/errors/install-sharp.mdx
+++ b/errors/install-sharp.mdx
@@ -28,10 +28,12 @@ pnpm add sharp
 bun add sharp
 ```
 
-Option 2: If using macOS, ensure XCode Build Tools are installed and try to install `sharp` again.
+Option 2: Try installing the wasm variant of `sharp` by running `npm install --cpu=wasm32 sharp`.
+
+Option 3: If using macOS, ensure XCode Build Tools are installed and try to install `sharp` again.
 
 For example, see [macOS Catalina instructions](https://github.com/nodejs/node-gyp/blob/66c0f0446749caa591ad841cd029b6d5b5c8da42/macOS_Catalina.md).
 
-Option 3: Use a different OS and try to install `sharp` again.
+Option 4: Use a different OS and try to install `sharp` again.
 
 For example, if you're using Windows, try using [WSL](https://docs.microsoft.com/en-us/windows/wsl/about) (Windows Subsystem for Linux).


### PR DESCRIPTION
Users no longer need to install `sharp` manually thanks to the following:

- https://github.com/vercel/next.js/pull/63321