### PR TITLE
[ppr] Remove canary requirement

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -270,16 +270,6 @@ function assignDefaults(
     )
   }
 
-  if (
-    result.experimental?.ppr &&
-    !process.env.__NEXT_VERSION!.includes('canary') &&
-    !process.env.__NEXT_TEST_MODE
-  ) {
-    throw new Error(
-      `The experimental.ppr preview feature can only be enabled when using the latest canary version of Next.js. See more info here: https://nextjs.org/docs/messages/ppr-preview`
-    )
-  }
-
   if (result.output === 'export') {
     if (result.i18n) {
       throw new Error(


### PR DESCRIPTION
This removes the canary requirement for using PPR in a project, and now enables use on stable releases.