### PR TITLE
fix missing command in next-codemod

### DIFF
--- a/packages/next-codemod/bin/cli.ts
+++ b/packages/next-codemod/bin/cli.ts
@@ -144,6 +144,10 @@ const TRANSFORMER_INQUIRER_CHOICES = [
     value: 'metadata-to-viewport-export',
   },
   {
+    name: 'next-dynamic-access-named-export: Transforms dynamic imports that return the named export itself to a module like object.',
+    value: 'next-dynamic-access-named-export',
+  },
+  {
     name: 'next-image-to-legacy-image: safely migrate Next.js 10, 11, 12 applications importing `next/image` to the renamed `next/legacy/image` import in Next.js 13',
     value: 'next-image-to-legacy-image',
   },


### PR DESCRIPTION
Running `pnpx @next/codemod@canary next-dynamic-access-named-export` found the following error

```
Invalid transform choice, pick one of:
- name-default-component
- add-missing-react-import
- withamp-to-config
- url-to-withrouter
- cra-to-next
- new-link
- next-og-import
- metadata-to-viewport-export
- next-image-to-legacy-image
- next-image-experimental
- built-in-next-font
```

Turns out we're missing it in cli command list