### PR TITLE
Fix swc test path from node_modules

### DIFF
--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -100,8 +100,17 @@ async function createNextInstall({
           const swcDirectory = fs
             .readdirSync(path.join(origRepoDir, 'node_modules/@next'))
             .find((directory) => directory.startsWith('swc-'))
-          process.env.NEXT_TEST_NATIVE_DIR = swcDirectory
+          process.env.NEXT_TEST_NATIVE_DIR = path.join(
+            origRepoDir,
+            'node_modules/@next',
+            swcDirectory
+          )
         }
+
+        // log for clarity of which version we're using
+        require('console').error({
+          swcDirectory: process.env.NEXT_TEST_NATIVE_DIR,
+        })
 
         pkgPaths = await rootSpan
           .traceChild('linkPackages')

--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -108,7 +108,7 @@ async function createNextInstall({
         }
 
         // log for clarity of which version we're using
-        require('console').error({
+        require('console').log({
           swcDirectory: process.env.NEXT_TEST_NATIVE_DIR,
         })
 


### PR DESCRIPTION
Noticed while testing turbopack version of tests that we weren't loading the correct swc binary since this path wasn't absolute and was just the relative path in `node_modules`. 