### PR TITLE
Add sharp to next's devDependencies

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -299,6 +299,7 @@
     "send": "0.17.1",
     "server-only": "0.0.1",
     "setimmediate": "1.0.5",
+    "sharp": "0.33.4",
     "shell-quote": "1.7.3",
     "source-map": "0.6.1",
     "source-map-loader": "5.0.0",


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### Why?

Currently, for a freshly installed clone of the Next.js repo in a fresh machine (no `pnpm` cache), running `pnpm build` will fail because `sharp` is not automatically installed (GitHub Codespaces, Node.js v20.2.0, `pnpm` v8.15.7).

<details><summary><code>pnpm build</code> log</summary>

```
┌ next#build > cache bypass, force executing 90354ed2b7dda4a9 
│ 
│ > next@15.0.0-canary.42 build /workspaces/next.js/packages/next
│ > pnpm release
│ 
│ 
│ > next@15.0.0-canary.42 release /workspaces/next.js/packages/next
│ > taskr release
│ 
│ <various things>
│ 
│ > next@15.0.0-canary.42 types /workspaces/next.js/packages/next
│ > tsc --declaration --emitDeclarationOnly --stripInternal --declarationDir dist
│ 
│ src/server/image-optimizer.ts:43:27 - error TS2307: Cannot find module 'sharp' or its corresponding type declaration
│ s.
│ 
│ 43 let _sharp: typeof import('sharp')
│                              ~~~~~~~
│ 
│ 
│ Found 1 error in src/server/image-optimizer.ts:43
│ 
│  ELIFECYCLE  Command failed with exit code 2.
│ [13:14:54] generate_types failed because Command failed with exit code 2 (ENOENT): pnpm run types
│ [13:14:54] Task chain was aborted!
│ [13:14:54] Finished build in 42.53s
│ [13:14:54] Finished release in 43.23s
│  ELIFECYCLE  Command failed with exit code 1.
│  ELIFECYCLE  Command failed with exit code 1.
│ command finished with error: command (/workspaces/next.js/packages/next) /home/node/.local/share/pnpm/pnpm run build
│  exited (1)
└────>
```

</details>

It could be a skill issue on my part, but if not, this certainly is a source of confusion for anyone trying to install the repository.

So I add `sharp` to `devDependencies` so that it *will* be installed all of the time for anyone running `pnpm i`, and the typing of `sharp` is guaranteed to be available.