### PR TITLE
ci(workflow): skip building next-swc with latest turbopack

### DIFF
--- a/.github/workflows/setup-nextjs-build.yml
+++ b/.github/workflows/setup-nextjs-build.yml
@@ -76,28 +76,8 @@ jobs:
           corepack enable
           pnpm install --loglevel error
 
-      - name: Build next-swc with latest turbopack
-        id: build-next-swc-turbopack-patch
-        continue-on-error: true
-        run: |
-          export TURBOPACK_REMOTE="https://github.com/vercel/turbo"
-          # Apply patches to the cargo to the latest turbopack's sha.
-          # Basic recipe to apply patch to cargo via cli looks like this:
-          # cargo check --config 'patch."https://github.com/vercel/turbo".$PKG_NAME.git="https://github.com/vercel/turbo.git?rev=$SHA"'
-          # Careful to preserve quote to allow dot expression can access git url based property key.
-          export BINDING=$(printf 'patch.\\"%s\\".%s.git=\\"%s?rev=%s\\"' "$TURBOPACK_REMOTE" "turbopack-binding" "$TURBOPACK_REMOTE" "$GITHUB_SHA")
-          export TASKS=$(printf 'patch.\\"%s\\".%s.git=\\"%s?rev=%s\\"' "$TURBOPACK_REMOTE" "turbo-tasks" "$TURBOPACK_REMOTE" "$GITHUB_SHA")
-          export TASKS_FS=$(printf 'patch.\\"%s\\".%s.git=\\"%s?rev=%s\\"' "$TURBOPACK_REMOTE" "turbo-tasks-fs" "$TURBOPACK_REMOTE" "$GITHUB_SHA")
-
-          echo "Trying to build next-swc with turbopack $GITHUB_SHA"
-          hyperfine --min-runs 1 --show-output 'pnpm run --filter=@next/swc build-native --features plugin --release --cargo-flags="--config $BINDING --config $TASKS --config $TASKS_FS"'
-          echo "built=pass" >> $GITHUB_OUTPUT
-          echo "Successfully built next-swc with turbopack $GITHUB_SHA"
-
       - name: Build next-swc
-        if: steps.build-next-swc-turbopack-patch.outputs.built != 'pass'
         run: |
-          echo "Looks like we could not apply latest turbopack to next-swc. Trying to build next-swc with published turbopack. This might happen when there is a breaking changes in turbopack, and next.js is not yet updated."
           hyperfine --min-runs 1 --show-output 'pnpm run --filter=@next/swc build-native --features plugin --release'
           echo "Successfully built next-swc with published turbopack"
 


### PR DESCRIPTION
### What

this was the way we run ci on turbopack's repo and to get the latest test results, which isn't required anymore.