### PR TITLE
fix middleware-general deploy test

### DIFF
--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -561,7 +561,8 @@ describe('Middleware Runtime', () => {
       const payload = readMiddlewareJSON(response)
       expect('error' in payload).toBe(true)
       expect(payload.error.name).toBe('AbortError')
-      expect(payload.error.message).toContain('This operation was aborted')
+      // AbortError messages differ depending on the runtime
+      expect(payload.error.message).toMatch(/(This|The) operation was aborted/)
     })
 
     it(`should validate & parse request url from any route`, async () => {


### PR DESCRIPTION
The copy on this error changed in #67565 but it caused an error when deployed since the message text was different ([ref](https://github.com/vercel/next.js/actions/runs/9899883735/job/27350409711#step:27:764))