### PR TITLE
Fix flaky redbox expectation in `unstable_after` e2e test

### DIFF
--- a/test/e2e/app-dir/next-after-app/index.test.ts
+++ b/test/e2e/app-dir/next-after-app/index.test.ts
@@ -362,6 +362,7 @@ describe.each(runtimes)('unstable_after() in %s runtime', (runtimeValue) => {
           '/invalid-in-client'
         )
         try {
+          expect(await session.hasRedbox()).toBe(true)
           expect(await session.getRedboxSource(true)).toMatch(
             /You're importing a component that needs "?unstable_after"?\. That only works in a Server Component but one of its parents is marked with "use client", so it's a Client Component\./
           )


### PR DESCRIPTION
It seems that all other usages of `getRedboxSource` are prefaced with the `hasRedbox` expectation which includes a waiting period.

x-ref: https://github.com/vercel/next.js/actions/runs/9348134530/job/25726665218
x-ref: #60522

/cc @lubieowoce 