### PR TITLE
feat: enhance Metadata 'other' API to support property attribute

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/01-app/03-api-reference/04-functions/generate-metadata.mdx
@@ -1018,6 +1018,22 @@ export const metadata = {
 <meta name="custom" content="meta1" /> <meta name="custom" content="meta2" />
 ```
 
+If you want to generate meta tags with the property attribute, you can use an array of objects.
+
+```jsx filename="layout.js | page.js"
+export const metadata = {
+  other: [
+    { property: 'customProperty', content: 'meta1' },
+    { name: 'customName', content: 'meta2' },
+  ],
+}
+```
+
+```html filename="<head> output" hideLineNumbers
+<meta property="customProperty" content="meta1" />
+<meta name="customName" content="meta2" />
+```
+
 ## Unsupported Metadata
 
 The following metadata types do not currently have built-in support. However, they can still be rendered in the layout or page itself.

--- a/packages/next/src/lib/metadata/default-metadata.tsx
+++ b/packages/next/src/lib/metadata/default-metadata.tsx
@@ -55,6 +55,6 @@ export function createDefaultMetadata(): ResolvedMetadata {
     bookmarks: null,
     category: null,
     classification: null,
-    other: {},
+    other: [],
   }
 }

--- a/packages/next/src/lib/metadata/generate/basic.tsx
+++ b/packages/next/src/lib/metadata/generate/basic.tsx
@@ -101,17 +101,9 @@ export function BasicMeta({ metadata }: { metadata: ResolvedMetadata }) {
       : []),
     Meta({ name: 'category', content: metadata.category }),
     Meta({ name: 'classification', content: metadata.classification }),
-    ...(metadata.other
-      ? Object.entries(metadata.other).map(([name, content]) => {
-          if (Array.isArray(content)) {
-            return content.map((contentItem) =>
-              Meta({ name, content: contentItem })
-            )
-          } else {
-            return Meta({ name, content })
-          }
-        })
-      : []),
+    ...metadata.other.map(({ name, property, content }) =>
+      Meta({ name, property, content })
+    ),
   ])
 }
 

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -267,7 +267,22 @@ function mergeMetadata({
         target[key] = source[key] || null
         break
       case 'other':
-        target.other = Object.assign({}, target.other, source.other)
+        if (Array.isArray(source.other)) {
+          target.other = [...target.other, ...source.other]
+        } else if (source.other) {
+          const sourceOtherArray = Object.entries(source.other).flatMap(
+            ([name, content]) => {
+              if (Array.isArray(content)) {
+                return content.map((contentItem) => ({
+                  name,
+                  content: contentItem,
+                }))
+              }
+              return { name, content }
+            }
+          )
+          target.other = [...target.other, ...sourceOtherArray]
+        }
         break
       case 'metadataBase':
         target.metadataBase = metadataBase

--- a/packages/next/src/lib/metadata/types/metadata-interface.ts
+++ b/packages/next/src/lib/metadata/types/metadata-interface.ts
@@ -477,13 +477,22 @@ interface Metadata extends DeprecatedMetadataFields {
   classification?: null | string | undefined
 
   /**
-   * Arbitrary name/value pairs for the document.
+   * Arbitrary name/value pairs for the document, can be an object or an array of objects.
    */
   other?:
     | ({
         [name: string]: string | number | Array<string | number>
       } & DeprecatedMetadataFields)
-    | undefined
+    | Array<
+        | {
+            name?: string
+            content?: string | number
+          }
+        | {
+            property?: string
+            content?: string | number
+          }
+      >
 }
 
 interface ResolvedMetadata extends DeprecatedMetadataFields {
@@ -571,12 +580,8 @@ interface ResolvedMetadata extends DeprecatedMetadataFields {
   category: null | string
   classification: null | string
 
-  // Arbitrary name/value pairs
-  other:
-    | null
-    | ({
-        [name: string]: string | number | Array<string | number>
-      } & DeprecatedMetadataFields)
+  // an array of objects
+  other: Array<{ name?: string; property?: string; content?: string | number }>
 }
 
 type RobotsFile = {

--- a/test/e2e/app-dir/metadata/app/layout.tsx
+++ b/test/e2e/app-dir/metadata/app/layout.tsx
@@ -11,4 +11,8 @@ export const metadata = {
   title: 'this is the layout title',
   description: 'this is the layout description',
   keywords: ['nextjs', 'react'],
+  other: {
+    custom: 'meta',
+    custom1: ['meta1', 'meta2'],
+  },
 }

--- a/test/e2e/app-dir/metadata/app/other/page.tsx
+++ b/test/e2e/app-dir/metadata/app/other/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next'
+
+export default function Page() {
+  return 'other'
+}
+
+export const metadata: Metadata = {
+  other: [
+    { name: 'customName', content: 'customName' },
+    { property: 'customProperty', content: 'customProperty' },
+  ],
+}

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -269,6 +269,21 @@ describe('app dir - metadata', () => {
       })
     })
 
+    it('should support other custom tags', async () => {
+      const browser = await next.browser('/other')
+      const matchMultiDom = createMultiDomMatcher(browser)
+
+      await matchMultiDom('meta', 'name', 'content', {
+        custom: 'meta',
+        custom1: ['meta1', 'meta2'],
+        customName: 'customName',
+      })
+
+      await matchMultiDom('meta', 'property', 'content', {
+        customProperty: 'customProperty',
+      })
+    })
+
     it('should apply metadata when navigating client-side', async () => {
       const browser = await next.browser('/')
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### Related Feature Request discussion

https://github.com/vercel/next.js/discussions/57527

### What?

Added array support to the `Metadata` `other` API, allowing developers to customize the use of `name` or `property` attributes without affecting existing functionality.

### Why?

In some cases, developers need to add meta tags with the `property` attribute, such as:

```jsx
<>
  <meta property="product:price:amount" content="19.9" />
  <meta property="product:price:currency" content="USD">
</>
```

or

```jsx
<meta property="fb:app_id" content="1234567890" />
```

I couldn't find detailed standard documentation for these attributes online, only some references like [Product-Based OG Tag](https://rankmath.com/kb/open-graph-meta-tags/#product-based-og-tags).

Allowing developers to customize the `property` attribute will provide greater flexibility, and is particularly useful for e-commerce product pages, and currently, the `other` option only supports the `name` attribute.

### How?

Added an array option to allow developers to customize meta tag attributes without affecting existing functionality.

Current usage will not be affected.

```ts
export const metadata: Metadata = {
  other: {
    custom: 'meta',
    custom1: ['meta1', 'meta2'],
  },
}
```

Additional array object support.

```ts
export const metadata: Metadata = {
  other: [
    { name: 'customName', content: 'customName' },
    { property: 'customProperty', content: 'customProperty' },
  ],
}
```