### PR TITLE
Fix Server Actions closure idents tracking

### DIFF
--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/32/input.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/32/input.js
@@ -1,0 +1,14 @@
+export function Component() {
+  const data = [1, 2, 3]
+  const foo = [2, 3, 4]
+  const baz = { value: { current: 1 } }
+
+  async function action() {
+    'use server'
+
+    console.log(data.at(1), baz.value, baz.value.current)
+    console.log(foo.push.call(foo, 5))
+  }
+
+  return <form action={action} />
+}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/32/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/32/output.js
@@ -1,0 +1,30 @@
+/* __next_internal_action_entry_do_not_use__ {"6d53ce510b2e36499b8f56038817b9bad86cabb4":"$$ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+export function Component() {
+    const data = [
+        1,
+        2,
+        3
+    ];
+    const foo = [
+        2,
+        3,
+        4
+    ];
+    const baz = {
+        value: {
+            current: 1
+        }
+    };
+    var action = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
+        data,
+        baz.value,
+        foo
+    ]));
+    return <form action={action}/>;
+}
+export async function $$ACTION_0($$ACTION_CLOSURE_BOUND) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);
+    console.log($$ACTION_ARG_0.at(1), $$ACTION_ARG_1, $$ACTION_ARG_1.current);
+    console.log($$ACTION_ARG_2.push.call($$ACTION_ARG_2, 5));
+}

--- a/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/7/output.js
+++ b/packages/next-swc/crates/next-custom-transforms/tests/fixture/server-actions/server/7/output.js
@@ -3,9 +3,6 @@ import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc
 import deleteFromDb from 'db';
 export function Item1(product, foo, bar) {
     const a = registerServerReference("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_0).bind(null, encryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", [
-        product.id,
-        product?.foo,
-        product.bar.baz,
         product,
         foo,
         bar
@@ -13,14 +10,11 @@ export function Item1(product, foo, bar) {
     return <Button action={a}>Delete</Button>;
 }
 export async function $$ACTION_0($$ACTION_CLOSURE_BOUND) {
-    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2, $$ACTION_ARG_3, $$ACTION_ARG_4, $$ACTION_ARG_5] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);
-    await deleteFromDb($$ACTION_ARG_3.id, $$ACTION_ARG_3?.foo, $$ACTION_ARG_3.bar.baz, $$ACTION_ARG_3[$$ACTION_ARG_4, $$ACTION_ARG_5]);
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2] = await decryptActionBoundArgs("6d53ce510b2e36499b8f56038817b9bad86cabb4", $$ACTION_CLOSURE_BOUND);
+    await deleteFromDb($$ACTION_ARG_0.id, $$ACTION_ARG_0?.foo, $$ACTION_ARG_0.bar.baz, $$ACTION_ARG_0[$$ACTION_ARG_1, $$ACTION_ARG_2]);
 }
 export function Item2(product, foo, bar) {
     var deleteItem2 = registerServerReference("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_1).bind(null, encryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", [
-        product.id,
-        product?.foo,
-        product.bar.baz,
         product,
         foo,
         bar
@@ -28,14 +22,11 @@ export function Item2(product, foo, bar) {
     return <Button action={deleteItem2}>Delete</Button>;
 }
 export async function $$ACTION_1($$ACTION_CLOSURE_BOUND) {
-    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2, $$ACTION_ARG_3, $$ACTION_ARG_4, $$ACTION_ARG_5] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
-    await deleteFromDb($$ACTION_ARG_3.id, $$ACTION_ARG_3?.foo, $$ACTION_ARG_3.bar.baz, $$ACTION_ARG_3[$$ACTION_ARG_4, $$ACTION_ARG_5]);
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2] = await decryptActionBoundArgs("188d5d945750dc32e2c842b93c75a65763d4a922", $$ACTION_CLOSURE_BOUND);
+    await deleteFromDb($$ACTION_ARG_0.id, $$ACTION_ARG_0?.foo, $$ACTION_ARG_0.bar.baz, $$ACTION_ARG_0[$$ACTION_ARG_1, $$ACTION_ARG_2]);
 }
 export function Item3(product, foo, bar) {
     const deleteItem3 = registerServerReference("56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_3).bind(null, encryptActionBoundArgs("56a859f462d35a297c46a1bbd1e6a9058c104ab8", [
-        product.id,
-        product?.foo,
-        product.bar.baz,
         product,
         foo,
         bar
@@ -43,14 +34,11 @@ export function Item3(product, foo, bar) {
     return <Button action={deleteItem3}>Delete</Button>;
 }
 export async function $$ACTION_3($$ACTION_CLOSURE_BOUND) {
-    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2, $$ACTION_ARG_3, $$ACTION_ARG_4, $$ACTION_ARG_5] = await decryptActionBoundArgs("56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_CLOSURE_BOUND);
-    await deleteFromDb($$ACTION_ARG_3.id, $$ACTION_ARG_3?.foo, $$ACTION_ARG_3.bar.baz, $$ACTION_ARG_3[$$ACTION_ARG_4, $$ACTION_ARG_5]);
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2] = await decryptActionBoundArgs("56a859f462d35a297c46a1bbd1e6a9058c104ab8", $$ACTION_CLOSURE_BOUND);
+    await deleteFromDb($$ACTION_ARG_0.id, $$ACTION_ARG_0?.foo, $$ACTION_ARG_0.bar.baz, $$ACTION_ARG_0[$$ACTION_ARG_1, $$ACTION_ARG_2]);
 }
 export function Item4(product, foo, bar) {
     const deleteItem4 = registerServerReference("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_4).bind(null, encryptActionBoundArgs("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", [
-        product.id,
-        product?.foo,
-        product.bar.baz,
         product,
         foo,
         bar
@@ -58,6 +46,6 @@ export function Item4(product, foo, bar) {
     return <Button action={deleteItem4}>Delete</Button>;
 }
 export async function $$ACTION_4($$ACTION_CLOSURE_BOUND) {
-    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2, $$ACTION_ARG_3, $$ACTION_ARG_4, $$ACTION_ARG_5] = await decryptActionBoundArgs("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_CLOSURE_BOUND);
-    await deleteFromDb($$ACTION_ARG_3.id, $$ACTION_ARG_3?.foo, $$ACTION_ARG_3.bar.baz, $$ACTION_ARG_3[$$ACTION_ARG_4, $$ACTION_ARG_5]);
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1, $$ACTION_ARG_2] = await decryptActionBoundArgs("9c0dd1f7c2b3f41d32e10f5c437de3d67ad32c6c", $$ACTION_CLOSURE_BOUND);
+    await deleteFromDb($$ACTION_ARG_0.id, $$ACTION_ARG_0?.foo, $$ACTION_ARG_0.bar.baz, $$ACTION_ARG_0[$$ACTION_ARG_1, $$ACTION_ARG_2]);
 }


### PR DESCRIPTION
This PR fixes the same case mention in #66464. Instead of collecting all values eagerly, here we merge fields (on any level of depth) of the same value and skip methods. For example:

```ts
foo.bar
foo.bar.baz

qux.fn()
```

Previously we're (wrongly) collecting `[foo.bar, foo.bar.baz, qux.fn]`, and now it will be just `[foo.bar, qux]`.

Merging of fields is critical for collecting methods correctly because in theory we can't tell if an object member is a method or not:

```ts
data.push.call(data, 1)

// or inside a function that does the same:
doPush(data.push, data)
```

If we don't merge fields we'll collect `[data.push, data]` which still fails.
