### PR TITLE
Allow dev server to exit cleanly (SIGINT/SIGTERM)

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -60,7 +60,10 @@ let sessionStarted = Date.now()
 
 // How long should we wait for the child to cleanly exit after sending
 // SIGINT/SIGTERM to the child process before sending SIGKILL?
-const CHILD_EXIT_TIMEOUT_MS = 1000
+const CHILD_EXIT_TIMEOUT_MS = parseInt(
+  process.env.NEXT_EXIT_TIMEOUT_MS ?? '100',
+  10
+)
 
 const handleSessionStop = async (signal: NodeJS.Signals | number | null) => {
   if (signal != null && child?.pid) child.kill(signal)

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -35,6 +35,7 @@ import {
 } from '../lib/helpers/get-reserved-port'
 import os from 'os'
 import { once } from 'node:events'
+import { clearTimeout } from 'timers'
 
 export type NextDevOptions = {
   turbo?: boolean
@@ -57,13 +58,26 @@ let traceUploadUrl: string
 let sessionStopHandled = false
 let sessionStarted = Date.now()
 
+// How long should we wait for the child to cleanly exit after sending
+// SIGINT/SIGTERM to the child process before sending SIGKILL?
+const CHILD_EXIT_TIMEOUT_MS = 1000
+
 const handleSessionStop = async (signal: NodeJS.Signals | number | null) => {
-  if (child?.pid) child.kill(signal ?? 0)
+  if (signal != null && child?.pid) child.kill(signal)
   if (sessionStopHandled) return
   sessionStopHandled = true
 
-  if (child?.pid && child.exitCode === null && child.signalCode === null) {
+  if (
+    signal != null &&
+    child?.pid &&
+    child.exitCode === null &&
+    child.signalCode === null
+  ) {
+    let exitTimeout = setTimeout(() => {
+      child?.kill('SIGKILL')
+    }, CHILD_EXIT_TIMEOUT_MS)
     await once(child, 'exit').catch(() => {})
+    clearTimeout(exitTimeout)
   }
 
   try {
@@ -124,8 +138,8 @@ const handleSessionStop = async (signal: NodeJS.Signals | number | null) => {
   process.exit(0)
 }
 
-process.on('SIGINT', () => handleSessionStop('SIGKILL'))
-process.on('SIGTERM', () => handleSessionStop('SIGKILL'))
+process.on('SIGINT', () => handleSessionStop('SIGINT'))
+process.on('SIGTERM', () => handleSessionStop('SIGTERM'))
 
 // exit event must be synchronous
 process.on('exit', () => child?.kill('SIGKILL'))
@@ -291,7 +305,9 @@ const nextDev = async (
           }
           return startServer(startServerOptions)
         }
-        await handleSessionStop(signal)
+        // Call handler (e.g. upload telemetry). Don't try to send a signal to
+        // the child, as it has already exited.
+        await handleSessionStop(/* signal */ null)
       })
     })
   }

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -270,10 +270,20 @@ export async function startServer(
 
       try {
         const cleanupListeners = [() => new Promise((res) => server.close(res))]
+        let cleanupStarted = false
         const cleanup = () => {
-          debug('start-server process cleanup')
+          if (cleanupStarted) {
+            // We can get duplicate signals, e.g. when `ctrl+c` is used in an
+            // interactive shell (i.e. bash, zsh), the shell will recursively
+            // send SIGINT to children. The parent `next-dev` process will also
+            // send us SIGINT.
+            return
+          }
+          cleanupStarted = true
           ;(async () => {
+            debug('start-server process cleanup')
             await Promise.all(cleanupListeners.map((f) => f()))
+            debug('start-server process cleanup finished')
             process.exit(0)
           })()
         }

--- a/test/production/graceful-shutdown/index.test.ts
+++ b/test/production/graceful-shutdown/index.test.ts
@@ -100,7 +100,11 @@ describe('Graceful Shutdown', () => {
       app = await initNextServerScript(
         serverFile,
         /- Local:/,
-        { ...process.env, PORT: appPort.toString() },
+        {
+          ...process.env,
+          NEXT_EXIT_TIMEOUT_MS: '10',
+          PORT: appPort.toString(),
+        },
         undefined,
         { cwd: next.testDir }
       )


### PR DESCRIPTION
Next's dev server uses a parent/child process model. The parent process acts as a monitor, and it able to restart the server upon configuration changes or upload telemetry even in the case of a crash. The child listens for http requests and does all the real work.

Previously we were sending `SIGKILL` immediately to the child when the parent process got `SIGINT` or `SIGTERM`. This ensures that the child exits as quickly as possible, but it also means that the child probably won't have time to finish flushing files to disk (trace files, cache hit statistics, etc.), and can lead to incomplete writes.

We should give the child a small amount of time to exit cleanly with `SIGINT`/`SIGTERM` before sending `SIGKILL`. The timeout is needed in case the child process is unresponsive/hanging.

## Tradeoffs

This does cause a short hang for 1 second when the server is heavily loaded (e.g. trying to compile a page, both with webpack and with turbo), and often the process is not able to exit within the 1 second threshold in this case.

At least on the turbopack side, we should be able to better handle this by shutting down the tokio runtime (but this would require creating a second runtime for cleanup) or by preventing turbo-tasks from spawning any more work. That would more quickly free up the CPU to be able to handle the high-priority exit work.

## Testing

Run the dev server with `DEBUG="next:*"` and see the log messages about server shutdown when pressing <kbd>ctrl</kbd>+<kbd>c</kbd>.