### PR TITLE
Report HMR latency when a Server Component changes

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
@@ -430,6 +430,7 @@ function processMessage(
         router.fastRefresh()
         dispatcher.onRefresh()
       })
+      reportHmrLatency(sendMessage, [])
 
       if (process.env.__NEXT_TEST_MODE) {
         if (self.__NEXT_HMR_CB) {

--- a/test/development/app-hmr/hmr.test.ts
+++ b/test/development/app-hmr/hmr.test.ts
@@ -77,8 +77,7 @@ describe(`app-dir-hmr`, () => {
           expect(await browser.elementByCss('p').text()).toBe('ipad')
         })
 
-        // FIXME: Should have a message to close off the prior "rebuilding"
-        expect(logs).not.toEqual(
+        expect(logs).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
               message: expect.stringContaining('[Fast Refresh] done in'),
@@ -114,8 +113,7 @@ describe(`app-dir-hmr`, () => {
           expect(await browser.elementByCss('p').text()).toBe('ipad')
         })
 
-        // FIXME: Should have a message to close off the prior "rebuilding"
-        expect(logs).not.toEqual(
+        expect(logs).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
               message: expect.stringContaining('[Fast Refresh] done in'),

--- a/test/development/app-hmr/hmr.test.ts
+++ b/test/development/app-hmr/hmr.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check, waitFor } from 'next-test-utils'
+import { retry, waitFor } from 'next-test-utils'
 
 const envFile = '.env.development.local'
 
@@ -40,11 +40,10 @@ describe(`app-dir-hmr`, () => {
 
       try {
         // Should be 404 in a few seconds
-        await check(async () => {
+        await retry(async () => {
           const body = await browser.elementByCss('body').text()
           expect(body).toContain('404')
-          return 'success'
-        }, 'success')
+        })
 
         // The new page should be rendered
         const newHTML = await next.render('/folder-renamed')
@@ -62,10 +61,9 @@ describe(`app-dir-hmr`, () => {
       await next.patchFile(envFile, 'MY_DEVICE="ipad"')
 
       try {
-        await check(async () => {
+        await retry(async () => {
           expect(await browser.elementByCss('p').text()).toBe('ipad')
-          return 'success'
-        }, /success/)
+        })
       } finally {
         await next.patchFile(envFile, envContent)
       }
@@ -78,10 +76,9 @@ describe(`app-dir-hmr`, () => {
       await next.patchFile(envFile, 'MY_DEVICE="ipad"')
 
       try {
-        await check(async () => {
+        await retry(async () => {
           expect(await browser.elementByCss('p').text()).toBe('ipad')
-          return 'success'
-        }, /success/)
+        })
       } finally {
         await next.patchFile(envFile, envContent)
       }

--- a/test/development/app-hmr/hmr.test.ts
+++ b/test/development/app-hmr/hmr.test.ts
@@ -60,10 +60,32 @@ describe(`app-dir-hmr`, () => {
       expect(await browser.elementByCss('p').text()).toBe('mac')
       await next.patchFile(envFile, 'MY_DEVICE="ipad"')
 
+      const logs = await browser.log()
+      await retry(async () => {
+        expect(logs).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              message: '[Fast Refresh] rebuilding',
+              source: 'log',
+            }),
+          ])
+        )
+      })
+
       try {
         await retry(async () => {
           expect(await browser.elementByCss('p').text()).toBe('ipad')
         })
+
+        // FIXME: Should have a message to close off the prior "rebuilding"
+        expect(logs).not.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              message: expect.stringContaining('[Fast Refresh] done in'),
+              source: 'log',
+            }),
+          ])
+        )
       } finally {
         await next.patchFile(envFile, envContent)
       }
@@ -75,10 +97,32 @@ describe(`app-dir-hmr`, () => {
       expect(await browser.elementByCss('p').text()).toBe('mac')
       await next.patchFile(envFile, 'MY_DEVICE="ipad"')
 
+      const logs = await browser.log()
+      await retry(async () => {
+        expect(logs).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              message: '[Fast Refresh] rebuilding',
+              source: 'log',
+            }),
+          ])
+        )
+      })
+
       try {
         await retry(async () => {
           expect(await browser.elementByCss('p').text()).toBe('ipad')
         })
+
+        // FIXME: Should have a message to close off the prior "rebuilding"
+        expect(logs).not.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              message: expect.stringContaining('[Fast Refresh] done in'),
+              source: 'log',
+            }),
+          ])
+        )
       } finally {
         await next.patchFile(envFile, envContent)
       }


### PR DESCRIPTION
We currently log a `[Fast Refresh] rebuilding` when a Server Component changes. Ignoring the misleading feature name, it's never closed off with a `[Fast Refresh] Done in X ms` like we do for the other Hot Updates.

This is confusing since it looks like something is still working even though we already did a router refresh. Now we close the log of after we started the router transition so you get the familiar
```bash
[Fast Refresh] rebuilding
[Fast Refresh] Done in 5ms
````

I only found this since I initially only marked Hot Updates as resolved in `onSuccessfulHotUpdate`. However, we also mark an Hot Update as pending when a Server Component changes leaving the Promise pending forever unless we also resolve if a Server Component update was complete.

It's not obvious to me if we can stop modelling Server Component updates as Hot Updates and this might go against the work @unstubbable is doing so I doubled down on Server Component updates = Hot Updates.