### PR TITLE
chore: fix react-is RC version pinning

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -289,7 +289,7 @@
     "punycode": "2.1.1",
     "querystring-es3": "0.2.1",
     "raw-body": "2.4.1",
-    "react-is": "19.0.0-canary-94eed63c49-20240425",
+    "react-is": "19.0.0-rc-f994737d14-20240522",
     "react-refresh": "0.12.0",
     "regenerator-runtime": "0.13.4",
     "sass-loader": "12.4.0",


### PR DESCRIPTION
### What?

This PR updates the `packages/next/package.json` version of `react-is` to the RC pinned in the `package.json` at the root. This PR does not modify the `pnpm-lock`, as it is already the version that is installed with the monorepo.

### Why?

The version of `react-is` that the package is currently pointing towards _does not exist_ in NPM. It appears that this version has not been kept up-to-date with other PRs that update React versions and wires got crossed somewhere along the lines.

While this is an insignificant change for this repo, when embedding the Next.js repo as a submodule in Git, it helps me fix the `NOT FOUND` issue using PNPM.
