### PR TITLE
Turbopack build: Ensure build manifest routes are sorted

### DIFF
--- a/packages/next/src/server/dev/turbopack/manifest-loader.ts
+++ b/packages/next/src/server/dev/turbopack/manifest-loader.ts
@@ -40,6 +40,7 @@ import type { Entrypoints } from './types'
 import getAssetPathFromRoute from '../../../shared/lib/router/utils/get-asset-path-from-route'
 import { getEntryKey, type EntryKey } from './entry-key'
 import type { CustomRoutes } from '../../../lib/load-custom-routes'
+import { getSortedRoutes } from '../../../shared/lib/router/utils'
 
 interface InstrumentationDefinition {
   files: string[]
@@ -348,15 +349,17 @@ export class TurbopackManifestLoader {
     if (entrypoints.global.error) {
       pagesKeys.push('/_error')
     }
+
+    const sortedPageKeys = getSortedRoutes(pagesKeys)
     const content: ClientBuildManifest = {
       __rewrites: normalizeRewritesForBuildManifest(rewrites) as any,
       ...Object.fromEntries(
-        pagesKeys.map((pathname) => [
+        sortedPageKeys.map((pathname) => [
           pathname,
           [`static/chunks/pages${pathname === '/' ? '/index' : pathname}.js`],
         ])
       ),
-      sortedPages: pagesKeys,
+      sortedPages: sortedPageKeys,
     }
     const buildManifestJs = `self.__BUILD_MANIFEST = ${JSON.stringify(
       content

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -13547,15 +13547,11 @@
         "Prefetching Links in viewport production mode should handle timed out prefetch correctly",
         "Prefetching Links in viewport production mode should not have unhandledRejection when failing to prefetch on link",
         "Prefetching Links in viewport production mode should not prefetch when prefetch is explicitly set to false",
-        "Prefetching Links in viewport production mode should not prefetch with bot UA"
-      ],
-      "failed": [
+        "Prefetching Links in viewport production mode should not prefetch with bot UA",
         "Prefetching Links in viewport production mode should de-dupe inflight SSG requests",
         "Prefetching Links in viewport production mode should inject a <script> tag when onMouseEnter (even with invalid ref)",
         "Prefetching Links in viewport production mode should inject script on hover with prefetching disabled",
         "Prefetching Links in viewport production mode should inject script on hover with prefetching disabled and fetch data",
-        "Prefetching Links in viewport production mode should not duplicate prefetches",
-        "Prefetching Links in viewport production mode should not prefetch already loaded scripts",
         "Prefetching Links in viewport production mode should not re-prefetch for an already prefetched page",
         "Prefetching Links in viewport production mode should prefetch data files",
         "Prefetching Links in viewport production mode should prefetch data files when mismatched",
@@ -13566,6 +13562,10 @@
         "Prefetching Links in viewport production mode should prefetch with link in viewport onload",
         "Prefetching Links in viewport production mode should prefetch with link in viewport when href changes",
         "Prefetching Links in viewport production mode should prefetch with non-bot UA"
+      ],
+      "failed": [
+        "Prefetching Links in viewport production mode should not prefetch already loaded scripts",
+        "Prefetching Links in viewport production mode should not duplicate prefetches"
       ],
       "pending": [],
       "flakey": [],


### PR DESCRIPTION
The build manifest holds routes that are sorted when using webpack, this sorting logic was missing when writing the equivalent manifest for Turbopack. This PR adds the same logic for the build manifest when using Turbopack.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
