### PR TITLE
chore: throw when three dot character is detected in segment

### DIFF
--- a/packages/next/src/shared/lib/router/utils/sorted-routes.ts
+++ b/packages/next/src/shared/lib/router/utils/sorted-routes.ts
@@ -94,6 +94,12 @@ class UrlNode {
         isOptional = true
       }
 
+      if (segmentName.startsWith('…')) {
+        throw new Error(
+          `Detected a three-dot character ('…') at ('${segmentName}'). Did you mean ('...')?`
+        )
+      }
+
       if (segmentName.startsWith('...')) {
         // Strip `...`, leaving only `something`
         segmentName = segmentName.substring(3)

--- a/test/unit/page-route-sorter.test.ts
+++ b/test/unit/page-route-sorter.test.ts
@@ -213,4 +213,10 @@ describe('getSortedRoutes', () => {
       ])
     ).toThrow(/differ only by non-word/)
   })
+
+  it('catches param names start with three-dot character not actual three dots', () => {
+    expect(() => getSortedRoutes(['[…three-dots]'])).toThrow(
+      /Detected a three-dot character/
+    )
+  })
 })


### PR DESCRIPTION
### Why?

It could be confusing between `...` and `…`, which the later is actually a single character.

### How?

We throw if we detect `…` instead of `...`.