### PR TITLE
[unstable_after] fixes for `waitUntil` in edge runtime

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
@@ -157,17 +157,27 @@ export function getRender({
     request: NextRequestHint,
     event?: NextFetchEvent
   ) {
+    const isAfterEnabled = !!process.env.__NEXT_AFTER
+
     const extendedReq = new WebNextRequest(request)
     const extendedRes = new WebNextResponse(
       undefined,
       // tracking onClose adds overhead, so only do it if `experimental.after` is on.
-      !!process.env.__NEXT_AFTER
+      isAfterEnabled
     )
 
     handler(extendedReq, extendedRes)
     const result = await extendedRes.toResponse()
 
     if (event?.waitUntil) {
+      if (isAfterEnabled) {
+        // make sure that NextRequestHint's awaiter stays open long enough
+        // for later `waitUntil`s called during streaming to get picked up.
+        event.waitUntil(
+          new Promise<void>((resolve) => extendedRes.onClose(resolve))
+        )
+      }
+
       // TODO(after):
       // remove `internal_runWithWaitUntil` and the `internal-edge-wait-until` module
       // when consumers switch to `unstable_after`.

--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
@@ -172,7 +172,7 @@ export function getRender({
     if (event?.waitUntil) {
       if (isAfterEnabled) {
         // make sure that NextRequestHint's awaiter stays open long enough
-        // for later `waitUntil`s called during streaming to get picked up.
+        // for late `waitUntil`s called during streaming to get picked up.
         event.waitUntil(
           new Promise<void>((resolve) => extendedRes.onClose(resolve))
         )

--- a/packages/next/src/client/components/lifecycle-async-storage-instance.ts
+++ b/packages/next/src/client/components/lifecycle-async-storage-instance.ts
@@ -1,0 +1,5 @@
+import { createAsyncLocalStorage } from './async-local-storage'
+import type { LifecycleAsyncStorage } from './lifecycle-async-storage.external'
+
+export const lifecycleAsyncStorage: LifecycleAsyncStorage =
+  createAsyncLocalStorage()

--- a/packages/next/src/client/components/lifecycle-async-storage-instance.ts
+++ b/packages/next/src/client/components/lifecycle-async-storage-instance.ts
@@ -1,5 +1,5 @@
 import { createAsyncLocalStorage } from './async-local-storage'
 import type { LifecycleAsyncStorage } from './lifecycle-async-storage.external'
 
-export const lifecycleAsyncStorage: LifecycleAsyncStorage =
+export const _lifecycleAsyncStorage: LifecycleAsyncStorage =
   createAsyncLocalStorage()

--- a/packages/next/src/client/components/lifecycle-async-storage.external.ts
+++ b/packages/next/src/client/components/lifecycle-async-storage.external.ts
@@ -1,0 +1,11 @@
+import type { AsyncLocalStorage } from 'async_hooks'
+// Share the instance module in the next-shared layer
+import { lifecycleAsyncStorage } from './lifecycle-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
+
+export interface LifecycleStore {
+  readonly waitUntil: ((promise: Promise<any>) => void) | undefined
+}
+
+export type LifecycleAsyncStorage = AsyncLocalStorage<LifecycleStore>
+
+export { lifecycleAsyncStorage }

--- a/packages/next/src/client/components/lifecycle-async-storage.external.ts
+++ b/packages/next/src/client/components/lifecycle-async-storage.external.ts
@@ -1,6 +1,6 @@
 import type { AsyncLocalStorage } from 'async_hooks'
 // Share the instance module in the next-shared layer
-import { lifecycleAsyncStorage } from './lifecycle-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
+import { _lifecycleAsyncStorage as lifecycleAsyncStorage } from './lifecycle-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
 
 export interface LifecycleStore {
   readonly waitUntil: ((promise: Promise<any>) => void) | undefined

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1670,18 +1670,18 @@ export default abstract class Server<
     )
   }
 
-  private getWaitUntil(): WaitUntil | undefined {
+  protected getWaitUntil(): WaitUntil | undefined {
+    const lifecycleStore = lifecycleAsyncStorage.getStore()
+    if (lifecycleStore) {
+      return lifecycleStore.waitUntil
+    }
+
     const builtinRequestContext = getBuiltinRequestContext()
     if (builtinRequestContext) {
       // the platform provided a request context.
       // use the `waitUntil` from there, whether actually present or not --
       // if not present, `unstable_after` will error.
       return builtinRequestContext.waitUntil
-    }
-
-    const lifecycleStore = lifecycleAsyncStorage.getStore()
-    if (lifecycleStore) {
-      return lifecycleStore.waitUntil
     }
 
     if (process.env.__NEXT_TEST_MODE) {

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -152,6 +152,7 @@ import {
   getBuiltinRequestContext,
   type WaitUntil,
 } from './after/builtin-request-context'
+import { lifecycleAsyncStorage } from '../client/components/lifecycle-async-storage.external'
 
 export type FindComponentsResult = {
   components: LoadComponentsReturnType
@@ -1676,6 +1677,11 @@ export default abstract class Server<
       // use the `waitUntil` from there, whether actually present or not --
       // if not present, `unstable_after` will error.
       return builtinRequestContext.waitUntil
+    }
+
+    const lifecycleStore = lifecycleAsyncStorage.getStore()
+    if (lifecycleStore) {
+      return lifecycleStore.waitUntil
     }
 
     if (process.env.__NEXT_TEST_MODE) {

--- a/packages/next/src/server/lib/awaiter.test.ts
+++ b/packages/next/src/server/lib/awaiter.test.ts
@@ -1,0 +1,81 @@
+import { InvariantError } from '../../shared/lib/invariant-error'
+import { AwaiterMulti, AwaiterOnce } from './awaiter'
+
+describe('AwaiterOnce/AwaiterMulti', () => {
+  describe.each([
+    { name: 'AwaiterMulti', impl: AwaiterMulti },
+    { name: 'AwaiterOnce', impl: AwaiterOnce },
+  ])('$name', ({ impl: AwaiterImpl }) => {
+    it('awaits promises added by other promises', async () => {
+      const awaiter = new AwaiterImpl()
+
+      const MAX_DEPTH = 5
+      const promises: TrackedPromise<unknown>[] = []
+
+      const waitUntil = (promise: Promise<unknown>) => {
+        promises.push(trackPromiseSettled(promise))
+        awaiter.waitUntil(promise)
+      }
+
+      const makeNestedPromise = async () => {
+        if (promises.length >= MAX_DEPTH) {
+          return
+        }
+        await sleep(100)
+        waitUntil(makeNestedPromise())
+      }
+
+      waitUntil(makeNestedPromise())
+
+      await awaiter.awaiting()
+
+      for (const promise of promises) {
+        expect(promise.isSettled).toBe(true)
+      }
+    })
+
+    it('calls onError for rejected promises', async () => {
+      const onError = jest.fn<void, [error: unknown]>()
+      const awaiter = new AwaiterImpl({ onError })
+
+      awaiter.waitUntil(Promise.reject('error 1'))
+      awaiter.waitUntil(
+        sleep(100).then(() => awaiter.waitUntil(Promise.reject('error 2')))
+      )
+
+      await awaiter.awaiting()
+
+      expect(onError).toHaveBeenCalledWith('error 1')
+      expect(onError).toHaveBeenCalledWith('error 2')
+    })
+  })
+})
+
+describe('AwaiterOnce', () => {
+  it("does not allow calling waitUntil after it's been awaited", async () => {
+    const awaiter = new AwaiterOnce()
+    awaiter.waitUntil(Promise.resolve(1))
+    await awaiter.awaiting()
+    expect(() => awaiter.waitUntil(Promise.resolve(2))).toThrow(InvariantError)
+  })
+})
+
+type TrackedPromise<T> = Promise<T> & { isSettled: boolean }
+
+function trackPromiseSettled<T>(promise: Promise<T>): TrackedPromise<T> {
+  const tracked = promise as TrackedPromise<T>
+  tracked.isSettled = false
+  tracked.then(
+    () => {
+      tracked.isSettled = true
+    },
+    () => {
+      tracked.isSettled = true
+    }
+  )
+  return tracked
+}
+
+function sleep(duration: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, duration))
+}

--- a/packages/next/src/server/lib/awaiter.ts
+++ b/packages/next/src/server/lib/awaiter.ts
@@ -1,0 +1,23 @@
+/**
+ * The Awaiter class is used to manage and await multiple promises.
+ */
+export class Awaiter {
+  private promises: Set<Promise<unknown>> = new Set()
+  private onError: ((error: unknown) => void) | undefined
+
+  constructor({ onError }: { onError?: (error: unknown) => void } = {}) {
+    this.onError = onError ?? console.error
+  }
+
+  public waitUntil = (promise: Promise<unknown>) => {
+    this.promises.add(promise.catch(this.onError))
+  }
+
+  public async awaiting(): Promise<void> {
+    while (this.promises.size > 0) {
+      const promises = Array.from(this.promises)
+      this.promises.clear()
+      await Promise.all(promises)
+    }
+  }
+}

--- a/packages/next/src/server/lib/awaiter.ts
+++ b/packages/next/src/server/lib/awaiter.ts
@@ -1,16 +1,31 @@
+import { InvariantError } from '../../shared/lib/invariant-error'
+
 /**
- * The Awaiter class is used to manage and await multiple promises.
+ * Provides a `waitUntil` implementation which gathers promises to be awaited later (via {@link AwaiterMulti.awaiting}).
+ * Unlike a simple `Promise.all`, {@link AwaiterMulti} works recursively --
+ * if a promise passed to {@link AwaiterMulti.waitUntil} calls `waitUntil` again,
+ * that second promise will also be awaited.
  */
-export class Awaiter {
+export class AwaiterMulti {
   private promises: Set<Promise<unknown>> = new Set()
-  private onError: ((error: unknown) => void) | undefined
+  private onError: (error: unknown) => void
 
   constructor({ onError }: { onError?: (error: unknown) => void } = {}) {
     this.onError = onError ?? console.error
   }
 
-  public waitUntil = (promise: Promise<unknown>) => {
-    this.promises.add(promise.catch(this.onError))
+  public waitUntil = (promise: Promise<unknown>): void => {
+    // if a promise settles before we await it, we can drop it.
+    const cleanup = () => {
+      this.promises.delete(promise)
+    }
+
+    this.promises.add(
+      promise.then(cleanup, (err) => {
+        cleanup()
+        this.onError(err)
+      })
+    )
   }
 
   public async awaiting(): Promise<void> {
@@ -19,5 +34,37 @@ export class Awaiter {
       this.promises.clear()
       await Promise.all(promises)
     }
+  }
+}
+
+/**
+ * Like {@link AwaiterMulti}, but can only be awaited once.
+ * If {@link AwaiterOnce.waitUntil} is called after that, it will throw.
+ */
+export class AwaiterOnce {
+  private awaiter: AwaiterMulti
+  private done: boolean = false
+  private pending: Promise<void> | undefined
+
+  constructor(options: { onError?: (error: unknown) => void } = {}) {
+    this.awaiter = new AwaiterMulti(options)
+  }
+
+  public waitUntil = (promise: Promise<unknown>): void => {
+    if (this.done) {
+      throw new InvariantError(
+        'Cannot call waitUntil() on an AwaiterOnce that was already awaited'
+      )
+    }
+    return this.awaiter.waitUntil(promise)
+  }
+
+  public async awaiting(): Promise<void> {
+    if (!this.pending) {
+      this.pending = this.awaiter.awaiting().finally(() => {
+        this.done = true
+      })
+    }
+    return this.pending
   }
 }

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1934,6 +1934,11 @@ export default class NextNodeServer extends BaseServer<
       }
     })
 
+    const waitUntil = this.getWaitUntil()
+    if (waitUntil) {
+      waitUntil(result.waitUntil)
+    }
+
     const { originalResponse } = params.res
     if (result.response.body) {
       await pipeToNodeResponse(result.response.body, originalResponse)

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -980,7 +980,12 @@ export default class NextNodeServer extends BaseServer<
         })
 
         // If we handled the request, we can return early.
-        if (handled) return true
+        if (handled) {
+          const waitUntil = this.getWaitUntil()
+          waitUntil?.(handled.waitUntil)
+
+          return true
+        }
       }
 
       // If the route was detected as being a Pages API route, then handle

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -415,7 +415,7 @@ export async function adapter(
 
   return {
     response: finalResponse,
-    waitUntil: event[waitUntilSymbol],
+    waitUntil: event[waitUntilSymbol](),
     fetchMetrics: request.fetchMetrics,
   }
 }

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -415,7 +415,7 @@ export async function adapter(
 
   return {
     response: finalResponse,
-    waitUntil: Promise.all(event[waitUntilSymbol]),
+    waitUntil: event[waitUntilSymbol],
     fetchMetrics: request.fetchMetrics,
   }
 }

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -22,7 +22,7 @@ import { getTracer } from '../lib/trace/tracer'
 import type { TextMapGetter } from 'next/dist/compiled/@opentelemetry/api'
 import { MiddlewareSpan } from '../lib/trace/constants'
 import { CloseController } from './web-on-close'
-import { lifecycleAsyncStorage } from '../../client/components/lifecycle-async-storage-instance'
+import { lifecycleAsyncStorage } from '../../client/components/lifecycle-async-storage.external'
 
 export class NextRequestHint extends NextRequest {
   sourcePage: string

--- a/packages/next/src/server/web/edge-route-module-wrapper.ts
+++ b/packages/next/src/server/web/edge-route-module-wrapper.ts
@@ -148,6 +148,13 @@ export class EdgeRouteModuleWrapper {
         const trackedBody = trackStreamConsumed(res.body, () =>
           _closeController.dispatchClose()
         )
+
+        // make sure that NextRequestHint's awaiter stays open long enough
+        // for `waitUntil`s called late during streaming to get picked up.
+        evt.waitUntil(
+          new Promise<void>((resolve) => _closeController.onClose(resolve))
+        )
+
         res = new Response(trackedBody, {
           status: res.status,
           statusText: res.statusText,

--- a/packages/next/src/server/web/sandbox/context.ts
+++ b/packages/next/src/server/web/sandbox/context.ts
@@ -452,6 +452,10 @@ Learn More: https://nextjs.org/docs/messages/edge-dynamic-code-evaluation`),
       context.clearTimeout = (timeout: number) =>
         timeoutsManager.remove(timeout)
 
+      if (process.env.__NEXT_TEST_MODE) {
+        context.__next_outer_globalThis__ = globalThis
+      }
+
       return context
     },
   })

--- a/packages/next/src/server/web/spec-extension/fetch-event.ts
+++ b/packages/next/src/server/web/spec-extension/fetch-event.ts
@@ -3,12 +3,24 @@ import type { NextRequest } from './request'
 
 const responseSymbol = Symbol('response')
 const passThroughSymbol = Symbol('passThrough')
+const awaiterSymbol = Symbol('awaiter')
+const waitUntilCacheSymbol = Symbol('waitUntil.cache')
+
 export const waitUntilSymbol = Symbol('waitUntil')
 
 class FetchEvent {
-  readonly [waitUntilSymbol]: Promise<any>[] = [];
   [responseSymbol]?: Promise<Response>;
-  [passThroughSymbol] = false
+  [passThroughSymbol] = false;
+
+  [awaiterSymbol] = new Awaiter();
+  [waitUntilCacheSymbol]: Promise<void> | undefined = undefined
+
+  get [waitUntilSymbol](): Promise<void> {
+    if (!this[waitUntilCacheSymbol]) {
+      this[waitUntilCacheSymbol] = this[awaiterSymbol].awaiting()
+    }
+    return this[waitUntilCacheSymbol]
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-useless-constructor
   constructor(_request: Request) {}
@@ -24,7 +36,7 @@ class FetchEvent {
   }
 
   waitUntil(promise: Promise<any>): void {
-    this[waitUntilSymbol].push(promise)
+    this[awaiterSymbol].waitUntil(promise)
   }
 }
 
@@ -56,5 +68,42 @@ export class NextFetchEvent extends FetchEvent {
     throw new PageSignatureError({
       page: this.sourcePage,
     })
+  }
+}
+
+/**
+ * The Awaiter class is used to manage and await multiple promises.
+ */
+export class Awaiter {
+  private promises: Set<Promise<unknown>> = new Set()
+  private onError: ((error: Error) => void) | undefined
+
+  constructor({ onError }: { onError?: (error: Error) => void } = {}) {
+    this.onError = onError ?? console.error
+  }
+
+  public waitUntil = (promise: Promise<unknown>) => {
+    this.promises.add(promise)
+  }
+
+  public async awaiting(): Promise<void> {
+    let hasMorePromises: boolean
+    do {
+      hasMorePromises = await this.waitForBatch()
+    } while (hasMorePromises)
+  }
+
+  private async waitForBatch() {
+    if (!this.promises.size) {
+      return false
+    }
+
+    const promises = Array.from(this.promises)
+    this.promises.clear()
+    await Promise.all(
+      promises.map((promise) => Promise.resolve(promise).catch(this.onError))
+    )
+
+    return this.promises.size > 0
   }
 }

--- a/packages/next/src/server/web/spec-extension/fetch-event.ts
+++ b/packages/next/src/server/web/spec-extension/fetch-event.ts
@@ -1,11 +1,10 @@
-import { Awaiter } from '../../lib/awaiter'
+import { AwaiterOnce } from '../../lib/awaiter'
 import { PageSignatureError } from '../error'
 import type { NextRequest } from './request'
 
 const responseSymbol = Symbol('response')
 const passThroughSymbol = Symbol('passThrough')
 const awaiterSymbol = Symbol('awaiter')
-const waitUntilCacheSymbol = Symbol('waitUntil.cache')
 
 export const waitUntilSymbol = Symbol('waitUntil')
 
@@ -13,14 +12,10 @@ class FetchEvent {
   [responseSymbol]?: Promise<Response>;
   [passThroughSymbol] = false;
 
-  [awaiterSymbol] = new Awaiter();
-  [waitUntilCacheSymbol]: Promise<void> | undefined = undefined;
+  [awaiterSymbol] = new AwaiterOnce();
 
   [waitUntilSymbol] = () => {
-    if (!this[waitUntilCacheSymbol]) {
-      this[waitUntilCacheSymbol] = this[awaiterSymbol].awaiting()
-    }
-    return this[waitUntilCacheSymbol]
+    return this[awaiterSymbol].awaiting()
   }
 
   // eslint-disable-next-line @typescript-eslint/no-useless-constructor

--- a/test/e2e/app-dir/next-after-app/app/delay-deep/page.js
+++ b/test/e2e/app-dir/next-after-app/app/delay-deep/page.js
@@ -1,0 +1,55 @@
+import { Suspense } from 'react'
+import { unstable_after as after } from 'next/server'
+import { cliLog } from '../../utils/log'
+import { sleep } from '../../utils/sleep'
+
+// don't waste time prerendering, after() will bail out anyway
+export const dynamic = 'force-dynamic'
+
+export default async function Page() {
+  cliLog({ source: '[page] /delay-deep (Page) - render' })
+  return (
+    <Suspense fallback={'Loading...'}>
+      <Inner>Delay</Inner>
+    </Suspense>
+  )
+}
+
+async function Inner({ children }) {
+  cliLog({
+    source: '[page] /delay-deep (Inner) - render, sleeping',
+  })
+
+  await sleep(1000)
+
+  cliLog({
+    source: '[page] /delay-deep (Inner) - render, done sleeping',
+  })
+
+  return (
+    <div>
+      <Suspense fallback="Loading 2...">
+        <Inner2>{children}</Inner2>
+      </Suspense>
+    </div>
+  )
+}
+
+async function Inner2({ children }) {
+  cliLog({
+    source: '[page] /delay-deep (Inner2) - render, sleeping',
+  })
+
+  await sleep(1000)
+
+  cliLog({
+    source: '[page] /delay-deep (Inner2) - render, done sleeping',
+  })
+
+  after(async () => {
+    await sleep(1000)
+    cliLog({ source: '[page] /delay-deep (Inner2) - after' })
+  })
+
+  return <>{children}</>
+}

--- a/test/e2e/app-dir/next-after-app/app/layout.js
+++ b/test/e2e/app-dir/next-after-app/app/layout.js
@@ -1,14 +1,11 @@
-import { installInvocationShutdownHook } from '../utils/simulated-invocation'
+import { maybeInstallInvocationShutdownHook } from '../utils/simulated-invocation'
 
 // (patched in tests)
 // export const runtime = 'REPLACE_ME'
 // export const dynamic = 'REPLACE_ME'
-const shouldInstallShutdownHook = false
 
 export default function AppLayout({ children }) {
-  if (shouldInstallShutdownHook) {
-    installInvocationShutdownHook()
-  }
+  maybeInstallInvocationShutdownHook()
   return (
     <html>
       <head>

--- a/test/e2e/app-dir/next-after-app/app/layout.js
+++ b/test/e2e/app-dir/next-after-app/app/layout.js
@@ -1,7 +1,14 @@
+import { installInvocationShutdownHook } from '../utils/simulated-invocation'
+
 // (patched in tests)
 // export const runtime = 'REPLACE_ME'
+// export const dynamic = 'REPLACE_ME'
+const shouldInstallShutdownHook = false
 
 export default function AppLayout({ children }) {
+  if (shouldInstallShutdownHook) {
+    installInvocationShutdownHook()
+  }
   return (
     <html>
       <head>

--- a/test/e2e/app-dir/next-after-app/app/route-streaming/route.js
+++ b/test/e2e/app-dir/next-after-app/app/route-streaming/route.js
@@ -1,11 +1,16 @@
 import { unstable_after as after } from 'next/server'
 import { cliLog } from '../../utils/log'
 import { sleep } from '../../utils/sleep'
+import { maybeInstallInvocationShutdownHook } from '../../utils/simulated-invocation'
 
-export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
+// (patched in tests)
+// export const runtime = 'REPLACE_ME'
+
 export async function GET() {
+  maybeInstallInvocationShutdownHook()
+
   /** @type {ReadableStream<Uint8Array>} */
   const result = new ReadableStream({
     async start(controller) {
@@ -22,6 +27,7 @@ export async function GET() {
         await sleep(500)
         controller.enqueue(encoder.encode(chunk + '\r\n'))
       }
+
       after(async () => {
         await sleep(1000)
         cliLog({

--- a/test/e2e/app-dir/next-after-app/app/route-streaming/route.js
+++ b/test/e2e/app-dir/next-after-app/app/route-streaming/route.js
@@ -1,0 +1,40 @@
+import { unstable_after as after } from 'next/server'
+import { cliLog } from '../../utils/log'
+import { sleep } from '../../utils/sleep'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  /** @type {ReadableStream<Uint8Array>} */
+  const result = new ReadableStream({
+    async start(controller) {
+      cliLog({
+        source: '[route handler] /route-streaming - body, sleeping',
+      })
+      await sleep(500)
+      cliLog({
+        source: '[route handler] /route-streaming - body, done sleeping',
+      })
+
+      const encoder = new TextEncoder()
+      for (const chunk of ['one', 'two', 'three']) {
+        await sleep(500)
+        controller.enqueue(encoder.encode(chunk + '\r\n'))
+      }
+      after(async () => {
+        await sleep(1000)
+        cliLog({
+          source: '[route handler] /route-streaming - after',
+        })
+      })
+      controller.close()
+    },
+  })
+  return new Response(result, {
+    headers: {
+      'content-type': 'text/plain; charset=utf-8',
+      'transfer-encoding': 'chunked',
+    },
+  })
+}

--- a/test/e2e/app-dir/next-after-app/index.test.ts
+++ b/test/e2e/app-dir/next-after-app/index.test.ts
@@ -22,25 +22,38 @@ describe.each(runtimes)('unstable_after() in %s runtime', (runtimeValue) => {
     },
   })
 
+  const filesToPatchRuntime = ['app/layout.js', 'app/route/route.js']
+  const replaceRuntime = (contents: string, file: string) => {
+    const placeholder = `// export const runtime = 'REPLACE_ME'`
+
+    if (!contents.includes(placeholder)) {
+      throw new Error(`Placeholder "${placeholder}" not found in ${file}`)
+    }
+
+    return contents.replace(
+      placeholder,
+      `export const runtime = '${runtimeValue}'`
+    )
+  }
+
+  const runtimePatches = new Map<
+    string,
+    string | ((contents: string) => string)
+  >(
+    filesToPatchRuntime.map(
+      (file) =>
+        [file, (contents: string) => replaceRuntime(contents, file)] as const
+    )
+  )
+
   {
     const originalContents: Record<string, string> = {}
 
     beforeAll(async () => {
-      const placeholder = `// export const runtime = 'REPLACE_ME'`
-
-      const filesToPatch = ['app/layout.js', 'app/route/route.js']
-
-      for (const file of filesToPatch) {
+      for (const file of filesToPatchRuntime) {
         await next.patchFile(file, (contents) => {
-          if (!contents.includes(placeholder)) {
-            throw new Error(`Placeholder "${placeholder}" not found in ${file}`)
-          }
           originalContents[file] = contents
-
-          return contents.replace(
-            placeholder,
-            `export const runtime = '${runtimeValue}'`
-          )
+          return replaceRuntime(contents, file)
         })
       }
     })
@@ -282,6 +295,7 @@ describe.each(runtimes)('unstable_after() in %s runtime', (runtimeValue) => {
     const { cleanup } = await sandbox(
       next,
       new Map([
+        ...runtimePatches,
         [
           // this needs to be injected as early as possible, before the server tries to read the context
           // (which may be even before we load the page component in dev mode)
@@ -323,12 +337,14 @@ describe.each(runtimes)('unstable_after() in %s runtime', (runtimeValue) => {
           const { session, cleanup } = await sandbox(
             next,
             new Map([
+              ...runtimePatches,
               [
                 'app/static/page.js',
-                (await next.readFile('app/static/page.js')).replace(
-                  `// export const dynamic = 'REPLACE_ME'`,
-                  `export const dynamic = '${dynamicValue}'`
-                ),
+                (contents) =>
+                  contents.replace(
+                    `// export const dynamic = 'REPLACE_ME'`,
+                    `export const dynamic = '${dynamicValue}'`
+                  ),
               ],
             ]),
             '/static'
@@ -350,12 +366,10 @@ describe.each(runtimes)('unstable_after() in %s runtime', (runtimeValue) => {
         const { session, cleanup } = await sandbox(
           next,
           new Map([
+            ...runtimePatches,
             [
               'app/invalid-in-client/page.js',
-              (await next.readFile('app/invalid-in-client/page.js')).replace(
-                `// 'use client'`,
-                `'use client'`
-              ),
+              (contents) => contents.replace(`// 'use client'`, `'use client'`),
             ],
           ]),
           '/invalid-in-client'

--- a/test/e2e/app-dir/next-after-app/utils/simulated-invocation.js
+++ b/test/e2e/app-dir/next-after-app/utils/simulated-invocation.js
@@ -2,6 +2,9 @@ import { requestAsyncStorage } from 'next/dist/client/components/request-async-s
 import { Awaiter } from 'next/dist/server/lib/awaiter'
 import { cliLog } from './log'
 
+// replaced in tests
+const shouldInstallShutdownHook = false
+
 /*
 This module is meant to help simulate a serverless invocation, which will shut down when
 - the response is finished
@@ -121,6 +124,13 @@ export function injectRequestContext() {
     },
   }
   globalThis[INVOCATION_CONTEXT] = invocationContext
+}
+
+export function maybeInstallInvocationShutdownHook() {
+  if (!shouldInstallShutdownHook) {
+    return
+  }
+  installInvocationShutdownHook()
 }
 
 /** Schedule a shutdown when the response is done and all `waitUntil` promises settled */

--- a/test/e2e/app-dir/next-after-app/utils/simulated-invocation.js
+++ b/test/e2e/app-dir/next-after-app/utils/simulated-invocation.js
@@ -1,0 +1,174 @@
+import { requestAsyncStorage } from 'next/dist/client/components/request-async-storage.external'
+import { Awaiter } from 'next/dist/server/lib/awaiter'
+import { cliLog } from './log'
+
+/*
+This module is meant to help simulate a serverless invocation, which will shut down when
+- the response is finished
+- all promises passed to waitUntil are settled
+this turns out to be a bit tricky, so here's an explanation of how this works.
+
+We need two pieces:
+
+1. `injectRequestContext` - the "waitUntil" part
+this injects a mock-ish '@next/request-context' that provides a `waitUntil`
+that collects the promises passed to it in an `Awaiter`, so that we can await them later, before exiting.
+(we need to call this in instrumentation.ts, because base-server accesses `waitUntil` it before render.)
+
+2. `installInvocationShutdownHook` - the "when the response is finished" part
+registers an `onClose` callback that will await the promises passed to `waitUntil`,
+and then shut down the process.
+(this can only be called during render/[handing a request], because we need `onClose` to be available)
+
+
+These two pieces are connected via `globalThis[Symbol.for("invocation-context")]`.
+This leads to a tricky situation when we're running a handler with `runtime = "edge"`.
+In tests/localhost, those handlers will be called in an EdgeRuntime sandbox (see `runEdgeFunction`),
+and won't have direct access to the `globalThis` of the "outer" nodejs process.
+
+So for edge, the flow goes like this:
+
+1. The "outer" node server starts, and runs `instrumentation.ts`
+   (injecting our 'invocation-context' that contains the "outer" `waitUntil`)
+
+2. The outer server gets a request, and runs the edge handler
+   (wrapped with `server/web/adapter`) inside `runEdgeFunction`, i.e. in an EdgeRuntime sandbox.
+
+   and then, within the sandbox:
+
+  3. `server/web/adapter` creates an "inner" `waitUntil` (see `NextFetchEvent.waitUntil`).
+     This is what `unstable_after` calls will use.
+     Notably, `adapter`'s `waitUntil` doesn't do much on its own --
+     it only collects the promises, which `adapter` then returns as part of a FetchEventResult,
+     expecting its caller to pass them to a "real" `waitUntil`.
+     I'm not sure why this inversion exists, but that's what it does.
+     
+  4. the edge handler creates an "inner" NextWebServer
+     - NOTE: this ALSO runs `instrumentation.ts`, so we need to make sure that
+       we don't create a second '@next/request-context' here
+       
+  5. Rendering (or other request handling) happens within the sandbox.
+  
+  6. During render, we install the shutdown hook, and will call it in onClose.
+
+     - NOTE: as outlined above, `installInvocationShutdownHook` runs in the edge sandbox,
+       but it needs to access the "outer" globalThis.
+     - NOTE 2: we also need to be able to call `process.exit` from here,
+       which means that `invocationContext.shutdownHook` has to be passed in from the nodejs runtime --
+       otherwise, edge compilation will replace it with a stub that calls `throwUnsupportedAPIError`.
+
+  7. the render hadnler returns a Response. `adapter` takes it and the promises passed to the inner `waitUntil`
+      and puts them on a FetchEventResult.
+     - NOTE: **no calls to the "outer" `waitUntil` occurred yet!** 
+       all that happened is that `adapter`'s Awaiter collected them.
+
+8. The "outer" server gets back the FetchEventResult, and passes the promise from that to the "outer" waitUntil.
+   This finally puts a promise into the Awaiter we created in `injectRequestContext`.
+   
+9. The response finishes, and `onClose` calls the shutdown hook (from inside the edge sandbox).
+   we await the single promise that got added to the awaiter, and finally shutdown the process.
+
+*/
+
+function createInvocationContext() {
+  const awaiter = new Awaiter()
+
+  const waitUntil = (promise) => {
+    awaiter.waitUntil(promise)
+  }
+
+  const shutdownHook = async () => {
+    if (!awaiter.promises.size) {
+      cliLog('Request finished, no `waitUntil` calls to await')
+    } else {
+      cliLog(
+        `Request finished, waiting for \`waitUntil\` promises (${awaiter.promises.size})`
+      )
+      await awaiter.awaiting()
+    }
+    cliLog('simulated-invocation :: end')
+    process.exit(0)
+  }
+
+  return { awaiter, waitUntil, shutdownHook }
+}
+
+const INVOCATION_CONTEXT = Symbol.for('invocation-context')
+
+/** Install a '@next/request-context' that will collect promises passed to `waitUntil` */
+export function injectRequestContext() {
+  // if we're in a edge runtime sandbox, skip installing --
+  // we already installed this "outside", in the nodejs runtime.
+  // (and process.exit won't work anyway)
+  if (process.env.NEXT_RUNTIME === 'edge' && getOuterGlobalThisInSandbox()) {
+    return
+  }
+
+  const globalThis = resolveGlobalThis()
+
+  if (globalThis[INVOCATION_CONTEXT]) {
+    throw new Error('Cannot call `injectRequestContext` twice')
+  }
+
+  const invocationContext = createInvocationContext()
+
+  /** @type {import('next/dist/server/after/builtin-request-context').BuiltinRequestContext} */
+  globalThis[Symbol.for('@next/request-context')] = {
+    get() {
+      return {
+        waitUntil: invocationContext.waitUntil,
+      }
+    },
+  }
+  globalThis[INVOCATION_CONTEXT] = invocationContext
+}
+
+/** Schedule a shutdown when the response is done and all `waitUntil` promises settled */
+export function installInvocationShutdownHook() {
+  const globalThis = resolveGlobalThis()
+  const context = globalThis[INVOCATION_CONTEXT]
+
+  if (!context) {
+    throw new Error('Missing invocation context')
+  }
+
+  onClose(() => {
+    context.shutdownHook()
+  })
+}
+
+function onClose(/** @type {() => void} */ callback) {
+  // this is a hack, but we don't want to do this with an after()
+  // because that'll call `waitUntil` and affect what we're trying to test here
+  const store = requestAsyncStorage.getStore()
+  if (!store) {
+    throw new Error('Could not access request store')
+  }
+  const ctx = store.afterContext
+  // AfterContextImpl has an `onClose` property, it's just not exposed on the interface
+  if (typeof ctx?.['onClose'] !== 'function') {
+    throw new Error('Could not access `onClose` from afterContext')
+  }
+  return ctx['onClose'](callback)
+}
+
+/** Get the real `globalThis`, regardless if we're in the actual server or an edge sandbox. */
+const resolveGlobalThis = () => {
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    const obj = getOuterGlobalThisInSandbox()
+    if (!obj) {
+      throw new Error('__next_outer_globalThis__ is not defined')
+    }
+    return obj
+  }
+
+  // eslint-disable-next-line no-undef
+  const _globalThis = globalThis
+  return _globalThis
+}
+
+const getOuterGlobalThisInSandbox = () => {
+  // eslint-disable-next-line no-undef
+  const _globalThis = globalThis
+  return _globalThis.__next_outer_globalThis__
+}

--- a/test/e2e/app-dir/next-after-app/utils/simulated-invocation.js
+++ b/test/e2e/app-dir/next-after-app/utils/simulated-invocation.js
@@ -1,5 +1,5 @@
 import { requestAsyncStorage } from 'next/dist/client/components/request-async-storage.external'
-import { Awaiter } from 'next/dist/server/lib/awaiter'
+import { AwaiterOnce } from 'next/dist/server/lib/awaiter'
 import { cliLog } from './log'
 
 // replaced in tests
@@ -74,7 +74,7 @@ So for edge, the flow goes like this:
 */
 
 function createInvocationContext() {
-  const awaiter = new Awaiter()
+  const awaiter = new AwaiterOnce()
 
   const waitUntil = (promise) => {
     awaiter.waitUntil(promise)

--- a/test/e2e/app-dir/next-after-app/utils/sleep.js
+++ b/test/e2e/app-dir/next-after-app/utils/sleep.js
@@ -1,0 +1,4 @@
+/** @returns {Promise<void>} */
+export function sleep(/** @type {number} */ duration) {
+  return new Promise((resolve) => setTimeout(resolve, duration))
+}

--- a/test/lib/development-sandbox.ts
+++ b/test/lib/development-sandbox.ts
@@ -32,7 +32,7 @@ export function waitForHydration(browser: BrowserInterface): Promise<void> {
 
 export async function sandbox(
   next: NextInstance,
-  initialFiles?: Map<string, string>,
+  initialFiles?: Map<string, string | ((contents: string) => string)>,
   initialUrl: string = '/',
   webDriverOptions: any = undefined
 ) {

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -356,7 +356,14 @@ export class NextInstance {
   public async stop(): Promise<void> {
     this.isStopping = true
     if (this.childProcess) {
-      const exitPromise = once(this.childProcess, 'exit')
+      const alreadyExited =
+        this.childProcess.exitCode !== null ||
+        this.childProcess.signalCode !== null
+
+      const exitPromise = alreadyExited
+        ? Promise.resolve()
+        : once(this.childProcess, 'exit')
+
       await new Promise<void>((resolve) => {
         treeKill(this.childProcess.pid, 'SIGKILL', (err) => {
           if (err) {
@@ -370,6 +377,7 @@ export class NextInstance {
       this.childProcess = undefined
       require('console').log(`Stopped next server`)
     }
+    this.isStopping = false
   }
 
   public async destroy(): Promise<void> {

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -452,7 +452,7 @@ export class NextInstance {
     // This is a temporary workaround for turbopack starting watching too late.
     // So we delay file changes by 500ms to give it some time
     // to connect the WebSocket and start watching.
-    if (process.env.TURBOPACK) {
+    if (isNextDev && process.env.TURBOPACK) {
       require('console').log('fs dev delay before', filename)
       await waitFor(500)
     }


### PR DESCRIPTION
**Closed this in favor of this stack: https://github.com/vercel/next.js/pull/66744, because there's parts of this that can be merged independently**

---

Fixes a bunch of bugs related to `waitUntil`.
- Fix: pass of `waitUntil` from `server/web/adapter` into edge SSR handlers
  - this worked in places that provide the global `@{next,vercel}/request-context` because `BaseServer.getWaitUntil` always read that, but broke on providers that don't have it
  - `waitUntil` will now be passed down via a new ALS, `lifecycleAsyncStorage` (because we don't really have a better method right now)
- Fix: Call `waitUntil` for edge functions running in an EdgeRuntime sandbox (i.e. `next start`)
  - (this came up when writing tests that simulate a serverless invocation that shuts down the process after the response is finished)
- Fix: Make sure that calls to `waitUntil` that happen after `adapter` returns (i.e. for streaming responses) are awaited too
  - this is done by making adapter's `FetchEventResult.waitUntil` promise wait until the request is closed + a new `Awaiter` class that supports late additions. this isn't ideal, because it requires us to always call `onClose` which is inefficient for web. but adapter's current signature basically forces us to do it this way

TBH, the various methods of passing `waitUntil` around are a mess. I think I'd' like to standardize on `lifecycleAsyncStorage` for this (instead of plumbing it through renderOpts everywhere), but that's a bit much to refactor right now. I promise I'll clean it up later!