### PR TITLE
Remove UnsupportedModule plugin and move ModuleFeatureReportResolvePlugin to BeforeResolvePlugin

### DIFF
--- a/packages/next-swc/crates/next-core/src/next_client/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/context.rs
@@ -49,7 +49,7 @@ use crate::{
     next_shared::{
         resolve::{
             get_invalid_server_only_resolve_plugin, ModuleFeatureReportResolvePlugin,
-            NextSharedRuntimeResolvePlugin, UnsupportedModulesResolvePlugin,
+            NextSharedRuntimeResolvePlugin,
         },
         transforms::{
             emotion::get_emotion_transform_rule, relay::get_relay_transform_rule,
@@ -160,13 +160,12 @@ pub async fn get_client_resolve_options_context(
         module: true,
         before_resolve_plugins: vec![
             Vc::upcast(get_invalid_server_only_resolve_plugin(project_path)),
+            Vc::upcast(ModuleFeatureReportResolvePlugin::new(project_path)),
             Vc::upcast(NextFontLocalResolvePlugin::new(project_path)),
         ],
-        after_resolve_plugins: vec![
-            Vc::upcast(ModuleFeatureReportResolvePlugin::new(project_path)),
-            Vc::upcast(UnsupportedModulesResolvePlugin::new(project_path)),
-            Vc::upcast(NextSharedRuntimeResolvePlugin::new(project_path)),
-        ],
+        after_resolve_plugins: vec![Vc::upcast(NextSharedRuntimeResolvePlugin::new(
+            project_path,
+        ))],
         ..Default::default()
     };
     Ok(ResolveOptionsContext {

--- a/packages/next-swc/crates/next-core/src/next_edge/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_edge/context.rs
@@ -28,7 +28,6 @@ use crate::{
     next_shared::resolve::{
         get_invalid_client_only_resolve_plugin, get_invalid_styled_jsx_resolve_plugin,
         ModuleFeatureReportResolvePlugin, NextSharedRuntimeResolvePlugin,
-        UnsupportedModulesResolvePlugin,
     },
     util::{foreign_code_context_condition, NextRuntime},
 };
@@ -101,7 +100,9 @@ pub async fn get_edge_resolve_options_context(
 
     let ty = ty.into_value();
 
-    let mut before_resolve_plugins = vec![];
+    let mut before_resolve_plugins = vec![Vc::upcast(ModuleFeatureReportResolvePlugin::new(
+        project_path,
+    ))];
     if matches!(
         ty,
         ServerContextType::Pages { .. }
@@ -127,11 +128,9 @@ pub async fn get_edge_resolve_options_context(
         )));
     }
 
-    let after_resolve_plugins = vec![
-        Vc::upcast(ModuleFeatureReportResolvePlugin::new(project_path)),
-        Vc::upcast(UnsupportedModulesResolvePlugin::new(project_path)),
-        Vc::upcast(NextSharedRuntimeResolvePlugin::new(project_path)),
-    ];
+    let after_resolve_plugins = vec![Vc::upcast(NextSharedRuntimeResolvePlugin::new(
+        project_path,
+    ))];
 
     // https://github.com/vercel/next.js/blob/bf52c254973d99fed9d71507a2e818af80b8ade7/packages/next/src/build/webpack-config.ts#L96-L102
     let mut custom_conditions = vec![mode.await?.condition().into()];

--- a/packages/next-swc/crates/next-core/src/next_font/local/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_font/local/mod.rs
@@ -15,7 +15,7 @@ use turbopack_binding::{
         resolve::{
             parse::Request,
             plugin::{BeforeResolvePlugin, BeforeResolvePluginCondition},
-            RequestKey, ResolveResult, ResolveResultItem, ResolveResultOption,
+            ResolveResult, ResolveResultItem, ResolveResultOption,
         },
         virtual_source::VirtualSource,
     },
@@ -125,16 +125,10 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                             .emit();
 
                             return Ok(ResolveResultOption::some(
-                                ResolveResult::primary_with_key(
-                                    RequestKey::new(font_path.clone()),
-                                    ResolveResultItem::Error(Vc::cell(
-                                        format!(
-                                            "Font file not found: Can't resolve {}'",
-                                            font_path
-                                        )
+                                ResolveResult::primary(ResolveResultItem::Error(Vc::cell(
+                                    format!("Font file not found: Can't resolve {}'", font_path)
                                         .into(),
-                                    )),
-                                )
+                                )))
                                 .into(),
                             ));
                         }


### PR DESCRIPTION
This removes `UnsupportedModulesResolvePlugin` as there are no longer any unsupported modules, and it was run on every resolution. This should improve resolution performance.

This also moves `ModuleFeatureReportResolvePlugin` to a `BeforeResolvePlugin`, as it never used the resolution result.