### PR TITLE
perf(turbopack): improve app structure performance

### DIFF
--- a/crates/next-core/src/app_segment_config.rs
+++ b/crates/next-core/src/app_segment_config.rs
@@ -1,6 +1,7 @@
 use std::ops::Deref;
 
 use anyhow::{bail, Result};
+use async_recursion::async_recursion;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use swc_core::{
@@ -470,20 +471,33 @@ fn parse_config_value(
 pub async fn parse_segment_config_from_loader_tree(
     loader_tree: Vc<LoaderTree>,
 ) -> Result<Vc<NextSegmentConfig>> {
-    let loader_tree = loader_tree.await?;
-    let components = loader_tree.components.await?;
+    let loader_tree = &*loader_tree.await?;
+
+    parse_segment_config_from_loader_tree_internal(loader_tree).await
+}
+
+#[async_recursion]
+pub async fn parse_segment_config_from_loader_tree_internal(
+    loader_tree: &LoaderTree,
+) -> Result<Vc<NextSegmentConfig>> {
     let mut config = NextSegmentConfig::default();
+
     let parallel_configs = loader_tree
         .parallel_routes
         .values()
-        .copied()
-        .map(parse_segment_config_from_loader_tree)
+        .map(|loader_tree| async move {
+            parse_segment_config_from_loader_tree_internal(loader_tree)
+                .await?
+                .await
+        })
         .try_join()
         .await?;
+
     for tree in parallel_configs {
         config.apply_parallel_config(&tree)?;
     }
 
+    let components = &loader_tree.components;
     for component in [components.page, components.default, components.layout]
         .into_iter()
         .flatten()

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 
 use anyhow::{bail, Context, Result};
-use async_recursion::async_recursion;
 use indexmap::{
     indexmap,
     map::{Entry, OccupiedEntry},
@@ -71,17 +70,6 @@ impl Components {
             route: None,
             metadata: self.metadata.clone(),
         }
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Components {
-    /// Returns a completion that changes when any route in the components
-    /// changes.
-    #[turbo_tasks::function]
-    pub async fn routes_changed(self: Vc<Self>) -> Result<Vc<Completion>> {
-        self.await?;
-        Ok(Completion::new())
     }
 }
 
@@ -217,7 +205,15 @@ impl GlobalMetadata {
 pub struct DirectoryTree {
     /// key is e.g. "dashboard", "(dashboard)", "@slot"
     pub subdirectories: BTreeMap<RcStr, Vc<DirectoryTree>>,
-    pub components: Vc<Components>,
+    pub components: Components,
+}
+
+#[turbo_tasks::value]
+#[derive(Clone, Debug)]
+struct PlainDirectoryTree {
+    /// key is e.g. "dashboard", "(dashboard)", "@slot"
+    pub subdirectories: BTreeMap<RcStr, PlainDirectoryTree>,
+    pub components: Components,
 }
 
 #[turbo_tasks::value_impl]
@@ -225,17 +221,28 @@ impl DirectoryTree {
     /// Returns a completion that changes when any route in the whole tree
     /// changes.
     #[turbo_tasks::function]
-    pub async fn routes_changed(self: Vc<Self>) -> Result<Vc<Completion>> {
-        let DirectoryTree {
-            subdirectories,
-            components,
-        } = &*self.await?;
+    pub async fn routes_changed(&self) -> Result<Vc<Completion>> {
         let mut children = Vec::new();
-        children.push(components.routes_changed());
-        for child in subdirectories.values() {
+        children.push(Completion::new());
+        for child in self.subdirectories.values() {
             children.push(child.routes_changed());
         }
         Ok(Vc::<Completions>::cell(children).completed())
+    }
+
+    #[turbo_tasks::function]
+    pub async fn into_plain(&self) -> Result<Vc<PlainDirectoryTree>> {
+        let mut subdirectories = BTreeMap::new();
+
+        for (name, subdirectory) in &self.subdirectories {
+            subdirectories.insert(name.clone(), subdirectory.into_plain().await?.clone_value());
+        }
+
+        Ok(PlainDirectoryTree {
+            subdirectories,
+            components: self.components.clone(),
+        }
+        .cell())
     }
 }
 
@@ -308,7 +315,7 @@ async fn get_directory_tree_internal(
         // so we just return an empty tree here.
         return Ok(DirectoryTree {
             subdirectories: Default::default(),
-            components: Components::default().cell(),
+            components: Components::default(),
         }
         .cell());
     };
@@ -421,7 +428,7 @@ async fn get_directory_tree_internal(
 
     Ok(DirectoryTree {
         subdirectories,
-        components: components.cell(),
+        components,
     }
     .cell())
 }
@@ -431,44 +438,41 @@ async fn get_directory_tree_internal(
 pub struct LoaderTree {
     pub page: AppPage,
     pub segment: RcStr,
-    pub parallel_routes: IndexMap<RcStr, Vc<LoaderTree>>,
-    pub components: Vc<Components>,
+    pub parallel_routes: IndexMap<RcStr, LoaderTree>,
+    pub components: Components,
     pub global_metadata: Vc<GlobalMetadata>,
 }
 
-#[turbo_tasks::value_impl]
 impl LoaderTree {
     /// Returns true if there's a page match in this loader tree.
-    #[turbo_tasks::function]
-    pub async fn has_page(&self) -> Result<Vc<bool>> {
+    pub fn has_page(&self) -> bool {
         if &*self.segment == "__PAGE__" {
-            return Ok(Vc::cell(true));
+            return true;
         }
 
         for (_, tree) in &self.parallel_routes {
-            if *tree.has_page().await? {
-                return Ok(Vc::cell(true));
+            if tree.has_page() {
+                return true;
             }
         }
 
-        Ok(Vc::cell(false))
+        false
     }
 
     /// Returns whether or not the only match in this tree is for a catch-all
     /// route.
-    #[turbo_tasks::function]
-    pub async fn has_only_catchall(&self) -> Result<Vc<bool>> {
+    pub fn has_only_catchall(&self) -> bool {
         if &*self.segment == "__PAGE__" && !self.page.is_catchall() {
-            return Ok(Vc::cell(false));
+            return false;
         }
 
         for (_, tree) in &self.parallel_routes {
-            if !*tree.has_only_catchall().await? {
-                return Ok(Vc::cell(false));
+            if !tree.has_only_catchall() {
+                return false;
             }
         }
 
-        Ok(Vc::cell(true))
+        true
     }
 }
 
@@ -560,12 +564,12 @@ fn conflict_issue(
     .emit();
 }
 
-async fn add_app_page(
+fn add_app_page(
     app_dir: Vc<FileSystemPath>,
     result: &mut IndexMap<AppPath, Entrypoint>,
     page: AppPage,
     loader_tree: Vc<LoaderTree>,
-) -> Result<()> {
+) {
     let mut e = match result.entry(page.clone().into()) {
         Entry::Occupied(e) => e,
         Entry::Vacant(e) => {
@@ -573,7 +577,7 @@ async fn add_app_page(
                 pages: vec![page],
                 loader_tree,
             });
-            return Ok(());
+            return;
         }
     };
 
@@ -617,8 +621,6 @@ async fn add_app_page(
             conflict("metadata", existing_page);
         }
     }
-
-    Ok(())
 }
 
 fn add_app_route(
@@ -760,10 +762,7 @@ impl Issue for DuplicateParallelRouteIssue {
     }
 }
 
-#[async_recursion]
-async fn page_path_except_parallel(loader_tree: Vc<LoaderTree>) -> Result<Option<AppPage>> {
-    let loader_tree = loader_tree.await?;
-
+fn page_path_except_parallel(loader_tree: &LoaderTree) -> Option<AppPage> {
     if loader_tree.page.iter().any(|v| {
         matches!(
             v,
@@ -772,28 +771,26 @@ async fn page_path_except_parallel(loader_tree: Vc<LoaderTree>) -> Result<Option
                 | PageSegment::Parallel(..)
         )
     }) {
-        return Ok(None);
+        return None;
     }
 
-    if loader_tree.components.await?.page.is_some() {
-        return Ok(Some(loader_tree.page.clone()));
+    if loader_tree.components.page.is_some() {
+        return Some(loader_tree.page.clone());
     }
 
     if let Some(children) = loader_tree.parallel_routes.get("children") {
-        return page_path_except_parallel(*children).await;
+        return page_path_except_parallel(children);
     }
 
-    Ok(None)
+    None
 }
 
-async fn check_duplicate(
+fn check_duplicate(
     duplicate: &mut FxHashMap<AppPath, AppPage>,
-    loader_tree_vc: Vc<LoaderTree>,
+    loader_tree: &LoaderTree,
     app_dir: Vc<FileSystemPath>,
-) -> Result<()> {
-    let loader_tree = loader_tree_vc.await?;
-
-    let page_path = page_path_except_parallel(loader_tree_vc).await?;
+) {
+    let page_path = page_path_except_parallel(loader_tree);
 
     if let Some(page_path) = page_path {
         if let Some(prev) = duplicate.insert(AppPath::from(page_path.clone()), page_path.clone()) {
@@ -807,8 +804,6 @@ async fn check_duplicate(
             }
         }
     }
-
-    Ok(())
 }
 
 /// creates the loader tree for a specific route (pathname / [AppPath])
@@ -822,14 +817,36 @@ async fn directory_tree_to_loader_tree(
     // the page this loader tree is constructed for
     for_app_path: AppPath,
 ) -> Result<Vc<Option<Vc<LoaderTree>>>> {
+    let plain_tree = &*directory_tree.into_plain().await?;
+
+    let tree = directory_tree_to_loader_tree_internal(
+        app_dir,
+        global_metadata,
+        directory_name,
+        plain_tree,
+        app_page,
+        for_app_path,
+    )?;
+
+    Ok(Vc::cell(tree.map(|tree| tree.cell())))
+}
+
+fn directory_tree_to_loader_tree_internal(
+    app_dir: Vc<FileSystemPath>,
+    global_metadata: Vc<GlobalMetadata>,
+    directory_name: RcStr,
+    directory_tree: &PlainDirectoryTree,
+    app_page: AppPage,
+    // the page this loader tree is constructed for
+    for_app_path: AppPath,
+) -> Result<Option<LoaderTree>> {
     let app_path = AppPath::from(app_page.clone());
 
     if !for_app_path.contains(&app_path) {
-        return Ok(Vc::cell(None));
+        return Ok(None);
     }
 
-    let directory_tree = &*directory_tree.await?;
-    let mut components = directory_tree.components.await?.clone_value();
+    let mut components = directory_tree.components.clone();
 
     // Capture the current page for the metadata to calculate segment relative to
     // the corresponding page for the static metadata files.
@@ -857,7 +874,7 @@ async fn directory_tree_to_loader_tree(
         page: app_page.clone(),
         segment: directory_name.clone(),
         parallel_routes: IndexMap::new(),
-        components: components.without_leafs().cell(),
+        components: components.without_leafs(),
         global_metadata,
     };
 
@@ -881,11 +898,9 @@ async fn directory_tree_to_loader_tree(
                     page: Some(page),
                     metadata: components.metadata,
                     ..Default::default()
-                }
-                .cell(),
+                },
                 global_metadata,
-            }
-            .cell(),
+            },
         );
 
         if current_level_is_parallel_route {
@@ -909,17 +924,16 @@ async fn directory_tree_to_loader_tree(
             illegal_path_error = Some(e);
         }
 
-        let subtree = *directory_tree_to_loader_tree(
+        let subtree = directory_tree_to_loader_tree_internal(
             app_dir,
             global_metadata,
             subdir_name.clone(),
-            *subdirectory,
+            subdirectory,
             child_app_page.clone(),
             for_app_path.clone(),
-        )
-        .await?;
+        )?;
 
-        if let Some(illegal_path) = subtree.and(illegal_path_error) {
+        if let Some(illegal_path) = subtree.as_ref().and(illegal_path_error) {
             return Err(illegal_path);
         }
 
@@ -930,19 +944,19 @@ async fn directory_tree_to_loader_tree(
             }
 
             // skip groups which don't have a page match.
-            if is_group_route(subdir_name) && !*subtree.has_page().await? {
+            if is_group_route(subdir_name) && !subtree.has_page() {
                 continue;
             }
 
-            if *subtree.has_page().await? {
-                check_duplicate(&mut duplicate, subtree, app_dir).await?;
+            if subtree.has_page() {
+                check_duplicate(&mut duplicate, &subtree, app_dir);
             }
 
             if let Some(current_tree) = tree.parallel_routes.get("children") {
-                if is_current_directory_catchall && *subtree.has_only_catchall().await? {
+                if is_current_directory_catchall && subtree.has_only_catchall() {
                     // there's probably already a more specific page in the
                     // slot.
-                } else if *current_tree.has_only_catchall().await? {
+                } else if current_tree.has_only_catchall() {
                     tree.parallel_routes.insert("children".into(), subtree);
                 } else {
                     // TODO: Investigate if this is still needed. Emitting the
@@ -982,8 +996,7 @@ async fn directory_tree_to_loader_tree(
             tree.components = Components {
                 default: Some(default),
                 ..Default::default()
-            }
-            .cell();
+            };
         } else if current_level_is_parallel_route {
             // default fallback component
             tree.components = Components {
@@ -992,10 +1005,9 @@ async fn directory_tree_to_loader_tree(
                         .join("dist/client/components/parallel-route-default.js".into()),
                 ),
                 ..Default::default()
-            }
-            .cell();
+            };
         } else {
-            return Ok(Vc::cell(None));
+            return Ok(None);
         }
     } else if tree.parallel_routes.get("children").is_none() {
         tree.parallel_routes.insert(
@@ -1009,7 +1021,6 @@ async fn directory_tree_to_loader_tree(
                         default: Some(default),
                         ..Default::default()
                     }
-                    .cell()
                 } else {
                     // default fallback component
                     Components {
@@ -1019,11 +1030,9 @@ async fn directory_tree_to_loader_tree(
                         ),
                         ..Default::default()
                     }
-                    .cell()
                 },
                 global_metadata,
-            }
-            .cell(),
+            },
         );
     }
 
@@ -1035,7 +1044,7 @@ async fn directory_tree_to_loader_tree(
             .move_index(tree.parallel_routes.len() - 1, 0);
     }
 
-    Ok(Vc::cell(Some(tree.cell())))
+    Ok(Some(tree))
 }
 
 #[turbo_tasks::function]
@@ -1074,7 +1083,7 @@ async fn directory_tree_to_entrypoints_internal_untraced(
     let directory_tree = &*directory_tree.await?;
 
     let subdirectories = &directory_tree.subdirectories;
-    let components = directory_tree.components.await?.clone_value();
+    let components = &directory_tree.components;
     // Route can have its own segment config, also can inherit from the layout root
     // segment config. https://nextjs.org/docs/app/building-your-application/rendering/edge-and-nodejs-runtimes#segment-runtime-option
     // Pass down layouts from each tree to apply segment config when adding route.
@@ -1104,8 +1113,7 @@ async fn directory_tree_to_entrypoints_internal_untraced(
             &mut result,
             app_page.complete(PageType::Page)?,
             loader_tree.context("loader tree should be created for a page/default")?,
-        )
-        .await?;
+        );
     }
 
     if let Some(route) = components.route {
@@ -1181,24 +1189,24 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                                 components: Components {
                                     page: components.not_found.or_else(|| Some(get_next_package(app_dir).join("dist/client/components/not-found-error.js".into()))),
                                     ..Default::default()
-                                }.cell(),
+                                },
                                 global_metadata
-                            }.cell()
+                            }
                         },
-                        components: Components::default().cell(),
+                        components: Components::default(),
                         global_metadata,
-                    }.cell(),
+                    },
                 },
-                components: components.without_leafs().cell(),
+                components: components.without_leafs(),
                 global_metadata,
-            }
-            .cell();
+            }.cell();
 
         {
             let app_page = app_page
                 .clone_push_str("_not-found")?
                 .complete(PageType::Page)?;
-            add_app_page(app_dir, &mut result, app_page, not_found_tree).await?;
+
+            add_app_page(app_dir, &mut result, app_page, not_found_tree);
         }
     }
 
@@ -1279,8 +1287,7 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                             page.clone(),
                             loader_tree
                                 .context("loader tree should be created for a page/default")?,
-                        )
-                        .await?;
+                        );
                     }
                 }
                 Entrypoint::AppRoute {

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -850,12 +850,6 @@ fn directory_tree_to_loader_tree_internal(
 
     // Capture the current page for the metadata to calculate segment relative to
     // the corresponding page for the static metadata files.
-    /*
-    let metadata = Metadata {
-        base_page: Some(app_page.clone()),
-        ..components.metadata.clone()
-    }; */
-
     components.metadata.base_page = Some(app_page.clone());
 
     // the root directory in the app dir.
@@ -958,25 +952,6 @@ fn directory_tree_to_loader_tree_internal(
                     // slot.
                 } else if current_tree.has_only_catchall() {
                     tree.parallel_routes.insert("children".into(), subtree);
-                } else {
-                    // TODO: Investigate if this is still needed. Emitting the
-                    // error causes the test "should
-                    // gracefully handle when two page
-                    // segments match the `children`
-                    // parallel slot" to fail
-                    // DirectoryTreeIssue {
-                    //     app_dir,
-                    //     message: StyledString::Text(format!(
-                    //         "You cannot have two parallel pages that resolve
-                    // to the same path. \          Route {}
-                    // has multiple matches in {}",
-                    //         for_app_path, app_page
-                    //     ))
-                    //     .cell(),
-                    //     severity: IssueSeverity::Error.cell(),
-                    // }
-                    // .cell()
-                    // .emit();
                 }
             } else {
                 tree.parallel_routes.insert("children".into(), subtree);

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -231,32 +231,11 @@ impl DirectoryTree {
     }
 
     #[turbo_tasks::function]
-    async fn plain_from_path(
-        &self,
-        app_page: AppPage,
-        for_app_path: AppPath,
-    ) -> Result<Vc<PlainDirectoryTree>> {
+    pub async fn into_plain(&self) -> Result<Vc<PlainDirectoryTree>> {
         let mut subdirectories = BTreeMap::new();
 
         for (name, subdirectory) in &self.subdirectories {
-            let mut child_app_page = app_page.clone();
-
-            // ignore result, gets handled in directory tree to loader tree
-            child_app_page.push_str(name).ok();
-
-            let app_path = AppPath::from(app_page.clone());
-
-            if !for_app_path.contains(&app_path) {
-                continue;
-            }
-
-            subdirectories.insert(
-                name.clone(),
-                subdirectory
-                    .plain_from_path(child_app_page, for_app_path.clone())
-                    .await?
-                    .clone_value(),
-            );
+            subdirectories.insert(name.clone(), subdirectory.into_plain().await?.clone_value());
         }
 
         Ok(PlainDirectoryTree {
@@ -838,9 +817,7 @@ async fn directory_tree_to_loader_tree(
     // the page this loader tree is constructed for
     for_app_path: AppPath,
 ) -> Result<Vc<Option<Vc<LoaderTree>>>> {
-    let plain_tree = &*directory_tree
-        .plain_from_path(app_page.clone(), for_app_path.clone())
-        .await?;
+    let plain_tree = &*directory_tree.into_plain().await?;
 
     let tree = directory_tree_to_loader_tree_internal(
         app_dir,


### PR DESCRIPTION
### What?

Improves the performance of loader tree creation.

The main change is `directory_tree_to_loader_tree` now being completely synchronous (ignoring the setup).
This improves performance a lot (at least for the initial build), as it's a recursive function, which was cached at every level before.
It also makes querying the loader tree easier, as not everything needs to be an async turbo tasks function now.


#### `get_entrypoints` Performance
|                | Initial         | Update |
| --------- | ---------- | ------- |
| `canary` | `1300ms` | `20ms` |
| PR           | `260ms`  | `50ms` |

