### PR TITLE
refactor(next): package.json keywords `back-end` should be `backend`

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -339,7 +339,7 @@
     "server",
     "node",
     "front-end",
-    "back-end",
+    "backend",
     "cli",
     "vercel"
   ],


### PR DESCRIPTION
### Why?

Following of #64173, keyword `back-end` was `backend`

https://github.com/vercel/next.js/assets/120007119/644fe2fb-3db4-4b47-9070-7c504987bdc2

