### PR TITLE
test: the nextjs internal errors should not be caught

### DIFF
--- a/test/e2e/on-request-error/basic/basic.test.ts
+++ b/test/e2e/on-request-error/basic/basic.test.ts
@@ -2,13 +2,17 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
 describe('on-request-error - basic', () => {
-  const { next } = nextTestSetup({
+  const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
     env: {
       __NEXT_EXPERIMENTAL_INSTRUMENTATION: '1',
     },
   })
+
+  if (skipped) {
+    return
+  }
 
   const outputLogPath = 'output-log.json'
 

--- a/test/e2e/on-request-error/basic/basic.test.ts
+++ b/test/e2e/on-request-error/basic/basic.test.ts
@@ -4,6 +4,7 @@ import { retry } from 'next-test-utils'
 describe('on-request-error - basic', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    skipDeployment: true,
     env: {
       __NEXT_EXPERIMENTAL_INSTRUMENTATION: '1',
     },

--- a/test/e2e/on-request-error/skip-next-internal-error/.gitignore
+++ b/test/e2e/on-request-error/skip-next-internal-error/.gitignore
@@ -1,0 +1,1 @@
+output-log.json

--- a/test/e2e/on-request-error/skip-next-internal-error/.gitignore
+++ b/test/e2e/on-request-error/skip-next-internal-error/.gitignore
@@ -1,1 +1,0 @@
-output-log.json

--- a/test/e2e/on-request-error/skip-next-internal-error/app/another/page.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/another/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>another</p>
+}

--- a/test/e2e/on-request-error/skip-next-internal-error/app/app-route/not-found/route.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/app-route/not-found/route.js
@@ -1,0 +1,7 @@
+import { notFound } from 'next/navigation'
+
+export function GET() {
+  notFound()
+}
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/skip-next-internal-error/app/app-route/redirect/route.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/app-route/redirect/route.js
@@ -1,0 +1,7 @@
+import { redirect } from 'next/navigation'
+
+export function GET() {
+  redirect('/another')
+}
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/skip-next-internal-error/app/client/dynamic-fetch/page.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/client/dynamic-fetch/page.js
@@ -1,0 +1,4 @@
+export default async function Page() {
+  await fetch('https://example.vercel.sh')
+  return <p>dynamic page</p>
+}

--- a/test/e2e/on-request-error/skip-next-internal-error/app/client/no-ssr/component.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/client/no-ssr/component.js
@@ -1,0 +1,3 @@
+export default function Component() {
+  return <p>Component</p>
+}

--- a/test/e2e/on-request-error/skip-next-internal-error/app/client/no-ssr/page.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/client/no-ssr/page.js
@@ -1,0 +1,11 @@
+'use client'
+
+import nextDynamic from 'next/dynamic'
+
+const Component = nextDynamic(() => import('./component'))
+
+export default function Page() {
+  return <Component />
+}
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/skip-next-internal-error/app/client/not-found/page.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/client/not-found/page.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { notFound } from 'next/navigation'
+
+export default function Page() {
+  notFound()
+}
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/skip-next-internal-error/app/client/redirect/page.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/client/redirect/page.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { redirect } from 'next/navigation'
+
+export default function Page() {
+  redirect('/another')
+}
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/skip-next-internal-error/app/layout.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/layout.js
@@ -5,3 +5,5 @@ export default function Layout({ children }) {
     </html>
   )
 }
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/skip-next-internal-error/app/layout.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/layout.js
@@ -1,0 +1,9 @@
+export default function Layout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/skip-next-internal-error/app/layout.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/layout.js
@@ -5,5 +5,3 @@ export default function Layout({ children }) {
     </html>
   )
 }
-
-export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/skip-next-internal-error/app/server/dynamic-fetch/page.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/server/dynamic-fetch/page.js
@@ -1,0 +1,4 @@
+export default async function Page() {
+  await fetch('https://example.vercel.sh')
+  return <p>dynamic page</p>
+}

