### PR TITLE
Make `InvalidImportResolvePlugin` a `BeforeResolvePlugin`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "serde",
  "smallvec",
@@ -3092,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "serde",
@@ -5227,9 +5227,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdff81d2ae11503b2cb34b37cd481c3400d19c7c05445dd5daad5cd29692ee69"
+checksum = "95ef85116a4d22dd66ebc8d1d1c7634565569fa4b80bf6728686b38e407f00f1"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -6964,12 +6964,12 @@ dependencies = [
 [[package]]
 name = "turbo-prehash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7001,7 +7001,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7013,7 +7013,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7027,7 +7027,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7041,7 +7041,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -7057,7 +7057,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7089,7 +7089,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "md4",
  "turbo-tasks-macros",
@@ -7099,7 +7099,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "proc-macro-error",
@@ -7113,7 +7113,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7123,7 +7123,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "mimalloc",
 ]
@@ -7131,7 +7131,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7158,7 +7158,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7188,7 +7188,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7229,7 +7229,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7252,7 +7252,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "clap",
@@ -7269,7 +7269,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7298,7 +7298,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7325,7 +7325,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7361,7 +7361,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7396,7 +7396,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "serde",
  "serde_json",
@@ -7407,7 +7407,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7432,7 +7432,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7448,7 +7448,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7464,7 +7464,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7483,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "serde",
@@ -7498,7 +7498,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7513,7 +7513,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7547,7 +7547,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7567,7 +7567,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7585,7 +7585,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "serde",
@@ -7601,7 +7601,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7612,7 +7612,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "either",
@@ -7632,7 +7632,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -7648,7 +7648,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.1#4592752b6dea8e23aef995dac3c46187864e602f"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.93.2", features = [
 testing = { version = "0.35.25" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240612.1" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240612.3" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240612.1" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240612.3" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240612.1" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240612.3" }
 
 # General Deps
 

