### PR TITLE
fix conflicting turbo run summary artifacts

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -168,7 +168,7 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: pnpm install && ./node_modules/.bin/devlow-bench ./scripts/devlow-bench.mjs --datadog=ubuntu-latest-16-core ${{ matrix.mode }} ${{ matrix.selector }}
-      stepName: 'devlow-bench-${{ matrix.group }}'
+      stepName: 'devlow-bench-${{ matrix.mode }}-${{ matrix.selector }}'
     secrets: inherit
 
   test-turbopack-dev:


### PR DESCRIPTION
`matrix.group` wasn't defined so this wasn't deduping the artifact keys causing errors.
[x-ref](https://github.com/vercel/next.js/actions/runs/9580021449/job/26413817804?pr=67015)