### PR TITLE
Extract mdx into custom rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "auto-hash-map"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "serde",
  "smallvec",
@@ -3096,7 +3096,7 @@ dependencies = [
 [[package]]
 name = "node-file-trace"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "serde",
@@ -6908,12 +6908,12 @@ dependencies = [
 [[package]]
 name = "turbo-prehash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 
 [[package]]
 name = "turbo-tasks"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6947,7 +6947,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-build"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -6960,7 +6960,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-bytes"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6974,7 +6974,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "dotenvs",
@@ -6988,7 +6988,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fetch"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -7004,7 +7004,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-fs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7036,7 +7036,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-hash"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "md4",
  "turbo-tasks-macros",
@@ -7046,7 +7046,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "either",
@@ -7061,7 +7061,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-macros-shared"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7071,7 +7071,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "mimalloc",
 ]
@@ -7079,7 +7079,7 @@ dependencies = [
 [[package]]
 name = "turbo-tasks-memory"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "auto-hash-map",
@@ -7107,7 +7107,7 @@ dependencies = [
 [[package]]
 name = "turbopack"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7137,7 +7137,7 @@ dependencies = [
 [[package]]
 name = "turbopack-binding"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "auto-hash-map",
  "mdxjs",
@@ -7178,7 +7178,7 @@ dependencies = [
 [[package]]
 name = "turbopack-browser"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7201,7 +7201,7 @@ dependencies = [
 [[package]]
 name = "turbopack-cli-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "clap",
@@ -7218,7 +7218,7 @@ dependencies = [
 [[package]]
 name = "turbopack-core"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -7247,7 +7247,7 @@ dependencies = [
 [[package]]
 name = "turbopack-css"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7274,7 +7274,7 @@ dependencies = [
 [[package]]
 name = "turbopack-dev-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -7310,7 +7310,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7345,7 +7345,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-hmr-protocol"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "serde",
  "serde_json",
@@ -7356,7 +7356,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-plugins"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7381,7 +7381,7 @@ dependencies = [
 [[package]]
 name = "turbopack-ecmascript-runtime"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "indoc",
@@ -7397,7 +7397,7 @@ dependencies = [
 [[package]]
 name = "turbopack-env"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7413,7 +7413,7 @@ dependencies = [
 [[package]]
 name = "turbopack-image"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7432,7 +7432,7 @@ dependencies = [
 [[package]]
 name = "turbopack-json"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "serde",
@@ -7447,7 +7447,7 @@ dependencies = [
 [[package]]
 name = "turbopack-mdx"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "mdxjs",
@@ -7462,7 +7462,7 @@ dependencies = [
 [[package]]
 name = "turbopack-node"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7496,7 +7496,7 @@ dependencies = [
 [[package]]
 name = "turbopack-nodejs"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7516,7 +7516,7 @@ dependencies = [
 [[package]]
 name = "turbopack-resolve"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",
@@ -7534,7 +7534,7 @@ dependencies = [
 [[package]]
 name = "turbopack-static"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "serde",
@@ -7550,7 +7550,7 @@ dependencies = [
 [[package]]
 name = "turbopack-swc-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "swc_core",
  "turbo-tasks",
@@ -7561,7 +7561,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-server"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "either",
@@ -7581,7 +7581,7 @@ dependencies = [
 [[package]]
 name = "turbopack-trace-utils"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -7597,7 +7597,7 @@ dependencies = [
 [[package]]
 name = "turbopack-wasm"
 version = "0.1.0"
-source = "git+https://github.com/vercel/turbo.git?tag=turbopack-240712.1#8a4be2d121b9e166384155becbb258e71da22cc8"
+source = "git+https://github.com/vercel/turbo.git?branch=mischnic/pack-1055-extract-mdx-into-custom-rules#aa4f7f76e5c6e91df4245dc268be509fae9b56d5"
 dependencies = [
  "anyhow",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,11 @@ swc_core = { version = "0.96.9", features = [
 testing = { version = "0.36.0" }
 
 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240712.1" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "mischnic/pack-1055-extract-mdx-into-custom-rules" } # last tag: "turbopack-240712.1"
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240712.1" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "mischnic/pack-1055-extract-mdx-into-custom-rules" } # last tag: "turbopack-240712.1"
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240712.1" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "mischnic/pack-1055-extract-mdx-into-custom-rules" } # last tag: "turbopack-240712.1"
 
 # General Deps
 

--- a/packages/next-swc/crates/napi/src/turbotrace.rs
+++ b/packages/next-swc/crates/napi/src/turbotrace.rs
@@ -32,7 +32,6 @@ pub async fn run_turbo_tracing(
         turbo_tasks.as_ref(),
         Some(ModuleOptionsContext {
             enable_types: true,
-            enable_mdx: true,
             ..Default::default()
         }),
         Some(ResolveOptionsContext {

--- a/packages/next-swc/crates/next-core/src/next_client/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/context.rs
@@ -52,7 +52,8 @@ use crate::{
             NextSharedRuntimeResolvePlugin,
         },
         transforms::{
-            emotion::get_emotion_transform_rule, relay::get_relay_transform_rule,
+            emotion::get_emotion_transform_rule, mdx::get_mdx_transform_rule,
+            relay::get_relay_transform_rule,
             styled_components::get_styled_components_transform_rule,
             styled_jsx::get_styled_jsx_transform_rule,
             swc_ecma_transform_plugins::get_swc_ecma_transform_plugin_rule,
@@ -249,6 +250,7 @@ pub async fn get_client_module_options_context(
         get_emotion_transform_rule(next_config).await?,
         get_styled_components_transform_rule(next_config).await?,
         get_styled_jsx_transform_rule(next_config, target_browsers).await?,
+        get_mdx_transform_rule(jsx_runtime_options, enable_mdx_rs, tsconfig).await?,
     ]
     .into_iter()
     .flatten()
@@ -297,7 +299,6 @@ pub async fn get_client_module_options_context(
         enable_jsx: Some(jsx_runtime_options),
         enable_webpack_loaders,
         enable_typescript_transform: Some(tsconfig),
-        enable_mdx_rs,
         decorators: Some(decorators_options),
         rules: vec![
             (

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -469,11 +469,21 @@ pub async fn get_server_module_options_context(
         get_swc_ecma_transform_plugin_rule(next_config, project_path).await?,
         get_relay_transform_rule(next_config, project_path).await?,
         get_emotion_transform_rule(next_config).await?,
-        get_mdx_transform_rule(jsx_runtime_options, enable_mdx_rs, tsconfig).await?,
     ]
     .into_iter()
     .flatten()
     .collect();
+
+    if let Some(mdx_rule) = get_mdx_transform_rule(
+        jsx_runtime_options,
+        enable_mdx_rs,
+        tsconfig,
+        decorators_options,
+    )
+    .await?
+    {
+        next_server_rules.insert(0, mdx_rule);
+    }
 
     // Custom ecma transform rules selectively being applied depends on the server
     // context type.

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -60,6 +60,7 @@ use crate::{
         },
         transforms::{
             emotion::get_emotion_transform_rule, get_ecma_transform_rule,
+            mdx::get_mdx_transform_rule,
             next_react_server_components::get_next_react_server_components_transform_rule,
             relay::get_relay_transform_rule,
             styled_components::get_styled_components_transform_rule,
@@ -468,6 +469,7 @@ pub async fn get_server_module_options_context(
         get_swc_ecma_transform_plugin_rule(next_config, project_path).await?,
         get_relay_transform_rule(next_config, project_path).await?,
         get_emotion_transform_rule(next_config).await?,
+        get_mdx_transform_rule(jsx_runtime_options, enable_mdx_rs, tsconfig).await?,
     ]
     .into_iter()
     .flatten()
@@ -549,7 +551,6 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders,
                 enable_postcss_transform,
                 enable_typescript_transform: Some(tsconfig),
-                enable_mdx_rs,
                 decorators: Some(decorators_options),
                 rules: vec![
                     (
@@ -602,7 +603,6 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders,
                 enable_postcss_transform,
                 enable_typescript_transform: Some(tsconfig),
-                enable_mdx_rs,
                 decorators: Some(decorators_options),
                 rules: vec![
                     (
@@ -669,7 +669,6 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders,
                 enable_postcss_transform,
                 enable_typescript_transform: Some(tsconfig),
-                enable_mdx_rs,
                 decorators: Some(decorators_options),
                 rules: vec![
                     (
@@ -732,7 +731,6 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders,
                 enable_postcss_transform,
                 enable_typescript_transform: Some(tsconfig),
-                enable_mdx_rs,
                 decorators: Some(decorators_options),
                 rules: vec![
                     (
@@ -812,7 +810,6 @@ pub async fn get_server_module_options_context(
                 enable_webpack_loaders,
                 enable_postcss_transform,
                 enable_typescript_transform: Some(tsconfig),
-                enable_mdx_rs,
                 decorators: Some(decorators_options),
                 rules: vec![
                     (

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/mdx.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/mdx.rs
@@ -1,0 +1,78 @@
+use anyhow::Result;
+use turbo_tasks::Vc;
+use turbopack_binding::turbopack::{
+    ecmascript::{EcmascriptInputTransform, EcmascriptOptions},
+    turbopack::module_options::{
+        DecoratorsKind, DecoratorsOptions, JsxTransformOptions, MdxTransformOptions, ModuleRule,
+        ModuleRuleCondition, ModuleRuleEffect, ModuleType, TypescriptTransformOptions,
+    },
+};
+
+pub async fn get_mdx_transform_rule(
+    jsx_runtime_options: Vc<JsxTransformOptions>,
+    mdx_transform_options: Option<Vc<MdxTransformOptions>>,
+    tsconfig: Vc<TypescriptTransformOptions>,
+    decorator_options: Vc<DecoratorsOptions>,
+) -> Result<Option<ModuleRule>> {
+    if let Some(mdx_transform_options) = mdx_transform_options {
+        let (jsx_runtime, jsx_import_source, development) = {
+            let jsx = jsx_runtime_options.await?;
+            (
+                jsx.runtime.clone(),
+                jsx.import_source.clone(),
+                jsx.development,
+            )
+        };
+
+        let decorator_options_value = decorator_options.await?;
+        let mdx_transforms = Vc::cell(
+            vec![
+                Some(EcmascriptInputTransform::TypeScript {
+                    use_define_for_class_fields: tsconfig.await?.use_define_for_class_fields,
+                }),
+                decorator_options_value
+                    .decorators_kind
+                    .as_ref()
+                    .map(|kind| EcmascriptInputTransform::Decorators {
+                        is_legacy: kind == &DecoratorsKind::Legacy,
+                        is_ecma: kind == &DecoratorsKind::Ecma,
+                        emit_decorators_metadata: decorator_options_value.emit_decorators_metadata,
+                        use_define_for_class_fields: decorator_options_value
+                            .use_define_for_class_fields,
+                    }),
+            ]
+            .into_iter()
+            .flatten()
+            // TODO previously this also included some more core JS transforms
+            // https://github.com/vercel/turbo/blob/c454e35586b9575d264457be562f82982d2468eb/crates/turbopack/src/module_options/mod.rs#L105-L166
+            // .chain(transforms.iter().cloned())
+            .collect(),
+        );
+
+        // TODO merge or overwrite settings in mdx_transform_options?
+        let mdx_transform_options_value = mdx_transform_options.await?.clone_value();
+        let mdx_transform_options = (MdxTransformOptions {
+            development: Some(development),
+            jsx: Some(false),
+            jsx_runtime,
+            jsx_import_source,
+            ..mdx_transform_options_value
+        })
+        .cell();
+
+        Ok(Some(ModuleRule::new(
+            ModuleRuleCondition::any(vec![
+                ModuleRuleCondition::ResourcePathEndsWith(".md".to_string()),
+                ModuleRuleCondition::ResourcePathEndsWith(".mdx".to_string()),
+            ]),
+            vec![ModuleRuleEffect::ModuleType(ModuleType::Mdx {
+                transforms: mdx_transforms,
+                options: mdx_transform_options,
+                // TODO where to get actual ecmascript_options from?
+                ecmascript_options: EcmascriptOptions::default().cell(),
+            })],
+        )))
+    } else {
+        Ok(None)
+    }
+}

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod emotion;
+pub(crate) mod mdx;
 pub(crate) mod modularize_imports;
 pub(crate) mod next_amp_attributes;
 pub(crate) mod next_cjs_optimizer;

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -205,7 +205,7 @@
     "@types/ws": "8.2.0",
     "@vercel/ncc": "0.34.0",
     "@vercel/nft": "0.27.1",
-    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240712.1",
+    "@vercel/turbopack-ecmascript-runtime": "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?aa4f7f76e5c6e91df4245dc268be509fae9b56d5",
     "acorn": "8.11.3",
     "amphtml-validator": "1.0.35",
     "anser": "1.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1114,8 +1114,8 @@ importers:
         specifier: 0.27.1
         version: 0.27.1(encoding@0.1.13)
       '@vercel/turbopack-ecmascript-runtime':
-        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240712.1
-        version: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240712.1
+        specifier: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?aa4f7f76e5c6e91df4245dc268be509fae9b56d5
+        version: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?aa4f7f76e5c6e91df4245dc268be509fae9b56d5
       acorn:
         specifier: 8.11.3
         version: 8.11.3
@@ -5164,8 +5164,8 @@ packages:
     resolution: {integrity: sha512-OTe0KE37F5Y2eTys6eMnfopC+P4qr2ooXUTFyFPTplYSPwowmFk/HLD1FXtbKLjqsIH0SgekcJWad+C5uX4nkg==}
     engines: {node: '>=16'}
 
-  '@vercel/turbopack-ecmascript-runtime@https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240712.1':
-    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240712.1}
+  '@vercel/turbopack-ecmascript-runtime@https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?aa4f7f76e5c6e91df4245dc268be509fae9b56d5':
+    resolution: {tarball: https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?aa4f7f76e5c6e91df4245dc268be509fae9b56d5}
     version: 0.0.0
 
   '@webassemblyjs/ast@1.11.6':
@@ -19736,7 +19736,7 @@ snapshots:
       satori: 0.10.9
       yoga-wasm-web: 0.3.3
 
-  '@vercel/turbopack-ecmascript-runtime@https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?turbopack-240712.1':
+  '@vercel/turbopack-ecmascript-runtime@https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-ecmascript-runtime/js?aa4f7f76e5c6e91df4245dc268be509fae9b56d5':
     dependencies:
       '@types/node': 20.12.3
 


### PR DESCRIPTION
Use custom rules instead of the the enable_mdx* Turbopack options.

There are various places where Turbopack itself previously applied some JS options and transforms that were already available but aren't anymore now. Is this still the approach we want to take, which will require some code duplication?