### PR TITLE
Fix two mistakes in next test instance classes

### DIFF
--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -368,9 +368,9 @@ export class NextInstance {
       this.childProcess.kill('SIGKILL')
       await exitPromise
       this.childProcess = undefined
+      this.isStopping = false
       require('console').log(`Stopped next server`)
     }
-    this.isStopping = false
   }
 
   public async destroy(): Promise<void> {

--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -195,7 +195,7 @@ export class NextDevInstance extends NextInstance {
 
   public override async deleteFile(filename: string) {
     await this.handleDevWatchDelayBeforeChange(filename)
-    super.deleteFile(filename)
+    await super.deleteFile(filename)
     await this.handleDevWatchDelayAfterChange(filename)
   }
 }


### PR DESCRIPTION
This is a quick follow-up from #67601:

- avoid floating promise in `NextDevInstance#deleteFile`
- fix nesting in `NextInstance#stop`