### PR TITLE
chore: add `swc-build-native` script at root package.json

### DIFF
--- a/contributing/core/building.md
+++ b/contributing/core/building.md
@@ -6,7 +6,7 @@ You can build Next.js, including all type definitions and packages, with:
 pnpm build
 ```
 
-By default, the latest canary of the `next-swc` binaries will be installed and used. If you are actively working on Rust code or you need to test out the most recent Rust code that hasn't been published as a canary yet, you can [install Rust](https://www.rust-lang.org/tools/install) and run `pnpm --filter=@next/swc build-native`.
+By default, the latest canary of the `next-swc` binaries will be installed and used. If you are actively working on Rust code or you need to test out the most recent Rust code that hasn't been published as a canary yet, you can [install Rust](https://www.rust-lang.org/tools/install) and run `pnpm swc-build-native`.
 
 If you want to test out the wasm build locally, you will need to [install wasm-pack](https://rustwasm.github.io/wasm-pack/installer/). Run `pnpm --filter=@next/swc build-wasm --target <wasm_target>` to build and `node ./scripts/setup-wasm.mjs` to copy it into your `node_modules`. Run next with `NODE_OPTIONS='--no-addons'` to force it to use the wasm binary.
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "version": "pnpm install --no-frozen-lockfile && IS_PUBLISH=yes ./scripts/check-pre-compiled.sh && git add .",
     "prepare": "husky",
     "sync-react": "node ./scripts/sync-react.js",
-    "update-google-fonts": "node ./scripts/update-google-fonts.js"
+    "update-google-fonts": "node ./scripts/update-google-fonts.js",
+    "swc-build-native": "pnpm --filter=@next/swc build-native"
   },
   "devDependencies": {
     "@actions/core": "1.10.1",


### PR DESCRIPTION
When developing in Next.js repo, the maintainers / contributors sometimes need to build swc native files.

Added a script `swc-build-native` to run the command `pnpm --filter=@next/swc build-native` which was verbose to run.