### PR TITLE
refactor: ensure `generateStaticParams` return an Array and `generateMetadata` does not

### DIFF
--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -355,9 +355,20 @@ async function getDefinedMetadata(
             'next.page': route,
           },
         },
-        () => mod.generateMetadata(props, parent)
+        () => {
+          if (Array.isArray(mod.generateMetadata(props, parent))) {
+            throw new Error(
+              'The return type of generateMetadata must be a non-Array object'
+            )
+          }
+          return mod.generateMetadata(props, parent)
+        }
       )
   }
+  if (Array.isArray(mod.metadata)) {
+    throw new Error('The return type of metadata must be a non-Array object')
+  }
+
   return mod.metadata || null
 }
 

--- a/test/e2e/app-dir/metadata-return-array/app/[id]/page.tsx
+++ b/test/e2e/app-dir/metadata-return-array/app/[id]/page.tsx
@@ -1,0 +1,12 @@
+export default function Page() {
+  return <p>hello world</p>
+}
+
+export async function generateMetadata() {
+  return [
+    {
+      title: 'hello world',
+      description: 'returned as an array',
+    },
+  ]
+}

--- a/test/e2e/app-dir/metadata-return-array/app/layout.tsx
+++ b/test/e2e/app-dir/metadata-return-array/app/layout.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}
+
+export const metadata = [
+  {
+    title: 'hello world',
+    description: 'returned as an array',
+  },
+]

--- a/test/e2e/app-dir/metadata-return-array/app/page.tsx
+++ b/test/e2e/app-dir/metadata-return-array/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/metadata-return-array/metadata-return-array.test.ts
+++ b/test/e2e/app-dir/metadata-return-array/metadata-return-array.test.ts
@@ -1,0 +1,45 @@
+import { nextTestSetup } from 'e2e-utils'
+import { check } from 'next-test-utils'
+
+describe('metadata-return-array', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    // we skip start & deploy because the build will fail and we won't be able to catch it
+    // start is re-triggered but caught in the assertions below.
+    skipStart: true,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should throw if metadata returns an Array object', async () => {
+    if (isNextDev) {
+      await next.start()
+      const html = await next.render('/')
+
+      expect(html).toContain(
+        'The return type of metadata must be a non-Array object'
+      )
+    } else {
+      await expect(next.start()).rejects.toThrow('next build failed')
+
+      await check(
+        () => next.cliOutput,
+        /The return type of metadata must be a non-Array object/
+      )
+    }
+  })
+  it('should throw if generateMetadata returns an Array object', async () => {
+    if (isNextDev) {
+      await next.start()
+      const html = await next.render('/1')
+
+      expect(html).toContain(
+        'The return type of generateMetadata must be a non-Array object'
+      )
+    }
+    // it will throw before reach building /1
+  })
+})

--- a/test/e2e/app-dir/metadata-return-array/next.config.js
+++ b/test/e2e/app-dir/metadata-return-array/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
### Why?

It could be confusing for the users since `generateStaticParams` requires to return an Array and the `generateMetadata` to return a non-Array object.

### How?

Throw if the expected object type is not given.