### PR TITLE
[ppr] Handle corrupted postponed state

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -90,6 +90,7 @@ import {
   createStaticRenderer,
   getDynamicDataPostponedState,
   getDynamicHTMLPostponedState,
+  type PostponedState,
 } from './static/static-renderer'
 import { isDynamicServerError } from '../../client/components/hooks-server-context'
 import {
@@ -1018,31 +1019,64 @@ async function renderToHTMLOrFlightImpl(
         tracingMetadata: tracingMetadata,
       })
 
-      const renderer = createStaticRenderer({
-        isRoutePPREnabled,
-        isStaticGeneration,
+      try {
         // If provided, the postpone state should be parsed as JSON so it can be
         // provided to React.
-        postponed:
-          typeof renderOpts.postponed === 'string'
-            ? JSON.parse(renderOpts.postponed)
-            : null,
-        streamOptions: {
-          onError: htmlRendererErrorHandler,
-          onHeaders,
-          maxHeadersLength: 600,
-          nonce,
-          // When debugging the static shell, client-side rendering should be
-          // disabled to prevent blanking out the page.
-          bootstrapScripts: renderOpts.isDebugStaticShell
-            ? []
-            : [bootstrapScript],
-          formState,
-        },
-      })
+        let postponed: PostponedState | null = null
+        if (renderOpts.postponed && isRoutePPREnabled) {
+          // Try to parse the postponed state. If we're unable to
+          try {
+            postponed = JSON.parse(renderOpts.postponed)
+          } catch {
+            // We couldn't parse the postponed state, so render the dynamic flight
+            // data only. We achieve this by passing the postponed value of `1`.
+            // If we error during this branch, we should fallback to the
+            // original error handling.
+            const result = await createStaticRenderer({
+              // We only hit this branch when PPR is enabled.
+              isRoutePPREnabled: true,
+              // We only hit this branch when we're generating dynamic HTML.
+              isStaticGeneration: false,
+              // If this branch is hit, we couldn't parse the postponed state, so
+              // we should render the dynamic flight data instead.
+              postponed: 1,
+              streamOptions: { onError: htmlRendererErrorHandler, nonce },
+            }).render(children)
 
-      try {
-        let { stream, postponed, resumed } = await renderer.render(children)
+            // Emit the dynamic data stream as script tags by using the dynamic
+            // HTML resume.
+            const stream = await continueDynamicHTMLResume(result.stream, {
+              inlinedDataStream: createInlinedDataReadableStream(
+                dataStream,
+                nonce,
+                formState
+              ),
+              getServerInsertedHTML,
+            })
+
+            return { stream }
+          }
+        }
+
+        const renderer = createStaticRenderer({
+          isRoutePPREnabled,
+          isStaticGeneration,
+          postponed,
+          streamOptions: {
+            onError: htmlRendererErrorHandler,
+            onHeaders,
+            maxHeadersLength: 600,
+            nonce,
+            // When debugging the static shell, client-side rendering should be
+            // disabled to prevent blanking out the page.
+            bootstrapScripts: renderOpts.isDebugStaticShell
+              ? []
+              : [bootstrapScript],
+            formState,
+          },
+        })
+
+        let result = await renderer.render(children)
 
         const prerenderState = staticGenerationStore.prerenderState
         if (prerenderState) {
@@ -1063,10 +1097,10 @@ async function renderToHTMLOrFlightImpl(
 
           // First we check if we have any dynamic holes in our HTML prerender
           if (usedDynamicAPIs(prerenderState)) {
-            if (postponed != null) {
+            if (result.postponed != null) {
               // This is the Dynamic HTML case.
               metadata.postponed = JSON.stringify(
-                getDynamicHTMLPostponedState(postponed)
+                getDynamicHTMLPostponedState(result.postponed)
               )
             } else {
               // This is the Dynamic Data case
@@ -1079,7 +1113,7 @@ async function renderToHTMLOrFlightImpl(
             // It is possible in the set of stream transforms for Dynamic HTML vs Dynamic Data may differ but currently both states
             // require the same set so we unify the code path here
             return {
-              stream: await continueDynamicPrerender(stream, {
+              stream: await continueDynamicPrerender(result.stream, {
                 getServerInsertedHTML,
               }),
             }
@@ -1093,10 +1127,10 @@ async function renderToHTMLOrFlightImpl(
 
             if (usedDynamicAPIs(prerenderState)) {
               // This is the same logic above just repeated after ensuring the RSC stream itself has completed
-              if (postponed != null) {
+              if (result.postponed != null) {
                 // This is the Dynamic HTML case.
                 metadata.postponed = JSON.stringify(
-                  getDynamicHTMLPostponedState(postponed)
+                  getDynamicHTMLPostponedState(result.postponed)
                 )
               } else {
                 // This is the Dynamic Data case
@@ -1109,14 +1143,14 @@ async function renderToHTMLOrFlightImpl(
               // It is possible in the set of stream transforms for Dynamic HTML vs Dynamic Data may differ but currently both states
               // require the same set so we unify the code path here
               return {
-                stream: await continueDynamicPrerender(stream, {
+                stream: await continueDynamicPrerender(result.stream, {
                   getServerInsertedHTML,
                 }),
               }
             } else {
               // This is the Static case
               // We still have not used any dynamic APIs. At this point we can produce an entirely static prerender response
-              let renderedHTMLStream = stream
+              let renderedHTMLStream = result.stream
 
               if (staticGenerationStore.forceDynamic) {
                 throw new StaticGenBailoutError(
@@ -1124,13 +1158,13 @@ async function renderToHTMLOrFlightImpl(
                 )
               }
 
-              if (postponed != null) {
+              if (result.postponed != null) {
                 // We postponed but nothing dynamic was used. We resume the render now and immediately abort it
                 // so we can set all the postponed boundaries to client render mode before we store the HTML response
                 const resumeRenderer = createStaticRenderer({
                   isRoutePPREnabled,
                   isStaticGeneration: false,
-                  postponed: getDynamicHTMLPostponedState(postponed),
+                  postponed: getDynamicHTMLPostponedState(result.postponed),
                   streamOptions: {
                     signal: createPostponedAbortSignal(
                       'static prerender resume'
@@ -1162,10 +1196,9 @@ async function renderToHTMLOrFlightImpl(
                   </HeadManagerContext.Provider>
                 )
 
-                const { stream: resumeStream } =
-                  await resumeRenderer.render(resumeChildren)
+                result = await resumeRenderer.render(resumeChildren)
                 // First we write everything from the prerender, then we write everything from the aborted resume render
-                renderedHTMLStream = chainStreams(stream, resumeStream)
+                renderedHTMLStream = chainStreams(result.stream, result.stream)
               }
 
               return {
@@ -1187,10 +1220,10 @@ async function renderToHTMLOrFlightImpl(
             nonce,
             formState
           )
-          if (resumed) {
+          if (result.resumed) {
             // We have new HTML to stream and we also need to include server inserted HTML
             return {
-              stream: await continueDynamicHTMLResume(stream, {
+              stream: await continueDynamicHTMLResume(result.stream, {
                 inlinedDataStream,
                 getServerInsertedHTML,
               }),
@@ -1198,7 +1231,7 @@ async function renderToHTMLOrFlightImpl(
           } else {
             // We are continuing a Dynamic Data Prerender and simply need to append new inlined flight data
             return {
-              stream: await continueDynamicDataResume(stream, {
+              stream: await continueDynamicDataResume(result.stream, {
                 inlinedDataStream,
               }),
             }
@@ -1208,7 +1241,7 @@ async function renderToHTMLOrFlightImpl(
           // @TODO factor this further to make the render types more clearly defined and remove
           // the deluge of optional params that passed to configure the various behaviors
           return {
-            stream: await continueFizzStream(stream, {
+            stream: await continueFizzStream(result.stream, {
               inlinedDataStream: createInlinedDataReadableStream(
                 dataStream,
                 nonce,

--- a/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
@@ -228,6 +228,27 @@ describe('required server files app router', () => {
     })
   })
 
+  it('should still render when postponed is corrupted', async () => {
+    const random = Math.random().toString(36).substring(2)
+
+    const res = await fetchViaHTTP(appPort, '/dyn/' + random, undefined, {
+      method: 'POST',
+      headers: {
+        'x-matched-path': '/_next/postponed/resume/dyn/' + random,
+      },
+      // This is a corrupted postponed JSON payload.
+      body: '{',
+    })
+
+    expect(res.status).toBe(200)
+
+    const html = await res.text()
+
+    // Expect that the closing HTML tag is still present, indicating a
+    // successful render.
+    expect(html).toContain('</html>')
+  })
+
   it('should send cache tags in minimal mode for ISR', async () => {
     for (const [path, tags] of [
       [

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -15997,7 +15997,8 @@
         "required server files app router should properly handle fallback for bot request",
         "required server files app router should properly handle prerender for bot request",
         "required server files app router should properly stream resume",
-        "required server files app router should send cache tags in minimal mode for ISR"
+        "required server files app router should send cache tags in minimal mode for ISR",
+        "required server files app router › should still render when postponed is corrupted"
       ],
       "pending": [],
       "flakey": [],

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -15998,7 +15998,7 @@
         "required server files app router should properly handle prerender for bot request",
         "required server files app router should properly stream resume",
         "required server files app router should send cache tags in minimal mode for ISR",
-        "required server files app router › should still render when postponed is corrupted"
+        "required server files app router should still render when postponed is corrupted"
       ],
       "pending": [],
       "flakey": [],


### PR DESCRIPTION
Previously, when the provided postponed state was corrupted, the render failed which resulted in a hydration error. Instead, when the postponed state is corrupted, we send the resume stream just for the hydration where it'll attempt to render client side with the data that's already available.