### PR TITLE
fix parallel-route-not-found-params deploy test

### DIFF
--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -30,7 +30,6 @@
       "test/e2e/react-dnd-compile/react-dnd-compile.test.ts",
       "test/e2e/skip-trailing-slash-redirect/index.test.ts",
       "test/e2e/app-dir/app-compilation/index.test.ts",
-      "test/e2e/app-dir/parallel-route-not-found-params/parallel-route-not-found-params.test.ts",
       "test/e2e/app-dir/ppr/ppr.test.ts",
       "test/e2e/app-dir/rsc-webpack-loader/rsc-webpack-loader.test.ts",
       "test/e2e/swc-warnings/index.test.ts",

--- a/test/e2e/app-dir/parallel-route-not-found-params/parallel-route-not-found-params.test.ts
+++ b/test/e2e/app-dir/parallel-route-not-found-params/parallel-route-not-found-params.test.ts
@@ -2,22 +2,26 @@ import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
 describe('parallel-route-not-found', () => {
-  const { next } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })
 
   it('should behave correctly without any errors', async () => {
     const browser = await next.browser('/en')
-    await check(() => {
-      if (
-        next.cliOutput.includes('TypeError') ||
-        next.cliOutput.includes('Warning')
-      ) {
-        return 'has-errors'
-      }
 
-      return 'success'
-    }, 'success')
+    // Deploy doesn't have access to runtime logs
+    if (!isNextDeploy) {
+      await check(() => {
+        if (
+          next.cliOutput.includes('TypeError') ||
+          next.cliOutput.includes('Warning')
+        ) {
+          return 'has-errors'
+        }
+
+        return 'success'
+      }, 'success')
+    }
 
     expect(await browser.elementByCss('body').text()).not.toContain(
       'Interception Modal'
@@ -26,16 +30,19 @@ describe('parallel-route-not-found', () => {
 
     await browser.elementByCss("[href='/en/show']").click()
 
-    await check(() => {
-      if (
-        next.cliOutput.includes('TypeError') ||
-        next.cliOutput.includes('Warning')
-      ) {
-        return 'has-errors'
-      }
+    // Deploy doesn't have access to runtime logs
+    if (!isNextDeploy) {
+      await check(() => {
+        if (
+          next.cliOutput.includes('TypeError') ||
+          next.cliOutput.includes('Warning')
+        ) {
+          return 'has-errors'
+        }
 
-      return 'success'
-    }, 'success')
+        return 'success'
+      }, 'success')
+    }
 
     await check(() => browser.elementByCss('body').text(), /Interception Modal/)
     await check(() => browser.elementByCss('body').text(), /Locale: en/)
@@ -47,16 +54,20 @@ describe('parallel-route-not-found', () => {
 
   it('should handle the not found case correctly without any errors', async () => {
     const browser = await next.browser('/de/show')
-    await check(() => {
-      if (
-        next.cliOutput.includes('TypeError') ||
-        next.cliOutput.includes('Warning')
-      ) {
-        return 'has-errors'
-      }
 
-      return 'success'
-    }, 'success')
+    // Deploy doesn't have access to runtime logs
+    if (!isNextDeploy) {
+      await check(() => {
+        if (
+          next.cliOutput.includes('TypeError') ||
+          next.cliOutput.includes('Warning')
+        ) {
+          return 'has-errors'
+        }
+
+        return 'success'
+      }, 'success')
+    }
 
     expect(await browser.elementByCss('body').text()).toContain(
       'Custom Not Found'


### PR DESCRIPTION
The rest of this test is valid for a deployed environment, we just won't have access to runtime logs. 