### PR TITLE
Tweak the display for error trace

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
@@ -11,13 +11,11 @@ export type RuntimeErrorProps = { error: ReadyRuntimeError }
 export function RuntimeError({ error }: RuntimeErrorProps) {
   const { firstFrame, allLeadingFrames, allCallStackFrames } =
     React.useMemo(() => {
-      const filteredFrames = error.frames.filter(
-        (f) =>
-          !(
-            f.sourceStackFrame.file === '<anonymous>' &&
-            ['stringify', '<unknown>'].includes(f.sourceStackFrame.methodName)
-          ) && !f.sourceStackFrame.file?.startsWith('node:internal')
-      )
+      const filteredFrames = error.frames
+        // Filter out nodejs internal frames since you can't do anything about them.
+        // e.g. node:internal/timers shows up pretty often due to timers, but not helpful to users.
+        // Only present the last line before nodejs internal trace.
+        .filter((f) => !f.sourceStackFrame.file?.startsWith('node:'))
 
       const firstFirstPartyFrameIndex = filteredFrames.findIndex(
         (entry) =>

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
@@ -117,8 +117,11 @@ function isWebpackBundled(file: string) {
  * webpack://_N_E/./src/hello.tsx => ./src/hello.tsx
  * webpack://./src/hello.tsx => ./src/hello.tsx
  * webpack:///./src/hello.tsx => ./src/hello.tsx
+ *
+ * <anonymous> => ''
  */
 function formatFrameSourceFile(file: string) {
+  if (file === '<anonymous>') return ''
   for (const regex of webpackRegExes) file = file.replace(regex, '')
   return file
 }
@@ -147,7 +150,7 @@ export function getFrameSource(frame: StackFrame): string {
     str += ' '
     str = formatFrameSourceFile(str)
   } catch {
-    str += formatFrameSourceFile(frame.file || '(unknown)') + ' '
+    str += formatFrameSourceFile(frame.file || '') + ' '
   }
 
   if (!isWebpackBundled(frame.file) && frame.lineNumber != null) {


### PR DESCRIPTION
### What

Change the display of error trace in error overlay. 

* Replace unknown location `<anonymous>` from the stack trace but still keep the content before the location.
* Filter out all `node:` prefixes (including node:async_hooks etc.)



### Why

Regarding to the chaneg in https://github.com/facebook/react/pull/30290

We only stripped the `(<anonymous>)` part but still keep the first part of stack trace, e.g. in react it could be the component name.

cc @sebmarkbage 