### PR TITLE
Prevent append of trailing slash in cases where path ends with a file extension

### DIFF
--- a/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
@@ -110,6 +110,13 @@ describe('resolveAbsoluteUrlWithPathname', () => {
         'https://example.com/foo?bar'
       )
     })
+
+    it('should not add trailing slash to relative url that ends with a file extension', () => {
+      expect(resolver('/foo.html')).toBe('https://example.com/foo.html')
+      expect(resolver(new URL('/foo.html', metadataBase))).toBe(
+        'https://example.com/foo.html'
+      )
+    })
   })
 })
 

--- a/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
@@ -111,7 +111,7 @@ describe('resolveAbsoluteUrlWithPathname', () => {
       )
     })
 
-    it('should not add trailing slash to relative url that ends with a file extension', () => {
+    it('should not add trailing slash to relative url that matches file pattern', () => {
       expect(resolver('/foo.html')).toBe('https://example.com/foo.html')
       expect(resolver(new URL('/foo.html', metadataBase))).toBe(
         'https://example.com/foo.html'

--- a/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
@@ -113,6 +113,10 @@ describe('resolveAbsoluteUrlWithPathname', () => {
 
     it('should not add trailing slash to relative url that matches file pattern', () => {
       expect(resolver('/foo.html')).toBe('https://example.com/foo.html')
+      expect(resolver('/foo.html?q=v')).toBe('https://example.com/foo.html?q=v')
+      expect(resolver(new URL('/.well-known/bar.jpg', metadataBase))).toBe(
+        'https://example.com/.well-known/bar.jpg/'
+      )
       expect(resolver(new URL('/foo.html', metadataBase))).toBe(
         'https://example.com/foo.html'
       )

--- a/packages/next/src/lib/metadata/resolvers/resolve-url.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.ts
@@ -86,6 +86,13 @@ function resolveRelativeUrl(url: string | URL, pathname: string): string | URL {
   return url
 }
 
+// The regex is matching logic from packages/next/src/lib/load-custom-routes.ts
+const FILE_REGEX =
+  /^(?:\/((?!\.well-known(?:\/.*)?)(?:[^/]+\/)*[^/]+\.\w+))\/[/#?]?$/i
+function isFilePattern(pathname: string): boolean {
+  return FILE_REGEX.test(pathname)
+}
+
 // Resolve `pathname` if `url` is a relative path the compose with `metadataBase`.
 function resolveAbsoluteUrlWithPathname(
   url: string | URL,
@@ -112,7 +119,8 @@ function resolveAbsoluteUrlWithPathname(
     let isRelative = resolvedUrl.startsWith('/')
     let isExternal = false
     let hasQuery = resolvedUrl.includes('?')
-    let hasFileExtension = /\.[0-9a-z]+$/i.test(resolvedUrl)
+    // Do not apply trailing slash for file like urls, aligning with the behavior with `trailingSlash`
+    let isFileUrl = isFilePattern(resolvedUrl)
 
     if (!isRelative) {
       try {
@@ -123,8 +131,7 @@ function resolveAbsoluteUrlWithPathname(
         // If it's not a valid URL, treat it as external
         isExternal = true
       }
-      if (!hasFileExtension && !isExternal && !hasQuery)
-        return `${resolvedUrl}/`
+      if (!isFileUrl && !isExternal && !hasQuery) return `${resolvedUrl}/`
     }
   }
 

--- a/packages/next/src/lib/metadata/resolvers/resolve-url.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.ts
@@ -88,7 +88,7 @@ function resolveRelativeUrl(url: string | URL, pathname: string): string | URL {
 
 // The regex is matching logic from packages/next/src/lib/load-custom-routes.ts
 const FILE_REGEX =
-  /^(?:\/((?!\.well-known(?:\/.*)?)(?:[^/]+\/)*[^/]+\.\w+))\/[/#?]?$/i
+  /^(?:\/((?!\.well-known(?:\/.*)?)(?:[^/]+\/)*[^/]+\.\w+))(\/?|$)/i
 function isFilePattern(pathname: string): boolean {
   return FILE_REGEX.test(pathname)
 }
@@ -117,21 +117,27 @@ function resolveAbsoluteUrlWithPathname(
   // - Doesn't have query
   if (trailingSlash && !resolvedUrl.endsWith('/')) {
     let isRelative = resolvedUrl.startsWith('/')
-    let isExternal = false
     let hasQuery = resolvedUrl.includes('?')
-    // Do not apply trailing slash for file like urls, aligning with the behavior with `trailingSlash`
-    let isFileUrl = isFilePattern(resolvedUrl)
+    let isExternal = false
+    let isFileUrl = false
 
     if (!isRelative) {
       try {
         const parsedUrl = new URL(resolvedUrl)
         isExternal =
           metadataBase != null && parsedUrl.origin !== metadataBase.origin
+        isFileUrl = isFilePattern(parsedUrl.pathname)
       } catch {
         // If it's not a valid URL, treat it as external
         isExternal = true
       }
-      if (!isFileUrl && !isExternal && !hasQuery) return `${resolvedUrl}/`
+      if (
+        // Do not apply trailing slash for file like urls, aligning with the behavior with `trailingSlash`
+        !isFileUrl &&
+        !isExternal &&
+        !hasQuery
+      )
+        return `${resolvedUrl}/`
     }
   }
 

--- a/packages/next/src/lib/metadata/resolvers/resolve-url.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.ts
@@ -112,6 +112,8 @@ function resolveAbsoluteUrlWithPathname(
     let isRelative = resolvedUrl.startsWith('/')
     let isExternal = false
     let hasQuery = resolvedUrl.includes('?')
+    let hasFileExtension = /\.[0-9a-z]+$/i.test(resolvedUrl)
+
     if (!isRelative) {
       try {
         const parsedUrl = new URL(resolvedUrl)
@@ -121,7 +123,8 @@ function resolveAbsoluteUrlWithPathname(
         // If it's not a valid URL, treat it as external
         isExternal = true
       }
-      if (!isExternal && !hasQuery) return `${resolvedUrl}/`
+      if (!hasFileExtension && !isExternal && !hasQuery)
+        return `${resolvedUrl}/`
     }
   }
 


### PR DESCRIPTION
### What

Skip adding trailing slash for file pattern like same origin urls

### Why

Fixes #66635

Next.js will not append trailing slash for file like pattern urls when `trailingSlash` is enabled. This PR aligns the behavior of the metadata trailing slash appending with next-server route handling.