### PR TITLE
fix revalidate-reason deploy test

### DIFF
--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -50,7 +50,6 @@
       "test/e2e/new-link-behavior/stitches.test.ts",
       "test/e2e/next-image-forward-ref/index.test.ts",
       "test/e2e/react-compiler/react-compiler.test.ts",
-      "test/e2e/revalidate-reason/revalidate-reason.test.ts",
       "test/e2e/app-dir/actions/app-action.test.ts",
       "test/e2e/app-dir/i18n-hybrid/i18n-hybrid.test.js",
       "test/e2e/app-dir/metadata/metadata.test.ts",

--- a/test/e2e/revalidate-reason/pages/index.tsx
+++ b/test/e2e/revalidate-reason/pages/index.tsx
@@ -7,11 +7,11 @@ export async function getStaticProps({ params, revalidateReason }) {
   )
   return {
     props: {
-      hello: 'world',
+      reason: revalidateReason,
     },
   }
 }
 
-export default ({ hello }) => {
-  return <p>hello: {hello}</p>
+export default ({ reason }) => {
+  return <p id="reason">revalidate reason: {reason}</p>
 }

--- a/test/e2e/revalidate-reason/pages/stale.tsx
+++ b/test/e2e/revalidate-reason/pages/stale.tsx
@@ -7,12 +7,12 @@ export async function getStaticProps({ params, revalidateReason }) {
   )
   return {
     props: {
-      hello: 'world',
+      reason: revalidateReason,
     },
     revalidate: 5,
   }
 }
 
-export default ({ hello }) => {
-  return <p>hello: {hello}</p>
+export default ({ reason }) => {
+  return <p id="reason">revalidate reason: {reason}</p>
 }

--- a/test/e2e/revalidate-reason/revalidate-reason.test.ts
+++ b/test/e2e/revalidate-reason/revalidate-reason.test.ts
@@ -38,9 +38,8 @@ describe('revalidate-reason', () => {
 
     expect(res.status).toBe(200)
 
-    expect(next.cliOutput).toContain(
-      'revalidate-reason/pages/index.tsx revalidateReason: on-demand'
-    )
+    const $ = await next.render$('/')
+    expect($('#reason').text()).toBe('revalidate reason: on-demand')
   })
 
   it('should support revalidateReason: "stale"', async () => {
@@ -51,11 +50,8 @@ describe('revalidate-reason', () => {
     await waitFor(5000)
 
     await retry(async () => {
-      await next.fetch('/stale')
-
-      expect(next.cliOutput).toContain(
-        'revalidate-reason/pages/stale.tsx revalidateReason: stale'
-      )
+      const $ = await next.render$('/stale')
+      expect($('#reason').text()).toBe('revalidate reason: stale')
     })
   })
 })


### PR DESCRIPTION
Since `next.cliOutput` won't have access to runtime logs we can refactor this test to render text on the page instead. 