### PR TITLE
fix(turbopack): add no-op `resolveAbsolutePath` to browser runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "serde",
  "smallvec",
@@ -3111,7 +3111,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "serde",
@@ -6977,12 +6977,12 @@ dependencies = [
 [[package]]
 name = "turbo-prehash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7014,7 +7014,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7027,7 +7027,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7041,7 +7041,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7055,7 +7055,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -7071,7 +7071,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7103,7 +7103,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "md4",
  "turbo-tasks-macros",
@@ -7113,7 +7113,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "proc-macro-error",
@@ -7127,7 +7127,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7137,7 +7137,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "mimalloc",
 ]
@@ -7145,7 +7145,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7171,7 +7171,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7201,7 +7201,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7242,7 +7242,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7265,7 +7265,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "clap",
@@ -7282,7 +7282,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7311,7 +7311,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7338,7 +7338,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7374,7 +7374,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7409,7 +7409,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "serde",
  "serde_json",
@@ -7420,7 +7420,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7445,7 +7445,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7461,7 +7461,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7477,7 +7477,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7496,7 +7496,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "serde",
@@ -7511,7 +7511,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7526,7 +7526,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7560,7 +7560,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7580,7 +7580,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7598,7 +7598,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "serde",
@@ -7614,7 +7614,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7625,7 +7625,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "either",
@@ -7645,7 +7645,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -7661,7 +7661,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.2#fe090caeafcf7676557bf5d998651002f16e7988"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,11 @@ swc_core = { version = "0.95.4", features = [
 testing = { version = "0.36.0" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240626.2" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240626.3" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240626.2" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240626.3" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240626.2" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240626.3" }
 
 # General Deps
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -205,7 +205,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.27.1",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240626.2",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240626.3",
     "acorn": "8.11.3",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1108,8 +1108,8 @@ importers:
         specifier: 0.27.1
         version: 0.27.1
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240626.2
-        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240626.2'
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240626.3
+        version: '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240626.3'
       acorn:
         specifier: 8.11.3
         version: 8.11.3
@@ -26759,8 +26759,8 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240626.2':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240626.2}
+  '@gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240626.3':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240626.3}
     name: '@vercel/turbopack-ecmascript-runtime'
     version: 0.0.0
     dependencies:

--- a/test/e2e/import-meta/import-meta.test.ts
+++ b/test/e2e/import-meta/import-meta.test.ts
@@ -1,0 +1,36 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('import-meta', () => {
+  const { next, isTurbopack } = nextTestSetup({
+    files: __dirname,
+  })
+
+  describe('import.meta.url', () => {
+    it('should work on the server', async () => {
+      const $ = await next.render$('/')
+      const testData = $('#test-data').text()
+      const data = JSON.parse(testData)
+
+      if (isTurbopack) {
+        expect(data.url).toStartWith('file:///')
+        expect(data.url).toEndWith('/pages/index.tsx')
+      } else {
+        expect(data.url).toStartWith('file:///')
+        expect(data.url).toEndWith('/pages/index.tsx')
+      }
+    })
+
+    it('should work in browser', async () => {
+      const browser = await next.browser('/')
+      const testData = await browser.elementByCss('#test-data').text()
+      const data = JSON.parse(testData)
+
+      if (isTurbopack) {
+        expect(data.url).toBe('file:///ROOT/pages/index.tsx')
+      } else {
+        expect(data.url).toStartWith('file:///')
+        expect(data.url).toEndWith('/pages/index.tsx')
+      }
+    })
+  })
+})

--- a/test/e2e/import-meta/pages/index.tsx
+++ b/test/e2e/import-meta/pages/index.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  const data = {
+    url: import.meta.url,
+  }
+
+  return <div id="test-data">{JSON.stringify(data)}</div>
+}


### PR DESCRIPTION
### What?

The turbopack browser runtime was throwing an error when trying to access `import.meta.url`.


Closes PACK-3095
Fixes https://github.com/vercel/next.js/issues/66005