--- a/test/e2e/on-request-error/skip-next-internal-error/app/server/not-found/page.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/server/not-found/page.js
@@ -1,0 +1,7 @@
+import { notFound } from 'next/navigation'
+
+export default function Page() {
+  notFound()
+}
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/skip-next-internal-error/app/server/redirect/page.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/server/redirect/page.js
@@ -1,0 +1,7 @@
+import { redirect } from 'next/navigation'
+
+export default function Page() {
+  redirect('/another')
+}
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/skip-next-internal-error/instrumentation.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/instrumentation.js
@@ -1,0 +1,3 @@
+export function onRequestError(err, request, context) {
+  console.log('[instrumentation]:error', err.message)
+}

--- a/test/e2e/on-request-error/skip-next-internal-error/next.config.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    instrumentationHook: true,
+  },
+}

--- a/test/e2e/on-request-error/skip-next-internal-error/skip-next-internal-error.test.ts
+++ b/test/e2e/on-request-error/skip-next-internal-error/skip-next-internal-error.test.ts
@@ -1,6 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 
-describe('on-request-error - skip-next-internal-error.test', () => {
+describe('on-request-error - skip-next-internal-error', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
@@ -18,6 +18,7 @@ describe('on-request-error - skip-next-internal-error.test', () => {
     // No navigation errors
     expect(output).not.toContain('NEXT_REDIRECT')
     expect(output).not.toContain('NEXT_NOT_FOUND')
+    expect(output).not.toContain('BAILOUT_TO_CLIENT_SIDE_RENDERING')
     // No dynamic usage errors
     expect(output).not.toContain('DYNAMIC_SERVER_USAGE')
     // No react postpone errors

--- a/test/e2e/on-request-error/skip-next-internal-error/skip-next-internal-error.test.ts
+++ b/test/e2e/on-request-error/skip-next-internal-error/skip-next-internal-error.test.ts
@@ -3,6 +3,7 @@ import { nextTestSetup } from 'e2e-utils'
 describe('on-request-error - skip-next-internal-error.test', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    skipDeployment: true,
     env: {
       __NEXT_EXPERIMENTAL_INSTRUMENTATION: '1',
     },

--- a/test/e2e/on-request-error/skip-next-internal-error/skip-next-internal-error.test.ts
+++ b/test/e2e/on-request-error/skip-next-internal-error/skip-next-internal-error.test.ts
@@ -1,13 +1,17 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('on-request-error - skip-next-internal-error.test', () => {
-  const { next } = nextTestSetup({
+  const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
     env: {
       __NEXT_EXPERIMENTAL_INSTRUMENTATION: '1',
     },
   })
+
+  if (skipped) {
+    return
+  }
 
   async function assertNoNextjsInternalErrors(
     pathname: string,

--- a/test/e2e/on-request-error/skip-next-internal-error/skip-next-internal-error.test.ts
+++ b/test/e2e/on-request-error/skip-next-internal-error/skip-next-internal-error.test.ts
@@ -13,13 +13,7 @@ describe('on-request-error - skip-next-internal-error.test', () => {
     return
   }
 
-  async function assertNoNextjsInternalErrors(
-    pathname: string,
-    expectedStatus = 200
-  ) {
-    const { status } = await next.fetch(pathname)
-    expect(status).toBe(expectedStatus)
-
+  async function assertNoNextjsInternalErrors() {
     const output = next.cliOutput
     // No navigation errors
     expect(output).not.toContain('NEXT_REDIRECT')
@@ -34,45 +28,54 @@ describe('on-request-error - skip-next-internal-error.test', () => {
   describe('app router render', () => {
     // Server navigation errors
     it('should not catch server component not-found errors', async () => {
-      await assertNoNextjsInternalErrors('/server/not-found', 404)
+      await next.fetch('/server/not-found')
+      await assertNoNextjsInternalErrors()
     })
 
     it('should not catch server component redirect errors', async () => {
-      await assertNoNextjsInternalErrors('/server/redirect')
+      await next.render('/server/redirect')
+      await assertNoNextjsInternalErrors()
     })
 
     // Client navigation errors
     it('should not catch client component not-found errors', async () => {
-      await assertNoNextjsInternalErrors('/client/not-found', 404)
+      await next.fetch('/server/not-found')
+      await assertNoNextjsInternalErrors()
     })
 
     it('should not catch client component redirect errors', async () => {
-      await assertNoNextjsInternalErrors('/client/redirect')
+      await next.render('/client/redirect')
+      await assertNoNextjsInternalErrors()
     })
 
     // Dynamic usage
     it('should not catch server component dynamic usage errors', async () => {
-      await assertNoNextjsInternalErrors('/client/dynamic-fetch')
+      await next.fetch('/server/dynamic-fetch')
+      await assertNoNextjsInternalErrors()
     })
 
     it('should not catch client component dynamic usage errors', async () => {
-      await assertNoNextjsInternalErrors('/client/dynamic-fetch')
+      await next.fetch('/client/dynamic-fetch')
+      await assertNoNextjsInternalErrors()
     })
 
     // No SSR
     it('should not catch next dynamic no-ssr errors', async () => {
-      await assertNoNextjsInternalErrors('/client/no-ssr')
+      await next.fetch('/client/no-ssr')
+      await assertNoNextjsInternalErrors()
     })
   })
 
   describe('app router API', () => {
     // API routes navigation errors
     it('should not catch server component not-found errors', async () => {
-      await assertNoNextjsInternalErrors('/app-route/not-found', 404)
+      await next.render('/app-route/not-found')
+      await assertNoNextjsInternalErrors()
     })
 
     it('should not catch server component redirect errors', async () => {
-      await assertNoNextjsInternalErrors('/app-route/redirect')
+      await next.render('/app-route/redirect')
+      await assertNoNextjsInternalErrors()
     })
   })
 })

--- a/test/e2e/on-request-error/skip-next-internal-error/skip-next-internal-error.test.ts
+++ b/test/e2e/on-request-error/skip-next-internal-error/skip-next-internal-error.test.ts
@@ -1,0 +1,73 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('on-request-error - skip-next-internal-error.test', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    env: {
+      __NEXT_EXPERIMENTAL_INSTRUMENTATION: '1',
+    },
+  })
+
+  async function assertNoNextjsInternalErrors(
+    pathname: string,
+    expectedStatus = 200
+  ) {
+    const { status } = await next.fetch(pathname)
+    expect(status).toBe(expectedStatus)
+
+    const output = next.cliOutput
+    // No navigation errors
+    expect(output).not.toContain('NEXT_REDIRECT')
+    expect(output).not.toContain('NEXT_NOT_FOUND')
+    // No dynamic usage errors
+    expect(output).not.toContain('DYNAMIC_SERVER_USAGE')
+    // No react postpone errors
+    // TODO: cover PPR errors later
+    expect(output).not.toContain('react.postpone')
+  }
+
+  describe('app router render', () => {
+    // Server navigation errors
+    it('should not catch server component not-found errors', async () => {
+      await assertNoNextjsInternalErrors('/server/not-found', 404)
+    })
+
+    it('should not catch server component redirect errors', async () => {
+      await assertNoNextjsInternalErrors('/server/redirect')
+    })
+
+    // Client navigation errors
+    it('should not catch client component not-found errors', async () => {
+      await assertNoNextjsInternalErrors('/client/not-found', 404)
+    })
+
+    it('should not catch client component redirect errors', async () => {
+      await assertNoNextjsInternalErrors('/client/redirect')
+    })
+
+    // Dynamic usage
+    it('should not catch server component dynamic usage errors', async () => {
+      await assertNoNextjsInternalErrors('/client/dynamic-fetch')
+    })
+
+    it('should not catch client component dynamic usage errors', async () => {
+      await assertNoNextjsInternalErrors('/client/dynamic-fetch')
+    })
+
+    // No SSR
+    it('should not catch next dynamic no-ssr errors', async () => {
+      await assertNoNextjsInternalErrors('/client/no-ssr')
+    })
+  })
+
+  describe('app router API', () => {
+    // API routes navigation errors
+    it('should not catch server component not-found errors', async () => {
+      await assertNoNextjsInternalErrors('/app-route/not-found', 404)
+    })
+
+    it('should not catch server component redirect errors', async () => {
+      await assertNoNextjsInternalErrors('/app-route/redirect')
+    })
+  })
+})


### PR DESCRIPTION
### What

Cover the Next.js internal errors are not captured by instrumentation onRequestError API

Also skip deployment tests for onRequestError API due to the private env flag `__NEXT_EXPERIMENTAL_INSTRUMENTATION` cannot be used in deployment

<!-- Closes NDX-33 -->