### PR TITLE
Fix `next/navigation` type augmentation

### DIFF
--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -34,7 +34,7 @@ import { ReadonlyURLSearchParams } from './navigation.react-server'
  *
  * Read more: [Next.js Docs: `useSearchParams`](https://nextjs.org/docs/app/api-reference/functions/use-search-params)
  */
-function useSearchParams(): ReadonlyURLSearchParams {
+export function useSearchParams(): ReadonlyURLSearchParams {
   const searchParams = useContext(SearchParamsContext)
 
   // In the case where this is `null`, the compat types added in
@@ -78,13 +78,13 @@ function useSearchParams(): ReadonlyURLSearchParams {
  *
  * Read more: [Next.js Docs: `usePathname`](https://nextjs.org/docs/app/api-reference/functions/use-pathname)
  */
-function usePathname(): string {
+export function usePathname(): string {
   // In the case where this is `null`, the compat types added in `next-env.d.ts`
   // will add a new overload that changes the return type to include `null`.
   return useContext(PathnameContext) as string
 }
 
-import {
+export {
   ServerInsertedHTMLContext,
   useServerInsertedHTML,
 } from '../../shared/lib/server-inserted-html.shared-runtime'
@@ -107,7 +107,7 @@ import {
  *
  * Read more: [Next.js Docs: `useRouter`](https://nextjs.org/docs/app/api-reference/functions/use-router)
  */
-function useRouter(): AppRouterInstance {
+export function useRouter(): AppRouterInstance {
   const router = useContext(AppRouterContext)
   if (router === null) {
     throw new Error('invariant expected app router to be mounted')
@@ -137,12 +137,12 @@ interface Params {
  *
  * Read more: [Next.js Docs: `useParams`](https://nextjs.org/docs/app/api-reference/functions/use-params)
  */
-function useParams<T extends Params = Params>(): T {
+export function useParams<T extends Params = Params>(): T {
   return useContext(PathParamsContext) as T
 }
 
 /** Get the canonical parameters from the current level to the leaf node. */
-function getSelectedLayoutSegmentPath(
+export function getSelectedLayoutSegmentPath(
   tree: FlightRouterState,
   parallelRouteKey: string,
   first = true,
@@ -201,7 +201,7 @@ function getSelectedLayoutSegmentPath(
  *
  * Read more: [Next.js Docs: `useSelectedLayoutSegments`](https://nextjs.org/docs/app/api-reference/functions/use-selected-layout-segments)
  */
-function useSelectedLayoutSegments(
+export function useSelectedLayoutSegments(
   parallelRouteKey: string = 'children'
 ): string[] {
   const context = useContext(LayoutRouterContext)
@@ -229,7 +229,7 @@ function useSelectedLayoutSegments(
  *
  * Read more: [Next.js Docs: `useSelectedLayoutSegment`](https://nextjs.org/docs/app/api-reference/functions/use-selected-layout-segment)
  */
-function useSelectedLayoutSegment(
+export function useSelectedLayoutSegment(
   parallelRouteKey: string = 'children'
 ): string | null {
   const selectedLayoutSegments = useSelectedLayoutSegments(parallelRouteKey)
@@ -248,18 +248,6 @@ function useSelectedLayoutSegment(
   return selectedLayoutSegment === DEFAULT_SEGMENT_KEY
     ? null
     : selectedLayoutSegment
-}
-
-// Client components APIs
-export {
-  useSearchParams,
-  usePathname,
-  useSelectedLayoutSegment,
-  useSelectedLayoutSegments,
-  useParams,
-  useRouter,
-  useServerInsertedHTML,
-  ServerInsertedHTMLContext,
 }
 
 // Shared components APIs

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -34,6 +34,7 @@ import { ReadonlyURLSearchParams } from './navigation.react-server'
  *
  * Read more: [Next.js Docs: `useSearchParams`](https://nextjs.org/docs/app/api-reference/functions/use-search-params)
  */
+// Client components API
 export function useSearchParams(): ReadonlyURLSearchParams {
   const searchParams = useContext(SearchParamsContext)
 
@@ -78,12 +79,14 @@ export function useSearchParams(): ReadonlyURLSearchParams {
  *
  * Read more: [Next.js Docs: `usePathname`](https://nextjs.org/docs/app/api-reference/functions/use-pathname)
  */
+// Client components API
 export function usePathname(): string {
   // In the case where this is `null`, the compat types added in `next-env.d.ts`
   // will add a new overload that changes the return type to include `null`.
   return useContext(PathnameContext) as string
 }
 
+// Client components API
 export {
   ServerInsertedHTMLContext,
   useServerInsertedHTML,
@@ -107,6 +110,7 @@ export {
  *
  * Read more: [Next.js Docs: `useRouter`](https://nextjs.org/docs/app/api-reference/functions/use-router)
  */
+// Client components API
 export function useRouter(): AppRouterInstance {
   const router = useContext(AppRouterContext)
   if (router === null) {
@@ -137,11 +141,13 @@ interface Params {
  *
  * Read more: [Next.js Docs: `useParams`](https://nextjs.org/docs/app/api-reference/functions/use-params)
  */
+// Client components API
 export function useParams<T extends Params = Params>(): T {
   return useContext(PathParamsContext) as T
 }
 
 /** Get the canonical parameters from the current level to the leaf node. */
+// Client components API
 export function getSelectedLayoutSegmentPath(
   tree: FlightRouterState,
   parallelRouteKey: string,
@@ -201,6 +207,7 @@ export function getSelectedLayoutSegmentPath(
  *
  * Read more: [Next.js Docs: `useSelectedLayoutSegments`](https://nextjs.org/docs/app/api-reference/functions/use-selected-layout-segments)
  */
+// Client components API
 export function useSelectedLayoutSegments(
   parallelRouteKey: string = 'children'
 ): string[] {
@@ -229,6 +236,7 @@ export function useSelectedLayoutSegments(
  *
  * Read more: [Next.js Docs: `useSelectedLayoutSegment`](https://nextjs.org/docs/app/api-reference/functions/use-selected-layout-segment)
  */
+// Client components API
 export function useSelectedLayoutSegment(
   parallelRouteKey: string = 'children'
 ): string | null {

--- a/test/e2e/app-dir/use-params/tsconfig.json
+++ b/test/e2e/app-dir/use-params/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "strict": false,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,


### PR DESCRIPTION
Follow-up from https://github.com/vercel/next.js/pull/66461#discussion_r1624096023

When using app dir and pages dir together, the [navigation compatibility types](https://github.com/vercel/next.js/blob/48e9cd9b60668c556f4304f8c082d7840db8f53e/packages/next/navigation-types/compat/navigation.d.ts) as introduced in #45919 are added to `next-env.d.ts` with the following triple-slash directive:

```
/// <reference types="next/navigation-types/compat/navigation" />
```

This augments the types from `next/navigation` ([source](https://github.com/vercel/next.js/blob/48e9cd9b60668c556f4304f8c082d7840db8f53e/packages/next/src/client/components/navigation.ts)). But TypeScript fails to do the augmentation and reports the following errors (excerpt):

```
Type error: Overload signatures must all be exported or non-exported.

> 11 |   export function useSearchParams(): ReadonlyURLSearchParams | null
```

However, this error is suppressed in most Next.js projects, because [`skipLibCheck` is set to `true`](https://github.com/vercel/next.js/blob/48e9cd9b60668c556f4304f8c082d7840db8f53e/packages/next/src/lib/typescript/writeConfigurationDefaults.ts#L35) per default. It only arises if users explicitly set it to `false`, e.g. if they don't mind the longer compilation times and want to avoid that third-party dependencies are accidentally untyped because of compile errors. [^1]

The error is caused by using a separate export declaration for those functions. If we use export modifiers on the function declarations the augmentation can be fixed.

I've verified that the e2e test `test/e2e/app-dir/use-params` fails on the first commit of this PR (setting `skipLibCheck` to `false`), and succeeds on the second commit.

[^1]: I don't want to open a can of worms, but maybe we should consider not using `"skipLibCheck": true` as a default compiler setting.