### PR TITLE
fix app-custom-routes deploy test

### DIFF
--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -7,7 +7,6 @@
       "test/production/**/*.test.{t,j}s{,x}"
     ],
     "exclude": [
-      "test/e2e/app-dir/app-routes/app-custom-routes.test.ts",
       "test/e2e/app-dir/next-after-app/index.test.ts",
       "test/e2e/app-dir/scss/nm-module-nested/nm-module-nested.test.ts",
       "test/e2e/cancel-request/stream-cancel.test.ts",

--- a/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check, waitFor } from 'next-test-utils'
+import { check, waitFor, retry } from 'next-test-utils'
 import { Readable } from 'stream'
 
 import {
@@ -679,18 +679,19 @@ describe('app-custom-routes', () => {
     })
   }
 
-  describe('no response returned', () => {
-    it('should print an error when no response is returned', async () => {
-      await next.fetch(basePath + '/no-response', { method: 'POST' })
-
-      await check(() => {
-        expect(next.cliOutput).toMatch(
-          /No response is returned from route handler '.+\/route\.ts'\. Ensure you return a `Response` or a `NextResponse` in all branches of your handler\./
-        )
-        return 'yes'
-      }, 'yes')
+  // This test is skipped in deploy mode because `next.cliOutput` will only contain build-time logs.
+  if (!isNextDeploy) {
+    describe('no response returned', () => {
+      it('should print an error when no response is returned', async () => {
+        await next.fetch(basePath + '/no-response', { method: 'POST' })
+        await retry(() => {
+          expect(next.cliOutput).toMatch(
+            /No response is returned from route handler '.+\/route\.ts'\. Ensure you return a `Response` or a `NextResponse` in all branches of your handler\./
+          )
+        })
+      })
     })
-  })
+  }
 
   describe('no bundle error', () => {
     it('should not print bundling warning about React', async () => {


### PR DESCRIPTION
- `next.cliOutput` will only refer to build time logs, so this particular assertion won't work
- Drive-by refactor for it to use `retry` instead of `check`

Verified this passes when deployed