### PR TITLE
chore: turbopack metadata routes normalizing

### DIFF
--- a/packages/next/src/lib/metadata/is-metadata-route.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.ts
@@ -131,7 +131,6 @@ export function isStaticMetadataRouteFile(appDirRelativePath: string) {
   return isMetadataRouteFile(appDirRelativePath, [], true)
 }
 
-// @deprecated
 export function isStaticMetadataRoute(page: string) {
   return (
     page === '/robots' ||

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -63,7 +63,7 @@ import {
   type TopLevelIssuesMap,
   isWellKnownError,
   printNonFatalIssue,
-  normalizeAppMetadataRoutePage,
+  normalizedPageToTurbopackStructureRoute,
 } from './turbopack-utils'
 import {
   propagateServerField,
@@ -808,7 +808,7 @@ export async function createHotReloaderTurbopack(
       await currentEntriesHandling
 
       const isInsideAppDir = routeDef.bundlePath.startsWith('app/')
-      const normalizedAppPage = normalizeAppMetadataRoutePage(
+      const normalizedAppPage = normalizedPageToTurbopackStructureRoute(
         page,
         extname(routeDef.filename)
       )

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -520,9 +520,7 @@ export async function handleRouteType({
 
       const type = writtenEndpoint?.type
 
-      await manifestLoader.loadAppPathsManifest(
-        normalizeAppMetadataRoutePage(page, false)
-      )
+      await manifestLoader.loadAppPathsManifest(page)
 
       if (type === 'edge') {
         await manifestLoader.loadMiddlewareManifest(page, 'app')
@@ -1000,7 +998,11 @@ export async function handlePagesErrorRoute({
   })
 }
 
-export function normalizeAppMetadataRoutePage(
+// Since turbopack will create app pages/route entries based on the structure,
+// which means the entry keys are based on file names.
+// But for special metadata conventions we'll change the page/pathname to a different path.
+// So we need this helper to map the new path back to original turbopack entry key.
+export function normalizedPageToTurbopackStructureRoute(
   route: string,
   ext: string | false
 ): string {

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -415,17 +415,6 @@ async function startWatcher(opts: SetupOpts) {
             pageName,
             !!(staticInfo.generateSitemaps || staticInfo.generateImageMetadata)
           )
-
-          // pageName = pageName.slice(0, -'/route'.length)
-          // if (pageName.endsWith('/sitemap')) {
-
-          //   if (staticInfo.generateSitemaps) {
-          //     pageName = `${pageName}/[__metadata_id__]`
-          //   } else {
-          //     pageName = `${pageName}.xml`
-          //   }
-          // }
-          // pageName = `${pageName}/route`
         }
 
         if (


### PR DESCRIPTION
### What

Remove unused helps on load app manifest for turbopack, clean up the previous sitemap related changes. The path/page mapping is still need to be kept now since the we create the entries is based on app folder structure for turbopack, and not able to change based on the module export, so still need to map the modified route path back to the file structure path