### PR TITLE
refactor: type check return type of generateMetadata

### DIFF
--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
@@ -51,7 +51,7 @@ import * as entry from '${relativePath}.js'
 ${
   options.type === 'route'
     ? `import type { NextRequest } from 'next/server.js'`
-    : `import type { ResolvingMetadata, ResolvingViewport } from 'next/dist/lib/metadata/types/metadata-interface.js'`
+    : `import type { Metadata, ResolvingMetadata, ResolvingViewport } from 'next/dist/lib/metadata/types/metadata-interface.js'`
 }
 
 type TEntry = typeof import('${relativePath}.js')
@@ -145,6 +145,7 @@ if ('generateMetadata' in entry) {
     options.type === 'page' ? 'PageProps' : 'LayoutProps'
   }, FirstArg<MaybeField<TEntry, 'generateMetadata'>>, 'generateMetadata'>>()
   checkFields<Diff<ResolvingMetadata, SecondArg<MaybeField<TEntry, 'generateMetadata'>>, 'generateMetadata'>>()
+  checkFields<Diff<{ __tag__: 'generateMetadata', __return_type__: Metadata }, { __tag__: 'generateMetadata', __return_type__: ReturnType<MaybeField<TEntry, 'generateMetadata'>> }>>()
 }
 
 // Check the arguments and return type of the generateViewport function

--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
@@ -145,7 +145,7 @@ if ('generateMetadata' in entry) {
     options.type === 'page' ? 'PageProps' : 'LayoutProps'
   }, FirstArg<MaybeField<TEntry, 'generateMetadata'>>, 'generateMetadata'>>()
   checkFields<Diff<ResolvingMetadata, SecondArg<MaybeField<TEntry, 'generateMetadata'>>, 'generateMetadata'>>()
-  checkFields<Diff<{ __tag__: 'generateMetadata', __return_type__: Metadata }, { __tag__: 'generateMetadata', __return_type__: ReturnType<MaybeField<TEntry, 'generateMetadata'>> }>>()
+  checkFields<Diff<{ __tag__: 'generateMetadata', __return_type__: Metadata | Promise<Metadata> }, { __tag__: 'generateMetadata', __return_type__: ReturnType<MaybeField<TEntry, 'generateMetadata'>> }>>()
 }
 
 // Check the arguments and return type of the generateViewport function

--- a/test/integration/app-types/app-types.test.js
+++ b/test/integration/app-types/app-types.test.js
@@ -83,6 +83,11 @@ describe('app type checking', () => {
 
         // Avoid invalid return types for exported functions.
         expect(errors).toContain(
+          `"Promise<number>" is not a valid generateMetadata return type`
+        )
+
+        // Avoid invalid return types for exported functions.
+        expect(errors).toContain(
           `"Promise<number>" is not a valid generateStaticParams return type`
         )
 

--- a/test/integration/app-types/src/app/type-checks/config/page.tsx
+++ b/test/integration/app-types/src/app/type-checks/config/page.tsx
@@ -5,7 +5,9 @@ export async function generateStaticParams(s: string) {
   return 1
 }
 
-async function generateMetadata({ s }: { s: number }) {}
+async function generateMetadata({ s }: { s: number }) {
+  return 1
+}
 export { generateMetadata }
 
 export const foo = 'bar'


### PR DESCRIPTION
### Why?

It could be confusing for the users since `generateStaticParams` requires to return an Array and the `generateMetadata` to return a non-Array object.

We do have a type check, but did not have one for strict checking on the return type of `generateStaticParams`.

### How?

Type check if the returned object type is not `Promise<Metadata>`.