### PR TITLE
chore: bump pnpm to 9.5.0

### DIFF
--- a/.github/actions/next-integration-stat/package.json
+++ b/.github/actions/next-integration-stat/package.json
@@ -23,5 +23,5 @@
   "engines": {
     "node": ">=18.18.0"
   },
-  "packageManager": "pnpm@9.4.0"
+  "packageManager": "pnpm@9.5.0"
 }

--- a/.github/actions/next-stats-action/package.json
+++ b/.github/actions/next-stats-action/package.json
@@ -20,5 +20,5 @@
   "engines": {
     "node": ">=18.18.0"
   },
-  "packageManager": "pnpm@9.4.0"
+  "packageManager": "pnpm@9.5.0"
 }

--- a/.github/actions/upload-turboyet-data/package.json
+++ b/.github/actions/upload-turboyet-data/package.json
@@ -14,5 +14,5 @@
   "engines": {
     "node": ">=18.18.0"
   },
-  "packageManager": "pnpm@9.4.0"
+  "packageManager": "pnpm@9.5.0"
 }

--- a/package.json
+++ b/package.json
@@ -264,9 +264,9 @@
   },
   "engines": {
     "node": ">=18.18.0",
-    "pnpm": "9.4.0"
+    "pnpm": "9.5.0"
   },
-  "packageManager": "pnpm@9.4.0",
+  "packageManager": "pnpm@9.5.0",
   "pnpm": {
     "patchedDependencies": {
       "webpack-sources@3.2.3": "patches/webpack-sources@3.2.3.patch"

--- a/scripts/normalize-version-bump.js
+++ b/scripts/normalize-version-bump.js
@@ -72,6 +72,6 @@ const writeJson = async (filePath, data) =>
     private: true,
     workspaces: ['packages/*'],
     scripts: {},
-    packageManager: 'pnpm@9.4.0',
+    packageManager: 'pnpm@9.5.0',
   })
 })()

--- a/test/.stats-app/package.json
+++ b/test/.stats-app/package.json
@@ -10,5 +10,5 @@
   "engines": {
     "node": ">=18.18.0"
   },
-  "packageManager": "pnpm@9.4.0"
+  "packageManager": "pnpm@9.5.0"
 }


### PR DESCRIPTION
## Why?

Upgrading to [9.5.0](https://github.com/pnpm/pnpm/releases/tag/v9.5.0) allows us to start using [catalogs](https://pnpm.io/catalogs).