### PR TITLE
perf: improve retrieving `versionInfo` on Turbo HMR

### DIFF
--- a/packages/next/src/lib/helpers/get-pkg-manager.ts
+++ b/packages/next/src/lib/helpers/get-pkg-manager.ts
@@ -34,3 +34,26 @@ export function getPkgManager(baseDir: string): PackageManager {
     return 'npm'
   }
 }
+
+// validate if the project is using yarn
+export function isPkgManagerYarn(baseDir: string = process.cwd()): boolean {
+  try {
+    const userAgent = process.env.npm_config_user_agent
+    if (userAgent) {
+      return userAgent.startsWith('yarn')
+    }
+
+    if (fs.existsSync(path.join(baseDir, 'yarn.lock'))) {
+      return true
+    }
+
+    try {
+      execSync('yarn --version', { stdio: 'ignore' })
+      return true
+    } catch {
+      return false
+    }
+  } catch {
+    return false
+  }
+}

--- a/packages/next/src/lib/helpers/get-pkg-manager.ts
+++ b/packages/next/src/lib/helpers/get-pkg-manager.ts
@@ -34,26 +34,3 @@ export function getPkgManager(baseDir: string): PackageManager {
     return 'npm'
   }
 }
-
-// validate if the project is using yarn
-export function isPkgManagerYarn(baseDir: string = process.cwd()): boolean {
-  try {
-    const userAgent = process.env.npm_config_user_agent
-    if (userAgent) {
-      return userAgent.startsWith('yarn')
-    }
-
-    if (fs.existsSync(path.join(baseDir, 'yarn.lock'))) {
-      return true
-    }
-
-    try {
-      execSync('yarn --version', { stdio: 'ignore' })
-      return true
-    } catch {
-      return false
-    }
-  } catch {
-    return false
-  }
-}

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -504,9 +504,6 @@ export async function createHotReloaderTurbopack(
     )
   )
   const overlayMiddleware = getOverlayMiddleware(project)
