### PR TITLE
docs: change dynamic sitemap output filename

### DIFF
--- a/docs/02-app/02-api-reference/02-file-conventions/01-metadata/sitemap.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/01-metadata/sitemap.mdx
@@ -97,7 +97,7 @@ export default function sitemap() {
 
 Output:
 
-```xml filename="acme.com/sitemap.xml"
+```xml filename="acme.com/sitemap"
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://acme.com</loc>
@@ -163,7 +163,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
 Output:
 
-```xml filename="acme.com/sitemap.xml"
+```xml filename="acme.com/sitemap"
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://acme.com</loc>


### PR DESCRIPTION
x-ref: #65507 

Updating the dynamic sitemap routes output url to the one without `.xml` extension