### PR TITLE
Dedupe double logged server errors

### DIFF
--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -107,7 +107,11 @@ export function createErrorHandler({
         })
       }
 
-      if (!silenceLogger) {
+      if (
+        !silenceLogger &&
+        // Only log the error from SSR rendering as RSC error will still be pipped there
+        source === 'html'
+      ) {
         if (errorLogger) {
           errorLogger(err).catch(() => {})
         } else {

--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -108,9 +108,11 @@ export function createErrorHandler({
       }
 
       if (
-        !silenceLogger &&
-        // Only log the error from SSR rendering as RSC error will still be pipped there
-        source === 'html'
+        (!silenceLogger &&
+          // Only log the error from SSR rendering errors and flight data render errors,
+          // as RSC renderer error will still be pipped into SSR renderer as well.
+          source === 'html') ||
+        source === 'flightData'
       ) {
         if (errorLogger) {
           errorLogger(err).catch(() => {})

--- a/test/e2e/app-dir/dedupe-rsc-error-log/app/client/edge/page.tsx
+++ b/test/e2e/app-dir/dedupe-rsc-error-log/app/client/edge/page.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { ErrorComponent } from '../../component'
+
+export default () => <ErrorComponent name="client-edge" />
+
+export const runtime = 'edge'

--- a/test/e2e/app-dir/dedupe-rsc-error-log/app/client/page.tsx
+++ b/test/e2e/app-dir/dedupe-rsc-error-log/app/client/page.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { ErrorComponent } from '../component'
+
+export default () => <ErrorComponent name="client-node" />
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/app-dir/dedupe-rsc-error-log/app/component.tsx
+++ b/test/e2e/app-dir/dedupe-rsc-error-log/app/component.tsx
@@ -1,0 +1,8 @@
+async function getData(name: string) {
+  throw new Error('Custom error:' + name)
+}
+
+export async function ErrorComponent({ name }: { name: string }) {
+  await getData(name)
+  return null
+}

--- a/test/e2e/app-dir/dedupe-rsc-error-log/app/layout.tsx
+++ b/test/e2e/app-dir/dedupe-rsc-error-log/app/layout.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/app-dir/dedupe-rsc-error-log/app/server/edge/page.tsx
+++ b/test/e2e/app-dir/dedupe-rsc-error-log/app/server/edge/page.tsx
@@ -1,0 +1,5 @@
+import { ErrorComponent } from '../../component'
+
+export default () => <ErrorComponent name="server-edge" />
+
+export const runtime = 'edge'

--- a/test/e2e/app-dir/dedupe-rsc-error-log/app/server/page.tsx
+++ b/test/e2e/app-dir/dedupe-rsc-error-log/app/server/page.tsx
@@ -1,0 +1,5 @@
+import { ErrorComponent } from '../component'
+
+export default () => <ErrorComponent name="server-node" />
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/app-dir/dedupe-rsc-error-log/dedupe-rsc-error-log.test.ts
+++ b/test/e2e/app-dir/dedupe-rsc-error-log/dedupe-rsc-error-log.test.ts
@@ -1,9 +1,10 @@
 import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
 
-function expectContainOnce(output: string, search: string) {
+async function expectContainOnce(output: string, search: string) {
   const parts = output.split(search)
   // Ensure the search string is found once
-  expect(parts.length).toBe(2)
+  await retry(() => expect(parts.length).toBe(2))
 }
 
 describe('dedupe-rsc-error-log', () => {
@@ -13,21 +14,21 @@ describe('dedupe-rsc-error-log', () => {
 
   it('should only log RSC error once for nodejs runtime', async () => {
     await next.fetch('/server')
-    expectContainOnce(next.cliOutput, 'Custom error:server-node')
+    await expectContainOnce(next.cliOutput, 'Custom error:server-node')
   })
 
   it('should only log RSC error once for edge runtime', async () => {
     await next.fetch('/server/edge')
-    expectContainOnce(next.cliOutput, 'Custom error:server-edge')
+    await expectContainOnce(next.cliOutput, 'Custom error:server-edge')
   })
 
   it('should only log SSR error once for nodejs runtime', async () => {
     await next.fetch('/client')
-    expectContainOnce(next.cliOutput, 'Custom error:client-node')
+    await expectContainOnce(next.cliOutput, 'Custom error:client-node')
   })
 
   it('should only log SSR error once for edge runtime', async () => {
     await next.fetch('/client/edge')
-    expectContainOnce(next.cliOutput, 'Custom error:client-edge')
+    await expectContainOnce(next.cliOutput, 'Custom error:client-edge')
   })
 })

--- a/test/e2e/app-dir/dedupe-rsc-error-log/dedupe-rsc-error-log.test.ts
+++ b/test/e2e/app-dir/dedupe-rsc-error-log/dedupe-rsc-error-log.test.ts
@@ -1,10 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
-async function expectContainOnce(output: string, search: string) {
-  const parts = output.split(search)
+async function expectContainOnce(next: any, search: string) {
   // Ensure the search string is found once
-  await retry(() => expect(parts.length).toBe(2))
+  await retry(() => {
+    const parts = next.cliOutput.split(search)
+    expect(parts.length).toBe(2)
+  })
 }
 
 describe('dedupe-rsc-error-log', () => {
@@ -14,21 +16,21 @@ describe('dedupe-rsc-error-log', () => {
 
   it('should only log RSC error once for nodejs runtime', async () => {
     await next.fetch('/server')
-    await expectContainOnce(next.cliOutput, 'Custom error:server-node')
+    await expectContainOnce(next, 'Custom error:server-node')
   })
 
   it('should only log RSC error once for edge runtime', async () => {
     await next.fetch('/server/edge')
-    await expectContainOnce(next.cliOutput, 'Custom error:server-edge')
+    await expectContainOnce(next, 'Custom error:server-edge')
   })
 
   it('should only log SSR error once for nodejs runtime', async () => {
     await next.fetch('/client')
-    await expectContainOnce(next.cliOutput, 'Custom error:client-node')
+    await expectContainOnce(next, 'Custom error:client-node')
   })
 
   it('should only log SSR error once for edge runtime', async () => {
     await next.fetch('/client/edge')
-    await expectContainOnce(next.cliOutput, 'Custom error:client-edge')
+    await expectContainOnce(next, 'Custom error:client-edge')
   })
 })

--- a/test/e2e/app-dir/dedupe-rsc-error-log/dedupe-rsc-error-log.test.ts
+++ b/test/e2e/app-dir/dedupe-rsc-error-log/dedupe-rsc-error-log.test.ts
@@ -1,0 +1,33 @@
+import { nextTestSetup } from 'e2e-utils'
+
+function expectContainOnce(output: string, search: string) {
+  const parts = output.split(search)
+  // Ensure the search string is found once
+  expect(parts.length).toBe(2)
+}
+
+describe('dedupe-rsc-error-log', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should only log RSC error once for nodejs runtime', async () => {
+    await next.fetch('/server')
+    expectContainOnce(next.cliOutput, 'Custom error:server-node')
+  })
+
+  it('should only log RSC error once for edge runtime', async () => {
+    await next.fetch('/server/edge')
+    expectContainOnce(next.cliOutput, 'Custom error:server-edge')
+  })
+
+  it('should only log SSR error once for nodejs runtime', async () => {
+    await next.fetch('/client')
+    expectContainOnce(next.cliOutput, 'Custom error:client-node')
+  })
+
+  it('should only log SSR error once for edge runtime', async () => {
+    await next.fetch('/client/edge')
+    expectContainOnce(next.cliOutput, 'Custom error:client-edge')
+  })
+})


### PR DESCRIPTION
### What

Only call error log in SSR renderer, instead of calling it in all RSC and SSR renderers.

Fixes #67352 
Close NEXT-3579

### Why

The RSC rendered generated result will be rendered by SSR renderer again, at there we can get the actual error. So when there's a RSC error happening, only logging once in SSR rendering layer is enough.
