### PR TITLE
skip incompatible deploy test

### DIFF
--- a/test/e2e/rsc-layers-transform/rsc-layers-transform.test.ts
+++ b/test/e2e/rsc-layers-transform/rsc-layers-transform.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('rsc layers transform', () => {
-  const { next } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })
 
@@ -14,9 +14,11 @@ describe('rsc layers transform', () => {
     })
   })
 
-  it('should call instrumentation hook without errors', async () => {
-    const output = next.cliOutput
-    expect(output).toContain('instrumentation:register')
-    expect(output).toContain('instrumentation:text:text-value')
-  })
+  if (!isNextDeploy) {
+    it('should call instrumentation hook without errors', async () => {
+      const output = next.cliOutput
+      expect(output).toContain('instrumentation:register')
+      expect(output).toContain('instrumentation:text:text-value')
+    })
+  }
 })


### PR DESCRIPTION
This is only available at runtime, so wouldn't be in build logs. 