### PR TITLE
Use turbo-tasks-malloc on all platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "serde",
  "smallvec",
@@ -3092,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "serde",
@@ -6964,12 +6964,12 @@ dependencies = [
 [[package]]
 name = "turbo-prehash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7001,7 +7001,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7013,7 +7013,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7027,7 +7027,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7041,7 +7041,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -7057,7 +7057,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7089,7 +7089,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "md4",
  "turbo-tasks-macros",
@@ -7099,7 +7099,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "proc-macro-error",
@@ -7113,7 +7113,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7123,7 +7123,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "mimalloc",
 ]
@@ -7131,7 +7131,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7158,7 +7158,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7188,7 +7188,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7229,7 +7229,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7252,7 +7252,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "clap",
@@ -7269,7 +7269,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7298,7 +7298,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7325,7 +7325,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7361,7 +7361,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7396,7 +7396,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "serde",
  "serde_json",
@@ -7407,7 +7407,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7432,7 +7432,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7448,7 +7448,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7464,7 +7464,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7483,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "serde",
@@ -7498,7 +7498,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7513,7 +7513,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7547,7 +7547,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7567,7 +7567,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7585,7 +7585,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "serde",
@@ -7601,7 +7601,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7612,7 +7612,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "either",
@@ -7632,7 +7632,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -7648,7 +7648,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240614.1#3d9c2de2b739d27574f0ffb17d4421bf073dd79f"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "serde",
  "smallvec",
@@ -2532,9 +2532,9 @@ dependencies = [
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.30"
+version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8c7cbf8b89019683667e347572e6d55a7df7ea36b0c4ce69961b0cde67b174"
+checksum = "0e7bb23d733dfcc8af652a78b7bf232f0e967710d044732185e561e47c0336b6"
 dependencies = [
  "cc",
  "libc",
@@ -2790,9 +2790,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.34"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcb174b18635f7561a0c6c9fc2ce57218ac7523cf72c50af80e2d79ab8f3ba1"
+checksum = "e9186d86b79b52f4a77af65604b51225e8db1d6ee7e3f41aec1e40829c71a176"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -3092,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "serde",
@@ -6964,12 +6964,12 @@ dependencies = [
 [[package]]
 name = "turbo-prehash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7001,7 +7001,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7013,7 +7013,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7027,7 +7027,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7041,7 +7041,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -7057,7 +7057,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7089,7 +7089,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "md4",
  "turbo-tasks-macros",
@@ -7099,7 +7099,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "proc-macro-error",
@@ -7113,7 +7113,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7123,7 +7123,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "mimalloc",
 ]
@@ -7131,7 +7131,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7158,7 +7158,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7188,7 +7188,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7229,7 +7229,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7252,7 +7252,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "clap",
@@ -7269,7 +7269,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7298,7 +7298,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7325,7 +7325,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7361,7 +7361,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7396,7 +7396,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7407,7 +7407,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7432,7 +7432,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7448,7 +7448,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7464,7 +7464,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7483,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "serde",
@@ -7498,7 +7498,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7513,7 +7513,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7547,7 +7547,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7567,7 +7567,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7585,7 +7585,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "serde",
@@ -7601,7 +7601,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7612,7 +7612,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "either",
@@ -7632,7 +7632,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -7648,7 +7648,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240612.3#15e7a68f36429aa966ade14267044797ade1ef19"
+source = "git+https://github.com/vercel/turbo.git?branch=bgw/mimalloc-updates#bfcbb2ba193adb27ccb4ee964c07e1675e9701e0"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.93.4", features = [
 testing = { version = "0.35.25" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240612.3" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "bgw/mimalloc-updates" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240612.3" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "bgw/mimalloc-updates" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240612.3" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "bgw/mimalloc-updates" }
 
 # General Deps
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.93.4", features = [
 testing = { version = "0.35.25" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "bgw/mimalloc-updates" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240614.1" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "bgw/mimalloc-updates" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240614.1" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "bgw/mimalloc-updates" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240614.1" }
 
 # General Deps
 

--- a/packages/next-swc/crates/napi/Cargo.toml
+++ b/packages/next-swc/crates/napi/Cargo.toml
@@ -35,26 +35,6 @@ __internal_dhat-heap = ["dhat"]
 # effectively does nothing.
 __internal_dhat-ad-hoc = ["dhat"]
 
-# Making custom_allocator as default feature will break some targets (i.e aarch64-linux), controlling it with
-# build-time cfg instead.
-#
-# [NOTE] this is a workaround to enable downstream features for the own pkgs, since
-# cargo does not support per-target features enablement.
-[target.'cfg(all(target_os = "linux", target_arch = "aarch64"))'.dependencies]
-turbopack-binding = { workspace = true, features = ["__turbo_tasks_malloc"] }
-
-[target.'cfg(all(target_os = "linux", not(any(target_arch = "aarch64", target_arch = "wasm32"))))'.dependencies]
-turbopack-binding = { workspace = true, features = [
-  "__turbo_tasks_malloc",
-  "__turbo_tasks_malloc_custom_allocator",
-] }
-
-[target.'cfg(not(any(target_os = "linux", target_arch = "wasm32")))'.dependencies]
-turbopack-binding = { workspace = true, features = [
-  "__turbo_tasks_malloc",
-  "__turbo_tasks_malloc_custom_allocator",
-] }
-
 # Enable specific tls features per-target.
 [target.'cfg(all(target_os = "windows", target_arch = "aarch64"))'.dependencies]
 next-core = { workspace = true, features = ["native-tls"] }
@@ -108,6 +88,8 @@ turbopack-binding = { workspace = true, features = [
   "__feature_mdx_rs",
   "__turbo",
   "__turbo_tasks",
+  "__turbo_tasks_malloc",
+  "__turbo_tasks_malloc_custom_allocator",
   "__turbo_tasks_memory",
   "__turbopack",
   "__turbopack_ecmascript_hmr_protocol",
@@ -121,6 +103,7 @@ turbopack-binding = { workspace = true, features = [
   "__swc_core_binding_napi",
   "__swc_core_serde",
   "__feature_mdx_rs",
+  "__turbo_tasks_malloc",
 ] }
 
 # wasi-only dependencies.

--- a/packages/next-swc/crates/napi/src/lib.rs
+++ b/packages/next-swc/crates/napi/src/lib.rs
@@ -68,14 +68,7 @@ pub mod util;
 // Declare build-time information variables generated in build.rs
 shadow_rs::shadow!(build);
 
-// don't use turbo malloc (`mimalloc`) on linux-musl-aarch64 because of the
-// compile error
-#[cfg(not(any(
-    all(target_os = "linux", target_env = "musl", target_arch = "aarch64"),
-    target_arch = "wasm32",
-    feature = "__internal_dhat-heap",
-    feature = "__internal_dhat-ad-hoc"
-)))]
+#[cfg(not(any(feature = "__internal_dhat-heap", feature = "__internal_dhat-ad-hoc")))]
 #[global_allocator]
 static ALLOC: turbopack_binding::turbo::malloc::TurboMalloc =
     turbopack_binding::turbo::malloc::TurboMalloc;

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -206,7 +206,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.27.1",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240612.1",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?bgw/mimalloc-updates",
     "acorn": "8.11.3",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -206,7 +206,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.27.1",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?bgw/mimalloc-updates",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240614.1",
     "acorn": "8.11.3",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1108,8 +1108,8 @@ importers:
         specifier: 0.27.1
         version: 0.27.1
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?bgw/mimalloc-updates
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?bgw/mimalloc-updates'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240614.1
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240614.1'
       acorn:
         specifier: 8.11.3
         version: 8.11.3
@@ -26558,8 +26558,8 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?bgw/mimalloc-updates':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?bgw/mimalloc-updates}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240614.1':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240614.1}
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1108,8 +1108,8 @@ importers:
         specifier: 0.27.1
         version: 0.27.1
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240612.1
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240612.1'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?bgw/mimalloc-updates
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?bgw/mimalloc-updates'
       acorn:
         specifier: 8.11.3
         version: 8.11.3
@@ -26558,8 +26558,8 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240612.1':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240612.1}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?bgw/mimalloc-updates':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?bgw/mimalloc-updates}
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:


