### PR TITLE
reliability of the release action

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -22,7 +22,7 @@ jobs:
       # canary next-swc binaries in the monorepo
       NEXT_SKIP_NATIVE_POSTINSTALL: 1
     outputs:
-      isRelease: ${{ github.event_name != 'workflow_dispatch' && steps.check-release.outputs.IS_RELEASE }}
+      isRelease: ${{ steps.check-release.outputs.IS_RELEASE }}
     steps:
       - name: Setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -22,6 +22,11 @@ on:
           - minor
           - major
 
+      force:
+        description: create a new release even if there are no new commits
+        default: false
+        type: boolean
+
     secrets:
       RELEASE_BOT_GITHUB_TOKEN:
         required: true
@@ -66,7 +71,7 @@ jobs:
         run: echo "LATEST_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
       - name: Check if new commits since last tag
-        if: ${{ github.event.inputs.releaseType != 'stable' }}
+        if: ${{ github.event.inputs.releaseType != 'stable' && github.event.inputs.force != true }}
         run: |
           if [ "$LATEST_TAG_COMMIT" = "$LATEST_COMMIT" ]; then
             echo "No new commits. Exiting..."


### PR DESCRIPTION
### What?

* [allow to re-run the action that publishes the release](https://github.com/vercel/next.js/commit/ce4f629d73115a6cb61f17d6554b0ddf667171d4)
* [allow to force trigger a new release](https://github.com/vercel/next.js/commit/7e26cd7794aaa0afc62169127edb09394692014e)

### Why?

On failure we might want to re-run the whole action or publish a new release without changes
