### PR TITLE
chore: safety check on lockfile patching

### DIFF
--- a/packages/next/src/lib/patch-incorrect-lockfile.ts
+++ b/packages/next/src/lib/patch-incorrect-lockfile.ts
@@ -21,6 +21,10 @@ async function fetchPkgInfo(pkg: string) {
   const data = await res.json()
   const versionData = data.versions[nextPkgJson.version]
 
+  if (!versionData) {
+    return null
+  }
+
   return {
     os: versionData.os,
     cpu: versionData.cpu,
@@ -60,7 +64,7 @@ export async function patchIncorrectLockfile(dir: string) {
 
   const patchDependency = (
     pkg: string,
-    pkgData: UnwrapPromise<ReturnType<typeof fetchPkgInfo>>
+    pkgData: NonNullable<UnwrapPromise<ReturnType<typeof fetchPkgInfo>>>
   ) => {
     lockfileParsed.dependencies[pkg] = {
       version: nextPkgJson.version,
@@ -72,7 +76,7 @@ export async function patchIncorrectLockfile(dir: string) {
 
   const patchPackage = (
     pkg: string,
-    pkgData: UnwrapPromise<ReturnType<typeof fetchPkgInfo>>
+    pkgData: NonNullable<UnwrapPromise<ReturnType<typeof fetchPkgInfo>>>
   ) => {
     lockfileParsed.packages[pkg] = {
       version: nextPkgJson.version,
@@ -150,6 +154,11 @@ export async function patchIncorrectLockfile(dir: string) {
     for (let i = 0; i < pkgsData.length; i++) {
       const pkg = missingSwcPkgs[i]
       const pkgData = pkgsData[i]
+
+      if (!pkgData) {
+        Log.warn(`Failed to fetch registry info for ${pkg}`)
+        continue
+      }
 
       if (shouldPatchDependencies) {
         patchDependency(pkg, pkgData)


### PR DESCRIPTION
### What
Add safety check when the dist-tag is in the versions list from github API, skip patching and give a warning


Notice this while running e2e tests locally
```
 ⨯ Failed to patch lockfile, please try uninstalling and reinstalling next in this workspace
TypeError: Cannot read properties of undefined (reading 'os')
    at fetchPkgInfo (/private/var/folders/gy/kq4zjn8s0ljf9sfjyyh_nj640000gn/T/next-install-2667
2d4a7e3871a32d51b4b929f9c83d13353576983f072d9287f7e0c55a8f24/node_modules/.pnpm/file+..+next-re
po-6e0cde375c2140e7bd8322619b71fd96_pghuaeiwbgs2rty7xgt6apn45q/node_modules/next/dist/lib/patch
-incorrect-lockfile.js:74:25)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 0)
    at async patchIncorrectLockfile (/private/var/folders/gy/kq4zjn8s0ljf9sfjyyh_nj640000gn/T/n
ext-install-26672d4a7e3871a32d51b4b929f9c83d13353576983f072d9287f7e0c55a8f24/node_modules/.pnpm
/file+..+next-repo-6e0cde375c2140e7bd8322619b71fd96_pghuaeiwbgs2rty7xgt6apn45q/node_modules/nex
t/dist/lib/patch-incorrect-lockfile.js:163:26)
```