### PR TITLE
[unstable_after] always use 'waitUntil' from '@next/request-context' if available

### DIFF
--- a/packages/next/src/server/after/builtin-request-context.ts
+++ b/packages/next/src/server/after/builtin-request-context.ts
@@ -1,11 +1,11 @@
-export type WaitUntil = (promise: Promise<any>) => void
-
-export function getBuiltinWaitUntil(): WaitUntil | undefined {
+export function getBuiltinRequestContext():
+  | BuiltinRequestContextValue
+  | undefined {
   const _globalThis = globalThis as GlobalThisWithRequestContext
   const ctx =
     _globalThis[NEXT_REQUEST_CONTEXT_SYMBOL] ??
     _globalThis[VERCEL_REQUEST_CONTEXT_SYMBOL]
-  return ctx?.get()?.waitUntil
+  return ctx?.get()
 }
 
 /** This should be considered unstable until `unstable_after` is stablized. */
@@ -16,12 +16,16 @@ const NEXT_REQUEST_CONTEXT_SYMBOL = Symbol.for('@next/request-context')
 const VERCEL_REQUEST_CONTEXT_SYMBOL = Symbol.for('@vercel/request-context')
 
 type GlobalThisWithRequestContext = typeof globalThis & {
-  [NEXT_REQUEST_CONTEXT_SYMBOL]?: RequestContext
+  [NEXT_REQUEST_CONTEXT_SYMBOL]?: BuiltinRequestContext
   /** @deprecated */
-  [VERCEL_REQUEST_CONTEXT_SYMBOL]?: RequestContext
+  [VERCEL_REQUEST_CONTEXT_SYMBOL]?: BuiltinRequestContext
 }
 
-/** This should be considered unstable until `unstable_after` is stablized. */
-type RequestContext = {
-  get(): { waitUntil: WaitUntil } | undefined
+/** A request context provided by the platform.
+ * It should be considered unstable until `unstable_after` is stablized. */
+export type BuiltinRequestContext = {
+  get(): BuiltinRequestContextValue | undefined
 }
+
+export type BuiltinRequestContextValue = { waitUntil?: WaitUntil }
+export type WaitUntil = (promise: Promise<any>) => void

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -146,7 +146,10 @@ import type { DeepReadonly } from '../shared/lib/deep-readonly'
 import { isNodeNextRequest, isNodeNextResponse } from './base-http/helpers'
 import { patchSetHeaderWithCookieSupport } from './lib/patch-set-header'
 import { checkIsAppPPREnabled } from './lib/experimental/ppr'
-import { getBuiltinWaitUntil } from './after/wait-until-builtin'
+import {
+  getBuiltinRequestContext,
+  type WaitUntil,
+} from './after/builtin-request-context'
 
 export type FindComponentsResult = {
   components: LoadComponentsReturnType
@@ -1667,24 +1670,36 @@ export default abstract class Server<
     )
   }
 
-  private getWaitUntil() {
-    const useBuiltinWaitUntil =
-      process.env.NEXT_RUNTIME === 'edge' || this.minimalMode
-
-    let waitUntil = useBuiltinWaitUntil ? getBuiltinWaitUntil() : undefined
-
-    if (!waitUntil) {
-      // if we're not running in a serverless environment,
-      // we don't actually need waitUntil -- the server will stay alive anyway.
-      // the only thing we want to do is prevent unhandled rejections.
-      waitUntil = function noopWaitUntil(promise) {
-        promise.catch((err: unknown) => {
-          console.error(err)
-        })
-      }
+  private getWaitUntil(): WaitUntil | undefined {
+    const builtinRequestContext = getBuiltinRequestContext()
+    if (builtinRequestContext) {
+      // the platform provided a request context.
+      // use the `waitUntil` from there, whether actually present or not --
+      // if not present, `unstable_after` will error.
+      return builtinRequestContext.waitUntil
     }
 
-    return waitUntil
+    if (process.env.__NEXT_TEST_MODE) {
+      // we're in a test, use a no-op.
+      return Server.noopWaitUntil
+    }
+
+    if (this.minimalMode || process.env.NEXT_RUNTIME === 'edge') {
+      // we're built for a serverless environment, and `waitUntil` is not available,
+      // but using a noop would likely lead to incorrect behavior,
+      // because we have no way of keeping the invocation alive.
+      // return nothing, and `unstable_after` will error if used.
+      return undefined
+    }
+
+    // we're in `next start` or `next dev`. noop is fine for both.
+    return Server.noopWaitUntil
+  }
+
+  private static noopWaitUntil(promise: Promise<any>) {
+    promise.catch((err: unknown) => {
+      console.error(err)
+    })
   }
 
   private async renderImpl(

--- a/test/e2e/app-dir/next-after-app/app/provided-request-context/page.js
+++ b/test/e2e/app-dir/next-after-app/app/provided-request-context/page.js
@@ -1,0 +1,9 @@
+import { unstable_after as after } from 'next/server'
+import { cliLog } from '../../utils/log'
+
+export default function Page() {
+  after(() => {
+    cliLog({ source: '[page] /provided-request-context' })
+  })
+  return <div>provided-request-context</div>
+}

--- a/test/e2e/app-dir/next-after-app/index.test.ts
+++ b/test/e2e/app-dir/next-after-app/index.test.ts
@@ -59,6 +59,10 @@ describe.each(runtimes)('unstable_after() in %s runtime', (runtimeValue) => {
   })
 
   const getLogs = () => {
+    if (next.cliOutput.length < currentCliOutputIndex) {
+      // cliOutput shrank since we started the test, so something (like a `sandbox`) reset the logs
+      currentCliOutputIndex = 0
+    }
     return Log.readCliLogs(next.cliOutput.slice(currentCliOutputIndex))
   }
 

--- a/test/e2e/app-dir/next-after-app/next.config.js
+++ b/test/e2e/app-dir/next-after-app/next.config.js
@@ -3,5 +3,6 @@ module.exports = {
   experimental: {
     after: true,
     testProxy: true,
+    instrumentationHook: true,
   },
 }

--- a/test/e2e/app-dir/next-after-app/utils/log.js
+++ b/test/e2e/app-dir/next-after-app/utils/log.js
@@ -1,4 +1,4 @@
-export function cliLog(/** @type {Record<string, any>} */ data) {
+export function cliLog(/** @type {string | Record<string, any>} */ data) {
   console.log('<test-log>' + JSON.stringify(data) + '</test-log>')
 }
 

--- a/test/e2e/app-dir/next-after-app/utils/provided-request-context.js
+++ b/test/e2e/app-dir/next-after-app/utils/provided-request-context.js
@@ -1,0 +1,24 @@
+import { cliLog } from './log'
+
+export function injectRequestContext() {
+  // eslint-disable-next-line no-undef
+  const _globalThis = globalThis
+
+  /** @type {import('next/dist/server/after/builtin-request-context').BuiltinRequestContext} */
+  _globalThis[Symbol.for('@next/request-context')] = {
+    get() {
+      return {
+        waitUntil(/** @type {Promise<any>} */ promise) {
+          cliLog('waitUntil from "@next/request-context" was called')
+          promise.catch((err) => {
+            console.error(err)
+          })
+        },
+      }
+    },
+  }
+
+  return () => {
+    delete _globalThis[Symbol.for('@next/request-context')]
+  }
+}


### PR DESCRIPTION
This PR changes the `getWaitUntil` logic to always check if the platform provided a request context with a `waitUntil` implementation (via [the `@next/request-context` symbol](https://github.com/vercel/next.js/blob/05e6b825768355372dcdfff06dfcd264f78507d3/packages/next/src/server/after/wait-until-builtin.ts#L12)) , regardless of minimalMode or runtime.

Previously, we wouldn't check the context at all unless `minimalMode` was set, and defaulted `waitUntil` to a noop otherwise. This would make integration more difficult for providers who don't use `minimalMode`, because they'd have no way to inject their `waitUntil` implementation.

