### PR TITLE
Automatically trigger sync with Front on release

### DIFF
--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -61,12 +61,11 @@ jobs:
           # Note `event_type` and `client_payload` are contract between vercel/front,
           # if these need to be changed both side should be updated accordingly.
           script: |
-            github.request('POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches', {
+            github.request('POST /repos/{owner}/{repo}/dispatches', {
               owner: 'vercel',
               repo: 'front',
-              workflow_id: '22486376',
-              ref: 'sebbie/06-01-add_support_for_starting_sync_with_a_specific_next.js_version',
-              inputs: {
+              event_type: 'update-next',
+              client_payload: {
                 version: '${{ steps.version.outputs.value }}'
               }
             })

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -48,24 +48,25 @@ jobs:
       - id: version
         name: Extract `next` version
         run: echo 'value=${{ fromJson(steps.nextPackageInfo.outputs.value).version }}' >> "$GITHUB_OUTPUT"
-      - run: echo ${{ steps.version.outputs.value }}
-      # - uses: actions/github-script@v7
-      #   id: trigger-front-sync
-      #   with:
-      #     result-encoding: string
-      #     retries: 3
-      #     retry-exempt-status-codes: 400,401
-      #     # Default github token cannot dispatch events to the remote repo, it should be
-      #     # a PAT with access to contenst:read&write + metadata:read.
-      #     github-token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
-      #     # Note `event_type` and `client_payload` are contract between vercel/front,
-      #     # if these need to be changed both side should be updated accordingly.
-      #     script: |
-      #       github.request('POST /repos/{owner}/{repo}/dispatches', {
-      #         owner: 'vercel',
-      #         repo: 'front',
-      #         event_type: 'cron-update-next',
-      #         client_payload: {
-      #           version: ${{ steps.version.outputs.version }}
-      #         }
-      #       })
+      - uses: actions/github-script@v7
+        id: trigger-front-sync
+        with:
+          result-encoding: string
+          retries: 3
+          retry-exempt-status-codes: 400,401
+          # Default github token cannot dispatch events to the remote repo, it should be
+          # a PAT with access to contenst:read&write + metadata:read.
+          github-token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          # Note `event_type` and `client_payload` are contract between vercel/front,
+          # if these need to be changed both side should be updated accordingly.
+          script: |
+            github.request('POST /repos/{owner}/{repo}/dispatches', {
+              owner: 'vercel',
+              repo: 'front',
+              event_type: 'cron-update-next',
+              client_payload: {
+                version: ${{ steps.version.outputs.value }}
+              }
+            })
+      - name: workflow_dispatch response
+        run: echo ${{ steps.trigger-front-sync.outputs.response }}

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -65,7 +65,7 @@ jobs:
           # Note `workflow_id` and `inputs` are contract between vercel/front,
           # if these need to be changed both side should be updated accordingly.
           script: |
-            github.request('POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches', {
+            await github.request('POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches', {
               owner: 'vercel',
               repo: 'front',
               workflow_id: 'cron-update-next.yml',
@@ -74,5 +74,7 @@ jobs:
                 version: '${{ steps.version.outputs.value }}'
               }
             })
-            # Ideally we'd include a URL to the started sync.
+            # Ideally we'd include a URL to this specific sync.
             # However, creating a workflow_dispatch event does not produce an ID: https://github.com/orgs/community/discussions/9752
+            console.info('Sync started in https://github.com/vercel/front/actions/workflows/cron-update-next.yml?query=event%3Aworkflow_dispatch')
+            console.info('This may not start a new sync if one is already in progress. Check the logs of the cron-update-next Workflow run.')

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -56,7 +56,6 @@ jobs:
         name: Trigger vercel/front sync
         id: trigger-front-sync
         with:
-          result-encoding: string
           retries: 3
           retry-exempt-status-codes: 400,401,404
           # Default github token cannot dispatch events to the remote repo, it should be
@@ -65,16 +64,23 @@ jobs:
           # Note `workflow_id` and `inputs` are contract between vercel/front,
           # if these need to be changed both side should be updated accordingly.
           script: |
-            await github.request('POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches', {
-              owner: 'vercel',
-              repo: 'front',
-              workflow_id: 'cron-update-next.yml',
-              ref: 'main',
-              inputs: {
-                version: '${{ steps.version.outputs.value }}'
+            await github.request(
+              "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
+              {
+                owner: "vercel",
+                repo: "front",
+                workflow_id: "cron-update-next.yml",
+                ref: "main",
+                inputs: {
+                  version: "${{ steps.version.outputs.value }}",
+                },
               }
-            })
-            # Ideally we'd include a URL to this specific sync.
-            # However, creating a workflow_dispatch event does not produce an ID: https://github.com/orgs/community/discussions/9752
-            console.info('Sync started in https://github.com/vercel/front/actions/workflows/cron-update-next.yml?query=event%3Aworkflow_dispatch')
-            console.info('This may not start a new sync if one is already in progress. Check the logs of the cron-update-next Workflow run.')
+            );
+            // Ideally we'd include a URL to this specific sync.
+            // However, creating a workflow_dispatch event does not produce an ID: https://github.com/orgs/community/discussions/9752
+            console.info(
+              "Sync started in https://github.com/vercel/front/actions/workflows/cron-update-next.yml?query=event%3Aworkflow_dispatch"
+            );
+            console.info(
+              "This may not start a new sync if one is already in progress. Check the logs of the cron-update-next Workflow run."
+            );

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -36,13 +36,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: corepack enable
       - id: nextPackageInfo
         name: Get `next` package info
-        run: echo "value=$(pnpm list next --json --filter next)" >> "$GITHUB_OUTPUT"
+        run: |
+          cd packages/next 
+          echo "value=$(cat package.json)" >> "$GITHUB_OUTPUT"
       - id: version
         name: Extract `next` version
-        run: echo 'value=${{ fromJson(steps.nextPackageInfo.outputs)[0].version }}' >> "$GITHUB_OUTPUT"
+        run: echo 'value=${{ fromJson(steps.nextPackageInfo.outputs.value).version }}' >> "$GITHUB_OUTPUT"
       - run: echo ${{ steps.version.outputs.version }}
       # - uses: actions/github-script@v7
       #   id: trigger-front-sync

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -15,7 +15,7 @@ jobs:
           result-encoding: string
           retries: 3
           retry-exempt-status-codes: 400,401
-          # Default github token cannot dispath events to the remote repo, it should be
+          # Default github token cannot dispatch events to the remote repo, it should be
           # a PAT with access to contenst:read&write + metadata:read.
           github-token: ${{ secrets.TURBOPACK_TEST_TOKEN }}
           # Note `event_type` and `client_payload` are contract between vercel/turbo,
@@ -38,7 +38,7 @@ jobs:
           result-encoding: string
           retries: 3
           retry-exempt-status-codes: 400,401
-          # Default github token cannot dispath events to the remote repo, it should be
+          # Default github token cannot dispatch events to the remote repo, it should be
           # a PAT with access to contenst:read&write + metadata:read.
           github-token: ${{ secrets.FRONT_TEST_TOKEN }}
           # Note `event_type` and `client_payload` are contract between vercel/front,

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -65,7 +65,7 @@ jobs:
               repo: 'front',
               event_type: 'cron-update-next',
               client_payload: {
-                version: ${{ steps.version.outputs.value }}
+                version: '${{ steps.version.outputs.value }}'
               }
             })
       - name: workflow_dispatch response

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -49,6 +49,7 @@ jobs:
         name: Extract `next` version
         run: echo 'value=${{ fromJson(steps.nextPackageInfo.outputs.value).version }}' >> "$GITHUB_OUTPUT"
       - uses: actions/github-script@v7
+        name: trigger 'cron-update-next.yml'
         id: trigger-front-sync
         with:
           result-encoding: string
@@ -63,7 +64,7 @@ jobs:
             github.request('POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches', {
               owner: 'vercel',
               repo: 'front',
-              workflow_id: 'cron-update-next',
+              workflow_id: '46394538',
               ref: 'main',
               inputs: {
                 version: '${{ steps.version.outputs.value }}'

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -40,7 +40,11 @@ jobs:
         name: Get `next` package info
         run: |
           cd packages/next 
-          echo "value=$(cat package.json)" >> "$GITHUB_OUTPUT"
+          {
+            echo 'value<<EOF'
+            cat package.json
+            echo EOF
+          } >> "$GITHUB_ENV"
       - id: version
         name: Extract `next` version
         run: echo 'value=${{ fromJson(steps.nextPackageInfo.outputs.value).version }}' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -4,10 +4,13 @@ name: Notify new Next.js release
 on:
   release:
     types: [published]
-
+  push:
+    branches:
+      - sebbie/06-01-automatically_trigger_sync_with_vercel.com_on_release
 jobs:
   notify:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'release' }}
     steps:
       - uses: actions/github-script@v7
         id: notify-new-release
@@ -32,23 +35,30 @@ jobs:
   front-sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
-        id: trigger-front-sync
-        with:
-          result-encoding: string
-          retries: 3
-          retry-exempt-status-codes: 400,401
-          # Default github token cannot dispatch events to the remote repo, it should be
-          # a PAT with access to contenst:read&write + metadata:read.
-          github-token: ${{ secrets.FRONT_TEST_TOKEN }}
-          # Note `event_type` and `client_payload` are contract between vercel/front,
-          # if these need to be changed both side should be updated accordingly.
-          script: |
-            github.request('POST /repos/{owner}/{repo}/dispatches', {
-              owner: 'vercel',
-              repo: 'front',
-              event_type: 'cron-update-next',
-              client_payload: {
-                version: context.ref
-              }
-            })
+      - id: nextPackageInfo
+        name: Get `next` package info
+        run: echo "value=$(pnpm list next --json --filter next)" >> "$GITHUB_OUTPUT"
+      - id: version
+        name: Extract `next` version
+        run: echo 'value="${{ fromJson(steps.nextPackageInfo.outputs)[0].version }}"' >> "$GITHUB_OUTPUT"
+      - run: echo ${{ steps.version.outputs.version }}
+      # - uses: actions/github-script@v7
+      #   id: trigger-front-sync
+      #   with:
+      #     result-encoding: string
+      #     retries: 3
+      #     retry-exempt-status-codes: 400,401
+      #     # Default github token cannot dispatch events to the remote repo, it should be
+      #     # a PAT with access to contenst:read&write + metadata:read.
+      #     github-token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+      #     # Note `event_type` and `client_payload` are contract between vercel/front,
+      #     # if these need to be changed both side should be updated accordingly.
+      #     script: |
+      #       github.request('POST /repos/{owner}/{repo}/dispatches', {
+      #         owner: 'vercel',
+      #         repo: 'front',
+      #         event_type: 'cron-update-next',
+      #         client_payload: {
+      #           version: ${{ steps.version.outputs.version }}
+      #         }
+      #       })

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -29,3 +29,26 @@ jobs:
                 version: context.ref
               }
             })
+  front-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        id: trigger-front-sync
+        with:
+          result-encoding: string
+          retries: 3
+          retry-exempt-status-codes: 400,401
+          # Default github token cannot dispath events to the remote repo, it should be
+          # a PAT with access to contenst:read&write + metadata:read.
+          github-token: ${{ secrets.FRONT_TEST_TOKEN }}
+          # Note `event_type` and `client_payload` are contract between vercel/front,
+          # if these need to be changed both side should be updated accordingly.
+          script: |
+            github.request('POST /repos/{owner}/{repo}/dispatches', {
+              owner: 'vercel',
+              repo: 'front',
+              event_type: 'cron-update-next',
+              client_payload: {
+                version: context.ref
+              }
+            })

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -64,7 +64,7 @@ jobs:
             github.request('POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches', {
               owner: 'vercel',
               repo: 'front',
-              workflow_id: '46394538',
+              workflow_id: '22486376',
               ref: 'main',
               inputs: {
                 version: '${{ steps.version.outputs.value }}'

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -35,12 +35,14 @@ jobs:
   front-sync:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      - run: corepack enable
       - id: nextPackageInfo
         name: Get `next` package info
         run: echo "value=$(pnpm list next --json --filter next)" >> "$GITHUB_OUTPUT"
       - id: version
         name: Extract `next` version
-        run: echo 'value="${{ fromJson(steps.nextPackageInfo.outputs)[0].version }}"' >> "$GITHUB_OUTPUT"
+        run: echo 'value=${{ fromJson(steps.nextPackageInfo.outputs)[0].version }}' >> "$GITHUB_OUTPUT"
       - run: echo ${{ steps.version.outputs.version }}
       # - uses: actions/github-script@v7
       #   id: trigger-front-sync

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -48,6 +48,10 @@ jobs:
       - id: version
         name: Extract `next` version
         run: echo 'value=${{ fromJson(steps.nextPackageInfo.outputs.value).version }}' >> "$GITHUB_OUTPUT"
+      - name: Check token
+        run: gh auth status
+        env:
+          GITHUB_TOKEN: ${{ secrets.FRONT_TEST_TOKEN }}
       - uses: actions/github-script@v7
         name: Trigger vercel/front sync
         id: trigger-front-sync
@@ -56,16 +60,16 @@ jobs:
           retries: 3
           retry-exempt-status-codes: 400,401,404
           # Default github token cannot dispatch events to the remote repo, it should be
-          # a PAT with access to contenst:read&write + metadata:read.
-          github-token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
-          # Note `event_type` and `client_payload` are contract between vercel/front,
+          # a PAT with Actions write access (https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event)
+          github-token: ${{ secrets.FRONT_TEST_TOKEN }}
+          # Note `workflow_id` and `inputs` are contract between vercel/front,
           # if these need to be changed both side should be updated accordingly.
           script: |
             github.request('POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches', {
               owner: 'vercel',
               repo: 'front',
               workflow_id: 'cron-update-next.yml',
-              ref: 'sebbie/06-01-add_support_for_starting_sync_with_a_specific_next.js_version',
+              ref: 'main',
               inputs: {
                 version: '${{ steps.version.outputs.value }}'
               }

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -65,7 +65,7 @@ jobs:
               owner: 'vercel',
               repo: 'front',
               workflow_id: '22486376',
-              ref: 'main',
+              ref: 'sebbie/06-01-add_support_for_starting_sync_with_a_specific_next.js_version',
               inputs: {
                 version: '${{ steps.version.outputs.value }}'
               }

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -48,7 +48,7 @@ jobs:
       - id: version
         name: Extract `next` version
         run: echo 'value=${{ fromJson(steps.nextPackageInfo.outputs.value).version }}' >> "$GITHUB_OUTPUT"
-      - run: echo ${{ steps.version.outputs.version }}
+      - run: echo ${{ steps.version.outputs.value }}
       # - uses: actions/github-script@v7
       #   id: trigger-front-sync
       #   with:

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -4,9 +4,6 @@ name: Notify new Next.js release
 on:
   release:
     types: [published]
-  push:
-    branches:
-      - sebbie/06-01-automatically_trigger_sync_with_vercel.com_on_release
 jobs:
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -53,18 +53,19 @@ jobs:
         with:
           result-encoding: string
           retries: 3
-          retry-exempt-status-codes: 400,401
+          retry-exempt-status-codes: 400,401,404
           # Default github token cannot dispatch events to the remote repo, it should be
           # a PAT with access to contenst:read&write + metadata:read.
           github-token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
           # Note `event_type` and `client_payload` are contract between vercel/front,
           # if these need to be changed both side should be updated accordingly.
           script: |
-            github.request('POST /repos/{owner}/{repo}/dispatches', {
+            github.request('POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches', {
               owner: 'vercel',
               repo: 'front',
-              event_type: 'cron-update-next',
-              client_payload: {
+              workflow_id: 'cron-update-next',
+              ref: 'main',
+              inputs: {
                 version: '${{ steps.version.outputs.value }}'
               }
             })

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -44,7 +44,7 @@ jobs:
             echo 'value<<EOF'
             cat package.json
             echo EOF
-          } >> "$GITHUB_ENV"
+          } >> "$GITHUB_OUTPUT"
       - id: version
         name: Extract `next` version
         run: echo 'value=${{ fromJson(steps.nextPackageInfo.outputs.value).version }}' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -49,7 +49,7 @@ jobs:
         name: Extract `next` version
         run: echo 'value=${{ fromJson(steps.nextPackageInfo.outputs.value).version }}' >> "$GITHUB_OUTPUT"
       - uses: actions/github-script@v7
-        name: trigger 'cron-update-next.yml'
+        name: Trigger vercel/front sync
         id: trigger-front-sync
         with:
           result-encoding: string
@@ -61,11 +61,12 @@ jobs:
           # Note `event_type` and `client_payload` are contract between vercel/front,
           # if these need to be changed both side should be updated accordingly.
           script: |
-            github.request('POST /repos/{owner}/{repo}/dispatches', {
+            github.request('POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches', {
               owner: 'vercel',
               repo: 'front',
-              event_type: 'update-next',
-              client_payload: {
+              workflow_id: 'cron-update-next.yml',
+              ref: 'sebbie/06-01-add_support_for_starting_sync_with_a_specific_next.js_version',
+              inputs: {
                 version: '${{ steps.version.outputs.value }}'
               }
             })

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -74,5 +74,5 @@ jobs:
                 version: '${{ steps.version.outputs.value }}'
               }
             })
-      - name: workflow_dispatch response
-        run: echo ${{ steps.trigger-front-sync.outputs.response }}
+            # Ideally we'd include a URL to the started sync.
+            # However, creating a workflow_dispatch event does not produce an ID: https://github.com/orgs/community/discussions/9752


### PR DESCRIPTION
Enabled by https://github.com/vercel/front/pull/32916

This will make it easier to bisect regressions since we automatically get a deploy for every release.


## Test plan
- Trigger front-sync temporarly from pushes:
  ![Screenshot 2024-07-02 at 14 40 02](https://github.com/vercel/next.js/assets/12292047/f7706077-807b-4a36-9f37-6ae6ff9b202b)
   -- https://github.com/vercel/next.js/actions/runs/9761106542/job/26941408087?pr=66453#step:6:31
  which triggered https://github.com/vercel/front/actions/runs/9761110735
