### PR TITLE
[ppr] Don't mark RSC requests as /_next/data requests

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -30,7 +30,12 @@ module.exports = {
 
     return [
       `prettier --with-node-modules --ignore-path .prettierignore --write ${escapedFileNames}`,
-      `eslint --no-ignore --max-warnings=0 --fix ${escape(eslintFileNames.filter((filename) => filename !== null)).join(' ')}`,
+      `eslint --no-ignore --max-warnings=0 --fix ${eslintFileNames
+        .filter((filename) => filename !== null)
+        .map((filename) => {
+          return `"${filename}"`
+        })
+        .join(' ')}`,
       `git add ${escapedFileNames}`,
     ]
   },

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1389,7 +1389,7 @@ export async function buildAppStaticPaths({
       renderOpts: {
         originalPathname: page,
         incrementalCache,
-        supportsDynamicHTML: true,
+        supportsDynamicResponse: true,
         isRevalidate: false,
         experimental: {
           after: false,

--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
@@ -93,7 +93,7 @@ export function getRender({
       extendRenderOpts: {
         buildId,
         runtime: SERVER_RUNTIME.experimentalEdge,
-        supportsDynamicHTML: true,
+        supportsDynamicResponse: true,
         disableOptimizedLoading: true,
         serverActionsManifest,
         serverActions,

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -398,7 +398,7 @@ export async function exportAppImpl(
     domainLocales: i18n?.domains,
     disableOptimizedLoading: nextConfig.experimental.disableOptimizedLoading,
     // Exported pages do not currently support dynamic HTML.
-    supportsDynamicHTML: false,
+    supportsDynamicResponse: false,
     crossOrigin: nextConfig.crossOrigin,
     optimizeCss: nextConfig.experimental.optimizeCss,
     nextConfigOutput: nextConfig.output,

--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -75,7 +75,7 @@ export async function exportAppRoute(
       experimental: experimental,
       originalPathname: page,
       nextExport: true,
-      supportsDynamicHTML: false,
+      supportsDynamicResponse: false,
       incrementalCache,
       waitUntil: undefined,
       onClose: undefined,

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -269,7 +269,7 @@ async function exportPageImpl(
       disableOptimizedLoading,
       fontManifest: optimizeFonts ? requireFontManifest(distDir) : undefined,
       locale,
-      supportsDynamicHTML: false,
+      supportsDynamicResponse: false,
       originalPathname: page,
       experimental: {
         ...input.renderOpts.experimental,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -643,7 +643,7 @@ async function renderToHTMLOrFlightImpl(
     ComponentMod,
     dev,
     nextFontManifest,
-    supportsDynamicHTML,
+    supportsDynamicResponse,
     serverActions,
     appDirDevErrorLogger,
     assetPrefix = '',
@@ -781,7 +781,7 @@ async function renderToHTMLOrFlightImpl(
    * These rules help ensure that other existing features like request caching,
    * coalescing, and ISR continue working as intended.
    */
-  const generateStaticHTML = supportsDynamicHTML !== true
+  const generateStaticHTML = supportsDynamicResponse !== true
 
   // Pull out the hooks/references from the component.
   const { tree: loaderTree, taintObjectReference } = ComponentMod

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -129,7 +129,7 @@ export interface RenderOptsPartial {
   basePath: string
   trailingSlash: boolean
   clientReferenceManifest?: DeepReadonly<ClientReferenceManifest>
-  supportsDynamicHTML: boolean
+  supportsDynamicResponse: boolean
   runtime?: ServerRuntime
   serverComponents?: boolean
   enableTainting?: boolean

--- a/packages/next/src/server/async-storage/static-generation-async-storage-wrapper.ts
+++ b/packages/next/src/server/async-storage/static-generation-async-storage-wrapper.ts
@@ -41,7 +41,7 @@ export type StaticGenerationContext = {
     // mirrored.
     RenderOptsPartial,
     | 'originalPathname'
-    | 'supportsDynamicHTML'
+    | 'supportsDynamicResponse'
     | 'isRevalidate'
     | 'nextExport'
     | 'isDraftMode'
@@ -77,7 +77,7 @@ export const StaticGenerationAsyncStorageWrapper: AsyncStorageWrapper<
      * coalescing, and ISR continue working as intended.
      */
     const isStaticGeneration =
-      !renderOpts.supportsDynamicHTML &&
+      !renderOpts.supportsDynamicResponse &&
       !renderOpts.isDraftMode &&
       !renderOpts.isServerAction
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2330,7 +2330,7 @@ export default abstract class Server<
               serverActions: this.nextConfig.experimental.serverActions,
             }
           : {}),
-        isNextDataRequest: isNextDataRequest,
+        isNextDataRequest,
         resolvedUrl,
         locale,
         locales,

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -527,7 +527,7 @@ export default abstract class Server<
     }
 
     this.renderOpts = {
-      supportsDynamicHTML: true,
+      supportsDynamicResponse: true,
       trailingSlash: this.nextConfig.trailingSlash,
       deploymentId: this.nextConfig.deploymentId,
       strictNextHead: this.nextConfig.experimental.strictNextHead ?? true,
@@ -1597,7 +1597,7 @@ export default abstract class Server<
       ...partialContext,
       renderOpts: {
         ...this.renderOpts,
-        supportsDynamicHTML: !isBotRequest,
+        supportsDynamicResponse: !isBotRequest,
         isBot: !!isBotRequest,
       },
     }
@@ -1643,7 +1643,7 @@ export default abstract class Server<
       ...partialContext,
       renderOpts: {
         ...this.renderOpts,
-        supportsDynamicHTML: false,
+        supportsDynamicResponse: false,
       },
     }
     const payload = await fn(ctx)
@@ -2093,7 +2093,7 @@ export default abstract class Server<
     // the query object. This ensures it won't be found by the `in` operator.
     if ('amp' in query && !query.amp) delete query.amp
 
-    if (opts.supportsDynamicHTML === true) {
+    if (opts.supportsDynamicResponse === true) {
       const isBotRequest = isBot(req.headers['user-agent'] || '')
       const isSupportedDocument =
         typeof components.Document?.getInitialProps !== 'function' ||
@@ -2105,14 +2105,14 @@ export default abstract class Server<
       // TODO-APP: should the first render for a dynamic app path
       // be static so we can collect revalidate and populate the
       // cache if there are no dynamic data requirements
-      opts.supportsDynamicHTML =
+      opts.supportsDynamicResponse =
         !isSSG && !isBotRequest && !query.amp && isSupportedDocument
       opts.isBot = isBotRequest
     }
 
     // In development, we always want to generate dynamic HTML.
     if (!isPagesDataRequest && isAppPath && opts.dev) {
-      opts.supportsDynamicHTML = true
+      opts.supportsDynamicResponse = true
     }
 
     const defaultLocale = isSSG
@@ -2208,7 +2208,7 @@ export default abstract class Server<
     if (
       !isPreviewMode &&
       isSSG &&
-      !opts.supportsDynamicHTML &&
+      !opts.supportsDynamicResponse &&
       !isServerAction &&
       !minimalPostponed &&
       !isDynamicRSCRequest
@@ -2284,7 +2284,7 @@ export default abstract class Server<
 
     const doRender: Renderer = async ({ postponed }) => {
       // In development, we always want to generate dynamic HTML.
-      let supportsDynamicHTML: boolean =
+      let supportsDynamicResponse: boolean =
         // If we're in development, we always support dynamic HTML, unless it's
         // a data request, in which case we only produce static HTML.
         (!isPagesDataRequest && opts.dev === true) ||
@@ -2351,7 +2351,7 @@ export default abstract class Server<
           ...opts.experimental,
           isRoutePPREnabled,
         },
-        supportsDynamicHTML,
+        supportsDynamicResponse,
         isOnDemandRevalidate,
         isDraftMode: isPreviewMode,
         isServerAction,
@@ -2361,9 +2361,9 @@ export default abstract class Server<
       }
 
       if (isDebugPPRSkeleton) {
-        supportsDynamicHTML = false
+        supportsDynamicResponse = false
         renderOpts.nextExport = true
-        renderOpts.supportsDynamicHTML = false
+        renderOpts.supportsDynamicResponse = false
         renderOpts.isStaticGeneration = true
         renderOpts.isRevalidate = true
         renderOpts.isDebugPPRSkeleton = true
@@ -2395,7 +2395,7 @@ export default abstract class Server<
                 after: renderOpts.experimental.after,
               },
               originalPathname: components.ComponentMod.originalPathname,
-              supportsDynamicHTML,
+              supportsDynamicResponse,
               incrementalCache,
               isRevalidate: isSSG,
               waitUntil: this.getWaitUntil(),

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -649,10 +649,6 @@ export default abstract class Server<
       return false
     }
 
-    // If we're here, this is a data request, as it didn't return and it matched
-    // either a RSC or a prefetch RSC request.
-    parsedUrl.query.__nextDataReq = '1'
-
     if (req.url) {
       const parsed = parseUrl(req.url)
       parsed.pathname = parsedUrl.pathname
@@ -2301,8 +2297,8 @@ export default abstract class Server<
     const doRender: Renderer = async ({ postponed }) => {
       // In development, we always want to generate dynamic HTML.
       let supportsDynamicHTML: boolean =
-        // If this isn't a data request and we're not in development, then we
-        // support dynamic HTML.
+        // If we're in development, we always support dynamic HTML, unless it's
+        // a data request, in which case we only produce static HTML.
         (!isDataReq && opts.dev === true) ||
         // If this is not SSG or does not have static paths, then it supports
         // dynamic HTML.

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1942,7 +1942,7 @@ export default abstract class Server<
     }
 
     // Toggle whether or not this is a Data request
-    const isPagesDataRequest =
+    const isNextDataRequest =
       !!(
         query.__nextDataReq ||
         (req.headers['x-nextjs-data'] &&
@@ -2052,7 +2052,7 @@ export default abstract class Server<
       isRoutePPREnabled && isRSCRequest && !isPrefetchRSCRequest
 
     // we need to ensure the status code if /404 is visited directly
-    if (is404Page && !isPagesDataRequest && !isRSCRequest) {
+    if (is404Page && !isNextDataRequest && !isRSCRequest) {
       res.statusCode = 404
     }
 
@@ -2111,7 +2111,7 @@ export default abstract class Server<
     }
 
     // In development, we always want to generate dynamic HTML.
-    if (!isPagesDataRequest && isAppPath && opts.dev) {
+    if (!isNextDataRequest && isAppPath && opts.dev) {
       opts.supportsDynamicResponse = true
     }
 
@@ -2199,7 +2199,7 @@ export default abstract class Server<
 
     // remove /_next/data prefix from urlPathname so it matches
     // for direct page visit and /_next/data visit
-    if (isPagesDataRequest) {
+    if (isNextDataRequest) {
       resolvedUrlPathname = this.stripNextDataPath(resolvedUrlPathname)
       urlPathname = this.stripNextDataPath(urlPathname)
     }
@@ -2287,7 +2287,7 @@ export default abstract class Server<
       let supportsDynamicResponse: boolean =
         // If we're in development, we always support dynamic HTML, unless it's
         // a data request, in which case we only produce static HTML.
-        (!isPagesDataRequest && opts.dev === true) ||
+        (!isNextDataRequest && opts.dev === true) ||
         // If this is not SSG or does not have static paths, then it supports
         // dynamic HTML.
         (!isSSG && !hasStaticPaths) ||
@@ -2330,7 +2330,7 @@ export default abstract class Server<
               serverActions: this.nextConfig.experimental.serverActions,
             }
           : {}),
-        isPagesDataRequest: isPagesDataRequest,
+        isNextDataRequest: isNextDataRequest,
         resolvedUrl,
         locale,
         locales,
@@ -2709,7 +2709,7 @@ export default abstract class Server<
           throw new NoFallbackError()
         }
 
-        if (!isPagesDataRequest) {
+        if (!isNextDataRequest) {
           // Production already emitted the fallback as static HTML.
           if (isProduction) {
             const html = await this.getFallback(
@@ -2843,11 +2843,11 @@ export default abstract class Server<
       revalidate = 0
     } else if (
       typeof cacheEntry.revalidate !== 'undefined' &&
-      (!this.renderOpts.dev || (hasServerProps && !isPagesDataRequest))
+      (!this.renderOpts.dev || (hasServerProps && !isNextDataRequest))
     ) {
       // If this is a preview mode request, we shouldn't cache it. We also don't
       // cache 404 pages.
-      if (isPreviewMode || (is404Page && !isPagesDataRequest)) {
+      if (isPreviewMode || (is404Page && !isNextDataRequest)) {
         revalidate = 0
       }
 
@@ -2901,7 +2901,7 @@ export default abstract class Server<
           })
         )
       }
-      if (isPagesDataRequest) {
+      if (isNextDataRequest) {
         res.statusCode = 404
         res.body('{"notFound":true}').send()
         return null
@@ -2924,7 +2924,7 @@ export default abstract class Server<
         )
       }
 
-      if (isPagesDataRequest) {
+      if (isNextDataRequest) {
         return {
           type: 'json',
           body: RenderResult.fromStatic(
@@ -3100,7 +3100,7 @@ export default abstract class Server<
         // to the client on the same request.
         revalidate: 0,
       }
-    } else if (isPagesDataRequest) {
+    } else if (isNextDataRequest) {
       return {
         type: 'json',
         body: RenderResult.fromStatic(JSON.stringify(cachedData.pageData)),

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1856,7 +1856,7 @@ export default class NextNodeServer extends BaseServer<
     }
 
     // For edge to "fetch" we must always provide an absolute URL
-    const isDataReq = !!query.__nextDataReq
+    const isPagesDataRequest = !!query.__nextDataReq
     const initialUrl = new URL(
       getRequestMeta(params.req, 'initURL') || '/',
       'http://n'
@@ -1867,7 +1867,7 @@ export default class NextNodeServer extends BaseServer<
       ...params.params,
     }).toString()
 
-    if (isDataReq) {
+    if (isPagesDataRequest) {
       params.req.headers['x-nextjs-data'] = '1'
     }
     initialUrl.search = queryString

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1856,7 +1856,7 @@ export default class NextNodeServer extends BaseServer<
     }
 
     // For edge to "fetch" we must always provide an absolute URL
-    const isPagesDataRequest = !!query.__nextDataReq
+    const isNextDataRequest = !!query.__nextDataReq
     const initialUrl = new URL(
       getRequestMeta(params.req, 'initURL') || '/',
       'http://n'
@@ -1867,7 +1867,7 @@ export default class NextNodeServer extends BaseServer<
       ...params.params,
     }).toString()
 
-    if (isPagesDataRequest) {
+    if (isNextDataRequest) {
       params.req.headers['x-nextjs-data'] = '1'
     }
     initialUrl.search = queryString

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -246,7 +246,7 @@ export type RenderOptsPartial = {
   ampValidator?: (html: string, pathname: string) => Promise<void>
   ampSkipValidation?: boolean
   ampOptimizerConfig?: { [key: string]: any }
-  isPagesDataRequest?: boolean
+  isNextDataRequest?: boolean
   params?: ParsedUrlQuery
   previewProps: __ApiPreviewProps | undefined
   basePath: string
@@ -449,7 +449,7 @@ export async function renderToHTMLImpl(
     getStaticProps,
     getStaticPaths,
     getServerSideProps,
-    isPagesDataRequest,
+    isNextDataRequest,
     params,
     previewProps,
     basePath,
@@ -1170,7 +1170,7 @@ export async function renderToHTMLImpl(
 
   // Avoid rendering page un-necessarily for getServerSideProps data request
   // and getServerSideProps/getStaticProps redirects
-  if ((isPagesDataRequest && !isSSG) || metadata.isRedirect) {
+  if ((isNextDataRequest && !isSSG) || metadata.isRedirect) {
     return new RenderResult(JSON.stringify(props), {
       metadata,
     })

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -246,7 +246,7 @@ export type RenderOptsPartial = {
   ampValidator?: (html: string, pathname: string) => Promise<void>
   ampSkipValidation?: boolean
   ampOptimizerConfig?: { [key: string]: any }
-  isDataReq?: boolean
+  isPagesDataRequest?: boolean
   params?: ParsedUrlQuery
   previewProps: __ApiPreviewProps | undefined
   basePath: string
@@ -449,7 +449,7 @@ export async function renderToHTMLImpl(
     getStaticProps,
     getStaticPaths,
     getServerSideProps,
-    isDataReq,
+    isPagesDataRequest,
     params,
     previewProps,
     basePath,
@@ -1170,7 +1170,7 @@ export async function renderToHTMLImpl(
 
   // Avoid rendering page un-necessarily for getServerSideProps data request
   // and getServerSideProps/getStaticProps redirects
-  if ((isDataReq && !isSSG) || metadata.isRedirect) {
+  if ((isPagesDataRequest && !isSSG) || metadata.isRedirect) {
     return new RenderResult(JSON.stringify(props), {
       metadata,
     })

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -268,7 +268,7 @@ export type RenderOptsPartial = {
   defaultLocale?: string
   domainLocales?: DomainLocale[]
   disableOptimizedLoading?: boolean
-  supportsDynamicHTML: boolean
+  supportsDynamicResponse: boolean
   isBot?: boolean
   runtime?: ServerRuntime
   serverComponents?: boolean

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -189,6 +189,11 @@ type NextQueryMetadata = {
 
   __nextSsgPath?: string
   _nextBubbleNoFallback?: '1'
+
+  /**
+   * When set to `1`, the request is for the `/_next/data` route using the pages
+   * router.
+   */
   __nextDataReq?: '1'
   __nextCustomErrorRender?: '1'
   [NEXT_RSC_UNION_QUERY]?: string

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -125,9 +125,9 @@ export async function adapter(
   const buildId = requestUrl.buildId
   requestUrl.buildId = ''
 
-  const isDataReq = params.request.headers['x-nextjs-data']
+  const isPagesDataRequest = params.request.headers['x-nextjs-data']
 
-  if (isDataReq && requestUrl.pathname === '/index') {
+  if (isPagesDataRequest && requestUrl.pathname === '/index') {
     requestUrl.pathname = '/'
   }
 
@@ -169,7 +169,7 @@ export async function adapter(
    * need to know about this property neither use it. We add it for testing
    * purposes.
    */
-  if (isDataReq) {
+  if (isPagesDataRequest) {
     Object.defineProperty(request, '__isData', {
       enumerable: false,
       value: true,
@@ -323,7 +323,7 @@ export async function adapter(
     )
 
     if (
-      isDataReq &&
+      isPagesDataRequest &&
       // if the rewrite is external and external rewrite
       // resolving config is enabled don't add this header
       // so the upstream app can set it instead
@@ -367,7 +367,7 @@ export async function adapter(
      * it may end up with CORS error. Instead we map to an internal header so
      * the client knows the destination.
      */
-    if (isDataReq) {
+    if (isPagesDataRequest) {
       response.headers.delete('Location')
       response.headers.set(
         'x-nextjs-redirect',

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -125,9 +125,9 @@ export async function adapter(
   const buildId = requestUrl.buildId
   requestUrl.buildId = ''
 
-  const isPagesDataRequest = params.request.headers['x-nextjs-data']
+  const isNextDataRequest = params.request.headers['x-nextjs-data']
 
-  if (isPagesDataRequest && requestUrl.pathname === '/index') {
+  if (isNextDataRequest && requestUrl.pathname === '/index') {
     requestUrl.pathname = '/'
   }
 
@@ -169,7 +169,7 @@ export async function adapter(
    * need to know about this property neither use it. We add it for testing
    * purposes.
    */
-  if (isPagesDataRequest) {
+  if (isNextDataRequest) {
     Object.defineProperty(request, '__isData', {
       enumerable: false,
       value: true,
@@ -323,7 +323,7 @@ export async function adapter(
     )
 
     if (
-      isPagesDataRequest &&
+      isNextDataRequest &&
       // if the rewrite is external and external rewrite
       // resolving config is enabled don't add this header
       // so the upstream app can set it instead
@@ -367,7 +367,7 @@ export async function adapter(
      * it may end up with CORS error. Instead we map to an internal header so
      * the client knows the destination.
      */
-    if (isPagesDataRequest) {
+    if (isNextDataRequest) {
       response.headers.delete('Location')
       response.headers.set(
         'x-nextjs-redirect',

--- a/packages/next/src/server/web/edge-route-module-wrapper.ts
+++ b/packages/next/src/server/web/edge-route-module-wrapper.ts
@@ -115,7 +115,7 @@ export class EdgeRouteModuleWrapper {
         notFoundRoutes: [],
       },
       renderOpts: {
-        supportsDynamicHTML: true,
+        supportsDynamicResponse: true,
         waitUntil,
         onClose: closeController
           ? closeController.onClose.bind(closeController)

--- a/test/e2e/app-dir/ppr-navigations/simple/app/[locale]/about/page.jsx
+++ b/test/e2e/app-dir/ppr-navigations/simple/app/[locale]/about/page.jsx
@@ -1,0 +1,5 @@
+import { TestPage } from '../../../components/page'
+
+export default function Page({ params: { locale } }) {
+  return <TestPage pathname={`/${locale}/about`} />
+}

--- a/test/e2e/app-dir/ppr-navigations/simple/app/[locale]/layout.jsx
+++ b/test/e2e/app-dir/ppr-navigations/simple/app/[locale]/layout.jsx
@@ -1,0 +1,13 @@
+import { locales } from '../../components/page'
+
+export async function generateStaticParams() {
+  return locales.map((locale) => ({ locale }))
+}
+
+export default function Layout({ children, params: { locale } }) {
+  return (
+    <html lang={locale}>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/ppr-navigations/simple/app/[locale]/page.jsx
+++ b/test/e2e/app-dir/ppr-navigations/simple/app/[locale]/page.jsx
@@ -1,0 +1,5 @@
+import { TestPage } from '../../components/page'
+
+export default function Page({ params: { locale } }) {
+  return <TestPage pathname={`/${locale}`} />
+}

--- a/test/e2e/app-dir/ppr-navigations/simple/app/layout.jsx
+++ b/test/e2e/app-dir/ppr-navigations/simple/app/layout.jsx
@@ -1,0 +1,3 @@
+export default ({ children }) => {
+  return children
+}

--- a/test/e2e/app-dir/ppr-navigations/simple/app/page.jsx
+++ b/test/e2e/app-dir/ppr-navigations/simple/app/page.jsx
@@ -1,0 +1,7 @@
+import { redirect } from 'next/navigation'
+import { locales } from '../components/page'
+
+export default () => {
+  // Redirect to the default locale
+  return redirect(`/${locales[0]}`)
+}

--- a/test/e2e/app-dir/ppr-navigations/simple/components/page.jsx
+++ b/test/e2e/app-dir/ppr-navigations/simple/components/page.jsx
@@ -1,0 +1,40 @@
+import { unstable_noStore } from 'next/cache'
+import Link from 'next/link'
+import { Suspense } from 'react'
+
+export const locales = ['en', 'fr']
+
+export const links = [
+  { href: '/', text: 'Home' },
+  ...locales
+    .map((locale) => {
+      return [
+        { href: `/${locale}`, text: locale },
+        { href: `/${locale}/about`, text: `${locale} - About` },
+      ]
+    })
+    .flat(),
+]
+
+function Dynamic() {
+  unstable_noStore()
+  return <div id="dynamic">Dynamic</div>
+}
+
+export function TestPage({ pathname }) {
+  return (
+    <div>
+      <ul>
+        {links.map(({ href, text }) => (
+          <li key={href}>
+            <Link href={href}>{text}</Link>
+          </li>
+        ))}
+      </ul>
+      <code data-value={pathname}>{pathname}</code>
+      <Suspense fallback={<div>Loading...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/ppr-navigations/simple/next.config.js
+++ b/test/e2e/app-dir/ppr-navigations/simple/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    ppr: true,
+  },
+}

--- a/test/e2e/app-dir/ppr-navigations/simple/simple.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/simple/simple.test.ts
@@ -1,0 +1,31 @@
+import { nextTestSetup } from 'e2e-utils'
+import { links, locales } from './components/page'
+
+describe('ppr-navigations simple', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('can navigate between all the links and back', async () => {
+    const browser = await next.browser('/')
+
+    try {
+      for (const { href } of links) {
+        // Find the link element for the href and click it.
+        await browser.elementByCss(`a[href="${href}"]`).click()
+
+        // Wait for that page to load.
+        if (href === '/') {
+          // The root page redirects to the first locale.
+          await browser.waitForElementByCss(`[data-value="/${locales[0]}"]`)
+        } else {
+          await browser.waitForElementByCss(`[data-value="${href}"]`)
+        }
+
+        await browser.elementByCss('#dynamic')
+      }
+    } finally {
+      await browser.close()
+    }
+  })
+})


### PR DESCRIPTION
Old logic from the pages router was previously being hit during development. This was more apparent when PPR was enabled as it was mixing dynamic + static rendering in development which propagated to errors. This change ensures that requests that are made with `RSC: 1` are not marked as `/_next/data` URL's, and don't use the same logic paths.

Previously it was a bit confusing because we used the variable `isDataReq` in a few places that made it hard to tell what it was referring to. In this case, the `isDataReq` is actually only used by the pages router. This renames the `isDataReq` to `isNextDataRequest` to make it clearer, as well as refactors to ensure that it's not used in the paths for app routes.

Also to better represent the rendering modes the `supportsDynamicHTML` variable was renamed to `supportsDynamicResponse`.

Fixes #66241 