### PR TITLE
Drop edge prerender manifest

### DIFF
--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -37,7 +37,6 @@ declare const nextConfig: NextConfigComplete
 const maybeJSONParse = (str?: string) => (str ? JSON.parse(str) : undefined)
 
 const buildManifest: BuildManifest = self.__BUILD_MANIFEST as any
-const prerenderManifest = maybeJSONParse(self.__PRERENDER_MANIFEST)
 const reactLoadableManifest = maybeJSONParse(self.__REACT_LOADABLE_MANIFEST)
 const rscManifest = self.__RSC_MANIFEST?.['VAR_PAGE']
 const rscServerManifest = maybeJSONParse(self.__RSC_SERVER_MANIFEST)
@@ -70,7 +69,6 @@ const render = getRender({
   error500Mod,
   Document,
   buildManifest,
-  prerenderManifest,
   renderToHTML,
   reactLoadableManifest,
   clientReferenceManifest: isServerComponent ? rscManifest : null,

--- a/packages/next/src/build/templates/edge-ssr.ts
+++ b/packages/next/src/build/templates/edge-ssr.ts
@@ -82,7 +82,6 @@ const error500Mod = userland500Page
 const maybeJSONParse = (str?: string) => (str ? JSON.parse(str) : undefined)
 
 const buildManifest: BuildManifest = self.__BUILD_MANIFEST as any
-const prerenderManifest = maybeJSONParse(self.__PRERENDER_MANIFEST)
 const reactLoadableManifest = maybeJSONParse(self.__REACT_LOADABLE_MANIFEST)
 const subresourceIntegrityManifest = sriEnabled
   ? maybeJSONParse(self.__SUBRESOURCE_INTEGRITY_MANIFEST)
@@ -99,7 +98,6 @@ const render = getRender({
   error500Mod,
   Document,
   buildManifest,
-  prerenderManifest,
   renderToHTML,
   reactLoadableManifest,
   subresourceIntegrityManifest,

--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
@@ -19,7 +19,6 @@ import type { SizeLimit } from '../../../../types'
 import { internal_getCurrentFunctionWaitUntil } from '../../../../server/web/internal-edge-wait-until'
 import type { PAGE_TYPES } from '../../../../lib/page-types'
 import type { NextRequestHint } from '../../../../server/web/adapter'
-import { getEdgePreviewProps } from '../../../../server/web/get-edge-preview-props'
 
 export function getRender({
   dev,
@@ -86,12 +85,6 @@ export function getRender({
       page,
       pathname: isAppPath ? normalizeAppPath(page) : page,
       pagesType,
-      prerenderManifest:
-        process.env.NODE_ENV === 'production'
-          ? {
-              preview: getEdgePreviewProps(),
-            }
-          : undefined,
       interceptionRouteRewrites,
       extendRenderOpts: {
         buildId,

--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
@@ -13,13 +13,12 @@ import {
   WebNextResponse,
 } from '../../../../server/base-http/web'
 import { SERVER_RUNTIME } from '../../../../lib/constants'
-import type { ManifestRewriteRoute, PrerenderManifest } from '../../..'
+import type { ManifestRewriteRoute } from '../../..'
 import { normalizeAppPath } from '../../../../shared/lib/router/utils/app-paths'
 import type { SizeLimit } from '../../../../types'
 import { internal_getCurrentFunctionWaitUntil } from '../../../../server/web/internal-edge-wait-until'
 import type { PAGE_TYPES } from '../../../../lib/page-types'
 import type { NextRequestHint } from '../../../../server/web/adapter'
-import type { DeepReadonly } from '../../../../shared/lib/deep-readonly'
 import { getEdgePreviewProps } from '../../../../server/web/get-edge-preview-props'
 
 export function getRender({
@@ -32,7 +31,6 @@ export function getRender({
   pagesType,
   Document,
   buildManifest,
-  prerenderManifest,
   reactLoadableManifest,
   interceptionRouteRewrites,
   renderToHTML,
@@ -55,7 +53,6 @@ export function getRender({
   renderToHTML?: any
   Document: DocumentType
   buildManifest: BuildManifest
-  prerenderManifest: DeepReadonly<PrerenderManifest>
   reactLoadableManifest: ReactLoadableManifest
   subresourceIntegrityManifest?: Record<string, string>
   interceptionRouteRewrites?: ManifestRewriteRoute[]
@@ -89,12 +86,12 @@ export function getRender({
       page,
       pathname: isAppPath ? normalizeAppPath(page) : page,
       pagesType,
-      prerenderManifest: prerenderManifest
-        ? {
-            ...prerenderManifest,
-            preview: getEdgePreviewProps(),
-          }
-        : undefined,
+      prerenderManifest:
+        process.env.NODE_ENV === 'production'
+          ? {
+              preview: getEdgePreviewProps(),
+            }
+          : undefined,
       interceptionRouteRewrites,
       extendRenderOpts: {
         buildId,

--- a/packages/next/src/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/middleware-plugin.ts
@@ -20,7 +20,6 @@ import {
   SUBRESOURCE_INTEGRITY_MANIFEST,
   NEXT_FONT_MANIFEST,
   SERVER_REFERENCE_MANIFEST,
-  PRERENDER_MANIFEST,
   INTERCEPTION_ROUTE_REWRITE_MANIFEST,
 } from '../../../shared/lib/constants'
 import type { MiddlewareConfig } from '../../analysis/get-page-static-info'
@@ -136,10 +135,6 @@ function getEntryFiles(
 
   if (hasInstrumentationHook) {
     files.push(`server/edge-${INSTRUMENTATION_HOOK_FILENAME}.js`)
-  }
-
-  if (process.env.NODE_ENV === 'production') {
-    files.push(PRERENDER_MANIFEST.replace('json', 'js'))
   }
 
   files.push(

--- a/packages/next/src/client/route-loader.ts
+++ b/packages/next/src/client/route-loader.ts
@@ -17,7 +17,6 @@ declare global {
     __BUILD_MANIFEST_CB?: Function
     __MIDDLEWARE_MATCHERS?: MiddlewareMatcher[]
     __MIDDLEWARE_MANIFEST_CB?: Function
-    __PRERENDER_MANIFEST?: string
     __REACT_LOADABLE_MANIFEST?: any
     __RSC_MANIFEST?: any
     __RSC_SERVER_MANIFEST?: any

--- a/packages/next/src/server/web-server.ts
+++ b/packages/next/src/server/web-server.ts
@@ -52,7 +52,9 @@ interface WebServerOptions extends Options {
       | typeof import('./app-render/app-render').renderToHTMLOrFlight
       | undefined
     incrementalCacheHandler?: any
-    prerenderManifest: DeepReadonly<PrerenderManifest> | undefined
+    prerenderManifest:
+      | DeepReadonly<Pick<PrerenderManifest, 'preview'>>
+      | undefined
     interceptionRouteRewrites?: Rewrite[]
   }
 }

--- a/packages/next/src/server/web-server.ts
+++ b/packages/next/src/server/web-server.ts
@@ -3,7 +3,6 @@ import type RenderResult from './render-result'
 import type { NextParsedUrlQuery, NextUrlWithParsedQuery } from './request-meta'
 import type { Params } from '../shared/lib/router/utils/route-matcher'
 import type { LoadComponentsReturnType } from './load-components'
-import type { PrerenderManifest } from '../build'
 import type {
   LoadedRenderOpts,
   MiddlewareRoutingItem,
@@ -33,7 +32,6 @@ import type { PAGE_TYPES } from '../lib/page-types'
 import type { Rewrite } from '../lib/load-custom-routes'
 import { buildCustomRoute } from '../lib/build-custom-route'
 import { UNDERSCORE_NOT_FOUND_ROUTE } from '../api/constants'
-import type { DeepReadonly } from '../shared/lib/deep-readonly'
 import { getEdgeInstrumentationModule } from './web/globals'
 import type { ServerOnInstrumentationRequestError } from './app-render/types'
 import { getEdgePreviewProps } from './web/get-edge-preview-props'
@@ -52,9 +50,6 @@ interface WebServerOptions extends Options {
       | typeof import('./app-render/app-render').renderToHTMLOrFlight
       | undefined
     incrementalCacheHandler?: any
-    prerenderManifest:
-      | DeepReadonly<Pick<PrerenderManifest, 'preview'>>
-      | undefined
     interceptionRouteRewrites?: Rewrite[]
   }
 }
@@ -142,17 +137,13 @@ export default class NextWebServer extends BaseServer<
   }
 
   protected getPrerenderManifest() {
-    const { prerenderManifest } = this.serverOptions.webServerConfig
-    if (this.renderOpts?.dev || !prerenderManifest) {
-      return {
-        version: -1 as any, // letting us know this doesn't conform to spec
-        routes: {},
-        dynamicRoutes: {},
-        notFoundRoutes: [],
-        preview: getEdgePreviewProps(),
-      }
+    return {
+      version: -1 as any, // letting us know this doesn't conform to spec
+      routes: {},
+      dynamicRoutes: {},
+      notFoundRoutes: [],
+      preview: getEdgePreviewProps(),
     }
-    return prerenderManifest
   }
 
   protected getNextFontManifest() {

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -40,12 +40,6 @@ describe('app dir - basic', () => {
       )
     })
 
-    it('should not have entire prerender-manifest for edge', async () => {
-      expect(await next.readFile('.next/prerender-manifest.js')).not.toContain(
-        'initialRevalidate'
-      )
-    })
-
     if (!process.env.NEXT_EXPERIMENTAL_COMPILE) {
       it('should have correct size in build output', async () => {
         expect(next.cliOutput).toMatch(

--- a/test/e2e/middleware-trailing-slash/test/index.test.ts
+++ b/test/e2e/middleware-trailing-slash/test/index.test.ts
@@ -115,7 +115,6 @@ describe('Middleware Runtime trailing slash', () => {
         delete middlewareWithoutEnvs.env
         expect(middlewareWithoutEnvs).toEqual({
           files: expect.arrayContaining([
-            'prerender-manifest.js',
             'server/edge-runtime-webpack.js',
             'server/middleware.js',
           ]),


### PR DESCRIPTION
### What

Follow up for #67779 , we don't have to generate the edge preview manifest since it's mainly for rendering the preview props and now preview props can be accessed through process env by a util `getEdgePreviewProps()`