### PR TITLE
Docs: Plugins usage in next.config.mjs

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/06-package-bundling.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/06-package-bundling.mdx
@@ -26,17 +26,20 @@ yarn add @next/bundle-analyzer
 pnpm add @next/bundle-analyzer
 ```
 
-Then, add the bundle analyzer's settings to your `next.config.js`.
+Then, add the bundle analyzer's settings to your `next.config.mjs`.
 
-```js filename="next.config.js"
-/** @type {import('next').NextConfig} */
-const nextConfig = {}
+```js filename="next.config.mjs"
+import NextBundleAnalyzer from '@next/bundle-analyzer'
 
-const withBundleAnalyzer = require('@next/bundle-analyzer')({
+const withBundleAnalyzer = NextBundleAnalyzer({
   enabled: process.env.ANALYZE === 'true',
 })
 
-module.exports = withBundleAnalyzer(nextConfig)
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+
+export default withBundleAnalyzer(nextConfig)
 ```
 
 ### Generating a report
@@ -57,9 +60,9 @@ The report will open three new tabs in your browser, which you can inspect. Peri
 
 Some packages, such as icon libraries, can export hundreds of modules, which can cause performance issues in development and production.
 
-You can optimize how these packages are imported by adding the [`optimizePackageImports`](/docs/app/api-reference/next-config-js/optimizePackageImports) option to your `next.config.js`. This option will only load the modules you _actually_ use, while still giving you the convenience of writing import statements with many named exports.
+You can optimize how these packages are imported by adding the [`optimizePackageImports`](/docs/app/api-reference/next-config-js/optimizePackageImports) option to your `next.config.mjs`. This option will only load the modules you _actually_ use, while still giving you the convenience of writing import statements with many named exports.
 
-```js filename="next.config.js"
+```js filename="next.config.mjs"
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {
@@ -67,7 +70,7 @@ const nextConfig = {
   },
 }
 
-module.exports = nextConfig
+export default nextConfig
 ```
 
 Next.js also optimizes some libraries automatically, thus they do not need to be included in the optimizePackageImports list. See the [full list](https://nextjs.org/docs/app/api-reference/next-config-js/optimizePackageImports).
@@ -76,35 +79,35 @@ Next.js also optimizes some libraries automatically, thus they do not need to be
 
 ## Bundling specific packages
 
-To bundle specific packages, you can use the [`transpilePackages`](/docs/app/api-reference/next-config-js/transpilePackages) option in your `next.config.js`. This option is useful for bundling external packages that are not pre-bundled, for example, in a monorepo or imported from `node_modules`.
+To bundle specific packages, you can use the [`transpilePackages`](/docs/app/api-reference/next-config-js/transpilePackages) option in your `next.config.mjs`. This option is useful for bundling external packages that are not pre-bundled, for example, in a monorepo or imported from `node_modules`.
 
-```js filename="next.config.js"
+```js filename="next.config.mjs"
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   transpilePackages: ['package-name'],
 }
 
-module.exports = nextConfig
+export default nextConfig
 ```
 
 ## Bundling all packages
 
-To automatically bundle all packages (default behavior in the App Router), you can use the [`bundlePagesRouterDependencies`](/docs/pages/api-reference/next-config-js/bundlePagesRouterDependencies) option in your `next.config.js`.
+To automatically bundle all packages (default behavior in the App Router), you can use the [`bundlePagesRouterDependencies`](/docs/pages/api-reference/next-config-js/bundlePagesRouterDependencies) option in your `next.config.mjs`.
 
-```js filename="next.config.js"
+```js filename="next.config.mjs"
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   bundlePagesRouterDependencies: true,
 }
 
-module.exports = nextConfig
+export default nextConfig
 ```
 
 ## Opting specific packages out of bundling
 
-If you have the [`bundlePagesRouterDependencies`](/docs/pages/api-reference/next-config-js/bundlePagesRouterDependencies) option enabled, you can opt specific packages out of automatic bundling using the [`serverExternalPackages`](/docs/pages/api-reference/next-config-js/serverExternalPackages) option in your `next.config.js`:
+If you have the [`bundlePagesRouterDependencies`](/docs/pages/api-reference/next-config-js/bundlePagesRouterDependencies) option enabled, you can opt specific packages out of automatic bundling using the [`serverExternalPackages`](/docs/pages/api-reference/next-config-js/serverExternalPackages) option in your `next.config.mjs`:
 
-```js filename="next.config.js"
+```js filename="next.config.mjs"
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // Automatically bundle external packages in the Pages Router:
@@ -113,7 +116,7 @@ const nextConfig = {
   serverExternalPackages: ['package-name'],
 }
 
-module.exports = nextConfig
+export default nextConfig
 ```
 
 </PagesOnly>
@@ -122,15 +125,15 @@ module.exports = nextConfig
 
 ## Opting specific packages out of bundling
 
