### PR TITLE
fix NextConfig detection in createTestDir

### DIFF
--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -234,13 +234,11 @@ export class NextInstance {
             await this.writeInitialFiles()
           })
 
-        let nextConfigFile = Object.keys(this.files).find((file) =>
+        const testDirFiles = await fs.readdir(this.testDir)
+
+        let nextConfigFile = testDirFiles.find((file) =>
           file.startsWith('next.config.')
         )
-
-        if (existsSync(path.join(this.testDir, 'next.config.js'))) {
-          nextConfigFile = 'next.config.js'
-        }
 
         if (nextConfigFile && this.nextConfig) {
           throw new Error(


### PR DESCRIPTION
We were creating a `next.config.js` file which conflicts with an existing `next.config.ts` file, since the next config detection wasn't properly looking at files in the test dir.

[x-ref](https://github.com/vercel/next.js/actions/runs/9862195913/job/27233838936)