### PR TITLE
Do not skip `react-owner-stacks-svgr` test for turbopack build

### DIFF
--- a/test/e2e/app-dir/react-owner-stacks-svgr/react-owner-stacks-svgr.test.ts
+++ b/test/e2e/app-dir/react-owner-stacks-svgr/react-owner-stacks-svgr.test.ts
@@ -1,20 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('react-owner-stacks-svgr', () => {
-  const { next, isNextStart, isTurbopack } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     packageJson: { dependencies: { '@svgr/webpack': '8.1.0' } },
   })
 
-  /* eslint-disable jest/no-standalone-expect */
-  // Turbopack currently only supports `next dev` and does not support `next
-  // build`: https://nextjs.org/docs/architecture/turbopack#unsupported-features
-  ;(isNextStart && isTurbopack ? it.skip : it)(
-    'renders an SVG that is transformed by @svgr/webpack into a React component',
-    async () => {
-      const browser = await next.browser('/')
-      expect(await browser.elementByCss('svg')).toBeDefined()
-    }
-  )
-  /* eslint-enable jest/no-standalone-expect */
+  it('renders an SVG that is transformed by @svgr/webpack into a React component', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('svg')).toBeDefined()
+  })
 })


### PR DESCRIPTION
Follow-up from #67104. Skipping the test was due to a misunderstanding. I executed the test with:

```
TURBOPACK=1 pnpm test-start test/e2e/app-dir/react-owner-stacks-svgr/react-owner-stacks-svgr.test.ts
```

With that, I ran into the `next build doesn't support turbopack yet` error.

But the error was only thrown because `TURBOPACK_BUILD` was not set, so I should have run:

```
TURBOPACK=1 TURBOPACK_BUILD=1 pnpm test-start test/e2e/app-dir/react-owner-stacks-svgr/react-owner-stacks-svgr.test.ts
```

or, even better:

```
pnpm test-start-turbo test/e2e/app-dir/react-owner-stacks-svgr/react-owner-stacks-svgr.test.ts
```

And with that, the test does succeed, so we don't need to skip it.