### PR TITLE
prevent duplicate RSC fetch when action redirects

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -125,6 +125,7 @@ export function refreshReducer(
           updatedTree: newTree,
           updatedCache: cache,
           includeNextUrl,
+          canonicalUrl: mutable.canonicalUrl || state.canonicalUrl,
         })
 
         mutable.cache = cache

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -210,6 +210,11 @@ export function serverActionReducer(
       // Remove cache.data as it has been resolved at this point.
       mutable.inFlightServerAction = null
 
+      if (redirectLocation) {
+        const newHref = createHrefFromUrl(redirectLocation, false)
+        mutable.canonicalUrl = newHref
+      }
+
       for (const flightDataPath of flightData) {
         // FlightDataPath with more than two items means unexpected Flight data was returned
         if (flightDataPath.length !== 4) {
@@ -268,6 +273,7 @@ export function serverActionReducer(
             updatedTree: newTree,
             updatedCache: cache,
             includeNextUrl: Boolean(nextUrl),
+            canonicalUrl: mutable.canonicalUrl || state.canonicalUrl,
           })
 
           mutable.cache = cache
@@ -275,14 +281,7 @@ export function serverActionReducer(
         }
 
         mutable.patchedTree = newTree
-        mutable.canonicalUrl = href
-
         currentTree = newTree
-      }
-
-      if (redirectLocation) {
-        const newHref = createHrefFromUrl(redirectLocation, false)
-        mutable.canonicalUrl = newHref
       }
 
       resolve(actionResult)

--- a/packages/next/src/client/components/router-reducer/refetch-inactive-parallel-segments.ts
+++ b/packages/next/src/client/components/router-reducer/refetch-inactive-parallel-segments.ts
@@ -10,6 +10,7 @@ interface RefreshInactiveParallelSegments {
   updatedTree: FlightRouterState
   updatedCache: CacheNode
   includeNextUrl: boolean
+  canonicalUrl: string
 }
 
 /**
@@ -41,6 +42,7 @@ async function refreshInactiveParallelSegmentsImpl({
   includeNextUrl,
   fetchedSegments,
   rootTree = updatedTree,
+  canonicalUrl,
 }: RefreshInactiveParallelSegments & {
   fetchedSegments: Set<string>
   rootTree: FlightRouterState
@@ -50,7 +52,7 @@ async function refreshInactiveParallelSegmentsImpl({
 
   if (
     refetchPath &&
-    refetchPath !== location.pathname + location.search &&
+    refetchPath !== canonicalUrl &&
     refetchMarker === 'refresh' &&
     // it's possible for the tree to contain multiple segments that contain data at the same URL
     // we keep track of them so we can dedupe the requests
@@ -94,6 +96,7 @@ async function refreshInactiveParallelSegmentsImpl({
       includeNextUrl,
       fetchedSegments,
       rootTree,
+      canonicalUrl,
     })
 
     fetchPromises.push(parallelFetchPromise)

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/page.tsx
@@ -8,7 +8,7 @@ export default async function Home() {
   ).then((res) => res.text())
 
   return (
-    <div>
+    <div id="root-page">
       <Link href="/revalidate-modal">Open Revalidate Modal</Link>
       <Link href="/refresh-modal">Open Refresh Modal</Link>
       <Link href="/redirect-modal">Open Redirect Modal</Link>

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/redirect/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/redirect/page.tsx
@@ -8,7 +8,9 @@ export default function Page() {
         redirect('/')
       }}
     >
-      <button type="submit">Redirect</button>
+      <button type="submit" id="redirect-page">
+        Redirect
+      </button>
     </form>
   )
 }


### PR DESCRIPTION
When checking which segment(s) need to be refreshed, we currently compare the current page URL with the segment's refresh marker.

We should inspect the `mutable.canonicalUrl` value first since that's the URL we're changing to, followed by `state.canonicalUrl` as a fallback (indicating that there's no URL change pending). This is because the server action handler will receive a redirect URL prior to `location.pathname` being updated, so the router will incorrectly think it needs to refresh the data for the page we're going to. 

Closes NEXT-3500
