### PR TITLE
Add videos to openGraph metadata object

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
@@ -497,6 +497,16 @@ export const metadata = {
     ],
     locale: 'en_US',
     type: 'website',
+    videos: [
+      '/link-to-video', // Can be a string of just the url - a relative path as shown can point to your public folder
+
+      // Or a video descriptor object
+      {
+        url: '/link-to-video',
+        width: 800,
+        height: 600,
+      },
+    ],
   },
 }
 ```

--- a/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
@@ -495,18 +495,15 @@ export const metadata = {
         alt: 'My custom alt',
       },
     ],
-    locale: 'en_US',
-    type: 'website',
     videos: [
-      '/link-to-video', // Can be a string of just the url - a relative path as shown can point to your public folder
-
-      // Or a video descriptor object
       {
-        url: '/link-to-video',
+        url: 'https://nextjs.org/video.mp4', // Must be an absolute URL
         width: 800,
         height: 600,
       },
     ],
+    locale: 'en_US',
+    type: 'website',
   },
 }
 ```


### PR DESCRIPTION
### What?
Adds a videos example to the `openGraph` object in `metadata`. 

### Why?
I came to the docs looking for `openGraph` video info and luckily checked in the actual type definitions to find it was there and easy to add. Figured some others would come looking for it as well and would be good to have a quick example in the docs.
