### PR TITLE
Fix noindex is missing on static not-found page

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -545,8 +545,6 @@ async function ReactServerError({
     requestId,
   } = ctx
 
-  console.log('ReactServerError', ctx.pagePath, errorType)
-
   const [MetadataTree] = createMetadataComponents({
     tree,
     metadataContext: createMetadataContext(url.pathname, ctx.renderOpts),

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -298,6 +298,17 @@ function makeGetDynamicParamFromSegment(
   }
 }
 
+function NonIndex({ ctx }: { ctx: AppRenderContext }) {
+  const is404Page = ctx.pagePath === '/404'
+  const isInvalidStatusCode =
+    typeof ctx.res.statusCode === 'number' && ctx.res.statusCode > 400
+
+  if (is404Page || isInvalidStatusCode) {
+    return <meta name="robots" content="noindex" />
+  }
+  return null
+}
+
 // Handle Flight render request. This is only used when client-side navigating. E.g. when you `router.push('/dashboard')` or `router.reload()`.
 async function generateFlight(
   ctx: AppRenderContext,
@@ -344,8 +355,11 @@ async function generateFlight(
         isFirst: true,
         // For flight, render metadata inside leaf page
         rscPayloadHead: (
-          // Adding requestId as react key to make metadata remount for each render
-          <MetadataTree key={requestId} />
+          <>
+            <NonIndex ctx={ctx} />
+            {/* Adding requestId as react key to make metadata remount for each render */}
+            <MetadataTree key={requestId} />
+          </>
         ),
         injectedCSS: new Set(),
         injectedJS: new Set(),
@@ -493,10 +507,7 @@ async function ReactServerApp({ tree, ctx, asNotFound }: ReactServerAppProps) {
       couldBeIntercepted={couldBeIntercepted}
       initialHead={
         <>
-          {typeof ctx.res.statusCode === 'number' &&
-            ctx.res.statusCode > 400 && (
-              <meta name="robots" content="noindex" />
-            )}
+          <NonIndex ctx={ctx} />
           {/* Adding requestId as react key to make metadata remount for each render */}
           <MetadataTree key={ctx.requestId} />
         </>
@@ -532,8 +543,9 @@ async function ReactServerError({
     },
     requestStore: { url },
     requestId,
-    res,
   } = ctx
+
+  console.log('ReactServerError', ctx.pagePath, errorType)
 
   const [MetadataTree] = createMetadataComponents({
     tree,
@@ -547,11 +559,9 @@ async function ReactServerError({
 
   const head = (
     <>
+      <NonIndex ctx={ctx} />
       {/* Adding requestId as react key to make metadata remount for each render */}
       <MetadataTree key={requestId} />
-      {typeof res.statusCode === 'number' && res.statusCode >= 400 && (
-        <meta name="robots" content="noindex" />
-      )}
       {process.env.NODE_ENV === 'development' && (
         <meta name="next-error" content="not-found" />
       )}
@@ -1269,7 +1279,7 @@ async function renderToHTMLOrFlightImpl(
           setHeader('Location', redirectUrl)
         }
 
-        const is404 = res.statusCode === 404
+        const is404 = ctx.res.statusCode === 404
         if (!is404 && !hasRedirectError && !shouldBailoutToCSR) {
           res.statusCode = 500
         }

--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -13,11 +13,6 @@
         "app dir - metadata react cache should have same title and page value when navigating"
       ]
     },
-    "test/e2e/app-dir/metadata-navigation/metadata-navigation.test.ts": {
-      "failed": [
-        "app dir - metadata navigation navigation should render root not-found with default metadata"
-      ]
-    },
     "test/e2e/middleware-rewrites/test/index.test.ts": {
       "failed": ["Middleware Rewrite should handle catch-all rewrite correctly"]
     }

--- a/test/e2e/app-dir/not-found/default/app/foo/page.js
+++ b/test/e2e/app-dir/not-found/default/app/foo/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Foo</h1>
+}

--- a/test/e2e/app-dir/not-found/default/app/layout.js
+++ b/test/e2e/app-dir/not-found/default/app/layout.js
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/not-found/default/default.test.ts
+++ b/test/e2e/app-dir/not-found/default/default.test.ts
@@ -1,0 +1,23 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('app dir - not-found - default', () => {
+  const { next, isNextStart } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  it('should has noindex in the head html', async () => {
+    const $ = await next.render$('/does-not-exist')
+    expect(await $('meta[name="robots"]').attr('content')).toBe('noindex')
+  })
+
+  if (isNextStart) {
+    it('should contain noindex contain in the page', async () => {
+      const html = await next.readFile('.next/server/app/_not-found.html')
+      const rsc = await next.readFile('.next/server/app/_not-found.rsc')
+
+      expect(html).toContain('noindex')
+      expect(rsc).toContain('noindex')
+    })
+  }
+})

--- a/test/e2e/app-dir/not-found/default/default.test.ts
+++ b/test/e2e/app-dir/not-found/default/default.test.ts
@@ -1,5 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
+const isPPREnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+
 describe('app dir - not-found - default', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,
@@ -14,7 +16,9 @@ describe('app dir - not-found - default', () => {
   if (isNextStart) {
     it('should contain noindex contain in the page', async () => {
       const html = await next.readFile('.next/server/app/_not-found.html')
-      const rsc = await next.readFile('.next/server/app/_not-found.rsc')
+      const rsc = await next.readFile(
+        `.next/server/app/_not-found.${isPPREnabled ? 'prefetch.' : ''}rsc`
+      )
 
       expect(html).toContain('noindex')
       expect(rsc).toContain('noindex')


### PR DESCRIPTION
### What

Render noindex into a flight data and rsc payload when page path is `/404` 

### Why

When it's static generation, noindex is not rendered due to the statusCode from mock request is 200, but we can relying on the pagePath as `/404` page should always contain `nonidex`

We were missing the noindex before for flight generation, now we'll render it when it's 404 page.