### PR TITLE
Skip setting to fetch cache when not modified

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
@@ -297,6 +297,26 @@ export default class FetchCache implements CacheHandler {
 
   public async set(...args: Parameters<CacheHandler['set']>) {
     const [key, data, ctx] = args
+
+    const newValue = data?.kind === 'FETCH' ? data.data : undefined
+    const existingCache = memoryCache?.get(key)
+    const existingValue = existingCache?.value
+    if (
+      existingValue?.kind === 'FETCH' &&
+      Object.keys(existingValue.data).every(
+        (field) =>
+          JSON.stringify(
+            (existingValue.data as Record<string, string | Object>)[field]
+          ) ===
+          JSON.stringify((newValue as Record<string, string | Object>)[field])
+      )
+    ) {
+      if (this.debug) {
+        console.log(`skipping cache set for ${key} as not modified`)
+      }
+      return
+    }
+
     const { fetchCache, fetchIdx, fetchUrl, tags } = ctx
     if (!fetchCache) return
 


### PR DESCRIPTION
To avoid extra network hops we can compare existing cache entries we've already fetched and see if the revalidated value matches and if it does we can avoid sending the set request with the identical data. 