### PR TITLE
React sync: Handle React PRs landed via ghstack

### DIFF
--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -211,8 +211,13 @@ async function getChangelogFromGitHub(baseSha, newSha) {
     }
     for (const { commit, sha } of commits) {
       const title = commit.message.split('\n')[0] || ''
-      // The "title" looks like "[Fiber][Float] preinitialized stylesheets should support integrity option (#26881)"
-      const match = /\(#([0-9]+)\)$/.exec(title)
+      const match =
+        // The "title" looks like "[Fiber][Float] preinitialized stylesheets should support integrity option (#26881)"
+        /\(#([0-9]+)\)$/.exec(title) ??
+        // or contains "Pull Request resolved: https://github.com/facebook/react/pull/12345" in the body if merged via ghstack (e.g. https://github.com/facebook/react/commit/0a0a5c02f138b37e93d5d93341b494d0f5d52373)
+        /^Pull Request resolved: https:\/\/github.com\/facebook\/react\/pull\/([0-9]+)$/m.exec(
+          commit.message
+        )
       const prNum = match ? match[1] : ''
       if (prNum) {
         changelog.push(`- https://github.com/facebook/react/pull/${prNum}`)

--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -218,9 +218,7 @@ async function getChangelogFromGitHub(baseSha, newSha) {
         changelog.push(`- https://github.com/facebook/react/pull/${prNum}`)
       } else {
         changelog.push(
-          `-  ${sha.slice(0, 9)} ${commit.message.split('\n')[0]} (${
-            commit.author.name
-          })`
+          `- [${commit.message.split('\n')[0]} facebook/react@${sha.slice(0, 9)}](https://github.com/facebook/react/commit/${sha}) (${commit.author.name})`
         )
       }
     }


### PR DESCRIPTION
1. [Linkify React commits in sync changelog](https://github.com/vercel/next.js/commit/87d026e57681aa2709c5652a47342779f9ee2edb)
  Example:
  `[[compiler:playground] Update babel.config.js facebook/react@0f5845480](facebook/react@0f58454) (Lauren Tan)`

   `facebook/react@commit` would be sufficient for GitHub but doesn't preview the title like PR linking does.
1. [Handle PRs landed via ghstack](https://github.com/vercel/next.js/commit/cad04a47ce76cfa46dd22cfa02ce81c3c9993117)

Tested in https://github.com/vercel/next.js/pull/65869