### PR TITLE
test: disable flaky duration assertion in image optimizer test

### DIFF
--- a/test/integration/image-optimizer/test/util.ts
+++ b/test/integration/image-optimizer/test/util.ts
@@ -967,7 +967,7 @@ export function runTests(ctx: RunTestsCtx) {
           query,
           opts
         )
-        expect(five.duration).toBeLessThan(one.duration)
+        // expect(five.duration).toBeLessThan(one.duration) // TODO: investigate why this timing varies randomly
         expect(five.res.status).toBe(200)
         expect(five.res.headers.get('X-Nextjs-Cache')).toBe('HIT')
         expect(five.res.headers.get('Content-Type')).toBe('image/webp')
@@ -1144,7 +1144,7 @@ export function runTests(ctx: RunTestsCtx) {
         query,
         opts
       )
-      expect(five.duration).toBeLessThan(one.duration)
+      // expect(five.duration).toBeLessThan(one.duration) // TODO: investigate why this timing varies randomly
       expect(five.res.status).toBe(200)
       expect(five.res.headers.get('X-Nextjs-Cache')).toBe('HIT')
       expect(five.res.headers.get('Content-Type')).toBe('image/webp')


### PR DESCRIPTION
This assertion flakes all the time, so I'd say that it it's not actually checking anything useful. I think it's better to disable this and save everyone some reruns