### PR TITLE
Update blog_starter to support dark mode

### DIFF
--- a/examples/blog-starter/package.json
+++ b/examples/blog-starter/package.json
@@ -10,7 +10,7 @@
     "date-fns": "^3.3.1",
     "gray-matter": "^4.0.3",
     "next": "14.1.0",
-    "nextjs-darkmode": "^0.3.0",
+    "nextjs-darkmode": "^1.0.1",
     "react": "^18",
     "react-dom": "^18",
     "remark": "^15.0.1",

--- a/examples/blog-starter/package.json
+++ b/examples/blog-starter/package.json
@@ -10,6 +10,7 @@
     "date-fns": "^3.3.1",
     "gray-matter": "^4.0.3",
     "next": "14.1.0",
+    "nextjs-darkmode": "^0.1.0",
     "react": "^18",
     "react-dom": "^18",
     "remark": "^15.0.1",

--- a/examples/blog-starter/package.json
+++ b/examples/blog-starter/package.json
@@ -10,7 +10,7 @@
     "date-fns": "^3.3.1",
     "gray-matter": "^4.0.3",
     "next": "14.1.0",
-    "nextjs-darkmode": "^0.1.0",
+    "nextjs-darkmode": "^0.2.0",
     "react": "^18",
     "react-dom": "^18",
     "remark": "^15.0.1",

--- a/examples/blog-starter/package.json
+++ b/examples/blog-starter/package.json
@@ -10,7 +10,7 @@
     "date-fns": "^3.3.1",
     "gray-matter": "^4.0.3",
     "next": "14.1.0",
-    "nextjs-darkmode": "^0.2.0",
+    "nextjs-darkmode": "^0.3.0",
     "react": "^18",
     "react-dom": "^18",
     "remark": "^15.0.1",

