### PR TITLE
refactor: avoid unnecessary after wrapper

### DIFF
--- a/packages/next/src/server/after/after-context.test.ts
+++ b/packages/next/src/server/after/after-context.test.ts
@@ -13,7 +13,7 @@ describe('AfterContext', () => {
   type AfterContextMod = typeof import('./after-context')
 
   let requestAsyncStorage: RASMod['requestAsyncStorage']
-  let AfterContextImpl: AfterContextMod['AfterContextImpl']
+  let AfterContext: AfterContextMod['AfterContext']
   let after: AfterMod['unstable_after']
 
   beforeAll(async () => {
@@ -26,7 +26,7 @@ describe('AfterContext', () => {
     requestAsyncStorage = RASMod.requestAsyncStorage
 
     const AfterContextMod = await import('./after-context')
-    AfterContextImpl = AfterContextMod.AfterContextImpl
+    AfterContext = AfterContextMod.AfterContext
 
     const AfterMod = await import('./after')
     after = AfterMod.unstable_after
@@ -49,7 +49,7 @@ describe('AfterContext', () => {
       onCloseCallback = cb
     })
 
-    const afterContext = new AfterContextImpl({
+    const afterContext = new AfterContext({
       waitUntil,
       onClose,
       cacheScope: undefined,
@@ -116,7 +116,7 @@ describe('AfterContext', () => {
       onCloseCallback = cb
     })
 
-    const afterContext = new AfterContextImpl({
+    const afterContext = new AfterContext({
       waitUntil,
       onClose,
       cacheScope: undefined,
@@ -164,7 +164,7 @@ describe('AfterContext', () => {
       onCloseCallback = cb
     })
 
-    const afterContext = new AfterContextImpl({
+    const afterContext = new AfterContext({
       waitUntil,
       onClose,
       cacheScope: undefined,
@@ -255,7 +255,7 @@ describe('AfterContext', () => {
       onCloseCallback = cb
     })
 
-    const afterContext = new AfterContextImpl({
+    const afterContext = new AfterContext({
       waitUntil,
       onClose,
       cacheScope: undefined,
@@ -315,7 +315,7 @@ describe('AfterContext', () => {
       throw new Error('onClose is broken for some reason')
     })
 
-    const afterContext = new AfterContextImpl({
+    const afterContext = new AfterContext({
       waitUntil,
       onClose,
       cacheScope: undefined,
@@ -353,7 +353,7 @@ describe('AfterContext', () => {
       onCloseCallback = cb
     })
 
-    const afterContext = new AfterContextImpl({
+    const afterContext = new AfterContext({
       waitUntil,
       onClose,
       cacheScope: undefined,
@@ -406,7 +406,7 @@ describe('AfterContext', () => {
     const waitUntil = undefined
     const onClose = jest.fn()
 
-    const afterContext = new AfterContextImpl({
+    const afterContext = new AfterContext({
       waitUntil,
       onClose,
       cacheScope: undefined,
@@ -436,7 +436,7 @@ describe('AfterContext', () => {
 
     const onClose = undefined
 
-    const afterContext = new AfterContextImpl({
+    const afterContext = new AfterContext({
       waitUntil,
       onClose,
       cacheScope: undefined,

--- a/packages/next/src/server/after/after-context.test.ts
+++ b/packages/next/src/server/after/after-context.test.ts
@@ -4,7 +4,7 @@ import { AsyncLocalStorage } from 'async_hooks'
 import type { RequestStore } from '../../client/components/request-async-storage.external'
 import type { AfterContext } from './after-context'
 
-describe('createAfterContext', () => {
+describe('AfterContext', () => {
   // 'async-local-storage.ts' needs `AsyncLocalStorage` on `globalThis` at import time,
   // so we have to do some contortions here to set it up before running anything else
   type RASMod =
@@ -13,7 +13,7 @@ describe('createAfterContext', () => {
   type AfterContextMod = typeof import('./after-context')
 
   let requestAsyncStorage: RASMod['requestAsyncStorage']
-  let createAfterContext: AfterContextMod['createAfterContext']
+  let AfterContextImpl: AfterContextMod['AfterContextImpl']
   let after: AfterMod['unstable_after']
 
   beforeAll(async () => {
@@ -26,7 +26,7 @@ describe('createAfterContext', () => {
     requestAsyncStorage = RASMod.requestAsyncStorage
 
     const AfterContextMod = await import('./after-context')
-    createAfterContext = AfterContextMod.createAfterContext
+    AfterContextImpl = AfterContextMod.AfterContextImpl
 
     const AfterMod = await import('./after')
     after = AfterMod.unstable_after
@@ -49,7 +49,7 @@ describe('createAfterContext', () => {
       onCloseCallback = cb
     })
 
-    const afterContext = createAfterContext({
+    const afterContext = new AfterContextImpl({
       waitUntil,
       onClose,
       cacheScope: undefined,
@@ -116,7 +116,7 @@ describe('createAfterContext', () => {
       onCloseCallback = cb
     })
 
-    const afterContext = createAfterContext({
+    const afterContext = new AfterContextImpl({
       waitUntil,
       onClose,
       cacheScope: undefined,
@@ -164,7 +164,7 @@ describe('createAfterContext', () => {
       onCloseCallback = cb
     })
 
-    const afterContext = createAfterContext({
+    const afterContext = new AfterContextImpl({
       waitUntil,
       onClose,
       cacheScope: undefined,
@@ -255,7 +255,7 @@ describe('createAfterContext', () => {
       onCloseCallback = cb
     })
 
-    const afterContext = createAfterContext({
+    const afterContext = new AfterContextImpl({
       waitUntil,
       onClose,
       cacheScope: undefined,
@@ -315,7 +315,7 @@ describe('createAfterContext', () => {
       throw new Error('onClose is broken for some reason')
     })
 
-    const afterContext = createAfterContext({
+    const afterContext = new AfterContextImpl({
       waitUntil,
       onClose,
       cacheScope: undefined,
@@ -353,7 +353,7 @@ describe('createAfterContext', () => {
       onCloseCallback = cb
     })
 
-    const afterContext = createAfterContext({
+    const afterContext = new AfterContextImpl({
       waitUntil,
       onClose,
       cacheScope: undefined,
@@ -406,7 +406,7 @@ describe('createAfterContext', () => {
     const waitUntil = undefined
     const onClose = jest.fn()
 
-    const afterContext = createAfterContext({
+    const afterContext = new AfterContextImpl({
       waitUntil,
       onClose,
       cacheScope: undefined,
@@ -436,7 +436,7 @@ describe('createAfterContext', () => {
 
     const onClose = undefined
 
-    const afterContext = createAfterContext({
+    const afterContext = new AfterContextImpl({
       waitUntil,
       onClose,
       cacheScope: undefined,

--- a/packages/next/src/server/after/after-context.ts
+++ b/packages/next/src/server/after/after-context.ts
@@ -9,18 +9,13 @@ import type { RequestLifecycleOpts } from '../base-server'
 import type { AfterCallback, AfterTask } from './after'
 import { InvariantError } from '../../shared/lib/invariant-error'
 
-export interface AfterContext {
-  run<T>(requestStore: RequestStore, callback: () => T): T
-  after(task: AfterTask): void
-}
-
 export type AfterContextOpts = {
   waitUntil: RequestLifecycleOpts['waitUntil'] | undefined
   onClose: RequestLifecycleOpts['onClose'] | undefined
   cacheScope: CacheScope | undefined
 }
 
-export class AfterContextImpl implements AfterContext {
+export class AfterContext {
   private waitUntil: RequestLifecycleOpts['waitUntil'] | undefined
   private onClose: RequestLifecycleOpts['onClose'] | undefined
   private cacheScope: CacheScope | undefined

--- a/packages/next/src/server/after/after-context.ts
+++ b/packages/next/src/server/after/after-context.ts
@@ -20,10 +20,6 @@ export type AfterContextOpts = {
   cacheScope: CacheScope | undefined
 }
 
-export function createAfterContext(opts: AfterContextOpts): AfterContext {
-  return new AfterContextImpl(opts)
-}
-
 export class AfterContextImpl implements AfterContext {
   private waitUntil: RequestLifecycleOpts['waitUntil'] | undefined
   private onClose: RequestLifecycleOpts['onClose'] | undefined

--- a/packages/next/src/server/async-storage/with-request-store.ts
+++ b/packages/next/src/server/async-storage/with-request-store.ts
@@ -20,7 +20,7 @@ import {
 import { ResponseCookies, RequestCookies } from '../web/spec-extension/cookies'
 import { DraftModeProvider } from './draft-mode-provider'
 import { splitCookiesString } from '../web/utils'
-import { AfterContextImpl, type AfterContext } from '../after/after-context'
+import { AfterContext } from '../after/after-context'
 import type { RequestLifecycleOpts } from '../base-server'
 
 function getHeaders(headers: Headers | IncomingHttpHeaders): ReadonlyHeaders {
@@ -192,7 +192,7 @@ function createAfterContext(
   const { waitUntil, onClose, ComponentMod } = renderOpts
   const cacheScope = ComponentMod?.createCacheScope()
 
-  return new AfterContextImpl({ waitUntil, onClose, cacheScope })
+  return new AfterContext({ waitUntil, onClose, cacheScope })
 }
 
 function isAfterEnabled(


### PR DESCRIPTION
I think the wrap function is a leftover from before #66767. We don't need to return a tuple here, and can just use the `AfterContext` directly on the call site. This makes its optionality a bit more obvious, and avoids the noop callback.