### PR TITLE
docs: update 03-fonts.mdx, Font.className should be used insted of Fo…

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/03-fonts.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/03-fonts.mdx
@@ -355,7 +355,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en" className={`${inter.variable} ${roboto_mono.variable}`}>
+    <html lang="en" className={`${inter.className} ${roboto_mono.className}`}>
       <body>
         <h1>My App</h1>
         <div>{children}</div>
@@ -382,7 +382,7 @@ const roboto_mono = Roboto_Mono({
 
 export default function RootLayout({ children }) {
   return (
-    <html lang="en" className={`${inter.variable} ${roboto_mono.variable}`}>
+    <html lang="en" className={`${inter.className} ${roboto_mono.className}`}>
       <body>
         <h1>My App</h1>
         <div>{children}</div>


### PR DESCRIPTION
…nt.variable in className

### What?

`03-fonts.mdx` contains `Font.variable` in className

### Why?

It should be `Font.className`
