### PR TITLE
Ensure Node.js 18.18 is used in Turbopack test manifest update

### DIFF
--- a/.github/workflows/setup-nextjs-build.yml
+++ b/.github/workflows/setup-nextjs-build.yml
@@ -16,6 +16,11 @@ jobs:
     outputs:
       output1: ${{ steps.build-next-swc-turbopack-patch.outputs.success }}
     steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }}
+          check-latest: true
       - name: Get number of CPU cores
         uses: SimenB/github-actions-cpu-cores@v2
         id: cpu-cores

--- a/.github/workflows/setup-nextjs-build.yml
+++ b/.github/workflows/setup-nextjs-build.yml
@@ -8,6 +8,10 @@ on:
       # If not specified, will use latest release version including canary.
       version:
         type: string
+      nodeVersion:
+        required: false
+        description: 'version of Node.js to use'
+        type: string
 
 jobs:
   build_nextjs:

--- a/.github/workflows/turbopack-nextjs-build-integration-tests.yml
+++ b/.github/workflows/turbopack-nextjs-build-integration-tests.yml
@@ -67,6 +67,11 @@ jobs:
         group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 
     steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.18.2
+          check-latest: true
       - uses: actions/cache/restore@v3
         id: restore-build
         with:

--- a/.github/workflows/turbopack-nextjs-build-integration-tests.yml
+++ b/.github/workflows/turbopack-nextjs-build-integration-tests.yml
@@ -118,6 +118,11 @@ jobs:
         group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 
     steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.18.2
+          check-latest: true
       - uses: actions/cache/restore@v3
         id: restore-build
         with:

--- a/.github/workflows/turbopack-nextjs-build-integration-tests.yml
+++ b/.github/workflows/turbopack-nextjs-build-integration-tests.yml
@@ -40,6 +40,7 @@ jobs:
     name: Setup Next.js build
     uses: ./.github/workflows/setup-nextjs-build.yml
     with:
+      nodeVersion: 18.18.2
       version: ${{ inputs.version || 'canary' }}
 
   # Actual test scheduling. These jobs mimic the same jobs in Next.js repo,

--- a/.github/workflows/turbopack-nextjs-dev-integration-tests.yml
+++ b/.github/workflows/turbopack-nextjs-dev-integration-tests.yml
@@ -67,6 +67,11 @@ jobs:
         group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 
     steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.18.2
+          check-latest: true
       - uses: actions/cache/restore@v3
         id: restore-build
         with:

--- a/.github/workflows/turbopack-nextjs-dev-integration-tests.yml
+++ b/.github/workflows/turbopack-nextjs-dev-integration-tests.yml
@@ -118,6 +118,11 @@ jobs:
         group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 
     steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.18.2
+          check-latest: true
       - uses: actions/cache/restore@v3
         id: restore-build
         with:

--- a/.github/workflows/turbopack-nextjs-dev-integration-tests.yml
+++ b/.github/workflows/turbopack-nextjs-dev-integration-tests.yml
@@ -40,6 +40,7 @@ jobs:
     name: Setup Next.js build
     uses: ./.github/workflows/setup-nextjs-build.yml
     with:
+      nodeVersion: 18.18.2
       version: ${{ inputs.version || 'canary' }}
 
   # Actual test scheduling. These jobs mimic the same jobs in Next.js repo,


### PR DESCRIPTION
For some reason these GitHub actions runs don't use `build_reusable.yml`, checking with @ijjk why that is the case before changing it, but this is a temporary fix for the tests failing as it uses 18.17 by default right now which fails the `engines` check.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
