### PR TITLE
Remove extra Fragment on dynamic component

### DIFF
--- a/packages/next/src/shared/lib/lazy-dynamic/loadable.tsx
+++ b/packages/next/src/shared/lib/lazy-dynamic/loadable.tsx
@@ -1,4 +1,4 @@
-import { Suspense, Fragment, lazy } from 'react'
+import { Suspense, lazy } from 'react'
 import { BailoutToCSR } from './dynamic-bailout-to-csr'
 import type { ComponentModule } from './types'
 import { PreloadChunks } from './preload-chunks'
@@ -40,18 +40,13 @@ interface LoadableOptions {
 
 function Loadable(options: LoadableOptions) {
   const opts = { ...defaultOptions, ...options }
+  // If it's non-SSR or provided a loading component, wrap it in a suspense boundary
+  const hasSuspenseBoundary = !opts.ssr || !!opts.loading
   const Lazy = lazy(() => opts.loader().then(convertModule))
   const Loading = opts.loading
 
   function LoadableComponent(props: any) {
-    const fallbackElement = Loading ? (
-      <Loading isLoading={true} pastDelay={true} error={null} />
-    ) : null
-
-    // If it's non-SSR or provided a loading component, wrap it in a suspense boundary
-    const hasSuspenseBoundary = !opts.ssr || !!opts.loading
-    const Wrap = hasSuspenseBoundary ? Suspense : Fragment
-    const wrapProps = hasSuspenseBoundary ? { fallback: fallbackElement } : {}
+    const fallbackElement = Loading ? <Loading /> : null
     const children = opts.ssr ? (
       <>
         {/* During SSR, we need to preload the CSS from the dynamic component to avoid flash of unstyled content */}
@@ -66,7 +61,11 @@ function Loadable(options: LoadableOptions) {
       </BailoutToCSR>
     )
 
-    return <Wrap {...wrapProps}>{children}</Wrap>
+    return hasSuspenseBoundary ? (
+      <Suspense fallback={fallbackElement}>{children}</Suspense>
+    ) : (
+      children
+    )
   }
 
   LoadableComponent.displayName = 'LoadableComponent'


### PR DESCRIPTION
### What

* Remove the unused props passed to `loading`
* Only wrap the `Suspense` to dynamic component when necessary, no extra `Fragment` when it's not nessary