### PR TITLE
fix: pass waitUntil from NextRequestHint to wrapped NextWebServer

### DIFF
--- a/packages/next/src/client/components/lifecycle-async-storage-instance.ts
+++ b/packages/next/src/client/components/lifecycle-async-storage-instance.ts
@@ -1,0 +1,5 @@
+import { createAsyncLocalStorage } from './async-local-storage'
+import type { LifecycleAsyncStorage } from './lifecycle-async-storage.external'
+
+export const _lifecycleAsyncStorage: LifecycleAsyncStorage =
+  createAsyncLocalStorage()

--- a/packages/next/src/client/components/lifecycle-async-storage.external.ts
+++ b/packages/next/src/client/components/lifecycle-async-storage.external.ts
@@ -1,0 +1,11 @@
+import type { AsyncLocalStorage } from 'async_hooks'
+// Share the instance module in the next-shared layer
+import { _lifecycleAsyncStorage as lifecycleAsyncStorage } from './lifecycle-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
+
+export interface LifecycleStore {
+  readonly waitUntil: ((promise: Promise<any>) => void) | undefined
+}
+
+export type LifecycleAsyncStorage = AsyncLocalStorage<LifecycleStore>
+
+export { lifecycleAsyncStorage }

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -159,6 +159,7 @@ import {
 } from './after/builtin-request-context'
 import { ENCODED_TAGS } from './stream-utils/encodedTags'
 import { NextRequestHint } from './web/adapter'
+import { lifecycleAsyncStorage } from '../client/components/lifecycle-async-storage.external'
 
 export type FindComponentsResult = {
   components: LoadComponentsReturnType
@@ -1736,6 +1737,11 @@ export default abstract class Server<
   }
 
   protected getWaitUntil(): WaitUntil | undefined {
+    const lifecycleStore = lifecycleAsyncStorage.getStore()
+    if (lifecycleStore) {
+      return lifecycleStore.waitUntil
+    }
+
     const builtinRequestContext = getBuiltinRequestContext()
     if (builtinRequestContext) {
       // the platform provided a request context.

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -22,6 +22,7 @@ import type { TextMapGetter } from 'next/dist/compiled/@opentelemetry/api'
 import { MiddlewareSpan } from '../lib/trace/constants'
 import { CloseController } from './web-on-close'
 import { getEdgePreviewProps } from './get-edge-preview-props'
+import { lifecycleAsyncStorage } from '../../client/components/lifecycle-async-storage.external'
 
 export class NextRequestHint extends NextRequest {
   sourcePage: string
@@ -207,13 +208,14 @@ export async function adapter(
     const isMiddleware =
       params.page === '/middleware' || params.page === '/src/middleware'
 
+    const isAfterEnabled =
+      params.request.nextConfig?.experimental?.after ??
+      !!process.env.__NEXT_AFTER
+
     if (isMiddleware) {
       // if we're in an edge function, we only get a subset of `nextConfig` (no `experimental`),
       // so we have to inject it via DefinePlugin.
       // in `next start` this will be passed normally (see `NextNodeServer.runMiddleware`).
-      const isAfterEnabled =
-        params.request.nextConfig?.experimental?.after ??
-        !!process.env.__NEXT_AFTER
 
       let waitUntil: WrapperRenderOpts['waitUntil'] = undefined
       let closeController: CloseController | undefined = undefined
@@ -271,6 +273,25 @@ export async function adapter(
         }
       )
     }
+
+    if (isAfterEnabled) {
+      // NOTE:
+      // Currently, `adapter` is expected to return promises passed to `waitUntil`
+      // as part of its result (i.e. a FetchEventResult).
+      // Because of this, we override any outer contexts that might provide a real `waitUntil`,
+      // and provide the `waitUntil` from the NextFetchEvent instead so that we can collect those promises.
+      // This is not ideal, but until we change this calling convention, it's the least surprising thing to do.
+      //
+      // Notably, the only case that currently cares about this ALS is Edge SSR
+      // (i.e. a handler created via `build/webpack/loaders/next-edge-ssr-loader/render.ts`)
+      // Other types of handlers will grab the waitUntil from the passed FetchEvent,
+      // but NextWebServer currently has no interface that'd allow for that.
+      return lifecycleAsyncStorage.run(
+        { waitUntil: event.waitUntil.bind(event) },
+        () => params.handler(request, event)
+      )
+    }
+
     return params.handler(request, event)
   })
 


### PR DESCRIPTION
### What?

Make sure that edge SSR handlers use the `waitUntil` that's created within `server/web/adapter`. 

### Why?

This is a corner case that can happen on a platform that
1. Uses edge runtime handlers
2. Has a waitUntil implementation
3. Does not inject that implementation via `@{next,vercel}/request-context`.

`next-on-pages` is an example of that.

The details of why this happens are a bit complicated:

Our edge handlers are wrapped with `server/web/adapter`, and return a `type FetchEventResult = { response: Response, waitUntil: Promise<any> }`. The handler's caller is then expected to pass `result.waitUntil` to the platform's `waitUntil` implementation (see example in [the vercel builder](https://github.com/vercel/vercel/blob/9d6088e0b55578d776ac95a038a9c00f8eb22030/packages/next/src/edge-function-source/get-edge-function.ts#L133)). For this purpose, `adapter` creates a `NextFetchEvent` which provides a "fake" `waitUntil` that gathers waitUntil'd promises so that they can be returned as described above.

However, previously, edge SSR handlers (i.e. a wrapped NextWebServer) **would not receive `adapter`'s `waitUntil`**. This means that `waitUntil` calls that happened during render would not be included in the result's promise.

This _would still work_ if the host provides `@{next,vercel}/request-context` (like Vercel does), because then the server would just read `waitUntil` off of there. So while the promises wouldn't be a part of the handler's result, they'd still go into the platform's `waitUntil`, which is the ultimate goal.

But if the host does NOT provide that context, then NextWebServer would end up either erroring with "missing waitUntil" or making `waitUntil` a no-op (see `BaseServer.getWaitUntil`). so `waitUntil` calls within render would either fail or drop promises on the floor.

### How?

The cleanest way seems to be to inject `waitUntil` via our own ALS (newly introduced `lifecycleAsyncStorage`), and make `BaseServer.getWaitUntil` prefer that over all other sources. This means that regardless of any other `waitUntil`s that we might have access to, we'll _always_ end up using `NextFetchEvent.waitUntil`, and thus always collect all the promises in the result.

The name `lifecycleAsyncStorage` may seem a bit generic. This is because I want to do more refactoring later and use it as the main mechanism of injecting `waitUntil` into the render. Currently, it's a mess of passing it via `renderOpts` and other similar things, and i want to get rid of that.