### PR TITLE
Allow busting reserved Github action caches

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -66,7 +66,7 @@ jobs:
         id: cache-build
         with:
           path: ./*
-          key: ${{ github.sha }}-${{ github.run_number }}
+          key: ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt}}
 
   # Build binaries for publishing
   build-native:
@@ -419,7 +419,12 @@ jobs:
         id: restore-build
         with:
           path: ./*
-          key: ${{ github.sha }}-${{ github.run_number }}
+          # Cache includes repo checkout which is required for later scripts
+          fail-on-cache-miss: true
+          key: ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ github.sha }}-${{ github.run_number }}
+            ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt}}
 
       - uses: actions/download-artifact@v4
         with:
@@ -467,7 +472,12 @@ jobs:
         id: restore-build
         with:
           path: ./*
-          key: ${{ github.sha }}-${{ github.run_number }}
+          # Cache includes repo checkout which is required for later scripts
+          fail-on-cache-miss: true
+          key: ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ github.sha }}-${{ github.run_number }}
+            ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt}}
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
In case you hit (e.g. https://github.com/vercel/next.js/actions/runs/9414174051/job/25932973210#step:17:3), you need to invalidate the cache: https://github.com/actions/cache/issues/485#issuecomment-744145040

You can now do that by restarting the full flow ("Restart all jobs" instead of "Restart failed jobs") and get a fresh cache that way since we now encode the run attempt in the cache key. Restart from failed would have never worked.