### PR TITLE
chore: use `'...'` instead of fragments or null in docs

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/11-parallel-routes.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/11-parallel-routes.mdx
@@ -264,13 +264,13 @@ Then, inside the `@auth` slot, add [`default.js`](/docs/app/api-reference/file-c
 
 ```tsx filename="app/@auth/default.tsx" switcher
 export default function Default() {
-  return null
+  return '...'
 }
 ```
 
 ```jsx filename="app/@auth/default.js" switcher
 export default function Default() {
-  return null
+  return '...'
 }
 ```
 
@@ -433,13 +433,13 @@ export function Modal({ children }) {
 
 ```tsx filename="app/@auth/page.tsx" switcher
 export default function Page() {
-  return null
+  return '...'
 }
 ```
 
 ```jsx filename="app/@auth/page.js" switcher
 export default function Page() {
-  return null
+  return '...'
 }
 ```
 
@@ -447,13 +447,13 @@ Or if navigating to any other page (such as `/foo`, `/foo/bar`, etc), you can us
 
 ```tsx filename="app/@auth/[...catchAll]/page.tsx" switcher
 export default function CatchAll() {
-  return null
+  return '...'
 }
 ```
 
 ```jsx filename="app/@auth/[...catchAll]/page.js" switcher
 export default function CatchAll() {
-  return null
+  return '...'
 }
 ```
 

--- a/docs/02-app/01-building-your-application/02-data-fetching/01-fetching.mdx
+++ b/docs/02-app/01-building-your-application/02-data-fetching/01-fetching.mdx
@@ -36,7 +36,7 @@ export default async function Page() {
     res.json()
   )
 
-  return <></>
+  return '...'
 }
 ```
 
@@ -46,7 +46,7 @@ export default async function Page() {
     res.json()
   )
 
-  return <></>
+  return '...'
 }
 ```
 
@@ -67,7 +67,7 @@ import { Suspense } from 'react'
 export default async function Cart() {
   const res = await fetch('https://api.example.com/...')
 
-  return <></>
+  return '...'
 }
 
 export default function Navigation() {
@@ -179,7 +179,7 @@ export default function PollingComponent {
   // Polling interval set to 2000 milliseconds
   const { data } = useSWR('/api/data', fetcher, { refreshInterval: 2000 });
 
-  return <></>
+  return '...'
 }
 ```
 
@@ -193,7 +193,7 @@ export default function PollingComponent {
   // Polling interval set to 2000 milliseconds
   const { data } = useSWR('/api/data', fetcher, { refreshInterval: 2000 });
 
-  return <></>
+  return '...'
 }
 ```
 
@@ -212,7 +212,7 @@ import fetcher from '@/utils/fetcher'
 export default function Message() {
   const { data } = useSWR('/api/messages', fetcher)
 
-  return <></>
+  return '...'
 }
 ```
 
@@ -225,7 +225,7 @@ import fetcher from '@/utils/fetcher'
 export default function Message() {
   const { data } = useSWR('/api/messages', fetcher)
 
-  return <></>
+  return '...'
 }
 ```
 

--- a/docs/02-app/01-building-your-application/02-data-fetching/03-server-actions-and-mutations.mdx
+++ b/docs/02-app/01-building-your-application/02-data-fetching/03-server-actions-and-mutations.mdx
@@ -28,7 +28,7 @@ export default function Page() {
     // Mutate data
   }
 
-  return <></>
+  return '...'
 }
 ```
 
@@ -40,7 +40,7 @@ export default function Page() {
     // Mutate data
   }
 
-  return <></>
+  return '...'
 }
 ```
 

--- a/docs/02-app/01-building-your-application/09-authentication/index.mdx
+++ b/docs/02-app/01-building-your-application/09-authentication/index.mdx
@@ -721,7 +721,7 @@ export async function updateSession() {
   const payload = await decrypt(session)
 
   if (!session || !payload) {
-    return '...'
+    return null
   }
 
   const expires = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
@@ -745,7 +745,7 @@ export async function updateSession() {
   const payload = await decrypt(session)
 
   if (!session || !payload) {
-    return '...'
+    return null
   }
 
   const expires = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
@@ -1162,7 +1162,7 @@ You can then invoke the `verifySession()` function in your data requests, Server
 ```tsx filename="app/lib/dal.ts" switcher
 export const getUser = cache(async () => {
   const session = await verifySession()
-  if (!session) return '...'
+  if (!session) return null
 
   try {
     const data = await db.query.users.findMany({
@@ -1180,7 +1180,7 @@ export const getUser = cache(async () => {
     return user
   } catch (error) {
     console.log('Failed to fetch user')
-    return '...'
+    return null
   }
 })
 ```
@@ -1188,7 +1188,7 @@ export const getUser = cache(async () => {
 ```jsx filename="app/lib/dal.js" switcher
 export const getUser = cache(async () => {
   const session = await verifySession()
-  if (!session) return '...'
+  if (!session) return null
 
   try {
     const data = await db.query.users.findMany({
@@ -1206,7 +1206,7 @@ export const getUser = cache(async () => {
     return user
   } catch (error) {
     console.log('Failed to fetch user')
-    return '...'
+    return null
   }
 })
 ```
@@ -1369,7 +1369,7 @@ export default async function Layout({ children }) {
 ```ts filename="app/lib/dal.ts" switcher
 export const getUser = cache(async () => {
   const session = await verifySession()
-  if (!session) return '...'
+  if (!session) return null
 
   // Get user ID from session and fetch data
 })
@@ -1378,7 +1378,7 @@ export const getUser = cache(async () => {
 ```js filename="app/lib/dal.js" switcher
 export const getUser = cache(async () => {
   const session = await verifySession()
-  if (!session) return '...'
+  if (!session) return null
 
   // Get user ID from session and fetch data
 })
@@ -1386,7 +1386,7 @@ export const getUser = cache(async () => {
 
 > **Good to know:**
 >
-> - A common pattern in SPAs is to `return '...'` in a layout or a top-level component if a user is not authorized. This pattern is not **not recommended** since Next.js applications have multiple entry points, which will not prevent nested route segments and Server Actions from being accessed.
+> - A common pattern in SPAs is to `return null` in a layout or a top-level component if a user is not authorized. This pattern is not **not recommended** since Next.js applications have multiple entry points, which will not prevent nested route segments and Server Actions from being accessed.
 
 ### Server Actions
 
@@ -1404,7 +1404,7 @@ export async function serverAction(formData: FormData) {
 
   // Return early if user is not authorized to perform the action
   if (userRole !== 'admin') {
-    return '...'
+    return null
   }
 
   // Proceed with the action for authorized users
@@ -1421,7 +1421,7 @@ export async function serverAction() {
 
   // Return early if user is not authorized to perform the action
   if (userRole !== 'admin') {
-    return '...'
+    return null
   }
 
   // Proceed with the action for authorized users

--- a/docs/02-app/01-building-your-application/09-authentication/index.mdx
+++ b/docs/02-app/01-building-your-application/09-authentication/index.mdx
@@ -721,7 +721,7 @@ export async function updateSession() {
   const payload = await decrypt(session)
 
   if (!session || !payload) {
-    return null
+    return '...'
   }
 
   const expires = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
@@ -745,7 +745,7 @@ export async function updateSession() {
   const payload = await decrypt(session)
 
   if (!session || !payload) {
-    return null
+    return '...'
   }
 
   const expires = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
@@ -1162,7 +1162,7 @@ You can then invoke the `verifySession()` function in your data requests, Server
 ```tsx filename="app/lib/dal.ts" switcher
 export const getUser = cache(async () => {
   const session = await verifySession()
-  if (!session) return null
+  if (!session) return '...'
 
   try {
     const data = await db.query.users.findMany({
@@ -1180,7 +1180,7 @@ export const getUser = cache(async () => {
     return user
   } catch (error) {
     console.log('Failed to fetch user')
-    return null
+    return '...'
   }
 })
 ```
@@ -1188,7 +1188,7 @@ export const getUser = cache(async () => {
 ```jsx filename="app/lib/dal.js" switcher
 export const getUser = cache(async () => {
   const session = await verifySession()
-  if (!session) return null
+  if (!session) return '...'
 
   try {
     const data = await db.query.users.findMany({
@@ -1206,7 +1206,7 @@ export const getUser = cache(async () => {
     return user
   } catch (error) {
     console.log('Failed to fetch user')
-    return null
+    return '...'
   }
 })
 ```
@@ -1369,7 +1369,7 @@ export default async function Layout({ children }) {
 ```ts filename="app/lib/dal.ts" switcher
 export const getUser = cache(async () => {
   const session = await verifySession()
-  if (!session) return null
+  if (!session) return '...'
 
   // Get user ID from session and fetch data
 })
@@ -1378,7 +1378,7 @@ export const getUser = cache(async () => {
 ```js filename="app/lib/dal.js" switcher
 export const getUser = cache(async () => {
   const session = await verifySession()
-  if (!session) return null
+  if (!session) return '...'
 
   // Get user ID from session and fetch data
 })
@@ -1386,7 +1386,7 @@ export const getUser = cache(async () => {
 
 > **Good to know:**
 >
-> - A common pattern in SPAs is to `return null` in a layout or a top-level component if a user is not authorized. This pattern is not **not recommended** since Next.js applications have multiple entry points, which will not prevent nested route segments and Server Actions from being accessed.
+> - A common pattern in SPAs is to `return '...'` in a layout or a top-level component if a user is not authorized. This pattern is not **not recommended** since Next.js applications have multiple entry points, which will not prevent nested route segments and Server Actions from being accessed.
 
 ### Server Actions
 
@@ -1404,7 +1404,7 @@ export async function serverAction(formData: FormData) {
 
   // Return early if user is not authorized to perform the action
   if (userRole !== 'admin') {
-    return null
+    return '...'
   }
 
   // Proceed with the action for authorized users
@@ -1421,7 +1421,7 @@ export async function serverAction() {
 
   // Return early if user is not authorized to perform the action
   if (userRole !== 'admin') {
-    return null
+    return '...'
   }
 
   // Proceed with the action for authorized users

--- a/docs/02-app/01-building-your-application/11-upgrading/05-from-create-react-app.mdx
+++ b/docs/02-app/01-building-your-application/11-upgrading/05-from-create-react-app.mdx
@@ -87,13 +87,13 @@ export default function RootLayout({
 }: {
   children: React.ReactNode
 }) {
-  return null
+  return '...'
 }
 ```
 
 ```jsx filename="app/layout.js" switcher
 export default function RootLayout({ children }) {
-  return null
+  return '...'
 }
 ```
 

--- a/docs/02-app/01-building-your-application/11-upgrading/05-from-vite.mdx
+++ b/docs/02-app/01-building-your-application/11-upgrading/05-from-vite.mdx
@@ -148,13 +148,13 @@ export default function RootLayout({
 }: {
   children: React.ReactNode
 }) {
-  return null
+  return '...'
 }
 ```
 
 ```jsx filename="app/layout.js" switcher
 export default function RootLayout({ children }) {
-  return null
+  return '...'
 }
 ```
 

--- a/docs/02-app/01-building-your-application/11-upgrading/06-from-create-react-app.mdx
+++ b/docs/02-app/01-building-your-application/11-upgrading/06-from-create-react-app.mdx
@@ -129,13 +129,13 @@ export default function RootLayout({
 }: {
   children: React.ReactNode
 }) {
-  return null
+  return '...'
 }
 ```
 
 ```jsx filename="app/layout.js" switcher
 export default function RootLayout({ children }) {
-  return null
+  return '...'
 }
 ```
 

--- a/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
@@ -995,7 +995,7 @@ export function PreloadResources() {
   ReactDOM.preconnect('...', { crossOrigin: '...' })
   ReactDOM.prefetchDNS('...')
 
-  return null
+  return '...'
 }
 ```
 
@@ -1009,7 +1009,7 @@ export function PreloadResources() {
   ReactDOM.preconnect('...', { crossOrigin: '...' })
   ReactDOM.prefetchDNS('...')
 
-  return null
+  return '...'
 }
 ```
 

--- a/docs/02-app/02-api-reference/04-functions/use-router.mdx
+++ b/docs/02-app/02-api-reference/04-functions/use-router.mdx
@@ -85,7 +85,7 @@ export function NavigationEvents() {
     // ...
   }, [pathname, searchParams])
 
-  return null
+  return '...'
 }
 ```
 


### PR DESCRIPTION
As some of our example codes in the docs return fragments `<></>` or `null`, we unify the return value as  `'...'`.

x-ref: https://github.com/vercel/next.js/pull/67384