### PR TITLE
enhance: ignore nextjs version fetch error in dev overlay

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -192,13 +192,14 @@ function erroredPages(compilation: webpack.Compilation) {
   return failedPages
 }
 
-const networkErrors = [
+const networkErrors = new Set([
   'EADDRINFO',
   'ENOTFOUND',
   'ETIMEDOUT',
   'ECONNREFUSED',
   'EAI_AGAIN',
-]
+  'UND_ERR_CONNECT_TIMEOUT',
+])
 
 export async function getVersionInfo(enabled: boolean): Promise<VersionInfo> {
   let installed = '0.0.0'
@@ -219,7 +220,7 @@ export async function getVersionInfo(enabled: boolean): Promise<VersionInfo> {
 
     return parseVersionInfo({ installed, latest, canary })
   } catch (e: any) {
-    if (!networkErrors.includes(e?.code)) console.error(e)
+    if (!networkErrors.has(e?.code)) console.error(e)
     return { installed, staleness: 'unknown' }
   }
 }


### PR DESCRIPTION
### What 

It's not helpful to see the network issue of fetching error on reading nextjs version in dev overlay

### Why

Error case:

<img width="400" src="https://github.com/vercel/next.js/assets/4800338/a7852d9b-1f98-4098-8498-a3b832efdbb0">

This should just be ignored, it's fine that the fetching is failed. There're so many fetch errors code, it's easy to try-catch on fetch instead of enumerate all the codes

