### PR TITLE
Make synced react-is version more obvious

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,6 +206,7 @@
     "react-dom-builtin": "npm:react-dom@19.0.0-rc-6230622a1a-20240610",
     "react-dom-experimental-builtin": "npm:react-dom@0.0.0-experimental-6230622a1a-20240610",
     "react-experimental-builtin": "npm:react@0.0.0-experimental-6230622a1a-20240610",
+    "react-is-builtin": "npm:react-is@19.0.0-rc-6230622a1a-20240610",
     "react-server-dom-turbopack": "19.0.0-rc-6230622a1a-20240610",
     "react-server-dom-turbopack-experimental": "npm:react-server-dom-turbopack@0.0.0-experimental-6230622a1a-20240610",
     "react-server-dom-webpack": "19.0.0-rc-6230622a1a-20240610",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -289,7 +289,6 @@
     "punycode": "2.1.1",
     "querystring-es3": "0.2.1",
     "raw-body": "2.4.1",
-    "react-is": "19.0.0-rc-f994737d14-20240522",
     "react-refresh": "0.12.0",
     "regenerator-runtime": "0.13.4",
     "sass-loader": "12.6.0",

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -731,13 +731,6 @@ export async function ncc_buffer(task, opts) {
 }
 
 // eslint-disable-next-line camelcase
-export async function copy_react_is(task, opts) {
-  await task
-    .source(join(dirname(require.resolve('react-is/package.json')), '**/*'))
-    .target('src/compiled/react-is')
-}
-
-// eslint-disable-next-line camelcase
 export async function copy_constants_browserify(task, opts) {
   await fs.mkdir(join(__dirname, 'src/compiled/constants-browserify'), {
     recursive: true,
@@ -1765,6 +1758,13 @@ export async function copy_vendor_react(task_) {
   for (const res of copy_vendor_react_impl(task_, { experimental: true })) {
     await res
   }
+
+  // TODO: Support react-is experimental channel. We currently assume Canary and Experimental are equal.
+  await task_
+    .source(
+      join(dirname(require.resolve('react-is-builtin/package.json')), '**/*')
+    )
+    .target('src/compiled/react-is')
 }
 
 // eslint-disable-next-line camelcase
@@ -2307,7 +2307,6 @@ export async function ncc(task, opts) {
       'copy_vercel_og',
       'copy_constants_browserify',
       'copy_vendor_react',
-      'copy_react_is',
       'ncc_sass_loader',
       'ncc_jest_worker',
       'ncc_edge_runtime_cookies',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -467,6 +467,9 @@ importers:
       react-experimental-builtin:
         specifier: npm:react@0.0.0-experimental-6230622a1a-20240610
         version: /react@0.0.0-experimental-6230622a1a-20240610
+      react-is-builtin:
+        specifier: npm:react-is@19.0.0-rc-6230622a1a-20240610
+        version: /react-is@19.0.0-rc-6230622a1a-20240610
       react-server-dom-turbopack:
         specifier: 19.0.0-rc-6230622a1a-20240610
         version: 19.0.0-rc-6230622a1a-20240610(react-dom@19.0.0-rc-6230622a1a-20240610)(react@19.0.0-rc-6230622a1a-20240610)
@@ -1356,9 +1359,6 @@ importers:
       raw-body:
         specifier: 2.4.1
         version: 2.4.1
-      react-is:
-        specifier: 19.0.0-rc-6230622a1a-20240610
-        version: 19.0.0-rc-6230622a1a-20240610
       react-refresh:
         specifier: 0.12.0
         version: 0.12.0


### PR DESCRIPTION
We treated react-is separately in a separate task but it really should be handled
the same as React, ReactDOM etc.

It is still missing a vendored version of the experimental release channel.
We only use `isValidElementType` though and that method needs to move to the renderer anyway.
I'd rather prioritize the renderer work instead of more aliasing effort in our bundler.

## Test plan

-`pushd packages/next && rm -rf src/compiled/react-is && pnpm taskr copy_vendor_react` will leave everything as-is