### PR TITLE
fix: global-error for dynamic routes

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -381,7 +381,7 @@ async function createTreeCodeFromPath(
 
       if (!globalError) {
         const resolvedGlobalErrorPath = await resolver(
-          `${appDirPrefix}/${GLOBAL_ERROR_FILE_TYPE}`
+          `${appDirPrefix}${parallelSegmentPath}/${GLOBAL_ERROR_FILE_TYPE}`
         )
         if (resolvedGlobalErrorPath) {
           globalError = resolvedGlobalErrorPath

--- a/test/e2e/app-dir/global-error/layout-error-dynamic-routes/app/[lang]/global-error.js
+++ b/test/e2e/app-dir/global-error/layout-error-dynamic-routes/app/[lang]/global-error.js
@@ -1,0 +1,14 @@
+'use client'
+
+export default function GlobalError({ error }) {
+  return (
+    <html>
+      <head></head>
+      <body>
+        <h1>Global Error</h1>
+        <p id="error">{`Global error: ${error?.message}`}</p>
+        {error?.digest && <p id="digest">{error?.digest}</p>}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/global-error/layout-error-dynamic-routes/app/[lang]/layout.js
+++ b/test/e2e/app-dir/global-error/layout-error-dynamic-routes/app/[lang]/layout.js
@@ -1,0 +1,5 @@
+export default function layout() {
+  throw new Error('Global error: layout error')
+}
+
+export const revalidate = 0

--- a/test/e2e/app-dir/global-error/layout-error-dynamic-routes/app/[lang]/page.js
+++ b/test/e2e/app-dir/global-error/layout-error-dynamic-routes/app/[lang]/page.js
@@ -1,0 +1,3 @@
+export default function page() {
+  return <div>Page</div>
+}

--- a/test/e2e/app-dir/global-error/layout-error-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/global-error/layout-error-dynamic-routes/index.test.ts
@@ -1,0 +1,32 @@
+import { getRedboxHeader, hasRedbox } from 'next-test-utils'
+import { nextTestSetup } from 'e2e-utils'
+
+async function testDev(browser, errorRegex) {
+  expect(await hasRedbox(browser)).toBe(true)
+  expect(await getRedboxHeader(browser)).toMatch(errorRegex)
+}
+
+describe('app dir - global error - layout error', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should render global error for error in server components inside dynamic route [lang]', async () => {
+    const browser = await next.browser('/en')
+
+    if (isNextDev) {
+      await testDev(browser, /Global error: layout error/)
+    } else {
+      expect(await browser.elementByCss('h1').text()).toBe('Global Error')
+      expect(await browser.elementByCss('#error').text()).toBe(
+        'Global error: An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.'
+      )
+      expect(await browser.elementByCss('#digest').text()).toMatch(/\w+/)
+    }
+  })
+})


### PR DESCRIPTION

### What?

Based on similar issues, I decided to investigate why I encountered the same problem with the `global-error.tsx` file when the root `layout.tsx` thrown an error.

Related issues:
https://github.com/vercel/next.js/issues/61400
https://github.com/vercel/next.js/issues/60245

Initially, I suspected that the i18n library (next-intl) I used in my main project was the cause. However, I later realized that the problem lies in [dynamic routes](https://nextjs.org/docs/app/building-your-application/routing/dynamic-routes).

### Why?

Many users, including myself, find it unintuitive from the [official documentation](https://nextjs.org/docs/app/building-your-application/routing/internationalization) about i18n and the example on [github.com](https://github.com/vercel/next.js/tree/canary/examples/app-dir-i18n-routing) that the `global-error.tsx` file should be placed in the root of the `app/` directory instead of `app/[lang]/`. The documentation and example **do not cover this detail**, which leads users to place `global-error.tsx` in `app/[lang]/`. As a result, when `global-error.tsx` **cannot catch errors** in root `layout.tsx`, users report this as a new issue on Next.js's GitHub, as seen in the related issues linked above.

### How?

My bug fix allows the `global-error.tsx` file to be placed not only in the root of `app/` but also in `app/[lang]/`. This fix eliminates the need to update the documentation to specify where the `global-error.tsx` file should be placed or to change the example on [github.com](https://github.com/vercel/next.js/tree/canary/examples/app-dir-i18n-routing) to clarify this point.

p.s. you can use any dynamic route for your i18n Next.js applications; `lang` is just an example as shown in the [official documentation](https://nextjs.org/docs/app/building-your-application/routing/internationalization).

Fixes #66905 