### PR TITLE
Update URL provided from unstable_cache

### DIFF
--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -105,12 +105,24 @@ export function unstable_cache<T extends Callback>(
     }
     const incrementalCache = maybeIncrementalCache
 
+    const { pathname, searchParams } = new URL(
+      store?.urlPathname || '/',
+      'http://n'
+    )
+    const sortedSearchKeys = [...searchParams.keys()].sort((a, b) => {
+      return a.localeCompare(b)
+    })
+    const sortedSearch = sortedSearchKeys
+      .map((key) => searchParams.get(key))
+      .join('&')
+
     // Construct the complete cache key for this function invocation
     // @TODO stringify is likely not safe here. We will coerce undefined to null which will make
     // the keyspace smaller than the execution space
     const invocationKey = `${fixedKey}-${JSON.stringify(args)}`
     const cacheKey = await incrementalCache.fetchCacheKey(invocationKey)
-    const fetchUrl = `unstable_cache ${cb.name ? ` ${cb.name}` : cacheKey}`
+    // $urlWithPath,$sortedQueryStringKeys,$hashOfEveryThingElse
+    const fetchUrl = `unstable_cache ${pathname}${sortedSearch.length ? '?' : ''}${sortedSearch} ${cb.name ? ` ${cb.name}` : cacheKey}`
     const fetchIdx = (store ? store.nextFetchId : noStoreFetchIdx) ?? 1
 
     if (store) {


### PR DESCRIPTION
As discussed this updates the URL value provided from `unstable_cache` to include the current pathname and sorted search params so that it's easier to identify where the call is being done for using debug metrics. 

x-ref: [slack thread](https://vercel.slack.com/archives/C042LHPJ1NX/p1717012449080709?thread_ts=1716942410.700499&cid=C042LHPJ1NX)