### PR TITLE
Ensure Turbopack build runs when experimental-compile option is used

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1582,9 +1582,7 @@ export default async function build(
 
       if (!isGenerateMode) {
         if (turboNextBuild) {
-          const { duration: compilerDuration, ...rest } = turboNextBuild
-            ? await turbopackBuild()
-            : await webpackBuild(useBuildWorker, null)
+          const { duration: compilerDuration, ...rest } = await turbopackBuild()
           traceMemoryUsage('Finished build', nextBuildSpan)
 
           buildTraceContext = rest.buildTraceContext

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -1016,7 +1016,6 @@
         "app dir - basic server components should serve client component should serve server-side",
         "app dir - basic server components should serve shared component",
         "app dir - basic should ensure the </body></html> suffix is at the end of the stream",
-        "app dir - basic should generate build traces correctly",
         "app dir - basic should handle hash in initial url",
         "app dir - basic should have correct searchParams and params (client)",
         "app dir - basic should have correct searchParams and params (server)",
@@ -1024,7 +1023,6 @@
         "app dir - basic should include layouts when no direct parent layout",
         "app dir - basic should include parent document when no direct parent layout",
         "app dir - basic should match redirects in pages correctly $path",
-        "app dir - basic should not apply client router filter on shallow",
         "app dir - basic should not create new root layout when nested (optional)",
         "app dir - basic should not include parent when not in parent directory",
         "app dir - basic should not rerender layout when navigating between routes in the same layout",
@@ -1043,7 +1041,6 @@
         "app dir - basic should serve from public",
         "app dir - basic should serve nested parent",
         "app dir - basic should serve page as a segment name correctly",
-        "app dir - basic should successfully detect app route during prefetch",
         "app dir - basic should use new root layout when provided",
         "app dir - basic should use text/x-component for flight",
         "app dir - basic should use text/x-component for flight with edge runtime",
@@ -1052,6 +1049,9 @@
         "app dir - basic template component should render the template that is a server component and rerender on navigation"
       ],
       "failed": [
+        "app dir - basic should successfully detect app route during prefetch",
+        "app dir - basic should not apply client router filter on shallow",
+        "app dir - basic should generate build traces correctly",
         "app dir - basic should encode chunk path correctly",
         "app dir - basic should serve polyfills for browsers that do not support modules"
       ],


### PR DESCRIPTION
Currently webpack would be incorrectly used when some of the experimental options for builds were enabled. For example `parallelServerCompiles` and `parallelServerBuildTraces`. This ensures Turbopack is always used when it's specified to be used.

Fixes around 100 Turbopack build tests

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
