### PR TITLE
Reduce log noise caused by `retry()` attempts

### DIFF
--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -804,7 +804,7 @@ export async function retry<T>(
         )
         throw err
       }
-      console.warn(
+      console.log(
         `Retrying${description ? ` ${description}` : ''} in ${interval}ms`
       )
       await waitFor(interval)


### PR DESCRIPTION
Retry attempts in tests, using the `retry()` test utility, are usually expected. Therefore, using `console.warn` to print the info that it's retrying, adds unnecessary noise to the test logs due to the call stack being printed as well. The call stack is not useful at this point. It's only needed when all retry attempts are exhausted, which we still get with the `console.error('Failed to retry...')` call.

**Before:**

<img width="908" alt="retry-warn" src="https://github.com/vercel/next.js/assets/761683/7fe7d75b-1f0f-4511-b418-f014246240d9">

**After:**

<img width="366" alt="retry-log" src="https://github.com/vercel/next.js/assets/761683/598aa139-d42a-44f0-9df0-4ac95101e882">
