### PR TITLE
Remove redundant React dependency declarations in test

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -405,7 +405,8 @@ ${ENDGROUP}`)
     // a starter Next.js install to re-use to speed up tests
     // to avoid having to run yarn each time
     console.log(`${GROUP}Creating Next.js install for isolated tests`)
-    const reactVersion = process.env.NEXT_TEST_REACT_VERSION || 'beta'
+    const reactVersion =
+      process.env.NEXT_TEST_REACT_VERSION || '19.0.0-rc-f994737d14-20240522'
     const { installDir, pkgPaths, tmpRepoDir } = await createNextInstall({
       parentSpan: mockTrace(),
       dependencies: {

--- a/test/development/acceptance-app/ReactRefresh.test.ts
+++ b/test/development/acceptance-app/ReactRefresh.test.ts
@@ -7,10 +7,6 @@ import { outdent } from 'outdent'
 describe('ReactRefresh app', () => {
   const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
-    dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
-    },
     skipStart: true,
   })
 

--- a/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
@@ -8,10 +8,6 @@ import { outdent } from 'outdent'
 describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
   const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
-    dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
-    },
     skipStart: true,
   })
 

--- a/test/development/acceptance-app/ReactRefreshLogBox-scss.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox-scss.test.ts
@@ -11,8 +11,6 @@ describe.skip('ReactRefreshLogBox scss app', () => {
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
     dependencies: {
       sass: 'latest',
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
     },
     skipStart: true,
   })

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -14,10 +14,6 @@ const IS_TURBOPACK = Boolean(process.env.TURBOPACK)
 describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
   const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
-    dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
-    },
     skipStart: true,
   })
 

--- a/test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts
@@ -8,10 +8,6 @@ import { outdent } from 'outdent'
 describe.skip('ReactRefreshLogBox app', () => {
   const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
-    dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
-    },
     skipStart: true,
   })
 

--- a/test/development/acceptance-app/ReactRefreshModule.test.ts
+++ b/test/development/acceptance-app/ReactRefreshModule.test.ts
@@ -6,10 +6,6 @@ import { outdent } from 'outdent'
 describe('ReactRefreshModule app', () => {
   const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
-    dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
-    },
     skipStart: true,
   })
 

--- a/test/development/acceptance-app/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance-app/ReactRefreshRegression.test.ts
@@ -12,8 +12,6 @@ describe('ReactRefreshRegression app', () => {
       'styled-components': '5.1.0',
       '@next/mdx': 'canary',
       '@mdx-js/loader': '0.18.0',
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
     },
     skipStart: true,
   })

--- a/test/development/acceptance-app/ReactRefreshRequire.test.ts
+++ b/test/development/acceptance-app/ReactRefreshRequire.test.ts
@@ -7,10 +7,6 @@ import { outdent } from 'outdent'
 describe('ReactRefreshRequire app', () => {
   const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
-    dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
-    },
     skipStart: true,
   })
 

--- a/test/development/acceptance-app/editor-links.test.ts
+++ b/test/development/acceptance-app/editor-links.test.ts
@@ -28,10 +28,6 @@ async function clickImportTraceFiles(browser: any) {
 describe('Error overlay - editor links', () => {
   const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
-    dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
-    },
     skipStart: true,
   })
 

--- a/test/development/acceptance-app/error-message-url.test.ts
+++ b/test/development/acceptance-app/error-message-url.test.ts
@@ -6,10 +6,6 @@ import { outdent } from 'outdent'
 describe('Error overlay - error message urls', () => {
   const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
-    dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
-    },
     skipStart: true,
   })
 

--- a/test/development/acceptance-app/error-recovery.test.ts
+++ b/test/development/acceptance-app/error-recovery.test.ts
@@ -8,10 +8,6 @@ import { outdent } from 'outdent'
 describe.each(['default', 'turbo'])('Error recovery app %s', () => {
   const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
-    dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
-    },
     skipStart: true,
   })
 

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -10,10 +10,6 @@ import { getRedboxTotalErrorCount } from 'next-test-utils'
 describe('Error overlay for hydration errors', () => {
   const { next, isTurbopack } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
-    dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
-    },
     skipStart: true,
   })
 

--- a/test/development/acceptance-app/invalid-imports.test.ts
+++ b/test/development/acceptance-app/invalid-imports.test.ts
@@ -8,8 +8,6 @@ describe('Error Overlay invalid imports', () => {
   const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
     dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
       'server-only': 'latest',
       'client-only': 'latest',
     },

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -7,10 +7,6 @@ import { outdent } from 'outdent'
 describe('Error overlay - RSC build errors', () => {
   const { next, isTurbopack } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'rsc-build-errors')),
-    dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
-    },
     skipStart: true,
   })
 

--- a/test/development/acceptance-app/server-components.test.ts
+++ b/test/development/acceptance-app/server-components.test.ts
@@ -8,10 +8,6 @@ import { outdent } from 'outdent'
 describe('Error Overlay for server components', () => {
   const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
-    dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
-    },
     skipStart: true,
   })
 

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -7,10 +7,6 @@ import path from 'path'
 describe('Error overlay for hydration errors', () => {
   const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
-    dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
-    },
     skipStart: true,
   })
 

--- a/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
+++ b/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
@@ -27,10 +27,6 @@ const initialFiles = new Map([
 describe('Error Overlay for server components compiler errors in pages', () => {
   const { next } = nextTestSetup({
     files: {},
-    dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
-    },
     skipStart: true,
   })
 

--- a/test/development/next-font/deprecated-package.test.ts
+++ b/test/development/next-font/deprecated-package.test.ts
@@ -8,8 +8,6 @@ describe('Deprecated @next/font warning', () => {
       'pages/index.js': '',
     },
     dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
       '@next/font': 'canary',
     },
     skipStart: true,

--- a/test/e2e/app-dir/actions-allowed-origins/app-action-allowed-origins.test.ts
+++ b/test/e2e/app-dir/actions-allowed-origins/app-action-allowed-origins.test.ts
@@ -7,8 +7,6 @@ describe('app-dir action allowed origins', () => {
     files: join(__dirname, 'safe-origins'),
     skipDeployment: true,
     dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
       'server-only': 'latest',
     },
     // An arbitrary & random port.

--- a/test/e2e/app-dir/actions-allowed-origins/app-action-disallowed-origins.test.ts
+++ b/test/e2e/app-dir/actions-allowed-origins/app-action-disallowed-origins.test.ts
@@ -7,8 +7,6 @@ describe('app-dir action disallowed origins', () => {
     files: join(__dirname, 'unsafe-origins'),
     skipDeployment: true,
     dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
       'server-only': 'latest',
     },
   })

--- a/test/e2e/app-dir/actions/app-action-export.test.ts
+++ b/test/e2e/app-dir/actions/app-action-export.test.ts
@@ -6,8 +6,6 @@ describe('app-dir action handling - next export', () => {
     skipStart: true,
     skipDeployment: true,
     dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
       'server-only': 'latest',
     },
   })

--- a/test/e2e/app-dir/actions/app-action-form-state.test.ts
+++ b/test/e2e/app-dir/actions/app-action-form-state.test.ts
@@ -5,10 +5,6 @@ import { check } from 'next-test-utils'
 describe('app-dir action useActionState', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
-    },
   })
   it('should support submitting form state with JS', async () => {
     const browser = await next.browser('/client/form-state')

--- a/test/e2e/app-dir/actions/app-action-progressive-enhancement.test.ts
+++ b/test/e2e/app-dir/actions/app-action-progressive-enhancement.test.ts
@@ -7,9 +7,7 @@ describe('app-dir action progressive enhancement', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
       nanoid: 'latest',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
       'server-only': 'latest',
     },
   })

--- a/test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts
+++ b/test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts
@@ -11,8 +11,6 @@ describe('app-dir action size limit invalid config', () => {
     skipDeployment: true,
     skipStart: true,
     dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
       'server-only': 'latest',
     },
   })

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -19,9 +19,7 @@ describe('app-dir action handling', () => {
     nextTestSetup({
       files: __dirname,
       dependencies: {
-        react: '19.0.0-rc-f994737d14-20240522',
         nanoid: 'latest',
-        'react-dom': '19.0.0-rc-f994737d14-20240522',
         'server-only': 'latest',
       },
     })

--- a/test/e2e/app-dir/app-css-pageextensions/index.test.ts
+++ b/test/e2e/app-dir/app-css-pageextensions/index.test.ts
@@ -6,8 +6,6 @@ describe('app dir - css with pageextensions', () => {
     skipDeployment: true,
     dependencies: {
       '@picocss/pico': '1.5.7',
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
       sass: 'latest',
     },
   })

--- a/test/e2e/app-dir/app-css/index.test.ts
+++ b/test/e2e/app-dir/app-css/index.test.ts
@@ -7,8 +7,6 @@ describe('app dir - css', () => {
     skipDeployment: true,
     dependencies: {
       '@picocss/pico': '1.5.7',
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
       sass: 'latest',
       '@next/mdx': 'canary',
     },

--- a/test/e2e/app-dir/app-routes-client-component/app-routes-client-component.test.ts
+++ b/test/e2e/app-dir/app-routes-client-component/app-routes-client-component.test.ts
@@ -4,10 +4,6 @@ import path from 'path'
 describe('referencing a client component in an app route', () => {
   const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname)),
-    dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
-    },
   })
 
   it('responds without error', async () => {

--- a/test/e2e/app-dir/create-root-layout/create-root-layout.test.ts
+++ b/test/e2e/app-dir/create-root-layout/create-root-layout.test.ts
@@ -73,10 +73,6 @@ import stripAnsi from 'strip-ansi'
                   path.join(__dirname, 'next.config.js')
                 ),
               },
-              dependencies: {
-                react: '19.0.0-rc-f994737d14-20240522',
-                'react-dom': '19.0.0-rc-f994737d14-20240522',
-              },
             })
           })
           afterAll(() => next.destroy())
@@ -126,10 +122,6 @@ import stripAnsi from 'strip-ansi'
                 'next.config.js': new FileRef(
                   path.join(__dirname, 'next.config.js')
                 ),
-              },
-              dependencies: {
-                react: '19.0.0-rc-f994737d14-20240522',
-                'react-dom': '19.0.0-rc-f994737d14-20240522',
               },
             })
           })
@@ -235,10 +227,6 @@ import stripAnsi from 'strip-ansi'
               'next.config.js': new FileRef(
                 path.join(__dirname, 'next.config.js')
               ),
-            },
-            dependencies: {
-              react: '19.0.0-rc-f994737d14-20240522',
-              'react-dom': '19.0.0-rc-f994737d14-20240522',
             },
           })
 

--- a/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
+++ b/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
@@ -9,8 +9,6 @@ describe('navigation between pages and app dir', () => {
     next = await createNext({
       files: new FileRef(__dirname),
       dependencies: {
-        react: '19.0.0-rc-f994737d14-20240522',
-        'react-dom': '19.0.0-rc-f994737d14-20240522',
         typescript: 'latest',
         '@types/react': 'latest',
         '@types/node': 'latest',

--- a/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
+++ b/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
@@ -4,8 +4,6 @@ describe('redirects and rewrites', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
-      react: '19.0.0-rc-f994737d14-20240522',
-      'react-dom': '19.0.0-rc-f994737d14-20240522',
       typescript: 'latest',
       '@types/react': 'latest',
       '@types/node': 'latest',

--- a/test/e2e/new-link-behavior/child-a-tag-error.test.ts
+++ b/test/e2e/new-link-behavior/child-a-tag-error.test.ts
@@ -17,8 +17,6 @@ describe('New Link Behavior with <a> child', () => {
       },
       dependencies: {
         next: 'latest',
-        react: '19.0.0-rc-f994737d14-20240522',
-        'react-dom': '19.0.0-rc-f994737d14-20240522',
       },
     })
   })

--- a/test/e2e/new-link-behavior/material-ui.test.ts
+++ b/test/e2e/new-link-behavior/material-ui.test.ts
@@ -24,8 +24,6 @@ describe('New Link Behavior with material-ui', () => {
         '@mui/material': 'latest',
         next: 'latest',
         'prop-types': 'latest',
-        react: '19.0.0-rc-f994737d14-20240522',
-        'react-dom': '19.0.0-rc-f994737d14-20240522',
         // Use minimum peer dep version instead of v9 of eslint to avoid breaking changes
         eslint: '8.56.0',
         'eslint-config-next': 'latest',

--- a/test/e2e/new-link-behavior/stitches.test.ts
+++ b/test/e2e/new-link-behavior/stitches.test.ts
@@ -21,8 +21,6 @@ describe('New Link Behavior with stitches', () => {
       dependencies: {
         '@stitches/react': '^1.2.6',
         next: 'latest',
-        react: '19.0.0-rc-f994737d14-20240522',
-        'react-dom': '19.0.0-rc-f994737d14-20240522',
       },
     })
   })

--- a/test/e2e/next-font/with-proxy.test.ts
+++ b/test/e2e/next-font/with-proxy.test.ts
@@ -29,10 +29,6 @@ describe('next/font/google with proxy', () => {
 
     next = await createNext({
       files: new FileRef(join(__dirname, 'with-proxy')),
-      dependencies: {
-        react: '19.0.0-rc-f994737d14-20240522',
-        'react-dom': '19.0.0-rc-f994737d14-20240522',
-      },
       env: {
         http_proxy: 'http://localhost:' + PROXY_PORT,
       },

--- a/test/e2e/next-script/index.test.ts
+++ b/test/e2e/next-script/index.test.ts
@@ -40,10 +40,6 @@ describe('beforeInteractive in document Head', () => {
           }
         `,
       },
