### PR TITLE
split CI retry workflows

### DIFF
--- a/.github/workflows/retry_deploy_test.yml
+++ b/.github/workflows/retry_deploy_test.yml
@@ -1,14 +1,13 @@
-name: retry-tests
+name: retry-deploy-tests
 
 on:
   workflow_run:
-    workflows: ['build-and-test']
-    branches: [canary]
+    workflows: ['test-e2e-deploy-release']
     types:
       - completed
 
 env:
-  SLACK_WEBHOOK_URL: ${{ secrets.BROKEN_CANARY_SLACK_WEBHOOK_URL }}
+  SLACK_WEBHOOK_URL: ${{ secrets.BROKEN_DEPLOY_SLACK_WEBHOOK_URL }}
 
 permissions:
   actions: write
@@ -16,12 +15,12 @@ permissions:
 jobs:
   retry-on-failure:
     name: retry failed jobs
-    # Retry the build-and-test workflow up to 3 times
+    # Retry the test-e2e-deploy-release workflow up to 2 times
     if: >-
       ${{ 
         github.event.workflow_run.conclusion == 'failure' &&
         github.repository == 'vercel/next.js' &&
-        github.event.workflow_run.run_attempt < 3)
+        github.event.workflow_run.run_attempt < 2
       }}
     runs-on: ubuntu-latest
     steps:
@@ -37,11 +36,11 @@ jobs:
 
   report-failure:
     name: report failure to slack
-    # Report the failure to Slack if the build-and-test workflow has failed 3 times
+    # Report the failure to Slack if the test-e2e-deploy-release workflow has failed 2 times
     if: >-
       ${{ 
         github.event.workflow_run.conclusion == 'failure' &&
-        github.event.workflow_run.run_attempt >= 3 &&
+        github.event.workflow_run.run_attempt >= 2 &&
         !github.event.workflow_run.head_repository.fork
       }}
     runs-on: ubuntu-latest
@@ -49,9 +48,6 @@ jobs:
       - name: send webhook
         uses: slackapi/slack-github-action@v1.25.0
         with:
-          # These urls are intentionally missing the protocol,
-          # allowing them to be transformed into actual links in the Slack workflow
-          # (through slightly hacky means).
           payload: |
             {
               "commit_title": ${{ toJSON(github.event.workflow_run.display_title) }},


### PR DESCRIPTION
Splitting these workflows up to improve readability & control the `workflow_run` condition a bit better.