### PR TITLE
fix PPR navigations when visiting route with seeded cache

### DIFF
--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -105,7 +105,9 @@ export function createInitialRouterState({
       location.origin
     )
 
-    const initialFlightData: FlightData = [['', initialTree, null, null]]
+    const initialFlightData: FlightData = [
+      [initialTree, initialSeedData, initialHead],
+    ]
     createPrefetchCacheEntryForInitialLoad({
       url,
       kind: PrefetchKind.AUTO,

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -717,9 +717,11 @@ describe('app dir - basic', () => {
         await browser.waitForElementByCss('#render-id')
         expect(await browser.eval('window.history.length')).toBe(2)
 
-        // Get the ID again, and compare, they should be the same.
-        const thirdID = await browser.elementById('render-id').text()
-        expect(thirdID).not.toBe(firstID)
+        await retry(async () => {
+          // Get the ID again, and compare, they should be the same.
+          const thirdID = await browser.elementById('render-id').text()
+          expect(thirdID).not.toBe(firstID)
+        })
 
         // verify that the flag is still set
         expect(await browser.eval('window.__nextSoftPushTest')).toBe(1)

--- a/test/e2e/app-dir/ppr-navigations/prefetch-navigation/prefetch-navigation.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/prefetch-navigation/prefetch-navigation.test.ts
@@ -62,5 +62,14 @@ describe('prefetch-navigation', () => {
 
     // Resolve the request to allow the page to finish loading
     await rscRequestPromise.get('/catch-all/2').resolve()
+
+    // Now go back to the first page to make sure that the server seeded
+    // prefetch cache entry behaves the same as one that is retrieved
+    // from the client prefetch.
+    await browser.elementByCss('a[href="/catch-all/1"]').click()
+    await browser.waitForElementByCss('#dynamic-page-1')
+
+    targetPageParams = await browser.elementById('params').text()
+    expect(targetPageParams).toBe('Params: {"slug":["1"]}')
   })
 })

--- a/test/ppr-tests-manifest.json
+++ b/test/ppr-tests-manifest.json
@@ -20,18 +20,6 @@
         "app-dir static/dynamic handling should output debug info for static bailouts"
       ]
     },
-    "test/e2e/app-dir/app-client-cache/client-cache.original.test.ts": {
-      "failed": [
-        "app dir client cache semantics (30s/5min) prefetch={undefined} - default should re-use the full cache for only 30 seconds",
-        "app dir client cache semantics (30s/5min) prefetch={undefined} - default should renew the 30s cache once the data is revalidated",
-        "app dir client cache semantics (30s/5min) prefetch={undefined} - default should refetch the full page after 5 mins"
-      ]
-    },
-    "test/e2e/app-dir/app-client-cache/client-cache.defaults.test.ts": {
-      "failed": [
-        "app dir client cache semantics (default semantics) prefetch={undefined} - default should refetch the full page after 5 mins"
-      ]
-    },
     "test/e2e/app-dir/headers-static-bailout/headers-static-bailout.test.ts": {
       "failed": [
         "headers-static-bailout it provides a helpful link in case static generation bailout is uncaught"
@@ -92,7 +80,9 @@
       "test/e2e/app-dir/ppr-*/**/*",
       "test/e2e/app-dir/app-prefetch*/**/*",
       "test/e2e/app-dir/searchparams-static-bailout/searchparams-static-bailout.test.ts",
-      "test/e2e/app-dir/app-client-cache/client-cache.experimental.test.ts"
+      "test/e2e/app-dir/app-client-cache/client-cache.experimental.test.ts",
+      "test/e2e/app-dir/app-client-cache/client-cache.original.test.ts",
+      "test/e2e/app-dir/app-client-cache/client-cache.defaults.test.ts"
     ]
   }
 }


### PR DESCRIPTION
During SSR, we walk the component tree and pass and immediately seed the router cache with the tree.

We also seed the prefetch cache for the initial route with the same tree data because navigations events will apply the data from the prefetch cache. The rationale for this is that since we already have the data, we might as well seed it in the prefetch cache, to save a server round trip later. 

The way we're seeding the cache introduced a bug when PPR is turned on: PPR expects that each element in `FlightDataPath` is of length 3, corresponding with: `[PrefetchedTree, SeedData, Head]`. However, we were seeding it with 4 items: `[Segment, PrefetchedTree, SeedData, Head]`. When the forked router implementation sees anything other than 3 items, it reverts back to the pre-PPR behavior, which means the data will be lazy-fetched during render rather than eagerly in the reducer. 

As a result, when navigating back to the page that was seeded during SSR, it wouldn't immediately apply the static parts to the UI: it'd block until the dynamic render finished.

This PR also includes a small change to ensure reused tasks don’t trigger a dynamic request. A navigation test was failing because this PR fixed a bug that was causing it to hit the non-PPR behavior, which already handles this correctly. 

I've added an explicit test for this in PPR. I've also excluded all of the `client-cache` tests from PPR, as many of them were already failing and aren't relevant to PPR, since PPR doesn't currently make use of the `staleTime`/ cache heuristics that the regular router does. 