### PR TITLE
Avoid race condition in ppr navigations test

### DIFF
--- a/test/e2e/app-dir/ppr-navigations/simple/simple.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/simple/simple.test.ts
@@ -10,7 +10,7 @@ describe('ppr-navigations simple', () => {
     const browser = await next.browser('/')
 
     try {
-      for (const { href } of links) {
+      for (const { href } of [...links].reverse()) {
         // Find the link element for the href and click it.
         await browser.elementByCss(`a[href="${href}"]`).click()
 

--- a/test/e2e/app-dir/ppr-navigations/simple/simple.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/simple/simple.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { links, locales } from './components/page'
+import { locales } from './components/page'
 
 describe('ppr-navigations simple', () => {
   const { next } = nextTestSetup({
@@ -10,7 +10,7 @@ describe('ppr-navigations simple', () => {
     const browser = await next.browser('/')
 
     try {
-      for (const { href } of [...links].reverse()) {
+      for (const href of ['/fr/about', '/fr', '/en/about', '/en', '/']) {
         // Find the link element for the href and click it.
         await browser.elementByCss(`a[href="${href}"]`).click()
 


### PR DESCRIPTION
Clicking through the links from bottom-to-top, instead of top-to-bottom, avoids a race condition when starting on `/en` and clicking the first link `/` that then redirects to `/en` again. In this case, the next `data-value` can already be found on the current page, before the navigation has completed. Then the next click on `/en` might be triggered exactly when the page is unmounted due to the redirect (this is expected, I hope?). At this moment, the link is not attached to the DOM anymore and the test fails.

The race condition can be reproduced locally by not running the test headless:

```
NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=dev pnpm jest --runInBand test/e2e/app-dir/ppr-navigations/simple/simple.test.ts
```

/cc @wyattjoh 

x-ref: https://github.com/vercel/next.js/actions/runs/9318716602/job/25651667832?pr=66415