### PR TITLE
Update create-next-app template CSS

### DIFF
--- a/packages/create-next-app/templates/app-tw/js/app/globals.css
+++ b/packages/create-next-app/templates/app-tw/js/app/globals.css
@@ -17,5 +17,5 @@
 body {
   color: var(--foreground);
   background: var(--background);
-  font-synthesis: none;
+  font-family: Arial, Helvetica, sans-serif;
 }

--- a/packages/create-next-app/templates/app-tw/js/app/layout.js
+++ b/packages/create-next-app/templates/app-tw/js/app/layout.js
@@ -4,10 +4,12 @@ import "./globals.css";
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
   variable: "--font-geist-sans",
+  weight: "100 900",
 });
 const geistMono = localFont({
   src: "./fonts/GeistMonoVF.woff",
   variable: "--font-geist-mono",
+  weight: "100 900",
 });
 
 export const metadata = {

--- a/packages/create-next-app/templates/app-tw/js/app/page.js
+++ b/packages/create-next-app/templates/app-tw/js/app/page.js
@@ -2,7 +2,10 @@ import Image from "next/image";
 
 export default function Home() {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
+    <div
+      className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20"
+      style={{ fontFamily: "var(--font-geist-sans)" }}
+    >
       <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
         <Image
           className="dark:invert"
@@ -12,7 +15,10 @@ export default function Home() {
           height={38}
           priority
         />
-        <ol className="font-mono list-inside list-decimal text-sm text-center sm:text-left">
+        <ol
+          className="list-inside list-decimal text-sm text-center sm:text-left"
+          style={{ fontFamily: "var(--font-geist-mono)" }}
+        >
           <li className="mb-2">
             Get started by editing{" "}
             <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-semibold">

--- a/packages/create-next-app/templates/app-tw/js/tailwind.config.js
+++ b/packages/create-next-app/templates/app-tw/js/tailwind.config.js
@@ -11,10 +11,6 @@ module.exports = {
         background: "var(--background)",
         foreground: "var(--foreground)",
       },
-      fontFamily: {
-        sans: ["var(--font-geist-sans)"],
-        mono: ["var(--font-geist-mono)"],
-      },
     },
   },
   plugins: [],

--- a/packages/create-next-app/templates/app-tw/ts/app/globals.css
+++ b/packages/create-next-app/templates/app-tw/ts/app/globals.css
@@ -17,5 +17,5 @@
 body {
   color: var(--foreground);
   background: var(--background);
-  font-synthesis: none;
+  font-family: Arial, Helvetica, sans-serif;
 }

--- a/packages/create-next-app/templates/app-tw/ts/app/layout.tsx
+++ b/packages/create-next-app/templates/app-tw/ts/app/layout.tsx
@@ -5,10 +5,12 @@ import "./globals.css";
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
   variable: "--font-geist-sans",
+  weight: "100 900",
 });
 const geistMono = localFont({
   src: "./fonts/GeistMonoVF.woff",
   variable: "--font-geist-mono",
+  weight: "100 900",
 });
 
 export const metadata: Metadata = {

--- a/packages/create-next-app/templates/app-tw/ts/app/page.tsx
+++ b/packages/create-next-app/templates/app-tw/ts/app/page.tsx
@@ -2,7 +2,10 @@ import Image from "next/image";
 
 export default function Home() {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
+    <div
+      className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20"
+      style={{ fontFamily: "var(--font-geist-sans)" }}
+    >
       <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
         <Image
           className="dark:invert"
@@ -12,7 +15,10 @@ export default function Home() {
           height={38}
           priority
         />
-        <ol className="font-mono list-inside list-decimal text-sm text-center sm:text-left">
+        <ol
+          className="list-inside list-decimal text-sm text-center sm:text-left"
+          style={{ fontFamily: "var(--font-geist-mono)" }}
+        >
           <li className="mb-2">
             Get started by editing{" "}
             <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-semibold">

--- a/packages/create-next-app/templates/app-tw/ts/tailwind.config.ts
+++ b/packages/create-next-app/templates/app-tw/ts/tailwind.config.ts
@@ -12,10 +12,6 @@ const config: Config = {
         background: "var(--background)",
         foreground: "var(--foreground)",
       },
-      fontFamily: {
-        sans: ["var(--font-geist-sans)"],
-        mono: ["var(--font-geist-mono)"],
-      },
     },
   },
   plugins: [],

--- a/packages/create-next-app/templates/app/js/app/globals.css
+++ b/packages/create-next-app/templates/app/js/app/globals.css
@@ -19,6 +19,7 @@ body {
 body {
   color: var(--foreground);
   background: var(--background);
+  font-family: Arial, Helvetica, sans-serif;
 }
 
 * {

--- a/packages/create-next-app/templates/app/js/app/layout.js
+++ b/packages/create-next-app/templates/app/js/app/layout.js
@@ -4,10 +4,12 @@ import "./globals.css";
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
   variable: "--font-geist-sans",
+  weight: "100 900",
 });
 const geistMono = localFont({
   src: "./fonts/GeistMonoVF.woff",
   variable: "--font-geist-mono",
+  weight: "100 900",
 });
 
 export const metadata = {

--- a/packages/create-next-app/templates/app/js/app/page.module.css
+++ b/packages/create-next-app/templates/app/js/app/page.module.css
@@ -13,7 +13,7 @@
   min-height: 100svh;
   padding: 80px;
   gap: 64px;
-  font-synthesis: none;
+  font-family: var(--font-geist-sans);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -67,7 +67,6 @@
   height: 48px;
   padding: 0 20px;
   border: none;
-  font-family: var(--font-geist-sans);
   border: 1px solid transparent;
   transition:
     background 0.2s,
@@ -94,7 +93,6 @@ a.secondary {
 }
 
 .footer {
-  font-family: var(--font-geist-sans);
   grid-row-start: 3;
   display: flex;
   gap: 24px;

--- a/packages/create-next-app/templates/app/ts/app/globals.css
+++ b/packages/create-next-app/templates/app/ts/app/globals.css
@@ -19,6 +19,7 @@ body {
 body {
   color: var(--foreground);
   background: var(--background);
+  font-family: Arial, Helvetica, sans-serif;
 }
 
 * {

--- a/packages/create-next-app/templates/app/ts/app/layout.tsx
+++ b/packages/create-next-app/templates/app/ts/app/layout.tsx
@@ -5,10 +5,12 @@ import "./globals.css";
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
   variable: "--font-geist-sans",
+  weight: "100 900",
 });
 const geistMono = localFont({
   src: "./fonts/GeistMonoVF.woff",
   variable: "--font-geist-mono",
+  weight: "100 900",
 });
 
 export const metadata: Metadata = {

--- a/packages/create-next-app/templates/app/ts/app/page.module.css
+++ b/packages/create-next-app/templates/app/ts/app/page.module.css
@@ -13,7 +13,7 @@
   min-height: 100svh;
   padding: 80px;
   gap: 64px;
-  font-synthesis: none;
+  font-family: var(--font-geist-sans);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -67,7 +67,6 @@
   height: 48px;
   padding: 0 20px;
   border: none;
-  font-family: var(--font-geist-sans);
   border: 1px solid transparent;
   transition:
     background 0.2s,
@@ -94,7 +93,6 @@ a.secondary {
 }
 
 .footer {
-  font-family: var(--font-geist-sans);
   grid-row-start: 3;
   display: flex;
   gap: 24px;

--- a/packages/create-next-app/templates/default-tw/js/pages/index.js
+++ b/packages/create-next-app/templates/default-tw/js/pages/index.js
@@ -4,16 +4,21 @@ import localFont from "next/font/local";
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
   variable: "--font-geist-sans",
+  weight: "100 900",
 });
 const geistMono = localFont({
   src: "./fonts/GeistMonoVF.woff",
   variable: "--font-geist-mono",
+  weight: "100 900",
 });
 
 export default function Home() {
   return (
     <div
       className={`${geistSans.variable} ${geistMono.variable} grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20`}
+      style={{
+        fontFamily: "var(--font-geist-sans)",
+      }}
     >
       <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
         <Image
@@ -24,7 +29,12 @@ export default function Home() {
           height={38}
           priority
         />
-        <ol className="font-mono list-inside list-decimal text-sm text-center sm:text-left">
+        <ol
+          className="list-inside list-decimal text-sm text-center sm:text-left"
+          style={{
+            fontFamily: "var(--font-geist-mono)",
+          }}
+        >
           <li className="mb-2">
             Get started by editing{" "}
             <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-semibold">
@@ -34,7 +44,7 @@ export default function Home() {
           <li>Save and see your changes instantly.</li>
         </ol>
 
-        <div className="font-sans flex gap-4 items-center flex-col sm:flex-row">
+        <div className="flex gap-4 items-center flex-col sm:flex-row">
           <a
             className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5"
             href="https://vercel.com/new?utm_source=create-next-app&utm_medium=default-template-tw&utm_campaign=create-next-app"
@@ -60,7 +70,7 @@ export default function Home() {
           </a>
         </div>
       </main>
-      <footer className="font-sans row-start-3 flex gap-6 flex-wrap items-center justify-center">
+      <footer className="row-start-3 flex gap-6 flex-wrap items-center justify-center">
         <a
           className="flex items-center gap-2 hover:underline hover:underline-offset-4"
           href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=default-template-tw&utm_campaign=create-next-app"

--- a/packages/create-next-app/templates/default-tw/js/styles/globals.css
+++ b/packages/create-next-app/templates/default-tw/js/styles/globals.css
@@ -17,5 +17,5 @@
 body {
   color: var(--foreground);
   background: var(--background);
-  font-synthesis: none;
+  font-family: Arial, Helvetica, sans-serif;
 }

--- a/packages/create-next-app/templates/default-tw/js/tailwind.config.js
+++ b/packages/create-next-app/templates/default-tw/js/tailwind.config.js
@@ -11,10 +11,6 @@ module.exports = {
         background: "var(--background)",
         foreground: "var(--foreground)",
       },
-      fontFamily: {
-        sans: ["var(--font-geist-sans)"],
-        mono: ["var(--font-geist-mono)"],
-      },
     },
   },
   plugins: [],

--- a/packages/create-next-app/templates/default-tw/ts/pages/index.tsx
+++ b/packages/create-next-app/templates/default-tw/ts/pages/index.tsx
@@ -4,16 +4,21 @@ import localFont from "next/font/local";
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
   variable: "--font-geist-sans",
+  weight: "100 900",
 });
 const geistMono = localFont({
   src: "./fonts/GeistMonoVF.woff",
   variable: "--font-geist-mono",
+  weight: "100 900",
 });
 
 export default function Home() {
   return (
     <div
       className={`${geistSans.variable} ${geistMono.variable} grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20`}
+      style={{
+        fontFamily: "var(--font-geist-sans)",
+      }}
     >
       <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
         <Image
@@ -24,7 +29,12 @@ export default function Home() {
           height={38}
           priority
         />
-        <ol className="font-mono list-inside list-decimal text-sm text-center sm:text-left">
+        <ol
+          className="list-inside list-decimal text-sm text-center sm:text-left"
+          style={{
+            fontFamily: "var(--font-geist-mono)",
+          }}
+        >
           <li className="mb-2">
             Get started by editing{" "}
             <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-semibold">
@@ -34,7 +44,7 @@ export default function Home() {
           <li>Save and see your changes instantly.</li>
         </ol>
 
-        <div className="font-sans flex gap-4 items-center flex-col sm:flex-row">
+        <div className="flex gap-4 items-center flex-col sm:flex-row">
           <a
             className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5"
             href="https://vercel.com/new?utm_source=create-next-app&utm_medium=default-template-tw&utm_campaign=create-next-app"
@@ -60,7 +70,7 @@ export default function Home() {
           </a>
         </div>
       </main>
-      <footer className="font-sans row-start-3 flex gap-6 flex-wrap items-center justify-center">
+      <footer className="row-start-3 flex gap-6 flex-wrap items-center justify-center">
         <a
           className="flex items-center gap-2 hover:underline hover:underline-offset-4"
           href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=default-template-tw&utm_campaign=create-next-app"

--- a/packages/create-next-app/templates/default-tw/ts/styles/globals.css
+++ b/packages/create-next-app/templates/default-tw/ts/styles/globals.css
@@ -17,5 +17,5 @@
 body {
   color: var(--foreground);
   background: var(--background);
-  font-synthesis: none;
+  font-family: Arial, Helvetica, sans-serif;
 }

--- a/packages/create-next-app/templates/default-tw/ts/tailwind.config.ts
+++ b/packages/create-next-app/templates/default-tw/ts/tailwind.config.ts
@@ -12,10 +12,6 @@ const config: Config = {
         background: "var(--background)",
         foreground: "var(--foreground)",
       },
-      fontFamily: {
-        sans: ["var(--font-geist-sans)"],
-        mono: ["var(--font-geist-mono)"],
-      },
     },
   },
   plugins: [],

--- a/packages/create-next-app/templates/default/js/pages/index.js
+++ b/packages/create-next-app/templates/default/js/pages/index.js
@@ -6,10 +6,12 @@ import styles from "@/styles/Home.module.css";
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
   variable: "--font-geist-sans",
+  weight: "100 900",
 });
 const geistMono = localFont({
   src: "./fonts/GeistMonoVF.woff",
   variable: "--font-geist-mono",
+  weight: "100 900",
 });
 
 export default function Home() {

--- a/packages/create-next-app/templates/default/js/styles/Home.module.css
+++ b/packages/create-next-app/templates/default/js/styles/Home.module.css
@@ -13,7 +13,7 @@
   min-height: 100svh;
   padding: 80px;
   gap: 64px;
-  font-synthesis: none;
+  font-family: var(--font-geist-sans);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -67,7 +67,6 @@
   height: 48px;
   padding: 0 20px;
   border: none;
-  font-family: var(--font-geist-sans);
   border: 1px solid transparent;
   transition:
     background 0.2s,
@@ -94,7 +93,6 @@ a.secondary {
 }
 
 .footer {
-  font-family: var(--font-geist-sans);
   grid-row-start: 3;
   display: flex;
   gap: 24px;

--- a/packages/create-next-app/templates/default/js/styles/globals.css
+++ b/packages/create-next-app/templates/default/js/styles/globals.css
@@ -19,6 +19,7 @@ body {
 body {
   color: var(--foreground);
   background: var(--background);
+  font-family: Arial, Helvetica, sans-serif;
 }
 
 * {

--- a/packages/create-next-app/templates/default/ts/pages/index.tsx
+++ b/packages/create-next-app/templates/default/ts/pages/index.tsx
@@ -6,10 +6,12 @@ import styles from "@/styles/Home.module.css";
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
   variable: "--font-geist-sans",
+  weight: "100 900",
 });
 const geistMono = localFont({
   src: "./fonts/GeistMonoVF.woff",
   variable: "--font-geist-mono",
+  weight: "100 900",
 });
 
 export default function Home() {

--- a/packages/create-next-app/templates/default/ts/styles/Home.module.css
+++ b/packages/create-next-app/templates/default/ts/styles/Home.module.css
@@ -13,7 +13,7 @@
   min-height: 100svh;
   padding: 80px;
   gap: 64px;
-  font-synthesis: none;
+  font-family: var(--font-geist-sans);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -67,7 +67,6 @@
   height: 48px;
   padding: 0 20px;
   border: none;
-  font-family: var(--font-geist-sans);
   border: 1px solid transparent;
   transition:
     background 0.2s,
@@ -94,7 +93,6 @@ a.secondary {
 }
 
 .footer {
-  font-family: var(--font-geist-sans);
   grid-row-start: 3;
   display: flex;
   gap: 24px;

--- a/packages/create-next-app/templates/default/ts/styles/globals.css
+++ b/packages/create-next-app/templates/default/ts/styles/globals.css
@@ -19,6 +19,7 @@ body {
 body {
   color: var(--foreground);
   background: var(--background);
+  font-family: Arial, Helvetica, sans-serif;
 }
 
 * {


### PR DESCRIPTION
Updates `create-next-app` template CSS:

- Declares variable font weights in `localFont` options and removes instances of `font-synthesis: none`
- Removes Geist font variables from Tailwind config files
- Adds fallback sans typefaces to the `body` CSS