### PR TITLE
refactor: `typedEnv` is not `readonly`

### DIFF
--- a/packages/next/src/server/lib/experimental/create-env-definitions.test.ts
+++ b/packages/next/src/server/lib/experimental/create-env-definitions.test.ts
@@ -17,10 +17,10 @@ describe('create-env-definitions', () => {
       declare global {
         namespace NodeJS {
           interface ProcessEnv {
-            FROM_DEV_ENV_LOCAL: readonly string
-            FROM_ENV_LOCAL: readonly string
-            FROM_ENV: readonly string
-            FROM_NEXT_CONFIG: readonly string
+            FROM_DEV_ENV_LOCAL: string
+            FROM_ENV_LOCAL: string
+            FROM_ENV: string
+            FROM_NEXT_CONFIG: string
           }
         }
       }

--- a/packages/next/src/server/lib/experimental/create-env-definitions.ts
+++ b/packages/next/src/server/lib/experimental/create-env-definitions.ts
@@ -10,7 +10,7 @@ export async function createEnvDefinitions({
   env: Env
 }) {
   const envKeysStr = Object.keys(env)
-    .map((key) => `      ${key}: readonly string`)
+    .map((key) => `      ${key}: string`)
     .join('\n')
 
   const definitionStr = `// Type definitions for Next.js environment variables

--- a/test/development/app-dir/typed-env/typed-env.test.ts
+++ b/test/development/app-dir/typed-env/typed-env.test.ts
@@ -13,15 +13,15 @@ describe('typed-env', () => {
       },
 
       // should not include from production-specific env
-      // e.g. FROM_PROD_ENV_LOCAL: readonly string
+      // e.g. FROM_PROD_ENV_LOCAL: string
       `// Type definitions for Next.js environment variables
 declare global {
   namespace NodeJS {
     interface ProcessEnv {
-      FROM_DEV_ENV_LOCAL: readonly string
-      FROM_ENV_LOCAL: readonly string
-      FROM_ENV: readonly string
-      FROM_NEXT_CONFIG: readonly string
+      FROM_DEV_ENV_LOCAL: string
+      FROM_ENV_LOCAL: string
+      FROM_ENV: string
+      FROM_NEXT_CONFIG: string
     }
   }
 }
@@ -35,15 +35,15 @@ export {}`
         return await next.readFile('.next/types/env.d.ts')
       },
       // env.d.ts is written from original .env
-      /FROM_ENV: readonly string/
+      /FROM_ENV: string/
     )
 
     // modify .env
     await next.patchFile('.env', 'MODIFIED_ENV="MODIFIED_ENV"')
 
     // should not include from original .env
-    // e.g. FROM_ENV: readonly string
-    // but have MODIFIED_ENV: readonly string
+    // e.g. FROM_ENV: string
+    // but have MODIFIED_ENV: string
     await check(
       async () => {
         return await next.readFile('.next/types/env.d.ts')
@@ -52,10 +52,10 @@ export {}`
 declare global {
   namespace NodeJS {
     interface ProcessEnv {
-      FROM_DEV_ENV_LOCAL: readonly string
-      FROM_ENV_LOCAL: readonly string
-      MODIFIED_ENV: readonly string
-      FROM_NEXT_CONFIG: readonly string
+      FROM_DEV_ENV_LOCAL: string
+      FROM_ENV_LOCAL: string
+      MODIFIED_ENV: string
+      FROM_NEXT_CONFIG: string
     }
   }
 }


### PR DESCRIPTION
### Why?

The process.env values may be modified, so is not `readonly string`.

### How?

Removed `readonly`.