### PR TITLE
Handle action middleware rewrite case

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1207,6 +1207,28 @@ export default abstract class Server<
               params = utils.defaultRouteMatches
             }
 
+            // if an action request is bypassing a prerender and we
+            // don't have the params in the URL since it was prerendered
+            // and matched during handle: 'filesystem' not dynamic route
+            // resolving we need to parse the params from the matched-path
+            if (
+              pageIsDynamic &&
+              !paramsResult.hasValidParams &&
+              !isDynamicRoute(matchedPath)
+            ) {
+              let matcherParams = utils.dynamicRouteMatcher?.(matchedPath)
+
+              if (matcherParams) {
+                const curParamsResult =
+                  utils.normalizeDynamicRouteParams(matcherParams)
+
+                if (curParamsResult.hasValidParams) {
+                  Object.assign(params, matcherParams)
+                  paramsResult = curParamsResult
+                }
+              }
+            }
+
             if (params) {
               matchedPath = utils.interpolateDynamicPath(srcPathname, params)
               req.url = utils.interpolateDynamicPath(req.url!, params)

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1148,7 +1148,6 @@ export default abstract class Server<
             // matching before the dynamic route has been matched
             if (
               !paramsResult.hasValidParams &&
-              pageIsDynamic &&
               !isDynamicRoute(normalizedUrlPath)
             ) {
               let matcherParams = utils.dynamicRouteMatcher?.(normalizedUrlPath)
@@ -1157,6 +1156,32 @@ export default abstract class Server<
                 utils.normalizeDynamicRouteParams(matcherParams)
                 Object.assign(paramsResult.params, matcherParams)
                 paramsResult.hasValidParams = true
+              }
+            }
+
+            // if an action request is bypassing a prerender and we
+            // don't have the params in the URL since it was prerendered
+            // and matched during handle: 'filesystem' rather than dynamic route
+            // resolving we need to parse the params from the matched-path.
+            // Note: this is similar to above case but from match-path instead
+            // of from the request URL since a rewrite could cause that to not
+            // match the src pathname
+            if (
+              // we can have a collision with /index and a top-level /[slug]
+              matchedPath !== '/index' &&
+              !paramsResult.hasValidParams &&
+              !isDynamicRoute(matchedPath)
+            ) {
+              let matcherParams = utils.dynamicRouteMatcher?.(matchedPath)
+
+              if (matcherParams) {
+                const curParamsResult =
+                  utils.normalizeDynamicRouteParams(matcherParams)
+
+                if (curParamsResult.hasValidParams) {
+                  Object.assign(params, matcherParams)
+                  paramsResult = curParamsResult
+                }
               }
             }
 
@@ -1197,7 +1222,6 @@ export default abstract class Server<
 
             // handle the actual dynamic route name being requested
             if (
-              pageIsDynamic &&
               utils.defaultRouteMatches &&
               normalizedUrlPath === srcPathname &&
               !paramsResult.hasValidParams &&
@@ -1205,30 +1229,6 @@ export default abstract class Server<
                 .hasValidParams
             ) {
               params = utils.defaultRouteMatches
-            }
-
-            // if an action request is bypassing a prerender and we
-            // don't have the params in the URL since it was prerendered
-            // and matched during handle: 'filesystem' rather than dynamic route
-            // resolving we need to parse the params from the matched-path
-            if (
-              // we can have a collision with /index and a top-level /[slug]
-              matchedPath !== '/index' &&
-              pageIsDynamic &&
-              !paramsResult.hasValidParams &&
-              !isDynamicRoute(matchedPath)
-            ) {
-              let matcherParams = utils.dynamicRouteMatcher?.(matchedPath)
-
-              if (matcherParams) {
-                const curParamsResult =
-                  utils.normalizeDynamicRouteParams(matcherParams)
-
-                if (curParamsResult.hasValidParams) {
-                  Object.assign(params, matcherParams)
-                  paramsResult = curParamsResult
-                }
-              }
             }
 
             if (params) {
@@ -1248,10 +1248,6 @@ export default abstract class Server<
           }
           parsedUrl.pathname = matchedPath
           url.pathname = parsedUrl.pathname
-          console.error('final', {
-            pathname: parsedUrl.pathname,
-            urlPathname: url.pathname,
-          })
           finished = await this.normalizeAndAttachMetadata(req, res, parsedUrl)
           if (finished) return
         } catch (err) {

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1212,6 +1212,8 @@ export default abstract class Server<
             // and matched during handle: 'filesystem' not dynamic route
             // resolving we need to parse the params from the matched-path
             if (
+              // we can have a collision with /index and a top-level /[slug]
+              matchedPath !== '/index' &&
               pageIsDynamic &&
               !paramsResult.hasValidParams &&
               !isDynamicRoute(matchedPath)
@@ -1246,7 +1248,10 @@ export default abstract class Server<
           }
           parsedUrl.pathname = matchedPath
           url.pathname = parsedUrl.pathname
-
+          console.error('final', {
+            pathname: parsedUrl.pathname,
+            urlPathname: url.pathname,
+          })
           finished = await this.normalizeAndAttachMetadata(req, res, parsedUrl)
           if (finished) return
         } catch (err) {

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1209,7 +1209,7 @@ export default abstract class Server<
 
             // if an action request is bypassing a prerender and we
             // don't have the params in the URL since it was prerendered
-            // and matched during handle: 'filesystem' not dynamic route
+            // and matched during handle: 'filesystem' rather than dynamic route
             // resolving we need to parse the params from the matched-path
             if (
               // we can have a collision with /index and a top-level /[slug]

--- a/test/e2e/app-dir/actions/app/static/[slug]/button.js
+++ b/test/e2e/app-dir/actions/app/static/[slug]/button.js
@@ -1,0 +1,23 @@
+'use client'
+
+import { useState } from 'react'
+import { inc } from '../../client/actions'
+
+export function Button() {
+  const [count, setCount] = useState(0)
+
+  return (
+    <>
+      <p id="count">{count}</p>
+      <button
+        id="inc"
+        onClick={async () => {
+          const newCount = await inc(count)
+          setCount(newCount)
+        }}
+      >
+        click me
+      </button>
+    </>
+  )
+}

--- a/test/e2e/app-dir/actions/app/static/[slug]/page.js
+++ b/test/e2e/app-dir/actions/app/static/[slug]/page.js
@@ -1,0 +1,18 @@
+import { Button } from './button'
+
+export default function Page() {
+  return (
+    <>
+      <p>/static/[slug]</p>
+      <Button />
+    </>
+  )
+}
+
+export function generateStaticParams() {
+  return [
+    {
+      slug: 'first',
+    },
+  ]
+}

--- a/test/e2e/app-dir/actions/middleware.js
+++ b/test/e2e/app-dir/actions/middleware.js
@@ -1,6 +1,11 @@
 // Ensure that https://github.com/vercel/next.js/issues/56286 is fixed.
 import { NextResponse } from 'next/server'
 
-export async function middleware() {
+export async function middleware(req) {
+  if (req.nextUrl.pathname.includes('rewrite-to-static-first')) {
+    req.nextUrl.pathname = '/static/first'
+    return NextResponse.rewrite(req.nextUrl)
+  }
+
   return NextResponse.next()
 }


### PR DESCRIPTION
This handles the case where a middleware rewrite causes us to fail to resolve the correct dynamic route params for an action sent to a prerendered ISR path since the matched path wouldn't be the original source path like we expect and instead is the prerendered path so we need to parse the params out instead.