### PR TITLE
Write out task statistics if NEXT_TURBOPACK_TASK_STATISTICS is set

### DIFF
--- a/packages/next-swc/crates/napi/src/next_api/project.rs
+++ b/packages/next-swc/crates/napi/src/next_api/project.rs
@@ -301,7 +301,7 @@ pub async fn project_new(
         let subscriber = subscriber.with(RawTraceLayer::new(trace_writer));
 
         exit.on_exit(async move {
-            drop(trace_writer_guard);
+            tokio::task::spawn_blocking(move || drop(trace_writer_guard));
         });
 
         let trace_server = std::env::var("NEXT_TURBOPACK_TRACE_SERVER").ok();

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -677,6 +677,8 @@ export interface Project {
   updateInfoSubscribe(
     aggregationMs: number
   ): AsyncIterableIterator<TurbopackResult<UpdateMessage>>
+
+  onExit(): Promise<void>
 }
 
 export type Route =
@@ -1087,6 +1089,10 @@ function bindingToApi(
           )
       )
       return subscription
+    }
+
+    onExit(): Promise<void> {
+      return binding.projectOnExit(this._nativeProject)
     }
   }
 

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -153,6 +153,7 @@ export async function createHotReloaderTurbopack(
       memoryLimit: opts.nextConfig.experimental.turbo?.memoryLimit,
     }
   )
+  opts.onCleanup(() => project.onExit())
   const entrypointsSubscription = project.entrypointsSubscribe()
 
   const currentEntrypoints: Entrypoints = {

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -65,6 +65,7 @@ export async function initialize(opts: {
   dir: string
   port: number
   dev: boolean
+  onCleanup: (listener: () => Promise<void>) => void
   server?: import('http').Server
   minimalMode?: boolean
   hostname?: string
@@ -132,6 +133,7 @@ export async function initialize(opts: {
         isCustomServer: opts.customServer,
         turbo: !!process.env.TURBOPACK,
         port: opts.port,
+        onCleanup: opts.onCleanup,
       })
     )
 

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -96,6 +96,7 @@ export type SetupOpts = {
   >
   nextConfig: NextConfigComplete
   port: number
+  onCleanup: (listener: () => Promise<void>) => void
 }
 
 export type ServerFields = {

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -50,6 +50,7 @@ export async function getRequestHandlers({
   dir,
   port,
   isDev,
+  onCleanup,
   server,
   hostname,
   minimalMode,
@@ -60,6 +61,7 @@ export async function getRequestHandlers({
   dir: string
   port: number
   isDev: boolean
+  onCleanup: (listener: () => Promise<void>) => void
   server?: import('http').Server
   hostname?: string
   minimalMode?: boolean
@@ -71,6 +73,7 @@ export async function getRequestHandlers({
     dir,
     port,
     hostname,
+    onCleanup,
     dev: isDev,
     minimalMode,
     server,
@@ -266,9 +269,13 @@ export async function startServer(
       Log.event(`Starting...`)
 
       try {
+        const cleanupListeners = [() => new Promise((res) => server.close(res))]
         const cleanup = () => {
           debug('start-server process cleanup')
-          server.close(() => process.exit(0))
+          ;(async () => {
+            await Promise.all(cleanupListeners.map((f) => f()))
+            process.exit(0)
+          })()
         }
         const exception = (err: Error) => {
           if (isPostpone(err)) {
@@ -298,6 +305,7 @@ export async function startServer(
           dir,
           port,
           isDev,
+          onCleanup: (listener) => cleanupListeners.push(listener),
           server,
           hostname,
           minimalMode,

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -62,6 +62,7 @@ export class NextServer {
   private reqHandlerPromise?: Promise<NodeRequestHandler>
   private preparedAssetPrefix?: string
 
+  protected cleanupListeners: (() => Promise<void>)[] = []
   protected standaloneMode?: boolean
 
   public options: NextServerOptions
@@ -155,8 +156,15 @@ export class NextServer {
   }
 
   async close() {
-    const server = await this.getServer()
-    return (server as any).close()
+    await Promise.all(
+      [
+        async () => {
+          const server = await this.getServer()
+          await (server as any).close()
+        },
+        ...this.cleanupListeners,
+      ].map((f) => f())
+    )
   }
 
   private async createServer(
@@ -278,6 +286,7 @@ class NextCustomServer extends NextServer {
       dir: this.options.dir!,
       port: this.options.port || 3000,
       isDev: !!this.options.dev,
+      onCleanup: (listener) => this.cleanupListeners.push(listener),
       hostname: this.options.hostname || 'localhost',
       minimalMode: this.options.minimalMode,
       quiet: this.options.quiet,


### PR DESCRIPTION
Writes out the statistics gathered via vercel/turbo#8286 to a file.

Stats can be formatted and sorted with jq:

```
jq 'to_entries | sort_by(.value.cache_miss) | reverse | from_entries' <input.json >output.json
```

Output looks something like this (once formatted and sorted): https://gist.github.com/bgw/4e2df35b9e410bf71fe51ecaffc3c7bf

Without #67165, this requires that SIGINT be sent directly to the `next-server` process to allow a clean exit:

```
pkill -INT next-server
```

But with #67165, a simple <kbd>ctrl</kbd>+<kbd>c</kbd> works.