### PR TITLE
fix hreflang is wrong in head displayed as hrefLang

### DIFF
--- a/packages/next/src/lib/metadata/generate/alternate.tsx
+++ b/packages/next/src/lib/metadata/generate/alternate.tsx
@@ -36,7 +36,7 @@ export function AlternatesMetadata({
     languages
       ? Object.entries(languages).flatMap(([locale, descriptors]) =>
           descriptors?.map((descriptor) =>
-            AlternateLink({ rel: 'alternate', hrefLang: locale, descriptor })
+            AlternateLink({ rel: 'alternate', hreflang: locale, descriptor })
           )
         )
       : null,


### PR DESCRIPTION
setting `alternates` `languages` results in `<link rel="alternate" hrefLang="en" ` output it should be `hreflang` google complains about this in lighthouse