### PR TITLE
Improve JSDoc link for Metadata API

### DIFF
--- a/packages/next/src/server/typescript/rules/config.ts
+++ b/packages/next/src/server/typescript/rules/config.ts
@@ -132,7 +132,7 @@ const API_DOCS: Record<
   },
   metadata: {
     description: 'Next.js Metadata configurations',
-    link: 'https://nextjs.org/docs/app/api-reference/file-conventions/metadata',
+    link: 'https://nextjs.org/docs/app/building-your-application/optimizing/metadata',
   },
   maxDuration: {
     description:


### PR DESCRIPTION
The JSDoc for `export const metadata` currently suggests reading https://nextjs.org/docs/app/api-reference/file-conventions/metadata. I don't think it makes sense. At least at this moment, I was looking for https://nextjs.org/docs/app/building-your-application/optimizing/metadata instead so that's what we link to now from this tooltip:

![Screenshot 2024-06-01 at 18 18 48](https://github.com/vercel/next.js/assets/12292047/8dace7b4-3984-4848-a020-ac2ce6de822c)
