### PR TITLE
feat(turbopack): Attempt to detect and warn about slow file IO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3082,6 +3082,7 @@ dependencies = [
  "next-build",
  "next-core",
  "next-custom-transforms",
+ "rand",
  "serde",
  "serde_json",
  "shadow-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6654,9 +6654,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6673,9 +6673,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6705,9 +6705,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
  "pin-project-lite",

--- a/packages/next-swc/crates/napi/Cargo.toml
+++ b/packages/next-swc/crates/napi/Cargo.toml
@@ -85,6 +85,7 @@ napi = { version = "2", default-features = false, features = [
 ] }
 napi-derive = "2"
 next-custom-transforms = { workspace = true }
+rand = { workspace = true }
 serde = "1"
 serde_json = "1"
 shadow-rs = { workspace = true }

--- a/packages/next-swc/crates/napi/src/next_api/project.rs
+++ b/packages/next-swc/crates/napi/src/next_api/project.rs
@@ -18,14 +18,15 @@ use next_core::tracing_presets::{
     TRACING_NEXT_OVERVIEW_TARGETS, TRACING_NEXT_TARGETS, TRACING_NEXT_TURBOPACK_TARGETS,
     TRACING_NEXT_TURBO_TASKS_TARGETS,
 };
+use tokio::time::Instant;
 use tracing::Instrument;
 use tracing_subscriber::{
     prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry,
 };
-use turbo_tasks::{ReadRef, TransientInstance, TurboTasks, UpdateInfo, Vc};
+use turbo_tasks::{Completion, ReadRef, TransientInstance, TurboTasks, UpdateInfo, Vc};
 use turbopack_binding::{
     turbo::{
-        tasks_fs::{FileContent, FileSystem},
+        tasks_fs::{DiskFileSystem, FileContent, FileSystem, FileSystemPath},
         tasks_memory::MemoryBackend,
     },
     turbopack::{
@@ -55,6 +56,10 @@ use super::{
     },
 };
 use crate::register;
+
+/// Used by [`benchmark_file_io`]. This is a noisy benchmark, so set the
+/// threshold high.
+const SLOW_FILESYSTEM_THRESHOLD: Duration = Duration::from_millis(100);
 
 #[napi(object)]
 #[derive(Clone, Debug)]
@@ -328,6 +333,12 @@ pub async fn project_new(
         })
         .await
         .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))?;
+
+    turbo_tasks.spawn_once_task(async move {
+        benchmark_file_io(container.project().node_root())
+            .await
+            .inspect_err(|err| tracing::warn!(%err, "failed to benchmark file IO"))
+    });
     Ok(External::new_with_size_hint(
         ProjectInstance {
             turbo_tasks,
@@ -336,6 +347,54 @@ pub async fn project_new(
         },
         100,
     ))
+}
+
+/// A very simple and low-overhead, but potentially noisy benchmark to detect
+/// very slow disk IO. Warns the user (via `println!`) if the benchmark takes
+/// more than `SLOW_FILESYSTEM_THRESHOLD`.
+///
+/// This idea is copied from Bun:
+/// - https://x.com/jarredsumner/status/1637549427677364224
+/// - https://github.com/oven-sh/bun/blob/06a9aa80c38b08b3148bfeabe560/src/install/install.zig#L3038
+#[tracing::instrument]
+async fn benchmark_file_io(directory: Vc<FileSystemPath>) -> Result<Vc<Completion>> {
+    let temp_path = directory.join(format!(
+        "tmp_file_io_benchmark_{:x}",
+        rand::random::<u128>()
+    ));
+
+    // try to get the real file path on disk so that we can use it with tokio
+    let fs = Vc::try_resolve_downcast_type::<DiskFileSystem>(temp_path.fs())
+        .await?
+        .context(anyhow!(
+            "expected node_root to be a DiskFileSystem, cannot benchmark"
+        ))?
+        .await?;
+    let temp_path = fs.to_sys_path(temp_path).await?;
+
+    // perform IO directly with tokio (skipping `tokio_tasks_fs`) to avoid the
+    // additional noise/overhead of tasks caching, invalidation, file locks,
+    // etc.
+    let start = Instant::now();
+    async move {
+        // create a new empty file
+        tokio::fs::write(&temp_path, b"").await?;
+        // remove the file
+        tokio::fs::remove_file(temp_path).await?;
+        anyhow::Ok(())
+    }
+    .instrument(tracing::info_span!("benchmark file IO (measurement)"))
+    .await?;
+
+    if Instant::now().duration_since(start) > SLOW_FILESYSTEM_THRESHOLD {
+        println!(
+            "Slow filesystem detected. If {} is a network drive, consider moving it to a local \
+             folder.",
+            directory.await?,
+        );
+    }
+
+    Ok(Completion::new())
 }
 
 #[napi(ts_return_type = "{ __napiType: \"Project\" }")]


### PR DESCRIPTION
We'd like to warn users if they have particularly slow file IO, so that they can correct the problem themselves, and don't send us reports of poor performance.

- Feature request: https://vercel.slack.com/archives/C03KAR5DCKC/p1716051650641529
- Tweet about how Bun does this: https://x.com/jarredsumner/status/1637549427677364224
- Bun implementation: https://github.com/oven-sh/bun/blob/06a9aa80c38b08b3148bfeabe560697956d38a64/src/install/install.zig#L3038

**Why 100ms?** Bun used to use 10ms, found it too noisy, and switched to 100ms.

This benchmark should run non-blocking in the background and should not meaningfully slow down server startup (even on slow disks).

## Testing

I looked around and found https://github.com/schoentoon/slowpokefs/. It hasn't been updated in 10 years, but still seems to build fine.

In a nextjs project directory, turn `.next` into an artifically slow mount point:

```
fusermount -uz .next; rm -rf .next .next.real && mkdir .next .next.real && ~/slowpokefs/slowpokefs -m 50 -M 50 --no-slow-read -F .next.real .next
```

<img width="695" alt="Screenshot 2024-05-21 at 4 14 58 PM" src="https://github.com/vercel/next.js/assets/180404/217d7692-33cf-42b7-bbf7-5a530b9e0df1">

Run `pnpm dev --turbo` and see that the warning is generated.

I'll also grab a really old USB 2.0 external HDD from home tomorrow and verify that I can trigger the warning with that.

## Questions

- Is `println!` good enough here? That seems like the only option we have right now for showing things to the user from within Rust. It would be nicer if we could use something structured like `tracing`, but that's not shown to the user.
- Is there some better place to put this check?
- Is the `.next` directory the right place to do this? We want something in the project directory, but we don't really have a cache or temporary directory for turbopack (yet). This benchmark should at least clean up after itself.

Fixes PACK-3087