### PR TITLE
Fix typescript setup for `packages/font` and `turbo/generators`

### DIFF
--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -13,7 +13,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "node ../../scripts/rm.mjs dist && pnpm ncc-fontkit && tsc -d -p tsconfig.json",
+    "build": "node ../../scripts/rm.mjs dist && pnpm ncc-fontkit && tsc -d -p tsconfig.build.json",
     "prepublishOnly": "cd ../../ && turbo run build",
     "dev": "pnpm ncc-fontkit && tsc -d -w -p tsconfig.json",
     "typescript": "tsec --noEmit -p tsconfig.json",

--- a/packages/font/tsconfig.build.json
+++ b/packages/font/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/font/tsconfig.json
+++ b/packages/font/tsconfig.json
@@ -8,6 +8,5 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "src/**/*.test.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,10 @@
       "test-log": ["./test/lib/test-log"]
     }
   },
-  "include": ["test/**/*.test.ts", "test/**/*.test.tsx", "test/lib/**/*.ts"]
+  "include": [
+    "test/**/*.test.ts",
+    "test/**/*.test.tsx",
+    "test/lib/**/*.ts",
+    "turbo/**/*.ts"
+  ]
 }


### PR DESCRIPTION
- Include test files when type checking `packages/font`, while still excluding them in `build`.
- Include `turbo/generators` files in root `tsconfig.json` so that they are type checked as well.