### PR TITLE
Remove obsolete `isNodeDebugging` option from next server

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -230,8 +230,6 @@ export interface Options {
    * The HTTP Server that Next.js is running behind
    */
   httpServer?: HTTPServer
-
-  isNodeDebugging?: 'brk' | boolean
 }
 
 export type RenderOpts = PagesRenderOptsPartial & AppRenderOptsPartial

--- a/packages/next/src/server/lib/render-server.ts
+++ b/packages/next/src/server/lib/render-server.ts
@@ -77,7 +77,6 @@ async function initializeImpl(opts: {
   dev: boolean
   minimalMode?: boolean
   hostname?: string
-  isNodeDebugging: boolean
   keepAliveTimeout?: number
   serverFields?: any
   server?: any
@@ -103,7 +102,6 @@ async function initializeImpl(opts: {
     customServer: false,
     httpServer: opts.server,
     port: opts.port,
-    isNodeDebugging: opts.isNodeDebugging,
   })
   requestHandler = app.getRequestHandler()
   upgradeHandler = app.getUpgradeHandler()

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -68,7 +68,6 @@ export async function initialize(opts: {
   server?: import('http').Server
   minimalMode?: boolean
   hostname?: string
-  isNodeDebugging: boolean
   keepAliveTimeout?: number
   customServer?: boolean
   experimentalHttpsServer?: boolean
@@ -599,7 +598,6 @@ export async function initialize(opts: {
     minimalMode: opts.minimalMode,
     dev: !!opts.dev,
     server: opts.server,
-    isNodeDebugging: !!opts.isNodeDebugging,
     serverFields: developmentBundler?.serverFields || {},
     experimentalTestProxy: !!config.experimental.testProxy,
     experimentalHttpsServer: !!opts.experimentalHttpsServer,

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -53,7 +53,6 @@ export async function getRequestHandlers({
   server,
   hostname,
   minimalMode,
-  isNodeDebugging,
   keepAliveTimeout,
   experimentalHttpsServer,
   quiet,
@@ -64,7 +63,6 @@ export async function getRequestHandlers({
   server?: import('http').Server
   hostname?: string
   minimalMode?: boolean
-  isNodeDebugging?: boolean
   keepAliveTimeout?: number
   experimentalHttpsServer?: boolean
   quiet?: boolean
@@ -76,7 +74,6 @@ export async function getRequestHandlers({
     dev: isDev,
     minimalMode,
     server,
-    isNodeDebugging: isNodeDebugging || false,
     keepAliveTimeout,
     experimentalHttpsServer,
     startServerSpan,
@@ -304,7 +301,6 @@ export async function startServer(
           server,
           hostname,
           minimalMode,
-          isNodeDebugging: Boolean(nodeDebugType),
           keepAliveTimeout,
           experimentalHttpsServer: !!selfSignedCertificate,
         })

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -25,7 +25,6 @@ import { PHASE_PRODUCTION_SERVER } from '../shared/lib/constants'
 import { getTracer } from './lib/trace/tracer'
 import { NextServerSpan } from './lib/trace/constants'
 import { formatUrl } from '../shared/lib/router/utils/format-url'
-import { getNodeDebugType } from './lib/utils'
 
 let ServerImpl: typeof Server
 
@@ -275,15 +274,12 @@ class NextCustomServer extends NextServer {
     const { getRequestHandlers } =
       require('./lib/start-server') as typeof import('./lib/start-server')
 
-    const isNodeDebugging = typeof getNodeDebugType() === 'string'
-
     const initResult = await getRequestHandlers({
       dir: this.options.dir!,
       port: this.options.port || 3000,
       isDev: !!this.options.dev,
       hostname: this.options.hostname || 'localhost',
       minimalMode: this.options.minimalMode,
-      isNodeDebugging,
       quiet: this.options.quiet,
     })
     this.requestHandler = initResult[0]


### PR DESCRIPTION
The last usage of the `isNodeDebugging` option was removed in #55383.