### PR TITLE
test: update component to async to avoid TS error in build

### DIFF
--- a/test/e2e/app-dir/dedupe-rsc-error-log/app/component.tsx
+++ b/test/e2e/app-dir/dedupe-rsc-error-log/app/component.tsx
@@ -1,8 +1,4 @@
-async function getData(name: string) {
+export function ErrorComponent({ name }: { name: string }) {
   throw new Error('Custom error:' + name)
-}
-
-export async function ErrorComponent({ name }: { name: string }) {
-  await getData(name)
   return null
 }


### PR DESCRIPTION
### What

Change the shared test component to async since it's used in both server/client components. Found this error while testing other stuff, it's because the async shared component is accidentally used in client component page

```
===== TS errors =====

[Test Mode] ./app/client/edge/page.tsx:5:23
Type error: 'ErrorComponent' cannot be used as a JSX component.
  Its type '({ name }: { name: string; }) => Promise<any>' is not a valid JSX element type.
```