### PR TITLE
Refactor internal routing headers to use request meta

### DIFF
--- a/packages/next/src/server/internal-utils.ts
+++ b/packages/next/src/server/internal-utils.ts
@@ -1,8 +1,6 @@
-import type { IncomingHttpHeaders } from 'http'
 import type { NextParsedUrlQuery } from './request-meta'
 
 import { NEXT_RSC_UNION_QUERY } from '../client/components/app-router-headers'
-import { INTERNAL_HEADERS } from '../shared/lib/constants'
 
 const INTERNAL_QUERY_NAMES = [
   '__nextFallback',
@@ -38,15 +36,4 @@ export function stripInternalSearchParams<T extends string | URL>(
   }
 
   return (isStringUrl ? instance.toString() : instance) as T
-}
-
-/**
- * Strip internal headers from the request headers.
- *
- * @param headers the headers to strip of internal headers
- */
-export function stripInternalHeaders(headers: IncomingHttpHeaders) {
-  for (const key of INTERNAL_HEADERS) {
-    delete headers[key]
-  }
 }

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -1,7 +1,7 @@
 // this must come first as it includes require hooks
 import type { WorkerRequestHandler, WorkerUpgradeHandler } from './types'
 import type { DevBundler } from './router-utils/setup-dev-bundler'
-import type { NextUrlWithParsedQuery } from '../request-meta'
+import type { NextUrlWithParsedQuery, RequestMeta } from '../request-meta'
 import type { NextServer } from '../next'
 
 // This is required before other imports to ensure the require hook is setup.
@@ -19,7 +19,7 @@ import { setupFsCheck } from './router-utils/filesystem'
 import { proxyRequest } from './router-utils/proxy-request'
 import { isAbortError, pipeToNodeResponse } from '../pipe-readable'
 import { getResolveRoutes } from './router-utils/resolve-routes'
-import { getRequestMeta } from '../request-meta'
+import { addRequestMeta, getRequestMeta } from '../request-meta'
 import { pathHasPrefix } from '../../shared/lib/router/utils/path-has-prefix'
 import { removePathPrefix } from '../../shared/lib/router/utils/remove-path-prefix'
 import setupCompression from 'next/dist/compiled/compression'