-      dependencies: {
-        react: '19.0.0-rc-f994737d14-20240522',
-        'react-dom': '19.0.0-rc-f994737d14-20240522',
-      },
     })
   })
   afterAll(() => next.destroy())
@@ -99,10 +95,6 @@ describe('beforeInteractive in document body', () => {
             )
           }
         `,
-      },
-      dependencies: {
-        react: '19.0.0-rc-f994737d14-20240522',
-        'react-dom': '19.0.0-rc-f994737d14-20240522',
       },
     })
   })
@@ -161,10 +153,6 @@ describe('empty strategy in document Head', () => {
           }
         `,
       },
-      dependencies: {
-        react: '19.0.0-rc-f994737d14-20240522',
-        'react-dom': '19.0.0-rc-f994737d14-20240522',
-      },
     })
   })
   afterAll(() => next.destroy())
@@ -220,10 +208,6 @@ describe('empty strategy in document body', () => {
           }
         `,
       },
-      dependencies: {
-        react: '19.0.0-rc-f994737d14-20240522',
-        'react-dom': '19.0.0-rc-f994737d14-20240522',
-      },
     })
   })
   afterAll(() => next.destroy())
@@ -266,11 +250,6 @@ describe('empty strategy in document body', () => {
             )
           }
         `,
-          },
-          // TODO: @housseindjirdeh: verify React 18 functionality
-          dependencies: {
-            react: '19.0.0-rc-f994737d14-20240522',
-            'react-dom': '19.0.0-rc-f994737d14-20240522',
           },
         })
       })
