### PR TITLE
de-flake next-image test

### DIFF
--- a/test/integration/next-image-legacy/custom-resolver/test/index.test.ts
+++ b/test/integration/next-image-legacy/custom-resolver/test/index.test.ts
@@ -50,11 +50,7 @@ describe('Custom Resolver Tests', () => {
       })
       describe('Client-side Custom Loader Tests', () => {
         beforeAll(async () => {
-          browser = await webdriver(appPort, '/')
-          await browser
-            .elementByCss('#clientlink')
-            .click()
-            .waitForElementByCss('#client-side')
+          browser = await webdriver(appPort, '/client-side')
         })
         afterAll(async () => {
           browser = null


### PR DESCRIPTION
This navigation event is timing out in Turbopack builds, but not for any particularly good reason: I think the link click is just taking a while, due to builds still being fairly experimental.

Rather than clicking a link to navigate to the client side test suite, this just starts the test there, which is similar to how the server test works anyway and still accomplishes what this test is intended for.

Flakes:
[1](https://github.com/vercel/next.js/actions/runs/9520142937/job/26245881436)
[2](https://github.com/vercel/next.js/actions/runs/9520142937/job/26245558183)
[3](https://github.com/vercel/next.js/actions/runs/9520142937/job/26244822150)
[4](https://github.com/vercel/next.js/actions/runs/9519242919/job/26244323363)