### PR TITLE
Fail early in release if auth fails with configured gh token

### DIFF
--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -56,8 +56,6 @@ jobs:
 
       - name: Check token
         run: gh auth status
-        # For testing purposes. Once we have a succesful run where this step passes, we should error here.
-        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
 


### PR DESCRIPTION
`gh auth status` works: https://github.com/vercel/next.js/actions/runs/9216143946/job/25355841804#step:4:16

We should fail early to hopefully get a better error message if authentication with the configured token fails.