### PR TITLE
Add test for Server Components HMR after navigating to page with Edge runtime

### DIFF
--- a/test/development/app-hmr/hmr.test.ts
+++ b/test/development/app-hmr/hmr.test.ts
@@ -131,6 +131,11 @@ describe(`app-dir-hmr`, () => {
     })
 
     it('should update server components pages when env files is changed (nodejs)', async () => {
+      // If "should update server components after navigating to a page with a different runtime" failed, the dev server is in a corrupted state.
+      // Restart fixes this.
+      await next.stop()
+      await next.start()
+
       const envContent = await next.readFile(envFile)
       const browser = await next.browser('/env/node')
       expect(await browser.elementByCss('p').text()).toBe('mac')
@@ -167,6 +172,10 @@ describe(`app-dir-hmr`, () => {
     })
 
     it('should update server components pages when env files is changed (edge)', async () => {
+      // Restart to work around a bug highlighted in the flakiness of "should update server components after navigating to a page with a different runtime"
+      await next.stop()
+      await next.start()
+
       const envContent = await next.readFile(envFile)
       const browser = await next.browser('/env/edge')
       expect(await browser.elementByCss('p').text()).toBe('mac')

--- a/test/development/app-hmr/hmr.test.ts
+++ b/test/development/app-hmr/hmr.test.ts
@@ -3,6 +3,8 @@ import { retry, waitFor } from 'next-test-utils'
 
 const envFile = '.env.development.local'
 
+const isPPREnabledByDefault = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+
 describe(`app-dir-hmr`, () => {
   const { next } = nextTestSetup({
     files: __dirname,
@@ -51,6 +53,80 @@ describe(`app-dir-hmr`, () => {
       } finally {
         // Rename it back
         await next.renameFolder('app/folder-renamed', 'app/folder')
+      }
+    })
+
+    it('should update server components after navigating to a page with a different runtime', async () => {
+      const envContent = await next.readFile(envFile)
+
+      const browser = await next.browser('/env/node')
+      await browser.loadPage(`${next.url}/env/edge`)
+      await browser.eval('window.__TEST_NO_RELOAD = true')
+
+      await next.patchFile(envFile, 'MY_DEVICE="ipad"')
+
+      try {
+        const logs = await browser.log()
+
+        if (process.env.TURBOPACK) {
+          await retry(async () => {
+            const fastRefreshLogs = logs.filter((log) => {
+              return log.message.startsWith('[Fast Refresh]')
+            })
+            // FIXME:  3+ "rebuilding" but single "done" is confusing.
+            // There may actually be more "rebuilding" but not reliably.
+            // To ignore this flakiness, we just assert on subset matches.
+            // Once the  bug is fixed, each "rebuilding" should be paired with a "done in" exactly.
+            expect(fastRefreshLogs).toEqual(
+              expect.arrayContaining([
+                { source: 'log', message: '[Fast Refresh] rebuilding' },
+                { source: 'log', message: '[Fast Refresh] rebuilding' },
+                {
+                  source: 'log',
+                  message: expect.stringContaining('[Fast Refresh] done in '),
+                },
+                { source: 'log', message: '[Fast Refresh] rebuilding' },
+              ])
+            )
+          })
+        } else {
+          await retry(
+            async () => {
+              const fastRefreshLogs = logs.filter((log) => {
+                return log.message.startsWith('[Fast Refresh]')
+              })
+              // FIXME: Should be either a single "rebuilding"+"done" or the last "rebuilding" should be followed by "done"
+              expect(fastRefreshLogs).toEqual([
+                { source: 'log', message: '[Fast Refresh] rebuilding' },
+                { source: 'log', message: '[Fast Refresh] rebuilding' },
+                {
+                  source: 'log',
+                  message: expect.stringContaining('[Fast Refresh] done in '),
+                },
+                { source: 'log', message: '[Fast Refresh] rebuilding' },
+              ])
+            },
+            // Very slow Hot Update for some reason.
+            // May be related to receiving 3 rebuild events but only one finish event
+            5000
+          )
+        }
+        const envValue = await browser.elementByCss('p').text()
+        const mpa = await browser.eval('window.__TEST_NO_RELOAD === undefined')
+        // Flaky sometimes in Webpack:
+        // A. misses update and just receives `{ envValue: 'mac', mpa: false }`
+        // B. triggers error on server resulting in MPA: `{ envValue: 'ipad', mpa: true }` and server logs: ⨯ [TypeError: Cannot read properties of undefined (reading 'polyfillFiles')] ⨯ [TypeError: Cannot read properties of null (reading 'default')]
+        // A is more common than B.
+        expect({ envValue, mpa }).toEqual({
+          envValue:
+            isPPREnabledByDefault && !process.env.TURBOPACK
+              ? // FIXME: Should be 'ipad' but PPR+Webpack swallows the update reliably
+                'mac'
+              : 'ipad',
+          mpa: false,
+        })
+      } finally {
+        await next.patchFile(envFile, envContent)
       }
     })
 


### PR DESCRIPTION
This codifies the [flakiness we're seeing in "should update server components pages when env files is changed (edge)"](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20env%3Aci%20%40git.repository.id%3Agithub.com%2Fvercel%2Fnext.js%20%40test.service%3Anextjs%20%40test.suite%3A%2Ahmr%2A%20%40test.name%3A%22app-dir-hmr%20filesystem%20changes%20should%20update%20server%20components%20pages%20when%20env%20files%20is%20changed%20%28edge%29%22%20%40test.status%3Afail&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=true&index=citest&start=1713009743249&end=1720785743249&paused=true) in a dedicated test. I added some more explicit assertions that may indicate why we sometimes stop applying HMR updates from `.env` file changes after we navigated from a page with Node.js runtime to a page with Edge runtime (slow HMR and multiple "building" logs without "done" logs).

With PPR in Webpack it reliably swallows updates.

Not having a "HMR done" signal is problematic for https://github.com/vercel/next.js/pull/67673. This means we can't rely on HMR updates being resolved by resolving a Promise when we receive a "done" signal. For now I don't plan to fix this bug and instead just fall back to MPA if we're waiting for the Webpack runtime to be updated for too long. After we landed the sync (which is blocked by this work) I may revisit this bug.