### PR TITLE
prefetch fetches should be priority: low

### DIFF
--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -102,10 +102,16 @@ export async function fetchServerResponse(
     // Add unique cache query to avoid caching conflicts on CDN which don't respect to Vary header
     fetchUrl.searchParams.set(NEXT_RSC_UNION_QUERY, uniqueCacheQuery)
 
+    // https://vercel.slack.com/archives/C03S8ED1DKM/p1719791391728039
+    // Prefetches should be priority: "low"
+    // Navigations not reusing a prefetch should be priority: "high"
+    const priority = typeof prefetchKind === 'undefined' ? 'high' : 'low'
+
     const res = await fetch(fetchUrl, {
       // Backwards compat for older browsers. `same-origin` is the default in modern browsers.
       credentials: 'same-origin',
       headers,
+      priority,
     })
 
     const responseUrl = urlToUrlWithoutFlightMarker(res.url)


### PR DESCRIPTION
### What?

Any page with a large number of prefetched links are congesting the network because prefetch fetches have a `priority` set to `high`.   This blocks any client-side navigation when that navigation was initiated before the page had time to fetch all of its resources / prefetches.  

This change sets the `fetch` priority to `low` for any prefetch mechanism and defaults to `high` otherwise (when there's no prefetch) set.

