### PR TITLE
Re-add support for inline snapshots using prettier v2

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -20,6 +20,8 @@ const customJestConfig = {
   moduleNameMapper: {
     '@next/font/(.*)': '@next/font/$1',
   },
+  // Re-add support for inline snapshots using prettier v2:
+  prettierPath: require.resolve('prettier-2'),
 }
 
 if (process.env.RECORD_REPLAY) {

--- a/package.json
+++ b/package.json
@@ -195,6 +195,7 @@
     "postcss-pseudoelements": "5.0.0",
     "postcss-short-size": "4.0.0",
     "postcss-trolling": "0.1.7",
+    "prettier-2": "npm:prettier@^2",
     "prettier": "3.2.5",
     "pretty-bytes": "5.3.0",
     "pretty-ms": "7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -434,6 +434,9 @@ importers:
       prettier:
         specifier: 3.2.5
         version: 3.2.5
+      prettier-2:
+        specifier: npm:prettier@^2
+        version: prettier@2.5.1
       pretty-bytes:
         specifier: 5.3.0
         version: 5.3.0


### PR DESCRIPTION
With prettier v3 we can not create/update inline snapshopts anymore.

The applied workaround is documented at
https://jestjs.io/docs/configuration/#prettierpath-string.

x-ref: https://github.com/vercel/next.js/actions/runs/9815872011/job/27105422658