### PR TITLE
Feat: Updates output.mdx docs to clarify standalone output usage

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/output.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/output.mdx
@@ -35,6 +35,8 @@ This will create a folder at `.next/standalone` which can then be deployed on it
 
 Additionally, a minimal `server.js` file is also output which can be used instead of `next start`. This minimal server does not copy the `public` or `.next/static` folders by default as these should ideally be handled by a CDN instead, although these folders can be copied to the `standalone/public` and `standalone/.next/static` folders manually, after which `server.js` file will serve these automatically.
 
+The `.next/static` folder must be in the same directory as `server.js`. In some builds, `server.js` might be generated in a nested directory under `.next/standalone`.
+
 <AppOnly>
 
 > **Good to know**:


### PR DESCRIPTION

### What?
Clarifies standalone output documentation regarding confusion in:
https://github.com/vercel/next.js/issues/49283
https://stackoverflow.com/questions/76506072/standalone-next-js-server-returns-404-for-static-content-unless-next-start-is-ca
https://www.reddit.com/r/nextjs/comments/18t6ltd/404s_for_public_and_static_content_in_standalone/

### Why?
The standalone build needs the static assets to be moved in a specific folder before being ready to be served via server.js.  Unfortunately it isn't so clear sometimes, as the .next/static assets need to be in the same directory as the server.js.  This is not always easy to tell, and debug, as with monorepos, the build ofter puts server.js into a nested directory.

