### PR TITLE
Check access token early during release

### DIFF
--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -54,6 +54,13 @@ jobs:
       - name: Clone Next.js repository
         run: git clone https://github.com/vercel/next.js.git --depth=25 --single-branch --branch ${GITHUB_REF_NAME:-canary} .
 
+      - name: Check token
+        run: gh auth status
+        # For testing purposes. Once we have a succesful run where this step passes, we should error here.
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+
       - name: Get commit of the latest tag
         run: echo "LATEST_TAG_COMMIT=$(git rev-list -n 1 $(git describe --tags --abbrev=0))" >> $GITHUB_ENV
 


### PR DESCRIPTION
Using `gh auth status` should get us some output

```bash
$ GITHUB_TOKEN=$GH__FINE_READ gh auth status
github.com
  ✓ Logged in to github.com as vit-zikmund (GITHUB_TOKEN)
  ✓ Git operations for github.com configured to use https protocol.
  ✓ Token: github_pat_***********************************************************
```

-- https://github.com/orgs/community/discussions/25259#discussioncomment-8384318

It doesn't protect us from bad permissions but hopefully catches expired tokens.