### PR TITLE
fix: ensure dynamic fetches are tracked correctly

### DIFF
--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -38,7 +38,7 @@ const { requestAsyncStorage, staticGenerationAsyncStorage, serverHooks } =
 const originalPathname = 'VAR_ORIGINAL_PATHNAME'
 
 function patchFetch() {
-  return _patchFetch({ serverHooks, staticGenerationAsyncStorage })
+  return _patchFetch({ staticGenerationAsyncStorage })
 }
 
 export {

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -76,17 +76,25 @@ export function markCurrentScopeAsDynamic(
   store: StaticGenerationStore,
   expression: string
 ): void {
+  // inside cache scopes marking a scope as dynamic has no effect because the outer cache scope
+  // creates a cache boundary. This is subtly different from reading a dynamic data source which is
+  // forbidden inside a cache scope.
+  if (store.isUnstableCacheCallback) return
+
+  // If we're forcing dynamic rendering or we're forcing static rendering, we
+  // don't need to do anything here because the entire page is already dynamic
+  // or it's static and it should not throw or postpone here.
+  if (store.forceDynamic || store.forceStatic) return
+
   const pathname = getPathname(store.urlPathname)
-  if (store.isUnstableCacheCallback) {
-    // inside cache scopes marking a scope as dynamic has no effect because the outer cache scope
-    // creates a cache boundary. This is subtly different from reading a dynamic data source which is
-    // forbidden inside a cache scope.
-    return
-  } else if (store.dynamicShouldError) {
+
+  if (store.dynamicShouldError) {
     throw new StaticGenBailoutError(
       `Route ${pathname} with \`dynamic = "error"\` couldn't be rendered statically because it used \`${expression}\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`
     )
-  } else if (
+  }
+
+  if (
     // We are in a prerender (PPR enabled, during build)
     store.prerenderState
   ) {
@@ -94,19 +102,19 @@ export function markCurrentScopeAsDynamic(
     // This will be used by the renderer to decide whether
     // the prerender requires a resume
     postponeWithTracking(store.prerenderState, expression, pathname)
-  } else {
-    store.revalidate = 0
+  }
 
-    if (store.isStaticGeneration) {
-      // We aren't prerendering but we are generating a static page. We need to bail out of static generation
-      const err = new DynamicServerError(
-        `Route ${pathname} couldn't be rendered statically because it used ${expression}. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
-      )
-      store.dynamicUsageDescription = expression
-      store.dynamicUsageStack = err.stack
+  store.revalidate = 0
 
-      throw err
-    }
+  if (store.isStaticGeneration) {
+    // We aren't prerendering but we are generating a static page. We need to bail out of static generation
+    const err = new DynamicServerError(
+      `Route ${pathname} couldn't be rendered statically because it used ${expression}. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
+    )
+    store.dynamicUsageDescription = expression
+    store.dynamicUsageStack = err.stack
+
+    throw err
   }
 }
 
@@ -170,21 +178,6 @@ export function Postpone({
   pathname,
 }: PostponeProps): never {
   postponeWithTracking(prerenderState, reason, pathname)
-}
-
-// @TODO refactor patch-fetch and this function to better model dynamic semantics. Currently this implementation
-// is too explicit about postponing if we are in a prerender and patch-fetch contains a lot of logic for determining
-// what makes the fetch "dynamic". It also doesn't handle Non PPR cases so it is isn't as consistent with the other
-// dynamic-rendering methods.
-export function trackDynamicFetch(
-  store: StaticGenerationStore,
-  expression: string
-) {
-  // If we aren't in a prerender, or we're in an unstable cache callback, we
-  // don't need to postpone.
-  if (!store.prerenderState || store.isUnstableCacheCallback) return
-
-  postponeWithTracking(store.prerenderState, expression, store.urlPathname)
 }
 
 function postponeWithTracking(

--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -44,7 +44,7 @@ function patchCacheScopeSupportIntoReact() {
 // patchFetch makes use of APIs such as `React.unstable_postpone` which are only available
 // in the experimental channel of React, so export it from here so that it comes from the bundled runtime
 function patchFetch() {
-  return _patchFetch({ serverHooks, staticGenerationAsyncStorage })
+  return _patchFetch({ staticGenerationAsyncStorage })
 }
 
 export {

--- a/packages/next/src/server/future/route-modules/app-route/module.ts
+++ b/packages/next/src/server/future/route-modules/app-route/module.ts
@@ -386,7 +386,6 @@ export class AppRouteRouteModule extends RouteModule<
                   async () => {
                     // Patch the global fetch.
                     patchFetch({
-                      serverHooks: this.serverHooks,
                       staticGenerationAsyncStorage:
                         this.staticGenerationAsyncStorage,
                     })

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -174,7 +174,7 @@ describe('app-dir static/dynamic handling', () => {
       it('should honor force-static with fetch cache: no-store correctly', async () => {
         const res = await next.fetch('/force-static-fetch-no-store')
         expect(res.status).toBe(200)
-        expect(res.headers.get('x-nextjs-cache').toLowerCase()).toBe('hit')
+        expect(res.headers.get('x-nextjs-cache')?.toLowerCase()).toBe('hit')
       })
     }
   }

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -864,6 +864,14 @@ describe('app-dir static/dynamic handling', () => {
           "unstable-cache/dynamic-undefined/page_client-reference-manifest.js",
           "unstable-cache/dynamic/page.js",
           "unstable-cache/dynamic/page_client-reference-manifest.js",
+          "unstable-cache/fetch/no-cache.html",
+          "unstable-cache/fetch/no-cache.rsc",
+          "unstable-cache/fetch/no-cache/page.js",
+          "unstable-cache/fetch/no-cache/page_client-reference-manifest.js",
+          "unstable-cache/fetch/no-store.html",
+          "unstable-cache/fetch/no-store.rsc",
+          "unstable-cache/fetch/no-store/page.js",
+          "unstable-cache/fetch/no-store/page_client-reference-manifest.js",
           "variable-config-revalidate/revalidate-3.html",
           "variable-config-revalidate/revalidate-3.rsc",
           "variable-config-revalidate/revalidate-3/page.js",
@@ -1611,6 +1619,38 @@ describe('app-dir static/dynamic handling', () => {
             ],
             "initialRevalidateSeconds": 50,
             "srcRoute": "/strip-header-traceparent",
+          },
+          "/unstable-cache/fetch/no-cache": {
+            "dataRoute": "/unstable-cache/fetch/no-cache.rsc",
+            "experimentalBypassFor": [
+              {
+                "key": "Next-Action",
+                "type": "header",
+              },
+              {
+                "key": "content-type",
+                "type": "header",
+                "value": "multipart/form-data;.*",
+              },
+            ],
+            "initialRevalidateSeconds": false,
+            "srcRoute": "/unstable-cache/fetch/no-cache",
+          },
+          "/unstable-cache/fetch/no-store": {
+            "dataRoute": "/unstable-cache/fetch/no-store.rsc",
+            "experimentalBypassFor": [
+              {
+                "key": "Next-Action",
+                "type": "header",
+              },
+              {
+                "key": "content-type",
+                "type": "header",
+                "value": "multipart/form-data;.*",
+              },
+            ],
+            "initialRevalidateSeconds": false,
+            "srcRoute": "/unstable-cache/fetch/no-store",
           },
           "/variable-config-revalidate/revalidate-3": {
             "dataRoute": "/variable-config-revalidate/revalidate-3.rsc",

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -3309,6 +3309,27 @@ describe('app-dir static/dynamic handling', () => {
       expect(data).toEqual(data2)
       expect(data).toEqual('typeof cachedData: undefined')
     })
+
+    it.each(['no-store', 'no-cache'])(
+      'should not error when calling a fetch %s',
+      async (cache) => {
+        const browser = await next.browser(`/unstable-cache/fetch/${cache}`)
+
+        try {
+          const first = await browser.waitForElementByCss('#data').text()
+          expect(first).not.toBe('')
+
+          // Ensure the data is the same after 3 refreshes.
+          for (let i = 0; i < 3; i++) {
+            await browser.refresh()
+            const refreshed = await browser.waitForElementByCss('#data').text()
+            expect(refreshed).toEqual(first)
+          }
+        } finally {
+          await browser.close()
+        }
+      }
+    )
   })
 
   it('should keep querystring on static page', async () => {

--- a/test/e2e/app-dir/app-static/app/unstable-cache/fetch/fetch.jsx
+++ b/test/e2e/app-dir/app-static/app/unstable-cache/fetch/fetch.jsx
@@ -1,0 +1,29 @@
+import { unstable_cache } from 'next/cache'
+import { Suspense } from 'react'
+
+const getData = unstable_cache(
+  async (cache) => {
+    const res = await fetch(
+      'https://next-data-api-endpoint.vercel.app/api/random',
+      { cache }
+    )
+
+    return res.text()
+  },
+  undefined,
+  {}
+)
+
+async function Data({ cache = undefined }) {
+  const data = await getData(cache)
+
+  return <div id="data">{data}</div>
+}
+
+export default function Page({ cache = undefined }) {
+  return (
+    <Suspense fallback={<div id="loading">Loading...</div>}>
+      <Data cache={cache} />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/app-static/app/unstable-cache/fetch/no-cache/page.jsx
+++ b/test/e2e/app-dir/app-static/app/unstable-cache/fetch/no-cache/page.jsx
@@ -1,0 +1,5 @@
+import Page from '../fetch'
+
+export default function UnstableCacheFetchNoStore() {
+  return <Page cache="no-cache" />
+}

--- a/test/e2e/app-dir/app-static/app/unstable-cache/fetch/no-store/page.jsx
+++ b/test/e2e/app-dir/app-static/app/unstable-cache/fetch/no-store/page.jsx
@@ -1,0 +1,5 @@
+import Page from '../fetch'
+
+export default function UnstableCacheFetchNoStore() {
+  return <Page cache="no-store" />
+}

--- a/test/e2e/app-dir/app-static/lib/fetch-retry.js
+++ b/test/e2e/app-dir/app-static/lib/fetch-retry.js
@@ -1,3 +1,5 @@
+import { unstable_rethrow } from 'next/navigation'
+
 const MAX_ATTEMPTS = 5
 
 export const fetchRetry = async (url, init) => {
@@ -5,12 +7,7 @@ export const fetchRetry = async (url, init) => {
     try {
       return await fetch(url, init)
     } catch (err) {
-      // FIXME: (PPR) this is a workaround  until we have a way to detect postpone errors
-      // For PPR, we need to detect if this is a postpone error so we can
-      // re-throw it.
-      if (err.$$typeof === Symbol.for('react.postpone')) {
-        throw err
-      }
+      unstable_rethrow(err)
 
       if (i === MAX_ATTEMPTS - 1) {
         throw err


### PR DESCRIPTION
This modifies the patched fetch implementation to better handle when called within an `unstable_cache` callback. In these callbacks, it should not throw an error related to dynamic access.

This replaces the verbose `trackDynamicFetch` instead with `markCurrentScopeAsDynamic` which already has support for checking if inside an unstable cache context. It also has been adjusted to be a no-op when `export const dynamic = "force-static"`, further simplifying the code within the patch fetch implementation.