### PR TITLE
avoid merging global css in a way that leaks into other chunk groups

### DIFF
--- a/test/e2e/app-dir/css-order/app/base.css
+++ b/test/e2e/app-dir/css-order/app/base.css
@@ -1,0 +1,3 @@
+#hello {
+  color: rgb(255, 0, 0);
+}

--- a/test/e2e/app-dir/css-order/app/base.css
+++ b/test/e2e/app-dir/css-order/app/base.css
@@ -1,3 +1,4 @@
-#hello {
+#hello1,
+#hello2 {
   color: rgb(255, 0, 0);
 }

--- a/test/e2e/app-dir/css-order/app/global-first/page.tsx
+++ b/test/e2e/app-dir/css-order/app/global-first/page.tsx
@@ -5,7 +5,7 @@ import Nav from '../nav'
 export default function Page() {
   return (
     <div>
-      <p id="hello">hello world</p>
+      <p id="hello1">hello world</p>
       <Nav />
     </div>
   )

--- a/test/e2e/app-dir/css-order/app/global-first/page.tsx
+++ b/test/e2e/app-dir/css-order/app/global-first/page.tsx
@@ -1,0 +1,12 @@
+import '../base.css'
+import './style.css'
+import Nav from '../nav'
+
+export default function Page() {
+  return (
+    <div>
+      <p id="hello">hello world</p>
+      <Nav />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/css-order/app/global-first/style.css
+++ b/test/e2e/app-dir/css-order/app/global-first/style.css
@@ -1,3 +1,4 @@
-#hello {
+#hello1,
+#hello2 {
   color: rgb(0, 255, 0);
 }

--- a/test/e2e/app-dir/css-order/app/global-first/style.css
+++ b/test/e2e/app-dir/css-order/app/global-first/style.css
@@ -1,0 +1,3 @@
+#hello {
+  color: rgb(0, 255, 0);
+}

--- a/test/e2e/app-dir/css-order/app/global-second/page.tsx
+++ b/test/e2e/app-dir/css-order/app/global-second/page.tsx
@@ -5,7 +5,7 @@ import Nav from '../nav'
 export default function Page() {
   return (
     <div>
-      <p id="hello">hello world</p>
+      <p id="hello2">hello world</p>
       <Nav />
     </div>
   )

--- a/test/e2e/app-dir/css-order/app/global-second/page.tsx
+++ b/test/e2e/app-dir/css-order/app/global-second/page.tsx
@@ -1,0 +1,12 @@
+import '../base.css'
+import './style.css'
+import Nav from '../nav'
+
+export default function Page() {
+  return (
+    <div>
+      <p id="hello">hello world</p>
+      <Nav />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/css-order/app/global-second/style.css
+++ b/test/e2e/app-dir/css-order/app/global-second/style.css
@@ -1,3 +1,4 @@
-#hello {
+#hello1,
+#hello2 {
   color: rgb(0, 0, 255);
 }

--- a/test/e2e/app-dir/css-order/app/global-second/style.css
+++ b/test/e2e/app-dir/css-order/app/global-second/style.css
@@ -1,0 +1,3 @@
+#hello {
+  color: rgb(0, 0, 255);
+}

--- a/test/e2e/app-dir/css-order/app/nav.tsx
+++ b/test/e2e/app-dir/css-order/app/nav.tsx
@@ -70,6 +70,16 @@ export default function Nav() {
             Partial Reversed B
           </Link>
         </li>
+        <li>
+          <Link href={'/global-first'} id="global-first">
+            Global First
+          </Link>
+        </li>
+        <li>
+          <Link href={'/global-second'} id="global-second">
+            Global Second
+          </Link>
+        </li>
       </ul>
       <h3>Pages</h3>
       <ul>

--- a/test/e2e/app-dir/css-order/css-order.test.ts
+++ b/test/e2e/app-dir/css-order/css-order.test.ts
@@ -183,6 +183,20 @@ const PAGES: Record<
     color: 'rgb(255, 55, 255)',
     background: 'rgba(0, 0, 0, 0)',
   },
+  'global-first': {
+    group: 'global',
+    conflict: true,
+    url: '/global-first',
+    selector: '#hello',
+    color: 'rgb(0, 255, 0)',
+  },
+  'global-second': {
+    group: 'global',
+    conflict: true,
+    url: '/global-second',
+    selector: '#hello',
+    color: 'rgb(0, 0, 255)',
+  },
 }
 
 const allPairs = getPairs(Object.keys(PAGES))

--- a/test/e2e/app-dir/css-order/css-order.test.ts
+++ b/test/e2e/app-dir/css-order/css-order.test.ts
@@ -187,14 +187,14 @@ const PAGES: Record<
     group: 'global',
     conflict: true,
     url: '/global-first',
-    selector: '#hello',
+    selector: '#hello1',
     color: 'rgb(0, 255, 0)',
   },
   'global-second': {
     group: 'global',
     conflict: true,
     url: '/global-second',
-    selector: '#hello',
+    selector: '#hello2',
     color: 'rgb(0, 0, 255)',
   },
 }


### PR DESCRIPTION
### What?

This disallows merging of global css with styles that appear on other pages/chunk groups.

### Why?

Before we made the assumption that all CSS is written in a way that it only affects the elements it should really affect.

In general writing CSS in that way is recommended. In App Router styles are only added and never removed. This means when a user uses client-side navigations to navigate the application, styles from all previous pages are still active on the current page. To avoid visual artefacts one need to write CSS in a way that it only affects certain elements. Usually this can be archived by using class names. CSS Modules even enforce this recommendation.

Assuming that all styles are written this way allows to optimize CSS loading as request count can be reduced when (small) styles are merged together.

But turns out that some applications are written differently. They use global styles that are not scoped to a class name (e. g. to `body` directly instead) and use them in different sections of the application. They are structured in a way that doesn't allow client-side navigations between these sections. This should be valid too, which makes our assumption not always holding true.

This PR changes the algorithm so we only make that assumption for CSS Modules, but not for global CSS. While this affects the ability to optimize, applications usually do not use too much global CSS files, so that can be accepted.

fixes #64773