### PR TITLE
[WIP] fix(next): rename catch-all route segment requires restart of server

### DIFF
--- a/test/development/app-dir/rename-catch-all-route-require-restart-server/app/[[...slug]]/page.tsx
+++ b/test/development/app-dir/rename-catch-all-route-require-restart-server/app/[[...slug]]/page.tsx
@@ -1,0 +1,7 @@
+export default function Page({
+  params: { slug },
+}: {
+  params: { slug: string[] }
+}) {
+  return <p>{slug?.[0]}</p>
+}

--- a/test/development/app-dir/rename-catch-all-route-require-restart-server/app/layout.tsx
+++ b/test/development/app-dir/rename-catch-all-route-require-restart-server/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/rename-catch-all-route-require-restart-server/next.config.js
+++ b/test/development/app-dir/rename-catch-all-route-require-restart-server/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/development/app-dir/rename-catch-all-route-require-restart-server/rename-catch-all-route-require-restart-server.test.ts
+++ b/test/development/app-dir/rename-catch-all-route-require-restart-server/rename-catch-all-route-require-restart-server.test.ts
@@ -1,0 +1,29 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('rename-catch-all-route-require-restart-server', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should render props param value after rename catch-all route folder', async () => {
+    // show text of param
+    const $ = await next.render$('/foo')
+    expect($('p').text()).toBe('foo')
+
+    // rename the folder
+    await next.renameFolder('app/[[...slug]]', 'app/[[...newSlug]]')
+
+    // should not show since passed props is still `slug`, not `newSlug`
+    const $1 = await next.render$('/foo')
+    expect($1('p').text()).toBe('')
+
+    // replace `slug` with `newSlug` of the page content
+    await next.patchFile('app/[[...newSlug]]/page.tsx', (content) =>
+      content.replaceAll('slug', 'newSlug')
+    )
+
+    // should show text of param again
+    const $2 = await next.render$('/foo')
+    expect($2('p').text()).toBe('foo')
+  })
+})


### PR DESCRIPTION
### Why?

When renaming a file/folder, our HMR updates the manifests and etc. but does not remove the previous name.
Therefore when `[[...slug]]` was renamed to `[[...newSlug]]`, both the info are stored and therefore throws as:

```jsonc
{
  "pages": {
    "/[[...slug]]/page": [
      // ...
    ],
    // ROUTE CONFLICT!!
    "/[[...new-slug]]/page": [
      // ... 
    ]
  }
}
```

```
Error: You cannot use different slug names for the same dynamic path ('slug' !== 'newSlug').
```