### PR TITLE
Fix Server Actions closure idents tracking

### DIFF
--- a/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -701,7 +701,6 @@ impl<C: Comments> VisitMut for ServerActions<C> {
             self.should_track_names = false;
             n.visit_mut_children_with(self);
             self.should_track_names = true;
-            return;
         }
     }
 
@@ -1159,7 +1158,7 @@ fn retain_names_from_declared_idents(child_names: &mut Vec<Id>, current_declared
     child_names.retain(|name| {
         if added_names.contains(name) {
             false
-        } else if current_declared_idents.contains(&name) {
+        } else if current_declared_idents.contains(name) {
             added_names.push(name.clone());
             true
         } else {

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/1/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/1/output.js
@@ -19,13 +19,12 @@ export default function Home() {
         test: 'test'
     };
     const action = registerServerReference("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
-        info.name,
-        info.test
+        info
     ]));
     return null;
 }
 export async function $$ACTION_1($$ACTION_CLOSURE_BOUND) {
-    var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
-    console.log($$ACTION_ARG_0);
-    console.log($$ACTION_ARG_1);
+    var [$$ACTION_ARG_0] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
+    console.log($$ACTION_ARG_0.name);
+    console.log($$ACTION_ARG_0.test);
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/32/input.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/32/input.js
@@ -1,0 +1,8 @@
+export function Foo({ data, payload }) {
+  async function action() {
+    'use server'
+    console.log(data.slice(0, 1), payload.user.id)
+  }
+
+  return <form action={action}>Hello</form>
+}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/32/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/32/output.js
@@ -1,0 +1,13 @@
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+export function Foo({ data, payload }) {
+    var action = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
+        data,
+        payload
+    ]));
+    return <form action={action}>Hello</form>;
+}
+export async function $$ACTION_0($$ACTION_CLOSURE_BOUND) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);
+    console.log($$ACTION_ARG_0.slice(0, 1), $$ACTION_ARG_1.user.id);
+}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/5/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/5/output.js
@@ -8,7 +8,7 @@ export function Item({ id1, id2, id3, id4 }) {
         id1,
         v2,
         id3,
-        id4.x
+        id4
     ]));
     return <Button action={deleteItem}>Delete</Button>;
 }
