### PR TITLE
use fetch priority for app prefetches

### DIFF
--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -56,6 +56,8 @@ export async function fetchServerResponse(
     [NEXT_ROUTER_STATE_TREE]: string
     [NEXT_URL]?: string
     [NEXT_ROUTER_PREFETCH_HEADER]?: '1'
+    // A header that is only added in test mode to assert on fetch priority
+    'Next-Test-Fetch-Priority'?: RequestInit['priority']
   } = {
     // Enable flight response
     [RSC_HEADER]: '1',
@@ -99,13 +101,28 @@ export async function fetchServerResponse(
       }
     }
 
-    // Add unique cache query to avoid caching conflicts on CDN which don't respect to Vary header
+    // Add unique cache query to avoid caching conflicts on CDN which don't respect the Vary header
     fetchUrl.searchParams.set(NEXT_RSC_UNION_QUERY, uniqueCacheQuery)
+
+    // When creating a "temporary" prefetch (e.g., one that is automatically created if one doesn't exist)
+    // we send the request with a "high" priority as it's in response to a user interaction that could be blocking a transition.
+    // Otherwise, all other prefetches are sent with a "low" priority.
+    // We use "auto" for in all other cases to match the existing default, as this function is shared outside of prefetching.
+    const fetchPriority = prefetchKind
+      ? prefetchKind === PrefetchKind.TEMPORARY
+        ? 'high'
+        : 'low'
+      : 'auto'
+
+    if (process.env.__NEXT_TEST_MODE) {
+      headers['Next-Test-Fetch-Priority'] = fetchPriority
+    }
 
     const res = await fetch(fetchUrl, {
       // Backwards compat for older browsers. `same-origin` is the default in modern browsers.
       credentials: 'same-origin',
       headers,
+      priority: fetchPriority,
     })
 
     const responseUrl = urlToUrlWithoutFlightMarker(res.url)

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -104,7 +104,7 @@ export async function fetchServerResponse(
     // Add unique cache query to avoid caching conflicts on CDN which don't respect the Vary header
     fetchUrl.searchParams.set(NEXT_RSC_UNION_QUERY, uniqueCacheQuery)
 
-    // When creating a "temporary" prefetch (e.g., one that is automatically created if one doesn't exist)
+    // When creating a "temporary" prefetch (the "on-demand" prefetch that gets created on navigation, if one doesn't exist)
     // we send the request with a "high" priority as it's in response to a user interaction that could be blocking a transition.
     // Otherwise, all other prefetches are sent with a "low" priority.
     // We use "auto" for in all other cases to match the existing default, as this function is shared outside of prefetching.


### PR DESCRIPTION
This leverages [fetch priority](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#priority) to ensure automatic prefetching as a result of visiting a page is sent with "low" priority, to signal to the browser it can prioritize more important work necessary for rendering the page.

A "temporary" prefetch (ie one that is created when there wasn't an existing prefetch cache entry on navigation) will use a "high" priority because it's critical to the navigation event. 

All other cases will be "auto" which is the current default. 