### PR TITLE
Remove `worker` condition name when resolving files in the Edge runtime

### DIFF
--- a/packages/next-swc/crates/next-core/src/util.rs
+++ b/packages/next-swc/crates/next-core/src/util.rs
@@ -150,7 +150,7 @@ impl NextRuntime {
     pub fn conditions(&self) -> &'static [&'static str] {
         match self {
             NextRuntime::NodeJs => &["node"],
-            NextRuntime::Edge => &["edge-light", "worker"],
+            NextRuntime::Edge => &["edge-light"],
         }
     }
 }

--- a/packages/next/src/build/webpack-config-rules/resolve.ts
+++ b/packages/next/src/build/webpack-config-rules/resolve.ts
@@ -11,14 +11,10 @@ export const edgeConditionNames = [
   '...',
 ]
 
-const mainFieldsPerCompiler: Record<
-  CompilerNameValues | 'server-esm',
-  string[]
-> = {
+const mainFieldsPerCompiler = {
   // For default case, prefer CJS over ESM on server side. e.g. pages dir SSR
   [COMPILER_NAMES.server]: ['main', 'module'],
   [COMPILER_NAMES.client]: ['browser', 'module', 'main'],
-  [COMPILER_NAMES.edgeServer]: edgeConditionNames,
   // For bundling-all strategy, prefer ESM over CJS
   'server-esm': ['module', 'main'],
 }

--- a/packages/next/src/build/webpack-config-rules/resolve.ts
+++ b/packages/next/src/build/webpack-config-rules/resolve.ts
@@ -6,7 +6,7 @@ import {
 // exports.<conditionName>
 export const edgeConditionNames = [
   'edge-light',
-  'worker',
+  'workerd',
   // inherits the default conditions
   '...',
 ]

--- a/packages/next/src/build/webpack-config-rules/resolve.ts
+++ b/packages/next/src/build/webpack-config-rules/resolve.ts
@@ -6,7 +6,6 @@ import {
 // exports.<conditionName>
 export const edgeConditionNames = [
   'edge-light',
-  'workerd',
   // inherits the default conditions
   '...',
 ]

--- a/test/e2e/import-conditions/import-conditions.test.ts
+++ b/test/e2e/import-conditions/import-conditions.test.ts
@@ -22,8 +22,8 @@ describe('react version', () => {
     }
     expect(middlewareHeaders).toEqual({
       react: 'react-server',
-      serverFavoringBrowser: 'worker',
-      serverFavoringEdge: 'worker',
+      serverFavoringBrowser: 'browser',
+      serverFavoringEdge: 'edge-light',
     })
   })
 
@@ -34,8 +34,8 @@ describe('react version', () => {
     expect(JSON.parse(json)).toEqual({
       server: {
         react: 'default',
-        serverFavoringBrowser: 'worker',
-        serverFavoringEdge: 'worker',
+        serverFavoringBrowser: 'browser',
+        serverFavoringEdge: 'edge-light',
       },
       client: {
         react: 'default',
@@ -59,8 +59,8 @@ describe('react version', () => {
     }
     expect(middlewareHeaders).toEqual({
       react: 'react-server',
-      serverFavoringBrowser: 'worker',
-      serverFavoringEdge: 'worker',
+      serverFavoringBrowser: 'browser',
+      serverFavoringEdge: 'edge-light',
     })
   })
 
@@ -96,8 +96,8 @@ describe('react version', () => {
     }
     expect(middlewareHeaders).toEqual({
       react: 'react-server',
-      serverFavoringBrowser: 'worker',
-      serverFavoringEdge: 'worker',
+      serverFavoringBrowser: 'browser',
+      serverFavoringEdge: 'edge-light',
     })
   })
 
@@ -111,8 +111,8 @@ describe('react version', () => {
     expect(JSON.parse(json)).toEqual({
       server: {
         react: 'react-server',
-        serverFavoringBrowser: 'worker',
-        serverFavoringEdge: 'worker',
+        serverFavoringBrowser: 'browser',
+        serverFavoringEdge: 'edge-light',
       },
       client: {
         react: 'default',
@@ -121,8 +121,8 @@ describe('react version', () => {
       },
       action: {
         react: 'react-server',
-        serverFavoringBrowser: 'worker',
-        serverFavoringEdge: 'worker',
+        serverFavoringBrowser: 'browser',
+        serverFavoringEdge: 'edge-light',
       },
     })
   })
@@ -141,8 +141,8 @@ describe('react version', () => {
     }
     expect(middlewareHeaders).toEqual({
       react: 'react-server',
-      serverFavoringBrowser: 'worker',
-      serverFavoringEdge: 'worker',
+      serverFavoringBrowser: 'browser',
+      serverFavoringEdge: 'edge-light',
     })
   })
 
@@ -188,8 +188,8 @@ describe('react version', () => {
     expect({ middlewareHeaders, data }).toEqual({
       middlewareHeaders: {
         react: 'react-server',
-        serverFavoringBrowser: 'worker',
-        serverFavoringEdge: 'worker',
+        serverFavoringBrowser: 'browser',
+        serverFavoringEdge: 'edge-light',
       },
       data: {
         react: 'react-server',
@@ -215,13 +215,13 @@ describe('react version', () => {
     expect({ middlewareHeaders, data }).toEqual({
       middlewareHeaders: {
         react: 'react-server',
-        serverFavoringBrowser: 'worker',
-        serverFavoringEdge: 'worker',
+        serverFavoringBrowser: 'browser',
+        serverFavoringEdge: 'edge-light',
       },
       data: {
         react: 'react-server',
-        serverFavoringBrowser: 'worker',
-        serverFavoringEdge: 'worker',
+        serverFavoringBrowser: 'browser',
+        serverFavoringEdge: 'edge-light',
       },
     })
   })


### PR DESCRIPTION
`workerd` is for Cloudflare Workers: https://runtime-keys.proposal.wintercg.org/#workerd
`worker` is for Web Workers: https://webpack.js.org/guides/package-exports/#target-environment

However, Next.js Edge runtime is neither of those. We're still setting `edge-light` and this is the export libraries should provide if they usually use APIs that are not available in Edge runtimes (e.g. Node.js, DOM, Web Workers etc).

Test follows. Filing this now to check our existing tests.
