### PR TITLE
fix ppr deploy test

### DIFF
--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -30,7 +30,6 @@
       "test/e2e/react-dnd-compile/react-dnd-compile.test.ts",
       "test/e2e/skip-trailing-slash-redirect/index.test.ts",
       "test/e2e/app-dir/app-compilation/index.test.ts",
-      "test/e2e/app-dir/ppr/ppr.test.ts",
       "test/e2e/app-dir/rsc-webpack-loader/rsc-webpack-loader.test.ts",
       "test/e2e/swc-warnings/index.test.ts",
       "test/e2e/third-parties/index.test.ts",

--- a/test/e2e/app-dir/ppr/ppr.test.ts
+++ b/test/e2e/app-dir/ppr/ppr.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check, findAllTelemetryEvents } from 'next-test-utils'
+import { retry, findAllTelemetryEvents } from 'next-test-utils'
 
 describe('ppr', () => {
   const { next, isNextDev, isNextStart } = nextTestSetup({
@@ -10,12 +10,10 @@ describe('ppr', () => {
   })
 
   it('should indicate the feature is experimental', async () => {
-    await check(() => {
-      return next.cliOutput.includes('Experiments (use with caution)') &&
-        next.cliOutput.includes('ppr')
-        ? 'success'
-        : 'fail'
-    }, 'success')
+    await retry(() => {
+      expect(next.cliOutput).toContain('Experiments (use with caution)')
+      expect(next.cliOutput).toContain('ppr')
+    })
   })
   if (isNextStart) {
     describe('build output', () => {

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -150,7 +150,17 @@ export class NextDeployInstance extends NextInstance {
     // Use the vercel logs command to get the CLI output from the build.
     const logs = await execa(
       'vercel',
-      ['logs', this._url, '--output', 'raw', ...vercelFlags],
+      [
+        'logs',
+        this._url,
+        '--output',
+        'raw',
+        // The default # of lines to show in the output is 100, but some of our tests have noisy output,
+        // so bump to 1000
+        '-n',
+        1000,
+        ...vercelFlags,
+      ],
       {
         env: vercelEnv,
         reject: false,


### PR DESCRIPTION
This test was only failing because `vercel logs` limit the output to 100 lines, and telemetry debugging was adding a lot of verbosity to the build logs.

This bumps the log lines to a higher value to give some more breathing room, and did a drive-by `check` -> `retry` refactor.