### PR TITLE
test: add test for `[[double-bracket]]` catch-all segment

### DIFF
--- a/test/e2e/app-dir/optional-route-parameters-are-not-yet-supported-double-bracket/app/[[double-bracket]]/page.tsx
+++ b/test/e2e/app-dir/optional-route-parameters-are-not-yet-supported-double-bracket/app/[[double-bracket]]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/optional-route-parameters-are-not-yet-supported-double-bracket/app/layout.tsx
+++ b/test/e2e/app-dir/optional-route-parameters-are-not-yet-supported-double-bracket/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/optional-route-parameters-are-not-yet-supported-double-bracket/next.config.js
+++ b/test/e2e/app-dir/optional-route-parameters-are-not-yet-supported-double-bracket/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/optional-route-parameters-are-not-yet-supported-double-bracket/optional-route-parameters-are-not-yet-supported-double-bracket.test.ts
+++ b/test/e2e/app-dir/optional-route-parameters-are-not-yet-supported-double-bracket/optional-route-parameters-are-not-yet-supported-double-bracket.test.ts
@@ -1,0 +1,32 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('optional-route-parameters-are-not-yet-supported-double-bracket', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
+  it('should work using cheerio', async () => {
+    const $ = await next.render$('/')
+    expect($('p').text()).toBe('hello world')
+  })
+
+  // Recommended for tests that need a full browser
+  it('should work using browser', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('p').text()).toBe('hello world')
+  })
+
+  // In case you need the full HTML. Can also use $.html() with cheerio.
+  it('should work with html', async () => {
+    const html = await next.render('/')
+    expect(html).toContain('hello world')
+  })
+
+  // In case you need to test the response object
+  it('should work with fetch', async () => {
+    const res = await next.fetch('/')
+    const html = await res.text()
+    expect(html).toContain('hello world')
+  })
+})


### PR DESCRIPTION
Found duplicate on unit test:

https://github.com/vercel/next.js/blob/b9bd23baec14508400c502b3651f4cf2497e883b/test/unit/page-route-sorter.test.ts#L153-L169