### PR TITLE
feat: Add a way to use latest SWC minfiier

### DIFF
--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1470,6 +1470,12 @@ function loadNative(importPath?: string) {
   }
 
   if (bindings) {
+    if (process.env.NEXT_SWC_MINIFY_BACKPORT) {
+      const pkg = require('@swc/next-minifier-backport')
+      bindings.minify = pkg.minify
+      bindings.minifySync = pkg.minifySync
+    }
+
     nativeBindings = {
       isWasm: false,
       transform(src: string, options: any) {

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -181,6 +181,14 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
           .optional(),
         relay: z
           .object({
+            projects: z
+              .array(
+                z.object({
+                  rootDir: z.string(),
+                  artifactDirectory: z.string().optional(),
+                })
+              )
+              .optional(),
             src: z.string(),
             artifactDirectory: z.string().optional(),
             language: z.enum(['javascript', 'typescript', 'flow']).optional(),


### PR DESCRIPTION
### What?

Add a way to use recent bugfixes of SWC Minfiier without updating next.js

Related: https://github.com/swc-project/pkgs/pull/47

### Why?

Updating next.js may require more considerations. This PR will provide a way to update only SWC Minfiier instead.

### How?

