### PR TITLE
Turbopack build: Exclude .d.ts files as routes

### DIFF
--- a/packages/next-swc/crates/next-core/src/app_structure.rs
+++ b/packages/next-swc/crates/next-core/src/app_structure.rs
@@ -323,6 +323,10 @@ async fn get_directory_tree_internal(
         match *entry {
             DirectoryEntry::File(file) => {
                 let file = file.resolve().await?;
+                // Do not process .d.ts files as routes
+                if basename.ends_with(".d.ts") {
+                    continue;
+                }
                 if let Some((stem, ext)) = basename.split_once('.') {
                     if page_extensions_value.iter().any(|e| e == ext) {
                         match stem {

--- a/packages/next-swc/crates/next-core/src/pages_structure.rs
+++ b/packages/next-swc/crates/next-core/src/pages_structure.rs
@@ -199,6 +199,10 @@ async fn get_pages_structure_for_root_directory(
             for (name, entry) in entries.iter() {
                 match entry {
                     DirectoryEntry::File(file_project_path) => {
+                        // Do not process .d.ts files as routes
+                        if name.ends_with(".d.ts") {
+                            continue;
+                        }
                         let Some(basename) = page_basename(name, page_extensions_raw) else {
                             continue;
                         };

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -6251,9 +6251,7 @@
         "404 Page Support development mode 2 does not show error with getStaticProps in pages/404 dev",
         "404 Page Support development mode 2 falls back to _error correctly without pages/404",
         "404 Page Support development mode 2 shows error with getInitialProps in pages/404 dev",
-        "404 Page Support development mode 2 shows error with getServerSideProps in pages/404 dev"
-      ],
-      "failed": [
+        "404 Page Support development mode 2 shows error with getServerSideProps in pages/404 dev",
         "404 Page Support production mode does not show error with getStaticProps in pages/404 build",
         "404 Page Support production mode should add /404 to pages-manifest correctly",
         "404 Page Support production mode should not cache for custom 404 page with gssp and revalidate disabled",
@@ -6268,6 +6266,7 @@
         "404 Page Support production mode shows error with getInitialProps in pages/404 build",
         "404 Page Support production mode shows error with getServerSideProps in pages/404 build"
       ],
+      "failed": [],
       "pending": [
         "404 Page Support development mode should not error when visited directly",
         "404 Page Support development mode should render _error for a 500 error still",


### PR DESCRIPTION
Matches the check we do for webpack here: https://github.com/vercel/next.js/blob/8c4bd571c1996eb1e42d64c9328d41a71690a028/packages/next/src/build/entries.ts#L251

`.d.ts` files are not routable but because the page extensions includes `.ts` it ends up matching at the end, which is correct, but we don't want to include `.d.` 👍 
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
