### PR TITLE
Revert "Don't fail the build if @types/ packages appear to be missing"

### DIFF
--- a/packages/next/src/lib/has-necessary-dependencies.ts
+++ b/packages/next/src/lib/has-necessary-dependencies.ts
@@ -4,7 +4,23 @@ import { dirname, join, relative } from 'path'
 
 export interface MissingDependency {
   file: string
+  /**
+   * The package's package.json (e.g. require(`${pkg}/package.json`)) MUST resolve.
+   * If `exportsRestrict` is false, `${file}` MUST also resolve.
+   */
   pkg: string
+  /**
+   * If true, the pkg's package.json needs to be resolvable.
+   * If true, will resolve `file` relative to the real path of the package.json.
+   *
+   * For example, `{ file: '@types/react/index.d.ts', pkg: '@types/react', exportsRestrict: true }`
+   * will try to resolve '@types/react/package.json' first and then assume `@types/react/index.d.ts`
+   * resolves to `path.join(dirname(resolvedPackageJsonPath), 'index.d.ts')`.
+   *
+   * If false, will resolve `file` relative to the baseDir.
+   * ForFor example, `{ file: '@types/react/index.d.ts', pkg: '@types/react', exportsRestrict: true }`
+   * will try to resolve `@types/react/index.d.ts` directly.
+   */
   exportsRestrict: boolean
 }
 

--- a/test/production/ci-missing-typescript-deps/index.test.ts
+++ b/test/production/ci-missing-typescript-deps/index.test.ts
@@ -68,15 +68,9 @@ describe('ci-missing-typescript-deps', () => {
     })
     try {
       const nextBuild = await next.build()
-      // build doesn't fail because types/ may not be installed.
-      expect(nextBuild.cliOutput.split('\n')).toEqual(
-        expect.arrayContaining([
-          'This may be a bug in Next.js. Please file an issue.',
-          'Make sure the following type packages are installed:',
-          // In cyan color but this changes between CI and local.
-          // TODO: Use picocolors in tests to ensure we can test local and CI.
-          expect.stringContaining('@types/react'),
-        ])
+      expect(nextBuild.cliOutput).toContain(
+        // matching the part of the success message that isn't colored.
+        `We detected TypeScript in your project and created`
       )
     } finally {
       await next.destroy()


### PR DESCRIPTION
This reverts commit https://github.com/vercel/next.js/commit/637033c41054ee1d50107b1fd63a91a2051e1653.

What wasn't clear originally is that we require that required packages have their `package.json` resolvable. So either they don't have an `exports` field, or their `package.json` is listed in the `exports` field. The React beta types didn't have `package.json` entry in `exports` so we accidentally thought they weren't installed. 

I published [`19.0.0-beta.2` that has `package.json` in `exports`](https://github.com/eps1lon/DefinitelyTyped/pull/31/commits/13879ee571bd3996ad2dffd58a288e9762bf31d1#diff-81cc573aa0c2bd0e13f9463499747741704aabccd7474f544db710befd7bcfc4R44) so we can restore the old behavior. It's still questionable IMO to do all that I/O work just for a nicer error message that may contain false-positive but that's for another time.