### PR TITLE
Upgrade Turbopack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "serde",
  "smallvec",
@@ -3111,7 +3111,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "serde",
@@ -3126,12 +3126,6 @@ dependencies = [
  "turbopack-core",
  "turbopack-resolve",
 ]
-
-[[package]]
-name = "nohash-hasher"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -6983,12 +6977,12 @@ dependencies = [
 [[package]]
 name = "turbo-prehash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7000,11 +6994,11 @@ dependencies = [
  "futures",
  "indexmap 1.9.3",
  "mopa",
- "nohash-hasher",
  "once_cell",
  "parking_lot",
  "pin-project-lite",
  "regex",
+ "rustc-hash",
  "serde",
  "serde_json",
  "serde_regex",
@@ -7020,11 +7014,12 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "cargo-lock",
  "glob",
+ "quote",
  "syn 1.0.109",
  "turbo-tasks-macros-shared",
 ]
@@ -7032,7 +7027,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7046,7 +7041,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7060,7 +7055,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -7076,7 +7071,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7108,7 +7103,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "md4",
  "turbo-tasks-macros",
@@ -7118,7 +7113,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "proc-macro-error",
@@ -7132,7 +7127,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7142,7 +7137,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "mimalloc",
 ]
@@ -7150,14 +7145,13 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "auto-hash-map",
  "concurrent-queue",
  "dashmap",
  "indexmap 1.9.3",
- "nohash-hasher",
  "num_cpus",
  "once_cell",
  "parking_lot",
@@ -7177,7 +7171,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7207,7 +7201,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7248,7 +7242,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7271,7 +7265,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "clap",
@@ -7288,7 +7282,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7317,7 +7311,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7344,7 +7338,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7380,7 +7374,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7415,7 +7409,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "serde",
  "serde_json",
@@ -7426,7 +7420,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7451,7 +7445,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7467,7 +7461,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7483,7 +7477,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7502,7 +7496,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "serde",
@@ -7517,7 +7511,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7532,7 +7526,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7566,7 +7560,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7586,7 +7580,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7604,7 +7598,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "serde",
@@ -7620,7 +7614,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7631,7 +7625,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "either",
@@ -7651,7 +7645,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -7667,7 +7661,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240621.2#7622f194490945aa904ae25791c867a5bf090ffb"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,11 @@ swc_core = { version = "0.95.4", features = [
 testing = { version = "0.36.0" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240621.2" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240626.2" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240621.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240626.2" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240621.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240626.2" }
 
 # General Deps
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -205,7 +205,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.27.1",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240619.2",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240626.2",
     "acorn": "8.11.3",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1108,8 +1108,8 @@ importers:
         specifier: 0.27.1
         version: 0.27.1
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240619.2
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240619.2'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240626.2
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240626.2'
       acorn:
         specifier: 8.11.3
         version: 8.11.3
@@ -26759,8 +26759,8 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240619.2':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240619.2}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240626.2':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240626.2}
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -1976,8 +1976,7 @@
       "runtimeError": false
     },
     "test/e2e/app-dir/mdx/mdx.test.ts": {
-      "passed": [],
-      "failed": [
+      "passed": [
         "mdx with-mdx-rs app directory should allow importing client components",
         "mdx with-mdx-rs app directory should allow overriding components",
         "mdx with-mdx-rs app directory should work in initial html",
@@ -1991,6 +1990,7 @@
         "mdx with-mdx-rs pages directory should work using browser",
         "mdx with-mdx-rs pages directory should work using browser with mdx import"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false


### PR DESCRIPTION
* https://github.com/vercel/turbo/pull/8546 <!-- Benjamin Woodruff - Decrease default scope_stress test size, add env var config  -->
* https://github.com/vercel/turbo/pull/8563 <!-- Donny/강동윤 - Update `swc_core` to `v0.95.4`  -->
* https://github.com/vercel/turbo/pull/8556 <!-- Tobias Koppers - avoid cloning the source code  -->
* https://github.com/vercel/turbo/pull/8562 <!-- Will Binns-Smith - HMR: handle non-Latin characters in text through base64-encoded sourcemaps  -->
* https://github.com/vercel/turbo/pull/8530 <!-- Benjamin Woodruff - Support turbo tasks inside of `mod` blocks  -->
* https://github.com/vercel/turbo/pull/8542 <!-- Benjamin Woodruff - Handle `#[cfg(...)]` attributes on turbo tasks  -->
* https://github.com/vercel/turbo/pull/8529 <!-- Benjamin Woodruff - Deduplicate persistent task get_function_name logic  -->
* https://github.com/vercel/turbo/pull/8547 <!-- Benjamin Woodruff - Add new ExitHandler API as an alternative to ExitGuard  -->
* https://github.com/vercel/turbo/pull/8604 <!-- Benjamin Woodruff - Delete unused TASK_ID_MAPPING support  -->
* https://github.com/vercel/turbo/pull/8605 <!-- Benjamin Woodruff - Remove nohash-hasher dependency  -->
* https://github.com/vercel/turbo/pull/8559 <!-- Tobias Koppers - move stateful flag into Done state  -->
* https://github.com/vercel/turbo/pull/8598 <!-- Tim Neutkens - MDX support: Ensure development transform is only used in development  -->
* https://github.com/vercel/turbo/pull/8557 <!-- Tobias Koppers - reduce size of task output struct  -->
* https://github.com/vercel/turbo/pull/8558 <!-- Tobias Koppers - remove prepared task type  -->


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
