### PR TITLE
Build deterministic server bundles (2nd attempt)

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2428,6 +2428,7 @@ export default async function getBaseWebpackConfig(
   const originalEntry: any = webpackConfig.entry
   if (typeof originalEntry !== 'undefined') {
     const updatedEntry = async () => {
+      const newEntry: webpack.EntryObject = {}
       const entry: webpack.EntryObject =
         typeof originalEntry === 'function'
           ? await originalEntry()
@@ -2441,15 +2442,15 @@ export default async function getBaseWebpackConfig(
         const originalFile = clientEntries[
           CLIENT_STATIC_FILES_RUNTIME_MAIN
         ] as string
-        entry[CLIENT_STATIC_FILES_RUNTIME_MAIN] = [
+        newEntry[CLIENT_STATIC_FILES_RUNTIME_MAIN] = [
           ...entry['main.js'],
           originalFile,
         ]
       }
       delete entry['main.js']
 
-      for (const name of Object.keys(entry)) {
-        entry[name] = finalizeEntrypoint({
+      for (const name of Object.keys(entry).sort()) {
+        newEntry[name] = finalizeEntrypoint({
           value: entry[name],
           compilerType,
           name,
@@ -2457,7 +2458,7 @@ export default async function getBaseWebpackConfig(
         })
       }
 
-      return entry
+      return newEntry
     }
     // @ts-ignore webpack 5 typings needed
     webpackConfig.entry = updatedEntry

--- a/test/production/deterministic-build/index.test.ts
+++ b/test/production/deterministic-build/index.test.ts
@@ -1,3 +1,4 @@
+// TEMP: touch file to trigger "Test new tests for flakes"
 import crypto from 'crypto'
 import { NextInstance, nextTestSetup } from 'e2e-utils'
 


### PR DESCRIPTION
My failed attempt in #66299 to make server bundles deterministic was grounded in an embarrassing misunderstanding of some Webpack internals. Thankfully, @sokra pointed out my wrong assumptions/conclusions [in detail](https://github.com/vercel/next.js/pull/66299#issuecomment-2146797930). This is the most important bit, which pointed me in the right direction:
> The conflict avoidance is deterministic, so you even get deterministic IDs even in case of conflicts. (https://github.com/webpack/webpack/blob/400db90db807d630b6c9f5e7ccde2b8f01690f3b/lib/ids/IdHelpers.js#L386)

More on that in a bit. But first let me comment on this quickly:

> Different IDs might be caused by different identifiers that are hashed.

In my testing, this turned out not to be true. I've observed different module IDs between two builds despite the full list of module identifiers being identical.

Back to the sorting of the modules: This must be deterministic so that module IDs are assigned deterministically even when there are ID collisions. It turns out that in the case of a failed "deterministic build" test, the sorting was indeed different between the two runs.

Here are the details recorded as diffs between the two runs (shown as rows of `"<moduleName>: <moduleId>"`):

<details><summary><code>modulesSortedByPreOrderIndexOrIdentifier</code> (as used in the plugin, shows the different order)</summary>

```diff
--- a/modulesSortedByPreOrderIndexOrIdentifier.json
+++ b/modulesSortedByPreOrderIndexOrIdentifier.json
@@ -47,48 +47,6 @@
   "./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[7].use[0]!./node_modules/.pnpm/styled-jsx@5.1.6_react@19.0.0-rc-f994737d14-20240522/node_modules/styled-jsx/dist/index/index.js: 3037",
   "./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/client-only/index.js: 7361",
   "./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[7].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/strip-ansi/index.js: 3769",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-edge-app-route-loader/index.js?absolutePagePath=private-next-app-dir%2Fapp-route%2Fedge%2Froute.js&page=%2Fapp-route%2Fedge%2Froute&appDirLoader=bmV4dC1hcHAtbG9hZGVyP25hbWU9YXBwJTJGYXBwLXJvdXRlJTJGZWRnZSUyRnJvdXRlJnBhZ2U9JTJGYXBwLXJvdXRlJTJGZWRnZSUyRnJvdXRlJnBhZ2VQYXRoPXByaXZhdGUtbmV4dC1hcHAtZGlyJTJGYXBwLXJvdXRlJTJGZWRnZSUyRnJvdXRlLmpzJmFwcERpcj0lMkZwcml2YXRlJTJGdmFyJTJGZm9sZGVycyUyRnFzJTJGZzJiOTRuZmo3OTUzOGhnXzF5NnQyZzUwMDAwMGduJTJGVCUyRm5leHQtaW5zdGFsbC05ZjRkZDA1MWNmMGM4M2NkZWM1Y2I5MjFiNTEwZmE4MmUxMzhkODcyNmJlNmYwMzI0Zjk0YTAxNmVlMzhmMDk4JTJGYXBwJmFwcFBhdGhzPSUyRmFwcC1yb3V0ZSUyRmVkZ2UlMkZyb3V0ZSZwYWdlRXh0ZW5zaW9ucz10c3gmcGFnZUV4dGVuc2lvbnM9dHMmcGFnZUV4dGVuc2lvbnM9anN4JnBhZ2VFeHRlbnNpb25zPWpzJmJhc2VQYXRoPSZhc3NldFByZWZpeD0mbmV4dENvbmZpZ091dHB1dD0mcHJlZmVycmVkUmVnaW9uPSZtaWRkbGV3YXJlQ29uZmlnPWUzMCUzRCE%3D&nextConfigOutput=&preferredRegion=&middlewareConfig=e30%3D!|rsc|ca2c03f3bffaa547: 4203",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/web/utils.js|rsc: 3439",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/lib/constants.js|rsc: 4970",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/web/spec-extension/cookies.js|rsc: 3409",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/@edge-runtime/cookies/index.js|rsc: 6791",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/web/spec-extension/adapters/reflect.js|rsc: 8440",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/client/components/app-router-headers.js|rsc: 5245",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/shared/lib/modern-browserslist-target.js|rsc: 5262",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/async-storage/request-async-storage-wrapper.js|rsc|fb7e3b95f1c3a0ee: 1698",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/web/spec-extension/adapters/headers.js|rsc: 1829",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/web/spec-extension/adapters/request-cookies.js|rsc: 2371",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/lib/trace/tracer.js|rsc: 3711",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/lib/trace/constants.js|rsc: 9402",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/@opentelemetry/api/index.js|rsc: 6722",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/cookie/index.js|rsc: 8893",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/p-queue/index.js|rsc: 2923",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/shared/lib/invariant-error.js|rsc: 1422",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/experimental/testmode/server-edge.js|rsc: 2909",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/experimental/testmode/context.js|rsc: 4902",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/experimental/testmode/fetch.js|rsc: 4096",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/lru-cache/index.js|rsc: 2509",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/shared/lib/isomorphic/path.js|rsc: 298",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/path-browserify/index.js|rsc: 2922",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/native-url/index.js|rsc: 7560",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/querystring-es3/index.js|rsc: 3413",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/path-to-regexp/index.js|rsc: 4800",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/future/route-modules/app-route/module.compiled.js|rsc: 9255",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/future/route-modules/app-route/module.js|rsc|5912d6217ddb4801: 1859",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/app-render/dynamic-rendering.js|rsc|972f78b85102b4b4: 317",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/react/react.react-server.js|rsc: 1523",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/react/cjs/react.react-server.production.js|rsc: 7647",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/client/components/hooks-server-context.js|rsc: 437",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/client/components/static-generation-bailout.js|rsc: 4486",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/lib/patch-fetch.js|rsc: 3931",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/build/output/log.js|rsc|535519012cda665c: 6093",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[7].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/client/components/action-async-storage.external.js|shared|15d7c78b52a4fca8: 7862",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/build/webpack/loaders/next-flight-loader/module-proxy.js|rsc: 2924",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/react-server-dom-webpack/server.edge.js|rsc: 414",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.production.js|rsc: 5869",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/react-dom/react-dom.react-server.js|rsc: 6502",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/react-dom/cjs/react-dom.react-server.production.js|rsc: 9651",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/future/route-kind.js|rsc: 391",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-edge-ssr-loader/index.js?{\"absolute500Path\":\"\",\"absoluteAppPath\":\"next/dist/pages/_app\",\"absoluteDocumentPath\":\"next/dist/pages/_document\",\"absoluteErrorPath\":\"next/dist/pages/_error\",\"absolutePagePath\":\"private-next-app-dir/app-page/edge/page.js\",\"dev\":false,\"isServerComponent\":true,\"page\":\"/app-page/edge/page\",\"stringifiedConfig\":\"eyJlbnYiOnt9LCJ3ZWJwYWNrIjpudWxsLCJlc2xpbnQiOnsiaWdub3JlRHVyaW5nQnVpbGRzIjpmYWxzZX0sInR5cGVzY3JpcHQiOnsiaWdub3JlQnVpbGRFcnJvcnMiOmZhbHNlLCJ0c2NvbmZpZ1BhdGgiOiJ0c2NvbmZpZy5qc29uIn0sImRpc3REaXIiOiIubmV4dCIsImNsZWFuRGlzdERpciI6dHJ1ZSwiYXNzZXRQcmVmaXgiOiIiLCJjYWNoZU1heE1lbW9yeVNpemUiOjUyNDI4ODAwLCJjb25maWdPcmlnaW4iOiJkZWZhdWx0IiwidXNlRmlsZVN5c3RlbVB1YmxpY1JvdXRlcyI6dHJ1ZSwiZ2VuZXJhdGVFdGFncyI6dHJ1ZSwicGFnZUV4dGVuc2lvbnMiOlsidHN4IiwidHMiLCJqc3giLCJqcyJdLCJwb3dlcmVkQnlIZWFkZXIiOnRydWUsImNvbXByZXNzIjp0cnVlLCJpbWFnZXMiOnsiZGV2aWNlU2l6ZXMiOls2NDAsNzUwLDgyOCwxMDgwLDEyMDAsMTkyMCwyMDQ4LDM4NDBdLCJpbWFnZVNpemVzIjpbMTYsMzIsNDgsNjQsOTYsMTI4LDI1NiwzODRdLCJwYXRoIjoiL19uZXh0L2ltYWdlIiwibG9hZGVyIjoiZGVmYXVsdCIsImxvYWRlckZpbGUiOiIiLCJkb21haW5zIjpbXSwiZGlzYWJsZVN0YXRpY0ltYWdlcyI6ZmFsc2UsIm1pbmltdW1DYWNoZVRUTCI6NjAsImZvcm1hdHMiOlsiaW1hZ2Uvd2VicCJdLCJkYW5nZXJvdXNseUFsbG93U1ZHIjpmYWxzZSwiY29udGVudFNlY3VyaXR5UG9saWN5Ijoic2NyaXB0LXNyYyAnbm9uZSc7IGZyYW1lLXNyYyAnbm9uZSc7IHNhbmRib3g7IiwiY29udGVudERpc3Bvc2l0aW9uVHlwZSI6ImF0dGFjaG1lbnQiLCJyZW1vdGVQYXR0ZXJucyI6W10sInVub3B0aW1pemVkIjpmYWxzZX0sImRldkluZGljYXRvcnMiOnsiYnVpbGRBY3Rpdml0eSI6dHJ1ZSwiYnVpbGRBY3Rpdml0eVBvc2l0aW9uIjoiYm90dG9tLXJpZ2h0In0sIm9uRGVtYW5kRW50cmllcyI6eyJtYXhJbmFjdGl2ZUFnZSI6NjAwMDAsInBhZ2VzQnVmZmVyTGVuZ3RoIjo1fSwiYW1wIjp7ImNhbm9uaWNhbEJhc2UiOiIifSwiYmFzZVBhdGgiOiIiLCJzYXNzT3B0aW9ucyI6e30sInRyYWlsaW5nU2xhc2giOmZhbHNlLCJpMThuIjpudWxsLCJwcm9kdWN0aW9uQnJvd3NlclNvdXJjZU1hcHMiOmZhbHNlLCJvcHRpbWl6ZUZvbnRzIjp0cnVlLCJleGNsdWRlRGVmYXVsdE1vbWVudExvY2FsZXMiOnRydWUsInNlcnZlclJ1bnRpbWVDb25maWciOnt9LCJwdWJsaWNSdW50aW1lQ29uZmlnIjp7fSwicmVhY3RQcm9kdWN0aW9uUHJvZmlsaW5nIjpmYWxzZSwicmVhY3RTdHJpY3RNb2RlIjpudWxsLCJodHRwQWdlbnRPcHRpb25zIjp7ImtlZXBBbGl2ZSI6dHJ1ZX0sInN0YXRpY1BhZ2VHZW5lcmF0aW9uVGltZW91dCI6NjAsIm1vZHVsYXJpemVJbXBvcnRzIjp7IkBtdWkvaWNvbnMtbWF0ZXJpYWwiOnsidHJhbnNmb3JtIjoiQG11aS9pY29ucy1tYXRlcmlhbC97e21lbWJlcn19In0sImxvZGFzaCI6eyJ0cmFuc2Zvcm0iOiJsb2Rhc2gve3ttZW1iZXJ9fSJ9fSwiZXhwZXJpbWVudGFsIjp7ImZseWluZ1NodXR0bGUiOmZhbHNlLCJwcmVyZW5kZXJFYXJseUV4aXQiOnRydWUsInNlcnZlck1pbmlmaWNhdGlvbiI6dHJ1ZSwic2VydmVyU291cmNlTWFwcyI6ZmFsc2UsImxpbmtOb1RvdWNoU3RhcnQiOmZhbHNlLCJjYXNlU2Vuc2l0aXZlUm91dGVzIjpmYWxzZSwicHJlbG9hZEVudHJpZXNPblN0YXJ0Ijp0cnVlLCJjbGllbnRSb3V0ZXJGaWx0ZXIiOnRydWUsImNsaWVudFJvdXRlckZpbHRlclJlZGlyZWN0cyI6ZmFsc2UsImZldGNoQ2FjaGVLZXlQcmVmaXgiOiIiLCJtaWRkbGV3YXJlUHJlZmV0Y2giOiJmbGV4aWJsZSIsIm9wdGltaXN0aWNDbGllbnRDYWNoZSI6dHJ1ZSwibWFudWFsQ2xpZW50QmFzZVBhdGgiOmZhbHNlLCJjcHVzIjoxMSwibWVtb3J5QmFzZWRXb3JrZXJzQ291bnQiOmZhbHNlLCJpc3JGbHVzaFRvRGlzayI6dHJ1ZSwid29ya2VyVGhyZWFkcyI6ZmFsc2UsIm9wdGltaXplQ3NzIjpmYWxzZSwibmV4dFNjcmlwdFdvcmtlcnMiOmZhbHNlLCJzY3JvbGxSZXN0b3JhdGlvbiI6ZmFsc2UsImV4dGVybmFsRGlyIjpmYWxzZSwiZGlzYWJsZU9wdGltaXplZExvYWRpbmciOmZhbHNlLCJnemlwU2l6ZSI6dHJ1ZSwiY3JhQ29tcGF0IjpmYWxzZSwiZXNtRXh0ZXJuYWxzIjp0cnVlLCJmdWxseVNwZWNpZmllZCI6ZmFsc2UsIm91dHB1dEZpbGVUcmFjaW5nUm9vdCI6Ii9wcml2YXRlL3Zhci9mb2xkZXJzL3FzL2cyYjk0bmZqNzk1MzhoZ18xeTZ0Mmc1MDAwMDBnbi9UL25leHQtaW5zdGFsbC05ZjRkZDA1MWNmMGM4M2NkZWM1Y2I5MjFiNTEwZmE4MmUxMzhkODcyNmJlNmYwMzI0Zjk0YTAxNmVlMzhmMDk4Iiwic3djVHJhY2VQcm9maWxpbmciOmZhbHNlLCJmb3JjZVN3Y1RyYW5zZm9ybXMiOmZhbHNlLCJsYXJnZVBhZ2VEYXRhQnl0ZXMiOjEyODAwMCwiYWRqdXN0Rm9udEZhbGxiYWNrcyI6ZmFsc2UsImFkanVzdEZvbnRGYWxsYmFja3NXaXRoU2l6ZUFkanVzdCI6ZmFsc2UsInR5cGVkUm91dGVzIjpmYWxzZSwiaW5zdHJ1bWVudGF0aW9uSG9vayI6ZmFsc2UsInBhcmFsbGVsU2VydmVyQ29tcGlsZXMiOmZhbHNlLCJwYXJhbGxlbFNlcnZlckJ1aWxkVHJhY2VzIjpmYWxzZSwicHByIjpmYWxzZSwid2VicGFja01lbW9yeU9wdGltaXphdGlvbnMiOmZhbHNlLCJvcHRpbWl6ZVNlcnZlclJlYWN0Ijp0cnVlLCJ1c2VFYXJseUltcG9ydCI6ZmFsc2UsInN0YWxlVGltZXMiOnsiZHluYW1pYyI6MCwic3RhdGljIjozMDB9LCJhZnRlciI6ZmFsc2UsIm9wdGltaXplUGFja2FnZUltcG9ydHMiOlsibHVjaWRlLXJlYWN0IiwiZGF0ZS1mbnMiLCJsb2Rhc2gtZXMiLCJyYW1kYSIsImFudGQiLCJyZWFjdC1ib290c3RyYXAiLCJhaG9va3MiLCJAYW50LWRlc2lnbi9pY29ucyIsIkBoZWFkbGVzc3VpL3JlYWN0IiwiQGhlYWRsZXNzdWktZmxvYXQvcmVhY3QiLCJAaGVyb2ljb25zL3JlYWN0LzIwL3NvbGlkIiwiQGhlcm9pY29ucy9yZWFjdC8yNC9zb2xpZCIsIkBoZXJvaWNvbnMvcmVhY3QvMjQvb3V0bGluZSIsIkB2aXN4L3Zpc3giLCJAdHJlbW9yL3JlYWN0IiwicnhqcyIsIkBtdWkvbWF0ZXJpYWwiLCJAbXVpL2ljb25zLW1hdGVyaWFsIiwicmVjaGFydHMiLCJyZWFjdC11c2UiLCJlZmZlY3QiLCJAZWZmZWN0L3NjaGVtYSIsIkBlZmZlY3QvcGxhdGZvcm0iLCJAZWZmZWN0L3BsYXRmb3JtLW5vZGUiLCJAZWZmZWN0L3BsYXRmb3JtLWJyb3dzZXIiLCJAZWZmZWN0L3BsYXRmb3JtLWJ1biIsIkBlZmZlY3Qvc3FsIiwiQGVmZmVjdC9zcWwtbXNzcWwiLCJAZWZmZWN0L3NxbC1teXNxbDIiLCJAZWZmZWN0L3NxbC1wZyIsIkBlZmZlY3Qvc3FsLXNxdWxpdGUtbm9kZSIsIkBlZmZlY3Qvc3FsLXNxdWxpdGUtYnVuIiwiQGVmZmVjdC9zcWwtc3F1bGl0ZS13YXNtIiwiQGVmZmVjdC9zcWwtc3F1bGl0ZS1yZWFjdC1uYXRpdmUiLCJAZWZmZWN0L3JwYyIsIkBlZmZlY3QvcnBjLWh0dHAiLCJAZWZmZWN0L3R5cGVjbGFzcyIsIkBlZmZlY3QvZXhwZXJpbWVudGFsIiwiQGVmZmVjdC9vcGVudGVsZW1ldHJ5IiwiQG1hdGVyaWFsLXVpL2NvcmUiLCJAbWF0ZXJpYWwtdWkvaWNvbnMiLCJAdGFibGVyL2ljb25zLXJlYWN0IiwibXVpLWNvcmUiLCJyZWFjdC1pY29ucy9haSIsInJlYWN0LWljb25zL2JpIiwicmVhY3QtaWNvbnMvYnMiLCJyZWFjdC1pY29ucy9jZyIsInJlYWN0LWljb25zL2NpIiwicmVhY3QtaWNvbnMvZGkiLCJyZWFjdC1pY29ucy9mYSIsInJlYWN0LWljb25zL2ZhNiIsInJlYWN0LWljb25zL2ZjIiwicmVhY3QtaWNvbnMvZmkiLCJyZWFjdC1pY29ucy9naSIsInJlYWN0LWljb25zL2dvIiwicmVhY3QtaWNvbnMvZ3IiLCJyZWFjdC1pY29ucy9oaSIsInJlYWN0LWljb25zL2hpMiIsInJlYWN0LWljb25zL2ltIiwicmVhY3QtaWNvbnMvaW8iLCJyZWFjdC1pY29ucy9pbzUiLCJyZWFjdC1pY29ucy9saWEiLCJyZWFjdC1pY29ucy9saWIiLCJyZWFjdC1pY29ucy9sdSIsInJlYWN0LWljb25zL21kIiwicmVhY3QtaWNvbnMvcGkiLCJyZWFjdC1pY29ucy9yaSIsInJlYWN0LWljb25zL3J4IiwicmVhY3QtaWNvbnMvc2kiLCJyZWFjdC1pY29ucy9zbCIsInJlYWN0LWljb25zL3RiIiwicmVhY3QtaWNvbnMvdGZpIiwicmVhY3QtaWNvbnMvdGkiLCJyZWFjdC1pY29ucy92c2MiLCJyZWFjdC1pY29ucy93aSJdfSwiYnVuZGxlUGFnZXNSb3V0ZXJEZXBlbmRlbmNpZXMiOmZhbHNlLCJjb25maWdGaWxlTmFtZSI6Im5leHQuY29uZmlnLmpzIn0=\",\"pagesType\":\"app\",\"appDirLoader\":\"bmV4dC1hcHAtbG9hZGVyP25hbWU9YXBwJTJGYXBwLXBhZ2UlMkZlZGdlJTJGcGFnZSZwYWdlPSUyRmFwcC1wYWdlJTJGZWRnZSUyRnBhZ2UmcGFnZVBhdGg9cHJpdmF0ZS1uZXh0LWFwcC1kaXIlMkZhcHAtcGFnZSUyRmVkZ2UlMkZwYWdlLmpzJmFwcERpcj0lMkZwcml2YXRlJTJGdmFyJTJGZm9sZGVycyUyRnFzJTJGZzJiOTRuZmo3OTUzOGhnXzF5NnQyZzUwMDAwMGduJTJGVCUyRm5leHQtaW5zdGFsbC05ZjRkZDA1MWNmMGM4M2NkZWM1Y2I5MjFiNTEwZmE4MmUxMzhkODcyNmJlNmYwMzI0Zjk0YTAxNmVlMzhmMDk4JTJGYXBwJmFwcFBhdGhzPSUyRmFwcC1wYWdlJTJGZWRnZSUyRnBhZ2UmcGFnZUV4dGVuc2lvbnM9dHN4JnBhZ2VFeHRlbnNpb25zPXRzJnBhZ2VFeHRlbnNpb25zPWpzeCZwYWdlRXh0ZW5zaW9ucz1qcyZiYXNlUGF0aD0mYXNzZXRQcmVmaXg9Jm5leHRDb25maWdPdXRwdXQ9JnByZWZlcnJlZFJlZ2lvbj0mbWlkZGxld2FyZUNvbmZpZz1lMzAlM0Qh\",\"sriEnabled\":false,\"middlewareConfig\":\"e30=\"}!|ssr|e712fb3bda90b9ba: 4068",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-client-module-loader.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[6].use[1]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/web/error.js|ssr: 712",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-client-module-loader.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[6].use[1]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/web/utils.js|ssr: 2935",
@@ -160,6 +118,7 @@
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-client-module-loader.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[6].use[1]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/client/components/hooks-server-context.js|ssr: 6129",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-client-module-loader.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[6].use[1]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/client/components/static-generation-bailout.js|ssr: 6749",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-client-module-loader.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[6].use[1]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/client/components/redirect.js|ssr: 8876",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[7].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/client/components/action-async-storage.external.js|shared|15d7c78b52a4fca8: 7862",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-client-module-loader.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[6].use[1]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/string-hash/index.js|ssr: 8927",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-client-module-loader.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[6].use[1]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/shared/lib/lazy-dynamic/bailout-to-csr.js|ssr: 2711",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-client-module-loader.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[6].use[1]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/export/helpers/is-navigation-signal-error.js|ssr: 9125",
@@ -180,6 +139,26 @@
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-client-module-loader.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[6].use[1]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/future/route-modules/app-page/module.js|ssr|fdcb0955f0061e1a: 7752",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-client-module-loader.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[6].use[1]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/shared/lib/app-router-context.shared-runtime.js|ssr: 7569",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-client-module-loader.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[6].use[1]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/shared/lib/hooks-client-context.shared-runtime.js|ssr: 7236",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/future/route-kind.js|rsc: 391",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/build/webpack/loaders/next-flight-loader/module-proxy.js|rsc: 2924",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/react-server-dom-webpack/server.edge.js|rsc: 414",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.production.js|rsc: 5869",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/react-dom/react-dom.react-server.js|rsc: 6502",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/react-dom/cjs/react-dom.react-server.production.js|rsc: 9651",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/react/react.react-server.js|rsc: 1523",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/react/cjs/react.react-server.production.js|rsc: 7647",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/app-render/dynamic-rendering.js|rsc|972f78b85102b4b4: 317",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/client/components/hooks-server-context.js|rsc: 437",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/client/components/static-generation-bailout.js|rsc: 4486",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/client/components/app-router-headers.js|rsc: 5245",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/web/spec-extension/adapters/reflect.js|rsc: 8440",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/lib/patch-fetch.js|rsc: 3931",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/lib/trace/constants.js|rsc: 9402",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/lib/trace/tracer.js|rsc: 3711",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/@opentelemetry/api/index.js|rsc: 6722",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/lib/constants.js|rsc: 3439",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/build/output/log.js|rsc|535519012cda665c: 6093",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/shared/lib/invariant-error.js|rsc: 1422",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./app/app-page/edge/page.js|rsc: 2476",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./app/layout.js|rsc: 2062",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/react/jsx-runtime.react-server.js|rsc: 9411",
@@ -201,5 +180,26 @@
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-client-module-loader.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[6].use[1]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/client/components/layout-router.js|ssr|692069f9cbce605d: 6503",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-client-module-loader.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[6].use[1]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/client/components/not-found-boundary.js|ssr: 7482",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-client-module-loader.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[6].use[1]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/client/components/render-from-template-context.js|ssr: 6212",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-client-entry-loader.js?server=true!|ssr: 1238"
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-client-entry-loader.js?server=true!|ssr: 1238",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-edge-app-route-loader/index.js?absolutePagePath=private-next-app-dir%2Fapp-route%2Fedge%2Froute.js&page=%2Fapp-route%2Fedge%2Froute&appDirLoader=bmV4dC1hcHAtbG9hZGVyP25hbWU9YXBwJTJGYXBwLXJvdXRlJTJGZWRnZSUyRnJvdXRlJnBhZ2U9JTJGYXBwLXJvdXRlJTJGZWRnZSUyRnJvdXRlJnBhZ2VQYXRoPXByaXZhdGUtbmV4dC1hcHAtZGlyJTJGYXBwLXJvdXRlJTJGZWRnZSUyRnJvdXRlLmpzJmFwcERpcj0lMkZwcml2YXRlJTJGdmFyJTJGZm9sZGVycyUyRnFzJTJGZzJiOTRuZmo3OTUzOGhnXzF5NnQyZzUwMDAwMGduJTJGVCUyRm5leHQtaW5zdGFsbC05ZjRkZDA1MWNmMGM4M2NkZWM1Y2I5MjFiNTEwZmE4MmUxMzhkODcyNmJlNmYwMzI0Zjk0YTAxNmVlMzhmMDk4JTJGYXBwJmFwcFBhdGhzPSUyRmFwcC1yb3V0ZSUyRmVkZ2UlMkZyb3V0ZSZwYWdlRXh0ZW5zaW9ucz10c3gmcGFnZUV4dGVuc2lvbnM9dHMmcGFnZUV4dGVuc2lvbnM9anN4JnBhZ2VFeHRlbnNpb25zPWpzJmJhc2VQYXRoPSZhc3NldFByZWZpeD0mbmV4dENvbmZpZ091dHB1dD0mcHJlZmVycmVkUmVnaW9uPSZtaWRkbGV3YXJlQ29uZmlnPWUzMCUzRCE%3D&nextConfigOutput=&preferredRegion=&middlewareConfig=e30%3D!|rsc|ca2c03f3bffaa547: 4203",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/web/utils.js|rsc: 5316",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/web/spec-extension/cookies.js|rsc: 3409",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/@edge-runtime/cookies/index.js|rsc: 6791",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/shared/lib/modern-browserslist-target.js|rsc: 5262",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/async-storage/request-async-storage-wrapper.js|rsc|fb7e3b95f1c3a0ee: 1698",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/web/spec-extension/adapters/headers.js|rsc: 1829",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/web/spec-extension/adapters/request-cookies.js|rsc: 2371",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/cookie/index.js|rsc: 8893",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/p-queue/index.js|rsc: 2923",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/experimental/testmode/server-edge.js|rsc: 2909",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/experimental/testmode/context.js|rsc: 4902",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/experimental/testmode/fetch.js|rsc: 4096",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/lru-cache/index.js|rsc: 2509",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/shared/lib/isomorphic/path.js|rsc: 298",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/path-browserify/index.js|rsc: 2922",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/native-url/index.js|rsc: 7560",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/querystring-es3/index.js|rsc: 3413",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/compiled/path-to-regexp/index.js|rsc: 4800",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/future/route-modules/app-route/module.compiled.js|rsc: 9255",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/future/route-modules/app-route/module.js|rsc|5912d6217ddb4801: 1859"
 ]
```
</details>

<details><summary><code>modulesSortedByName</code> (shows the effect: two module IDs changed)</summary>

```diff
--- a/modulesSortedByName.json
+++ b/modulesSortedByName.json
@@ -174,7 +174,7 @@
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/client/components/hooks-server-context.js|rsc: 437",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/client/components/not-found-error.js|rsc: 6887",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/client/components/static-generation-bailout.js|rsc: 4486",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/lib/constants.js|rsc: 4970",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/lib/constants.js|rsc: 3439",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/app-render/dynamic-rendering.js|rsc|972f78b85102b4b4: 317",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/async-storage/request-async-storage-wrapper.js|rsc|fb7e3b95f1c3a0ee: 1698",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/future/route-kind.js|rsc: 391",
@@ -188,7 +188,7 @@
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/web/spec-extension/adapters/reflect.js|rsc: 8440",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/web/spec-extension/adapters/request-cookies.js|rsc: 2371",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/web/spec-extension/cookies.js|rsc: 3409",
-  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/web/utils.js|rsc: 3439",
+  "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/server/web/utils.js|rsc: 5316",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/shared/lib/invariant-error.js|rsc: 1422",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/shared/lib/isomorphic/path.js|rsc: 298",
   "javascript/auto|./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/build/webpack/loaders/next-swc-loader.js??ruleSet[1].rules[19].oneOf[3].use[0]!./node_modules/.pnpm/file+..+tmpdirname/node_modules/next/dist/esm/shared/lib/modern-browserslist-target.js|rsc: 5262",
```
</details>

And notably, the `compilation.entries` were in a different order:

```diff
--- a/entries.json
+++ b/entries.json
@@ -1,6 +1,6 @@
 [
   "pages/api/pages-api/edge",
   "pages/pages-page/edge",
-  "app/app-route/edge/route",
-  "app/app-page/edge/page"
+  "app/app-page/edge/page",
+  "app/app-route/edge/route"
 ]
```

Without being too familiar with the Webpack internals, my understanding is that the order of the entries has an effect on how the `preOrderIndex` for each module is set in the module graph of the compilation. And the `preOrderIndex` controls the result of `compareModulesByPreOrderIndexOrIdentifier` which is used to sort the modules in the `DeterministicModuleIdsPlugin`.

Therefore, my conclusion is to try to make the order of the entries deterministic. Webpack allows either an array of strings for the `entry` config, or an object, but not an array of objects. So I think the only solution to fix this on our site is to ensure that the insertion order into the entry object is deterministic. We can accomplish that by not modifying the original object in `updatedEntry`, but creating a new one instead.

With the fix, I ran the test 10 times in a loop without a failure. Without the fix, the test usually fails after only a few runs.

I hope I didn't make another wrong assumption along the way, but if I did, please point it out!