### PR TITLE
docs: add server actions to unsupported features of static exports

### DIFF
--- a/docs/02-app/01-building-your-application/10-deploying/02-static-exports.mdx
+++ b/docs/02-app/01-building-your-application/10-deploying/02-static-exports.mdx
@@ -287,6 +287,7 @@ Features that require a Node.js server, or dynamic logic that cannot be computed
 - [Incremental Static Regeneration](/docs/app/building-your-application/data-fetching/caching-and-revalidating)
 - [Image Optimization](/docs/app/building-your-application/optimizing/images) with the default `loader`
 - [Draft Mode](/docs/app/building-your-application/configuring/draft-mode)
+- [Server Actions](/docs/app/building-your-application/data-fetching/server-actions-and-mutations)
 
 Attempting to use any of these features with `next dev` will result in an error, similar to setting the [`dynamic`](/docs/app/api-reference/file-conventions/route-segment-config#dynamic) option to `error` in the root layout.
 


### PR DESCRIPTION
Server actions require running code on-demand (as an API route) and cannot be used without a server environment.