### PR TITLE
feat(next/font): add falllbackPaths option (minor feature)

### DIFF
--- a/packages/font/src/local/index.ts
+++ b/packages/font/src/local/index.ts
@@ -11,9 +11,11 @@ type LocalFont<T extends CssVariable | undefined = undefined> = {
     | string
     | Array<{
         path: string
+        fallbackPaths?: string[]
         weight?: string
         style?: string
       }>
+  fallbackPaths?: string[]
   display?: Display
   weight?: string
   style?: string

--- a/packages/font/src/local/loader.test.ts
+++ b/packages/font/src/local/loader.test.ts
@@ -229,5 +229,38 @@ describe('next/font/local loader', () => {
         "
       `)
     })
+    test('fallbackPaths', async () => {
+      const { css } = await nextFontLocalFontLoader({
+        functionName: '',
+        data: [
+          {
+            weight: '400',
+            src: './fonts/font1.woff2',
+            fallbackPaths: ['./fonts/font1.woff', './fonts/font1.otf'],
+            adjustFontFallback: false,
+          },
+        ],
+        emitFontFile: (_, ext) => `/_next/static/media/my-font.${ext}`,
+        resolve: jest.fn(),
+        isDev: false,
+        isServer: true,
+        variableName: 'myFont',
+        loaderContext: {
+          fs: {
+            readFile: (path: string, cb: any) => cb(null, path),
+          },
+        } as any,
+      })
+
+      expect(css).toMatchInlineSnapshot(`
+        "@font-face {
+        font-family: myFont;
+        src: url(/_next/static/media/my-font.woff2) format('woff2'),url(/_next/static/media/my-font.woff) format('woff'),url(/_next/static/media/my-font.otf) format('opentype');
+        font-display: swap;
+        font-weight: 400;
+        }
+        "
+      `)
+    })
   })
 })


### PR DESCRIPTION
### What?
Support falllbackPaths option on next/font/local module.

### Why?
We need to add multiple web font file(another extension) in a font-face for legacy browsers. But, we could't not found any way to add multiple font file on currently api. 

### How?
Add falllbackPaths option in LocalFontOption. And just add url and format to function to generating font-face.

Resolves #49207 
