### PR TITLE
React sync: Reduce manual tasks

### DIFF
--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -95,7 +95,9 @@ Or, run this command with no arguments to use the most recently published versio
   }
   await fsp.writeFile(
     path.join(cwd, 'package.json'),
-    JSON.stringify(pkgJson, null, 2)
+    JSON.stringify(pkgJson, null, 2) +
+      // Prettier would add a newline anyway so do it manually to skip the additional `pnpm prettier-write`
+      '\n'
   )
   console.log('Successfully updated React dependencies in package.json.\n')
 

--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -117,7 +117,7 @@ Or, run this command with no arguments to use the most recently published versio
     }
 
     console.log('Building vendored React files...\n')
-    const nccSubprocess = execa('pnpm', ['taskr', 'copy_vendor_react'], {
+    const nccSubprocess = execa('pnpm', ['ncc-compiled'], {
       cwd: path.join(cwd, 'packages', 'next'),
     })
     if (nccSubprocess.stdout) {
@@ -161,7 +161,7 @@ Or, run this command with no arguments to use the most recently published versio
 To finish upgrading, complete the following steps:
 
 - Install the updated dependencies: pnpm install
-- Build the vendored React files: (inside packages/next dir) pnpm taskr ncc
+- Build the vendored React files: (inside packages/next dir) pnpm ncc-compiled
 
 Or run this command again without the --no-install flag to do both automatically.
     `

--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -57,6 +57,7 @@ Or, run this command with no arguments to use the most recently published versio
     await fsp.readFile(path.join(cwd, 'package.json'), 'utf-8')
   )
   const devDependencies = pkgJson.devDependencies
+  const resolutions = pkgJson.resolutions
   const baseVersionStr = devDependencies[
     useExperimental ? 'react-experimental-builtin' : 'react-builtin'
   ].replace(/^npm:react@/, '')
@@ -88,6 +89,14 @@ Or, run this command with no arguments to use the most recently published versio
   for (const [dep, version] of Object.entries(devDependencies)) {
     if (version.endsWith(`${baseReleaseLabel}-${baseSha}-${baseDateString}`)) {
       devDependencies[dep] = version.replace(
+        `${baseReleaseLabel}-${baseSha}-${baseDateString}`,
+        `${newReleaseLabel}-${newSha}-${newDateString}`
+      )
+    }
+  }
+  for (const [dep, version] of Object.entries(resolutions)) {
+    if (version.endsWith(`${baseReleaseLabel}-${baseSha}-${baseDateString}`)) {
+      resolutions[dep] = version.replace(
         `${baseReleaseLabel}-${baseSha}-${baseDateString}`,
         `${newReleaseLabel}-${newSha}-${newDateString}`
       )


### PR DESCRIPTION
1. [Update all compiled files](https://github.com/vercel/next.js/pull/66095/commits/cfa4579589540b173fcbfa37e13fbb8ce1d5c0a4)
   `unistore` always gets new bundle ids and react-is is currently not part of `copy_vendor_react`.
   Both of them can be fixed but this is a perf optimization.
   Recompiling everything for now.

1. [Persist prettified package.json](https://github.com/vercel/next.js/pull/66095/commits/6dceae1c82b7a8edafdc00d831d018132429d256)
1. [Sync resolutions in package.json](https://github.com/vercel/next.js/pull/66095/commits/86ff2650b479417f8a177b46dfeb610c98845728)