### PR TITLE
[chore] Update turbopack to turbopack-240703.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "serde",
  "smallvec",
@@ -3111,7 +3111,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "serde",
@@ -6922,12 +6922,13 @@ dependencies = [
 
 [[package]]
 name = "triomphe"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859eb650cfee7434994602c3a68b25d77ad9e68c8a6cd491616ef86661382eb3"
+checksum = "e6631e42e10b40c0690bf92f404ebcfe6e1fdb480391d15f17cc8e96eeed5369"
 dependencies = [
  "serde",
  "stable_deref_trait",
+ "unsize",
 ]
 
 [[package]]
@@ -6977,12 +6978,12 @@ dependencies = [
 [[package]]
 name = "turbo-prehash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7005,16 +7006,18 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "triomphe",
  "turbo-tasks-build",
  "turbo-tasks-hash",
  "turbo-tasks-macros",
  "turbo-tasks-malloc",
+ "unsize",
 ]
 
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -7027,7 +7030,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7041,7 +7044,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -7055,7 +7058,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -7071,7 +7074,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7103,7 +7106,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "md4",
  "turbo-tasks-macros",
@@ -7113,7 +7116,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "proc-macro-error",
@@ -7127,7 +7130,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7137,7 +7140,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "mimalloc",
 ]
@@ -7145,12 +7148,13 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "auto-hash-map",
  "concurrent-queue",
  "dashmap",
+ "either",
  "indexmap 1.9.3",
  "num_cpus",
  "once_cell",
