### PR TITLE
Ensure metadata routes dont skip static optimization

### DIFF
--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -29,6 +29,7 @@ import {
   isMetadataRouteFile,
   isStaticMetadataRoute,
 } from '../../lib/metadata/is-metadata-route'
+import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 
 export const enum ExportedAppRouteFiles {
   BODY = 'BODY',
@@ -46,7 +47,6 @@ export async function exportAppRoute(
   fileWriter: FileWriter,
   experimental: Required<Pick<ExperimentalConfig, 'after'>>
 ): Promise<ExportRouteResult> {
-  const pathname = new URL(req.url, 'http://n').pathname
   // Ensure that the URL is absolute.
   req.url = `http://localhost:3000${req.url}`
 
@@ -96,9 +96,10 @@ export async function exportAppRoute(
     const userland = module.userland
     // we don't bail from the static optimization for
     // metadata routes
+    const normalizedPage = normalizeAppPath(page)
     const isMetadataRoute =
-      isStaticMetadataRoute(pathname) ||
-      isMetadataRouteFile(`${pathname}.ts`, ['ts'], true)
+      isStaticMetadataRoute(normalizedPage) ||
+      isMetadataRouteFile(`${normalizedPage}.ts`, ['ts'], true)
 
     if (!isStaticGenEnabled(userland) && !isMetadataRoute) {
       return { revalidate: 0 }

--- a/test/production/app-dir/metadata-static/app/favicon.tsx
+++ b/test/production/app-dir/metadata-static/app/favicon.tsx
@@ -1,0 +1,37 @@
+import { ImageResponse } from 'next/og'
+
+// Image metadata
+export const size = {
+  width: 32,
+  height: 32,
+}
+export const contentType = 'image/png'
+
+// Image generation
+export default function Icon() {
+  return new ImageResponse(
+    (
+      // ImageResponse JSX element
+      <div
+        style={{
+          fontSize: 24,
+          background: 'black',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'white',
+        }}
+      >
+        A
+      </div>
+    ),
+    // ImageResponse options
+    {
+      // For convenience, we can re-use the exported icons size metadata
+      // config to also set the ImageResponse's width and height.
+      ...size,
+    }
+  )
+}

--- a/test/production/app-dir/metadata-static/app/manifest.ts
+++ b/test/production/app-dir/metadata-static/app/manifest.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from 'next'
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'Next.js App',
+    short_name: 'Next.js App',
+    description: 'Next.js App',
+    start_url: '/',
+    display: 'standalone',
+    background_color: '#fff',
+    theme_color: '#fff',
+    icons: [
+      {
+        src: '/favicon.ico',
+        sizes: 'any',
+        type: 'image/x-icon',
+      },
+    ],
+  }
+}

--- a/test/production/app-dir/metadata-static/app/opengraph-image.tsx
+++ b/test/production/app-dir/metadata-static/app/opengraph-image.tsx
@@ -1,0 +1,38 @@
+import { ImageResponse } from 'next/og'
+
+// Image metadata
+export const alt = 'About Acme'
+export const size = {
+  width: 1200,
+  height: 630,
+}
+
+export const contentType = 'image/png'
+
+// Image generation
+export default async function Image() {
+  return new ImageResponse(
+    (
+      // ImageResponse JSX element
+      <div
+        style={{
+          fontSize: 128,
+          background: 'white',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        About Acme
+      </div>
+    ),
+    // ImageResponse options
+    {
+      // For convenience, we can re-use the exported opengraph-image
+      // size config to also set the ImageResponse's width and height.
+      ...size,
+    }
+  )
+}

--- a/test/production/app-dir/metadata-static/app/robots.ts
+++ b/test/production/app-dir/metadata-static/app/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: '/private/',
+    },
+    sitemap: 'https://acme.com/sitemap.xml',
+  }
+}

--- a/test/production/app-dir/metadata-static/app/sitemap.ts
+++ b/test/production/app-dir/metadata-static/app/sitemap.ts
@@ -1,0 +1,24 @@
+import type { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: 'https://acme.com',
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 1,
+    },
+    {
+      url: 'https://acme.com/about',
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: 'https://acme.com/blog',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.5,
+    },
+  ]
+}

--- a/test/production/app-dir/metadata-static/metadata-static.test.ts
+++ b/test/production/app-dir/metadata-static/metadata-static.test.ts
@@ -1,0 +1,27 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('app dir - metadata', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should have statically optimized metadata routes by default', async () => {
+    const prerenderManifest = JSON.parse(
+      await next.readFile('.next/prerender-manifest.json')
+    )
+
+    for (const key of [
+      '/robots.txt',
+      '/sitemap',
+      '/opengraph-image',
+      '/manifest.webmanifest',
+    ]) {
+      expect(prerenderManifest.routes[key]).toBeTruthy()
+      expect(prerenderManifest.routes[key].initialRevalidateSeconds).toBe(false)
+
+      const res = await next.fetch(key)
+      expect(res.status).toBe(200)
+      expect(res.headers.get('x-nextjs-cache')).toBe('HIT')
+    }
+  })
+})

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -14684,6 +14684,13 @@
       "flakey": [],
       "runtimeError": false
     },
+    "test/production/app-dir/metadata-static/metadata-static.test.ts": {
+      "passed": [],
+      "pending": [],
+      "failed": [
+        "app dir - metadata should have statically optimized metadata routes by default"
+      ]
+    },
     "test/production/allow-development-build/allow-development-build.test.ts": {
       "passed": [
         "allow-development-build with NODE_ENV not set to development should fail the build with a message about not setting NODE_ENV",


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/65825 this ensures we don't skip the static optimization specifically for metadata routes as this most often should be static as they aren't dynamic content and are requested very frequently. 