### PR TITLE
Remove lazyDataResolved flag

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -188,7 +188,6 @@ export function createEmptyCacheNode(): CacheNode {
     prefetchLayerAssets: null,
     prefetchHead: null,
     parallelRoutes: new Map(),
-    lazyDataResolved: false,
     loading: null,
   }
 }

--- a/packages/next/src/client/components/router-reducer/clear-cache-node-data-for-segment-path.test.tsx
+++ b/packages/next/src/client/components/router-reducer/clear-cache-node-data-for-segment-path.test.tsx
@@ -21,7 +21,6 @@ describe('clearCacheNodeDataForSegmentPath', () => {
       prefetchLayerAssets: null,
       prefetchHead: null,
       parallelRoutes: new Map(),
-      lazyDataResolved: false,
       loading: null,
     }
     const existingCache: CacheNode = {
@@ -32,7 +31,6 @@ describe('clearCacheNodeDataForSegmentPath', () => {
       layerAssets: null,
       prefetchLayerAssets: null,
       prefetchHead: null,
-      lazyDataResolved: false,
       loading: null,
       parallelRoutes: new Map([
         [
@@ -44,7 +42,6 @@ describe('clearCacheNodeDataForSegmentPath', () => {
                 lazyData: null,
                 rsc: <>Linking</>,
                 prefetchRsc: null,
-                lazyDataResolved: false,
                 head: null,
                 layerAssets: null,
                 prefetchLayerAssets: null,
@@ -65,7 +62,6 @@ describe('clearCacheNodeDataForSegmentPath', () => {
                           prefetchLayerAssets: null,
                           prefetchHead: null,
                           parallelRoutes: new Map(),
-                          lazyDataResolved: false,
                           loading: null,
                         },
                       ],
@@ -86,7 +82,6 @@ describe('clearCacheNodeDataForSegmentPath', () => {
         "head": null,
         "layerAssets": null,
         "lazyData": null,
-        "lazyDataResolved": false,
         "loading": null,
         "parallelRoutes": Map {
           "children" => Map {
@@ -94,7 +89,6 @@ describe('clearCacheNodeDataForSegmentPath', () => {
               "head": null,
               "layerAssets": null,
               "lazyData": null,
-              "lazyDataResolved": false,
               "loading": null,
               "parallelRoutes": Map {
                 "children" => Map {
@@ -102,7 +96,6 @@ describe('clearCacheNodeDataForSegmentPath', () => {
                     "head": null,
                     "layerAssets": null,
                     "lazyData": null,
-                    "lazyDataResolved": false,
                     "loading": null,
                     "parallelRoutes": Map {},
                     "prefetchHead": null,
@@ -125,7 +118,6 @@ describe('clearCacheNodeDataForSegmentPath', () => {
               "head": null,
               "layerAssets": null,
               "lazyData": null,
-              "lazyDataResolved": false,
               "loading": null,
               "parallelRoutes": Map {},
               "prefetchHead": null,

--- a/packages/next/src/client/components/router-reducer/clear-cache-node-data-for-segment-path.ts
+++ b/packages/next/src/client/components/router-reducer/clear-cache-node-data-for-segment-path.ts
@@ -44,7 +44,6 @@ export function clearCacheNodeDataForSegmentPath(
         prefetchLayerAssets: null,
         prefetchHead: null,
         parallelRoutes: new Map(),
-        lazyDataResolved: false,
         loading: null,
       })
     }
@@ -63,7 +62,6 @@ export function clearCacheNodeDataForSegmentPath(
         prefetchLayerAssets: null,
         prefetchHead: null,
         parallelRoutes: new Map(),
-        lazyDataResolved: false,
         loading: null,
       })
     }
@@ -80,7 +78,6 @@ export function clearCacheNodeDataForSegmentPath(
       prefetchLayerAssets: childCacheNode.prefetchLayerAssets,
       prefetchHead: childCacheNode.prefetchHead,
       parallelRoutes: new Map(childCacheNode.parallelRoutes),
-      lazyDataResolved: childCacheNode.lazyDataResolved,
       loading: childCacheNode.loading,
     } as CacheNode
     childSegmentMap.set(cacheKey, childCacheNode)

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
@@ -64,7 +64,6 @@ describe('createInitialRouterState', () => {
       layerAssets: null,
       prefetchLayerAssets: null,
       prefetchHead: null,
-      lazyDataResolved: false,
       loading: null,
       parallelRoutes: new Map([
         [
@@ -89,7 +88,6 @@ describe('createInitialRouterState', () => {
                           layerAssets: null,
                           prefetchLayerAssets: null,
                           prefetchHead: null,
-                          lazyDataResolved: false,
                         },
                       ],
                     ]),
@@ -102,7 +100,6 @@ describe('createInitialRouterState', () => {
                 layerAssets: null,
                 prefetchLayerAssets: null,
                 prefetchHead: null,
-                lazyDataResolved: false,
                 loading: null,
               },
             ],

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -49,7 +49,6 @@ export function createInitialRouterState({
     prefetchHead: null,
     // The cache gets seeded during the first render. `initialParallelRoutes` ensures the cache from the first render is there during the second render.
     parallelRoutes: isServer ? new Map() : initialParallelRoutes,
-    lazyDataResolved: false,
     loading: initialSeedData[3],
   }
 

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
@@ -36,7 +36,6 @@ describe('fillCacheWithNewSubtreeData', () => {
       prefetchHead: null,
       loading: null,
       parallelRoutes: new Map(),
-      lazyDataResolved: false,
     }
     const existingCache: CacheNode = {
       lazyData: null,
@@ -46,7 +45,6 @@ describe('fillCacheWithNewSubtreeData', () => {
       layerAssets: null,
       prefetchLayerAssets: null,
       prefetchHead: null,
-      lazyDataResolved: false,
       loading: null,
       parallelRoutes: new Map([
         [
@@ -62,7 +60,6 @@ describe('fillCacheWithNewSubtreeData', () => {
                 layerAssets: null,
                 prefetchLayerAssets: null,
                 prefetchHead: null,
-                lazyDataResolved: false,
                 loading: null,
                 parallelRoutes: new Map([
                   [
@@ -78,7 +75,6 @@ describe('fillCacheWithNewSubtreeData', () => {
                           layerAssets: null,
                           prefetchLayerAssets: null,
                           prefetchHead: null,
-                          lazyDataResolved: false,
                           loading: null,
                           parallelRoutes: new Map(),
                         },
@@ -112,7 +108,6 @@ describe('fillCacheWithNewSubtreeData', () => {
       layerAssets: null,
       prefetchLayerAssets: null,
       prefetchHead: null,
-      lazyDataResolved: false,
       loading: null,
       parallelRoutes: new Map([
         [
@@ -128,7 +123,6 @@ describe('fillCacheWithNewSubtreeData', () => {
                 layerAssets: null,
                 prefetchLayerAssets: null,
                 prefetchHead: null,
-                lazyDataResolved: false,
                 loading: null,
                 parallelRoutes: new Map([
                   [
@@ -145,7 +139,6 @@ describe('fillCacheWithNewSubtreeData', () => {
                           layerAssets: null,
                           prefetchLayerAssets: null,
                           prefetchHead: null,
-                          lazyDataResolved: false,
                           loading: null,
                           parallelRoutes: new Map(),
                         },
@@ -154,7 +147,6 @@ describe('fillCacheWithNewSubtreeData', () => {
                         'about',
                         {
                           lazyData: null,
-                          lazyDataResolved: false,
                           head: null,
                           layerAssets: null,
                           prefetchLayerAssets: null,

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
@@ -63,7 +63,6 @@ export function fillCacheWithNewSubTreeData(
         parallelRoutes: existingChildCacheNode
           ? new Map(existingChildCacheNode.parallelRoutes)
           : new Map(),
-        lazyDataResolved: false,
       }
 
       if (existingChildCacheNode) {
@@ -105,7 +104,6 @@ export function fillCacheWithNewSubTreeData(
       prefetchLayerAssets: childCacheNode.prefetchLayerAssets,
       prefetchHead: childCacheNode.prefetchHead,
       parallelRoutes: new Map(childCacheNode.parallelRoutes),
-      lazyDataResolved: false,
       loading: childCacheNode.loading,
     } as CacheNode
     childSegmentMap.set(cacheKey, childCacheNode)

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
@@ -44,7 +44,6 @@ describe('fillLazyItemsTillLeafWithHead', () => {
       prefetchLayerAssets: null,
       prefetchHead: null,
       parallelRoutes: new Map(),
-      lazyDataResolved: false,
       loading: null,
     }
     const existingCache: CacheNode = {
@@ -55,7 +54,6 @@ describe('fillLazyItemsTillLeafWithHead', () => {
       layerAssets: null,
       prefetchLayerAssets: null,
       prefetchHead: null,
-      lazyDataResolved: false,
       loading: null,
       parallelRoutes: new Map([
         [
@@ -71,7 +69,6 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                 layerAssets: null,
                 prefetchLayerAssets: null,
                 prefetchHead: null,
-                lazyDataResolved: false,
                 loading: null,
                 parallelRoutes: new Map([
                   [
@@ -87,7 +84,6 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                           layerAssets: null,
                           prefetchLayerAssets: null,
                           prefetchHead: null,
-                          lazyDataResolved: false,
                           loading: null,
                           parallelRoutes: new Map(),
                         },
@@ -128,7 +124,6 @@ describe('fillLazyItemsTillLeafWithHead', () => {
       layerAssets: null,
       prefetchLayerAssets: null,
       prefetchHead: null,
-      lazyDataResolved: false,
       loading: null,
       parallelRoutes: new Map([
         [
@@ -144,7 +139,6 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                 layerAssets: null,
                 prefetchLayerAssets: null,
                 prefetchHead: null,
-                lazyDataResolved: false,
                 loading: null,
                 parallelRoutes: new Map([
                   [
@@ -154,7 +148,6 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                         'about',
                         {
                           lazyData: null,
-                          lazyDataResolved: false,
                           loading: null,
                           parallelRoutes: new Map([
                             [
@@ -170,7 +163,6 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                                     prefetchLayerAssets: null,
                                     loading: null,
                                     parallelRoutes: new Map(),
-                                    lazyDataResolved: false,
                                     head: (
                                       <>
                                         <title>About page!</title>
@@ -202,7 +194,6 @@ describe('fillLazyItemsTillLeafWithHead', () => {
                           prefetchHead: null,
                           loading: null,
                           parallelRoutes: new Map(),
-                          lazyDataResolved: false,
                         },
                       ],
                     ]),

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
@@ -73,7 +73,6 @@ export function fillLazyItemsTillLeafWithHead(
             prefetchHead: null,
             loading,
             parallelRoutes: new Map(existingCacheNode?.parallelRoutes),
-            lazyDataResolved: false,
           }
         } else if (hasReusablePrefetch && existingCacheNode) {
           // No new data was sent from the server, but the existing cache node
@@ -90,7 +89,6 @@ export function fillLazyItemsTillLeafWithHead(
             prefetchLayerAssets: existingCache.prefetchLayerAssets,
             prefetchHead: existingCacheNode.prefetchHead,
             parallelRoutes: new Map(existingCacheNode.parallelRoutes),
-            lazyDataResolved: existingCacheNode.lazyDataResolved,
             loading: existingCacheNode.loading,
           } as CacheNode
         } else {
@@ -105,7 +103,6 @@ export function fillLazyItemsTillLeafWithHead(
             layerAssets: null,
             prefetchHead: null,
             parallelRoutes: new Map(existingCacheNode?.parallelRoutes),
-            lazyDataResolved: false,
             loading: null,
           }
         }
@@ -142,7 +139,6 @@ export function fillLazyItemsTillLeafWithHead(
         layerAssets: null,
         prefetchHead: null,
         parallelRoutes: new Map(),
-        lazyDataResolved: false,
         loading,
       }
     } else {
@@ -157,7 +153,6 @@ export function fillLazyItemsTillLeafWithHead(
         layerAssets: null,
         prefetchHead: null,
         parallelRoutes: new Map(),
-        lazyDataResolved: false,
         loading: null,
       }
     }

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
@@ -37,7 +37,6 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
       prefetchHead: null,
       loading: null,
       parallelRoutes: new Map(),
-      lazyDataResolved: false,
     }
     const existingCache: CacheNode = {
       lazyData: null,
@@ -47,7 +46,6 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
       layerAssets: null,
       prefetchLayerAssets: null,
       prefetchHead: null,
-      lazyDataResolved: false,
       loading: null,
       parallelRoutes: new Map([
         [
@@ -63,7 +61,6 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
                 layerAssets: null,
                 prefetchLayerAssets: null,
                 prefetchHead: null,
-                lazyDataResolved: false,
                 loading: null,
                 parallelRoutes: new Map([
                   [
@@ -79,7 +76,6 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
                           layerAssets: null,
                           prefetchLayerAssets: null,
                           prefetchHead: null,
-                          lazyDataResolved: false,
                           loading: null,
                           parallelRoutes: new Map(),
                         },
@@ -119,7 +115,6 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
 
     const expectedCache: CacheNode = {
       lazyData: null,
-      lazyDataResolved: false,
       head: null,
       layerAssets: null,
       prefetchLayerAssets: null,
@@ -133,7 +128,6 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
               'linking',
               {
                 lazyData: null,
-                lazyDataResolved: false,
                 head: null,
                 layerAssets: null,
                 prefetchLayerAssets: null,
@@ -155,7 +149,6 @@ describe('invalidateCacheBelowFlightSegmentPath', () => {
                           layerAssets: null,
                           prefetchLayerAssets: null,
                           prefetchHead: null,
-                          lazyDataResolved: false,
                         },
                       ],
                     ]),

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.ts
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.ts
@@ -54,7 +54,6 @@ export function invalidateCacheBelowFlightSegmentPath(
       layerAssets: childCacheNode.layerAssets,
       prefetchHead: childCacheNode.prefetchHead,
       parallelRoutes: new Map(childCacheNode.parallelRoutes),
-      lazyDataResolved: childCacheNode.lazyDataResolved,
     } as CacheNode
     childSegmentMap.set(cacheKey, childCacheNode)
   }

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.test.tsx
@@ -15,7 +15,6 @@ describe('invalidateCacheByRouterState', () => {
       prefetchHead: null,
       loading: null,
       parallelRoutes: new Map(),
-      lazyDataResolved: false,
     }
     const existingCache: CacheNode = {
       lazyData: null,
@@ -25,7 +24,6 @@ describe('invalidateCacheByRouterState', () => {
       layerAssets: null,
       prefetchLayerAssets: null,
       prefetchHead: null,
-      lazyDataResolved: false,
       loading: null,
       parallelRoutes: new Map([
         [
@@ -41,7 +39,6 @@ describe('invalidateCacheByRouterState', () => {
                 layerAssets: null,
                 prefetchLayerAssets: null,
                 prefetchHead: null,
-                lazyDataResolved: false,
                 loading: null,
                 parallelRoutes: new Map([
                   [
@@ -57,7 +54,6 @@ describe('invalidateCacheByRouterState', () => {
                           layerAssets: null,
                           prefetchLayerAssets: null,
                           prefetchHead: null,
-                          lazyDataResolved: false,
                           loading: null,
                           parallelRoutes: new Map(),
                         },
@@ -102,7 +98,6 @@ describe('invalidateCacheByRouterState', () => {
       layerAssets: null,
       prefetchLayerAssets: null,
       prefetchHead: null,
-      lazyDataResolved: false,
       loading: null,
       parallelRoutes: new Map([['children', new Map()]]),
     }

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -245,7 +245,6 @@ export function updateCacheNodeOnNavigation(
 
     // Everything is cloned except for the children, which we computed above.
     parallelRoutes: prefetchParallelRoutes,
-    lazyDataResolved: false,
   }
 
   return {
@@ -547,7 +546,6 @@ function createPendingCacheNode(
     rsc: createDeferredRsc() as React.ReactNode,
     head: isLeafSegment ? (createDeferredRsc() as React.ReactNode) : null,
     layerAssets: createDeferredRsc() as React.ReactNode,
-    lazyDataResolved: false,
   }
 }
 
@@ -808,7 +806,6 @@ export function updateCacheNodeOnPopstateRestoration(
 
     // These are the cloned children we computed above
     parallelRoutes: newParallelRoutes,
-    lazyDataResolved: false,
   }
 }
 

--- a/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx
@@ -33,7 +33,6 @@ describe('findHeadInCache', () => {
       layerAssets: null,
       prefetchLayerAssets: null,
       prefetchHead: null,
-      lazyDataResolved: false,
       loading: null,
       parallelRoutes: new Map([
         [
@@ -49,7 +48,6 @@ describe('findHeadInCache', () => {
                 layerAssets: null,
                 prefetchLayerAssets: null,
                 prefetchHead: null,
-                lazyDataResolved: false,
                 loading: null,
                 parallelRoutes: new Map([
                   [
@@ -59,7 +57,6 @@ describe('findHeadInCache', () => {
                         'about',
                         {
                           lazyData: null,
-                          lazyDataResolved: false,
                           head: null,
                           layerAssets: null,
                           prefetchLayerAssets: null,
@@ -76,7 +73,6 @@ describe('findHeadInCache', () => {
                                     rsc: null,
                                     prefetchRsc: null,
                                     prefetchHead: null,
-                                    lazyDataResolved: false,
                                     loading: null,
                                     parallelRoutes: new Map(),
                                     head: (

--- a/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
@@ -22,11 +22,6 @@ export type LoadingModuleData =
 
 export type LazyCacheNode = {
   /**
-   * Whether the lazy cache node data promise has been resolved.
-   * This value is only true after we've called `use` on the promise (and applied the data to the tree).
-   */
-  lazyDataResolved: boolean
-  /**
    * When rsc is null, this is a lazily-initialized cache node.
    *
    * If the app attempts to render it, it triggers a lazy data fetch,
@@ -69,11 +64,6 @@ export type LazyCacheNode = {
 }
 
 export type ReadyCacheNode = {
-  /**
-   * Whether the lazy cache node data promise has been resolved.
-   * This value is only true after we've called `use` on the promise (and applied the data to the tree).
-   */
-  lazyDataResolved: boolean
   /**
    * When rsc is not null, it represents the RSC data for the
    * corresponding segment.


### PR DESCRIPTION
This removes the `lazyDataResolved` property on the CacheNode -- it was added to avoid repeatedly applying the server-patch action while data is missing (and while waiting for the server to respond), but if we just move the patch action be attached to then server fetch, there's no need to separate these (we're already suspending indefinitely while data is missing)