### PR TITLE
Testmode: use ipv4 address to reduce dependency on local system configuration

### DIFF
--- a/packages/next/src/experimental/testmode/fetch.ts
+++ b/packages/next/src/experimental/testmode/fetch.ts
@@ -95,7 +95,7 @@ export async function handleFetch(
   const { testData, proxyPort } = testInfo
   const proxyRequest = await buildProxyRequest(testData, request)
 
-  const resp = await originalFetch(`http://localhost:${proxyPort}`, {
+  const resp = await originalFetch(`http://127.0.0.1:${proxyPort}`, {
     method: 'POST',
     body: JSON.stringify(proxyRequest),
     next: {

--- a/packages/next/src/experimental/testmode/fetch.ts
+++ b/packages/next/src/experimental/testmode/fetch.ts
@@ -95,7 +95,7 @@ export async function handleFetch(
   const { testData, proxyPort } = testInfo
   const proxyRequest = await buildProxyRequest(testData, request)
 
-  const resp = await originalFetch(`http://127.0.0.1:${proxyPort}`, {
+  const resp = await originalFetch(`http://localhost:${proxyPort}`, {
     method: 'POST',
     body: JSON.stringify(proxyRequest),
     next: {

--- a/packages/next/src/experimental/testmode/proxy/server.ts
+++ b/packages/next/src/experimental/testmode/proxy/server.ts
@@ -58,7 +58,7 @@ export async function createProxyServer({
   })
 
   await new Promise((resolve) => {
-    server.listen(0, '127.0.0.1', () => {
+    server.listen(0, '::', () => {
       resolve(undefined)
     })
   })

--- a/packages/next/src/experimental/testmode/proxy/server.ts
+++ b/packages/next/src/experimental/testmode/proxy/server.ts
@@ -58,7 +58,7 @@ export async function createProxyServer({
   })
 
   await new Promise((resolve) => {
-    server.listen(0, 'localhost', () => {
+    server.listen(0, '127.0.0.1', () => {
       resolve(undefined)
     })
   })


### PR DESCRIPTION
We've run into numerous issues with local system configurations that prefer ipv6 and failing to connect to the test proxy.