### PR TITLE
Update labeler config for CI approved

### DIFF
--- a/.github/labeler.json
+++ b/.github/labeler.json
@@ -15,6 +15,11 @@
       { "type": "user", "pattern": "kyliau" },
       { "type": "user", "pattern": "spanicker" }
     ],
+    "created-by: Trusted contributors": [
+      { "type": "user", "pattern": "SukkaW" },
+      { "type": "user", "pattern": "unstubbable" },
+      { "type": "user", "pattern": "vercel-release-bot" }
+    ],
     "created-by: Next.js team": [
       { "type": "user", "pattern": "acdlite" },
       { "type": "user", "pattern": "balazsorban44" },

--- a/.github/labeler.json
+++ b/.github/labeler.json
@@ -15,7 +15,7 @@
       { "type": "user", "pattern": "kyliau" },
       { "type": "user", "pattern": "spanicker" }
     ],
-    "ci-approved": [
+    "CI approved": [
       { "type": "user", "pattern": "SukkaW" },
       { "type": "user", "pattern": "unstubbable" },
       { "type": "user", "pattern": "vercel-release-bot" }

--- a/.github/labeler.json
+++ b/.github/labeler.json
@@ -15,7 +15,7 @@
       { "type": "user", "pattern": "kyliau" },
       { "type": "user", "pattern": "spanicker" }
     ],
-    "created-by: Trusted contributors": [
+    "ci-approved": [
       { "type": "user", "pattern": "SukkaW" },
       { "type": "user", "pattern": "unstubbable" },
       { "type": "user", "pattern": "vercel-release-bot" }


### PR DESCRIPTION


This should automatically enable CI for them so we don't have to [change and rebuild our custom runner](https://github.com/vercel/nextjs-ci-config/blame/19a99c7faa9a3807d0ec598741de0364cc31a538/validate-job.js#L3).
