### PR TITLE
Update cookies.mdx to show that maxAge accepts a value in seconds

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/cookies.mdx
+++ b/docs/02-app/02-api-reference/04-functions/cookies.mdx
@@ -121,7 +121,7 @@ async function delete(data) {
 
 ### `cookies().set(name, value, { maxAge: 0 })`
 
-Setting `maxAge` to 0 will immediately expire a cookie.
+Setting `maxAge` to 0 will immediately expire a cookie. maxAge accepts a value in seconds.
 
 ```js filename="app/actions.js"
 'use server'

--- a/docs/02-app/02-api-reference/04-functions/cookies.mdx
+++ b/docs/02-app/02-api-reference/04-functions/cookies.mdx
@@ -121,7 +121,7 @@ async function delete(data) {
 
 ### `cookies().set(name, value, { maxAge: 0 })`
 
-Setting `maxAge` to 0 will immediately expire a cookie. maxAge accepts a value in seconds.
+Setting `maxAge` to 0 will immediately expire a cookie. `maxAge` accepts a value in seconds.
 
 ```js filename="app/actions.js"
 'use server'
@@ -143,7 +143,7 @@ Setting `expires` to any value in the past will immediately expire a cookie.
 import { cookies } from 'next/headers'
 
 async function delete(data) {
-  const oneDay = 24 * 60 * 60 * 1000
+  const oneDay = 24 * 60 * 60
   cookies().set('name', 'value', { expires: Date.now() - oneDay })
 }
 ```


### PR DESCRIPTION
In the discord server, people were confused whether maxAge accepts in second or millisecond. It would be worth specifying it

