### PR TITLE
Fix flakiness of `error-hydration` test with turbopack

### DIFF
--- a/test/production/error-hydration/error-hydration.test.ts
+++ b/test/production/error-hydration/error-hydration.test.ts
@@ -1,93 +1,70 @@
-import { NextInstance, nextTestSetup } from 'e2e-utils'
-
-async function setupErrorHydrationTests(
-  next: NextInstance,
-  targetPath: string
-) {
-  const consoleMessages: string[] = []
-
-  const browser = await next.browser(targetPath, {
-    beforePageLoad(page) {
-      page.on('console', (event) => {
-        consoleMessages.push(event.text())
-      })
-    },
-  })
-
-  return [browser, consoleMessages] as const
-}
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
 
 describe('error-hydration', () => {
   const { next } = nextTestSetup({
     files: __dirname,
   })
 
-  // Recommended for tests that need a full browser
-  it('should log no error messages for server-side errors', async () => {
-    const [, consoleMessages] = await setupErrorHydrationTests(
-      next,
-      '/with-error'
+  it('should not log server-side errors', async () => {
+    const browser = await next.browser('/with-error')
+    const messages = await browser.log()
+
+    expect(messages).not.toEqual(
+      expect.arrayContaining([
+        {
+          message: expect.stringContaining('Error: custom error'),
+          source: 'error',
+        },
+      ])
     )
-
-    expect(
-      consoleMessages.find((message) =>
-        message.startsWith('A client-side exception has occurred')
-      )
-    ).toBeUndefined()
-
-    expect(
-      consoleMessages.find(
-        (message) =>
-          message ===
-          '{name: Internal Server Error., message: 500 - Internal Server Error., statusCode: 500}'
-      )
-    ).toBeUndefined()
   })
 
   it('should not invoke the error page getInitialProps client-side for server-side errors', async () => {
-    const [b] = await setupErrorHydrationTests(next, '/with-error')
-
-    expect(
-      await b.eval(
-        () =>
-          (window as any).__ERROR_PAGE_GET_INITIAL_PROPS_INVOKED_CLIENT_SIDE__
-      )
-    ).toBe(undefined)
-  })
-
-  it('should log an message for client-side errors, including the full, custom error', async () => {
-    const [browser, consoleMessages] = await setupErrorHydrationTests(
-      next,
-      '/no-error'
-    )
-
-    const link = await browser.elementByCss('a')
-    await link.click()
-
-    expect(consoleMessages.some((m) => m.includes('Error: custom error'))).toBe(
-      true
-    )
-
-    expect(
-      consoleMessages.some((m) =>
-        m.includes(
-          'A client-side exception has occurred, see here for more info'
-        )
-      )
-    ).toBe(true)
-  })
-
-  it("invokes _error's getInitialProps for client-side errors", async () => {
-    const [browser] = await setupErrorHydrationTests(next, '/no-error')
-
-    const link = await browser.elementByCss('a')
-    await link.click()
+    const browser = await next.browser('/with-error')
 
     expect(
       await browser.eval(
         () =>
           (window as any).__ERROR_PAGE_GET_INITIAL_PROPS_INVOKED_CLIENT_SIDE__
       )
-    ).toBe(true)
+    ).toBe(undefined)
+  })
+
+  it('should log a message for client-side errors, including the full, custom error', async () => {
+    const browser = await next.browser('/no-error')
+    await browser.elementByCss('a').click()
+    const messages = await browser.log()
+
+    retry(() => {
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          {
+            message: expect.stringContaining('Error: custom error'),
+            source: 'error',
+          },
+          {
+            message: expect.stringContaining(
+              'A client-side exception has occurred, see here for more info'
+            ),
+            source: 'error',
+          },
+        ])
+      )
+    })
+  })
+
+  it("invokes _error's getInitialProps for client-side errors", async () => {
+    const browser = await next.browser('/no-error')
+    await browser.elementByCss('a').click()
+
+    retry(async () => {
+      expect(
+        await browser.eval(
+          () =>
+            (window as any).__ERROR_PAGE_GET_INITIAL_PROPS_INVOKED_CLIENT_SIDE__
+        )
+      ).toBe(true)
+    })
   })
 })

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -15671,12 +15671,11 @@
     "test/production/error-hydration/error-hydration.test.ts": {
       "passed": [
         "error-hydration invokes _error's getInitialProps for client-side errors",
-        "error-hydration should log no error messages for server-side errors",
+        "error-hydration should log a message for client-side errors, including the full, custom error",
+        "error-hydration should not log server-side errors",
         "error-hydration should not invoke the error page getInitialProps client-side for server-side errors"
       ],
-      "failed": [
-        "error-hydration should log an message for client-side errors, including the full, custom error"
-      ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false


### PR DESCRIPTION
x-ref: [Flakiness metric](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20env%3Aci%20%40git.repository.id%3Agithub.com%2Fvercel%2Fnext.js%20%40test.service%3Anextjs%20%40test.suite%3A%2Aerror-hydration%2A%20%40test.status%3Afail&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&start=1720275488446&end=1720880288446&paused=false)