### PR TITLE
Fix: remove enegine requried pnpm version

### DIFF
--- a/.github/actions/next-integration-stat/package.json
+++ b/.github/actions/next-integration-stat/package.json
@@ -21,8 +21,7 @@
     "strip-ansi": "^7.0.1"
   },
   "engines": {
-    "node": ">=18.17.0",
-    "pnpm": "8.15.7"
+    "node": ">=18.17.0"
   },
   "packageManager": "pnpm@8.15.7"
 }

--- a/.github/actions/next-stats-action/package.json
+++ b/.github/actions/next-stats-action/package.json
@@ -18,8 +18,7 @@
     "typescript": "5.1.6"
   },
   "engines": {
-    "node": ">=18.17.0",
-    "pnpm": "8.15.7"
+    "node": ">=18.17.0"
   },
   "packageManager": "pnpm@8.15.7"
 }

--- a/.github/actions/upload-turboyet-data/package.json
+++ b/.github/actions/upload-turboyet-data/package.json
@@ -12,8 +12,7 @@
     "@vercel/ncc": "^0.36.0"
   },
   "engines": {
-    "node": ">=18.17.0",
-    "pnpm": "8.15.7"
+    "node": ">=18.17.0"
   },
   "packageManager": "pnpm@8.15.7"
 }

--- a/packages/create-next-app/package.json
+++ b/packages/create-next-app/package.json
@@ -51,8 +51,6 @@
     "validate-npm-package-name": "5.0.1"
   },
   "engines": {
-    "node": ">=18.17.0",
-    "pnpm": "8.15.7"
-  },
-  "packageManager": "pnpm@8.15.7"
+    "node": ">=18.17.0"
+  }
 }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -344,8 +344,6 @@
     "vercel"
   ],
   "engines": {
-    "node": ">=18.17.0",
-    "pnpm": "8.15.7"
-  },
-  "packageManager": "pnpm@8.15.7"
+    "node": ">=18.17.0"
+  }
 }

--- a/test/.stats-app/package.json
+++ b/test/.stats-app/package.json
@@ -8,8 +8,7 @@
     "react-dom": "19.0.0-rc-6230622a1a-20240610"
   },
   "engines": {
-    "node": ">=18.17.0",
-    "pnpm": "8.15.7"
+    "node": ">=18.17.0"
   },
   "packageManager": "pnpm@8.15.7"
 }


### PR DESCRIPTION
### What

Remove `pnpm` field from `engine` fields in package.json of next.js packages. It's not required to be matched.

### Why

Specifying `pnpm` version is not required to be matched when you pnpm install it, it's accidentally introduced in https://github.com/vercel/next.js/pull/66784 for `packages/next` or `packages/create-next-app`. 

You will get error if pnpm version is not matched

```
ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)
  
  This error happened while installing a direct dependency of /home/runner/_work/.../apps/admin
  
  Your pnpm version is incompatible with "registry.npmjs.org/next/15.0.0-canary.33".
  
  Expected version: 8.15.7
  Got: 8.11.0
  
  This is happening because the package's manifest has an engines.pnpm field specified.
  To fix this issue, install the required pnpm version globally.
  
  To install the latest version of pnpm, run "pnpm i -g pnpm".
  To check your pnpm version, run "pnpm -v".
  /home/runner/_work/.../node_modules/.pnpm/@actions+exec@1.1.1/node_modules/@actions/exec/lib/toolrunner.js:592
                  error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
                          ^
```

`packageManager` field is in root monorepo package.json is enough for corepack to opt into the version. For the `.github` testing apps are also enough for runing them with GA.

