### PR TITLE
Tweak flakey metadata error tests

### DIFF
--- a/test/e2e/app-dir/css-client-side-nav-parallel-routes/css-client-side-nav-parallel-routes.test.ts
+++ b/test/e2e/app-dir/css-client-side-nav-parallel-routes/css-client-side-nav-parallel-routes.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
 
 describe('css-client-side-nav-parallel-routes', () => {
   const { next } = nextTestSetup({
@@ -9,11 +10,15 @@ describe('css-client-side-nav-parallel-routes', () => {
   it('should apply styles after navigation', async () => {
     const browser = await next.browser('/source')
     await browser.elementByCss('a').click()
-    expect(
-      await browser.elementByCss('#global').getComputedCss('background-color')
-    ).toBe('rgb(0, 255, 0)')
-    expect(
-      await browser.elementByCss('#module').getComputedCss('background-color')
-    ).toBe('rgb(0, 255, 0)')
+
+    // transition might not be instant so we wrap in retry
+    retry(async () => {
+      expect(
+        await browser.elementByCss('#global').getComputedCss('background-color')
+      ).toBe('rgb(0, 255, 0)')
+      expect(
+        await browser.elementByCss('#module').getComputedCss('background-color')
+      ).toBe('rgb(0, 255, 0)')
+    })
   })
 })

--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -463,17 +463,14 @@ describe('app dir - metadata dynamic routes', () => {
       }
       `
 
-      const outputBeforeFetch = next.cliOutput + ''
+      const originalOutputIndex = next.cliOutput.length
 
       await next.patchFile(iconFilePath, contentMissingIdProperty)
       await next.fetch('/metadata-base/unset/icon/100')
 
-      const outputAfterFetch = next.cliOutput + ''
-      const output = outputAfterFetch.replace(outputBeforeFetch, '')
-
       try {
         await check(async () => {
-          expect(output).toContain(
+          expect(next.cliOutput.substring(originalOutputIndex)).toContain(
             `id property is required for every item returned from generateImageMetadata`
           )
           return 'success'
@@ -504,17 +501,14 @@ describe('app dir - metadata dynamic routes', () => {
         ]
       }`
 
-      const outputBeforeFetch = next.cliOutput + ''
+      const originalOutputIndex = next.cliOutput.length
 
       await next.patchFile(sitemapFilePath, contentMissingIdProperty)
       await next.fetch('/metadata-base/unset/sitemap/0')
 
-      const outputAfterFetch = next.cliOutput + ''
-      const output = outputAfterFetch.replace(outputBeforeFetch, '')
-
       try {
         await check(async () => {
-          expect(output).toContain(
+          expect(next.cliOutput.substring(originalOutputIndex)).toContain(
             `id property is required for every item returned from generateSitemaps`
           )
           return 'success'


### PR DESCRIPTION
Seems we weren't grabbing the latest cli output inside of `check` so if it wasn't ready by the time the first check successive checks wouldn't have it either. 

x-ref: https://github.com/vercel/next.js/actions/runs/9182806177/job/25253023758
x-ref: https://github.com/vercel/next.js/actions/runs/9182324607/job/25254072867