### PR TITLE
Fix source map loading failure for `path-to-regexp`

### DIFF
--- a/packages/next/taskfile-webpack.js
+++ b/packages/next/taskfile-webpack.js
@@ -26,18 +26,18 @@ module.exports = function (task) {
           })
         }
 
+        if (stats.hasWarnings()) {
+          this.emit('plugin_warning', {
+            plugin: 'taskfile-webpack',
+            warning: `webpack compiled ${options.name} with warnings:\n${stats.toString('errors-warnings')}`,
+          })
+        }
+
         if (process.env.ANALYZE_STATS) {
           require('fs').writeFileSync(
             require('path').join(__dirname, options.name + '-stats.json'),
             JSON.stringify(stats.toJson())
           )
-        }
-
-        if (process.env.PRINT_WEBPACK_WARNINGS) {
-          this.emit('plugin_warning', {
-            plugin: 'taskfile-webpack',
-            warning: `webpack compiled ${options.name} with warnings:\n${stats.toString('errors-warnings')}`,
-          })
         }
 
         resolve()

--- a/packages/next/taskfile-webpack.js
+++ b/packages/next/taskfile-webpack.js
@@ -26,11 +26,18 @@ module.exports = function (task) {
           })
         }
 
-        if (process.env.ANALYZE_STATS) {
+        if (process.env.ANALYZE_WEBPACK_STATS) {
           require('fs').writeFileSync(
             require('path').join(__dirname, options.name + '-stats.json'),
             JSON.stringify(stats.toJson())
           )
+        }
+
+        if (process.env.PRINT_WEBPACK_WARNINGS) {
+          this.emit('plugin_warning', {
+            plugin: 'taskfile-webpack',
+            warning: `webpack compiled ${options.name} with warnings:\n${stats.toString('errors-warnings')}`,
+          })
         }
 
         resolve()

--- a/packages/next/taskfile-webpack.js
+++ b/packages/next/taskfile-webpack.js
@@ -26,7 +26,7 @@ module.exports = function (task) {
           })
         }
 
-        if (process.env.ANALYZE_WEBPACK_STATS) {
+        if (process.env.ANALYZE_STATS) {
           require('fs').writeFileSync(
             require('path').join(__dirname, options.name + '-stats.json'),
             JSON.stringify(stats.toJson())

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -2120,7 +2120,12 @@ export async function ncc_ws(task, opts) {
 externals['path-to-regexp'] = 'next/dist/compiled/path-to-regexp'
 export async function path_to_regexp(task, opts) {
   await task
-    .source(relative(__dirname, require.resolve('path-to-regexp')))
+    .source(
+      join(
+        dirname(relative(__dirname, require.resolve('path-to-regexp'))),
+        '*.{js,map}'
+      )
+    )
     .target('dist/compiled/path-to-regexp')
 }
 


### PR DESCRIPTION
The warning by the source-map-loader[^1] went unnoticed when adding it in #64527. Warnings like this are now printed by default.

Side note: Another printed warning is currently about the React version missing in `react-dom` with the `react-server` condition [^2]. I've upstreamed a fix for this in https://github.com/facebook/react/pull/29596.

[^1]: source-map-loader warning for path-to-regexp
    ```
    WARNING in ./dist/compiled/path-to-regexp/index.js
    Module Warning (from ../../node_modules/.pnpm/source-map-loader@5.0.0_webpack@5.90.0/node_modules/source-map-loader/dist/cjs.js):
    Failed to parse source map from '[...]/packages/next/dist/compiled/path-to-regexp/index.js.map' file: Error: ENOENT: no such file or directory, open '[...]/packages/next/dist/compiled/path-to-regexp/index.js.map'
     @ ./dist/esm/lib/generate-interception-routes-rewrites.js 1:0-65 46:41-53
     @ ./dist/esm/server/next-server.js 49:0-90 469:93-119
     ```
[^2]: react-dom version warning
    ```
    [13:57:56] taskfile-webpack warned that webpack compiled next-bundle-app-prod with warnings:
    WARNING in ./dist/esm/server/future/route-modules/app-page/vendored/rsc/entrypoints.js 44:4-20
    export 'version' (imported as 'ReactDOM') was not found in 'react-dom' (possible exports: __DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE, preconnect, prefetchDNS, preinit, preinitModule, preload, preloadModule)
    
    WARNING in ./dist/esm/server/future/route-modules/app-page/vendored/rsc/entrypoints.js 49:4-20
    export 'version' (imported as 'ReactDOM') was not found in 'react-dom' (possible exports: __DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE, preconnect, prefetchDNS, preinit, preinitModule, preload, preloadModule)
    
    webpack compiled with 2 warnings
    ```