### PR TITLE
feat: Enable tree shaking of turbopack

### DIFF
--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -633,7 +633,7 @@ impl PageEndpoint {
             );
 
             let Some(client_module) =
-                Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(client_module).await?
+                Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(client_module).await?
             else {
                 bail!("expected an ECMAScript module asset");
             };
@@ -659,7 +659,7 @@ impl PageEndpoint {
             .context("expected Next.js client runtime to resolve to a module")?;
 
             let Some(client_main_module) =
-                Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(client_main_module).await?
+                Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(client_main_module).await?
             else {
                 bail!("expected an ECMAScript module asset");
             };
@@ -670,8 +670,8 @@ impl PageEndpoint {
                 client_module.ident(),
                 this.pages_project
                     .client_runtime_entries()
-                    .with_entry(Vc::upcast(client_main_module))
-                    .with_entry(Vc::upcast(client_module)),
+                    .with_entry(client_main_module)
+                    .with_entry(client_module),
                 Value::new(AvailabilityInfo::Root),
             );
 

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -37,7 +37,7 @@ use turbopack_binding::{
             asset::AssetContent,
             chunk::{
                 availability_info::AvailabilityInfo, ChunkingContext, ChunkingContextExt,
-                EntryChunkGroupResult, EvaluatableAssets,
+                EntryChunkGroupResult, EvaluatableAsset, EvaluatableAssets,
             },
             context::AssetContext,
             file_source::FileSource,

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -51,7 +51,7 @@ use turbopack_binding::{
             source::Source,
             virtual_output::VirtualOutputAsset,
         },
-        ecmascript::{resolve::esm_resolve, EcmascriptModuleAsset},
+        ecmascript::resolve::esm_resolve,
         nodejs::NodeJsChunkingContext,
         turbopack::{
             module_options::ModuleOptionsContext,

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -29,7 +29,8 @@ use turbopack_binding::{
             virtual_source::VirtualSource,
         },
         ecmascript::{
-            chunk::EcmascriptChunkPlaceable, parse::ParseResult, EcmascriptModuleAsset,
+            chunk::EcmascriptChunkPlaceable, parse::ParseResult,
+            tree_shake::asset::EcmascriptModulePartAsset, EcmascriptModuleAsset,
             EcmascriptModuleAssetType,
         },
     },
@@ -246,6 +247,14 @@ async fn to_rsc_context(
         } else {
             ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined)
         }
+    } else if let Some(module) =
+        Vc::try_resolve_downcast_type::<EcmascriptModulePartAsset>(module).await?
+    {
+        if module.await?.full_module.await?.ty == EcmascriptModuleAssetType::Ecmascript {
+            ReferenceType::EcmaScriptModules(EcmaScriptModulesReferenceSubType::Undefined)
+        } else {
+            ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined)
+        }
     } else {
         ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined)
     };
