### PR TITLE
More improvements to error overlay copy button

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/components/copy-button/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/components/copy-button/index.tsx
@@ -89,13 +89,15 @@ export function CopyButton({
       type="button"
       title={title}
       aria-label={label}
-      disabled={isDisabled}
+      aria-disabled={isDisabled}
       data-nextjs-data-runtime-error-copy-stack
       className={`nextjs-data-runtime-error-copy-stack nextjs-data-runtime-error-copy-stack--${copyState.state}`}
       onClick={() => {
-        React.startTransition(() => {
-          dispatch('copy')
-        })
+        if (!isDisabled) {
+          React.startTransition(() => {
+            dispatch('copy')
+          })
+        }
       }}
     >
       {icon}

--- a/packages/next/src/client/components/react-dev-overlay/internal/components/copy-button/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/components/copy-button/index.tsx
@@ -1,4 +1,4 @@
-import { useActionState, useEffect } from 'react'
+import * as React from 'react'
 
 type CopyState =
   | {
@@ -20,8 +20,11 @@ export function CopyButton({
   successLabel: string
   content: string
 }) {
-  const [copyState, dispatch, isPending] = useActionState(
-    async (state: CopyState, action: 'reset' | 'copy'): Promise<CopyState> => {
+  const [copyState, dispatch, isPending] = React.useActionState(
+    (
+      state: CopyState,
+      action: 'reset' | 'copy'
+    ): CopyState | Promise<CopyState> => {
       if (action === 'reset') {
         return { state: 'initial' }
       }
@@ -34,12 +37,14 @@ export function CopyButton({
             ),
           }
         }
-        try {
-          await navigator.clipboard.writeText(content)
-          return { state: 'success' }
-        } catch (error) {
-          return { state: 'error', error }
-        }
+        return navigator.clipboard.writeText(content).then(
+          () => {
+            return { state: 'success' }
+          },
+          (error) => {
+            return { state: 'error', error }
+          }
+        )
       }
       return state
     },
@@ -49,13 +54,13 @@ export function CopyButton({
   )
 
   const error = copyState.state === 'error' ? copyState.error : null
-  useEffect(() => {
+  React.useEffect(() => {
     if (error !== null) {
       // Additional console.error to get the stack.
       console.error(error)
     }
   }, [error])
-  useEffect(() => {
+  React.useEffect(() => {
     if (copyState.state === 'success') {
       const timeoutId = setTimeout(() => {
         dispatch('reset')
@@ -88,9 +93,9 @@ export function CopyButton({
       data-nextjs-data-runtime-error-copy-stack
       className={`nextjs-data-runtime-error-copy-stack nextjs-data-runtime-error-copy-stack--${copyState.state}`}
       onClick={() => {
-        if (!isDisabled) {
+        React.startTransition(() => {
           dispatch('copy')
-        }
+        })
       }}
     >
       {icon}

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
@@ -143,7 +143,7 @@ export const styles = css`
   .nextjs-data-runtime-error-copy-stack--initial:hover {
     cursor: pointer;
   }
-  .nextjs-data-runtime-error-copy-stack:disabled {
+  .nextjs-data-runtime-error-copy-stack[aria-disabled='true'] {
     opacity: 0.3;
     cursor: not-allowed;
   }


### PR DESCRIPTION
Async actions need to be wrapped in `startTransition`:  https://github.com/facebook/react/pull/29694

Also ensured we don't loose (keyboard) focus when we just copied:

https://github.com/vercel/next.js/assets/12292047/43f46f68-87c0-4731-a562-b22a6d0abc3a

