### PR TITLE
chore(github-workflow): fix issue_bankrupt workflow

### DIFF
--- a/.github/workflows/issue_bankrupt.yml
+++ b/.github/workflows/issue_bankrupt.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       created:
-        description: 'github created range'
+        description: 'created date range'
         required: true
         type: string
 
@@ -18,6 +18,8 @@ jobs:
       - run: corepack enable
       - name: 'Bankrupt issues & send notification to Slack'
         run: node ./.github/actions/next-repo-actions/dist/bankrupt/index.js
+        with:
+          created: ${{ github.event.inputs.created }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}


### PR DESCRIPTION
## Why?

Add `with` so `getInput('created')` is not undefined.