### PR TITLE
Add release candidate handling to start release

### DIFF
--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -6,12 +6,13 @@ on:
   workflow_dispatch:
     inputs:
       releaseType:
-        description: stable or canary?
+        description: stable, canary, or release candidate?
         required: true
         type: choice
         options:
           - canary
           - stable
+          - release-candidate
 
       semverType:
         description: semver type?

--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -11,6 +11,7 @@ const cwd = process.cwd()
 
 ;(async function () {
   let isCanary = true
+  let isReleaseCandidate = false
 
   try {
     const tagOutput = execSync(
@@ -21,6 +22,7 @@ const cwd = process.cwd()
     if (tagOutput.trim().startsWith('v')) {
       isCanary = tagOutput.includes('-canary')
     }
+    isReleaseCandidate = tagOutput.includes('-rc')
   } catch (err) {
     console.log(err)
 
@@ -30,7 +32,9 @@ const cwd = process.cwd()
     }
     throw err
   }
-  console.log(`Publishing ${isCanary ? 'canary' : 'stable'}`)
+  console.log(
+    `Publishing ${isCanary ? 'canary' : isReleaseCandidate ? 'rc' : 'stable'}`
+  )
 
   if (!process.env.NPM_TOKEN) {
     console.log('No NPM_TOKEN, exiting...')
@@ -53,7 +57,11 @@ const cwd = process.cwd()
           '--access',
           'public',
           '--ignore-scripts',
-          ...(isCanary ? ['--tag', 'canary'] : []),
+          ...(isCanary
+            ? ['--tag', 'canary']
+            : isReleaseCandidate
+              ? ['--tag', 'rc']
+              : []),
         ],
         { stdio: 'pipe' }
       )

--- a/scripts/start-release.js
+++ b/scripts/start-release.js
@@ -1,3 +1,4 @@
+// @ts-check
 const path = require('path')
 const execa = require('execa')
 const resolveFrom = require('resolve-from')
@@ -8,9 +9,14 @@ async function main() {
   const args = process.argv
   const releaseType = args[args.indexOf('--release-type') + 1]
   const semverType = args[args.indexOf('--semver-type') + 1]
-  const isCanary = releaseType !== 'stable'
+  const isCanary = releaseType === 'canary'
+  const isReleaseCandidate = releaseType === 'release-candidate'
 
-  if (releaseType !== 'stable' && releaseType !== 'canary') {
+  if (
+    releaseType !== 'stable' &&
+    releaseType !== 'canary' &&
+    releaseType !== 'release-candidate'
+  ) {
     console.log(`Invalid release type ${releaseType}, must be stable or canary`)
     return
   }
@@ -58,15 +64,23 @@ async function main() {
       ? `pnpm lerna version ${
           semverType === 'minor' ? 'preminor' : 'prerelease'
         } --preid canary --force-publish -y && pnpm release --pre --skip-questions --show-url`
-      : `pnpm lerna version ${semverType} --force-publish -y`,
+      : isReleaseCandidate
+        ? `pnpm lerna version ${
+            semverType === 'major'
+              ? 'premajor'
+              : semverType === 'minor'
+                ? 'preminor'
+                : 'prerelease'
+          } --preid rc --force-publish && pnpm release --pre --skip-questions --show-url`
+        : `pnpm lerna version ${semverType} --force-publish -y`,
     {
       stdio: 'pipe',
       shell: true,
     }
   )
 
-  child.stdout.pipe(process.stdout)
-  child.stderr.pipe(process.stderr)
+  child.stdout?.pipe(process.stdout)
+  child.stderr?.pipe(process.stderr)
   await child
   console.log('Release process is finished')
 }


### PR DESCRIPTION
This adds support for a new `rc` publish tag to our start release workflow. 