### PR TITLE
fix caching of client chunks

### DIFF
--- a/packages/next-swc/crates/next-api/src/app.rs
+++ b/packages/next-swc/crates/next-api/src/app.rs
@@ -50,6 +50,7 @@ use turbopack_binding::{
                 EntryChunkGroupResult, EvaluatableAssets,
             },
             file_source::FileSource,
+            ident::AssetIdent,
             module::Module,
             output::{OutputAsset, OutputAssets},
             raw_output::RawOutput,
@@ -627,6 +628,11 @@ pub fn app_entry_point_to_route(
     .cell()
 }
 
+#[turbo_tasks::function]
+fn client_shared_chunks() -> Vc<RcStr> {
+    Vc::cell("client_shared_chunks".into())
+}
+
 #[derive(Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Debug, TraceRawVcs)]
 enum AppPageEndpointType {
     Html,
@@ -772,10 +778,8 @@ impl AppEndpoint {
 
         let (app_server_reference_modules, client_dynamic_imports) = if process_client {
             let client_shared_chunk_group = get_app_client_shared_chunk_group(
-                app_entry
-                    .rsc_entry
-                    .ident()
-                    .with_modifier(Vc::cell("client_shared_chunks".into())),
+                AssetIdent::from_path(this.app_project.project().project_path())
+                    .with_modifier(client_shared_chunks()),
                 this.app_project.client_runtime_entries(),
                 client_chunking_context,
             )

--- a/packages/next-swc/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -163,16 +163,17 @@ pub async fn get_app_client_references_chunks(
                     .try_flat_join()
                     .await?;
                 let ssr_chunk_group = if !ssr_modules.is_empty() {
-                    let ssr_entry_module = IncludeModulesModule::new(
-                        base_ident.with_modifier(client_modules_ssr_modifier()),
-                        ssr_modules,
-                    );
-                    let _span = tracing::info_span!(
-                        "server side rendering",
-                        layout_segment = display(&server_component_path),
-                    )
-                    .entered();
                     ssr_chunking_context.map(|ssr_chunking_context| {
+                        let _span = tracing::info_span!(
+                            "server side rendering",
+                            layout_segment = display(&server_component_path),
+                        )
+                        .entered();
+
+                        let ssr_entry_module = IncludeModulesModule::new(
+                            base_ident.with_modifier(client_modules_ssr_modifier()),
+                            ssr_modules,
+                        );
                         ssr_chunking_context.chunk_group(
                             Vc::upcast(ssr_entry_module),
                             Value::new(current_ssr_availability_info),
@@ -201,16 +202,16 @@ pub async fn get_app_client_references_chunks(
                     .try_join()
                     .await?;
                 let client_chunk_group = if !client_modules.is_empty() {
-                    let client_entry_module = IncludeModulesModule::new(
-                        base_ident.with_modifier(client_modules_modifier()),
-                        client_modules,
-                    );
-
                     let _span = tracing::info_span!(
                         "client side rendering",
                         layout_segment = display(&server_component_path),
                     )
                     .entered();
+
+                    let client_entry_module = IncludeModulesModule::new(
+                        base_ident.with_modifier(client_modules_modifier()),
+                        client_modules,
+                    );
                     Some(client_chunking_context.chunk_group(
                         Vc::upcast(client_entry_module),
                         Value::new(current_client_availability_info),


### PR DESCRIPTION
### What?

cache wasn't well reused since all client chunks depend on the client shared chunk, which had a different name for every page.
This fixes that and allows caching of all client component chunks
