### PR TITLE
Update image.mdx

### DIFF
--- a/docs/02-app/02-api-reference/01-components/image.mdx
+++ b/docs/02-app/02-api-reference/01-components/image.mdx
@@ -197,7 +197,7 @@ By default, the img element will automatically be assigned the `position: "absol
 
 If no styles are applied to the image, the image will stretch to fit the container. You may prefer to set `object-fit: "contain"` for an image which is letterboxed to fit the container and preserve aspect ratio.
 
-Alternatively, `object-fit: "cover"` will cause the image to fill the entire container and be cropped to preserve aspect ratio. For this to look correct, the `overflow: "hidden"` style should be assigned to the parent element.
+Alternatively, `object-fit: "cover"` will cause the image to fill the entire container and be cropped to preserve aspect ratio.
 
 For more information, see also:
 


### PR DESCRIPTION
Using `overflow: hidden` on the image's parent element is not necessary, as the image is already set to be the same dimensions as its parent with no overflow, and `object-fit` only changes the image aspect ratio & crop within those dimensions.