### PR TITLE
Wait for `✓ Ready` log in `NextInstance#start`

### DIFF
--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -84,6 +84,7 @@ import { ModuleBuildError } from '../../dev/turbopack-utils'
 import { isMetadataRoute } from '../../../lib/metadata/is-metadata-route'
 import { normalizeMetadataPageToRoute } from '../../../lib/metadata/get-metadata-route'
 import { createEnvDefinitions } from '../experimental/create-env-definitions'
+import { JsConfigPathsPlugin } from '../../../build/webpack/plugins/jsconfig-paths-plugin'
 
 export type SetupOpts = {
   renderServer: LazyRenderServerInstance
@@ -626,16 +627,16 @@ async function startWatcher(opts: SetupOpts) {
             config.resolve?.plugins?.forEach((plugin: any) => {
               // look for the JsConfigPathsPlugin and update with
               // the latest paths/baseUrl config
-              if (plugin && plugin.jsConfigPlugin && tsconfigResult) {
+              if (plugin instanceof JsConfigPathsPlugin && tsconfigResult) {
                 const { resolvedBaseUrl, jsConfig } = tsconfigResult
                 const currentResolvedBaseUrl = plugin.resolvedBaseUrl
                 const resolvedUrlIndex = config.resolve?.modules?.findIndex(
-                  (item) => item === currentResolvedBaseUrl
+                  (item) => item === currentResolvedBaseUrl?.baseUrl
                 )
 
                 if (resolvedBaseUrl) {
                   if (
-                    resolvedBaseUrl.baseUrl !== currentResolvedBaseUrl.baseUrl
+                    resolvedBaseUrl.baseUrl !== currentResolvedBaseUrl?.baseUrl
                   ) {
                     // remove old baseUrl and add new one
                     if (resolvedUrlIndex && resolvedUrlIndex > -1) {

--- a/test/development/jsconfig-path-reloading/index.test.ts
+++ b/test/development/jsconfig-path-reloading/index.test.ts
@@ -44,8 +44,6 @@ describe('jsconfig-path-reloading', () => {
 
       if (addAfterStart) {
         await next.patchFile(tsConfigFile, tsConfigContent)
-        // wait a bit for the file watcher to pick up the change
-        await new Promise((resolve) => setTimeout(resolve, 200))
       }
     })
     afterAll(() => next.destroy())

--- a/test/development/start-no-build/start-no-build.test.ts
+++ b/test/development/start-no-build/start-no-build.test.ts
@@ -6,6 +6,7 @@ describe('next start without next build', () => {
       files: __dirname,
       skipStart: true,
       startCommand: `pnpm next start`,
+      serverReadyPattern: /✓ Starting.../,
     })
 
     await next.start()

--- a/test/development/tsconfig-path-reloading/index.test.ts
+++ b/test/development/tsconfig-path-reloading/index.test.ts
@@ -44,8 +44,6 @@ describe('tsconfig-path-reloading', () => {
 
       if (addAfterStart) {
         await next.patchFile(tsConfigFile, tsConfigContent)
-        // wait a bit for the file watcher to pick up the change
-        await new Promise((resolve) => setTimeout(resolve, 200))
       }
     })
     afterAll(() => next.destroy())

--- a/test/e2e/app-dir/app-basepath-custom-server/index.test.ts
+++ b/test/e2e/app-dir/app-basepath-custom-server/index.test.ts
@@ -7,6 +7,7 @@ describe('custom-app-server-action-redirect', () => {
     files: join(__dirname, 'custom-server'),
     skipDeployment: true,
     startCommand: 'node server.js',
+    serverReadyPattern: /Next mode: (production|development)/,
     dependencies: {
       'get-port': '5.1.1',
     },

--- a/test/e2e/custom-app-render/custom-app-render.test.ts
+++ b/test/e2e/custom-app-render/custom-app-render.test.ts
@@ -5,6 +5,7 @@ describe('custom-app-render', () => {
     files: __dirname,
     skipDeployment: true,
     startCommand: 'node server.js',
+    serverReadyPattern: /Next mode: (production|development)/,
     dependencies: {
       'get-port': '5.1.1',
     },

--- a/test/e2e/multi-zone/multi-zone.test.ts
+++ b/test/e2e/multi-zone/multi-zone.test.ts
@@ -8,6 +8,7 @@ describe('multi-zone', () => {
     skipDeployment: true,
     buildCommand: 'pnpm build',
     startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
+    serverReadyPattern: /Next mode: (production|development)/,
     packageJson: {
       scripts: {
         dev: 'node server.js',

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -36,6 +36,7 @@ export interface NextInstanceOpts {
   dirSuffix?: string
   turbo?: boolean
   forcedPort?: string
+  serverReadyPattern?: RegExp
 }
 
 /**
@@ -68,6 +69,7 @@ export class NextInstance {
   public env: Record<string, string>
   public forcedPort?: string
   public dirSuffix: string = ''
+  public serverReadyPattern?: RegExp = /^\s* ✓ Ready in /
 
   constructor(opts: NextInstanceOpts) {
     this.env = {}
@@ -332,6 +334,19 @@ export class NextInstance {
           }
         }
       })
+  }
+
+  protected setServerReadyTimeout(
+    reject: (reason?: unknown) => void,
+    ms = 5000
+  ): NodeJS.Timeout {
+    return setTimeout(() => {
+      reject(
+        new Error(
+          `Failed to start server after ${ms}ms, waiting for this log pattern: ${this.serverReadyPattern}`
+        )
+      )
+    }, ms)
   }
 
   // normalize snapshots or stack traces being tested

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -338,7 +338,7 @@ export class NextInstance {
 
   protected setServerReadyTimeout(
     reject: (reason?: unknown) => void,
-    ms = 5000
+    ms = 10_000
   ): NodeJS.Timeout {
     return setTimeout(() => {
       reject(

--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -111,6 +111,7 @@ export class NextDevInstance extends NextInstance {
               .split(/\s*- Local:/)
               .pop()
               .trim()
+          } else if (colorStrippedMsg.startsWith(' ✓ Ready in ')) {
             resolveServer()
           } else if (
             msg.includes('started server on') &&

--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -89,8 +89,11 @@ export class NextDevInstance extends NextInstance {
           }
         })
 
+        const serverReadyTimeoutId = this.setServerReadyTimeout(reject)
+
         const readyCb = (msg) => {
           const resolveServer = () => {
+            clearTimeout(serverReadyTimeoutId)
             try {
               this._parsedUrl = new URL(this._url)
             } catch (err) {
@@ -111,13 +114,9 @@ export class NextDevInstance extends NextInstance {
               .split(/\s*- Local:/)
               .pop()
               .trim()
-          } else if (colorStrippedMsg.startsWith(' ✓ Ready in ')) {
-            resolveServer()
-          } else if (
-            msg.includes('started server on') &&
-            msg.includes('url:')
-          ) {
-            this._url = msg.split('url: ').pop().split(/\s/, 1)[0].trim()
+          }
+
+          if (this.serverReadyPattern.test(colorStrippedMsg)) {
             resolveServer()
           }
         }

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -151,8 +151,9 @@ export class NextStartInstance extends NextInstance {
               .pop()
               .trim()
             this._parsedUrl = new URL(this._url)
-            this.off('stdout', readyCb)
+          } else if (colorStrippedMsg.startsWith(' ✓ Ready in ')) {
             resolve()
+            this.off('stdout', readyCb)
           }
         }
         this.on('stdout', readyCb)

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -121,7 +121,7 @@ export class NextStartInstance extends NextInstance {
     ).trim()
 
     console.log('running', startArgs.join(' '))
-    await new Promise<void>((resolve) => {
+    await new Promise<void>((resolve, reject) => {
       try {
         this.childProcess = spawn(
           startArgs[0],
@@ -141,6 +141,8 @@ export class NextStartInstance extends NextInstance {
           }
         })
 
+        const serverReadyTimeoutId = this.setServerReadyTimeout(reject)
+
         const readyCb = (msg) => {
           const colorStrippedMsg = stripAnsi(msg)
           if (colorStrippedMsg.includes('- Local:')) {
@@ -151,7 +153,10 @@ export class NextStartInstance extends NextInstance {
               .pop()
               .trim()
             this._parsedUrl = new URL(this._url)
-          } else if (colorStrippedMsg.startsWith(' ✓ Ready in ')) {
+          }
+
+          if (this.serverReadyPattern.test(colorStrippedMsg)) {
+            clearTimeout(serverReadyTimeoutId)
             resolve()
             this.off('stdout', readyCb)
           }

--- a/test/production/custom-server/custom-server.test.ts
+++ b/test/production/custom-server/custom-server.test.ts
@@ -4,6 +4,7 @@ describe('custom server', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     startCommand: 'node server.js',
+    serverReadyPattern: /^- Local:/,
     dependencies: {
       'get-port': '5.1.1',
     },
@@ -36,6 +37,7 @@ describe('custom server with quiet setting', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     startCommand: 'node server.js',
+    serverReadyPattern: /^- Local:/,
     env: { USE_QUIET: 'true' },
     dependencies: {
       'get-port': '5.1.1',


### PR DESCRIPTION
This may or may not help with the [flakiness](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20env%3Aci%20%40git.repository.id%3Agithub.com%2Fvercel%2Fnext.js%20%40test.service%3Anextjs%20%40test.suite%3A%22tsconfig-path-reloading%22%20%40test.status%3Afail&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&start=1713291659981&end=1721067659981&paused=false) of the `tsconfig-path-reloading` test with turbopack.

I also found a race condition bug in `packages/next/src/server/lib/router-utils/setup-dev-bundler.ts` after removing an artificial delay of 200ms in the `jsconfig-path-reloading` test.