--- a/examples/blog-starter/src/app/_components/alert.tsx
+++ b/examples/blog-starter/src/app/_components/alert.tsx
@@ -9,7 +9,7 @@ type Props = {
 const Alert = ({ preview }: Props) => {
   return (
     <div
-      className={cn("border-b", {
+      className={cn("border-b dark:bg-slate-800", {
         "bg-neutral-800 border-neutral-800 text-white": preview,
         "bg-neutral-50 border-neutral-200": !preview,
       })}

--- a/examples/blog-starter/src/app/_components/footer.tsx
+++ b/examples/blog-starter/src/app/_components/footer.tsx
@@ -3,7 +3,7 @@ import { EXAMPLE_PATH } from "@/lib/constants";
 
 export function Footer() {
   return (
-    <footer className="bg-neutral-50 border-t border-neutral-200">
+    <footer className="bg-neutral-50 border-t border-neutral-200 dark:bg-slate-800">
       <Container>
         <div className="py-28 flex flex-col lg:flex-row items-center">
           <h3 className="text-4xl lg:text-[2.5rem] font-bold tracking-tighter leading-tight text-center lg:text-left mb-10 lg:mb-0 lg:pr-4 lg:w-1/2">

--- a/examples/blog-starter/src/app/_components/header.tsx
+++ b/examples/blog-starter/src/app/_components/header.tsx
@@ -1,12 +1,13 @@
 import Link from "next/link";
+import { Switch } from "nextjs-darkmode/switch";
 
 const Header = () => {
   return (
-    <h2 className="text-2xl md:text-4xl font-bold tracking-tight md:tracking-tighter leading-tight mb-20 mt-8">
+    <h2 className="text-2xl md:text-4xl font-bold tracking-tight md:tracking-tighter leading-tight mb-20 mt-8 flex justify-between items-center">
       <Link href="/" className="hover:underline">
-        Blog
+        Blog.
       </Link>
-      .
+      <Switch size={28} />
     </h2>
   );
 };

--- a/examples/blog-starter/src/app/globals.css
+++ b/examples/blog-starter/src/app/globals.css
@@ -1,3 +1,6 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* import styles for Switch component */
+@import "nextjs-darkmode/css";

--- a/examples/blog-starter/src/app/layout.tsx
+++ b/examples/blog-starter/src/app/layout.tsx
@@ -60,7 +60,7 @@ export default function RootLayout({
       <body
         className={cn(inter.className, "dark:bg-slate-900 dark:text-slate-400")}
       >
-        <Core />
+        <Core dp />
         <div className="min-h-screen">{children}</div>
         <Footer />
       </body>

--- a/examples/blog-starter/src/app/layout.tsx
+++ b/examples/blog-starter/src/app/layout.tsx
@@ -2,6 +2,7 @@ import Footer from "@/app/_components/footer";
 import { CMS_NAME, HOME_OG_IMAGE_URL } from "@/lib/constants";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import cn from "classnames";
 
 import "./globals.css";
 
@@ -56,10 +57,7 @@ export default function RootLayout({
         <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
       </head>
       <body
-        className={[
-          inter.className,
-          "dark:bg-slate-900 dark:text-slate-400",
-        ].join(" ")}
+        className={cn(inter.className, "dark:bg-slate-900 dark:text-slate-400")}
       >
         <div className="min-h-screen">{children}</div>
         <Footer />

--- a/examples/blog-starter/src/app/layout.tsx
+++ b/examples/blog-starter/src/app/layout.tsx
@@ -60,7 +60,7 @@ export default function RootLayout({
       <body
         className={cn(inter.className, "dark:bg-slate-900 dark:text-slate-400")}
       >
-        <Core t="background .3s" dp />
+        <Core t="background .5s" />
         <div className="min-h-screen">{children}</div>
         <Footer />
       </body>

--- a/examples/blog-starter/src/app/layout.tsx
+++ b/examples/blog-starter/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <ServerTarget tag="html" lang="en">
       <head>
         <link
           rel="apple-touch-icon"
@@ -61,11 +61,10 @@ export default function RootLayout({
       <body
         className={cn(inter.className, "dark:bg-slate-900 dark:text-slate-400")}
       >
-        <ServerTarget />
         <Core />
         <div className="min-h-screen">{children}</div>
         <Footer />
       </body>
-    </html>
+    </ServerTarget>
   );
 }

--- a/examples/blog-starter/src/app/layout.tsx
+++ b/examples/blog-starter/src/app/layout.tsx
@@ -3,6 +3,8 @@ import { CMS_NAME, HOME_OG_IMAGE_URL } from "@/lib/constants";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import cn from "classnames";
+import { ServerTarget } from "nextjs-darkmode/server";
+import { Core } from "nextjs-darkmode";
 
 import "./globals.css";
 
@@ -59,6 +61,8 @@ export default function RootLayout({
       <body
         className={cn(inter.className, "dark:bg-slate-900 dark:text-slate-400")}
       >
+        <ServerTarget />
+        <Core />
         <div className="min-h-screen">{children}</div>
         <Footer />
       </body>

--- a/examples/blog-starter/src/app/layout.tsx
+++ b/examples/blog-starter/src/app/layout.tsx
@@ -55,7 +55,12 @@ export default function RootLayout({
         <meta name="theme-color" content="#000" />
         <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
       </head>
-      <body className={inter.className}>
+      <body
+        className={[
+          inter.className,
+          "dark:bg-slate-900 dark:text-slate-400",
+        ].join(" ")}
+      >
         <div className="min-h-screen">{children}</div>
         <Footer />
       </body>

--- a/examples/blog-starter/src/app/layout.tsx
+++ b/examples/blog-starter/src/app/layout.tsx
@@ -3,7 +3,6 @@ import { CMS_NAME, HOME_OG_IMAGE_URL } from "@/lib/constants";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import cn from "classnames";
-import { ServerTarget } from "nextjs-darkmode/server";
 import { Core } from "nextjs-darkmode";
 
 import "./globals.css";
@@ -24,7 +23,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <ServerTarget tag="html" lang="en">
+    <html lang="en">
       <head>
         <link
           rel="apple-touch-icon"
@@ -65,6 +64,6 @@ export default function RootLayout({
         <div className="min-h-screen">{children}</div>
         <Footer />
       </body>
-    </ServerTarget>
+    </html>
   );
 }

--- a/examples/blog-starter/src/app/layout.tsx
+++ b/examples/blog-starter/src/app/layout.tsx
@@ -60,7 +60,7 @@ export default function RootLayout({
       <body
         className={cn(inter.className, "dark:bg-slate-900 dark:text-slate-400")}
       >
-        <Core dp />
+        <Core t="background .3s" dp />
         <div className="min-h-screen">{children}</div>
         <Footer />
       </body>

--- a/examples/blog-starter/src/app/page.tsx
+++ b/examples/blog-starter/src/app/page.tsx
@@ -3,6 +3,7 @@ import { HeroPost } from "@/app/_components/hero-post";
 import { Intro } from "@/app/_components/intro";
 import { MoreStories } from "@/app/_components/more-stories";
 import { getAllPosts } from "@/lib/api";
+import { Switch } from "nextjs-darkmode/switch";
 
 export default function Index() {
   const allPosts = getAllPosts();
@@ -14,6 +15,7 @@ export default function Index() {
   return (
     <main>
       <Container>
+        <Switch size={28} className="float-right" />
         <Intro />
         <HeroPost
           title={heroPost.title}

--- a/examples/blog-starter/src/app/posts/[slug]/page.tsx
+++ b/examples/blog-starter/src/app/posts/[slug]/page.tsx
@@ -9,6 +9,9 @@ import Header from "@/app/_components/header";
 import { PostBody } from "@/app/_components/post-body";
 import { PostHeader } from "@/app/_components/post-header";
 
+// ensure that the page is statically generated
+export const dynamic = "error";
+
 export default async function Post({ params }: Params) {
   const post = getPostBySlug(params.slug);
 

--- a/examples/blog-starter/tailwind.config.ts
+++ b/examples/blog-starter/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
+  darkMode: "class",
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",

--- a/examples/blog-starter/tailwind.config.ts
+++ b/examples/blog-starter/tailwind.config.ts
@@ -1,7 +1,13 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-  darkMode: "class",
+  darkMode: [
+    "variant",
+    [
+      "@media (prefers-color-scheme: dark) { &:not(.light *) }",
+      "&:is(.dark *)",
+    ],
+  ],
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",

--- a/examples/blog-starter/tailwind.config.ts
+++ b/examples/blog-starter/tailwind.config.ts
@@ -1,13 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-  darkMode: [
-    "variant",
-    [
-      "@media (prefers-color-scheme: dark) { &:not(.light *) }",
-      "&:is(.dark *)",
-    ],
-  ],
+  darkMode: "class",
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",


### PR DESCRIPTION
### What?
Updated `blog-starter` example to support dark theme.

### Why?
Now that dark mode is a first-class feature of many operating systems, it’s becoming more and more common to design a dark version of your website to go along with the default design.

### How?
Using Tailwind `dark` variant.