### PR TITLE
revert app-render changes related to determining RSC/Prefetch requests

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -10,7 +10,7 @@ import type {
 } from './types'
 import type { StaticGenerationStore } from '../../client/components/static-generation-async-storage.external'
 import type { RequestStore } from '../../client/components/request-async-storage.external'
-import { getRequestMeta, type NextParsedUrlQuery } from '../request-meta'
+import type { NextParsedUrlQuery } from '../request-meta'
 import type { LoaderTree } from '../lib/app-dir-module'
 import type { AppPageModule } from '../route-modules/app-page/module'
 import type { ClientReferenceManifest } from '../../build/webpack/plugins/flight-manifest-plugin'
@@ -37,8 +37,10 @@ import {
 import { canSegmentBeOverridden } from '../../client/components/match-segments'
 import { stripInternalQueries } from '../internal-utils'
 import {
+  NEXT_ROUTER_PREFETCH_HEADER,
   NEXT_ROUTER_STATE_TREE,
   NEXT_URL,
+  RSC_HEADER,
 } from '../../client/components/app-router-headers'
 import {
   createMetadataComponents,
@@ -797,11 +799,13 @@ async function renderToHTMLOrFlightImpl(
   query = { ...query }
   stripInternalQueries(query)
 
-  const isRSCRequest = Boolean(getRequestMeta(req, 'isRSCRequest'))
+  // We read these values from the request object as, in certain cases, base-server
+  // will strip them to opt into different rendering behavior.
+  const isRSCRequest = req.headers[RSC_HEADER.toLowerCase()] !== undefined
+  const isPrefetchRSCRequest =
+    isRSCRequest &&
+    req.headers[NEXT_ROUTER_PREFETCH_HEADER.toLowerCase()] !== undefined
 
-  const isPrefetchRSCRequest = Boolean(
-    getRequestMeta(req, 'isPrefetchRSCRequest')
-  )
   /**
    * Router state provided from the client-side router. Used to handle rendering
    * from the common layout down. This value will be undefined if the request

--- a/test/e2e/app-dir/fallback-prefetch/app/[id]/loading.tsx
+++ b/test/e2e/app-dir/fallback-prefetch/app/[id]/loading.tsx
@@ -1,0 +1,3 @@
+export default function IdLoadingPage() {
+  return <div>Loading page...</div>
+}

--- a/test/e2e/app-dir/fallback-prefetch/app/[id]/page.tsx
+++ b/test/e2e/app-dir/fallback-prefetch/app/[id]/page.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link'
+
+export const dynamic = 'force-static'
+
+export async function generateStaticParams() {
+  return []
+}
+
+export default async function IdPage({
+  params: { id },
+}: {
+  params: { id: string }
+}) {
+  await new Promise((resolve) => setTimeout(resolve, Math.random() * 5000))
+
+  return (
+    <div id="random-page">
+      <h1>{id} page</h1>
+      <Link href="/">Go Home</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/fallback-prefetch/app/layout.tsx
+++ b/test/e2e/app-dir/fallback-prefetch/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/fallback-prefetch/app/page.tsx
+++ b/test/e2e/app-dir/fallback-prefetch/app/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export const dynamic = 'force-dynamic'
+
+export default function HomePage() {
+  const randomId = crypto.randomUUID()
+
+  return (
+    <section>
+      <Link href={`/${randomId}`} id="link-to-random">
+        Go to Random Page
+      </Link>
+    </section>
+  )
+}

--- a/test/e2e/app-dir/fallback-prefetch/fallback-prefetch.test.ts
+++ b/test/e2e/app-dir/fallback-prefetch/fallback-prefetch.test.ts
@@ -1,0 +1,29 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('fallback-prefetch', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should prefetch the page without errors', async () => {
+    let hasNetworkError = false
+    const browser = await next.browser('/', {
+      beforePageLoad: (page) => {
+        page.on('response', (response) => {
+          if (!response.ok()) {
+            hasNetworkError = true
+          }
+        })
+      },
+    })
+
+    // set a flag on the window to ensure we don't perform an MPA navigation when navigating to the prefetched link
+    await browser.eval('window.beforeNav = 1')
+    await browser.elementById('link-to-random').click()
+
+    await browser.waitForElementByCss('#random-page')
+
+    expect(await browser.eval('window.beforeNav')).toBe(1)
+    expect(hasNetworkError).toBe(false)
+  })
+})

--- a/test/e2e/app-dir/fallback-prefetch/next.config.js
+++ b/test/e2e/app-dir/fallback-prefetch/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
This change introduced some unexpected behavior when prefetching pages that were statically generated on-demand. We currently conditionally strip flight headers in base-server to opt into special rendering behavior ([ref](https://github.com/vercel/next.js/blob/71153eaa3b1d1a72f99e080f432e234d3c1f5fb5/packages/next/src/server/base-server.ts#L2153)) but this doesn't apply to "request meta" properties.

This reverts that change specifically and adds a comment clarifying why it's there, and adds a test-case. 

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
