### PR TITLE
Revert "feat(turbopack-ecmascript): cache external modules with wrapper (#63337)"

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/parseStack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/parseStack.ts
@@ -16,22 +16,6 @@ export function parseStack(stack: string): StackFrame[] {
     }
   }
 
-  // throw away eval information that stacktrace-parser doesn't support
-  // adapted from https://github.com/stacktracejs/error-stack-parser/blob/9f33c224b5d7b607755eb277f9d51fcdb7287e24/error-stack-parser.js#L59C33-L59C62
-  stack = stack
-    .split('\n')
-    .map((line) => {
-      if (line.includes('(eval ')) {
-        line = line
-          .replace(/eval code/g, 'eval')
-          .replace(/\(eval at [^()]* \(/, '(file://')
-          .replace(/\),.*$/g, ')')
-      }
-
-      return line
-    })
-    .join('\n')
-
   const frames = parse(stack)
   return frames.map((frame) => {
     try {

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -107,7 +107,7 @@ describe('middleware - development errors', () => {
 
     it('logs the error correctly', async () => {
       await next.fetch('/')
-      // const output = stripAnsi(next.cliOutput)
+      const output = stripAnsi(next.cliOutput)
       await check(() => {
         expect(stripAnsi(next.cliOutput)).toMatch(
           /middleware.js \(\d+:\d+\) @ eval/
@@ -115,9 +115,9 @@ describe('middleware - development errors', () => {
         expect(stripAnsi(next.cliOutput)).toMatch(/test is not defined/)
         return 'success'
       }, 'success')
-      // expect(output).not.toContain(
-      //   'webpack-internal:///(middleware)/./middleware.js'
-      // )
+      expect(output).not.toContain(
+        'webpack-internal:///(middleware)/./middleware.js'
+      )
     })
 
     it('renders the error correctly and recovers', async () => {

--- a/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
+++ b/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
@@ -41,10 +41,18 @@ describe('fetch failures have good stack traces in edge runtime', () => {
   it('when returning `fetch` using an unknown domain, stack traces are preserved', async () => {
     await webdriver(next.url, '/api/unknown-domain-no-await')
 
-    // TODO: turbopack needs to have its source maps picked up by node.js
-    await check(
-      () => stripAnsi(next.cliOutput),
-      /at.+\/pages\/api\/unknown-domain-no-await.js/
-    )
+    if (process.env.TURBOPACK) {
+      // pages_api_unknown-domain-no-await_d8c7f5.js:14:5
+      await check(
+        () => stripAnsi(next.cliOutput),
+        /pages_api_unknown-domain-no-await_.*?\.js/
+      )
+    } else {
+      // webpack-internal:///(middleware)/./pages/api/unknown-domain-no-await.js:10:5
+      await check(
+        () => stripAnsi(next.cliOutput),
+        /at.+\/pages\/api\/unknown-domain-no-await.js/
+      )
+    }
   })
 })

--- a/test/integration/externals-pages-bundle/test/externals.test.js
+++ b/test/integration/externals-pages-bundle/test/externals.test.js
@@ -32,7 +32,7 @@ describe('default', () => {
           allBundles += output
         }
         expect(allBundles).toContain(
-          '__turbopack_external_require__("external-package")'
+          '__turbopack_external_require__("external-package", true)'
         )
       } else {
         const output = await fs.readFile(

--- a/test/integration/externals-pages-bundle/test/index.test.js
+++ b/test/integration/externals-pages-bundle/test/index.test.js
@@ -28,9 +28,7 @@ describe('bundle pages externals with config.bundlePagesRouterDependencies', () 
           }
 
           // we don't know the name of the minified `__turbopack_external_require__`, so we just check the arguments.
-          expect(allBundles).not.toContain(
-            '"[externals]/ [external] (external-package, cjs)"'
-          )
+          expect(allBundles).not.toContain('("external-package",!0)')
         } else {
           const output = await fs.readFile(
             join(appDir, '.next/server/pages/index.js'),
@@ -54,9 +52,7 @@ describe('bundle pages externals with config.bundlePagesRouterDependencies', () 
           }
 
           // we don't know the name of the minified `__turbopack_external_require__`, so we just check the arguments.
-          expect(allBundles).toContain(
-            '"[externals]/ [external] (opted-out-external-package, cjs)"'
-          )
+          expect(allBundles).toContain('("opted-out-external-package",!0)')
         } else {
           const output = await fs.readFile(
             join(appDir, '.next/server/pages/index.js'),

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -4052,9 +4052,10 @@
       "runtimeError": false
     },
     "test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts": {
-      "passed": [],
+      "passed": [
+        "fetch failures have good stack traces in edge runtime when returning `fetch` using an unknown domain, stack traces are preserved"
+      ],
       "failed": [
-        "fetch failures have good stack traces in edge runtime when returning `fetch` using an unknown domain, stack traces are preserved",
         "fetch failures have good stack traces in edge runtime when awaiting `fetch` using an unknown domain, stack traces are preserved"
       ],
       "pending": [],

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -6134,11 +6134,10 @@
   },
   "test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts": {
     "passed": [
-      "fetch failures have good stack traces in edge runtime when awaiting `fetch` using an unknown domain, stack traces are preserved"
-    ],
-    "failed": [
+      "fetch failures have good stack traces in edge runtime when awaiting `fetch` using an unknown domain, stack traces are preserved",
       "fetch failures have good stack traces in edge runtime when returning `fetch` using an unknown domain, stack traces are preserved"
     ],
+    "failed": [],
     "pending": [],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
Revert https://github.com/vercel/next.js/pull/63337

It's not passing the tests