### PR TITLE
docs: otel use anchor instead of path

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/10-open-telemetry.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/10-open-telemetry.mdx
@@ -180,7 +180,7 @@ Once you have your collector up and running, you can deploy your Next.js app to 
 
 ### Custom Exporters
 
-OpenTelemetry Collector is not necessary. You can use a custom OpenTelemetry exporter with [`@vercel/otel`](#using-vercelotel) or [manual OpenTelemetry configuration](/docs/pages/building-your-application/optimizing/open-telemetry#manual-opentelemetry-configuration).
+OpenTelemetry Collector is not necessary. You can use a custom OpenTelemetry exporter with [`@vercel/otel`](#using-vercelotel) or [manual OpenTelemetry configuration](#manual-opentelemetry-configuration).
 
 ## Custom Spans
 


### PR DESCRIPTION
### What?
Open Telementry app directory docs directing to page directory docs as the url links to the pages docs

### Why?
User suddenly ends up in the documentation of the pages directory

### How?
Use header anchor on page instead of the full path as it's on the same page