### PR TITLE
fix: app-router prefetch crash when an invalid URL is passed to Link

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -369,7 +369,17 @@ function Router({
         ) {
           return
         }
-        const url = new URL(addBasePath(href), window.location.href)
+
+        let url: URL
+        try {
+          url = new URL(addBasePath(href), window.location.href)
+        } catch (err) {
+          console.error(
+            `Cannot prefetch '${href}' because it cannot be converted to a URL.`
+          )
+          return
+        }
+
         // External urls can't be prefetched in the same way.
         if (isExternalURL(url)) {
           return

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -362,11 +362,7 @@ function Router({
       forward: () => window.history.forward(),
       prefetch: (href, options) => {
         // Don't prefetch for bots as they don't navigate.
-        // Don't prefetch during development (improves compilation performance)
-        if (
-          isBot(window.navigator.userAgent) ||
-          process.env.NODE_ENV === 'development'
-        ) {
+        if (isBot(window.navigator.userAgent)) {
           return
         }
 
@@ -377,6 +373,11 @@ function Router({
           console.error(
             `Cannot prefetch '${href}' because it cannot be converted to a URL.`
           )
+          return
+        }
+
+        // Don't prefetch during development (improves compilation performance)
+        if (process.env.NODE_ENV === 'development') {
           return
         }
 

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -369,11 +369,10 @@ function Router({
         let url: URL
         try {
           url = new URL(addBasePath(href), window.location.href)
-        } catch (err) {
-          console.error(
+        } catch (_) {
+          throw new Error(
             `Cannot prefetch '${href}' because it cannot be converted to a URL.`
           )
-          return
         }
 
         // Don't prefetch during development (improves compilation performance)

--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -161,15 +161,21 @@ function prefetch(
     prefetched.add(prefetchedKey)
   }
 
-  const prefetchPromise = isAppRouter
-    ? (router as AppRouterInstance).prefetch(href, appOptions)
-    : (router as NextRouter).prefetch(href, as, options)
+  const doPrefetch = async () => {
+    if (isAppRouter) {
+      // note that `appRouter.prefetch()` is currently sync,
+      // so we have to wrap this call in an async function to be able to catch() errors below.
+      return (router as AppRouterInstance).prefetch(href, appOptions)
+    } else {
+      return (router as NextRouter).prefetch(href, as, options)
+    }
+  }
 
   // Prefetch the JSON page if asked (only in the client)
   // We need to handle a prefetch error here since we may be
   // loading with priority which can reject but we don't
   // want to force navigation since this is only a prefetch
-  Promise.resolve(prefetchPromise).catch((err) => {
+  doPrefetch().catch((err) => {
     if (process.env.NODE_ENV !== 'production') {
       // rethrow to show invalid URL errors
       throw err

--- a/test/e2e/app-dir/app-prefetch/app/invalid-url/delay.js
+++ b/test/e2e/app-dir/app-prefetch/app/invalid-url/delay.js
@@ -1,0 +1,15 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useState } from 'react'
+
+export function Delay({ duration = 500, children }) {
+  const [isVisible, setIsVisible] = useState(false)
+  useEffect(() => {
+    const timeout = setTimeout(() => setIsVisible(true), duration)
+    return () => clearTimeout(timeout)
+  }, [duration])
+
+  if (!isVisible) return null
+  return <>{children}</>
+}

--- a/test/e2e/app-dir/app-prefetch/app/invalid-url/error.js
+++ b/test/e2e/app-dir/app-prefetch/app/invalid-url/error.js
@@ -1,0 +1,4 @@
+'use client'
+export default function Error() {
+  return <h1>A prefetch threw an error</h1>
+}

--- a/test/e2e/app-dir/app-prefetch/app/invalid-url/from-link/page.js
+++ b/test/e2e/app-dir/app-prefetch/app/invalid-url/from-link/page.js
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+import { INVALID_URL } from '../invalid-url'
+import { Delay } from '../delay'
+
+export const dynamic = 'force-dynamic'
+
+export default async function Page() {
+  return (
+    <>
+      <Link href={INVALID_URL}>invalid link</Link>
+      <Delay>
+        <h1>Hello, world!</h1>
+      </Delay>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-prefetch/app/invalid-url/from-link/page.js
+++ b/test/e2e/app-dir/app-prefetch/app/invalid-url/from-link/page.js
@@ -4,7 +4,7 @@ import { Delay } from '../delay'
 
 export const dynamic = 'force-dynamic'
 
-export default async function Page() {
+export default function Page() {
   return (
     <>
       <Link href={INVALID_URL}>invalid link</Link>

--- a/test/e2e/app-dir/app-prefetch/app/invalid-url/from-router-prefetch/page.js
+++ b/test/e2e/app-dir/app-prefetch/app/invalid-url/from-router-prefetch/page.js
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation'
 
 export const dynamic = 'force-dynamic'
 
-export default async function Page() {
+export default function Page() {
   const router = useRouter()
   useEffect(() => {
     router.prefetch(INVALID_URL)

--- a/test/e2e/app-dir/app-prefetch/app/invalid-url/from-router-prefetch/page.js
+++ b/test/e2e/app-dir/app-prefetch/app/invalid-url/from-router-prefetch/page.js
@@ -1,0 +1,20 @@
+'use client'
+import { useEffect } from 'react'
+import { INVALID_URL } from '../invalid-url'
+import { Delay } from '../delay'
+import { useRouter } from 'next/navigation'
+
+export const dynamic = 'force-dynamic'
+
+export default async function Page() {
+  const router = useRouter()
+  useEffect(() => {
+    router.prefetch(INVALID_URL)
+  }, [router])
+
+  return (
+    <Delay>
+      <h1>Hello, world!</h1>
+    </Delay>
+  )
+}

--- a/test/e2e/app-dir/app-prefetch/app/invalid-url/invalid-url.js
+++ b/test/e2e/app-dir/app-prefetch/app/invalid-url/invalid-url.js
@@ -1,0 +1,8 @@
+// We need a URL that reliably fails `new URL(url, window.location)
+// This only fails if `window.location` starts with `https://`:
+//
+//   const invalidUrl = 'http:'
+//
+// because `new URL('http:', 'http://localhost:3000')` works fine.
+// So better to pick something that's always invalid
+export const INVALID_URL = '///'

--- a/test/e2e/app-dir/app-prefetch/prefetching.test.ts
+++ b/test/e2e/app-dir/app-prefetch/prefetching.test.ts
@@ -329,4 +329,20 @@ describe('app dir - prefetching', () => {
       })
     })
   })
+
+  describe('should not crash for invalid URLs', () => {
+    it.each([
+      { title: 'passed to Link', path: '/invalid-url/from-link' },
+      {
+        title: 'passed to router.prefetch',
+        path: '/invalid-url/from-router-prefetch',
+      },
+    ])('$title', async ({ path }) => {
+      const browser = await next.browser(path)
+
+      await check(() => browser.hasElementByCssSelector('h1'), true)
+
+      expect(await browser.elementByCss('h1').text()).toEqual('Hello, world!')
+    })
+  })
 })

--- a/test/e2e/app-dir/app-prefetch/prefetching.test.ts
+++ b/test/e2e/app-dir/app-prefetch/prefetching.test.ts
@@ -330,19 +330,21 @@ describe('app dir - prefetching', () => {
     })
   })
 
-  describe('should not crash for invalid URLs', () => {
-    it.each([
-      { title: 'passed to Link', path: '/invalid-url/from-link' },
-      {
-        title: 'passed to router.prefetch',
-        path: '/invalid-url/from-router-prefetch',
-      },
-    ])('$title', async ({ path }) => {
-      const browser = await next.browser(path)
+  describe('invalid URLs', () => {
+    it('should not throw when an invalid URL is passed to Link', async () => {
+      const browser = await next.browser('/invalid-url/from-link')
 
       await check(() => browser.hasElementByCssSelector('h1'), true)
-
       expect(await browser.elementByCss('h1').text()).toEqual('Hello, world!')
+    })
+
+    it('should throw when an invalid URL is passed to router.prefetch', async () => {
+      const browser = await next.browser('/invalid-url/from-router-prefetch')
+
+      await check(() => browser.hasElementByCssSelector('h1'), true)
+      expect(await browser.elementByCss('h1').text()).toEqual(
+        'A prefetch threw an error'
+      )
     })
   })
 })


### PR DESCRIPTION
Closes [#66650](https://github.com/vercel/next.js/issues/66650)
Closes NEXT-3520

### What?

- Make Link not throw during prefetch if it received an invalid `href` (see [#66650](https://github.com/vercel/next.js/issues/66650))
- Throw in dev mode if an invalid link was passed to `router.prefetch` -- this matches current prod behavior
  - (previously, we'd immediately exit out of `router.prefetch`, so the user would see no indication that this'd fail in prod)

### Why?

If an invalid URL was passed to `<Link>`, the whole app would crash and show "A client-side exception occurred". A failed prefetch should not bring down the whole app.

Note that This preserves the current behavior of explicit `router.prefetch(url)` throwing an error if `url` is invalid. We may want to adjust this in the future, but that could be considered a breaking change, so I'm leaving it out for now. This only affects `Link`, which was intended to catch any errors thrown from `router.prefetch`, but that bit was accidentally broken. 
