### PR TITLE
📝 docs: Add missing example code file name

### DIFF
--- a/docs/02-app/01-building-your-application/05-styling/01-css-modules.mdx
+++ b/docs/02-app/01-building-your-application/05-styling/01-css-modules.mdx
@@ -114,7 +114,7 @@ Global styles can be imported into any layout, page, or component inside the `ap
 
 For example, consider a stylesheet named `app/global.css`:
 
-```css
+```css filename="app/global.css"
 body {
   padding: 20px 20px 60px;
   max-width: 680px;


### PR DESCRIPTION
### What?
The app/global.css example code in the Global Styles section

### Why?
To improve the clarity of the documentation by adding the file name to the missing example code

Fixes #66250 

-->
