### PR TITLE
Add playwright-core to server-external-packages.json

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/serverExternalPackages.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/serverExternalPackages.mdx
@@ -58,6 +58,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `oslo`
 - `pg`
 - `playwright`
+- `playwright-core`
 - `postcss`
 - `prettier`
 - `prisma`

--- a/docs/03-pages/02-api-reference/03-next-config-js/serverExternalPackages.mdx
+++ b/docs/03-pages/02-api-reference/03-next-config-js/serverExternalPackages.mdx
@@ -58,6 +58,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `oslo`
 - `pg`
 - `playwright`
+- `playwright-core`
 - `postcss`
 - `prettier`
 - `prisma`

--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -39,6 +39,7 @@
   "oslo",
   "pg",
   "playwright",
+  "playwright-core",
   "postcss",
   "prettier",
   "prisma",


### PR DESCRIPTION
Related to https://github.com/vercel/next.js/pull/62063, this change adds playwright-core to the server-external-packages.json. Playwright-core is a very popular library doesn't currently bundle with NextJS. 