### PR TITLE
run changed/added tests in deploy mode

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -443,7 +443,7 @@ jobs:
           name: wasm-binaries-${{matrix.target}}
           path: packages/next-swc/crates/wasm/pkg-*
 
-  deployTarball:
+  deploy-tarball:
     if: ${{ needs.deploy-target.outputs.value != 'production' }}
     name: Deploy preview tarball
     runs-on: ubuntu-latest

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -313,6 +313,23 @@ jobs:
 
     secrets: inherit
 
+  test-new-tests-deploy:
+    name: Test new tests when deployed
+    needs: ['changes', 'build-native', 'build-next']
+    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1/4, 2/4, 3/4, 4/4]
+
+    uses: ./.github/workflows/build_reusable.yml
+    with:
+      afterBuild: node scripts/test-new-tests.mjs --mode deploy --group ${{ matrix.group }}
+      stepName: 'test-new-tests-deploy-${{matrix.group}}'
+
+    secrets: inherit
+
   test-dev:
     name: test dev
     needs: ['changes', 'build-native', 'build-next']
@@ -490,6 +507,7 @@ jobs:
         'test-turbopack-integration',
         'test-new-tests-dev',
         'test-new-tests-start',
+        'test-new-tests-deploy',
         'test-turbopack-production',
         'test-turbopack-production-integration',
       ]

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -315,7 +315,7 @@ jobs:
 
   test-new-tests-deploy:
     name: Test new tests when deployed
-    needs: ['test-new-tests-dev', 'test-new-tests-start']
+    needs: ['test-prod', 'test-new-tests-dev', 'test-new-tests-start']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
 
     strategy:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -315,7 +315,7 @@ jobs:
 
   test-new-tests-deploy:
     name: Test new tests when deployed
-    needs: ['changes', 'build-native', 'build-next']
+    needs: ['test-new-tests-dev', 'test-new-tests-start']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
 
     strategy:

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -3,6 +3,7 @@ import { retry, waitFor } from 'next-test-utils'
 import type { Response } from 'playwright'
 
 describe('app dir - navigation', () => {
+  console.log('modifying test file')
   const { next, isNextDev, isNextStart, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -3,7 +3,6 @@ import { retry, waitFor } from 'next-test-utils'
 import type { Response } from 'playwright'
 
 describe('app dir - navigation', () => {
-  console.log('modifying test file')
   const { next, isNextDev, isNextStart, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })


### PR DESCRIPTION
Leverages the work from https://github.com/vercel/next.js/pull/66445 to download artifacts for a particular commit SHA, so that it can be passed to the `test-deploy` script.

This will let us run deploy tests on PRs, ensuring that they're run from the Next.js on the target branch rather than `canary`.

This waits until `test-new-tests-dev` and `test-new-tests-start` complete for 2 reasons:
- No reason to waste deploy resources if the changed/added tests don't even work in dev/start
- It gives time for deploy-tarball to finish

Sample run: https://github.com/vercel/next.js/actions/runs/9865244781/job/27241944533?pr=67612#step:28:54