### PR TITLE
Ensure serverSourceMaps is in webpack cache key

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2133,6 +2133,7 @@ export default async function getBaseWebpackConfig(
     modularizeImports: config.modularizeImports,
     imageLoaderFile: config.images.loaderFile,
     clientTraceMetadata: config.experimental.clientTraceMetadata,
+    serverSourceMaps: config.experimental.serverSourceMaps,
   })
 
   const cache: any = {


### PR DESCRIPTION
This needs to invalidate webpack cache since source maps require regenerating the entries same as productionBrowserSourceMaps config. 

x-ref: [slack thread](https://vercel.slack.com/archives/C056QDZARTM/p1721058737378969)