### PR TITLE
fix deploy test manifest for metadata navigation test

### DIFF
--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -9,9 +9,13 @@
     },
     "test/e2e/app-dir/metadata/metadata.test.ts": {
       "failed": [
-        "app dir - metadata navigation should render root not-found with default metadata",
         "app dir - metadata react cache should have same title and page value on initial load",
         "app dir - metadata react cache should have same title and page value when navigating"
+      ]
+    },
+    "test/e2e/app-dir/metadata-navigation/metadata-navigation.test.ts": {
+      "failed": [
+        "app dir - metadata navigation navigation should render root not-found with default metadata"
       ]
     },
     "test/e2e/middleware-rewrites/test/index.test.ts": {


### PR DESCRIPTION
This test got moved in a recent PR, so this updates the deploy test manifest with the new location. 