-Since packages imported inside Server Components and Route Handlers are automatically bundled by Next.js, you can opt specific packages out of bundling using the [`serverExternalPackages`](/docs/app/api-reference/next-config-js/serverExternalPackages) option in your `next.config.js`.
+Since packages imported inside Server Components and Route Handlers are automatically bundled by Next.js, you can opt specific packages out of bundling using the [`serverExternalPackages`](/docs/app/api-reference/next-config-js/serverExternalPackages) option in your `next.config.mjs`.
 
-```js filename="next.config.js"
+```js filename="next.config.mjs"
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   serverExternalPackages: ['package-name'],
 }
 
-module.exports = nextConfig
+export default nextConfig
 ```
 
 Next.js includes a list of popular packages that currently are working on compatibility and automatically opt-ed out. See the [full list](/docs/app/api-reference/next-config-js/serverExternalPackages).

--- a/docs/02-app/02-api-reference/05-next-config-js/mdxRs.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/mdxRs.mdx
@@ -7,8 +7,10 @@ description: Use the new Rust compiler to compile MDX files in the App Router.
 
 For experimental use with `@next/mdx`. Compiles MDX files using the new Rust compiler.
 
-```js filename="next.config.js"
-const withMDX = require('@next/mdx')()
+```js filename="next.config.mjs"
+import nextMDX from '@next/mdx'
+
+const withMDX = nextMDX()
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -18,5 +20,5 @@ const nextConfig = {
   },
 }
 
-module.exports = withMDX(nextConfig)
+export default withMDX(nextConfig)
 ```

--- a/docs/02-app/02-api-reference/05-next-config-js/pageExtensions.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/pageExtensions.mdx
@@ -9,25 +9,27 @@ description: Extend the default page extensions used by Next.js when resolving p
 
 By default, Next.js accepts files with the following extensions: `.tsx`, `.ts`, `.jsx`, `.js`. This can be modified to allow other extensions like markdown (`.md`, `.mdx`).
 
-```js filename="next.config.js"
-const withMDX = require('@next/mdx')()
+```js filename="next.config.mjs"
+import nextMDX from '@next/mdx'
+
+const withMDX = nextMDX()
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],
 }
 
