### PR TITLE
Turbopack build: Fix preload-viewport tests

### DIFF
--- a/test/integration/preload-viewport/test/index.test.js
+++ b/test/integration/preload-viewport/test/index.test.js
@@ -410,33 +410,38 @@ describe('Prefetching Links in viewport', () => {
         expect(found).toBe(false)
       })
 
-      it('should not prefetch already loaded scripts', async () => {
-        const browser = await webdriver(appPort, '/')
+      // Turbopack handling of chunks is different, by default it does not include a script tag for the page itself.
+      ;(process.env.TURBOPACK ? it.skip : it)(
+        'should not prefetch already loaded scripts',
+        async () => {
+          const browser = await webdriver(appPort, '/')
 
-        const scriptSrcs = await browser.eval(`(function() {
+          const scriptSrcs = await browser.eval(`(function() {
       return Array.from(document.querySelectorAll('script'))
         .map(function(el) {
           return el.src && new URL(el.src).pathname
         }).filter(Boolean)
     })()`)
 
-        await browser.eval('next.router.prefetch("/")')
+          await browser.eval('next.router.prefetch("/")')
 
-        const linkHrefs = await browser.eval(`(function() {
+          const linkHrefs = await browser.eval(`(function() {
       return Array.from(document.querySelectorAll('link'))
         .map(function(el) {
           return el.href && new URL(el.href).pathname
         }).filter(Boolean)
     })()`)
 
-        console.log({ linkHrefs, scriptSrcs })
-        expect(scriptSrcs.some((src) => src.includes('pages/index-'))).toBe(
-          true
-        )
-        expect(linkHrefs.some((href) => href.includes('pages/index-'))).toBe(
-          false
-        )
-      })
+          // eslint-disable-next-line jest/no-standalone-expect
+          expect(scriptSrcs.some((src) => src.includes('pages/index-'))).toBe(
+            true
+          )
+          // eslint-disable-next-line jest/no-standalone-expect
+          expect(linkHrefs.some((href) => href.includes('pages/index-'))).toBe(
+            false
+          )
+        }
+      )
 
       it('should not duplicate prefetches', async () => {
         const browser = await webdriver(appPort, '/multi-prefetch')
@@ -454,7 +459,7 @@ describe('Prefetching Links in viewport', () => {
         expect(hrefs).toEqual([...new Set(hrefs)])
 
         // Verify encoding
-        expect(hrefs.some((e) => e.includes(`%5Bhello%5D-`))).toBe(true)
+        expect(hrefs.some((e) => e.includes(`%5Bhello%5D`))).toBe(true)
       })
 
       it('should not re-prefetch for an already prefetched page', async () => {

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -13657,13 +13657,13 @@
         "Prefetching Links in viewport production mode should prefetch with link in viewport on scroll",
         "Prefetching Links in viewport production mode should prefetch with link in viewport onload",
         "Prefetching Links in viewport production mode should prefetch with link in viewport when href changes",
-        "Prefetching Links in viewport production mode should prefetch with non-bot UA"
-      ],
-      "failed": [
-        "Prefetching Links in viewport production mode should not prefetch already loaded scripts",
+        "Prefetching Links in viewport production mode should prefetch with non-bot UA",
         "Prefetching Links in viewport production mode should not duplicate prefetches"
       ],
-      "pending": [],
+      "failed": [],
+      "pending": [
+        "Prefetching Links in viewport production mode should not prefetch already loaded scripts"
+      ],
       "flakey": [],
       "runtimeError": false
     },


### PR DESCRIPTION
- Skip a test that only applies to webpack as it relies on the chunk loading
- Updated a test to look for the scheme that works in both Turbopack and Webpack
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
