### PR TITLE
fix NextRequest proxy in edge runtime

### DIFF
--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -55,6 +55,7 @@ import { cleanURL } from './helpers/clean-url'
 import { StaticGenBailoutError } from '../../../client/components/static-generation-bailout'
 import { isStaticGenEnabled } from './helpers/is-static-gen-enabled'
 import { trackDynamicDataAccessed } from '../../app-render/dynamic-rendering'
+import { ReflectAdapter } from '../../web/spec-extension/adapters/reflect'
 
 /**
  * The AppRouteModule is the type of the module exported by the bundled App
@@ -598,11 +599,7 @@ const forceStaticRequestHandlers = {
             ))
         )
       default:
-        const result = Reflect.get(target, prop, receiver)
-        if (typeof result === 'function') {
-          return result.bind(target)
-        }
-        return result
+        return ReflectAdapter.get(target, prop, receiver)
     }
   },
   // We don't need to proxy set because all the properties we proxy are ready only
@@ -649,11 +646,7 @@ const forceStaticNextUrlHandlers = {
             new Proxy(target.clone(), forceStaticNextUrlHandlers))
         )
       default:
-        const result = Reflect.get(target, prop, receiver)
-        if (typeof result === 'function') {
-          return result.bind(target)
-        }
-        return result
+        return ReflectAdapter.get(target, prop, receiver)
     }
   },
 }
@@ -677,11 +670,7 @@ function proxyNextRequest(
         case 'toString':
         case 'origin': {
           trackDynamicDataAccessed(staticGenerationStore, `nextUrl.${prop}`)
-          const result = Reflect.get(target, prop, receiver)
-          if (typeof result === 'function') {
-            return result.bind(target)
-          }
-          return result
+          return ReflectAdapter.get(target, prop, receiver)
         }
         case 'clone':
           return (
@@ -690,11 +679,7 @@ function proxyNextRequest(
               new Proxy(target.clone(), nextUrlHandlers))
           )
         default:
-          const result = Reflect.get(target, prop, receiver)
-          if (typeof result === 'function') {
-            return result.bind(target)
-          }
-          return result
+          return ReflectAdapter.get(target, prop, receiver)
       }
     },
   }
@@ -702,8 +687,7 @@ function proxyNextRequest(
   const nextRequestHandlers = {
     get(
       target: NextRequest & RequestSymbolTarget,
-      prop: string | symbol,
-      receiver: any
+      prop: string | symbol
     ): unknown {
       switch (prop) {
         case 'nextUrl':
@@ -721,12 +705,10 @@ function proxyNextRequest(
         case 'arrayBuffer':
         case 'formData': {
           trackDynamicDataAccessed(staticGenerationStore, `request.${prop}`)
-
-          const result = Reflect.get(target, prop, receiver)
-          if (typeof result === 'function') {
-            return result.bind(target)
-          }
-          return result
+          // The receiver arg is intentionally the same as the target to fix an issue with
+          // edge runtime, where attempting to access internal slots with the wrong `this` context
+          // results in an error.
+          return ReflectAdapter.get(target, prop, target)
         }
         case 'clone':
           return (
@@ -745,11 +727,10 @@ function proxyNextRequest(
               ))
           )
         default:
-          const result = Reflect.get(target, prop, receiver)
-          if (typeof result === 'function') {
-            return result.bind(target)
-          }
-          return result
+          // The receiver arg is intentionally the same as the target to fix an issue with
+          // edge runtime, where attempting to access internal slots with the wrong `this` context
+          // results in an error.
+          return ReflectAdapter.get(target, prop, target)
       }
     },
     // We don't need to proxy set because all the properties we proxy are ready only
@@ -803,11 +784,7 @@ const requireStaticRequestHandlers = {
             ))
         )
       default:
-        const result = Reflect.get(target, prop, receiver)
-        if (typeof result === 'function') {
-          return result.bind(target)
-        }
-        return result
+        return ReflectAdapter.get(target, prop, receiver)
     }
   },
   // We don't need to proxy set because all the properties we proxy are ready only
@@ -838,11 +815,7 @@ const requireStaticNextUrlHandlers = {
             new Proxy(target.clone(), requireStaticNextUrlHandlers))
         )
       default:
-        const result = Reflect.get(target, prop, receiver)
-        if (typeof result === 'function') {
-          return result.bind(target)
-        }
-        return result
+        return ReflectAdapter.get(target, prop, receiver)
     }
   },
 }


### PR DESCRIPTION
Properties such as the native `Headers` / `Cookies` on the `NextRequest` proxy make use of internal slots, so passing `receiver` (the proxy object) which does not have the internal slots on it causes an issue in the edge runtime. Instead, we want to make sure that the target is the native object. This is similar to https://github.com/vercel/next.js/pull/47088.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
