### PR TITLE
Enable `experimental.serverComponentsHmrCache` by default

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1007,7 +1007,7 @@ export const defaultConfig: NextConfig = {
     reactCompiler: undefined,
     after: false,
     staticGenerationRetryCount: undefined,
-    serverComponentsHmrCache: false,
+    serverComponentsHmrCache: true,
   },
   bundlePagesRouterDependencies: false,
 }

--- a/test/development/app-dir/server-components-hmr-cache/next.config.js
+++ b/test/development/app-dir/server-components-hmr-cache/next.config.js
@@ -4,7 +4,7 @@
 const nextConfig = {
   experimental: {
     after: true,
-    serverComponentsHmrCache: true,
+    // serverComponentsHmrCache: false,
   },
 }
 

--- a/test/development/app-dir/server-components-hmr-cache/server-components-hmr-cache.test.ts
+++ b/test/development/app-dir/server-components-hmr-cache/server-components-hmr-cache.test.ts
@@ -81,12 +81,12 @@ describe('server-components-hmr-cache', () => {
       })
     })
 
-    describe('with experimental.serverComponentsHmrCache not enabled', () => {
+    describe('with experimental.serverComponentsHmrCache disabled', () => {
       beforeAll(async () => {
         await next.patchFile('next.config.js', (content) =>
           content.replace(
-            'serverComponentsHmrCache: true,',
-            '// serverComponentsHmrCache: true,'
+            '// serverComponentsHmrCache: false,',
+            'serverComponentsHmrCache: false,'
           )
         )
       })
@@ -94,8 +94,8 @@ describe('server-components-hmr-cache', () => {
       afterAll(async () => {
         await next.patchFile('next.config.js', (content) =>
           content.replace(
-            '// serverComponentsHmrCache: true,',
-            'serverComponentsHmrCache: true,'
+            'serverComponentsHmrCache: false,',
+            '// serverComponentsHmrCache: false,'
           )
         )
       })

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -1691,14 +1691,14 @@
       "server-components-hmr-cache edge runtime in after() should use cached fetch calls for fast refresh requests",
       "server-components-hmr-cache edge runtime should not use cached fetch calls for intentional refresh requests",
       "server-components-hmr-cache edge runtime should use cached fetch calls for fast refresh requests",
-      "server-components-hmr-cache edge runtime with experimental.serverComponentsHmrCache not enabled in after() should not use cached fetch calls for fast refresh requests",
-      "server-components-hmr-cache edge runtime with experimental.serverComponentsHmrCache not enabled should not use cached fetch calls for fast refresh requests",
+      "server-components-hmr-cache edge runtime with experimental.serverComponentsHmrCache disabled in after() should not use cached fetch calls for fast refresh requests",
+      "server-components-hmr-cache edge runtime with experimental.serverComponentsHmrCache disabled should not use cached fetch calls for fast refresh requests",
       "server-components-hmr-cache node runtime in after() should not use cached fetch calls for intentional refresh requests",
       "server-components-hmr-cache node runtime in after() should use cached fetch calls for fast refresh requests",
       "server-components-hmr-cache node runtime should not use cached fetch calls for intentional refresh requests",
       "server-components-hmr-cache node runtime should use cached fetch calls for fast refresh requests",
-      "server-components-hmr-cache node runtime with experimental.serverComponentsHmrCache not enabled in after() should not use cached fetch calls for fast refresh requests",
-      "server-components-hmr-cache node runtime with experimental.serverComponentsHmrCache not enabled should not use cached fetch calls for fast refresh requests"
+      "server-components-hmr-cache node runtime with experimental.serverComponentsHmrCache disabled in after() should not use cached fetch calls for fast refresh requests",
+      "server-components-hmr-cache node runtime with experimental.serverComponentsHmrCache disabled should not use cached fetch calls for fast refresh requests"
     ],
     "failed": [],
     "pending": [],


### PR DESCRIPTION
The target release for the [server components HMR cache](https://github.com/vercel/next.js/pull/67527) feature is 15, so we want to enable it already for canaries.