### PR TITLE
fix: propagate waitUntil from edge runtime sandbox

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1735,7 +1735,7 @@ export default abstract class Server<
     )
   }
 
-  private getWaitUntil(): WaitUntil | undefined {
+  protected getWaitUntil(): WaitUntil | undefined {
     const builtinRequestContext = getBuiltinRequestContext()
     if (builtinRequestContext) {
       // the platform provided a request context.

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -966,7 +966,6 @@ export default class NextNodeServer extends BaseServer<
         delete query._nextBubbleNoFallback
         delete query[NEXT_RSC_UNION_QUERY]
 
-        // If we handled the request, we can return early.
         // For api routes edge runtime
         try {
           const handled = await this.runEdgeFunction({
@@ -978,7 +977,13 @@ export default class NextNodeServer extends BaseServer<
             match,
             appPaths: null,
           })
-          if (handled) return true
+          // If we handled the request, we can return early.
+          if (handled) {
+            const waitUntil = this.getWaitUntil()
+            waitUntil?.(handled.waitUntil)
+
+            return true
+          }
         } catch (apiError) {
           await this.instrumentationOnRequestError(apiError, req, {
             routePath: match.definition.page,
@@ -1795,6 +1800,11 @@ export default class NextNodeServer extends BaseServer<
         params.res.appendHeader(key, value)
       }
     })
+
+    const waitUntil = this.getWaitUntil()
+    if (waitUntil) {
+      waitUntil(result.waitUntil)
+    }
 
     const { originalResponse } = params.res
     if (result.response.body) {


### PR DESCRIPTION
### What?
As part of this stack, it turned out that if `next start` is running an edge function in a sandbox (via `runEdgeFunction`), we're ignoring the `FetchEventResult.waitUntil` promise, which [should be passed to an actual `waitUntil` function](https://github.com/vercel/vercel/blob/9d6088e0b55578d776ac95a038a9c00f8eb22030/packages/next/src/edge-function-source/get-edge-function.ts#L133)

### Why?
This is a small bug, which is unlikely to affect many users -- they'd need to be
1. running `next start`
2. in a context which has a `waitUntil` implementation
3. and specify `runtime = 'edge' for some reason

but importantly, it affects tests of pages/handlers that specify `runtime = edge`, and in particular the test introduced in the previous PR, which fulfills all three of those conditions.