### PR TITLE
Remove `ReactDOM.version` workaround for `react-server` condition

### DIFF
--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/entrypoints.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/entrypoints.ts
@@ -69,14 +69,6 @@ if (process.env.TURBOPACK) {
   }
 }
 
-if (ReactDOM.version === undefined) {
-  // FIXME: ReactDOM's 'react-server' entrypoint is missing `.version`,
-  // which makes our tests fail when it's used, so this is an ugly workaround
-  // (but should be safe because these are always kept in sync anyway)
-  // @ts-expect-error
-  ReactDOM.version = React.version
-}
-
 export {
   React,
   ReactJsxDevRuntime,


### PR DESCRIPTION
The workaround is not needed anymore because of https://github.com/facebook/react/pull/29596.

(Test failures are the same as in #66533.)