### PR TITLE
Explicitly return a 137 code when exiting unexpectedly. OOMkills duri…

### DIFF
--- a/packages/next/src/cli/next-build.ts
+++ b/packages/next/src/cli/next-build.ts
@@ -27,6 +27,9 @@ const nextBuild = (options: NextBuildOptions, directory?: string) => {
   process.on('SIGTERM', () => process.exit(0))
   process.on('SIGINT', () => process.exit(0))
 
+  // Prevents unintentional hiding of SIGKILLs e.g. for OOMKills
+  process.on('exit', () => process.exit(137))
+
   const {
     debug,
     experimentalDebugMemoryUsage,


### PR DESCRIPTION
fixes https://github.com/vercel/next.js/issues/67097

### What?

We recently ran into an issue when releasing our application. The `next build` process was being OOMKill'ed but what really caused the problem was that an exit code of `0` was being returned after the OOMKill. This made our build process (Dockerfile) think the build step had succeeded and it only became derailed several steps further on when the expected build artifacts weren't present.

### Why?

It looks like, for some reason, SIGKILLs result in an error code of zero during build. I couldn't find a good cause for this but note that adding a `process.on('exit', () => process.exit(137));` to the build function seems to resolve the issue i.e. lets us capture the SIGKILL and return the appropriate error code.

Fixes #67097

