### PR TITLE
Add experimental flag for providing entry paths

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -871,14 +871,15 @@ export default async function build(
       )
 
       let pagesPaths =
-        providedPagePaths ||
-        (!appDirOnly && pagesDir
-          ? await nextBuildSpan.traceChild('collect-pages').traceAsyncFn(() =>
-              recursiveReadDir(pagesDir, {
-                pathnameFilter: validFileMatcher.isPageFile,
-              })
-            )
-          : [])
+        providedPagePaths.length > 0
+          ? providedPagePaths
+          : !appDirOnly && pagesDir
+            ? await nextBuildSpan.traceChild('collect-pages').traceAsyncFn(() =>
+                recursiveReadDir(pagesDir, {
+                  pathnameFilter: validFileMatcher.isPageFile,
+                })
+              )
+            : []
 
       const middlewareDetectionRegExp = new RegExp(
         `^${MIDDLEWARE_FILENAME}\\.(?:${config.pageExtensions.join('|')})$`
@@ -946,19 +947,20 @@ export default async function build(
         )
 
         let appPaths =
-          providedAppPaths ||
-          (await nextBuildSpan
-            .traceChild('collect-app-paths')
-            .traceAsyncFn(() =>
-              recursiveReadDir(appDir, {
-                pathnameFilter: (absolutePath) =>
-                  validFileMatcher.isAppRouterPage(absolutePath) ||
-                  // For now we only collect the root /not-found page in the app
-                  // directory as the 404 fallback
-                  validFileMatcher.isRootNotFound(absolutePath),
-                ignorePartFilter: (part) => part.startsWith('_'),
-              })
-            ))
+          providedAppPaths.length > 0
+            ? providedAppPaths
+            : await nextBuildSpan
+                .traceChild('collect-app-paths')
+                .traceAsyncFn(() =>
+                  recursiveReadDir(appDir, {
+                    pathnameFilter: (absolutePath) =>
+                      validFileMatcher.isAppRouterPage(absolutePath) ||
+                      // For now we only collect the root /not-found page in the app
+                      // directory as the 404 fallback
+                      validFileMatcher.isRootNotFound(absolutePath),
+                    ignorePartFilter: (part) => part.startsWith('_'),
+                  })
+                )
 
         mappedAppPages = await nextBuildSpan
           .traceChild('create-app-mapping')

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -921,7 +921,7 @@ export const defaultConfig: NextConfig = {
   output: !!process.env.NEXT_PRIVATE_STANDALONE ? 'standalone' : undefined,
   modularizeImports: undefined,
   experimental: {
-    flyingShuttle: false,
+    flyingShuttle: Boolean(process.env.NEXT_PRIVATE_FLYING_SHUTTLE),
     prerenderEarlyExit: true,
     serverMinification: true,
     serverSourceMaps: false,

--- a/test/e2e/app-dir/app/provide-paths.test.ts
+++ b/test/e2e/app-dir/app/provide-paths.test.ts
@@ -1,0 +1,53 @@
+import { nextTestSetup } from 'e2e-utils'
+import glob from 'glob'
+import path from 'path'
+
+describe('Provided page/app paths', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+    dependencies: {
+      nanoid: '4.0.1',
+    },
+    env: {
+      NEXT_PROVIDED_PAGE_PATHS: JSON.stringify(['/index.js', '/ssg.js']),
+      NEXT_PROVIDED_APP_PATHS: JSON.stringify([
+        '/dashboard/page.js',
+        '/(newroot)/dashboard/another/page.js',
+      ]),
+    },
+  })
+
+  if (isNextDev) {
+    it('should skip dev', () => {})
+    return
+  }
+
+  it('should only build the provided paths', async () => {
+    const appPaths = await glob.sync('**/*.js', {
+      cwd: path.join(next.testDir, '.next/server/app'),
+    })
+    const pagePaths = await glob.sync('**/*.js', {
+      cwd: path.join(next.testDir, '.next/server/pages'),
+    })
+
+    expect(appPaths).toEqual([
+      '_not-found/page_client-reference-manifest.js',
+      '_not-found/page.js',
+      '(newroot)/dashboard/another/page_client-reference-manifest.js',
+      '(newroot)/dashboard/another/page.js',
+      'dashboard/page_client-reference-manifest.js',
+      'dashboard/page.js',
+    ])
+    expect(pagePaths).toEqual([
+      '_app.js',
+      '_document.js',
+      '_error.js',
+      'ssg.js',
+    ])
+
+    for (const pathname of ['/', '/ssg', '/dashboard', '/dashboard/another']) {
+      const res = await next.fetch(pathname)
+      expect(res.status).toBe(200)
+    }
+  })
+})

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -1,6 +1,11 @@
 {
   "version": 2,
   "suites": {
+    "test/e2e/app-dir/app/provide-paths.test.ts": {
+      "passed": [],
+      "pending": [],
+      "failed": ["Provided page/app paths should only build the provided paths"]
+    },
     "test/e2e/404-page-router/index.test.ts": {
       "passed": [
         "404-page-router 404-page-router with basePath of false and i18n of false and middleware false for /error should have the correct router parameters after it is ready",


### PR DESCRIPTION
Adds a flag for experimentally building on specifically provided entry paths. This should not be relied on as it is NOT a public facing API. 