### PR DESCRIPTION
This was previously disabled on `aarch64-unknown-linux-musl` and `wasm`, due to compilation errors.
    
I moved the logic to disable `mimalloc` on these platforms into the `turbo-tasks-malloc` crates in https://github.com/vercel/turbo/pull/8462 (which this PR depends on).
    
In addition to centralizing mimalloc platform support logic, this means that we can get allocation data from these platforms while using the system allocator.

**Depends on:** https://github.com/vercel/turbo/pull/8462

Included turbopack changes:
* https://github.com/vercel/turbo/pull/8409 <!-- hrmny - fix(turbopack-ecmascript-runtime): prevent hanging when top level await is skipped  -->
* https://github.com/vercel/turbo/pull/8466 <!-- hrmny - fix(turbopack): make external module wrapper return not found instead of panicking  -->
* https://github.com/vercel/turbo/pull/8469 <!-- hrmny - fix(turbopack): add ecmascript options to mdx  -->
* https://github.com/vercel/turbo/pull/8447 <!-- Donny/강동윤 - build: Update `swc_core` to `v0.93.4`  -->
* https://github.com/vercel/turbo/pull/8472 <!-- Donny/강동윤 - feat: Reduce the number of parts created by tree shaking  -->
* https://github.com/vercel/turbo/pull/8480 <!-- Will Binns-Smith - Publish `@vercel/devlow-bench`  -->
* https://github.com/vercel/turbo/pull/8481 <!-- Will Binns-Smith - chore: release npm packages  -->
* https://github.com/vercel/turbo/pull/8462 <!-- Benjamin Woodruff - Update mimalloc, enable for glibc Linux aarch64, explicitly disable for wasm and musl  -->
