### PR TITLE
docs: remove invalid og image cases

### DIFF
--- a/docs/02-app/02-api-reference/02-file-conventions/01-metadata/app-icons.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/01-metadata/app-icons.mdx
@@ -196,7 +196,6 @@ export default function Icon({ params }) {
 | `app/shop/icon.js`              | `/shop`     | `undefined`               |
 | `app/shop/[slug]/icon.js`       | `/shop/1`   | `{ slug: '1' }`           |
 | `app/shop/[tag]/[item]/icon.js` | `/shop/1/2` | `{ tag: '1', item: '2' }` |
-| `app/shop/[...slug]/icon.js`    | `/shop/1/2` | `{ slug: ['1', '2'] }`    |
 
 ### Returns
 

--- a/docs/02-app/02-api-reference/04-functions/generate-image-metadata.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-image-metadata.mdx
@@ -40,7 +40,6 @@ export function generateImageMetadata({ params }) {
 | `app/shop/icon.js`              | `/shop`     | `undefined`               |
 | `app/shop/[slug]/icon.js`       | `/shop/1`   | `{ slug: '1' }`           |
 | `app/shop/[tag]/[item]/icon.js` | `/shop/1/2` | `{ tag: '1', item: '2' }` |
-| `app/shop/[...slug]/icon.js`    | `/shop/1/2` | `{ slug: ['1', '2'] }`    |
 
 ## Returns
 


### PR DESCRIPTION
### What

Removing the `/[...catchall]/<metadata image convention>.js` case from docs

### Why

Since og image and icon routes are using catch-all routes to handle the both single or multiple routes. For instance:

`app/opengraph-image.js` can possibly generate two cases: 

- single route: `/opengraph-image`
- multi routes with `generateImageMetadata()`:  `/opengraph-image/[id]`

We're not able to detect if there's `generateImageMetadata` defined in the file before mapping the routes, and decided to create the different routes to either `/opengraph-image` or `/opengraph-image/[id]`. That's why we're using a catch-all routes to handle them rn.

Related #48106 
Related #57349 