### PR TITLE
fix parallel-routes-revalidation deploy test

### DIFF
--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -43,7 +43,6 @@
       "test/e2e/app-dir/actions-navigation/index.test.ts",
       "test/e2e/app-dir/app-static/app-static-custom-handler.test.ts",
       "test/e2e/app-dir/options-request/options-request.test.ts",
-      "test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts",
       "test/e2e/app-dir/revalidate-dynamic/revalidate-dynamic.test.ts",
       "test/e2e/app-dir/scss/npm-import-nested/npm-import-nested.test.ts",
       "test/e2e/app-dir/syntax-highlighter-crash/syntax-highlighter-crash.test.ts",

--- a/test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts
+++ b/test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts
@@ -2,43 +2,46 @@ import { nextTestSetup } from 'e2e-utils'
 import { check, retry } from 'next-test-utils'
 
 describe('parallel-routes-revalidation', () => {
-  const { next, isNextStart } = nextTestSetup({
+  const { next, isNextStart, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })
 
-  it('should submit the action and revalidate the page data', async () => {
-    const browser = await next.browser('/')
-    await check(() => browser.hasElementByCssSelector('#create-entry'), false)
+  // This test is skipped when deployed as it relies on a shared data store
+  // For testing purposes we just use an in-memory object, but when deployed
+  // this could hit a separate lambda instance that won't share the same reference
+  if (!isNextDeploy) {
+    it('should submit the action and revalidate the page data', async () => {
+      const browser = await next.browser('/')
+      await check(() => browser.hasElementByCssSelector('#create-entry'), false)
 
-    // there shouldn't be any data yet
-    expect((await browser.elementsByCss('#entries li')).length).toBe(0)
+      // there shouldn't be any data yet
+      expect((await browser.elementsByCss('#entries li')).length).toBe(0)
 
-    await browser.elementByCss("[href='/revalidate-modal']").click()
+      await browser.elementByCss("[href='/revalidate-modal']").click()
 
-    await check(() => browser.hasElementByCssSelector('#create-entry'), true)
+      await check(() => browser.hasElementByCssSelector('#create-entry'), true)
 
-    await browser.elementById('create-entry').click()
+      await browser.elementById('create-entry').click()
 
-    // we created an entry and called revalidate, so we should have 1 entry
-    await check(
-      async () => (await browser.elementsByCss('#entries li')).length,
-      1
-    )
+      // we created an entry and called revalidate, so we should have 1 entry
+      await retry(async () => {
+        expect((await browser.elementsByCss('#entries li')).length).toBe(1)
+      })
 
-    await browser.elementById('create-entry').click()
+      await browser.elementById('create-entry').click()
 
-    // we created an entry and called revalidate, so we should have 2 entries
-    await check(
-      async () => (await browser.elementsByCss('#entries li')).length,
-      2
-    )
+      // we created an entry and called revalidate, so we should have 2 entries
+      await retry(async () => {
+        expect((await browser.elementsByCss('#entries li')).length).toBe(2)
+      })
 
-    await browser.elementByCss("[href='/']").click()
+      await browser.elementByCss("[href='/']").click()
 
-    // following a link back to `/` should close the modal
-    await check(() => browser.hasElementByCssSelector('#create-entry'), false)
-    await check(() => browser.elementByCss('body').text(), /Current Data/)
-  })
+      // following a link back to `/` should close the modal
+      await check(() => browser.hasElementByCssSelector('#create-entry'), false)
+      await check(() => browser.elementByCss('body').text(), /Current Data/)
+    })
+  }
 
   it('should handle router.refresh() when called in a slot', async () => {
     const browser = await next.browser('/')
@@ -182,28 +185,33 @@ describe('parallel-routes-revalidation', () => {
     )
   })
 
-  it('should refresh the correct page when a server action triggers a redirect', async () => {
-    const browser = await next.browser('/redirect')
-    await browser.elementByCss('button').click()
+  // This test is skipped when deployed as it relies on a shared data store
+  // For testing purposes we just use an in-memory object, but when deployed
+  // this could hit a separate lambda instance that won't share the same reference
+  if (!isNextDeploy) {
+    it('should refresh the correct page when a server action triggers a redirect', async () => {
+      const browser = await next.browser('/redirect')
+      await browser.elementByCss('button').click()
 
-    await browser.elementByCss("[href='/revalidate-modal']").click()
+      await browser.elementByCss("[href='/revalidate-modal']").click()
 
-    await check(() => browser.hasElementByCssSelector('#create-entry'), true)
+      await check(() => browser.hasElementByCssSelector('#create-entry'), true)
 
-    await browser.elementById('clear-entries').click()
+      await browser.elementById('clear-entries').click()
 
-    await retry(async () => {
-      // confirm there aren't any entries yet
-      expect((await browser.elementsByCss('#entries li')).length).toBe(0)
+      await retry(async () => {
+        // confirm there aren't any entries yet
+        expect((await browser.elementsByCss('#entries li')).length).toBe(0)
+      })
+
+      await browser.elementById('create-entry').click()
+
+      await retry(async () => {
+        // we created an entry and called revalidate, so we should have 1 entry
+        expect((await browser.elementsByCss('#entries li')).length).toBe(1)
+      })
     })
-
-    await browser.elementById('create-entry').click()
-
-    await retry(async () => {
-      // we created an entry and called revalidate, so we should have 1 entry
-      expect((await browser.elementsByCss('#entries li')).length).toBe(1)
-    })
-  })
+  }
 
   describe.each([
     { basePath: '/refreshing', label: 'regular', withSearchParams: false },


### PR DESCRIPTION
These 2 tests use an in-memory data store that won't be necessarily shared across invocations of the lambda. This skips the tests that rely on that functionality as testing it in `next start` should be sufficient.