### PR TITLE
Add additional eslint config for CLI execution (including CI)

### DIFF
--- a/.eslintrc.cli.json
+++ b/.eslintrc.cli.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/eslintrc",
+  "extends": [".eslintrc.json"],
+  "overrides": [
+    {
+      // This override adds type-checked rules.
+      "files": ["**/*.ts", "**/*.tsx"],
+      // Linting with type-checked rules is very slow and needs a lot of memory,
+      // so we exclude non-essential files.
+      "excludedFiles": ["examples/**/*", "test/**/*", "**/*.d.ts"],
+      "parserOptions": {
+        "project": true
+      },
+      "rules": {
+        // TODO: enable in follow-up PR
+        "@typescript-eslint/no-floating-promises": "off"
+      }
+    }
+  ]
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,9 @@
 {
+  // This is the default eslint config that is used by IDEs. It does not use
+  // computation-heavy type-checked rules to ensure maximum responsiveness while
+  // writing code. In addition, there is .eslintrc.cli.json that does use
+  // type-checked rules, and it is used when running `pnpm lint-eslint`.
+  "$schema": "https://json.schemastore.org/eslintrc",
   "root": true,
   "parser": "@babel/eslint-parser",
   "plugins": ["react", "react-hooks", "jest", "import", "jsdoc"],

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "types-and-precompiled": "run-p lint-typescript check-precompiled validate-externals-doc",
     "validate-externals-doc": "node ./scripts/validate-externals-doc.js",
     "lint": "run-p test-types lint-typescript prettier-check lint-eslint lint-language",
-    "lint-fix": "pnpm prettier-fix && eslint . --ext js,jsx,ts,tsx --fix --config .eslintrc.json --no-eslintrc",
+    "lint-fix": "pnpm prettier-fix && pnpm lint-eslint --fix",
     "lint-language": "alex .",
     "prettier-check": "prettier --check .",
     "check-examples": "./scripts/check-examples.sh",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "git-clean": "git clean -d -x -e node_modules -e packages -f",
     "typescript": "tsc --noEmit",
     "lint-typescript": "turbo run typescript",
-    "lint-eslint": "eslint . --ext js,jsx,ts,tsx --config .eslintrc.json --no-eslintrc",
+    "lint-eslint": "eslint . --ext js,jsx,ts,tsx --config .eslintrc.cli.json --no-eslintrc",
     "lint-no-typescript": "run-p prettier-check lint-eslint lint-language",
     "types-and-precompiled": "run-p lint-typescript check-precompiled validate-externals-doc",
     "validate-externals-doc": "node ./scripts/validate-externals-doc.js",


### PR DESCRIPTION
The default eslint config `.eslintrc.json` is used by IDEs. It does not use any computation-heavy type-checked rules. This is to ensure maximum responsiveness while writing code.

In addition, there is now an additional config that extends from the default one: `.eslintrc.cli.json` has the `project` parser option enabled, and will therefore be able to use type-checked rules. It is used when running `pnpm lint-eslint`, which is also used in the CI.

The immediate goal is to enable `@typescript-eslint/no-floating-promises` so that we don't need to rely on authors or reviewers catching unintentional missing `await`s for example.