### PR TITLE
docs: add good to know for ignored metadata files

### DIFF
--- a/docs/02-app/01-building-your-application/11-upgrading/05-from-create-react-app.mdx
+++ b/docs/02-app/01-building-your-application/11-upgrading/05-from-create-react-app.mdx
@@ -143,7 +143,7 @@ export default function RootLayout({ children }) {
 }
 ```
 
-> **Good to know**: We'll ignore the [manifest file](/docs/app/api-reference/file-conventions/metadata), additional iconography other than the favicon, and [testing configuration](/docs/app/building-your-application/testing), but if these are requirements, Next.js also supports these options.
+> **Good to know**: We'll ignore the [manifest file](/docs/app/api-reference/file-conventions/metadata/manifest), additional iconography other than the favicon, and [testing configuration](/docs/app/building-your-application/testing), but if these are requirements, Next.js also supports these options. View the [Metadata Files API Reference](/docs/app/api-reference/file-conventions/metadata) and [Testing Guides](/docs/app/building-your-application/testing#guides) for more information.
 
 ### Step 4: Metadata
 

--- a/docs/02-app/01-building-your-application/11-upgrading/06-from-create-react-app.mdx
+++ b/docs/02-app/01-building-your-application/11-upgrading/06-from-create-react-app.mdx
@@ -185,7 +185,7 @@ export default function RootLayout({ children }) {
 }
 ```
 
-> **Good to know**: We'll ignore the [manifest file](/docs/app/api-reference/file-conventions/metadata), additional iconography other than the favicon, and [testing configuration](/docs/app/building-your-application/testing), but if these are requirements, Next.js also supports these options.
+> **Good to know**: We'll ignore the [manifest file](/docs/app/api-reference/file-conventions/metadata/manifest), additional iconography other than the favicon, and [testing configuration](/docs/app/building-your-application/testing), but if these are requirements, Next.js also supports these options. View the [Metadata Files API Reference](/docs/app/api-reference/file-conventions/metadata) and [Testing Guides](/docs/app/building-your-application/testing#guides) for more information.
 
 ### Step 5: Metadata
 

--- a/docs/02-app/02-api-reference/02-file-conventions/01-metadata/app-icons.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/01-metadata/app-icons.mdx
@@ -61,6 +61,7 @@ Add an `apple-icon.(jpg|jpeg|png)` image file.
 
 > **Good to know**
 >
+> - By default, app icons are ignored and not displayed, except `favicon.ico`. To enable them, extend the [matcher](/docs/app/building-your-application/routing/middleware#matcher) in the `middleware.js` file.
 > - You can set multiple icons by adding a number suffix to the file name. For example, `icon1.png`, `icon2.png`, etc. Numbered files will sort lexically.
 > - Favicons can only be set in the root `/app` segment. If you need more granularity, you can use [`icon`](#icon).
 > - The appropriate `<link>` tags and attributes such as `rel`, `href`, `type`, and `sizes` are determined by the icon type and metadata of the evaluated file.

--- a/docs/02-app/02-api-reference/02-file-conventions/01-metadata/manifest.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/01-metadata/manifest.mdx
@@ -5,6 +5,8 @@ description: API Reference for manifest.json file.
 
 Add or generate a `manifest.(json|webmanifest)` file that matches the [Web Manifest Specification](https://developer.mozilla.org/docs/Web/Manifest) in the **root** of `app` directory to provide information about your web application for the browser.
 
+> **Good to know**: By default, manifest file is ignored and not displayed. To enable it, extend the [matcher](/docs/app/building-your-application/routing/middleware#matcher) in the `middleware.js` file.
+
 ## Static Manifest file
 
 ```json filename="app/manifest.json | app/manifest.webmanifest"

--- a/docs/02-app/02-api-reference/02-file-conventions/01-metadata/robots.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/01-metadata/robots.mdx
@@ -5,6 +5,8 @@ description: API Reference for robots.txt file.
 
 Add or generate a `robots.txt` file that matches the [Robots Exclusion Standard](https://en.wikipedia.org/wiki/Robots.txt#Standard) in the **root** of `app` directory to tell search engine crawlers which URLs they can access on your site.
 
+> **Good to know**: By default, robots file is ignored and not displayed. To enable it, extend the [matcher](/docs/app/building-your-application/routing/middleware#matcher) in the `middleware.js` file.
+
 ## Static `robots.txt`
 
 ```txt filename="app/robots.txt"

--- a/docs/02-app/02-api-reference/02-file-conventions/01-metadata/sitemap.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/01-metadata/sitemap.mdx
@@ -10,6 +10,8 @@ related:
 
 `sitemap.(xml|js|ts)` is a special file that matches the [Sitemaps XML format](https://www.sitemaps.org/protocol.html) to help search engine crawlers index your site more efficiently.
 
+> **Good to know**: By default, sitemap file is ignored and not displayed. To enable it, extend the [matcher](/docs/app/building-your-application/routing/middleware#matcher) in the `middleware.js` file.
+
 ### Sitemap files (.xml)
 
 For smaller applications, you can create a `sitemap.xml` file and place it in the root of your `app` directory.


### PR DESCRIPTION
### What?
Add a "Good to know" block for `icons`, `sitemap`, `manifest` and `robots` files to help developers spend less time configuring them

### Why?
While configuring `middleware.ts`, I encountered an issue where  `icons`, `sitemap`, `manifest` and `robots`  files returned a 404 status in my Next.js app

The documentation only contains one vague sentence about this behavior (["Good to know: We'll ignore the manifest file, additional iconography other than the favicon, and testing configuration, but if these are requirements, Next.js also supports these options."](https://nextjs.org/docs/app/building-your-application/upgrading/from-create-react-app#step-4-create-the-root-layout)), which does not clearly explain how to handle it

### How?
Add short and comprehensive "Good to know" that will reduce the time it takes to configure these files