@@ -20,5 +20,5 @@ export async function $$ACTION_0($$ACTION_CLOSURE_BOUND) {
     await deleteFromDb({
         id3: $$ACTION_ARG_2
     });
-    await deleteFromDb($$ACTION_ARG_3);
+    await deleteFromDb($$ACTION_ARG_3.x);
 }

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/7/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/7/output.js
@@ -3,9 +3,6 @@ import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc
 import deleteFromDb from 'db';
 export function Item1(product, foo, bar) {
     const a = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
-        product.id,
-        product?.foo,
-        product.bar.baz,
         product,
         foo,
         bar
@@ -13,14 +10,11 @@ export function Item1(product, foo, bar) {
     return <Button action={a}>Delete</Button>;
 }
 export async function $$ACTION_0($$ACTION_CLOSURE_BOUND) {
-    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2, $$ACTION_ARG_3, $$ACTION_ARG_4, $$ACTION_ARG_5] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);
-    await deleteFromDb($$ACTION_ARG_3.id, $$ACTION_ARG_3?.foo, $$ACTION_ARG_3.bar.baz, $$ACTION_ARG_3[$$ACTION_ARG_4, $$ACTION_ARG_5]);
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);
+    await deleteFromDb($$ACTION_ARG_0.id, $$ACTION_ARG_0?.foo, $$ACTION_ARG_0.bar.baz, $$ACTION_ARG_0[$$ACTION_ARG_1, $$ACTION_ARG_2]);
 }
 export function Item2(product, foo, bar) {
     var deleteItem2 = registerServerReference("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
-        product.id,
-        product?.foo,
-        product.bar.baz,
         product,
         foo,
         bar
@@ -28,14 +22,11 @@ export function Item2(product, foo, bar) {
     return <Button action={deleteItem2}>Delete</Button>;
 }
 export async function $$ACTION_1($$ACTION_CLOSURE_BOUND) {
-    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2, $$ACTION_ARG_3, $$ACTION_ARG_4, $$ACTION_ARG_5] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
-    await deleteFromDb($$ACTION_ARG_3.id, $$ACTION_ARG_3?.foo, $$ACTION_ARG_3.bar.baz, $$ACTION_ARG_3[$$ACTION_ARG_4, $$ACTION_ARG_5]);
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
+    await deleteFromDb($$ACTION_ARG_0.id, $$ACTION_ARG_0?.foo, $$ACTION_ARG_0.bar.baz, $$ACTION_ARG_0[$$ACTION_ARG_1, $$ACTION_ARG_2]);
 }
 export function Item3(product, foo, bar) {
     const deleteItem3 = registerServerReference("56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_3).bind(null, encryptActionBoundArgs("56a859f462d35a297c46a1bbd1e6a9058c104ab8", [
-        product.id,
-        product?.foo,
-        product.bar.baz,
         product,
         foo,
         bar
@@ -43,14 +34,11 @@ export function Item3(product, foo, bar) {
     return <Button action={deleteItem3}>Delete</Button>;
 }
 export async function $$ACTION_3($$ACTION_CLOSURE_BOUND) {
-    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2, $$ACTION_ARG_3, $$ACTION_ARG_4, $$ACTION_ARG_5] = await decryptActionBoundArgs("56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_CLOSURE_BOUND);
-    await deleteFromDb($$ACTION_ARG_3.id, $$ACTION_ARG_3?.foo, $$ACTION_ARG_3.bar.baz, $$ACTION_ARG_3[$$ACTION_ARG_4, $$ACTION_ARG_5]);
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2] = await decryptActionBoundArgs("56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_CLOSURE_BOUND);
+    await deleteFromDb($$ACTION_ARG_0.id, $$ACTION_ARG_0?.foo, $$ACTION_ARG_0.bar.baz, $$ACTION_ARG_0[$$ACTION_ARG_1, $$ACTION_ARG_2]);
 }
 export function Item4(product, foo, bar) {
     const deleteItem4 = registerServerReference("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_4).bind(null, encryptActionBoundArgs("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", [
-        product.id,
-        product?.foo,
-        product.bar.baz,
         product,
         foo,
         bar
@@ -58,6 +46,6 @@ export function Item4(product, foo, bar) {
     return <Button action={deleteItem4}>Delete</Button>;
 }
 export async function $$ACTION_4($$ACTION_CLOSURE_BOUND) {
-    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2, $$ACTION_ARG_3, $$ACTION_ARG_4, $$ACTION_ARG_5] = await decryptActionBoundArgs("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_CLOSURE_BOUND);
-    await deleteFromDb($$ACTION_ARG_3.id, $$ACTION_ARG_3?.foo, $$ACTION_ARG_3.bar.baz, $$ACTION_ARG_3[$$ACTION_ARG_4, $$ACTION_ARG_5]);
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2] = await decryptActionBoundArgs("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_CLOSURE_BOUND);
+    await deleteFromDb($$ACTION_ARG_0.id, $$ACTION_ARG_0?.foo, $$ACTION_ARG_0.bar.baz, $$ACTION_ARG_0[$$ACTION_ARG_1, $$ACTION_ARG_2]);
 }


### PR DESCRIPTION
This PR fixes (and simplifies) identifier tracking in the Server Actions SWC transform. 

In an inlined `"use server"` function, the transform tracks which variables are used inside the function body, but defined in an upper-level closure. These variables need to be automatically passed via `$$bound` and encrypted.

Previously, we are tracking these variables as "Names", which is a pair of identifier and property access list. For example if `foo.bar.baz` is used inside the function body, we track `(Ident(foo), [Ident(bar), Ident(baz)])` as an occurrence and only pass that `.bar.baz` sub-field across the RSC boundary. This saves the bytes being transfered over the network, comparing to passing the full `foo` value.

However, that causes a couple of tricky problems in the past. For example, the transform becomes too complicated so it can handle duplicated fields:

```js
async function () {
  "use server"
  console.log(foo.bar, foo.bar.baz)
}
```

In that case we need to pass only `foo.bar` as the other one is a subset. And then, there're cases like dynamic field access like `foo[field]` where we need to opt-out.

The hard blocking issue that makes me removing this optimization is that we can't tell if a member expression is a field of a value, or a JS builtin method. For example:

```js
async function () {
  "use server"
  foo.push('123')
}
```

In this case we can't pass `foo.push` over the boundary as it's likely an array. One workaround is to check if it's a function call. But an opposite case can be that `foo` is an object with a field `push` of another Server Action, which is totally valid. And also, the code might not be statically analyzable and we can't tell if it will be a function call or not.

A better workaround can be keeping a full list of potential JS native method names for data types that are RSC compatible, and opt-out only one of them are seen. But that list is just too long (consider arrays, objects, sets, maps, ...).

Because of all the reasons and for simplicity and correctness, I think it's better to just send the full value along.

cc @sebmarkbage 