### PR TITLE
Revert "examples(with-mdx): update to MDX 3"

### DIFF
--- a/examples/with-mdx/package.json
+++ b/examples/with-mdx/package.json
@@ -6,7 +6,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "@mdx-js/loader": "^3.0.1",
+    "@mdx-js/loader": "^1.5.1",
+    "@mdx-js/react": "^1.6.18",
     "@next/mdx": "^9.1.1",
     "next": "latest",
     "react": "^18.2.0",


### PR DESCRIPTION
Reverts vercel/next.js#62503

This is currently failing tests that use this example

[x-ref](https://github.com/vercel/next.js/actions/runs/9699835771/job/26771391310)