### PR TITLE
Ensure turbo is setup when building in docker

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -279,7 +279,7 @@ jobs:
       # issues with turbo caching
       - name: pull build cache
         if: ${{ matrix.settings.docker }}
-        run: node ./scripts/pull-turbo-cache.js ${{ matrix.settings.target }}
+        run: npm i -g turbo@${{ env.TURBO_VERSION }} && node ./scripts/pull-turbo-cache.js ${{ matrix.settings.target }}
 
       - name: check build exists
         if: ${{ matrix.settings.docker }}


### PR DESCRIPTION
This ensures we always set up turbo to the version we expect even if we're building in docker since the cache is pulled outside of docker. 

x-ref: https://github.com/vercel/next.js/actions/runs/9484631800/job/26134568488