@@ -218,7 +218,7 @@ export async function initialize(opts: {
       parsedUrl: NextUrlWithParsedQuery,
       invokePath: string,
       handleIndex: number,
-      additionalInvokeHeaders: Record<string, string> = {}
+      additionalRequestMeta?: RequestMeta
     ) {
       // invokeRender expects /api routes to not be locale prefixed
       // so normalize here before continuing
@@ -249,16 +249,19 @@ export async function initialize(opts: {
         throw new Error('Failed to initialize render server')
       }
 
-      const invokeHeaders: typeof req.headers = {
-        ...req.headers,
-        'x-middleware-invoke': '',
-        'x-invoke-path': invokePath,
-        'x-invoke-query': encodeURIComponent(JSON.stringify(parsedUrl.query)),
-        ...(additionalInvokeHeaders || {}),
-      }
-      Object.assign(req.headers, invokeHeaders)
+      addRequestMeta(req, 'invokePath', invokePath)
+      addRequestMeta(req, 'invokeQuery', parsedUrl.query)
+      addRequestMeta(req, 'middlewareInvoke', false)
 
-      debug('invokeRender', req.url, invokeHeaders)
+      for (const key in additionalRequestMeta || {}) {
+        addRequestMeta(
+          req,
+          key as keyof RequestMeta,
+          additionalRequestMeta![key as keyof RequestMeta]
+        )
+      }
+
+      debug('invokeRender', req.url, req.headers)
 
       try {
         const initResult =
@@ -405,10 +408,10 @@ export async function initialize(opts: {
         ) {
           res.statusCode = 500
           await invokeRender(parsedUrl, '/_error', handleIndex, {
-            'x-invoke-status': '500',
-            'x-invoke-error': JSON.stringify({
-              message: `A conflicting public file and page file was found for path ${matchedOutput.itemPath} https://nextjs.org/docs/messages/conflicting-public-file-page`,
-            }),
+            invokeStatus: 500,
+            invokeError: new Error(
+              `A conflicting public file and page file was found for path ${matchedOutput.itemPath} https://nextjs.org/docs/messages/conflicting-public-file-page`
+            ),
           })
           return
         }
@@ -432,10 +435,7 @@ export async function initialize(opts: {
           return await invokeRender(
             url.parse('/405', true),
             '/405',
-            handleIndex,
-            {
-              'x-invoke-status': '405',
-            }
+            handleIndex
           )
         }
 
@@ -492,14 +492,14 @@ export async function initialize(opts: {
 
           if (typeof err.statusCode === 'number') {
             const invokePath = `/${err.statusCode}`
-            const invokeStatus = `${err.statusCode}`
+            const invokeStatus = err.statusCode
             res.statusCode = err.statusCode
             return await invokeRender(
               url.parse(invokePath, true),
               invokePath,
               handleIndex,
               {
-                'x-invoke-status': invokeStatus,
+                invokeStatus,
               }
             )
           }
@@ -515,7 +515,7 @@ export async function initialize(opts: {
           parsedUrl.pathname || '/',
           handleIndex,
           {
-            'x-invoke-output': matchedOutput.itemPath,
+            invokeOutput: matchedOutput.itemPath,
           }
         )
       }
@@ -545,13 +545,13 @@ export async function initialize(opts: {
           UNDERSCORE_NOT_FOUND_ROUTE,
           handleIndex,
           {
-            'x-invoke-status': '404',
+            invokeStatus: 404,
           }
         )
       }
 
       await invokeRender(parsedUrl, '/404', handleIndex, {
-        'x-invoke-status': '404',
+        invokeStatus: 404,
       })
     }
 
@@ -570,7 +570,7 @@ export async function initialize(opts: {
         }
         res.statusCode = Number(invokeStatus)
         return await invokeRender(url.parse(invokePath, true), invokePath, 0, {
-          'x-invoke-status': invokeStatus,
+          invokeStatus: res.statusCode,
         })
       } catch (err2) {
         console.error(err2)

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -435,7 +435,10 @@ export async function initialize(opts: {
           return await invokeRender(
             url.parse('/405', true),
             '/405',
-            handleIndex
+            handleIndex,
+            {
+              invokeStatus: 405,
+            }
           )
         }
 

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -459,15 +459,8 @@ export function getResolveRoutes(
               throw new Error(`Failed to initialize render server "middleware"`)
             }
 
-            const invokeHeaders: typeof req.headers = {
-              'x-invoke-path': '',
-              'x-invoke-query': '',
-              'x-invoke-output': '',
-              'x-middleware-invoke': '1',
-            }
-            Object.assign(req.headers, invokeHeaders)
-
-            debug('invoking middleware', req.url, invokeHeaders)
+            addRequestMeta(req, 'middlewareInvoke', true)
+            debug('invoking middleware', req.url, req.headers)
 
             let middlewareRes: Response | undefined = undefined
             let bodyStream: ReadableStream | undefined = undefined
@@ -572,9 +565,6 @@ export function getResolveRoutes(
                   'x-middleware-rewrite',
                   'x-middleware-redirect',
                   'x-middleware-refresh',
-                  'x-middleware-invoke',
-                  'x-invoke-path',
-                  'x-invoke-query',
                 ].includes(key)
               ) {
                 continue

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1121,7 +1121,7 @@ export default class NextNodeServer extends BaseServer<
         const { originalResponse } = normalizedRes
 
         const reqStart = Date.now()
-        const isMiddlewareRequest = req.headers['x-middleware-invoke']
+        const isMiddlewareRequest = getRequestMeta(req, 'middlewareInvoke')
 
         const reqCallback = () => {
           // we don't log for non-route requests
@@ -1640,14 +1640,14 @@ export default class NextNodeServer extends BaseServer<
     res,
     parsed
   ) => {
-    const isMiddlewareInvoke = req.headers['x-middleware-invoke']
+    const isMiddlewareInvoke = getRequestMeta(req, 'middlewareInvoke')
 
     if (!isMiddlewareInvoke) {
       return false
     }
 
     const handleFinished = () => {
-      res.setHeader('x-middleware-invoke', '1')
+      addRequestMeta(req, 'middlewareInvoke', true)
       res.body('').send()
       return true
     }
@@ -1674,9 +1674,6 @@ export default class NextNodeServer extends BaseServer<
       ReturnType<typeof NextNodeServer.prototype.runMiddleware>
     >
     let bubblingResult = false
-
-    // Strip the internal headers.
-    this.stripInternalHeaders(req)
 
     try {
       await this.ensureMiddleware(req.url)

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -99,6 +99,36 @@ export interface RequestMeta {
    * The previous revalidate before rendering 404 page for notFound: true
    */
   notFoundRevalidate?: number | false
+
+  /**
+   * The path we routed to and should be invoked
+   */
+  invokePath?: string
+
+  /**
+   * The specific page output we should be matching
+   */
+  invokeOutput?: string
+
+  /**
+   * The status we are invoking the request with from routing
+   */
+  invokeStatus?: number
+
+  /**
+   * The routing error we are invoking with
+   */
+  invokeError?: Error
+
+  /**
+   * The query parsed for the invocation
+   */
+  invokeQuery?: Record<string, undefined | string | string[]>
+
+  /**
+   * Whether the request is a middleware invocation
+   */
+  middlewareInvoke?: boolean
 }
 
 /**

--- a/packages/next/src/shared/lib/constants.ts
+++ b/packages/next/src/shared/lib/constants.ts
@@ -10,19 +10,6 @@ export const COMPILER_NAMES = {
   edgeServer: 'edge-server',
 } as const
 
-/**
- * Headers that are set by the Next.js server and should be stripped from the
- * request headers going to the user's application.
- */
-export const INTERNAL_HEADERS = [
-  'x-invoke-error',
-  'x-invoke-output',
-  'x-invoke-path',
-  'x-invoke-query',
-  'x-invoke-status',
-  'x-middleware-invoke',
-] as const
-
 export type CompilerNameValues = ValueOf<typeof COMPILER_NAMES>
 
 export const COMPILER_INDEXES: {

--- a/test/e2e/i18n-data-route/i18n-data-route.test.ts
+++ b/test/e2e/i18n-data-route/i18n-data-route.test.ts
@@ -10,7 +10,6 @@ const pages = [
 function checkDataRoute(data: any, page: string) {
   expect(data).toHaveProperty('pageProps')
   expect(data.pageProps).toHaveProperty('page', page)
-  expect(data.pageProps).toHaveProperty('output', page)
 }
 
 describe('i18n-data-route', () => {


### PR DESCRIPTION
This refactors our handling of passing routing information to the render logic via headers which is legacy from when we had separate routing and render workers. Now this will just attach this meta in our normal request meta handling which is more consistent and type safe. 