### PR TITLE
chore(next-font): bump @capsizecss/metrics package to the latest

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -148,7 +148,7 @@
     "@babel/runtime": "7.22.5",
     "@babel/traverse": "7.22.5",
     "@babel/types": "7.22.5",
-    "@capsizecss/metrics": "3.0.0",
+    "@capsizecss/metrics": "3.2.0",
     "@edge-runtime/cookies": "4.1.1",
     "@edge-runtime/ponyfill": "2.4.2",
     "@edge-runtime/primitives": "4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -916,8 +916,8 @@ importers:
         specifier: 7.22.5
         version: 7.22.5
       '@capsizecss/metrics':
-        specifier: 3.0.0
-        version: 3.0.0
+        specifier: 3.2.0
+        version: 3.2.0
       '@edge-runtime/cookies':
         specifier: 4.1.1
         version: 4.1.1
@@ -3420,8 +3420,8 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@capsizecss/metrics@3.0.0:
-    resolution: {integrity: sha512-GTOIvDhuZKBDLeLPaA4mgwuKVwm2eaKR6Oaa76reaSkWTa5GCSe6W+DWPKEUJqjJyxsvkOYpC8reQ8njk90t5w==}
+  /@capsizecss/metrics@3.2.0:
+    resolution: {integrity: sha512-EVWRXJaakH6NTq+7cZawgFiqA+UyESMszN/c1oDHbC/b0SAzQJ/QLS0xpaa3Y+YMfXOkEEjkuChYIV5pSkgmcg==}
     dev: true
 
   /@csstools/postcss-color-function@1.1.0(postcss@8.4.31):


### PR DESCRIPTION
## Why?

Upgrade `@capsizecss/metrics` package to the [latest](https://github.com/seek-oss/capsize/releases/tag/%40capsizecss%2Fmetrics%403.2.0).