### PR TITLE
Fix sync-react changelog

### DIFF
--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -145,8 +145,6 @@ Or, run this command with no arguments to use the most recently published versio
     console.log()
   }
 
-  console.log(`Successfully updated React from ${baseSha} to ${newSha}.\n`)
-
   // Fetch the changelog from GitHub and print it to the console.
   try {
     const changelog = await getChangelogFromGitHub(baseSha, newSha)
@@ -178,6 +176,13 @@ Or run this command again without the --no-install flag to do both automatically
     `
     )
   }
+
+  console.log(
+    `Successfully updated React from ${baseSha} to ${newSha}.\n` +
+      `Don't forget to find & replace all references to the React version '${baseVersionStr}' with '${newVersionStr}':\n` +
+      `-${baseVersionStr}\n` +
+      `+${newVersionStr}\n`
+  )
 }
 
 function readBoolArg(argv, argName) {
@@ -189,8 +194,8 @@ function readStringArg(argv, argName) {
   return argIndex === -1 ? null : argv[argIndex + 1]
 }
 
-function extractInfoFromReactVersion(reactCanaryVersion) {
-  const match = reactCanaryVersion.match(
+function extractInfoFromReactVersion(reactVersion) {
+  const match = reactVersion.match(
     /(?<semverVersion>.*)-(?<releaseLabel>.*)-(?<sha>.*)-(?<dateString>.*)$/
   )
   return match ? match.groups : null
@@ -251,8 +256,8 @@ async function getChangelogFromGitHub(baseSha, newSha) {
   return changelog.length > 0 ? changelog.join('\n') : null
 }
 
-sync('rc')
-  .then(() => sync('experimental'))
+sync('experimental')
+  .then(() => sync('rc'))
   .catch((error) => {
     console.error(error)
     process.exit(1)

--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -204,7 +204,7 @@ function extractInfoFromReactVersion(reactVersion) {
 async function getChangelogFromGitHub(baseSha, newSha) {
   const pageSize = 50
   let changelog = []
-  for (let currentPage = 0; ; currentPage++) {
+  for (let currentPage = 1; ; currentPage++) {
     const url = `https://api.github.com/repos/facebook/react/compare/${baseSha}...${newSha}?per_page=${pageSize}&page=${currentPage}`
     const headers = {}
     // GITHUB_TOKEN is optional but helps in case of rate limiting during development.
@@ -221,10 +221,7 @@ async function getChangelogFromGitHub(baseSha, newSha) {
     }
     const data = await response.json()
 
-    const { base_commit, commits } = data
-    if (currentPage === 0) {
-      commits.unshift(base_commit)
-    }
+    const { commits } = data
     for (const { commit, sha } of commits) {
       const title = commit.message.split('\n')[0] || ''
       const match =


### PR DESCRIPTION
Seems like their API either changed or is broken.

But page 0 and 1 are now equal.
We also no longer need to include the base.

## Test plan

- Used new changelog in https://github.com/vercel/next.js/pull/66533