### PR TITLE
Docs: Highlight the "You cannot import a Server Component into a Client Component"

### DIFF
--- a/docs/02-app/01-building-your-application/03-rendering/04-composition-patterns.mdx
+++ b/docs/02-app/01-building-your-application/03-rendering/04-composition-patterns.mdx
@@ -425,7 +425,7 @@ Within those client subtrees, you can still nest Server Components or call Serve
 
 The following pattern is not supported. You cannot import a Server Component into a Client Component:
 
-```tsx filename="app/client-component.tsx" switcher highlight={3,4,17,18}
+```tsx filename="app/client-component.tsx" switcher highlight={3,4,17}
 'use client'
 
 // You cannot import a Server Component into a Client Component.
@@ -442,8 +442,7 @@ export default function ClientComponent({
     <>
       <button onClick={() => setCount(count + 1)}>{count}</button>
 
-      {/* You cannot import a Server Component into a Client Component. */}
-      <ServerComponent />
+      <ServerComponent /> {/* <- Unsupported Pattern */}
     </>
   )
 }

--- a/docs/02-app/01-building-your-application/03-rendering/04-composition-patterns.mdx
+++ b/docs/02-app/01-building-your-application/03-rendering/04-composition-patterns.mdx
@@ -425,7 +425,7 @@ Within those client subtrees, you can still nest Server Components or call Serve
 
 The following pattern is not supported. You cannot import a Server Component into a Client Component:
 
-```tsx filename="app/client-component.tsx" switcher highlight={4,17}
+```tsx filename="app/client-component.tsx" switcher highlight={3,4,17,18}
 'use client'
 
 // You cannot import a Server Component into a Client Component.
@@ -442,6 +442,7 @@ export default function ClientComponent({
     <>
       <button onClick={() => setCount(count + 1)}>{count}</button>
 
+      {/* You cannot import a Server Component into a Client Component. */}
       <ServerComponent />
     </>
   )

--- a/docs/02-app/01-building-your-application/03-rendering/04-composition-patterns.mdx
+++ b/docs/02-app/01-building-your-application/03-rendering/04-composition-patterns.mdx
@@ -442,7 +442,7 @@ export default function ClientComponent({
     <>
       <button onClick={() => setCount(count + 1)}>{count}</button>
 
-      <ServerComponent /> {/* <- Unsupported Pattern */}
+      <ServerComponent />
     </>
   )
 }


### PR DESCRIPTION
This will update [this section](https://nextjs.org/docs/app/building-your-application/rendering/composition-patterns#unsupported-pattern-importing-server-components-into-client-components)
> <img width="674" alt="image" src="https://github.com/vercel/next.js/assets/111561/003c768c-a027-438a-b529-3832241b9c00">

The issue that is fixed is…
- this is a negative example, which is not highlighted enough; it still suggests that this way of writing the code is valid
- one has to look close and read the not-highlighted comment to understand that it is a "this does not work" example

Solution:
- highlight the comment as well
- repeat the comment where the component is used and highlight it