### PR TITLE
fix: bad script tag in layout hydration error

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/hydration-error-info.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/hydration-error-info.ts
@@ -17,7 +17,6 @@ export const hydrationErrorState: HydrationErrorState = {}
 
 // https://github.com/facebook/react/blob/main/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js used as a reference
 const htmlTagsWarnings = new Set([
-  'Warning: Cannot render a sync or defer <script> outside the main document without knowing its order. Try adding async="" or moving it into the root <head> tag.%s',
   'Warning: In HTML, %s cannot be a child of <%s>.%s\nThis will cause a hydration error.%s',
   'Warning: In HTML, %s cannot be a descendant of <%s>.\nThis will cause a hydration error.%s',
   'Warning: In HTML, text nodes cannot be a child of <%s>.\nThis will cause a hydration error.',

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -720,16 +720,28 @@ describe('Error overlay for hydration errors', () => {
     expect(await getRedboxTotalErrorCount(browser)).toBe(1)
 
     const description = await session.getRedboxDescription()
-    // FIXME
-    expect(description).toContain(
-      "TypeError: Cannot read properties of undefined (reading 'replace')"
-    )
+    expect(description).toEqual(outdent`
+      In HTML, <script> cannot be a child of <html>.
+      This will cause a hydration error.
+    `)
 
-    // const pseudoHtml = await session.getRedboxComponentStack()
-    // expect(pseudoHtml).toEqual(outdent`
-    //   <script>
-    //   ^^^^^^^^
-    // `)
+    const pseudoHtml = await session.getRedboxComponentStack()
+    if (isTurbopack) {
+      expect(pseudoHtml).toEqual(outdent`
+        ...
+          <Layout>
+            <html>
+            ^^^^^^
+              <Script>
+                <script>
+                ^^^^^^^^
+      `)
+    } else {
+      expect(pseudoHtml).toEqual(outdent`
+        <script>
+        ^^^^^^^^
+      `)
+    }
     await cleanup()
   })
 


### PR DESCRIPTION
### What

<img width="860" alt="image" src="https://github.com/vercel/next.js/assets/4800338/a615c6dc-f86d-4b73-89c2-32b86d8c21bf">

It was initially introduced in #63403 , but now react can give the hydration error so we don't need to intercept that specific warning.

cc @eps1lon 