### PR TITLE
MongoDB, Mongoose, Jest, Jest-mongodb - Connection to DB will not close during tests

### DIFF
--- a/examples/with-mongodb-mongoose/globalConfig.json
+++ b/examples/with-mongodb-mongoose/globalConfig.json
@@ -1,1 +1,1 @@
-{"mongoUri":"mongodb://127.0.0.1:19530/","mongoDBName":"jest"}
+{"mongoUri":"mongodb://127.0.0.1:25422/","mongoDBName":"jest"}

--- a/examples/with-mongodb-mongoose/globalConfig.json
+++ b/examples/with-mongodb-mongoose/globalConfig.json
@@ -1,0 +1,1 @@
+{"mongoUri":"mongodb://127.0.0.1:19530/","mongoDBName":"jest"}

--- a/examples/with-mongodb-mongoose/jest-mongodb-config.js
+++ b/examples/with-mongodb-mongoose/jest-mongodb-config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  mongodbMemoryServerOptions: {
+    binary: {
+      version: '4.0.3',
+      skipMD5: true,
+    },
+    instance: {
+      dbName: 'jest',
+    },
+    autoStart: false,
+  },
+  mongoURLEnvName: 'MONGODB_URI',
+};

--- a/examples/with-mongodb-mongoose/jest.config.js
+++ b/examples/with-mongodb-mongoose/jest.config.js
@@ -1,0 +1,204 @@
+/**
+ * For a detailed explanation regarding each configuration property, visit:
+ * https://jestjs.io/docs/configuration
+ */
+
+module.exports = {
+  // All imported modules in your tests should be mocked automatically
+  // automock: false,
+
+  // Stop running tests after `n` failures
+  // bail: 0,
+
+  // The directory where Jest should store its cached dependency information
+  // cacheDirectory: "/private/var/folders/ss/sh2p536n3kng76vxl6_f73_80000gn/T/jest_dx",
+
+  // Automatically clear mock calls, instances, contexts and results before every test
+  clearMocks: true,
+
+  // Indicates whether the coverage information should be collected while executing the test
+  collectCoverage: true,
+
+  // An array of glob patterns indicating a set of files for which coverage information should be collected
+  // collectCoverageFrom: undefined,
+
+  // The directory where Jest should output its coverage files
+  coverageDirectory: 'coverage',
+
+  // An array of regexp pattern strings used to skip coverage collection
+  // coveragePathIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // Indicates which provider should be used to instrument code for coverage
+  coverageProvider: 'v8',
+
+  // A list of reporter names that Jest uses when writing coverage reports
+  // coverageReporters: [
+  //   "json",
+  //   "text",
+  //   "lcov",
+  //   "clover"
+  // ],
+
+  // An object that configures minimum threshold enforcement for coverage results
+  // coverageThreshold: undefined,
+
+  // A path to a custom dependency extractor
+  // dependencyExtractor: undefined,
+
+  // Make calling deprecated APIs throw helpful error messages
+  // errorOnDeprecated: false,
+
+  // The default configuration for fake timers
+  // fakeTimers: {
+  //   "enableGlobally": false
+  // },
+
+  // Force coverage collection from ignored files using an array of glob patterns
+  // forceCoverageMatch: [],
+
+  // A path to a module which exports an async function that is triggered once before all test suites
+  // globalSetup: undefined,
+
+  // A path to a module which exports an async function that is triggered once after all test suites
+  globalTeardown: './test/teardown.ts',
+
+  // A set of global variables that need to be available in all test environments
+  // globals: {},
+
+  // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
+  // maxWorkers: "50%",
+
+  // An array of directory names to be searched recursively up from the requiring module's location
+  // moduleDirectories: [
+  //   "node_modules"
+  // ],
+
+  // An array of file extensions your modules use
+  // moduleFileExtensions: [
+  //   "js",
+  //   "mjs",
+  //   "cjs",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "json",
+  //   "node"
+  // ],
+
+  // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
+  // moduleNameMapper: {},
+
+  // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
+  // modulePathIgnorePatterns: [],
+
+  // Activates notifications for test results
+  // notify: false,
+
+  // An enum that specifies notification mode. Requires { notify: true }
+  // notifyMode: "failure-change",
+
+  // A preset that is used as a base for Jest's configuration
+  // preset: undefined,
+  preset: '@shelf/jest-mongodb',
+
+  // Run tests from one or more projects
+  // projects: undefined,
+
+  // Use this configuration option to add custom reporters to Jest
+  // reporters: undefined,
+
+  // Automatically reset mock state before every test
+  // resetMocks: false,
+
+  // Reset the module registry before running each individual test
+  // resetModules: false,
+
+  // A path to a custom resolver
+  // resolver: undefined,
+
+  // Automatically restore mock state and implementation before every test
+  // restoreMocks: false,
+
+  // The root directory that Jest should scan for tests and modules within
+  // rootDir: undefined,
+
+  // A list of paths to directories that Jest should use to search for files in
+  // roots: [
+  //   "<rootDir>"
+  // ],
+
+  // Allows you to use a custom runner instead of Jest's default test runner
+  // runner: "jest-runner",
+
+  // The paths to modules that run some code to configure or set up the testing environment before each test
+  // setupFiles: [],
+
+  // A list of paths to modules that run some code to configure or set up the testing framework before each test
+  // setupFilesAfterEnv: [],
+
+  // The number of seconds after which a test is considered as slow and reported as such in the results.
+  // slowTestThreshold: 5,
+
+  // A list of paths to snapshot serializer modules Jest should use for snapshot testing
+  // snapshotSerializers: [],
+
+  // The test environment that will be used for testing
+  // testEnvironment: "jest-environment-node",
+
+  // Options that will be passed to the testEnvironment
+  // testEnvironmentOptions: {},
+
+  // Adds a location field to test results
+  // testLocationInResults: false,
+
+  // The glob patterns Jest uses to detect test files
+  testMatch: ['**/*.test.ts'],
+
+  // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
+  // testPathIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // The regexp pattern or array of patterns that Jest uses to detect test files
+  // testRegex: [],
+
+  // This option allows the use of a custom results processor
+  // testResultsProcessor: undefined,
+
+  // This option allows use of a custom test runner
+  // testRunner: "jest-circus/runner",
+
+  // A map from regular expressions to paths to transformers
+  transformIgnorePatterns: ['/node_modules/(?!(@browserfs)/)'],
+  transform: {
+    '(\\.ts$|@browserfs)': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.json',
+        useESM: true,
+      },
+    ],
+  },
+
+  // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+  // transformIgnorePatterns: [
+  //   "/node_modules/",
+  //   "\\.pnp\\.[^\\/]+$"
+  // ],
+
+  // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
+  // unmockedModulePathPatterns: undefined,
+
+  // Indicates whether each individual test should be reported during the run
+  // verbose: undefined,
+
+  // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
+  // watchPathIgnorePatterns: [],
+  watchPathIgnorePatterns: ['globalConfig'],
+
+  // Whether to use watchman for file crawling
+  // watchman: true,
+};
+

