### PR TITLE
docs: replace `let` with `const` for `useState`

### DIFF
--- a/docs/02-app/01-building-your-application/03-rendering/04-composition-patterns.mdx
+++ b/docs/02-app/01-building-your-application/03-rendering/04-composition-patterns.mdx
@@ -117,7 +117,7 @@ import { useState } from 'react'
 import { Carousel } from 'acme-carousel'
 
 export default function Gallery() {
-  let [isOpen, setIsOpen] = useState(false)
+  const [isOpen, setIsOpen] = useState(false)
 
   return (
     <div>
@@ -137,7 +137,7 @@ import { useState } from 'react'
 import { Carousel } from 'acme-carousel'
 
 export default function Gallery() {
-  let [isOpen, setIsOpen] = useState(false)
+  const [isOpen, setIsOpen] = useState(false)
 
   return (
     <div>


### PR DESCRIPTION
### What?

I replaced `let` with `const` for `useState`.

### Why?

Since in these examples, it doesn't need to be a `let`, as it doesn't do any reassignment.