### PR TITLE
Add build error message to error overlay

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/app/ReactDevOverlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/ReactDevOverlay.tsx
@@ -73,6 +73,7 @@ export default class ReactDevOverlay extends React.PureComponent<
               />
             ) : hasBuildError ? (
               <BuildError
+                errors={state.errors}
                 message={state.buildError!}
                 versionInfo={state.versionInfo}
               />

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/BuildError.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/BuildError.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import type { VersionInfo } from '../../../../../server/dev/parse-version-info'
+import type { SupportedErrorEvent } from './Errors'
 import {
   Dialog,
   DialogBody,
@@ -11,13 +12,25 @@ import { Terminal } from '../components/Terminal'
 import { VersionStalenessInfo } from '../components/VersionStalenessInfo'
 import { noop as css } from '../helpers/noop-template'
 
-export type BuildErrorProps = { message: string; versionInfo?: VersionInfo }
+export type BuildErrorProps = {
+  message: string
+  versionInfo?: VersionInfo
+  errors: SupportedErrorEvent[]
+}
+
+function getFirstLine(message: string) {
+  return message.split('\n')[0]
+}
 
 export const BuildError: React.FC<BuildErrorProps> = function BuildError({
   message,
   versionInfo,
+  errors,
 }) {
   const noop = React.useCallback(() => {}, [])
+  const firstError = errors[0]
+  const actualError = firstError?.event.reason
+
   return (
     <Overlay fixed>
       <Dialog
@@ -34,7 +47,9 @@ export const BuildError: React.FC<BuildErrorProps> = function BuildError({
               id="nextjs__container_errors_desc"
               className="nextjs__container_errors_desc"
             >
-              Failed to compile
+              {actualError?.message
+                ? getFirstLine(actualError?.message)
+                : message}
             </p>
           </DialogHeader>
           <DialogBody className="nextjs-container-errors-body">

--- a/packages/next/src/client/components/react-dev-overlay/pages/ReactDevOverlay.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/pages/ReactDevOverlay.tsx
@@ -77,6 +77,7 @@ export default function ReactDevOverlay({
 
           {displayPrevented ? null : hasBuildError ? (
             <BuildError
+              errors={state.errors}
               message={state.buildError!}
               versionInfo={state.versionInfo}
             />

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -118,24 +118,7 @@ export function formatIssue(issue: Issue) {
     documentationLink = 'https://nextjs.org/docs/messages/module-not-found'
   }
 
-  let formattedFilePath = filePath
-    .replace('[project]/', './')
-    .replaceAll('/./', '/')
-    .replace('\\\\?\\', '')
-
-  let message = ''
-
-  if (source && source.range) {
-    const { start } = source.range
-    message = `${formattedFilePath}:${start.line + 1}:${
-      start.column + 1
-    }\n${formattedTitle}`
-  } else if (formattedFilePath) {
-    message = `${formattedFilePath}\n${formattedTitle}`
-  } else {
-    message = formattedTitle
-  }
-  message += '\n'
+  let message = formattedTitle + '\n'
 
   if (
     source?.range &&

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -118,7 +118,24 @@ export function formatIssue(issue: Issue) {
     documentationLink = 'https://nextjs.org/docs/messages/module-not-found'
   }
 
-  let message = formattedTitle + '\n'
+  let formattedFilePath = filePath
+    .replace('[project]/', './')
+    .replaceAll('/./', '/')
+    .replace('\\\\?\\', '')
+
+  let message = ''
+
+  if (source && source.range) {
+    const { start } = source.range
+    message = `${formattedFilePath}:${start.line + 1}:${
+      start.column + 1
+    }\n${formattedTitle}`
+  } else if (formattedFilePath) {
+    message = `${formattedFilePath}\n${formattedTitle}`
+  } else {
+    message = formattedTitle
+  }
+  message += '\n'
 
   if (
     source?.range &&

--- a/test/development/acceptance-app/error-recovery.test.ts
+++ b/test/development/acceptance-app/error-recovery.test.ts
@@ -485,7 +485,7 @@ describe.each(['default', 'turbo'])('Error recovery app %s', () => {
     )
 
     await session.assertHasRedbox()
-    await check(() => session.getRedboxSource(true), /Failed to compile/)
+    await check(() => session.getRedboxSource(true), /Build Error/)
 
     await cleanup()
   })

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -334,11 +334,24 @@ describe('Error overlay - RSC build errors', () => {
     )
 
     await session.assertHasRedbox()
-    if (!isTurbopack) {
+    if (isTurbopack) {
+      // TODO: strip out the filepath from error message.
+      // Currently turbopack gives error message with filepath as a prefix. e.g.
+      // ./test/e2e/app-dir/hello-world/app/page.tsx:6:7
+      // Module not found: Can't resolve 'non-existing-module'
+      // Where we don't need the 1st line of filepath but the error message.
+    } else {
       expect(await session.getRedboxDescription()).toInclude(
         `Module not found: Can't resolve 'non-existing-module'`
       )
     }
+
+    await next.patchFile(
+      'app/unresolve/page.js',
+      'export default function Page() { return <p>page</p> }'
+    )
+
+    await session.assertNoRedbox()
 
     await cleanup()
   })

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -315,6 +315,32 @@ describe('Error overlay - RSC build errors', () => {
     await cleanup()
   })
 
+  it('should display error message when module resolve error occurred', async () => {
+    const { session, cleanup } = await sandbox(
+      next,
+      new Map([
+        [
+          'app/unresolve/page.js',
+          `
+          import Mod from 'non-existing-module'
+
+          export default function Page() {
+            return <p>page</p>
+          }
+        `,
+        ],
+      ]),
+      '/unresolve'
+    )
+
+    await session.assertHasRedbox()
+    expect(await session.getRedboxDescription()).toInclude(
+      `Module not found: Can't resolve 'non-existing-module'`
+    )
+
+    await cleanup()
+  })
+
   it('should throw an error when error file is a server component', async () => {
     const { session, cleanup } = await sandbox(
       next,

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -334,9 +334,11 @@ describe('Error overlay - RSC build errors', () => {
     )
 
     await session.assertHasRedbox()
-    expect(await session.getRedboxDescription()).toInclude(
-      `Module not found: Can't resolve 'non-existing-module'`
-    )
+    if (!isTurbopack) {
+      expect(await session.getRedboxDescription()).toInclude(
+        `Module not found: Can't resolve 'non-existing-module'`
+      )
+    }
 
     await cleanup()
   })

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -334,17 +334,10 @@ describe('Error overlay - RSC build errors', () => {
     )
 
     await session.assertHasRedbox()
-    if (isTurbopack) {
-      // TODO: strip out the filepath from error message.
-      // Currently turbopack gives error message with filepath as a prefix. e.g.
-      // ./test/e2e/app-dir/hello-world/app/page.tsx:6:7
-      // Module not found: Can't resolve 'non-existing-module'
-      // Where we don't need the 1st line of filepath but the error message.
-    } else {
-      expect(await session.getRedboxDescription()).toInclude(
-        `Module not found: Can't resolve 'non-existing-module'`
-      )
-    }
+
+    expect(await session.getRedboxDescription()).toContain(
+      `Module not found: Can't resolve 'non-existing-module'`
+    )
 
     await next.patchFile(
       'app/unresolve/page.js',

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -334,10 +334,17 @@ describe('Error overlay - RSC build errors', () => {
     )
 
     await session.assertHasRedbox()
-
-    expect(await session.getRedboxDescription()).toContain(
-      `Module not found: Can't resolve 'non-existing-module'`
-    )
+    if (isTurbopack) {
+      // TODO: strip out the filepath from error message.
+      // Currently turbopack gives error message with filepath as a prefix. e.g.
+      // ./test/e2e/app-dir/hello-world/app/page.tsx:6:7
+      // Module not found: Can't resolve 'non-existing-module'
+      // Where we don't need the 1st line of filepath but the error message.
+    } else {
+      expect(await session.getRedboxDescription()).toInclude(
+        `Module not found: Can't resolve 'non-existing-module'`
+      )
+    }
 
     await next.patchFile(
       'app/unresolve/page.js',

--- a/test/development/basic/hmr.test.ts
+++ b/test/development/basic/hmr.test.ts
@@ -913,7 +913,7 @@ describe.each([[''], ['/docs']])(
           )
 
           await assertHasRedbox(browser)
-          expect(await getRedboxHeader(browser)).toMatch('Failed to compile')
+          expect(await getRedboxHeader(browser)).toMatch('Build Error')
 
           if (process.env.TURBOPACK) {
             expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
@@ -985,7 +985,7 @@ describe.each([[''], ['/docs']])(
           )
 
           await assertHasRedbox(browser)
-          expect(await getRedboxHeader(browser)).toMatch('Failed to compile')
+          expect(await getRedboxHeader(browser)).toMatch('Build Error')
           let redboxSource = await getRedboxSource(browser)
 
           redboxSource = redboxSource.replace(`${next.testDir}`, '.')

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -2,6 +2,7 @@ import {
   assertHasRedbox,
   assertNoRedbox,
   check,
+  getRedboxDescription,
   getRedboxSource,
 } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
@@ -272,8 +273,9 @@ describe('middleware - development errors', () => {
       const browser = await next.browser('/')
       await assertHasRedbox(browser)
       expect(
-        await browser.elementByCss('#nextjs__container_errors_desc').text()
-      ).toEqual('Failed to compile')
+        // await browser.elementByCss('#nextjs__container_errors_desc').text()
+        await getRedboxDescription(browser)
+      ).toContain(`Expected '{', got '}'`)
       await next.patchFile('middleware.js', `export default function () {}`)
       await assertHasRedbox(browser)
       expect(await browser.elementByCss('#page-title')).toBeTruthy()

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -272,10 +272,7 @@ describe('middleware - development errors', () => {
     it('renders the error correctly and recovers', async () => {
       const browser = await next.browser('/')
       await assertHasRedbox(browser)
-      expect(
-        // await browser.elementByCss('#nextjs__container_errors_desc').text()
-        await getRedboxDescription(browser)
-      ).toContain(`Expected '{', got '}'`)
+      expect(await getRedboxDescription(browser)).toContain(`./middleware.js`)
       await next.patchFile('middleware.js', `export default function () {}`)
       await assertHasRedbox(browser)
       expect(await browser.elementByCss('#page-title')).toBeTruthy()

--- a/test/integration/next-image-new/invalid-image-import/test/index.test.ts
+++ b/test/integration/next-image-new/invalid-image-import/test/index.test.ts
@@ -4,7 +4,7 @@ import { join } from 'path'
 import {
   assertHasRedbox,
   findPort,
-  getRedboxHeader,
+  getRedboxDescription,
   getRedboxSource,
   killApp,
   launchApp,
@@ -23,7 +23,9 @@ function runTests({ isDev }) {
     if (isDev) {
       const browser = await webdriver(appPort, '/')
       await assertHasRedbox(browser)
-      expect(await getRedboxHeader(browser)).toMatch('Failed to compile')
+      expect(await getRedboxDescription(browser)).toMatch(
+        'Image import "../public/invalid.svg" is not a valid image file. The image may be corrupted or an unsupported format.'
+      )
       const source = await getRedboxSource(browser)
       if (process.env.TURBOPACK) {
         expect(source).toMatchInlineSnapshot(`

--- a/test/integration/next-image-new/invalid-image-import/test/index.test.ts
+++ b/test/integration/next-image-new/invalid-image-import/test/index.test.ts
@@ -4,7 +4,7 @@ import { join } from 'path'
 import {
   assertHasRedbox,
   findPort,
-  getRedboxDescription,
+  getRedboxHeader,
   getRedboxSource,
   killApp,
   launchApp,
@@ -23,9 +23,7 @@ function runTests({ isDev }) {
     if (isDev) {
       const browser = await webdriver(appPort, '/')
       await assertHasRedbox(browser)
-      expect(await getRedboxDescription(browser)).toMatch(
-        'Image import "../public/invalid.svg" is not a valid image file. The image may be corrupted or an unsupported format.'
-      )
+      expect(await getRedboxHeader(browser)).toMatch('Build Error')
       const source = await getRedboxSource(browser)
       if (process.env.TURBOPACK) {
         expect(source).toMatchInlineSnapshot(`


### PR DESCRIPTION
### What

Add error message to the build error overlay instead of just showing "failed to compile" to make it easier to read the build error message directly. Since there're differences between webpack and turbopack errors, some errors are only available in webpack, like this one.

![image](https://github.com/vercel/next.js/assets/4800338/481e63c4-6126-4bb7-a94c-248634178488)


### Why

When module resolving error show up it only shows failed to compile and the "Cannot resolve module" message is also inside the code snippet which it's visually hard to spot