-  const versionInfo: VersionInfo = await getVersionInfo(
-    isTestMode || opts.telemetry.isEnabled
-  )
 
   const hotReloader: NextJsHotReloaderInterface = {
     turbopackProject: project,
@@ -544,7 +541,7 @@ export async function createHotReloaderTurbopack(
 
     // TODO: Figure out if socket type can match the NextJsHotReloaderInterface
     onHMR(req, socket: Socket, head) {
-      wsServer.handleUpgrade(req, socket, head, (client) => {
+      wsServer.handleUpgrade(req, socket, head, async (client) => {
         const clientIssues: EntryIssuesMap = new Map()
         const subscriptions: Map<string, AsyncIterator<any>> = new Map()
 
@@ -665,6 +662,10 @@ export async function createHotReloaderTurbopack(
             }
           }
         }
+
+        const versionInfo: VersionInfo = await getVersionInfo(
+          isTestMode || opts.telemetry.isEnabled
+        )
 
         const sync: SyncAction = {
           action: HMR_ACTIONS_SENT_TO_BROWSER.SYNC,

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -80,7 +80,6 @@ import {
 } from './turbopack/entry-key'
 import { FAST_REFRESH_RUNTIME_RELOAD } from './messages'
 import { generateEncryptionKeyBase64 } from '../app-render/encryption-utils'
-import type { VersionInfo } from './parse-version-info'
 
 const wsServer = new ws.Server({ noServer: true })
 const isTestMode = !!(
@@ -507,7 +506,6 @@ export async function createHotReloaderTurbopack(
   const versionInfoPromise = getVersionInfo(
     isTestMode || opts.telemetry.isEnabled
   )
-  let versionInfo: VersionInfo | undefined
 
   const hotReloader: NextJsHotReloaderInterface = {
     turbopackProject: project,
@@ -668,9 +666,7 @@ export async function createHotReloaderTurbopack(
         }
 
         ;(async function () {
-          if (!versionInfo) {
-            versionInfo = await versionInfoPromise
-          }
+          const versionInfo = await versionInfoPromise
 
           const sync: SyncAction = {
             action: HMR_ACTIONS_SENT_TO_BROWSER.SYNC,

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -41,7 +41,6 @@ import {
 } from '../lib/render-server'
 import { denormalizePagePath } from '../../shared/lib/page-path/denormalize-page-path'
 import { trace } from '../../trace'
-import type { VersionInfo } from './parse-version-info'
 import {
   AssetMapper,
   type ChangeSubscriptions,
@@ -541,7 +540,7 @@ export async function createHotReloaderTurbopack(
 
     // TODO: Figure out if socket type can match the NextJsHotReloaderInterface
     onHMR(req, socket: Socket, head) {
-      wsServer.handleUpgrade(req, socket, head, async (client) => {
+      wsServer.handleUpgrade(req, socket, head, (client) => {
         const clientIssues: EntryIssuesMap = new Map()
         const subscriptions: Map<string, AsyncIterator<any>> = new Map()
 
@@ -663,19 +662,21 @@ export async function createHotReloaderTurbopack(
           }
         }
 
-        const versionInfo: VersionInfo = await getVersionInfo(
-          isTestMode || opts.telemetry.isEnabled
-        )
+        ;(async function () {
+          const versionInfo = await getVersionInfo(
+            isTestMode || opts.telemetry.isEnabled
+          )
 
-        const sync: SyncAction = {
-          action: HMR_ACTIONS_SENT_TO_BROWSER.SYNC,
-          errors,
-          warnings: [],
-          hash: '',
-          versionInfo,
-        }
+          const sync: SyncAction = {
+            action: HMR_ACTIONS_SENT_TO_BROWSER.SYNC,
+            errors,
+            warnings: [],
+            hash: '',
+            versionInfo,
+          }
 
-        sendToClient(client, sync)
+          sendToClient(client, sync)
+        })()
       })
     },
 

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -667,23 +667,21 @@ export async function createHotReloaderTurbopack(
           }
         }
 
-        if (!versionInfo) {
-          ;(async function () {
+        ;(async function () {
+          if (!versionInfo) {
             versionInfo = await versionInfoPromise
-          })()
-        }
+          }
 
-        versionInfo ??= { installed: '0.0.0', staleness: 'unknown' }
+          const sync: SyncAction = {
+            action: HMR_ACTIONS_SENT_TO_BROWSER.SYNC,
+            errors,
+            warnings: [],
+            hash: '',
+            versionInfo,
+          }
 
-        const sync: SyncAction = {
-          action: HMR_ACTIONS_SENT_TO_BROWSER.SYNC,
-          errors,
-          warnings: [],
-          hash: '',
-          versionInfo,
-        }
-
-        sendToClient(client, sync)
+          sendToClient(client, sync)
+        })()
       })
     },
 

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -62,7 +62,6 @@ import { getProperError } from '../../lib/is-error'
 import ws from 'next/dist/compiled/ws'
 import { existsSync, promises as fs } from 'fs'
 import type { UnwrapPromise } from '../../lib/coalesced-function'
-import { getRegistry } from '../../lib/helpers/get-registry'
 import { parseVersionInfo } from './parse-version-info'
 import type { VersionInfo } from './parse-version-info'
 import { isAPIRoute } from '../../lib/is-api-route'
@@ -202,11 +201,11 @@ export async function getVersionInfo(enabled: boolean): Promise<VersionInfo> {
   try {
     installed = require('next/package.json').version
 
-    const registry = getRegistry()
     let res
 
     try {
-      res = await fetch(`${registry}-/package/next/dist-tags`)
+      // use NPM registry regardless user using Yarn
+      res = await fetch('https://registry.npmjs.org/-/package/next/dist-tags')
     } catch {
       // ignore fetch errors
     }


### PR DESCRIPTION
### Why?

Identified the bottleneck of Turbopack HMR, one of the reason is that we run `execSync` to get user's package manager and fetch their registry to get the latest & canary version of Next.js.
This process was located at the initial of HMR, which could have been delayed to the initial of the error handling.

### How?

- Remove getting user's package manager and just fetch from NPM regardless the user uses Yarn.
- Used an async IIFE to await the promise of `getVerionInfo` value inside the synchronous `ws.handleUpgrade`.

### Benchmark

> Benchmarked with console inside try-finally

#### Webpack -- no cache

| Version                              | Ready |
|-------------------------------------|---------|
| Canary | 1185ms |
| Delta | 896ms |
| Delta Webpack vs Canary Webpack | -24.39% |

#### Turbopack

| Version                              | Ready |
|-------------------------------------|---------|
| Canary | 1002ms |
| Delta (Turbopack) | 509ms |
| Delta Turbopack vs Canary Turbopack | -49.20% |