### PR TITLE
Fix server action edge redirect with middleware rewrite

### DIFF
--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -91,7 +91,8 @@ export async function adapter(
   ensureTestApisIntercepted()
   await ensureInstrumentationRegistered()
 
-  const isEdgeRendering = process.env.NEXT_RUNTIME === 'edge'
+  // TODO-APP: use explicit marker for this
+  const isEdgeRendering = typeof self.__BUILD_MANIFEST !== 'undefined'
   const prerenderManifest: PrerenderManifest | undefined =
     typeof self.__PRERENDER_MANIFEST === 'string'
       ? JSON.parse(self.__PRERENDER_MANIFEST)

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -91,8 +91,7 @@ export async function adapter(
   ensureTestApisIntercepted()
   await ensureInstrumentationRegistered()
 
-  // TODO-APP: use explicit marker for this
-  const isEdgeRendering = typeof self.__BUILD_MANIFEST !== 'undefined'
+  const isEdgeRendering = process.env.NEXT_RUNTIME === 'edge'
   const prerenderManifest: PrerenderManifest | undefined =
     typeof self.__PRERENDER_MANIFEST === 'string'
       ? JSON.parse(self.__PRERENDER_MANIFEST)
@@ -300,7 +299,7 @@ export async function adapter(
    * a data URL if the request was a data request.
    */
   const rewrite = response?.headers.get('x-middleware-rewrite')
-  if (response && rewrite) {
+  if (response && rewrite && !isEdgeRendering) {
     const rewriteUrl = new NextURL(rewrite, {
       forceLocale: true,
       headers: params.request.headers,

--- a/test/e2e/app-dir/server-actions-redirect-middleware-rewrite/app/actions.ts
+++ b/test/e2e/app-dir/server-actions-redirect-middleware-rewrite/app/actions.ts
@@ -1,0 +1,11 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+
+export async function relativeRedirect() {
+  return redirect('./subpage')
+}
+
+export async function absoluteRedirect() {
+  return redirect('/subpage')
+}

--- a/test/e2e/app-dir/server-actions-redirect-middleware-rewrite/app/layout.tsx
+++ b/test/e2e/app-dir/server-actions-redirect-middleware-rewrite/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/server-actions-redirect-middleware-rewrite/app/redirect/page.tsx
+++ b/test/e2e/app-dir/server-actions-redirect-middleware-rewrite/app/redirect/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div id="redirected">Redirected</div>
+}

--- a/test/e2e/app-dir/server-actions-redirect-middleware-rewrite/app/server-action/_action.ts
+++ b/test/e2e/app-dir/server-actions-redirect-middleware-rewrite/app/server-action/_action.ts
@@ -1,0 +1,7 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+
+export const redirectAction = async () => {
+  redirect('/redirect')
+}

--- a/test/e2e/app-dir/server-actions-redirect-middleware-rewrite/app/server-action/edge/page.tsx
+++ b/test/e2e/app-dir/server-actions-redirect-middleware-rewrite/app/server-action/edge/page.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { redirectAction } from '../_action'
+
+export default function Page() {
+  return (
+    <form action={redirectAction}>
+      <button type="submit">Submit</button>
+    </form>
+  )
+}
+
+export const runtime = 'edge'

--- a/test/e2e/app-dir/server-actions-redirect-middleware-rewrite/app/server-action/node/page.tsx
+++ b/test/e2e/app-dir/server-actions-redirect-middleware-rewrite/app/server-action/node/page.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { redirectAction } from '../_action'
+
+export default function Page() {
+  return (
+    <form action={redirectAction}>
+      <button type="submit">Submit</button>
+    </form>
+  )
+}
+
+export const runtime = 'nodejs'

--- a/test/e2e/app-dir/server-actions-redirect-middleware-rewrite/middleware.ts
+++ b/test/e2e/app-dir/server-actions-redirect-middleware-rewrite/middleware.ts
@@ -1,0 +1,5 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export default function middleware(request: NextRequest) {
+  return NextResponse.rewrite(request.url)
+}

--- a/test/e2e/app-dir/server-actions-redirect-middleware-rewrite/server-actions-redirect-middleware-rewrite.test.ts
+++ b/test/e2e/app-dir/server-actions-redirect-middleware-rewrite/server-actions-redirect-middleware-rewrite.test.ts
@@ -1,0 +1,33 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('app-dir - server-actions-redirect-middleware-rewrite.test', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should redirect correctly in nodejs runtime with middleware rewrite', async () => {
+    const browser = await next.browser('/server-action/node')
+    await browser.waitForElementByCss('button').click()
+
+    await retry(async () => {
+      expect(await browser.waitForElementByCss('#redirected').text()).toBe(
+        'Redirected'
+      )
+    })
+    expect(await browser.url()).toBe(`${next.url}/redirect`)
+  })
+
+  it('should redirect correctly in edge runtime with middleware rewrite', async () => {
+    const browser = await next.browser('/server-action/edge')
+    await browser.waitForElementByCss('button').click()
+
+    await retry(async () => {
+      expect(await browser.waitForElementByCss('#redirected').text()).toBe(
+        'Redirected'
+      )
+
+      expect(await browser.url()).toBe(`${next.url}/redirect`)
+    })
+  })
+})


### PR DESCRIPTION
### What

Add isEdgeRendering check condition for rewrite logic in edge adpator 

Fixes #66837 
Closes NEXT-3545

### Why

From headers `x-middleware-rewrite`, it's still relative url `/rewrite`, reconstructing the url will lead to crash as it doesn't contain host.

