### PR TITLE
Handle premajor version for canary

### DIFF
--- a/scripts/start-release.js
+++ b/scripts/start-release.js
@@ -59,19 +59,18 @@ async function main() {
   })
 
   console.log(`Running pnpm release-${isCanary ? 'canary' : 'stable'}...`)
+  const preleaseType =
+    semverType === 'major'
+      ? 'premajor'
+      : semverType === 'minor'
+        ? 'preminor'
+        : 'prerelease'
+
   const child = execa(
     isCanary
-      ? `pnpm lerna version ${
-          semverType === 'minor' ? 'preminor' : 'prerelease'
-        } --preid canary --force-publish -y && pnpm release --pre --skip-questions --show-url`
+      ? `pnpm lerna version ${preleaseType} --preid canary --force-publish -y && pnpm release --pre --skip-questions --show-url`
       : isReleaseCandidate
-        ? `pnpm lerna version ${
-            semverType === 'major'
-              ? 'premajor'
-              : semverType === 'minor'
-                ? 'preminor'
-                : 'prerelease'
-          } --preid rc --force-publish -y && pnpm release --pre --skip-questions --show-url`
+        ? `pnpm lerna version ${preleaseType} --preid rc --force-publish -y && pnpm release --pre --skip-questions --show-url`
         : `pnpm lerna version ${semverType} --force-publish -y`,
     {
       stdio: 'pipe',


### PR DESCRIPTION
Ensures we can cut premajors for canary the same as release-candidate tags. 