### PR TITLE
refactor: simplified lint-staged config

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,44 +1,8 @@
-const { quote } = require('shell-quote')
-const { ESLint } = require('eslint')
-
-const eslint = new ESLint()
-
-/**
- * Escape filenames to ensure that spaces and such aren't interpreted as
- * separators.
- *
- * @param {string[]} filenames
- * @returns {string[]}
- */
-function escape(filenames) {
-  if (process.platform === 'win32') {
-    return filenames
-  }
-
-  return filenames.map((filename) => quote([filename]).replace(/\\@/g, '@'))
-}
-
 module.exports = {
-  '*.{js,jsx,mjs,ts,tsx,mts}': async (filenames) => {
-    const escapedFileNames = escape(filenames).join(' ')
-    const eslintFileNames = await Promise.all(
-      filenames.map(async (filename) => {
-        const ignored = await eslint.isPathIgnored(filename)
-        return ignored ? null : filename
-      })
-    )
-
-    return [
-      `prettier --with-node-modules --ignore-path .prettierignore --write ${escapedFileNames}`,
-      `eslint --no-ignore --fix ${eslintFileNames
-        .filter((filename) => filename !== null)
-        .map((filename) => {
-          return `"${filename}"`
-        })
-        .join(' ')}`,
-      `git add ${escapedFileNames}`,
-    ]
-  },
+  '*.{js,jsx,mjs,ts,tsx,mts}': [
+    'prettier --with-node-modules --ignore-path .prettierignore --write',
+    'eslint --fix',
+  ],
   '*.{json,md,mdx,css,html,yml,yaml,scss}': [
     'prettier --with-node-modules --ignore-path .prettierignore --write',
   ],


### PR DESCRIPTION
This restores the changes that were reverted in #66554. This corrects the issue that triggered the revert by removing the `--no-ignore` flag which allows ESLint to handle the ignored files correctly.