--- a/packages/next-swc/crates/next-core/src/next_client/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/context.rs
@@ -49,7 +49,7 @@ use crate::{
     next_shared::{
         resolve::{
             get_invalid_server_only_resolve_plugin, ModuleFeatureReportResolvePlugin,
-            NextSharedRuntimeResolvePlugin, UnsupportedModulesResolvePlugin,
+            NextSharedRuntimeResolvePlugin,
         },
         transforms::{
             emotion::get_emotion_transform_rule, relay::get_relay_transform_rule,
@@ -160,13 +160,12 @@ pub async fn get_client_resolve_options_context(
         module: true,
         before_resolve_plugins: vec![
             Vc::upcast(get_invalid_server_only_resolve_plugin(project_path)),
+            Vc::upcast(ModuleFeatureReportResolvePlugin::new(project_path)),
             Vc::upcast(NextFontLocalResolvePlugin::new(project_path)),
         ],
-        after_resolve_plugins: vec![
-            Vc::upcast(ModuleFeatureReportResolvePlugin::new(project_path)),
-            Vc::upcast(UnsupportedModulesResolvePlugin::new(project_path)),
-            Vc::upcast(NextSharedRuntimeResolvePlugin::new(project_path)),
-        ],
+        after_resolve_plugins: vec![Vc::upcast(NextSharedRuntimeResolvePlugin::new(
+            project_path,
+        ))],
         ..Default::default()
     };
     Ok(ResolveOptionsContext {

--- a/packages/next-swc/crates/next-core/src/next_client/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/context.rs
@@ -158,12 +158,14 @@ pub async fn get_client_resolve_options_context(
         resolved_map: Some(next_client_resolved_map),
         browser: true,
         module: true,
-        before_resolve_plugins: vec![Vc::upcast(NextFontLocalResolvePlugin::new(project_path))],
+        before_resolve_plugins: vec![
+            Vc::upcast(get_invalid_server_only_resolve_plugin(project_path)),
+            Vc::upcast(NextFontLocalResolvePlugin::new(project_path)),
+        ],
         after_resolve_plugins: vec![
             Vc::upcast(ModuleFeatureReportResolvePlugin::new(project_path)),
             Vc::upcast(UnsupportedModulesResolvePlugin::new(project_path)),
             Vc::upcast(NextSharedRuntimeResolvePlugin::new(project_path)),
-            Vc::upcast(get_invalid_server_only_resolve_plugin(project_path)),
         ],
         ..Default::default()
     };

--- a/packages/next-swc/crates/next-core/src/next_edge/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_edge/context.rs
@@ -28,7 +28,6 @@ use crate::{
     next_shared::resolve::{
         get_invalid_client_only_resolve_plugin, get_invalid_styled_jsx_resolve_plugin,
         ModuleFeatureReportResolvePlugin, NextSharedRuntimeResolvePlugin,
-        UnsupportedModulesResolvePlugin,
     },
     util::{foreign_code_context_condition, NextRuntime},
 };
@@ -101,7 +100,9 @@ pub async fn get_edge_resolve_options_context(
 
     let ty = ty.into_value();
 
-    let mut before_resolve_plugins = vec![];
+    let mut before_resolve_plugins = vec![Vc::upcast(ModuleFeatureReportResolvePlugin::new(
+        project_path,
+    ))];
     if matches!(
         ty,
         ServerContextType::Pages { .. }
@@ -127,11 +128,9 @@ pub async fn get_edge_resolve_options_context(
         )));
     }
 
-    let after_resolve_plugins = vec![
-        Vc::upcast(ModuleFeatureReportResolvePlugin::new(project_path)),
-        Vc::upcast(UnsupportedModulesResolvePlugin::new(project_path)),
-        Vc::upcast(NextSharedRuntimeResolvePlugin::new(project_path)),
-    ];
+    let after_resolve_plugins = vec![Vc::upcast(NextSharedRuntimeResolvePlugin::new(
+        project_path,
+    ))];
 
     // https://github.com/vercel/next.js/blob/bf52c254973d99fed9d71507a2e818af80b8ade7/packages/next/src/build/webpack-config.ts#L96-L102
     let mut custom_conditions = vec![mode.await?.condition().into()];

--- a/packages/next-swc/crates/next-core/src/next_edge/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_edge/context.rs
@@ -101,44 +101,37 @@ pub async fn get_edge_resolve_options_context(
 
     let ty = ty.into_value();
 
-    let before_resolve_plugins = match ty {
+    let mut before_resolve_plugins = vec![];
+    if matches!(
+        ty,
         ServerContextType::Pages { .. }
-        | ServerContextType::AppSSR { .. }
-        | ServerContextType::AppRSC { .. } => {
-            vec![Vc::upcast(NextFontLocalResolvePlugin::new(project_path))]
-        }
-        ServerContextType::PagesData { .. }
-        | ServerContextType::PagesApi { .. }
-        | ServerContextType::AppRoute { .. }
-        | ServerContextType::Middleware { .. }
-        | ServerContextType::Instrumentation => vec![],
-    };
+            | ServerContextType::AppSSR { .. }
+            | ServerContextType::AppRSC { .. }
+    ) {
+        before_resolve_plugins.push(Vc::upcast(NextFontLocalResolvePlugin::new(project_path)));
+    }
 
-    let mut after_resolve_plugins = match ty {
-        ServerContextType::Pages { .. }
-        | ServerContextType::PagesApi { .. }
-        | ServerContextType::AppSSR { .. } => {
-            vec![]
-        }
+    if matches!(
+        ty,
         ServerContextType::AppRSC { .. }
-        | ServerContextType::AppRoute { .. }
-        | ServerContextType::PagesData { .. }
-        | ServerContextType::Middleware { .. }
-        | ServerContextType::Instrumentation => {
-            vec![
-                Vc::upcast(get_invalid_client_only_resolve_plugin(project_path)),
-                Vc::upcast(get_invalid_styled_jsx_resolve_plugin(project_path)),
-            ]
-        }
-    };
+            | ServerContextType::AppRoute { .. }
+            | ServerContextType::PagesData { .. }
+            | ServerContextType::Middleware { .. }
+            | ServerContextType::Instrumentation
+    ) {
+        before_resolve_plugins.push(Vc::upcast(get_invalid_client_only_resolve_plugin(
+            project_path,
+        )));
+        before_resolve_plugins.push(Vc::upcast(get_invalid_styled_jsx_resolve_plugin(
+            project_path,
+        )));
+    }
 
-    let base_plugins = vec![
+    let after_resolve_plugins = vec![
         Vc::upcast(ModuleFeatureReportResolvePlugin::new(project_path)),
         Vc::upcast(UnsupportedModulesResolvePlugin::new(project_path)),
         Vc::upcast(NextSharedRuntimeResolvePlugin::new(project_path)),
     ];
-
-    after_resolve_plugins.extend_from_slice(&base_plugins);
 
     // https://github.com/vercel/next.js/blob/bf52c254973d99fed9d71507a2e818af80b8ade7/packages/next/src/build/webpack-config.ts#L96-L102
     let mut custom_conditions = vec![mode.await?.condition().into()];

--- a/packages/next-swc/crates/next-core/src/next_font/local/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_font/local/mod.rs
@@ -70,7 +70,7 @@ impl NextFontLocalResolvePlugin {
 impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
     #[turbo_tasks::function]
     async fn before_resolve_condition(&self) -> Vc<BeforeResolvePluginCondition> {
-        BeforeResolvePluginCondition::new(Glob::new(
+        BeforeResolvePluginCondition::from_request_glob(Glob::new(
             "{next,@vercel/turbopack-next/internal}/font/local/*".into(),
         ))
     }

--- a/packages/next-swc/crates/next-core/src/next_font/local/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_font/local/mod.rs
@@ -15,7 +15,7 @@ use turbopack_binding::{
         resolve::{
             parse::Request,
             plugin::{BeforeResolvePlugin, BeforeResolvePluginCondition},
-            RequestKey, ResolveResult, ResolveResultItem, ResolveResultOption,
+            ResolveResult, ResolveResultItem, ResolveResultOption,
         },
         virtual_source::VirtualSource,
     },
@@ -125,16 +125,10 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                             .emit();
 
                             return Ok(ResolveResultOption::some(
-                                ResolveResult::primary_with_key(
-                                    RequestKey::new(font_path.clone()),
-                                    ResolveResultItem::Error(Vc::cell(
-                                        format!(
-                                            "Font file not found: Can't resolve {}'",
-                                            font_path
-                                        )
+                                ResolveResult::primary(ResolveResultItem::Error(Vc::cell(
+                                    format!("Font file not found: Can't resolve {}'", font_path)
                                         .into(),
-                                    )),
-                                )
+                                )))
                                 .into(),
                             ));
                         }

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -202,7 +202,7 @@ pub async fn get_server_resolve_options_context(
     let next_node_shared_runtime_plugin =
         NextNodeSharedRuntimeResolvePlugin::new(project_path, Value::new(ty));
 
-    let before_resolve_plugins = match ty {
+    let mut before_resolve_plugins = match ty {
         ServerContextType::Pages { .. }
         | ServerContextType::AppSSR { .. }
         | ServerContextType::AppRSC { .. } => {
@@ -215,7 +215,7 @@ pub async fn get_server_resolve_options_context(
         | ServerContextType::Instrumentation => vec![],
     };
 
-    let mut after_resolve_plugins = match ty {
+    let after_resolve_plugins = match ty {
         ServerContextType::Pages { .. }
         | ServerContextType::PagesApi { .. }
         | ServerContextType::PagesData { .. } => {
@@ -271,8 +271,8 @@ pub async fn get_server_resolve_options_context(
         | ServerContextType::AppRoute { .. }
         | ServerContextType::Middleware { .. }
         | ServerContextType::Instrumentation => {
-            after_resolve_plugins.push(Vc::upcast(invalid_client_only_resolve_plugin));
-            after_resolve_plugins.push(Vc::upcast(invalid_styled_jsx_client_only_resolve_plugin));
+            before_resolve_plugins.push(Vc::upcast(invalid_client_only_resolve_plugin));
+            before_resolve_plugins.push(Vc::upcast(invalid_styled_jsx_client_only_resolve_plugin));
         }
         ServerContextType::AppSSR { .. } => {
             //[TODO] Build error in this context makes rsc-build-error.ts fail which expects runtime error code


### PR DESCRIPTION
https://github.com/vercel/turbo/pull/8165 introduced plugins that operate before resolving occurs, meaning that plugins like `InvalidImportResolvePlugin` which never use the initial resolve result and report issues can avoid that work.

Test Plan: `TURBOPACK_DEV=1 TURBOPACK=1 pnpm test-dev test/development/acceptance-app/invalid-imports.test.ts`
