### PR TITLE
Fix inconsistency with 404 getStaticProps cache-control

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2860,9 +2860,8 @@ export default abstract class Server<
       typeof cacheEntry.revalidate !== 'undefined' &&
       (!this.renderOpts.dev || (hasServerProps && !isNextDataRequest))
     ) {
-      // If this is a preview mode request, we shouldn't cache it. We also don't
-      // cache 404 pages.
-      if (isPreviewMode || (is404Page && !isNextDataRequest)) {
+      // If this is a preview mode request, we shouldn't cache it
+      if (isPreviewMode) {
         revalidate = 0
       }
 

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -94,6 +94,11 @@ export interface RequestMeta {
     cacheEntry: any,
     requestMeta: any
   ) => Promise<boolean | void> | boolean | void
+
+  /**
+   * The previous revalidate before rendering 404 page for notFound: true
+   */
+  notFoundRevalidate?: number | false
 }
 
 /**

--- a/test/integration/not-found-revalidate/pages/404.js
+++ b/test/integration/not-found-revalidate/pages/404.js
@@ -14,6 +14,6 @@ export const getStaticProps = () => {
       notFound: true,
       random: Math.random(),
     },
-    revalidate: 1,
+    revalidate: 6000,
   }
 }

--- a/test/integration/not-found-revalidate/test/index.test.js
+++ b/test/integration/not-found-revalidate/test/index.test.js
@@ -81,9 +81,9 @@ const runTests = () => {
     let res = await fetchViaHTTP(appPort, '/fallback-blocking/hello')
     let $ = cheerio.load(await res.text())
 
-    const privateCache =
-      'private, no-cache, no-store, max-age=0, must-revalidate'
-    expect(res.headers.get('cache-control')).toBe(privateCache)
+    expect(res.headers.get('cache-control')).toBe(
+      `s-maxage=1, stale-while-revalidate`
+    )
     expect(res.status).toBe(404)
     expect(JSON.parse($('#props').text()).notFound).toBe(true)
 
@@ -91,7 +91,9 @@ const runTests = () => {
     res = await fetchViaHTTP(appPort, '/fallback-blocking/hello')
     $ = cheerio.load(await res.text())
 
-    expect(res.headers.get('cache-control')).toBe(privateCache)
+    expect(res.headers.get('cache-control')).toBe(
+      `s-maxage=1, stale-while-revalidate`
+    )
     expect(res.status).toBe(404)
     expect(JSON.parse($('#props').text()).notFound).toBe(true)
 
@@ -146,7 +148,7 @@ const runTests = () => {
     let $ = cheerio.load(await res.text())
 
     expect(res.headers.get('cache-control')).toBe(
-      'private, no-cache, no-store, max-age=0, must-revalidate'
+      `s-maxage=1, stale-while-revalidate`
     )
     expect(res.status).toBe(404)
     expect(JSON.parse($('#props').text()).notFound).toBe(true)


### PR DESCRIPTION
While investigating unexpected stale responses when leveraging `getStaticProps` on the 404 page noticed we have an inconsistency between local and deployed due to `Cache-Control` being set to `no-store, must-revalidate` even though a revalidate period is provided. The inconsistency also differs between the HTML response and the data response `_next/data` which causes even more unexpected behavior. To avoid this behavior, this replaces the handling to ensure we honor the originally provided revalidate period during `notFound: true` for the `Cache-Control` header. 

Validated against provided reproduction here https://github.com/fusdev0/next-notfound-revalidate
Deployment: https://vercel.live/link/next-notfound-revalidate-govzskknf-vtest314-ijjk-testing.vercel.app/fallback-blocking/fasdf

Prior PR for prior context that introduced this https://github.com/vercel/next.js/pull/19165

x-ref: [slack thread](https://vercel.slack.com/archives/C0676QZBWKS/p1717492459342109)