### PR TITLE
Move resolveExtensions config up to experimental

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -397,7 +397,6 @@ pub struct ExperimentalTurboConfig {
     pub loaders: Option<JsonValue>,
     pub rules: Option<IndexMap<RcStr, RuleConfigItemOrShortcut>>,
     pub resolve_alias: Option<IndexMap<RcStr, JsonValue>>,
-    pub resolve_extensions: Option<Vec<RcStr>>,
     pub use_swc_css: Option<bool>,
     pub tree_shaking: Option<bool>,
 }
@@ -502,6 +501,7 @@ pub struct ExperimentalConfig {
     pub web_vitals_attribution: Option<Vec<RcStr>>,
     pub server_actions: Option<ServerActionsOrLegacyBool>,
     pub sri: Option<SubResourceIntegrity>,
+    pub resolve_extensions: Option<Vec<RcStr>>,
     react_compiler: Option<ReactCompilerOptionsOrBoolean>,
 
     // ---
@@ -940,12 +940,7 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub async fn resolve_extension(self: Vc<Self>) -> Result<Vc<ResolveExtensions>> {
         let this = self.await?;
-        let Some(resolve_extensions) = this
-            .experimental
-            .turbo
-            .as_ref()
-            .and_then(|t| t.resolve_extensions.as_ref())
-        else {
+        let Some(resolve_extensions) = this.experimental.resolve_extensions.as_ref() else {
             return Ok(Vc::cell(None));
         };
         Ok(Vc::cell(Some(resolve_extensions.clone())))

--- a/docs/02-app/02-api-reference/05-next-config-js/resolveExtensions.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/resolveExtensions.mdx
@@ -1,0 +1,30 @@
+---
+title: resolveExtensions
+description: Use the `resolveExtensions` option to define the list and order of extensions that Webpack and Turbopack will attempt to resolve.
+version: experimental
+---
+
+{/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
+
+Through `experimental.resolveExtensions`, Turbopack and Webpack can be configured to resolve modules with custom extensions, as in Webpack's [`resolve.extensions`](https://webpack.js.org/configuration/resolve/#resolveextensions) configuration. The order of the extensions in the array defines the order in which extensions are attempted to be resolved. Affects both Turbopack and Webpack.
+
+If not specified, it takes the default value `['.js', '.mjs', '.tsx', '.ts', '.jsx', '.json', '.node']`.
+
+```js filename="next.config.js"
+module.exports = {
+  experimental: {
+    resolveExtensions: ['.mdx', '.tsx', '.ts', '.jsx', '.js', '.mjs', '.json'],
+  },
+}
+```
+
+This overwrites the original resolve extensions with the provided list. Make sure to include the default extensions.
+
+For more information and guidance for how to migrate your app to Turbopack from webpack, see [Turbopack's documentation on webpack compatibility](https://turbo.build/pack/docs/migrating-from-webpack).
+
+## Version History
+
+| Version   | Changes                                                                                                                   |
+| --------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `v15.0.0` | `resolveExtensions` moved up one level to `experimental.resolveExtensions`, which now affects both Turbopack and Webpack. |
+| `v14.1.1` | `experimental.turbo.resolveExtensions` is used to configure resolve extensions in Turbopack.                              |

--- a/docs/02-app/02-api-reference/05-next-config-js/turbo.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/turbo.mdx
@@ -74,31 +74,3 @@ module.exports = {
 This aliases imports of the `underscore` package to the `lodash` package. In other words, `import underscore from 'underscore'` will load the `lodash` module instead of `underscore`.
 
 Turbopack also supports conditional aliasing through this field, similar to Node.js's [conditional exports](https://nodejs.org/docs/latest-v18.x/api/packages.html#conditional-exports). At the moment only the `browser` condition is supported. In the case above, imports of the `mocha` module will be aliased to `mocha/browser-entry.js` when Turbopack targets browser environments.
-
-## Resolve extensions
-
-Through `next.config.js`, Turbopack can be configured to resolve modules with custom extensions, similar to webpack's [`resolve.extensions`](https://webpack.js.org/configuration/resolve/#resolveextensions) configuration.
-
-To configure resolve extensions, use the `resolveExtensions` field in `next.config.js`:
-
-```js filename="next.config.js"
-module.exports = {
-  experimental: {
-    turbo: {
-      resolveExtensions: [
-        '.mdx',
-        '.tsx',
-        '.ts',
-        '.jsx',
-        '.js',
-        '.mjs',
-        '.json',
-      ],
-    },
-  },
-}
-```
-
-This overwrites the original resolve extensions with the provided list. Make sure to include the default extensions.
-
-For more information and guidance for how to migrate your app to Turbopack from webpack, see [Turbopack's documentation on webpack compatibility](https://turbo.build/pack/docs/migrating-from-webpack).

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -693,7 +693,9 @@ export default async function getBaseWebpackConfig(
 
   const resolveConfig: webpack.Configuration['resolve'] = {
     // Disable .mjs for node_modules bundling
-    extensions: ['.js', '.mjs', '.tsx', '.ts', '.jsx', '.json', '.wasm'],
+    extensions: config.experimental?.resolveExtensions
+      ? config.experimental.resolveExtensions
+      : ['.js', '.mjs', '.tsx', '.ts', '.jsx', '.json', '.node'],
     extensionAlias: config.experimental.extensionAlias,
     modules: [
       'node_modules',

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -386,12 +386,12 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
                 ])
               )
               .optional(),
-            resolveExtensions: z.array(z.string()).optional(),
             useSwcCss: z.boolean().optional(),
             treeShaking: z.boolean().optional(),
             memoryLimit: z.number().optional(),
           })
           .optional(),
+        resolveExtensions: z.array(z.string()).optional(),
         optimizePackageImports: z.array(z.string()).optional(),
         optimizeServerReact: z.boolean().optional(),
         instrumentationHook: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -124,13 +124,6 @@ export interface ExperimentalTurboOptions {
   >
 
   /**
-   * (`next --turbo` only) A list of extensions to resolve when importing files.
-   *
-   * @see [Resolve Extensions](https://nextjs.org/docs/app/api-reference/next-config-js/turbo#resolve-extensions)
-   */
-  resolveExtensions?: string[]
-
-  /**
    * (`next --turbo` only) A list of webpack loaders to apply when running with Turbopack.
    *
    * @see [Turbopack Loaders](https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders)
@@ -302,6 +295,14 @@ export interface ExperimentalConfig {
   adjustFontFallbacksWithSizeAdjust?: boolean
 
   webVitalsAttribution?: Array<(typeof WEB_VITALS)[number]>
+
+  /**
+   * A list of extensions to resolve when importing files.
+   * The default value is `['.js', '.mjs', '.tsx', '.ts', '.jsx', '.json', '.node']`.
+   *
+   * @see [Resolve Extensions](https://nextjs.org/docs/app/api-reference/next-config-js/resolve-extensions)
+   */
+  resolveExtensions?: string[]
 
   /**
    * Automatically apply the "modularizeImports" optimization to imports of the specified packages.

--- a/test/e2e/app-dir/resolve-extensions/next.config.js
+++ b/test/e2e/app-dir/resolve-extensions/next.config.js
@@ -5,13 +5,7 @@ const extensions = ['', '.png', '.tsx', '.ts', '.jsx', '.js', '.json']
  */
 const nextConfig = {
   experimental: {
-    turbo: {
-      resolveExtensions: [...extensions],
-    },
-  },
-  webpack(config) {
-    config.resolve.extensions = [...extensions]
-    return config
+    resolveExtensions: [...extensions],
   },
 }
 


### PR DESCRIPTION
### What?

Moves resolveExtensions up from experimental.turbo to experimental in next.config.js. Makes Webpack configuration also read from that field.

Closes PACK-2578