-module.exports = withMDX(nextConfig)
+export default withMDX(nextConfig)
 ```
 
 </AppOnly>
 
 <PagesOnly>
 
-You can extend the default Page extensions (`.tsx`, `.ts`, `.jsx`, `.js`) used by Next.js. Inside `next.config.js`, add the `pageExtensions` config:
+You can extend the default Page extensions (`.tsx`, `.ts`, `.jsx`, `.js`) used by Next.js. Inside `next.config.mjs`, add the `pageExtensions` config:
 
-```js filename="next.config.js"
-module.exports = {
+```js filename="next.config.mjs"
+export default {
   pageExtensions: ['mdx', 'md', 'jsx', 'js', 'tsx', 'ts'],
 }
 ```
@@ -44,10 +46,10 @@ For example, if you reconfigure `.ts` page extensions to `.page.ts`, you would n
 
 ## Including non-page files in the `pages` directory
 
-You can colocate test files or other files used by components in the `pages` directory. Inside `next.config.js`, add the `pageExtensions` config:
+You can colocate test files or other files used by components in the `pages` directory. Inside `next.config.mjs`, add the `pageExtensions` config:
 
-```js filename="next.config.js"
-module.exports = {
+```js filename="next.config.mjs"
+export default {
   pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'],
 }
 ```

--- a/packages/next-bundle-analyzer/readme.md
+++ b/packages/next-bundle-analyzer/readme.md
@@ -14,23 +14,26 @@ or
 yarn add @next/bundle-analyzer
 ```
 
-Note: if installing as a `devDependency` make sure to wrap the require in a `process.env` check as `next.config.js` is loaded during `next start` as well.
+Note: if installing as a `devDependency` make sure to wrap the require in a `process.env` check as `next.config.mjs` is loaded during `next start` as well.
 
 ### Usage with environment variables
 
-Create a next.config.js (and make sure you have next-bundle-analyzer set up)
+Create a next.config.mjs (and make sure you have next-bundle-analyzer set up)
 
 ```js
-const withBundleAnalyzer = require('@next/bundle-analyzer')({
+import NextBundleAnalyzer from '@next/bundle-analyzer'
+
+const withBundleAnalyzer = NextBundleAnalyzer({
   enabled: process.env.ANALYZE === 'true',
+  openAnalyzer: false,
 })
-module.exports = withBundleAnalyzer({})
+export default withBundleAnalyzer({})
 ```
 
 Or configuration as a function:
 
 ```js
-module.exports = (phase, defaultConfig) => {
+export default (phase, { defaultConfig }) => {
   return withBundleAnalyzer(defaultConfig)
 }
 ```
@@ -49,11 +52,14 @@ When enabled three HTML files (client.html, edge.html and nodejs.html) will be o
 To disable automatically opening the report in your default browser, set `openAnalyzer` to false:
 
 ```js
-const withBundleAnalyzer = require('@next/bundle-analyzer')({
+import NextBundleAnalyzer from '@next/bundle-analyzer'
+
+const withBundleAnalyzer = NextBundleAnalyzer({
   enabled: process.env.ANALYZE === 'true',
   openAnalyzer: false,
 })
-module.exports = withBundleAnalyzer({})
+
+export default withBundleAnalyzer({})
 ```
 
 ### Usage with next-compose-plugins
@@ -61,12 +67,14 @@ module.exports = withBundleAnalyzer({})
 From version 2.0.0 of next-compose-plugins you need to call bundle-analyzer in this way to work
 
 ```js
-const withPlugins = require('next-compose-plugins')
-const withBundleAnalyzer = require('@next/bundle-analyzer')({
+import withPlugins from 'next-compose-plugins'
+import NextBundleAnalyzer from '@next/bundle-analyzer'
+
+const withBundleAnalyzer = NextBundleAnalyzer({
   enabled: process.env.ANALYZE === 'true',
 })
 
-module.exports = withPlugins([
+export default withPlugins([
   [withBundleAnalyzer],
   // your other plugins here
 ])

--- a/packages/next-mdx/readme.md
+++ b/packages/next-mdx/readme.md
@@ -18,33 +18,39 @@ yarn add @next/mdx @mdx-js/loader @mdx-js/react
 
 ## Usage
 
-Create a `next.config.js` in your project
+Create a `next.config.mjs` in your project
 
 ```js
-// next.config.js
-const withMDX = require('@next/mdx')()
-module.exports = withMDX()
+// next.config.mjs
+import nextMDX from '@next/mdx'
+
+const withMDX = nextMDX()
+export default withMDX()
 ```
 
 Optionally you can provide [MDX plugins](https://mdxjs.com/advanced/plugins#plugins):
 
 ```js
-// next.config.js
-const withMDX = require('@next/mdx')({
+// next.config.mjs
+import nextMDX from '@next/mdx'
+
+const withMDX = nextMDX({
   options: {
     remarkPlugins: [],
     rehypePlugins: [],
   },
 })
-module.exports = withMDX()
+export default withMDX()
 ```
 
 Optionally you can add your custom Next.js configuration as parameter
 
 ```js
-// next.config.js
-const withMDX = require('@next/mdx')()
-module.exports = withMDX({
+// next.config.mjs
+import nextMDX from '@next/mdx'
+
+const withMDX = nextMDX()
+export default withMDX({
   webpack(config, options) {
     return config
   },
@@ -55,11 +61,13 @@ By default MDX will only match and compile MDX files with the `.mdx` extension.
 However, it can also be optionally configured to handle markdown files with the `.md` extension, as shown below:
 
 ```js
-// next.config.js
-const withMDX = require('@next/mdx')({
+// next.config.mjs
+import nextMDX from '@next/mdx'
+
+const withMDX = nextMDX({
   extension: /\.(md|mdx)$/,
 })
-module.exports = withMDX()
+export default withMDX()
 ```
 
 In addition, MDX can be customized with compiler options, see the [mdx documentation](https://mdxjs.com/packages/mdx/#compilefile-options) for details on supported options.
@@ -69,11 +77,13 @@ In addition, MDX can be customized with compiler options, see the [mdx documenta
 Define the `pageExtensions` option to have Next.js handle `.md` and `.mdx` files in the `pages` directory as pages:
 
 ```js
-// next.config.js
-const withMDX = require('@next/mdx')({
+// next.config.mjs
+import nextMDX from '@next/mdx'
+
+const withMDX = nextMDX({
   extension: /\.mdx?$/,
 })
-module.exports = withMDX({
+export default withMDX({
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],
 })
 ```
@@ -116,16 +126,15 @@ export function useMDXComponents(components) {
 }
 ```
 
-Create a `next.config.js` in your project
+Create a `next.config.mjs` in your project
 
 ```js
-// next.config.js
-const withMDX = require('@next/mdx')({
+// next.config.mjs
+import nextMDX from '@next/mdx'
+
+const withMDX = nextMDX({
   // Optionally provide remark and rehype plugins
   options: {
-    // If you use remark-gfm, you'll need to use next.config.mjs
-    // as the package is ESM only
-    // https://github.com/remarkjs/remark-gfm#install
     remarkPlugins: [],
     rehypePlugins: [],
     // If you use `MDXProvider`, uncomment the following line.
@@ -142,7 +151,7 @@ const nextConfig = {
 }
 
 // Merge MDX config with Next.js config
-module.exports = withMDX(nextConfig)
+export default withMDX(nextConfig)
 ```
 
 ## TypeScript


### PR DESCRIPTION
Documentation updates to show the ESM usage of plugins since `create-next-app` uses `next.config.mjs` starting from `14.1.0` https://github.com/vercel/next.js/releases/tag/v14.1.0 https://github.com/vercel/next.js/pull/60494
