### PR TITLE
Clean up flight headers

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -139,11 +139,11 @@ import { getFilesInDir } from '../lib/get-files-in-dir'
 import { eventSwcPlugins } from '../telemetry/events/swc-plugins'
 import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
 import {
-  ACTION,
+  ACTION_HEADER,
   NEXT_ROUTER_PREFETCH_HEADER,
   RSC_HEADER,
   RSC_CONTENT_TYPE_HEADER,
-  NEXT_ROUTER_STATE_TREE,
+  NEXT_ROUTER_STATE_TREE_HEADER,
   NEXT_DID_POSTPONE_HEADER,
 } from '../client/components/app-router-headers'
 import { webpackBuild } from './webpack-build'
@@ -1136,7 +1136,7 @@ export default async function build(
               header: RSC_HEADER,
               // This vary header is used as a default. It is technically re-assigned in `base-server`,
               // and may include an additional Vary option for `Next-URL`.
-              varyHeader: `${RSC_HEADER}, ${NEXT_ROUTER_STATE_TREE}, ${NEXT_ROUTER_PREFETCH_HEADER}`,
+              varyHeader: `${RSC_HEADER}, ${NEXT_ROUTER_STATE_TREE_HEADER}, ${NEXT_ROUTER_PREFETCH_HEADER}`,
               prefetchHeader: NEXT_ROUTER_PREFETCH_HEADER,
               didPostponeHeader: NEXT_DID_POSTPONE_HEADER,
               contentTypeHeader: RSC_CONTENT_TYPE_HEADER,
@@ -2699,7 +2699,7 @@ export default async function build(
             // this flag is used to selectively bypass the static cache and invoke the lambda directly
             // to enable server actions on static routes
             const bypassFor: RouteHas[] = [
-              { type: 'header', key: ACTION },
+              { type: 'header', key: ACTION_HEADER },
               {
                 type: 'header',
                 key: 'content-type',

--- a/packages/next/src/client/components/app-router-headers.ts
+++ b/packages/next/src/client/components/app-router-headers.ts
@@ -1,15 +1,14 @@
 export const RSC_HEADER = 'RSC' as const
-export const ACTION = 'Next-Action' as const
-
-export const NEXT_ROUTER_STATE_TREE = 'Next-Router-State-Tree' as const
+export const ACTION_HEADER = 'Next-Action' as const
+export const NEXT_ROUTER_STATE_TREE_HEADER = 'Next-Router-State-Tree' as const
 export const NEXT_ROUTER_PREFETCH_HEADER = 'Next-Router-Prefetch' as const
 export const NEXT_URL = 'Next-Url' as const
 export const RSC_CONTENT_TYPE_HEADER = 'text/x-component' as const
 
-export const FLIGHT_PARAMETERS = [
-  [RSC_HEADER],
-  [NEXT_ROUTER_STATE_TREE],
-  [NEXT_ROUTER_PREFETCH_HEADER],
+export const FLIGHT_HEADERS = [
+  RSC_HEADER,
+  NEXT_ROUTER_STATE_TREE_HEADER,
+  NEXT_ROUTER_PREFETCH_HEADER,
 ] as const
 
 export const NEXT_RSC_UNION_QUERY = '_rsc' as const

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -18,7 +18,7 @@ import type {
 } from '../../../server/app-render/types'
 import {
   NEXT_ROUTER_PREFETCH_HEADER,
-  NEXT_ROUTER_STATE_TREE,
+  NEXT_ROUTER_STATE_TREE_HEADER,
   NEXT_RSC_UNION_QUERY,
   NEXT_URL,
   RSC_HEADER,
@@ -53,7 +53,7 @@ export async function fetchServerResponse(
 ): Promise<FetchServerResponseResult> {
   const headers: {
     [RSC_HEADER]: '1'
-    [NEXT_ROUTER_STATE_TREE]: string
+    [NEXT_ROUTER_STATE_TREE_HEADER]: string
     [NEXT_URL]?: string
     [NEXT_ROUTER_PREFETCH_HEADER]?: '1'
     // A header that is only added in test mode to assert on fetch priority
@@ -62,7 +62,7 @@ export async function fetchServerResponse(
     // Enable flight response
     [RSC_HEADER]: '1',
     // Provide the current router state
-    [NEXT_ROUTER_STATE_TREE]: encodeURIComponent(
+    [NEXT_ROUTER_STATE_TREE_HEADER]: encodeURIComponent(
       JSON.stringify(flightRouterState)
     ),
   }
@@ -84,7 +84,7 @@ export async function fetchServerResponse(
   const uniqueCacheQuery = hexHash(
     [
       headers[NEXT_ROUTER_PREFETCH_HEADER] || '0',
-      headers[NEXT_ROUTER_STATE_TREE],
+      headers[NEXT_ROUTER_STATE_TREE_HEADER],
       headers[NEXT_URL],
     ].join(',')
   )

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -5,8 +5,8 @@ import type {
 } from '../../../../server/app-render/types'
 import { callServer } from '../../../app-call-server'
 import {
-  ACTION,
-  NEXT_ROUTER_STATE_TREE,
+  ACTION_HEADER,
+  NEXT_ROUTER_STATE_TREE_HEADER,
   NEXT_URL,
   RSC_CONTENT_TYPE_HEADER,
 } from '../../app-router-headers'
@@ -63,8 +63,10 @@ async function fetchServerAction(
     method: 'POST',
     headers: {
       Accept: RSC_CONTENT_TYPE_HEADER,
-      [ACTION]: actionId,
-      [NEXT_ROUTER_STATE_TREE]: encodeURIComponent(JSON.stringify(state.tree)),
+      [ACTION_HEADER]: actionId,
+      [NEXT_ROUTER_STATE_TREE_HEADER]: encodeURIComponent(
+        JSON.stringify(state.tree)
+      ),
       ...(process.env.NEXT_DEPLOYMENT_ID
         ? {
             'x-deployment-id': process.env.NEXT_DEPLOYMENT_ID,

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -8,8 +8,8 @@ import type { BaseNextRequest, BaseNextResponse } from '../base-http'
 import {
   RSC_HEADER,
   RSC_CONTENT_TYPE_HEADER,
-  NEXT_ROUTER_STATE_TREE,
-  ACTION,
+  NEXT_ROUTER_STATE_TREE_HEADER,
+  ACTION_HEADER,
 } from '../../client/components/app-router-headers'
 import { isNotFoundError } from '../../client/components/not-found'
 import {
@@ -325,10 +325,10 @@ async function createRedirectRenderResult(
     }
 
     // Ensures that when the path was revalidated we don't return a partial response on redirects
-    forwardedHeaders.delete(NEXT_ROUTER_STATE_TREE)
+    forwardedHeaders.delete(NEXT_ROUTER_STATE_TREE_HEADER)
     // When an action follows a redirect, it's no longer handling an action: it's just a normal RSC request
     // to the requested URL. We should remove the `next-action` header so that it's not treated as an action
-    forwardedHeaders.delete(ACTION)
+    forwardedHeaders.delete(ACTION_HEADER)
 
     try {
       const response = await fetch(fetchUrl, {

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -37,7 +37,7 @@ import {
 import { stripInternalQueries } from '../internal-utils'
 import {
   NEXT_ROUTER_PREFETCH_HEADER,
-  NEXT_ROUTER_STATE_TREE,
+  NEXT_ROUTER_STATE_TREE_HEADER,
   NEXT_URL,
   RSC_HEADER,
 } from '../../client/components/app-router-headers'
@@ -768,7 +768,7 @@ async function renderToHTMLOrFlightImpl(
     isRSCRequest && (!isPrefetchRSCRequest || !isRoutePPREnabled)
 
   const parsedFlightRouterState = parseAndValidateFlightRouterState(
-    req.headers[NEXT_ROUTER_STATE_TREE.toLowerCase()]
+    req.headers[NEXT_ROUTER_STATE_TREE_HEADER.toLowerCase()]
   )
 
   /**

--- a/packages/next/src/server/app-render/strip-flight-headers.ts
+++ b/packages/next/src/server/app-render/strip-flight-headers.ts
@@ -1,6 +1,6 @@
 import type { IncomingHttpHeaders } from 'node:http'
 
-import { FLIGHT_PARAMETERS } from '../../client/components/app-router-headers'
+import { FLIGHT_HEADERS } from '../../client/components/app-router-headers'
 
 /**
  * Removes the flight headers from the request.
@@ -8,7 +8,7 @@ import { FLIGHT_PARAMETERS } from '../../client/components/app-router-headers'
  * @param req the request to strip the headers from
  */
 export function stripFlightHeaders(headers: IncomingHttpHeaders) {
-  for (const [header] of FLIGHT_PARAMETERS) {
+  for (const header of FLIGHT_HEADERS) {
     delete headers[header.toLowerCase()]
   }
 }

--- a/packages/next/src/server/async-storage/with-request-store.ts
+++ b/packages/next/src/server/async-storage/with-request-store.ts
@@ -7,7 +7,7 @@ import type { WithStore } from './with-store'
 import type { NextRequest } from '../web/spec-extension/request'
 import type { __ApiPreviewProps } from '../api-utils'
 
-import { FLIGHT_PARAMETERS } from '../../client/components/app-router-headers'
+import { FLIGHT_HEADERS } from '../../client/components/app-router-headers'
 import {
   HeadersAdapter,
   type ReadonlyHeaders,
@@ -25,8 +25,8 @@ import type { RequestLifecycleOpts } from '../base-server'
 
 function getHeaders(headers: Headers | IncomingHttpHeaders): ReadonlyHeaders {
   const cleaned = HeadersAdapter.from(headers)
-  for (const param of FLIGHT_PARAMETERS) {
-    cleaned.delete(param.toString().toLowerCase())
+  for (const header of FLIGHT_HEADERS) {
+    cleaned.delete(header.toLowerCase())
   }
 
   return HeadersAdapter.seal(cleaned)

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -95,7 +95,7 @@ import {
   NEXT_ROUTER_PREFETCH_HEADER,
   NEXT_DID_POSTPONE_HEADER,
   NEXT_URL,
-  NEXT_ROUTER_STATE_TREE,
+  NEXT_ROUTER_STATE_TREE_HEADER,
 } from '../client/components/app-router-headers'
 import type {
   MatchOptions,
@@ -1817,7 +1817,7 @@ export default abstract class Server<
     isAppPath: boolean,
     resolvedPathname: string
   ): void {
-    const baseVaryHeader = `${RSC_HEADER}, ${NEXT_ROUTER_STATE_TREE}, ${NEXT_ROUTER_PREFETCH_HEADER}`
+    const baseVaryHeader = `${RSC_HEADER}, ${NEXT_ROUTER_STATE_TREE_HEADER}, ${NEXT_ROUTER_PREFETCH_HEADER}`
     const isRSCRequest = getRequestMeta(req, 'isRSCRequest') ?? false
 
     let addedNextUrlToVary = false

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -37,7 +37,7 @@ import {
   prepareDestination,
 } from '../../../shared/lib/router/utils/prepare-destination'
 import type { TLSSocket } from 'tls'
-import { NEXT_ROUTER_STATE_TREE } from '../../../client/components/app-router-headers'
+import { NEXT_ROUTER_STATE_TREE_HEADER } from '../../../client/components/app-router-headers'
 import { getSelectedParams } from '../../../client/components/router-reducer/compute-changed-path'
 import { isInterceptionRouteRewrite } from '../../../lib/generate-interception-routes-rewrites'
 import { parseAndValidateFlightRouterState } from '../../app-render/parse-and-validate-flight-router-state'
@@ -701,7 +701,7 @@ export function getResolveRoutes(
             // This attempts to extract the dynamic params from the provided router state.
             if (isInterceptionRouteRewrite(route as Rewrite)) {
               const stateHeader =
-                req.headers[NEXT_ROUTER_STATE_TREE.toLowerCase()]
+                req.headers[NEXT_ROUTER_STATE_TREE_HEADER.toLowerCase()]
 
               if (stateHeader) {
                 rewriteParams = {

--- a/packages/next/src/server/lib/server-action-request-meta.ts
+++ b/packages/next/src/server/lib/server-action-request-meta.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage } from 'http'
 import type { BaseNextRequest } from '../base-http'
 import type { NextRequest } from '../web/exports'
-import { ACTION } from '../../client/components/app-router-headers'
+import { ACTION_HEADER } from '../../client/components/app-router-headers'
 
 export function getServerActionRequestMetadata(
   req: IncomingMessage | BaseNextRequest | NextRequest
@@ -16,10 +16,10 @@ export function getServerActionRequestMetadata(
   let contentType: string | null
 
   if (req.headers instanceof Headers) {
-    actionId = req.headers.get(ACTION.toLowerCase()) ?? null
+    actionId = req.headers.get(ACTION_HEADER.toLowerCase()) ?? null
     contentType = req.headers.get('content-type')
   } else {
-    actionId = (req.headers[ACTION.toLowerCase()] as string) ?? null
+    actionId = (req.headers[ACTION_HEADER.toLowerCase()] as string) ?? null
     contentType = req.headers['content-type'] ?? null
   }
 

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -11,7 +11,7 @@ import { waitUntilSymbol } from './spec-extension/fetch-event'
 import { NextURL } from './next-url'
 import { stripInternalSearchParams } from '../internal-utils'
 import { normalizeRscURL } from '../../shared/lib/router/utils/app-paths'
-import { FLIGHT_PARAMETERS } from '../../client/components/app-router-headers'
+import { FLIGHT_HEADERS } from '../../client/components/app-router-headers'
 import { ensureInstrumentationRegistered } from './globals'
 import {
   withRequestStore,
@@ -133,13 +133,13 @@ export async function adapter(
 
   const requestHeaders = fromNodeOutgoingHttpHeaders(params.request.headers)
   const flightHeaders = new Map()
-  // Parameters should only be stripped for middleware
+  // Headers should only be stripped for middleware
   if (!isEdgeRendering) {
-    for (const param of FLIGHT_PARAMETERS) {
-      const key = param.toString().toLowerCase()
+    for (const header of FLIGHT_HEADERS) {
+      const key = header.toLowerCase()
       const value = requestHeaders.get(key)
       if (value) {
-        flightHeaders.set(key, requestHeaders.get(key))
+        flightHeaders.set(key, value)
         requestHeaders.delete(key)
       }
     }


### PR DESCRIPTION
- The array nesting was most likely done accidentally in #42482.
- The wording 'parameters' is vestigial from when those were actually query params.
- Some header consts were missing the `_HEADER` suffix.