@@ -7158,6 +7162,7 @@ dependencies = [
  "priority-queue",
  "ref-cast",
  "rustc-hash",
+ "serde",
  "smallvec",
  "tokio",
  "tracing",
@@ -7171,7 +7176,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7201,7 +7206,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7242,7 +7247,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7265,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "clap",
@@ -7282,7 +7287,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7311,7 +7316,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7338,7 +7343,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7374,7 +7379,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7409,7 +7414,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "serde",
  "serde_json",
@@ -7420,7 +7425,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7445,7 +7450,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7461,7 +7466,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7477,7 +7482,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7496,7 +7501,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "serde",
@@ -7511,7 +7516,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7526,7 +7531,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7560,7 +7565,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7580,7 +7585,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7598,7 +7603,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "serde",
@@ -7614,7 +7619,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7625,7 +7630,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "either",
@@ -7645,7 +7650,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -7661,7 +7666,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240626.3#9f9f359d55f875ac6a26bb7971a1931f6d630086"
+source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240703.1#69bb5947d173f3b84a3f9cef9f338485c931dc9f"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7813,6 +7818,15 @@ name = "unsafe-libyaml"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+
+[[package]]
+name = "unsize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fa7a7a734c1a5664a662ddcea0b6c9472a21da8888c957c7f1eaa09dba7a939"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,11 @@ swc_core = { version = "0.95.4", features = [
 testing = { version = "0.36.0" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240626.3" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240703.1" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240626.3" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240703.1" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240626.3" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240703.1" }
 
 # General Deps
 

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -205,7 +205,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.27.1",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240626.3",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240703.1",
     "acorn": "8.11.3",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -781,31 +781,31 @@ importers:
         version: 1.3.3
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.4.2 || ^6.0.0 || 7.0.0 - 7.2.0
-        version: 6.14.0(@typescript-eslint/parser@6.14.0(eslint@9.6.0)(typescript@5.5.3))(eslint@9.6.0)(typescript@5.5.3)
+        version: 6.14.0(@typescript-eslint/parser@6.14.0(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3)
       '@typescript-eslint/parser':
         specifier: ^5.4.2 || ^6.0.0 || 7.0.0 - 7.2.0
-        version: 6.14.0(eslint@9.6.0)(typescript@5.5.3)
+        version: 6.14.0(eslint@8.56.0)(typescript@5.5.3)
       eslint:
         specifier: ^7.23.0 || ^8.0.0
-        version: 9.6.0
+        version: 8.56.0
       eslint-import-resolver-node:
         specifier: ^0.3.6
         version: 0.3.6
       eslint-import-resolver-typescript:
         specifier: ^3.5.2
-        version: 3.5.2(eslint-plugin-import@2.28.1)(eslint@9.6.0)
+        version: 3.5.2(eslint-plugin-import@2.28.1)(eslint@8.56.0)
       eslint-plugin-import:
         specifier: ^2.28.1
-        version: 2.28.1(@typescript-eslint/parser@6.14.0(eslint@9.6.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.5.2)(eslint@9.6.0)
+        version: 2.28.1(@typescript-eslint/parser@6.14.0(eslint@8.56.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.5.2)(eslint@8.56.0)
       eslint-plugin-jsx-a11y:
         specifier: ^6.7.1
-        version: 6.7.1(eslint@9.6.0)
+        version: 6.7.1(eslint@8.56.0)
       eslint-plugin-react:
         specifier: ^7.33.2
-        version: 7.33.2(eslint@9.6.0)
+        version: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks:
         specifier: ^4.5.0 || 5.0.0-canary-7118f5dd7-20230705
-        version: 4.5.0(eslint@9.6.0)
+        version: 4.5.0(eslint@8.56.0)
       typescript:
         specifier: '>=3.3.1'
         version: 5.5.3
@@ -824,7 +824,7 @@ importers:
     dependencies:
       next:
         specifier: 14.3.0-canary.15
-        version: 14.3.0-canary.15(@babel/core@7.22.5)(@opentelemetry/api@1.6.0)(@playwright/test@1.41.2)(babel-plugin-macros@3.1.0)(react-dom@19.0.0-rc-6230622a1a-20240610(react@19.0.0-rc-6230622a1a-20240610))(react@19.0.0-rc-6230622a1a-20240610)(sass@1.54.0)
+        version: 14.3.0-canary.15(@babel/core@7.22.5)(@opentelemetry/api@1.6.0)(@playwright/test@1.45.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0-rc-6230622a1a-20240610(react@19.0.0-rc-6230622a1a-20240610))(react@19.0.0-rc-6230622a1a-20240610)(sass@1.77.6)
     devDependencies:
       '@types/fontkit':
         specifier: 2.0.0
@@ -1111,8 +1111,8 @@ importers:
         specifier: 0.27.1
         version: 0.27.1(encoding@0.1.13)
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240626.3
-        version: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240626.3
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240703.1
+        version: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240703.1
       acorn:
         specifier: 8.11.3
         version: 8.11.3
@@ -1530,7 +1530,7 @@ importers:
     dependencies:
       '@mdx-js/loader':
         specifier: '>=0.15.0'
-        version: 2.2.1(webpack@5.90.0(@swc/core@1.5.7(@swc/helpers@0.5.11)))
+        version: 2.2.1(webpack@5.90.0(@swc/core@1.6.6(@swc/helpers@0.5.11)))
       '@mdx-js/react':
         specifier: '>=0.15.0'
         version: 2.2.1(react@19.0.0-rc-6230622a1a-20240610)
@@ -4485,22 +4485,10 @@ packages:
       chokidar:
         optional: true
 
-  '@swc/core-darwin-arm64@1.5.7':
-    resolution: {integrity: sha512-bZLVHPTpH3h6yhwVl395k0Mtx8v6CGhq5r4KQdAoPbADU974Mauz1b6ViHAJ74O0IVE5vyy7tD3OpkQxL/vMDQ==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@swc/core-darwin-arm64@1.6.6':
     resolution: {integrity: sha512-5DA8NUGECcbcK1YLKJwNDKqdtTYDVnkfDU1WvQSXq/rU+bjYCLtn5gCe8/yzL7ISXA6rwqPU1RDejhbNt4ARLQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@swc/core-darwin-x64@1.5.7':
-    resolution: {integrity: sha512-RpUyu2GsviwTc2qVajPL0l8nf2vKj5wzO3WkLSHAHEJbiUZk83NJrZd1RVbEknIMO7+Uyjh54hEh8R26jSByaw==}
-    engines: {node: '>=10'}
-    cpu: [x64]
     os: [darwin]
 
   '@swc/core-darwin-x64@1.6.6':
@@ -4509,32 +4497,14 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@swc/core-linux-arm-gnueabihf@1.5.7':
-    resolution: {integrity: sha512-cTZWTnCXLABOuvWiv6nQQM0hP6ZWEkzdgDvztgHI/+u/MvtzJBN5lBQ2lue/9sSFYLMqzqff5EHKlFtrJCA9dQ==}
-    engines: {node: '>=10'}
-    cpu: [arm]
-    os: [linux]
-
   '@swc/core-linux-arm-gnueabihf@1.6.6':
     resolution: {integrity: sha512-YgytuyUfR7b0z0SRHKV+ylr83HmgnROgeT7xryEkth6JGpAEHooCspQ4RrWTU8+WKJ7aXiZlGXPgybQ4TiS+TA==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
 
-  '@swc/core-linux-arm64-gnu@1.5.7':
-    resolution: {integrity: sha512-hoeTJFBiE/IJP30Be7djWF8Q5KVgkbDtjySmvYLg9P94bHg9TJPSQoC72tXx/oXOgXvElDe/GMybru0UxhKx4g==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [linux]
-
   '@swc/core-linux-arm64-gnu@1.6.6':
     resolution: {integrity: sha512-yGwx9fddzEE0iURqRVwKBQ4IwRHE6hNhl15WliHpi/PcYhzmYkUIpcbRXjr0dssubXAVPVnx6+jZVDSbutvnfg==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@swc/core-linux-arm64-musl@1.5.7':
-    resolution: {integrity: sha512-+NDhK+IFTiVK1/o7EXdCeF2hEzCiaRSrb9zD7X2Z7inwWlxAntcSuzZW7Y6BRqGQH89KA91qYgwbnjgTQ22PiQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -4545,20 +4515,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@swc/core-linux-x64-gnu@1.5.7':
-    resolution: {integrity: sha512-25GXpJmeFxKB+7pbY7YQLhWWjkYlR+kHz5I3j9WRl3Lp4v4UD67OGXwPe+DIcHqcouA1fhLhsgHJWtsaNOMBNg==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [linux]
-
   '@swc/core-linux-x64-gnu@1.6.6':
     resolution: {integrity: sha512-hRGsUKNzzZle28YF0dYIpN0bt9PceR9LaVBq7x8+l9TAaDLFbgksSxcnU/ubTtsy+WsYSYGn+A83w3xWC0O8CQ==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@swc/core-linux-x64-musl@1.5.7':
-    resolution: {integrity: sha512-0VN9Y5EAPBESmSPPsCJzplZHV26akC0sIgd3Hc/7S/1GkSMoeuVL+V9vt+F/cCuzr4VidzSkqftdP3qEIsXSpg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -4569,22 +4527,10 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@swc/core-win32-arm64-msvc@1.5.7':
-    resolution: {integrity: sha512-RtoNnstBwy5VloNCvmvYNApkTmuCe4sNcoYWpmY7C1+bPR+6SOo8im1G6/FpNem8AR5fcZCmXHWQ+EUmRWJyuA==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [win32]
-
   '@swc/core-win32-arm64-msvc@1.6.6':
     resolution: {integrity: sha512-lzYdI4qb4k1dFG26yv+9Jaq/bUMAhgs/2JsrLncGjLof86+uj74wKYCQnbzKAsq2hDtS5DqnHnl+//J+miZfGA==}
     engines: {node: '>=10'}
     cpu: [arm64]
-    os: [win32]
-
-  '@swc/core-win32-ia32-msvc@1.5.7':
-    resolution: {integrity: sha512-Xm0TfvcmmspvQg1s4+USL3x8D+YPAfX2JHygvxAnCJ0EHun8cm2zvfNBcsTlnwYb0ybFWXXY129aq1wgFC9TpQ==}
-    engines: {node: '>=10'}
-    cpu: [ia32]
     os: [win32]
 
   '@swc/core-win32-ia32-msvc@1.6.6':
@@ -4593,26 +4539,11 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@swc/core-win32-x64-msvc@1.5.7':
-    resolution: {integrity: sha512-tp43WfJLCsKLQKBmjmY/0vv1slVywR5Q4qKjF5OIY8QijaEW7/8VwPyUyVoJZEnDgv9jKtUTG5PzqtIYPZGnyg==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [win32]
-
   '@swc/core-win32-x64-msvc@1.6.6':
     resolution: {integrity: sha512-WAP0JoCTfgeYKgOeYJoJV4ZS0sQUmU3OwvXa2dYYtMLF7zsNqOiW4niU7QlThBHgUv/qNZm2p6ITEgh3w1cltw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
-
-  '@swc/core@1.5.7':
-    resolution: {integrity: sha512-U4qJRBefIJNJDRCCiVtkfa/hpiZ7w0R6kASea+/KLp+vkus3zcLSB8Ub8SvKgTIxjWpwsKcZlPf5nrv4ls46SQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@swc/helpers': ^0.5.0
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
 
   '@swc/core@1.6.6':
     resolution: {integrity: sha512-sHfmIUPUXNrQTwFMVCY5V5Ena2GTOeaWjS2GFUpjLhAgVfP90OP67DWow7+cYrfFtqBdILHuWnjkTcd0+uPKlg==}
@@ -4734,23 +4665,14 @@ packages:
   '@types/babel__generator@7.6.2':
     resolution: {integrity: sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==}
 
-  '@types/babel__generator@7.6.8':
-    resolution: {integrity: sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==}
-
   '@types/babel__template@7.4.0':
     resolution: {integrity: sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==}
-
-  '@types/babel__template@7.4.4':
-    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
 
   '@types/babel__traverse@7.11.0':
     resolution: {integrity: sha512-kSjgDMZONiIfSH1Nxcr5JIRMwUetDki63FSQfpTCz8ogF3Ulqm8+mr5f78dUYs6vMiB6gBusQqfQmBvHZj/lwg==}
 
   '@types/babel__traverse@7.11.1':
     resolution: {integrity: sha512-Vs0hm0vPahPMYi9tDjtP66llufgO3ST16WXaSTtDGEl9cewAl3AibmxWw6TINOqHPT9z0uABKAYjT9jNSg4npw==}
-
-  '@types/babel__traverse@7.20.6':
-    resolution: {integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==}
 
   '@types/body-parser@1.17.1':
     resolution: {integrity: sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==}
@@ -5189,8 +5111,8 @@ packages:
     resolution: {integrity: sha512-OTe0KE37F5Y2eTys6eMnfopC+P4qr2ooXUTFyFPTplYSPwowmFk/HLD1FXtbKLjqsIH0SgekcJWad+C5uX4nkg==}
     engines: {node: '>=16'}
 
-  '@vercel/turbopack-ecmascript-runtime@https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240626.3':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240626.3}
+  '@vercel/turbopack-ecmascript-runtime@https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240703.1':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240703.1}
     version: 0.0.0
 
   '@webassemblyjs/ast@1.11.6':
@@ -11419,9 +11341,6 @@ packages:
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
 
-  picocolors@1.0.1:
-    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
-
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
@@ -15075,7 +14994,7 @@ snapshots:
   '@babel/code-frame@7.24.7':
     dependencies:
       '@babel/highlight': 7.24.7
-      picocolors: 1.0.1
+      picocolors: 1.0.0
 
   '@babel/compat-data@7.22.20': {}
 
@@ -15273,7 +15192,7 @@ snapshots:
       '@babel/core': 7.22.5
       '@babel/helper-compilation-targets': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7
-      debug: 4.3.5
+      debug: 4.1.1
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -15507,7 +15426,7 @@ snapshots:
       '@babel/helper-validator-identifier': 7.24.7
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.0.1
+      picocolors: 1.0.0
 
   '@babel/parser@7.22.5':
     dependencies:
@@ -18239,14 +18158,6 @@ snapshots:
       - encoding
       - supports-color
 
-  '@mdx-js/loader@2.2.1(webpack@5.90.0(@swc/core@1.5.7(@swc/helpers@0.5.11)))':
-    dependencies:
-      '@mdx-js/mdx': 2.2.1
-      source-map: 0.7.4
-      webpack: 5.90.0(@swc/core@1.5.7(@swc/helpers@0.5.11))
-    transitivePeerDependencies:
-      - supports-color
-
   '@mdx-js/loader@2.2.1(webpack@5.90.0(@swc/core@1.6.6(@swc/helpers@0.5.11)))':
     dependencies:
       '@mdx-js/mdx': 2.2.1
@@ -18967,82 +18878,34 @@ snapshots:
     optionalDependencies:
       chokidar: 3.6.0
 
-  '@swc/core-darwin-arm64@1.5.7':
-    optional: true
-
   '@swc/core-darwin-arm64@1.6.6':
-    optional: true
-
-  '@swc/core-darwin-x64@1.5.7':
     optional: true
 
   '@swc/core-darwin-x64@1.6.6':
     optional: true
 
-  '@swc/core-linux-arm-gnueabihf@1.5.7':
-    optional: true
-
   '@swc/core-linux-arm-gnueabihf@1.6.6':
-    optional: true
-
-  '@swc/core-linux-arm64-gnu@1.5.7':
     optional: true
 
   '@swc/core-linux-arm64-gnu@1.6.6':
     optional: true
 
-  '@swc/core-linux-arm64-musl@1.5.7':
-    optional: true
-
   '@swc/core-linux-arm64-musl@1.6.6':
-    optional: true
-
-  '@swc/core-linux-x64-gnu@1.5.7':
     optional: true
 
   '@swc/core-linux-x64-gnu@1.6.6':
     optional: true
 
-  '@swc/core-linux-x64-musl@1.5.7':
-    optional: true
-
   '@swc/core-linux-x64-musl@1.6.6':
-    optional: true
-
-  '@swc/core-win32-arm64-msvc@1.5.7':
     optional: true
 
   '@swc/core-win32-arm64-msvc@1.6.6':
     optional: true
 
-  '@swc/core-win32-ia32-msvc@1.5.7':
-    optional: true
-
   '@swc/core-win32-ia32-msvc@1.6.6':
     optional: true
 
-  '@swc/core-win32-x64-msvc@1.5.7':
-    optional: true
-
   '@swc/core-win32-x64-msvc@1.6.6':
-    optional: true
-
-  '@swc/core@1.5.7(@swc/helpers@0.5.11)':
-    dependencies:
-      '@swc/counter': 0.1.3
-      '@swc/types': 0.1.7
-    optionalDependencies:
-      '@swc/core-darwin-arm64': 1.5.7
-      '@swc/core-darwin-x64': 1.5.7
-      '@swc/core-linux-arm-gnueabihf': 1.5.7
-      '@swc/core-linux-arm64-gnu': 1.5.7
-      '@swc/core-linux-arm64-musl': 1.5.7
-      '@swc/core-linux-x64-gnu': 1.5.7
-      '@swc/core-linux-x64-musl': 1.5.7
-      '@swc/core-win32-arm64-msvc': 1.5.7
-      '@swc/core-win32-ia32-msvc': 1.5.7
-      '@swc/core-win32-x64-msvc': 1.5.7
-      '@swc/helpers': 0.5.11
     optional: true
 
   '@swc/core@1.6.6(@swc/helpers@0.5.11)':
@@ -19185,30 +19048,19 @@ snapshots:
     dependencies:
       '@babel/parser': 7.22.5
       '@babel/types': 7.22.5
-      '@types/babel__generator': 7.6.8
-      '@types/babel__template': 7.4.4
-      '@types/babel__traverse': 7.20.6
+      '@types/babel__generator': 7.6.2
+      '@types/babel__template': 7.4.0
+      '@types/babel__traverse': 7.11.0
     optional: true
 
   '@types/babel__generator@7.6.2':
     dependencies:
       '@babel/types': 7.22.5
 
-  '@types/babel__generator@7.6.8':
-    dependencies:
-      '@babel/types': 7.22.5
-    optional: true
-
   '@types/babel__template@7.4.0':
     dependencies:
       '@babel/parser': 7.22.5
       '@babel/types': 7.22.5
-
-  '@types/babel__template@7.4.4':
-    dependencies:
-      '@babel/parser': 7.22.5
-      '@babel/types': 7.22.5
-    optional: true
 
   '@types/babel__traverse@7.11.0':
     dependencies:
@@ -19217,11 +19069,6 @@ snapshots:
   '@types/babel__traverse@7.11.1':
     dependencies:
       '@babel/types': 7.22.5
-
-  '@types/babel__traverse@7.20.6':
-    dependencies:
-      '@babel/types': 7.22.5
-    optional: true
 
   '@types/body-parser@1.17.1':
     dependencies:
@@ -19580,16 +19427,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@6.14.0(@typescript-eslint/parser@6.14.0(eslint@9.6.0)(typescript@5.5.3))(eslint@9.6.0)(typescript@5.5.3)':
+  '@typescript-eslint/eslint-plugin@6.14.0(@typescript-eslint/parser@6.14.0(eslint@8.56.0)(typescript@5.5.3))(eslint@8.56.0)(typescript@5.5.3)':
     dependencies:
       '@eslint-community/regexpp': 4.5.1
-      '@typescript-eslint/parser': 6.14.0(eslint@9.6.0)(typescript@5.5.3)
+      '@typescript-eslint/parser': 6.14.0(eslint@8.56.0)(typescript@5.5.3)
       '@typescript-eslint/scope-manager': 6.14.0
-      '@typescript-eslint/type-utils': 6.14.0(eslint@9.6.0)(typescript@5.5.3)
-      '@typescript-eslint/utils': 6.14.0(eslint@9.6.0)(typescript@5.5.3)
+      '@typescript-eslint/type-utils': 6.14.0(eslint@8.56.0)(typescript@5.5.3)
+      '@typescript-eslint/utils': 6.14.0(eslint@8.56.0)(typescript@5.5.3)
       '@typescript-eslint/visitor-keys': 6.14.0
       debug: 4.3.4
-      eslint: 9.6.0
+      eslint: 8.56.0
       graphemer: 1.4.0
       ignore: 5.2.4
       natural-compare: 1.4.0
@@ -19613,14 +19460,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@6.14.0(eslint@9.6.0)(typescript@5.5.3)':
+  '@typescript-eslint/parser@6.14.0(eslint@8.56.0)(typescript@5.5.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.14.0
       '@typescript-eslint/types': 6.14.0
       '@typescript-eslint/typescript-estree': 6.14.0(typescript@5.5.3)
       '@typescript-eslint/visitor-keys': 6.14.0
       debug: 4.3.4
-      eslint: 9.6.0
+      eslint: 8.56.0
     optionalDependencies:
       typescript: 5.5.3
     transitivePeerDependencies:
@@ -19648,12 +19495,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@6.14.0(eslint@9.6.0)(typescript@5.5.3)':
+  '@typescript-eslint/type-utils@6.14.0(eslint@8.56.0)(typescript@5.5.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 6.14.0(typescript@5.5.3)
-      '@typescript-eslint/utils': 6.14.0(eslint@9.6.0)(typescript@5.5.3)
+      '@typescript-eslint/utils': 6.14.0(eslint@8.56.0)(typescript@5.5.3)
       debug: 4.3.4
-      eslint: 9.6.0
+      eslint: 8.56.0
       ts-api-utils: 1.0.1(typescript@5.5.3)
     optionalDependencies:
       typescript: 5.5.3
@@ -19735,15 +19582,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@6.14.0(eslint@9.6.0)(typescript@5.5.3)':
+  '@typescript-eslint/utils@6.14.0(eslint@8.56.0)(typescript@5.5.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.6.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
       '@types/json-schema': 7.0.12
       '@types/semver': 7.5.6
       '@typescript-eslint/scope-manager': 6.14.0
       '@typescript-eslint/types': 6.14.0
       '@typescript-eslint/typescript-estree': 6.14.0(typescript@5.5.3)
-      eslint: 9.6.0
+      eslint: 8.56.0
       semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
@@ -19826,7 +19673,7 @@ snapshots:
       satori: 0.10.9
       yoga-wasm-web: 0.3.3
 
-  '@vercel/turbopack-ecmascript-runtime@https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240626.3':
+  '@vercel/turbopack-ecmascript-runtime@https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240703.1':
     dependencies:
       '@types/node': 20.12.3
 
@@ -22659,12 +22506,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.5.2(eslint-plugin-import@2.28.1)(eslint@9.6.0):
+  eslint-import-resolver-typescript@3.5.2(eslint-plugin-import@2.28.1)(eslint@8.56.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.16.0
-      eslint: 9.6.0
-      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.14.0(eslint@9.6.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.5.2)(eslint@9.6.0)
+      eslint: 8.56.0
+      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.14.0(eslint@8.56.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.5.2)(eslint@8.56.0)
       get-tsconfig: 4.2.0
       globby: 13.1.2
       is-core-module: 2.11.0
@@ -22683,14 +22530,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.14.0(eslint@9.6.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.2(eslint-plugin-import@2.28.1)(eslint@9.6.0))(eslint@9.6.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.14.0(eslint@8.56.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.2(eslint-plugin-import@2.28.1)(eslint@8.56.0))(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 6.14.0(eslint@9.6.0)(typescript@5.5.3)
-      eslint: 9.6.0
+      '@typescript-eslint/parser': 6.14.0(eslint@8.56.0)(typescript@5.5.3)
+      eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.5.2(eslint-plugin-import@2.28.1)(eslint@9.6.0)
+      eslint-import-resolver-typescript: 3.5.2(eslint-plugin-import@2.28.1)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -22700,7 +22547,7 @@ snapshots:
       eslint-utils: 3.0.0(eslint@8.56.0)
       estraverse: 5.3.0
 
-  eslint-plugin-import@2.28.1(@typescript-eslint/parser@6.14.0(eslint@9.6.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.5.2)(eslint@9.6.0):
+  eslint-plugin-import@2.28.1(@typescript-eslint/parser@6.14.0(eslint@8.56.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.5.2)(eslint@8.56.0):
     dependencies:
       array-includes: 3.1.6
       array.prototype.findlastindex: 1.2.2
@@ -22708,9 +22555,9 @@ snapshots:
       array.prototype.flatmap: 1.3.1
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.6.0
+      eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.14.0(eslint@9.6.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.2(eslint-plugin-import@2.28.1)(eslint@9.6.0))(eslint@9.6.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.14.0(eslint@8.56.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.2(eslint-plugin-import@2.28.1)(eslint@8.56.0))(eslint@8.56.0)
       has: 1.0.3
       is-core-module: 2.13.0
       is-glob: 4.0.3
@@ -22721,7 +22568,7 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.14.2
     optionalDependencies:
-      '@typescript-eslint/parser': 6.14.0(eslint@9.6.0)(typescript@5.5.3)
+      '@typescript-eslint/parser': 6.14.0(eslint@8.56.0)(typescript@5.5.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -22780,7 +22627,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.7.1(eslint@9.6.0):
+  eslint-plugin-jsx-a11y@6.7.1(eslint@8.56.0):
     dependencies:
       '@babel/runtime': 7.22.3
       aria-query: 5.3.0
@@ -22791,7 +22638,7 @@ snapshots:
       axobject-query: 3.2.1
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.6.0
+      eslint: 8.56.0
       has: 1.0.3
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.5
@@ -22800,9 +22647,9 @@ snapshots:
       object.fromentries: 2.0.6
       semver: 6.3.0
 
-  eslint-plugin-react-hooks@4.5.0(eslint@9.6.0):
+  eslint-plugin-react-hooks@4.5.0(eslint@8.56.0):
     dependencies:
-      eslint: 9.6.0
+      eslint: 8.56.0
 
   eslint-plugin-react-hooks@4.6.0(eslint@8.56.0):
     dependencies:
@@ -22816,26 +22663,6 @@ snapshots:
       doctrine: 2.1.0
       es-iterator-helpers: 1.0.13
       eslint: 8.56.0
-      estraverse: 5.3.0
-      jsx-ast-utils: 3.3.5
-      minimatch: 3.1.2
-      object.entries: 1.1.6
-      object.fromentries: 2.0.6
-      object.hasown: 1.1.2
-      object.values: 1.1.6
-      prop-types: 15.8.1
-      resolve: 2.0.0-next.4
-      semver: 6.3.1
-      string.prototype.matchall: 4.0.8
-
-  eslint-plugin-react@7.33.2(eslint@9.6.0):
-    dependencies:
-      array-includes: 3.1.6
-      array.prototype.flatmap: 1.3.1
-      array.prototype.tosorted: 1.1.1
-      doctrine: 2.1.0
-      es-iterator-helpers: 1.0.13
-      eslint: 9.6.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.5
       minimatch: 3.1.2
@@ -27031,7 +26858,7 @@ snapshots:
 
   next-tick@1.0.0: {}
 
-  next@14.3.0-canary.15(@babel/core@7.22.5)(@opentelemetry/api@1.6.0)(@playwright/test@1.41.2)(babel-plugin-macros@3.1.0)(react-dom@19.0.0-rc-6230622a1a-20240610(react@19.0.0-rc-6230622a1a-20240610))(react@19.0.0-rc-6230622a1a-20240610)(sass@1.54.0):
+  next@14.3.0-canary.15(@babel/core@7.22.5)(@opentelemetry/api@1.6.0)(@playwright/test@1.45.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0-rc-6230622a1a-20240610(react@19.0.0-rc-6230622a1a-20240610))(react@19.0.0-rc-6230622a1a-20240610)(sass@1.77.6):
     dependencies:
       '@next/env': 14.3.0-canary.15
       '@swc/helpers': 0.5.5
@@ -27053,8 +26880,8 @@ snapshots:
       '@next/swc-win32-ia32-msvc': 14.3.0-canary.15
       '@next/swc-win32-x64-msvc': 14.3.0-canary.15
       '@opentelemetry/api': 1.6.0
-      '@playwright/test': 1.41.2
-      sass: 1.54.0
+      '@playwright/test': 1.45.0
+      sass: 1.77.6
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -27839,8 +27666,6 @@ snapshots:
       is-reference: 3.0.1
 
   picocolors@1.0.0: {}
-
-  picocolors@1.0.1: {}
 
   picomatch@2.3.1: {}
 
@@ -30555,17 +30380,6 @@ snapshots:
 
   term-size@3.0.2: {}
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.5.7(@swc/helpers@0.5.11))(webpack@5.90.0(@swc/core@1.5.7(@swc/helpers@0.5.11))):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.22
-      jest-worker: 27.5.1
-      schema-utils: 3.2.0
-      serialize-javascript: 6.0.1
-      terser: 5.27.0
-      webpack: 5.90.0(@swc/core@1.5.7(@swc/helpers@0.5.11))
-    optionalDependencies:
-      '@swc/core': 1.5.7(@swc/helpers@0.5.11)
-
   terser-webpack-plugin@5.3.10(@swc/core@1.6.6(@swc/helpers@0.5.11))(webpack@5.90.0(@swc/core@1.6.6(@swc/helpers@0.5.11))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.22
@@ -31482,37 +31296,6 @@ snapshots:
   webpack-sources@3.2.3(patch_hash=exarmjd4pnde4auoeobjrmju54): {}
 
   webpack-stats-plugin@1.1.0: {}
-
-  webpack@5.90.0(@swc/core@1.5.7(@swc/helpers@0.5.11)):
-    dependencies:
-      '@types/eslint-scope': 3.7.3
-      '@types/estree': 1.0.5
-      '@webassemblyjs/ast': 1.11.6
-      '@webassemblyjs/wasm-edit': 1.11.6
-      '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.11.3
-      acorn-import-assertions: 1.9.0(acorn@8.11.3)
-      browserslist: 4.22.2
-      chrome-trace-event: 1.0.2
-      enhanced-resolve: 5.16.0
-      es-module-lexer: 1.2.1
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.30
-      neo-async: 2.6.2
-      schema-utils: 3.2.0
-      tapable: 2.2.0
-      terser-webpack-plugin: 5.3.10(@swc/core@1.5.7(@swc/helpers@0.5.11))(webpack@5.90.0(@swc/core@1.5.7(@swc/helpers@0.5.11)))
-      watchpack: 2.4.0
-      webpack-sources: 3.2.3(patch_hash=exarmjd4pnde4auoeobjrmju54)
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
 
   webpack@5.90.0(@swc/core@1.6.6(@swc/helpers@0.5.11)):
     dependencies:


### PR DESCRIPTION
Tobias Koppers - fix typo (vercel/turbo#8619)
Benjamin Woodruff - Store aggregate read/execute count statistics (vercel/turbo#8286)
Tobias Koppers - box InProgress task state (vercel/turbo#8644)
Tobias Koppers - Task Edges Set/List (vercel/turbo#8624)
Benjamin Woodruff - Memory: Use `triomphe::Arc` for `SharedReference` (vercel/turbo#8622)
Will Binns-Smith - chore: release npm packages (vercel/turbo#8614)
Will Binns-Smith - devlow-bench: add git branch and sha to datapoints (vercel/turbo#8602)

---

Fixes a `triomphe` package version conflict between turbopack and swc by bumping it from 0.1.11 to 0.1.13.