### PR TITLE
Fix test-new-tests args parsing

### DIFF
--- a/scripts/test-new-tests.mjs
+++ b/scripts/test-new-tests.mjs
@@ -6,10 +6,10 @@ import yargs from 'yargs'
 
 async function main() {
   let argv = await yargs(process.argv.slice(2))
-    .boolean('--dev-mode')
+    .boolean('dev-mode')
     .string('group').argv
 
-  let testMode = argv['--dev-mode'] ? 'dev' : 'start'
+  let testMode = argv.devMode ? 'dev' : 'start'
   const rawGroup = argv['group']
   let currentGroup = 1
   let groupTotal = 1


### PR DESCRIPTION
Noticed we weren't detecting test mode correctly due to incorrect args parsing so this fixes that

x-ref: https://github.com/vercel/next.js/actions/runs/9725297814/job/26842454638?pr=67306#step:28:69