### PR TITLE
Fix: patched fetch function name

### DIFF
--- a/packages/next/src/server/lib/dedupe-fetch.ts
+++ b/packages/next/src/server/lib/dedupe-fetch.ts
@@ -27,7 +27,7 @@ function generateCacheKey(request: Request): string {
 }
 
 export function createDedupeFetch(originalFetch: typeof fetch) {
-  return function dedupeFetch(
+  const dedupeFetch = function fetch(
     resource: URL | RequestInfo,
     options?: RequestInit
   ) {
@@ -98,4 +98,6 @@ export function createDedupeFetch(originalFetch: typeof fetch) {
     // of the body so that it can be read multiple times.
     return match.then((response) => response.clone())
   }
+
+  return dedupeFetch
 }

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -774,7 +774,6 @@ function createPatchedFetcher(
   }
 
   // Attach the necessary properties to the patched fetch function.
-  patched.name = 'fetch'
   patched.__nextPatched = true as const
   patched.__nextGetStaticStore = () => staticGenerationAsyncStorage
   patched._nextOriginalFetch = originFetch

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -774,6 +774,7 @@ function createPatchedFetcher(
   }
 
   // Attach the necessary properties to the patched fetch function.
+  patched.name = 'fetch'
   patched.__nextPatched = true as const
   patched.__nextGetStaticStore = () => staticGenerationAsyncStorage
   patched._nextOriginalFetch = originFetch

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -218,10 +218,10 @@ function createPatchedFetcher(
 ): PatchedFetcher {
   // Create the patched fetch function. We don't set the type here, as it's
   // verified as the return value of this function.
-  const patched = async (
+  const patched = async function fetch(
     input: RequestInfo | URL,
     init: RequestInit | undefined
-  ) => {
+  ) {
     let url: URL | undefined
     try {
       url = new URL(input instanceof Request ? input.url : input)

--- a/test/e2e/app-dir/patched-fetch/app/client-component/page.js
+++ b/test/e2e/app-dir/patched-fetch/app/client-component/page.js
@@ -1,0 +1,5 @@
+'use client'
+
+export default function Page() {
+  return <p id="fetch-function-name">{fetch.name}</p>
+}

--- a/test/e2e/app-dir/patched-fetch/app/layout.js
+++ b/test/e2e/app-dir/patched-fetch/app/layout.js
@@ -1,0 +1,9 @@
+export default function Layout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/app-dir/patched-fetch/app/page.js
+++ b/test/e2e/app-dir/patched-fetch/app/page.js
@@ -1,0 +1,16 @@
+export default function Page() {
+  return (
+    <>
+      <p>
+        <a id="to-server-component" href="/patch-fetch/server-component">
+          To Server Component
+        </a>
+      </p>
+      <p>
+        <a id="to-client-component" href="/patch-fetch/client-component">
+          To Client Component
+        </a>
+      </p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/patched-fetch/app/server-component/page.js
+++ b/test/e2e/app-dir/patched-fetch/app/server-component/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="fetch-function-name">{fetch.name}</p>
+}

--- a/test/e2e/app-dir/patched-fetch/patched-fetch.test.ts
+++ b/test/e2e/app-dir/patched-fetch/patched-fetch.test.ts
@@ -1,0 +1,19 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('app-dir - patched-fetch', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should return string fetch for fetch.name in server component', async () => {
+    const $ = await next.render$('/server-component')
+    const fetchName = $('#fetch-function-name').text()
+    expect(fetchName).toBe('fetch')
+  })
+
+  it('should return string fetch for fetch.name in client component', async () => {
+    const $ = await next.render$('/client-component')
+    const fetchName = $('#fetch-function-name').text()
+    expect(fetchName).toBe('fetch')
+  })
+})


### PR DESCRIPTION
### What

Notice the patched fetch function name is changed, it should be `fetch` like native fetch