@@ -320,8 +299,6 @@ describe('empty strategy in document body', () => {
         `,
           },
           dependencies: {
-            react: '19.0.0-rc-f994737d14-20240522',
-            'react-dom': '19.0.0-rc-f994737d14-20240522',
             '@builder.io/partytown': '0.4.2',
           },
         })
@@ -409,8 +386,6 @@ describe('empty strategy in document body', () => {
       `,
           },
           dependencies: {
-            react: '19.0.0-rc-f994737d14-20240522',
-            'react-dom': '19.0.0-rc-f994737d14-20240522',
             '@builder.io/partytown': '0.4.2',
           },
         })
@@ -525,8 +500,6 @@ describe('empty strategy in document body', () => {
           },
           dependencies: {
             '@builder.io/partytown': '0.4.2',
-            react: '19.0.0-rc-f994737d14-20240522',
-            'react-dom': '19.0.0-rc-f994737d14-20240522',
           },
         })
       })

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -43,10 +43,6 @@ describe('Switchable runtime', () => {
   beforeAll(async () => {
     next = await createNext({
       files: new FileRef(__dirname),
-      dependencies: {
-        react: '19.0.0-rc-f994737d14-20240522',
-        'react-dom': '19.0.0-rc-f994737d14-20240522',
-      },
     })
     context = {
       appPort: next.url,

--- a/test/e2e/transpile-packages/index.test.ts
+++ b/test/e2e/transpile-packages/index.test.ts
@@ -16,8 +16,6 @@ describe('transpile packages', () => {
     next = await createNext({
       files: new FileRef(path.join(__dirname, './npm')),
       dependencies: {
-        react: '19.0.0-rc-f994737d14-20240522',
-        'react-dom': '19.0.0-rc-f994737d14-20240522',
         sass: 'latest',
       },
       packageJson: {

--- a/test/e2e/yarn-pnp/test/utils.ts
+++ b/test/e2e/yarn-pnp/test/utils.ts
@@ -29,6 +29,11 @@ export function runTests(
       const srcFiles = await fs.readdir(srcDir)
 
       const packageJson = await fs.readJson(join(srcDir, 'package.json'))
+      // Use the default versions that are usually used in tests.
+      // Since we replace `next` in the install, we also need to fulfill the peerDependencies.
+      // However, the example specified latest next which may have different peerDependencies that the next that we test here i.e. the next on this commit.
+      delete packageJson.dependencies['react']
+      delete packageJson.dependencies['react-dom']
 
       next = await createNext({
         files: srcFiles.reduce(

--- a/test/e2e/yarn-pnp/test/utils.ts
+++ b/test/e2e/yarn-pnp/test/utils.ts
@@ -43,8 +43,6 @@ export function runTests(
         dependencies: {
           ...packageJson.dependencies,
           ...packageJson.devDependencies,
-          react: '19.0.0-rc-f994737d14-20240522',
-          'react-dom': '19.0.0-rc-f994737d14-20240522',
         },
         installCommand: ({ dependencies }) => {
           const pkgs = Object.keys(dependencies).reduce((prev, cur) => {


### PR DESCRIPTION
The reduces the number of manual replacements one has to do after using `sync-react`.

Flake detection is expected to fail because too many tests were changed.