### PR TITLE
Improve `sync-react` changelog generator

### DIFF
--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -215,7 +215,7 @@ async function getChangelogFromGitHub(baseSha, newSha) {
       }
     }
 
-    if (commits.length !== pageSize) {
+    if (commits.length < pageSize) {
       // If the number of commits is less than the page size, we've reached
       // the end. Otherwise we'll keep fetching until we run out.
       break

--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -189,11 +189,19 @@ async function getChangelogFromGitHub(baseSha, newSha) {
   const pageSize = 50
   let changelog = []
   for (let currentPage = 0; ; currentPage++) {
-    const response = await fetch(
-      `https://api.github.com/repos/facebook/react/compare/${baseSha}...${newSha}?per_page=${pageSize}&page=${currentPage}`
-    )
+    const url = `https://api.github.com/repos/facebook/react/compare/${baseSha}...${newSha}?per_page=${pageSize}&page=${currentPage}`
+    const headers = {}
+    // GITHUB_TOKEN is optional but helps in case of rate limiting during development.
+    if (process.env.GITHUB_TOKEN) {
+      headers.Authorization = `token ${process.env.GITHUB_TOKEN}`
+    }
+    const response = await fetch(url, {
+      headers,
+    })
     if (!response.ok) {
-      throw new Error('Failed to fetch commit log from GitHub.')
+      throw new Error(
+        `${response.url}: Failed to fetch commit log from GitHub:\n${response.statusText}\n${await response.text()}`
+      )
     }
     const data = await response.json()
 

--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -144,7 +144,9 @@ Or, run this command with no arguments to use the most recently published versio
         `GitHub reported no changes between ${baseSha} and ${newSha}.`
       )
     } else {
-      console.log(`### React upstream changes\n\n${changelog}\n\n`)
+      console.log(
+        `<details>\n<summary>React upstream changes</summary>\n\n${changelog}\n\n</details>`
+      )
     }
   } catch (error) {
     console.error(error)


### PR DESCRIPTION
1. [Ensure sync-react collects changes beyond page 1](https://github.com/vercel/next.js/commit/fda1a569d502feb3bce8bf79ebcf5cf02c1e7e2c)
1. [Use `<details>` for React upstream changes](https://github.com/vercel/next.js/commit/f572d006c2f8b07b084692f57b288f835eeb2068) 
   A list takes up too much vertical space for syncs that took longer.
   Especially now with more momentum from the React Compiler, we want these syncs to remain readable.
1. [Improve debugging for GH changelog](https://github.com/vercel/next.js/commit/9f1d7014afdba2caa9e671fbbfcd518d9093d621) 

   Adds support for `GITHUB_TOKEN=*** pnpm run sync-react`.
   The token is optional.
   Specifying one, helps prevent rate limiting during development.