### PR TITLE
fix: typo prerender indicator link

### DIFF
--- a/packages/next/src/client/components/prerender-indicator.ts
+++ b/packages/next/src/client/components/prerender-indicator.ts
@@ -116,7 +116,7 @@ function createContainer(prefix: string) {
     <button id="${prefix}close" title="Hide indicator for session">
       <span>×</span>
     </button>
-    <a href="https://nextjs.org/docs/api-reference/next.config.js/devIndicators" target="_blank" rel="noreferrer">
+    <a href="https://nextjs.org/docs/app/api-reference/next-config-js/devIndicators" target="_blank" rel="noreferrer">
       <div id="${prefix}icon-wrapper">
           <svg width="15" height="20" viewBox="0 0 60 80" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M36 3L30.74 41H8L36 3Z" fill="black"/>


### PR DESCRIPTION
# Summary
I updated [prerender indicator](https://github.com/vercel/next.js/pull/67306)'s href to https://nextjs.org/docs/app/api-reference/next-config-js/devIndicators.

## Description
Currently prerender indicator link is https://nextjs.org/docs/api-reference/next.config.js/devIndicators.
This isn't work.

I would like to see [devIndicators in app router docs](https://nextjs.org/docs/app/api-reference/next-config-js/devIndicators) instead of the above wrong link.

x-ref: #67306 
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
