### PR TITLE
tweak import-conditions test

### DIFF
--- a/test/e2e/import-conditions/import-conditions.test.ts
+++ b/test/e2e/import-conditions/import-conditions.test.ts
@@ -1,11 +1,18 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('react version', () => {
+  const dependencies = (global as any).isNextDeploy
+    ? // `link` is incompatible with the npm version used when this test is deployed
+      {
+        'library-with-exports': 'file:./library-with-exports',
+      }
+    : {
+        'library-with-exports': 'link:./library-with-exports',
+      }
+
   const { next } = nextTestSetup({
     files: __dirname,
-    dependencies: {
-      'library-with-exports': 'link:./library-with-exports',
-    },
+    dependencies,
   })
 
   it('Pages Router page headers with edge runtime', async () => {


### PR DESCRIPTION
This test was failing when deployed with _"Unsupported URL Type "link:"._ 

This tweaks the linking behavior when deployed. I wasn't able to get this test to pass when changing both `start` and deploy to use `link`.