### PR TITLE
packages/next: opt ts-morph into serverExternalPackages

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/serverExternalPackages.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/serverExternalPackages.mdx
@@ -69,6 +69,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `shiki`
 - `sqlite3`
 - `ts-node`
+- `ts-morph`
 - `typescript`
 - `vscode-oniguruma`
 - `webpack`

--- a/docs/03-pages/02-api-reference/03-next-config-js/serverExternalPackages.mdx
+++ b/docs/03-pages/02-api-reference/03-next-config-js/serverExternalPackages.mdx
@@ -69,6 +69,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `shiki`
 - `sqlite3`
 - `ts-node`
+- `ts-morph`
 - `typescript`
 - `vscode-oniguruma`
 - `webpack`

--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -50,6 +50,7 @@
   "shiki",
   "sqlite3",
   "ts-node",
+  "ts-morph",
   "typescript",
   "vscode-oniguruma",
   "webpack",


### PR DESCRIPTION
### What?
Adds `ts-morph` (https://ts-morph.com/) to the `serverExternalPackages` defaults (and the relevant docs)

### Why?
I was debugging an extremely slow to load Next.js Route Handler (20+ seconds to be invoked) and it was due to bundling ts-morph (which pulls in `typescript`)

### How?
