### PR TITLE
skip test-new-tests-deploy on forks

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -316,7 +316,7 @@ jobs:
   test-new-tests-deploy:
     name: Test new tests when deployed
     needs: ['test-prod', 'test-new-tests-dev', 'test-new-tests-start']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.changes.outputs.docs-only == 'false' && !github.event.pull_request.head.repo.fork }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Forgot to do this. These won't work on forks because they need build artifacts to be published & secrets to be available, which isn't the case on PRs from forks.