### PR TITLE
feat: Pass `module: "unknown"` to SWC minfiier

### DIFF
--- a/packages/next/src/build/webpack/plugins/terser-webpack-plugin/src/index.ts
+++ b/packages/next/src/build/webpack/plugins/terser-webpack-plugin/src/index.ts
@@ -146,6 +146,7 @@ export class TerserPlugin {
                   : {}),
                 compress: true,
                 mangle: true,
+                module: 'unknown',
               }
             )
 


### PR DESCRIPTION
### What?

Pass `module: "unknown"` to the minifier.

### Why?

It can minify both a module and a script. `module: "unknown"` lets the parser to detect the type of the program.

The problematic library is `react-pdf` and next.js currently errors with 

```
Failed to compile.

static/media/pdf.worker.1f09ce21.mjs from Terser
  x 'import', and 'export' cannot be used outside of module code
       ,-[56104:1]
 56104 | const pdfjsBuild = "0cec64437";
 56105 | 
 56106 | var __webpack_exports__WorkerMessageHandler = __webpack_exports__.WorkerMessageHandler;
 56107 | export { __webpack_exports__WorkerMessageHandler as WorkerMessageHandler };
       : ^^^^^^
 56108 | 
 56109 | //# sourceMappingURL=pdf.worker.mjs.map
       `----

Caused by:
    0: failed to parse input file
    1: Syntax Error
Error: 
  x 'import', and 'export' cannot be used outside of module code
       ,-[56104:1]
```

### How?

Related: https://github.com/vercel/next.js/discussions/30237#discussioncomment-9735075