### PR TITLE
[ppr] Improve DX for static shell debugging in dev mode

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1024,7 +1024,11 @@ async function renderToHTMLOrFlightImpl(
           onHeaders,
           maxHeadersLength: 600,
           nonce,
-          bootstrapScripts: [bootstrapScript],
+          // When debugging the static shell, client-side rendering should be
+          // disabled to prevent blanking out the page.
+          bootstrapScripts: renderOpts.isDebugStaticShell
+            ? []
+            : [bootstrapScript],
           formState,
         },
       })

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -152,6 +152,7 @@ import {
   getBuiltinRequestContext,
   type WaitUntil,
 } from './after/builtin-request-context'
+import { ENCODED_TAGS } from './stream-utils/encodedTags'
 
 export type FindComponentsResult = {
   components: LoadComponentsReturnType
@@ -3134,6 +3135,17 @@ export default abstract class Server<
       // HTML will be the static shell so all the Dynamic API's will be used
       // during static generation.
       if (isDebugStaticShell || isDebugDynamicAccesses) {
+        // Since we're not resuming the render, we need to at least add the
+        // closing body and html tags to create valid HTML.
+        body.chain(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(ENCODED_TAGS.CLOSED.BODY_AND_HTML)
+              controller.close()
+            },
+          })
+        )
+
         return { type: 'html', body, revalidate: 0 }
       }
 

--- a/test/e2e/app-dir/static-shell-debugging/static-shell-debugging.test.ts
+++ b/test/e2e/app-dir/static-shell-debugging/static-shell-debugging.test.ts
@@ -7,7 +7,7 @@ describe('static-shell-debugging', () => {
     { ppr: true, debugging: false },
     { ppr: false, debugging: false },
   ])('ppr = $ppr, debugging = $debugging', (context) => {
-    const { next, skipped } = nextTestSetup({
+    const { next, skipped, isNextDev } = nextTestSetup({
       files: __dirname,
       // This test skips deployment because env vars that are doubled underscore prefixed
       // are not supported. This is also intended to be used in development.
@@ -31,6 +31,20 @@ describe('static-shell-debugging', () => {
         expect(html).toContain('Fallback')
         expect(html).not.toContain('Dynamic')
       })
+
+      // The __nextppronly query param is currently only supported in dev mode.
+      if (isNextDev) {
+        it('should skip hydration to avoid blanking out the page', async () => {
+          const browser = await next.browser('/?__nextppronly=1', {
+            waitHydration: false,
+          })
+
+          expect(await browser.elementByCss('div').text()).toBe('Fallback')
+
+          // Must not log the page error "Error: Connection closed."
+          expect(await browser.log()).toEqual([])
+        })
+      }
     } else {
       it('should render the full page', async () => {
         const res = await next.fetch('/?__nextppronly=1')


### PR DESCRIPTION
Users that experiment with PPR and might have seen #61798, or #62703, or most recently #65483, may try the `__nextppronly=1` query param to debug the static shell. This will lead to the following uncaught error and blank page:

<img width="1045" alt="static shell debugging hydration error" src="https://github.com/vercel/next.js/assets/761683/ed382d97-82ae-4a23-9930-bb4d4419e88e">

It might not be immediately obvious that javascript must be disabled to see the static shell. To improve the DX in this scenario we can omit the bootstrap script to skip hydration, and thus prevent the error. Then debugging the static shell works even without disabling javascript in the devtools.

<img width="1045" alt="static shell debugging without hydration" src="https://github.com/vercel/next.js/assets/761683/57f6cb88-f5b4-473f-963f-7fda8c8e7f00">

In addition, we should add the closing body and html tags to the shell so that a valid HTML document is returned.