@@ -294,14 +303,21 @@ pub fn parse_server_actions<C: Comments>(
 /// the exported action function. If not, we return a None.
 #[turbo_tasks::function]
 async fn parse_actions(module: Vc<Box<dyn Module>>) -> Result<Vc<OptionActionMap>> {
-    let Some(ecmascript_asset) =
+    let parsed = if let Some(ecmascript_asset) =
         Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(module).await?
-    else {
+    {
+        ecmascript_asset.failsafe_parse()
+    } else if let Some(ecmascript_asset) =
+        Vc::try_resolve_downcast_type::<EcmascriptModulePartAsset>(module).await?
+    {
+        ecmascript_asset.await?.full_module.failsafe_parse()
+    } else {
         return Ok(OptionActionMap::none());
     };
+
     let ParseResult::Ok {
         comments, program, ..
-    } = &*ecmascript_asset.failsafe_parse().await?
+    } = &*parsed.await?
     else {
         // The file might be be parse-able, but this is reported separately.
         return Ok(OptionActionMap::none());

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -18,6 +18,7 @@ use turbopack_binding::{
             free_var_references,
             resolve::{parse::Request, pattern::Pattern},
         },
+        ecmascript::TreeShakingMode,
         node::{
             execution_context::ExecutionContext,
             transforms::postcss::{PostCssConfigLocation, PostCssTransformOptions},

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -278,7 +278,7 @@ pub async fn get_client_module_options_context(
         enable_typeof_window_inlining: Some(TypeofWindow::Object),
         preset_env_versions: Some(env),
         execution_context: Some(execution_context),
-        tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
+        tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
         enable_postcss_transform,
         side_effect_free_packages: next_config.optimize_package_imports().await?.clone_value(),
         ..Default::default()

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -240,8 +240,11 @@ pub async fn get_client_module_options_context(
     let enable_webpack_loaders =
         webpack_loader_options(project_path, next_config, false, conditions).await?;
 
-    let tree_shaking_mode = *next_config
-        .tree_shaking_mode(Vc::cell(next_mode.is_development()))
+    let tree_shaking_mode_for_user_code = *next_config
+        .tree_shaking_mode_for_user_code(Vc::cell(next_mode.is_development()))
+        .await?;
+    let tree_shaking_mode_for_foreign_code = *next_config
+        .tree_shaking_mode_for_foreign_code(Vc::cell(next_mode.is_development()))
         .await?;
     let use_swc_css = *next_config.use_swc_css().await?;
     let target_browsers = env.runtime_versions();
@@ -283,7 +286,7 @@ pub async fn get_client_module_options_context(
         enable_typeof_window_inlining: Some(TypeofWindow::Object),
         preset_env_versions: Some(env),
         execution_context: Some(execution_context),
-        tree_shaking_mode,
+        tree_shaking_mode: tree_shaking_mode_for_user_code,
         special_exports: Some(next_js_special_exports()),
         enable_postcss_transform,
         side_effect_free_packages: next_config.optimize_package_imports().await?.clone_value(),
@@ -296,6 +299,7 @@ pub async fn get_client_module_options_context(
         enable_webpack_loaders: foreign_enable_webpack_loaders,
         enable_postcss_transform: enable_foreign_postcss_transform,
         custom_rules: foreign_next_client_rules,
+        tree_shaking_mode: tree_shaking_mode_for_foreign_code,
         // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
         ..module_options_context.clone()
     };

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -280,7 +280,7 @@ pub async fn get_client_module_options_context(
         preset_env_versions: Some(env),
         execution_context: Some(execution_context),
         tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
-        special_exports: next_js_special_exports(),
+        special_exports: Some(next_js_special_exports()),
         enable_postcss_transform,
         side_effect_free_packages: next_config.optimize_package_imports().await?.clone_value(),
         ..Default::default()

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -47,6 +47,7 @@ use crate::{
         get_next_client_resolved_map,
     },
     next_shared::{
+        next_js_special_exports,
         resolve::{
             get_invalid_server_only_resolve_plugin, ModuleFeatureReportResolvePlugin,
             NextSharedRuntimeResolvePlugin,
@@ -279,6 +280,7 @@ pub async fn get_client_module_options_context(
         preset_env_versions: Some(env),
         execution_context: Some(execution_context),
         tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
+        special_exports: next_js_special_exports(),
         enable_postcss_transform,
         side_effect_free_packages: next_config.optimize_package_imports().await?.clone_value(),
         ..Default::default()

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -237,7 +237,6 @@ pub async fn get_client_module_options_context(
     let enable_webpack_loaders =
         webpack_loader_options(project_path, next_config, false, conditions).await?;
 
-    let tree_shaking_mode = *next_config.tree_shaking_mode().await?;
     let use_swc_css = *next_config.use_swc_css().await?;
     let target_browsers = env.runtime_versions();
 
@@ -278,7 +277,7 @@ pub async fn get_client_module_options_context(
         enable_typeof_window_inlining: Some(TypeofWindow::Object),
         preset_env_versions: Some(env),
         execution_context: Some(execution_context),
-        tree_shaking_mode,
+        tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
         enable_postcss_transform,
         side_effect_free_packages: next_config.optimize_package_imports().await?.clone_value(),
         ..Default::default()

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -18,7 +18,6 @@ use turbopack_binding::{
             free_var_references,
             resolve::{parse::Request, pattern::Pattern},
         },
-        ecmascript::TreeShakingMode,
         node::{
             execution_context::ExecutionContext,
             transforms::postcss::{PostCssConfigLocation, PostCssTransformOptions},
@@ -238,6 +237,7 @@ pub async fn get_client_module_options_context(
     let enable_webpack_loaders =
         webpack_loader_options(project_path, next_config, false, conditions).await?;
 
+    let tree_shaking_mode = *next_config.tree_shaking_mode().await?;
     let use_swc_css = *next_config.use_swc_css().await?;
     let target_browsers = env.runtime_versions();
 
@@ -278,7 +278,7 @@ pub async fn get_client_module_options_context(
         enable_typeof_window_inlining: Some(TypeofWindow::Object),
         preset_env_versions: Some(env),
         execution_context: Some(execution_context),
-        tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
+        tree_shaking_mode,
         enable_postcss_transform,
         side_effect_free_packages: next_config.optimize_package_imports().await?.clone_value(),
         ..Default::default()

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -241,10 +241,10 @@ pub async fn get_client_module_options_context(
         webpack_loader_options(project_path, next_config, false, conditions).await?;
 
     let tree_shaking_mode_for_user_code = *next_config
-        .tree_shaking_mode_for_user_code(Vc::cell(next_mode.is_development()))
+        .tree_shaking_mode_for_user_code(next_mode.is_development())
         .await?;
     let tree_shaking_mode_for_foreign_code = *next_config
-        .tree_shaking_mode_for_foreign_code(Vc::cell(next_mode.is_development()))
+        .tree_shaking_mode_for_foreign_code(next_mode.is_development())
         .await?;
     let use_swc_css = *next_config.use_swc_css().await?;
     let target_browsers = env.runtime_versions();

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
@@ -22,7 +22,6 @@ use turbopack_binding::turbopack::{
             EcmascriptChunkType, EcmascriptExports,
         },
         utils::StringifyJs,
-        EcmascriptModuleAsset,
     },
 };
 
@@ -65,7 +64,7 @@ impl EcmascriptClientReferenceProxyModule {
     }
 
     #[turbo_tasks::function]
-    async fn proxy_module(&self) -> Result<Vc<EcmascriptModuleAsset>> {
+    async fn proxy_module(&self) -> Result<Vc<Box<dyn EcmascriptChunkPlaceable>>> {
         let mut code = CodeBuilder::default();
 
         let server_module_path = &*self.server_module_ident.path().to_string().await?;
@@ -156,7 +155,7 @@ impl EcmascriptClientReferenceProxyModule {
             .module();
 
         let Some(proxy_module) =
-            Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(proxy_module).await?
+            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(proxy_module).await?
         else {
             bail!("proxy asset is not an ecmascript module");
         };

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
@@ -7,10 +7,7 @@ use turbo_tasks_fs::File;
 use turbopack_binding::turbopack::{
     core::{
         asset::{Asset, AssetContent},
-        chunk::{
-            AsyncModuleInfo, ChunkItem, ChunkType, ChunkableModule, ChunkingContext,
-            EvaluatableAsset,
-        },
+        chunk::{AsyncModuleInfo, ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
         code_builder::CodeBuilder,
         context::AssetContext,
         ident::AssetIdent,
@@ -68,7 +65,7 @@ impl EcmascriptClientReferenceProxyModule {
     }
 
     #[turbo_tasks::function]
-    async fn proxy_module(&self) -> Result<Vc<Box<dyn EvaluatableAsset>>> {
+    async fn proxy_module(&self) -> Result<Vc<EcmascriptModuleAsset>> {
         let mut code = CodeBuilder::default();
 
         let server_module_path = &*self.server_module_ident.path().to_string().await?;
@@ -159,7 +156,7 @@ impl EcmascriptClientReferenceProxyModule {
             .module();
 
         let Some(proxy_module) =
-            Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(proxy_module).await?
+            Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(proxy_module).await?
         else {
             bail!("proxy asset is not an ecmascript module");
         };

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -12,7 +12,7 @@ use turbopack_binding::{
             issue::{Issue, IssueSeverity, IssueStage, OptionStyledString, StyledString},
             resolve::ResolveAliasMap,
         },
-        ecmascript::TreeShakingMode,
+        ecmascript::{OptionTreeShaking, TreeShakingMode},
         ecmascript_plugin::transform::{
             emotion::EmotionTransformConfig, relay::RelayConfig,
             styled_components::StyledComponentsTransformConfig,
@@ -1122,12 +1122,8 @@ impl NextConfig {
 
     #[turbo_tasks::function]
     pub async fn tree_shaking_mode(self: Vc<Self>) -> Result<Vc<OptionTreeShaking>> {
-        if self
-            .await?
-            .experimental
-            .disable_tree_shaking
-            .unwrap_or_default()
-        {
+        let tree_shaking = self.await?.experimental.tree_shaking.unwrap_or(true);
+        if !tree_shaking {
             return Ok(OptionTreeShaking(None).cell());
         }
 

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -582,7 +582,7 @@ pub struct ExperimentalConfig {
     webpack_build_worker: Option<bool>,
     worker_threads: Option<bool>,
 
-    disable_tree_shaking: Option<bool>,
+    tree_shaking: Option<bool>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs)]

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1203,6 +1203,3 @@ impl Issue for OutdatedConfigIssue {
         Vc::cell(Some(StyledString::Text(self.description.clone()).cell()))
     }
 }
-
-#[turbo_tasks::value(transparent)]
-pub struct OptionTreeShaking(Option<TreeShakingMode>);

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -12,6 +12,7 @@ use turbopack_binding::{
             issue::{Issue, IssueSeverity, IssueStage, OptionStyledString, StyledString},
             resolve::ResolveAliasMap,
         },
+        ecmascript::TreeShakingMode,
         ecmascript_plugin::transform::{
             emotion::EmotionTransformConfig, relay::RelayConfig,
             styled_components::StyledComponentsTransformConfig,
@@ -580,6 +581,8 @@ pub struct ExperimentalConfig {
     /// (doesn't apply to Turbopack).
     webpack_build_worker: Option<bool>,
     worker_threads: Option<bool>,
+
+    disable_tree_shaking: Option<bool>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs)]
@@ -1116,6 +1119,20 @@ impl NextConfig {
                 .unwrap_or_default(),
         ))
     }
+
+    #[turbo_tasks::function]
+    pub async fn tree_shaking_mode(self: Vc<Self>) -> Result<Vc<OptionTreeShaking>> {
+        if self
+            .await?
+            .experimental
+            .disable_tree_shaking
+            .unwrap_or_default()
+        {
+            return Ok(OptionTreeShaking(None).cell());
+        }
+
+        Ok(OptionTreeShaking(Some(TreeShakingMode::ModuleFragments)).cell())
+    }
 }
 
 /// A subset of ts/jsconfig that next.js implicitly
@@ -1186,3 +1203,6 @@ impl Issue for OutdatedConfigIssue {
         Vc::cell(Some(StyledString::Text(self.description.clone()).cell()))
     }
 }
+
+#[turbo_tasks::value(transparent)]
+pub struct OptionTreeShaking(Option<TreeShakingMode>);

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1125,13 +1125,20 @@ impl NextConfig {
         self: Vc<Self>,
         is_development: Vc<bool>,
     ) -> Result<Vc<OptionTreeShaking>> {
+        let is_development = *is_development.await?;
         let tree_shaking = self.await?.experimental.tree_shaking;
 
         if let Some(false) = tree_shaking {
             // The user has explicitly disabled tree shaking.
-            return Ok(OptionTreeShaking(None).cell());
+
+            return Ok(OptionTreeShaking(if is_development {
+                None
+            } else {
+                Some(TreeShakingMode::ReexportsOnly)
+            })
+            .cell());
         }
-        Ok(OptionTreeShaking(Some(if *is_development.await? {
+        Ok(OptionTreeShaking(Some(if is_development {
             TreeShakingMode::ReexportsOnly
         } else {
             TreeShakingMode::ModuleFragments

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1131,11 +1131,7 @@ impl NextConfig {
         Ok(OptionTreeShaking(match tree_shaking {
             Some(false) => Some(TreeShakingMode::ReexportsOnly),
             Some(true) => {
-                if is_development {
-                    Some(TreeShakingMode::ModuleFragments)
-                } else {
-                    Some(TreeShakingMode::ReexportsOnly)
-                }
+                Some(TreeShakingMode::ModuleFragments)
             }
             None => {
                 if is_development {

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1123,7 +1123,7 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub async fn tree_shaking_mode_for_foreign_code(
         self: Vc<Self>,
-        is_development: Vc<bool>,
+        is_development: bool,
     ) -> Result<Vc<OptionTreeShaking>> {
         let is_development = *is_development.await?;
         let tree_shaking = self.await?.experimental.tree_shaking;

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1125,14 +1125,11 @@ impl NextConfig {
         self: Vc<Self>,
         is_development: bool,
     ) -> Result<Vc<OptionTreeShaking>> {
-        let is_development = *is_development.await?;
         let tree_shaking = self.await?.experimental.tree_shaking;
 
         Ok(OptionTreeShaking(match tree_shaking {
             Some(false) => Some(TreeShakingMode::ReexportsOnly),
-            Some(true) => {
-                Some(TreeShakingMode::ModuleFragments)
-            }
+            Some(true) => Some(TreeShakingMode::ModuleFragments),
             None => {
                 if is_development {
                     Some(TreeShakingMode::ReexportsOnly)
@@ -1147,7 +1144,7 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub async fn tree_shaking_mode_for_user_code(
         self: Vc<Self>,
-        _is_development: Vc<bool>,
+        _is_development: bool,
     ) -> Result<Vc<OptionTreeShaking>> {
         Ok(Vc::cell(Some(TreeShakingMode::ReexportsOnly)))
     }

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1149,7 +1149,7 @@ impl NextConfig {
         self: Vc<Self>,
         _is_development: Vc<bool>,
     ) -> Result<Vc<OptionTreeShaking>> {
-        Ok(OptionTreeShaking(Some(TreeShakingMode::ReexportsOnly)).cell())
+        Ok(Vc::cell(Some(TreeShakingMode::ReexportsOnly)))
     }
 }
 

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -444,6 +444,7 @@ pub async fn get_server_module_options_context(
     let enable_webpack_loaders =
         webpack_loader_options(project_path, next_config, false, conditions).await?;
 
+    let tree_shaking_mode = *next_config.tree_shaking_mode().await?;
     let use_swc_css = *next_config.use_swc_css().await?;
     let versions = RuntimeVersions(Default::default()).cell();
 
@@ -536,7 +537,7 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
-                tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
+                tree_shaking_mode,
                 ..module_options_context.clone()
             };
 
@@ -593,7 +594,7 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
-                tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
+                tree_shaking_mode,
                 ..module_options_context.clone()
             };
             let internal_module_options_context = ModuleOptionsContext {
@@ -663,7 +664,7 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
-                tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
+                tree_shaking_mode,
                 ..module_options_context.clone()
             };
             let internal_module_options_context = ModuleOptionsContext {
@@ -729,7 +730,7 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
-                tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
+                tree_shaking_mode,
                 ..module_options_context.clone()
             };
             let internal_module_options_context = ModuleOptionsContext {
@@ -812,7 +813,7 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
-                tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
+                tree_shaking_mode,
                 ..module_options_context.clone()
             };
             let internal_module_options_context = ModuleOptionsContext {

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -486,7 +486,6 @@ pub async fn get_server_module_options_context(
         enable_typeof_window_inlining: Some(TypeofWindow::Undefined),
         execution_context: Some(execution_context),
         use_swc_css,
-        tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
         import_externals: *next_config.import_externals().await?,
         ignore_dynamic_requests: true,
         side_effect_free_packages: next_config.optimize_package_imports().await?.clone_value(),
@@ -537,6 +536,7 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
+                tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
                 ..module_options_context.clone()
             };
 
@@ -593,6 +593,7 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
+                tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
                 ..module_options_context.clone()
             };
             let internal_module_options_context = ModuleOptionsContext {
@@ -728,6 +729,7 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
+                tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
                 ..module_options_context.clone()
             };
             let internal_module_options_context = ModuleOptionsContext {
@@ -809,6 +811,7 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
+                tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
                 ..module_options_context.clone()
             };
             let internal_module_options_context = ModuleOptionsContext {

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -486,7 +486,7 @@ pub async fn get_server_module_options_context(
         enable_typeof_window_inlining: Some(TypeofWindow::Undefined),
         execution_context: Some(execution_context),
         use_swc_css,
-        tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
+        tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
         import_externals: *next_config.import_externals().await?,
         ignore_dynamic_requests: true,
         side_effect_free_packages: next_config.optimize_package_imports().await?.clone_value(),

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -672,11 +672,7 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
-                // TODO(PACK-3131): Enable tree shaking.
-                // This is disabled because pages that are built as a static page has an issue with
-                // tree shaking.
-
-                // tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
+                tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
                 ..module_options_context.clone()
             };
             let internal_module_options_context = ModuleOptionsContext {

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -841,7 +841,7 @@ pub async fn get_server_module_options_context(
 pub fn get_build_module_options_context() -> Vc<ModuleOptionsContext> {
     ModuleOptionsContext {
         enable_typescript_transform: Some(Default::default()),
-        tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
+        tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
         esm_url_rewrite_behavior: Some(UrlRewriteBehavior::Full),
         ..Default::default()
     }

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -663,7 +663,11 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
-                tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
+                // TODO(PACK-3131): Enable tree shaking.
+                // This is disabled because pages that are built as a static page has an issue with
+                // tree shaking.
+
+                // tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
                 ..module_options_context.clone()
             };
             let internal_module_options_context = ModuleOptionsContext {

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -617,6 +617,8 @@ pub async fn get_server_module_options_context(
                         internal_module_options_context.cell(),
                     ),
                 ],
+                // TODO(kdy1): Use ModuleFragments after fixing a bug.
+                tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
                 custom_rules: next_server_rules,
                 ..module_options_context
             }

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -53,6 +53,7 @@ use crate::{
     next_import_map::get_next_server_import_map,
     next_server::resolve::ExternalPredicate,
     next_shared::{
+        next_js_special_exports,
         resolve::{
             get_invalid_client_only_resolve_plugin, get_invalid_styled_jsx_resolve_plugin,
             ModuleFeatureReportResolvePlugin, NextExternalResolvePlugin,
@@ -489,6 +490,7 @@ pub async fn get_server_module_options_context(
         use_swc_css,
         tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
         import_externals: *next_config.import_externals().await?,
+        special_exports: next_js_special_exports(),
         ignore_dynamic_requests: true,
         side_effect_free_packages: next_config.optimize_package_imports().await?.clone_value(),
         ..Default::default()

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -617,8 +617,6 @@ pub async fn get_server_module_options_context(
                         internal_module_options_context.cell(),
                     ),
                 ],
-                // TODO(kdy1): Use ModuleFragments after fixing a bug.
-                tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
                 custom_rules: next_server_rules,
                 ..module_options_context
             }

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -593,7 +593,16 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
-                tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
+                // TODO(kdy1): Enable tree shaking.
+                // This is disabled because of strange behavior with
+                //
+                // export const runtime = "edge";
+                //
+                // The code above, and the next.js module exporting NextReponse is not tree shaken
+                // but the import resolves as undefined. But it works if the runtime export is
+                // removed or tree shaking is disabled.
+                //
+                // tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
                 ..module_options_context.clone()
             };
             let internal_module_options_context = ModuleOptionsContext {

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -490,7 +490,7 @@ pub async fn get_server_module_options_context(
         use_swc_css,
         tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
         import_externals: *next_config.import_externals().await?,
-        special_exports: next_js_special_exports(),
+        special_exports: Some(next_js_special_exports()),
         ignore_dynamic_requests: true,
         side_effect_free_packages: next_config.optimize_package_imports().await?.clone_value(),
         ..Default::default()

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -544,6 +544,7 @@ pub async fn get_server_module_options_context(
                 enable_typescript_transform: Some(TypescriptTransformOptions::default().cell()),
                 enable_jsx: Some(JsxTransformOptions::default().cell()),
                 custom_rules: foreign_next_server_rules,
+                tree_shaking_mode: None,
                 ..module_options_context.clone()
             };
 
@@ -597,6 +598,7 @@ pub async fn get_server_module_options_context(
             let internal_module_options_context = ModuleOptionsContext {
                 enable_typescript_transform: Some(TypescriptTransformOptions::default().cell()),
                 custom_rules: foreign_next_server_rules,
+                tree_shaking_mode: None,
                 ..module_options_context.clone()
             };
 
@@ -665,6 +667,7 @@ pub async fn get_server_module_options_context(
             let internal_module_options_context = ModuleOptionsContext {
                 enable_typescript_transform: Some(TypescriptTransformOptions::default().cell()),
                 custom_rules: foreign_next_server_rules,
+                tree_shaking_mode: None,
                 ..module_options_context.clone()
             };
             ModuleOptionsContext {
@@ -729,6 +732,7 @@ pub async fn get_server_module_options_context(
             let internal_module_options_context = ModuleOptionsContext {
                 enable_typescript_transform: Some(TypescriptTransformOptions::default().cell()),
                 custom_rules: internal_custom_rules,
+                tree_shaking_mode: None,
                 ..module_options_context.clone()
             };
             ModuleOptionsContext {
@@ -809,6 +813,7 @@ pub async fn get_server_module_options_context(
             let internal_module_options_context = ModuleOptionsContext {
                 enable_typescript_transform: Some(TypescriptTransformOptions::default().cell()),
                 custom_rules: internal_custom_rules,
+                tree_shaking_mode: None,
                 ..module_options_context.clone()
             };
             ModuleOptionsContext {

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -662,6 +662,7 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
+                tree_shaking_mode: None,
                 ..module_options_context.clone()
             };
             let internal_module_options_context = ModuleOptionsContext {

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -663,7 +663,7 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
-                tree_shaking_mode: None,
+                tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
                 ..module_options_context.clone()
             };
             let internal_module_options_context = ModuleOptionsContext {
@@ -756,6 +756,7 @@ pub async fn get_server_module_options_context(
                     ),
                 ],
                 custom_rules: next_server_rules,
+                tree_shaking_mode: None,
                 ..module_options_context
             }
         }

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -729,7 +729,16 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
-                tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
+                // TODO(kdy1): Enable tree shaking.
+                // This is disabled because of strange behavior with
+                //
+                // export const runtime = "edge";
+                //
+                // The code above, and the next.js module exporting NextReponse is not tree shaken
+                // but the import resolves as undefined. But it works if the runtime export is
+                // removed or tree shaking is disabled.
+                //
+                // tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
                 ..module_options_context.clone()
             };
             let internal_module_options_context = ModuleOptionsContext {

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -446,8 +446,11 @@ pub async fn get_server_module_options_context(
     let enable_webpack_loaders =
         webpack_loader_options(project_path, next_config, false, conditions).await?;
 
-    let tree_shaking_mode = *next_config
-        .tree_shaking_mode(Vc::cell(next_mode.is_development()))
+    let tree_shaking_mode_for_user_code = *next_config
+        .tree_shaking_mode_for_user_code(Vc::cell(next_mode.is_development()))
+        .await?;
+    let tree_shaking_mode_for_foreign_code = *next_config
+        .tree_shaking_mode_for_foreign_code(Vc::cell(next_mode.is_development()))
         .await?;
     let use_swc_css = *next_config.use_swc_css().await?;
     let versions = RuntimeVersions(Default::default()).cell();
@@ -491,7 +494,7 @@ pub async fn get_server_module_options_context(
         enable_typeof_window_inlining: Some(TypeofWindow::Undefined),
         execution_context: Some(execution_context),
         use_swc_css,
-        tree_shaking_mode,
+        tree_shaking_mode: tree_shaking_mode_for_user_code,
         import_externals: *next_config.import_externals().await?,
         special_exports: Some(next_js_special_exports()),
         ignore_dynamic_requests: true,
@@ -543,7 +546,7 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
-                tree_shaking_mode,
+                tree_shaking_mode: tree_shaking_mode_for_foreign_code,
                 ..module_options_context.clone()
             };
 
@@ -599,7 +602,7 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
-                tree_shaking_mode,
+                tree_shaking_mode: tree_shaking_mode_for_foreign_code,
                 ..module_options_context.clone()
             };
             let internal_module_options_context = ModuleOptionsContext {
@@ -668,7 +671,7 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
-                tree_shaking_mode,
+                tree_shaking_mode: tree_shaking_mode_for_foreign_code,
                 ..module_options_context.clone()
             };
             let internal_module_options_context = ModuleOptionsContext {
@@ -732,7 +735,7 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
-                tree_shaking_mode,
+                tree_shaking_mode: tree_shaking_mode_for_foreign_code,
                 ..module_options_context.clone()
             };
             let internal_module_options_context = ModuleOptionsContext {
@@ -813,7 +816,7 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
-                tree_shaking_mode,
+                tree_shaking_mode: tree_shaking_mode_for_foreign_code,
                 ..module_options_context.clone()
             };
             let internal_module_options_context = ModuleOptionsContext {

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -593,16 +593,7 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
-                // TODO(kdy1): Enable tree shaking.
-                // This is disabled because of strange behavior with
-                //
-                // export const runtime = "edge";
-                //
-                // The code above, and the next.js module exporting NextReponse is not tree shaken
-                // but the import resolves as undefined. But it works if the runtime export is
-                // removed or tree shaking is disabled.
-                //
-                // tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
+                tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
                 ..module_options_context.clone()
             };
             let internal_module_options_context = ModuleOptionsContext {
@@ -738,16 +729,7 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,
-                // TODO(kdy1): Enable tree shaking.
-                // This is disabled because of strange behavior with
-                //
-                // export const runtime = "edge";
-                //
-                // The code above, and the next.js module exporting NextReponse is not tree shaken
-                // but the import resolves as undefined. But it works if the runtime export is
-                // removed or tree shaking is disabled.
-                //
-                // tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
+                tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
                 ..module_options_context.clone()
             };
             let internal_module_options_context = ModuleOptionsContext {

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -685,6 +685,7 @@ pub async fn get_server_module_options_context(
                     ),
                 ],
                 custom_rules: next_server_rules,
+                tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
                 ..module_options_context
             }
         }

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -487,6 +487,7 @@ pub async fn get_server_module_options_context(
         enable_typeof_window_inlining: Some(TypeofWindow::Undefined),
         execution_context: Some(execution_context),
         use_swc_css,
+        tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
         import_externals: *next_config.import_externals().await?,
         ignore_dynamic_requests: true,
         side_effect_free_packages: next_config.optimize_package_imports().await?.clone_value(),
@@ -545,7 +546,6 @@ pub async fn get_server_module_options_context(
                 enable_typescript_transform: Some(TypescriptTransformOptions::default().cell()),
                 enable_jsx: Some(JsxTransformOptions::default().cell()),
                 custom_rules: foreign_next_server_rules,
-                tree_shaking_mode: None,
                 ..module_options_context.clone()
             };
 
@@ -600,7 +600,6 @@ pub async fn get_server_module_options_context(
             let internal_module_options_context = ModuleOptionsContext {
                 enable_typescript_transform: Some(TypescriptTransformOptions::default().cell()),
                 custom_rules: foreign_next_server_rules,
-                tree_shaking_mode: None,
                 ..module_options_context.clone()
             };
 
@@ -670,7 +669,6 @@ pub async fn get_server_module_options_context(
             let internal_module_options_context = ModuleOptionsContext {
                 enable_typescript_transform: Some(TypescriptTransformOptions::default().cell()),
                 custom_rules: foreign_next_server_rules,
-                tree_shaking_mode: None,
                 ..module_options_context.clone()
             };
             ModuleOptionsContext {
@@ -691,7 +689,6 @@ pub async fn get_server_module_options_context(
                     ),
                 ],
                 custom_rules: next_server_rules,
-                tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
                 ..module_options_context
             }
         }
@@ -736,7 +733,6 @@ pub async fn get_server_module_options_context(
             let internal_module_options_context = ModuleOptionsContext {
                 enable_typescript_transform: Some(TypescriptTransformOptions::default().cell()),
                 custom_rules: internal_custom_rules,
-                tree_shaking_mode: None,
                 ..module_options_context.clone()
             };
             ModuleOptionsContext {
@@ -757,7 +753,6 @@ pub async fn get_server_module_options_context(
                     ),
                 ],
                 custom_rules: next_server_rules,
-                tree_shaking_mode: None,
                 ..module_options_context
             }
         }
@@ -819,7 +814,6 @@ pub async fn get_server_module_options_context(
             let internal_module_options_context = ModuleOptionsContext {
                 enable_typescript_transform: Some(TypescriptTransformOptions::default().cell()),
                 custom_rules: internal_custom_rules,
-                tree_shaking_mode: None,
                 ..module_options_context.clone()
             };
             ModuleOptionsContext {
@@ -853,7 +847,7 @@ pub async fn get_server_module_options_context(
 pub fn get_build_module_options_context() -> Vc<ModuleOptionsContext> {
     ModuleOptionsContext {
         enable_typescript_transform: Some(Default::default()),
-        tree_shaking_mode: Some(TreeShakingMode::ModuleFragments),
+        tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
         esm_url_rewrite_behavior: Some(UrlRewriteBehavior::Full),
         ..Default::default()
     }

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -447,10 +447,10 @@ pub async fn get_server_module_options_context(
         webpack_loader_options(project_path, next_config, false, conditions).await?;
 
     let tree_shaking_mode_for_user_code = *next_config
-        .tree_shaking_mode_for_user_code(Vc::cell(next_mode.is_development()))
+        .tree_shaking_mode_for_user_code(next_mode.is_development())
         .await?;
     let tree_shaking_mode_for_foreign_code = *next_config
-        .tree_shaking_mode_for_foreign_code(Vc::cell(next_mode.is_development()))
+        .tree_shaking_mode_for_foreign_code(next_mode.is_development())
         .await?;
     let use_swc_css = *next_config.use_swc_css().await?;
     let versions = RuntimeVersions(Default::default()).cell();

--- a/crates/next-core/src/next_shared/mod.rs
+++ b/crates/next-core/src/next_shared/mod.rs
@@ -1,3 +1,31 @@
+use turbo_tasks::{RcStr, Vc};
+
 pub(crate) mod resolve;
 pub(crate) mod transforms;
 pub(crate) mod webpack_rules;
+
+#[turbo_tasks::function]
+pub fn next_js_special_exports() -> Vc<Vec<RcStr>> {
+    Vc::cell(
+        [
+            "config",
+            "middleware",
+            "runtime",
+            "revalidate",
+            "dynamic",
+            "dynamicParams",
+            "fetchCache",
+            "preferredRegion",
+            "maxDuration",
+            "generateStaticParams",
+            "metadata",
+            "generateMetadata",
+            "getServerSideProps",
+            "getInitialProps",
+            "getStaticProps",
+        ]
+        .into_iter()
+        .map(RcStr::from)
+        .collect::<Vec<RcStr>>(),
+    )
+}

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -389,6 +389,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
               .optional(),
             resolveExtensions: z.array(z.string()).optional(),
             useSwcCss: z.boolean().optional(),
+            disableTreeShaking: z.boolean().optional(),
             memoryLimit: z.number().optional(),
           })
           .optional(),

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -389,7 +389,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
               .optional(),
             resolveExtensions: z.array(z.string()).optional(),
             useSwcCss: z.boolean().optional(),
-            disableTreeShaking: z.boolean().optional(),
+            treeShaking: z.boolean().optional(),
             memoryLimit: z.number().optional(),
           })
           .optional(),


### PR DESCRIPTION
# Turbopack

* https://github.com/vercel/turbo/pull/8875 <!-- Tobias Koppers - improve test glob to exclude output folder  -->
* https://github.com/vercel/turbo/pull/8874 <!-- Tobias Koppers - only add import references when they are used  -->
* https://github.com/vercel/turbo/pull/8766 <!-- Niklas Mischkulnig - Replace MDX ModuleType with MDX SourceTransform  -->

### What?

Enable tree shaking of turbopack.

### Why?

Verify the implementation and improve the bundle size.

### How?

Closes PACK-3111
