### PR TITLE
Use next-swc from branch for PR size stats

### DIFF
--- a/.github/actions/next-stats-action/native/.gitignore
+++ b/.github/actions/next-stats-action/native/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/.github/actions/next-stats-action/src/prepare/repo-setup.js
+++ b/.github/actions/next-stats-action/src/prepare/repo-setup.js
@@ -65,7 +65,11 @@ module.exports = (actionInfo) => {
      * @param {{ repoDir: string, nextSwcVersion: null | string }} options Required options
      * @returns {Promise<Map<string, string>>} List packages key is the package name, value is the path to the packed tar file.'
      */
-    async linkPackages({ repoDir, nextSwcVersion, parentSpan }) {
+    async linkPackages({
+      repoDir,
+      nextSwcVersion: nextSwcVersionSpecified,
+      parentSpan,
+    }) {
       if (!parentSpan) {
         // Not all callers provide a parent span
         parentSpan = mockSpan()
@@ -117,6 +121,11 @@ module.exports = (actionInfo) => {
           pkgPaths.set(packageName, packedPackageTarPath)
         }
       })
+
+      const nextSwcVersion =
+        nextSwcVersionSpecified ??
+        pkgDatas.get('@next/swc')?.packedPackageTarPath ??
+        null
 
       await parentSpan
         .traceChild('write-packagejson')
@@ -171,9 +180,11 @@ module.exports = (actionInfo) => {
               })
               if (nextSwcVersion) {
                 Object.assign(packageJson.dependencies, {
+                  // CI
                   '@next/swc-linux-x64-gnu': nextSwcVersion,
+                  // Vercel issued laptops
+                  '@next/swc-darwin-arm64': nextSwcVersion,
                 })
-              } else {
               }
             }
 

--- a/test/.stats-app/package.json
+++ b/test/.stats-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "MIT",
   "dependencies": {
-    "next": "19.0.0-rc-6230622a1a-20240610",
+    "next": "latest",
     "react": "19.0.0-rc-6230622a1a-20240610",
     "react-dom": "19.0.0-rc-6230622a1a-20240610"
   },


### PR DESCRIPTION
Currently, PR stats are always downloading published binaries:

> cd /tmp/next-statsJoJEbE/stats-app && NEXT_TELEMETRY_DISABLED=1 pnpm next build
> [...]
> Downloading swc package @next/swc-linux-x64-gnu...

-- https://github.com/vercel/next.js/actions/runs/9505097022/job/26199227309#step:7:1713

## test plan
- [x] Makes https://github.com/vercel/next.js/pull/66711 go green
- [x] `GIT_ROOT_DIR=https://github.com/ GITHUB_REPOSITORY=vercel/next.js GITHUB_REF=sebbie/06-10-update_react_from_1df34bdf62_to_20b6f4c0e8 GITHUB_ACTION=synchronize node .github/actions/next-stats-action/src/index.js` completes `pnpm build` (but fails afterwards locally which is expected)