### PR TITLE
perf: Optmize `react_server_component` transform

### DIFF
--- a/packages/next-swc/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, path::PathBuf, rc::Rc};
 
 use regex::Regex;
 use serde::Deserialize;
@@ -52,7 +52,7 @@ struct ReactServerComponents<C: Comments> {
     filepath: String,
     app_dir: Option<PathBuf>,
     comments: C,
-    directive_import_collection: Option<(bool, bool, Vec<ModuleImports>, Vec<String>)>,
+    directive_import_collection: Option<(bool, bool, Rc<Vec<ModuleImports>>, Rc<Vec<String>>)>,
 }
 
 #[derive(Clone, Debug)]
@@ -475,7 +475,7 @@ struct ReactServerComponentValidator {
     invalid_server_lib_apis_mapping: HashMap<&'static str, Vec<&'static str>>,
     invalid_client_imports: Vec<JsWord>,
     invalid_client_lib_apis_mapping: HashMap<&'static str, Vec<&'static str>>,
-    pub directive_import_collection: Option<(bool, bool, Vec<ModuleImports>, Vec<String>)>,
+    pub directive_import_collection: Option<(bool, bool, Rc<Vec<ModuleImports>>, Rc<Vec<String>>)>,
 }
 
 impl ReactServerComponentValidator {
@@ -784,6 +784,8 @@ impl Visit for ReactServerComponentValidator {
     fn visit_module(&mut self, module: &Module) {
         let (is_client_entry, is_action_file, imports, export_names) =
             collect_top_level_directives_and_imports(&self.app_dir, &self.filepath, module);
+        let imports = Rc::new(imports);
+        let export_names = Rc::new(export_names);
 
         self.directive_import_collection = Some((
             is_client_entry,

--- a/packages/next-swc/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/packages/next-swc/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -52,7 +52,7 @@ struct ReactServerComponents<C: Comments> {
     filepath: String,
     app_dir: Option<PathBuf>,
     comments: C,
-    directive_import_collection: Option<(bool, bool, Rc<Vec<ModuleImports>>, Rc<Vec<String>>)>,
+    directive_import_collection: Option<(bool, bool, RcVec<ModuleImports>, RcVec<String>)>,
 }
 
 #[derive(Clone, Debug)]
@@ -475,8 +475,11 @@ struct ReactServerComponentValidator {
     invalid_server_lib_apis_mapping: HashMap<&'static str, Vec<&'static str>>,
     invalid_client_imports: Vec<JsWord>,
     invalid_client_lib_apis_mapping: HashMap<&'static str, Vec<&'static str>>,
-    pub directive_import_collection: Option<(bool, bool, Rc<Vec<ModuleImports>>, Rc<Vec<String>>)>,
+    pub directive_import_collection: Option<(bool, bool, RcVec<ModuleImports>, RcVec<String>)>,
 }
+
+// A type to workaround a clippy warning.
+type RcVec<T> = Rc<Vec<T>>;
 
 impl ReactServerComponentValidator {
     pub fn new(is_react_server_layer: bool, filename: String, app_dir: Option<PathBuf>) -> Self {


### PR DESCRIPTION
### What?

 - Use `Rc` instead of cloning vector.
 - Use faster hash algorithm.

### Why?

`react_server_component` showed up in the profiling result.

### How?

Closes PACK-3120
