### PR TITLE
skip provide-paths test when deployed

### DIFF
--- a/test/e2e/app-dir/app/provide-paths.test.ts
+++ b/test/e2e/app-dir/app/provide-paths.test.ts
@@ -5,6 +5,8 @@ import path from 'path'
 describe('Provided page/app paths', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,
+    // Deployments are unable to inspect the `.next` directory.
+    skipDeployment: true,
     dependencies: {
       nanoid: '4.0.1',
     },


### PR DESCRIPTION
This test cannot be run in `test-deploy` because it inspects the contents of the `.next` folder. 