### PR TITLE
Add support for IPv6 in tests

### DIFF
--- a/test/e2e/custom-app-render/server.js
+++ b/test/e2e/custom-app-render/server.js
@@ -34,7 +34,7 @@ async function main() {
     process.exit(1)
   })
 
-  server.listen(port, '0.0.0.0', () => {
+  server.listen(port, '::', () => {
     console.log(`- Local: http://localhost:${port}`)
     console.log(`- Next mode: ${dev ? 'development' : process.env.NODE_ENV}`)
   })

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -52,7 +52,7 @@ export function initNextServerScript(
       'node',
       [...((opts && opts.nodeArgs) || []), '--no-deprecation', scriptPath],
       {
-        env,
+        env: { ...env, HOSTNAME: '::' },
         cwd: opts && opts.cwd,
       }
     )
@@ -434,12 +434,11 @@ export function launchApp(
       dir,
       '-p',
       port as string,
+      '--hostname',
+      '::',
     ].filter(Boolean),
     undefined,
-    {
-      ...options,
-      turbo: useTurbo,
-    }
+    { ...options, turbo: useTurbo }
   )
 }
 
@@ -484,10 +483,11 @@ export function nextStart(
   port: string | number,
   opts: NextDevOptions = {}
 ) {
-  return runNextCommandDev(['start', '-p', port as string, dir], undefined, {
-    ...opts,
-    nextStart: true,
-  })
+  return runNextCommandDev(
+    ['start', '-p', port as string, '--hostname', '::', dir],
+    undefined,
+    { ...opts, nextStart: true }
+  )
 }
 
 export function buildTS(

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -52,7 +52,7 @@ export function initNextServerScript(
       'node',
       [...((opts && opts.nodeArgs) || []), '--no-deprecation', scriptPath],
       {
-        env: { ...env, HOSTNAME: '::' },
+        env: { HOSTNAME: '::', ...env },
         cwd: opts && opts.cwd,
       }
     )


### PR DESCRIPTION
Using the hostname `::` enables dual-stack support. This prevents `ECONNREFUSED` errors when running tests locally, and `localhost` being resolved to `::1` (IPv6) instead of `127.0.0.1` (IPv4).