### PR TITLE
fix: Add version into process polyfill (RE #66180)

### DIFF
--- a/packages/next/src/server/web/sandbox/context.ts
+++ b/packages/next/src/server/web/sandbox/context.ts
@@ -128,11 +128,11 @@ Learn more: https://nextjs.org/docs/api-reference/edge-runtime`)
 }
 
 function createProcessPolyfill(env: Record<string, string>) {
-  const processPolyfill = { env: buildEnvironmentVariablesFrom(env) }
+  const processPolyfill = { env: buildEnvironmentVariablesFrom(env), version: process.version }
   const overriddenValue: Record<string, any> = {}
 
   for (const key of Object.keys(process)) {
-    if (key === 'env') continue
+    if (key === 'env' || key === 'version') continue
     Object.defineProperty(processPolyfill, key, {
       get() {
         if (overriddenValue[key] !== undefined) {


### PR DESCRIPTION
### Fixing a bug

- Related issues linked using `fixes #66180`
- Tests added. No new test added since the build just fails without this change.
- Errors are attached inside of the issue.

### What?

The current process polyfill is missing the node version and the backend renders insert a process.exit() into the script
on a no-matching node, version, but the version is always "undefined". Therefore the build fails.

### Why?

Failing builds.

### How?

Fixes #66180
