### PR TITLE
Add another error solution for prerender errors

### DIFF
--- a/errors/prerender-error.mdx
+++ b/errors/prerender-error.mdx
@@ -9,6 +9,7 @@ While prerendering a page an error occurred. This can occur for many reasons fro
 ## Possible Ways to Fix It
 
 - Use Next.js 13 (or higher) and the [App Router](/docs#app-router-vs-pages-router), which allows [colocation](/docs/app/building-your-application/routing#colocation) of pages and other files (e.g. components, styles, tests, etc)
+- In Next.js 13, ensure that no files are named `icon`
 - Make sure to move any non-pages out of the `pages` folder
 - Check for any code that assumes a prop is available, even when it might not be
 - Set default values for all dynamic pages' props (avoid `undefined`, use `null` instead so it can be serialized)


### PR DESCRIPTION

This pr adds another potential solution to this error that was not previously in the docs. I suspect other names may also have similar issues (i.e. favicon), but if there's a place with an exhaustive list that I can just drop into the pr, that would be much appreciated


