### PR TITLE
 Update Sanity example deps and prepare for next v15

### DIFF
--- a/examples/cms-sanity/package.json
+++ b/examples/cms-sanity/package.json
@@ -14,23 +14,23 @@
   },
   "dependencies": {
     "@sanity/assist": "^3.0.4",
-    "@sanity/icons": "^2.11.8",
+    "@sanity/icons": "^3.0.0",
     "@sanity/image-url": "^1.0.2",
-    "@sanity/preview-url-secret": "^1.6.13",
-    "@sanity/vision": "^3.42.1",
+    "@sanity/preview-url-secret": "^1.6.7",
+    "@sanity/vision": "^3.44.0",
     "@tailwindcss/typography": "^0.5.13",
-    "@types/node": "^20.12.12",
-    "@types/react": "^18.3.2",
+    "@types/node": "^20.14.1",
+    "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "@vercel/speed-insights": "^1.0.10",
+    "@vercel/speed-insights": "^1.0.11",
     "autoprefixer": "^10.4.19",
     "date-fns": "^3.6.0",
-    "next": "latest",
-    "next-sanity": "^9.0.18",
+    "next": "^14.2.3",
+    "next-sanity": "^9.3.10",
     "postcss": "^8.4.38",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "sanity": "^3.42.1",
+    "sanity": "^3.44.0",
     "sanity-plugin-asset-source-unsplash": "^3.0.1",
     "server-only": "^0.0.1",
     "styled-components": "^6.1.11",
@@ -39,6 +39,6 @@
   },
   "devDependencies": {
     "eslint": "^8.57.0",
-    "eslint-config-next": "latest"
+    "eslint-config-next": "^14.2.3"
   }
 }

--- a/examples/cms-sanity/sanity.types.ts
+++ b/examples/cms-sanity/sanity.types.ts
@@ -393,7 +393,6 @@ export type SanityAssistSchemaTypeField = {
   >;
 };
 export declare const internalGroqTypeReferenceTo: unique symbol;
-
 // Source: ./sanity/lib/queries.ts
 // Variable: settingsQuery
 // Query: *[_type == "settings"][0]
@@ -454,7 +453,6 @@ export type SettingsQueryResult = {
     _type: "image";
   };
 } | null;
-
 // Variable: heroQuery
 // Query: *[_type == "post" && defined(slug.current)] | order(date desc, _updatedAt desc) [0] {  content,    _id,  "status": select(_originalId in path("drafts.**") => "draft", "published"),  "title": coalesce(title, "Untitled"),  "slug": slug.current,  excerpt,  coverImage,  "date": coalesce(date, _updatedAt),  "author": author->{"name": coalesce(name, "Anonymous"), picture},}
 export type HeroQueryResult = {
@@ -510,7 +508,6 @@ export type HeroQueryResult = {
     } | null;
   } | null;
 } | null;
-
 // Variable: moreStoriesQuery
 // Query: *[_type == "post" && _id != $skip && defined(slug.current)] | order(date desc, _updatedAt desc) [0...$limit] {    _id,  "status": select(_originalId in path("drafts.**") => "draft", "published"),  "title": coalesce(title, "Untitled"),  "slug": slug.current,  excerpt,  coverImage,  "date": coalesce(date, _updatedAt),  "author": author->{"name": coalesce(name, "Anonymous"), picture},}
 export type MoreStoriesQueryResult = Array<{
@@ -548,7 +545,6 @@ export type MoreStoriesQueryResult = Array<{
     } | null;
   } | null;
 }>;
-
 // Variable: postQuery
 // Query: *[_type == "post" && slug.current == $slug] [0] {  content,    _id,  "status": select(_originalId in path("drafts.**") => "draft", "published"),  "title": coalesce(title, "Untitled"),  "slug": slug.current,  excerpt,  coverImage,  "date": coalesce(date, _updatedAt),  "author": author->{"name": coalesce(name, "Anonymous"), picture},}
 export type PostQueryResult = {
@@ -604,7 +600,6 @@ export type PostQueryResult = {
     } | null;
   } | null;
 } | null;
-
 // Source: ./app/(blog)/posts/[slug]/page.tsx
 // Variable: postSlugs
 // Query: *[_type == "post"]{slug}


### PR DESCRIPTION
We've been testing React v19 and we're mostly ready. Since we have a number of upstream packages we have to update peer deps from:
```json
{
  "peerDependencies": {
    "react": "^18.3",
    "react-dom": "^18.3"
  }
}
```
to:
```json
{
  "peerDependencies": {
    "react": "^18.3 || ^19",
    "react-dom": "^18.3 || ^19"
  }
}
```
We are choosing to change the `next` semver from `latest` to `^14.2.3`.
This is to avoid the template from breaking after v15 becomes `latest`, since package manager default behaviour doesn't handle conflicting peer dep ranges for react very well 🙌 