### PR TITLE
docs(community): remove Grammarly extension recommendation

### DIFF
--- a/docs/05-community/01-contribution-guide.mdx
+++ b/docs/05-community/01-contribution-guide.mdx
@@ -53,7 +53,6 @@ Next, open the command palette again, and search for `Markdown: Preview File` or
 We also recommend the following extensions for VSCode users:
 
 - [MDX](https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-mdx): Intellisense and syntax highlighting for MDX.
-- [Grammarly](https://marketplace.visualstudio.com/items?itemName=znck.grammarly): Grammar and spell checker.
 - [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode): Format MDX files on save.
 
 ### Review Process


### PR DESCRIPTION
## Why?

The Grammarly extension is no longer active.

- https://github.com/znck/grammarly
- Closes https://github.com/vercel/next.js/issues/66194