### PR TITLE
add shared handling for deploy tests that use patched node_modules

### DIFF
--- a/test/e2e/app-dir/app-routes-client-component/.vercelignore
+++ b/test/e2e/app-dir/app-routes-client-component/.vercelignore
@@ -1,1 +1,0 @@
-!node_modules

--- a/test/e2e/app-dir/app-routes-client-component/vercel.json
+++ b/test/e2e/app-dir/app-routes-client-component/vercel.json
@@ -1,4 +1,0 @@
-{
-  "installCommand": "mv node_modules node_modules.bak && npm i",
-  "buildCommand": "cp -r node_modules.bak/* node_modules && npm run build"
-}

--- a/test/e2e/app-dir/scss/nm-module-nested/.vercelignore
+++ b/test/e2e/app-dir/scss/nm-module-nested/.vercelignore
@@ -1,1 +1,0 @@
-!node_modules

--- a/test/e2e/app-dir/scss/nm-module-nested/vercel.json
+++ b/test/e2e/app-dir/scss/nm-module-nested/vercel.json
@@ -1,4 +1,0 @@
-{
-  "installCommand": "mv node_modules node_modules.bak && npm i",
-  "buildCommand": "cp -r node_modules.bak/* node_modules && npm run build"
-}

--- a/test/e2e/app-dir/scss/nm-module/.vercelignore
+++ b/test/e2e/app-dir/scss/nm-module/.vercelignore
@@ -1,1 +1,0 @@
-!node_modules

--- a/test/e2e/app-dir/scss/nm-module/vercel.json
+++ b/test/e2e/app-dir/scss/nm-module/vercel.json
@@ -1,4 +1,0 @@
-{
-  "installCommand": "mv node_modules node_modules.bak && npm i",
-  "buildCommand": "cp -r node_modules.bak/* node_modules && npm run build"
-}

--- a/test/e2e/app-dir/scss/npm-import-nested/.vercelignore
+++ b/test/e2e/app-dir/scss/npm-import-nested/.vercelignore
@@ -1,1 +1,0 @@
-!node_modules

--- a/test/e2e/app-dir/scss/npm-import-nested/vercel.json
+++ b/test/e2e/app-dir/scss/npm-import-nested/vercel.json
@@ -1,4 +1,0 @@
-{
-  "installCommand": "mv node_modules node_modules.bak && npm i",
-  "buildCommand": "cp -r node_modules.bak/* node_modules && npm run build"
-}

--- a/test/e2e/esm-externals/.vercelignore
+++ b/test/e2e/esm-externals/.vercelignore
@@ -1,1 +1,0 @@
-!node_modules

--- a/test/e2e/esm-externals/vercel.json
+++ b/test/e2e/esm-externals/vercel.json
@@ -1,4 +1,0 @@
-{
-  "installCommand": "mv node_modules node_modules.bak && npm i",
-  "buildCommand": "cp -r node_modules.bak/* node_modules && npm run build"
-}

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -320,9 +320,8 @@ export class NextInstance {
             await fs.writeFile(
               path.join(this.testDir, 'vercel.json'),
               JSON.stringify({
-                installCommand: 'mv node_modules node_modules.bak && npm i',
-                buildCommand:
-                  'cp -r node_modules.bak/* node_modules && npm run build',
+                installCommand:
+                  'mv node_modules node_modules.bak && npm i && cp -r node_modules.bak/* node_modules',
               })
             )
 


### PR DESCRIPTION
Removes the special case we have in each deploy test in favor of one that automatically adds the `.vercelignore` and `vercel.json` to support deploying tests that contain a patched `node_modules` dir.

[x-ref](https://github.com/vercel/next.js/actions/runs/9877060529/job/27279468442)