--- a/examples/with-mongodb-mongoose/package.json
+++ b/examples/with-mongodb-mongoose/package.json
@@ -3,7 +3,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "jest --watch",
+    "test-once": "jest --detectOpenHandles"
   },
   "dependencies": {
     "@types/node": "^20.12.7",
@@ -15,5 +17,10 @@
     "react-dom": "^18.2.0",
     "swr": "^2.2.5",
     "typescript": "^5.4.5"
+  },
+  "devDependencies": {
+    "@shelf/jest-mongodb": "^4.3.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.2"
   }
 }

--- a/examples/with-mongodb-mongoose/test/Pet.test.ts
+++ b/examples/with-mongodb-mongoose/test/Pet.test.ts
@@ -5,21 +5,27 @@ import Pet from "../models/Pet";
 describe('Pet', () => {
   beforeAll(async () => {
     await dbConnect()
+    await Pet.deleteMany({})
+  });
+
+  afterAll(async () => {
+    const connection = await dbConnect();
+    connection.disconnect();
   });
 
   it('should create a pet', async () => {
     const result = await Pet.create({
-      name: "",
-      owner_name: "",
-      species: "",
-      age: 0,
+      name: "Rex",
+      owner_name: "John",
+      species: "Cat",
+      age: 10,
       poddy_trained: false,
       diet: [],
-      image_url: "",
+      image_url: "https://www.google.com",
       likes: [],
       dislikes: [],
     })
 
     expect(result._id).toBeDefined();
-  })
+  });
 });

--- a/examples/with-mongodb-mongoose/test/Pet.test.ts
+++ b/examples/with-mongodb-mongoose/test/Pet.test.ts
@@ -1,0 +1,25 @@
+import dbConnect from "../lib/dbConnect"
+import { beforeAll, describe, it, expect, afterAll } from '@jest/globals';
+import Pet from "../models/Pet";
+
+describe('Pet', () => {
+  beforeAll(async () => {
+    await dbConnect()
+  });
+
+  it('should create a pet', async () => {
+    const result = await Pet.create({
+      name: "",
+      owner_name: "",
+      species: "",
+      age: 0,
+      poddy_trained: false,
+      diet: [],
+      image_url: "",
+      likes: [],
+      dislikes: [],
+    })
+
+    expect(result._id).toBeDefined();
+  })
+});

--- a/examples/with-mongodb-mongoose/test/teardown.ts
+++ b/examples/with-mongodb-mongoose/test/teardown.ts
@@ -1,0 +1,9 @@
+import dbConnect from "../lib/dbConnect";
+
+async function globalTeardown() {
+  dbConnect().then(async (connection) => {
+    await connection.disconnect();
+  });
+}
+
+export default globalTeardown;


### PR DESCRIPTION
I'm starting from NextJS' `with-mongodb-mongoose` example, and trying to implement tests with `jest`, as well as `@shelf/jest-mongodb` for a fast in-memory DB.

My issue is I don't understand how to disconnect at a global level from the database, and so the test runner just stays stuck forever and never exits. I tried to use Jest's global teardown, but it does not work. If I disconnect from within the test suite itself, it does work, but that's not a scaleable approach.

Happy to merge this in the examples if we can make it work!

Maybe @harazdovskiy (& team?) you have an idea how to address this?

### To reproduce the issue

* Clone this branch
* cd into the `examples/with-mongodb-mongoose` folder
* run `npm run test-once`
* Notice the runner will never exit