### PR TITLE
ensure accessing search params mark dynamic usage

### DIFF
--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -780,6 +780,8 @@ describe('app-dir static/dynamic handling', () => {
           "blog/tim.rsc",
           "blog/tim/first-post.html",
           "blog/tim/first-post.rsc",
+          "default-cache-search-params/page.js",
+          "default-cache-search-params/page_client-reference-manifest.js",
           "default-cache/page.js",
           "default-cache/page_client-reference-manifest.js",
           "dynamic-error/[id]/page.js",
@@ -2201,6 +2203,32 @@ describe('app-dir static/dynamic handling', () => {
       }
       return 'success'
     }, 'success')
+  })
+
+  it('should cache correctly when accessing search params opts into dynamic rendering', async () => {
+    const res = await next.fetch('/default-cache-search-params')
+    expect(res.status).toBe(200)
+
+    let prevHtml = await res.text()
+    let prev$ = cheerio.load(prevHtml)
+
+    await retry(async () => {
+      const curRes = await next.fetch('/default-cache-search-params')
+      expect(curRes.status).toBe(200)
+
+      const curHtml = await curRes.text()
+      const cur$ = cheerio.load(curHtml)
+
+      expect(cur$('#data-default-cache').text()).not.toBe(
+        prev$('#data-default-cache').text()
+      )
+      expect(cur$('#data-request-cache').text()).not.toBe(
+        prev$('#data-request-cache').text()
+      )
+      expect(cur$('#data-cache-auto').text()).not.toBe(
+        prev$('#data-cache-auto').text()
+      )
+    })
   })
 
   it('should cache correctly for fetchCache = force-cache', async () => {

--- a/test/e2e/app-dir/app-static/app/default-cache-search-params/page.js
+++ b/test/e2e/app-dir/app-static/app/default-cache-search-params/page.js
@@ -1,0 +1,28 @@
+export default async function Page({ searchParams }) {
+  // this page is using searchParams to opt into dynamic rendering
+  // meaning the page will bail from ISR cache and hint to patch-fetch
+  // that it's in a dynamic scope and shouldn't cache the fetch.
+  console.log(searchParams.q)
+  const data1 = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?1',
+    { cache: 'default' }
+  ).then((res) => res.text())
+  const data2 = await fetch(
+    new Request('https://next-data-api-endpoint.vercel.app/api/random?2')
+  ).then((res) => res.text())
+
+  const data3 = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?3'
+  ).then((res) => res.text())
+
+  return (
+    <>
+      <p>/default-cache-fetch</p>
+      <p id="data-default-cache">"cache: default" {data1}</p>
+      <p id="data-request-cache">
+        "cache: default" (Request constructor) {data2}
+      </p>
+      <p id="data-cache-auto">"cache: auto" {data3}</p>
+    </>
+  )
+}


### PR DESCRIPTION
When accessing search params, we only track dynamic access during static generation. This has implications on fetch caching, because the fetch cache relies on hints set during render that it's in a dynamic scope. In 15, this would signal that it should not attempt to cache the fetch at all. In 14, this could impact the heuristic that bails from fetch cache if dynamic access came before certain requests types, e.g. POSTs. 