### PR TITLE
Wait for dev server restart after `next.config.js` changes in tests

### DIFF
--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -183,7 +183,10 @@ export class NextDeployInstance extends NextInstance {
     // no-op as the deployment is created during setup()
   }
 
-  public async patchFile(filename: string, content: string): Promise<void> {
+  public async patchFile(
+    filename: string,
+    content: string
+  ): Promise<{ newFile: boolean }> {
     throw new Error('patchFile is not available in deploy test mode')
   }
   public async readFile(filename: string): Promise<string> {

--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -2,6 +2,7 @@ import spawn from 'cross-spawn'
 import { Span } from 'next/dist/trace'
 import { NextInstance } from './base'
 import { getTurbopackFlag } from '../turbo'
+import { waitFor, retry } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
 export class NextDevInstance extends NextInstance {
@@ -125,5 +126,76 @@ export class NextDevInstance extends NextInstance {
         setTimeout(() => process.exit(1), 0)
       }
     })
+  }
+
+  private async handleDevWatchDelayBeforeChange(filename: string) {
+    // This is a temporary workaround for turbopack starting watching too late.
+    // So we delay file changes by 500ms to give it some time
+    // to connect the WebSocket and start watching.
+    if (process.env.TURBOPACK) {
+      require('console').log('fs dev delay before', filename)
+      await waitFor(500)
+    }
+  }
+
+  private async handleDevWatchDelayAfterChange(filename: string) {
+    // to help alleviate flakiness with tests that create
+    // dynamic routes // and then request it we give a buffer
+    // of 500ms to allow WatchPack to detect the changed files
+    // TODO: replace this with an event directly from WatchPack inside
+    // router-server for better accuracy
+    if (filename.startsWith('app/') || filename.startsWith('pages/')) {
+      require('console').log('fs dev delay', filename)
+      await new Promise((resolve) => setTimeout(resolve, 500))
+    }
+  }
+
+  public override async patchFile(
+    filename: string,
+    content: string | ((contents: string) => string)
+  ) {
+    const isServerRunning = this.childProcess && !this.isStopping
+    const cliOutputLength = this.cliOutput.length
+
+    if (isServerRunning) {
+      await this.handleDevWatchDelayBeforeChange(filename)
+    }
+
+    const { newFile } = await super.patchFile(filename, content)
+
+    if (isServerRunning) {
+      if (newFile) {
+        await this.handleDevWatchDelayAfterChange(filename)
+      } else if (filename.startsWith('next.config')) {
+        await retry(() => {
+          if (!this.cliOutput.slice(cliOutputLength).includes('Ready in')) {
+            throw new Error('Server has not finished restarting.')
+          }
+        })
+      }
+    }
+
+    return { newFile }
+  }
+
+  public override async renameFile(filename: string, newFilename: string) {
+    await this.handleDevWatchDelayBeforeChange(filename)
+    await super.renameFile(filename, newFilename)
+    await this.handleDevWatchDelayAfterChange(filename)
+  }
+
+  public override async renameFolder(
+    foldername: string,
+    newFoldername: string
+  ) {
+    await this.handleDevWatchDelayBeforeChange(foldername)
+    await super.renameFolder(foldername, newFoldername)
+    await this.handleDevWatchDelayAfterChange(foldername)
+  }
+
+  public override async deleteFile(filename: string) {
+    await this.handleDevWatchDelayBeforeChange(filename)
+    super.deleteFile(filename)
+    await this.handleDevWatchDelayAfterChange(filename)
   }
 }

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -42,6 +42,7 @@ export class NextStartInstance extends NextInstance {
     if (this.childProcess) {
       throw new Error('next already started')
     }
+
     this._cliOutput = ''
     this.spawnOpts = {
       cwd: this.testDir,


### PR DESCRIPTION
This allows us to change the `next.config.js` file before a test with an already running dev server, without getting connection issues because the dev server may not have restarted in time for the next test to trigger requests.