### PR TITLE
fix: ensure babel errors are output to browser

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -676,6 +676,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       config: this.config,
       buildId: this.buildId,
       encryptionKey: this.encryptionKey,
+      appDir: this.appDir,
       pagesDir: this.pagesDir,
       rewrites: {
         beforeFiles: [],


### PR DESCRIPTION
### What?

Previously errors were only visible in the terminal, rather than the browser when using a babel config and app router. Additionally, this produced a cryptic error `The "path" argument must be of type string. Received undefined`, which made it difficult to see the actual issue (ref #66997)

Before:

<img width="1724" alt="image" src="https://github.com/vercel/next.js/assets/17622801/6aaa4e22-4558-4235-a930-242407bd7458">

After:

<img width="1723" alt="image" src="https://github.com/vercel/next.js/assets/17622801/c3e6bbf1-7d3d-4298-b782-468affef7d8a">


### Why?

Improves DexEx

### How?

Ensures `appDir` is available to build dev config. 

Fixes #66997
