### PR TITLE
Turbopack build: Implement app/global-error.tsx

### DIFF
--- a/packages/next-swc/crates/napi/src/app_structure.rs
+++ b/packages/next-swc/crates/napi/src/app_structure.rs
@@ -153,6 +153,7 @@ async fn prepare_components_for_js(
         page,
         layout,
         error,
+        global_error: _,
         loading,
         template,
         not_found,

--- a/packages/next-swc/crates/next-core/src/app_structure.rs
+++ b/packages/next-swc/crates/next-core/src/app_structure.rs
@@ -44,6 +44,8 @@ pub struct Components {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<Vc<FileSystemPath>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub global_error: Option<Vc<FileSystemPath>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub loading: Option<Vc<FileSystemPath>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub template: Option<Vc<FileSystemPath>>,
@@ -63,6 +65,7 @@ impl Components {
             page: None,
             layout: self.layout,
             error: self.error,
+            global_error: self.global_error,
             loading: self.loading,
             template: self.template,
             not_found: self.not_found,
@@ -333,6 +336,7 @@ async fn get_directory_tree_internal(
                             "page" => components.page = Some(file),
                             "layout" => components.layout = Some(file),
                             "error" => components.error = Some(file),
+                            "global-error" => components.global_error = Some(file),
                             "loading" => components.loading = Some(file),
                             "template" => components.template = Some(file),
                             "not-found" => components.not_found = Some(file),

--- a/packages/next-swc/crates/next-core/src/loader_tree.rs
+++ b/packages/next-swc/crates/next-core/src/loader_tree.rs
@@ -107,8 +107,14 @@ impl LoaderTreeBuilder {
             let i = self.unique_number();
             let identifier = magic_identifier::mangle(&format!("{name} #{i}"));
 
-            let module =
-                process_module(&self.context, &self.server_component_transition, component);
+            let source = Vc::upcast(FileSource::new(component));
+            let reference_ty = Value::new(ReferenceType::EcmaScriptModules(
+                EcmaScriptModulesReferenceSubType::Undefined,
+            ));
+            let module = self
+                .server_component_transition
+                .process(source, self.context, reference_ty)
+                .module();
 
             writeln!(
                 self.loader_tree_code,
@@ -449,20 +455,4 @@ impl LoaderTreeModule {
             .build(loader_tree)
             .await
     }
-}
-
-pub fn process_module(
-    &context: &Vc<ModuleAssetContext>,
-    &server_component_transition: &Vc<Box<dyn Transition>>,
-    component: Vc<FileSystemPath>,
-) -> Vc<Box<dyn Module>> {
-    let source = Vc::upcast(FileSource::new(component));
-    let reference_ty = Value::new(ReferenceType::EcmaScriptModules(
-        EcmaScriptModulesReferenceSubType::Undefined,
-    ));
-    let module = server_component_transition
-        .process(source, context, reference_ty)
-        .module();
-
-    module
 }

--- a/packages/next-swc/crates/next-core/src/loader_tree.rs
+++ b/packages/next-swc/crates/next-core/src/loader_tree.rs
@@ -120,7 +120,7 @@ impl LoaderTreeBuilder {
             self.imports.push(
                 formatdoc!(
                     r#"
-                    import {} from "COMPONENT_{}";
+                    import * as {} from "COMPONENT_{}";
                     "#,
                     identifier,
                     i

--- a/packages/next-swc/crates/next-core/src/loader_tree.rs
+++ b/packages/next-swc/crates/next-core/src/loader_tree.rs
@@ -472,9 +472,8 @@ fn process_module(
     let reference_ty = Value::new(ReferenceType::EcmaScriptModules(
         EcmaScriptModulesReferenceSubType::Undefined,
     ));
-    let module = server_component_transition
-        .process(source, context, reference_ty)
-        .module();
 
-    module
+    server_component_transition
+        .process(source, context, reference_ty)
+        .module()
 }

--- a/packages/next-swc/crates/next-core/src/loader_tree.rs
+++ b/packages/next-swc/crates/next-core/src/loader_tree.rs
@@ -381,6 +381,7 @@ impl LoaderTreeBuilder {
             page,
             default,
             error,
+            global_error: _,
             layout,
             loading,
             template,

--- a/packages/next-swc/crates/next-core/src/loader_tree.rs
+++ b/packages/next-swc/crates/next-core/src/loader_tree.rs
@@ -421,7 +421,7 @@ impl LoaderTreeBuilder {
     }
 
     async fn build(mut self, loader_tree: Vc<LoaderTree>) -> Result<LoaderTreeModule> {
-        let components = loader_tree.clone().await?.components.await?;
+        let components = loader_tree.await?.components.await?;
         if let Some(global_error) = components.global_error {
             let module = process_module(
                 &self.context,

--- a/packages/next-swc/crates/next-core/src/loader_tree.rs
+++ b/packages/next-swc/crates/next-core/src/loader_tree.rs
@@ -422,16 +422,13 @@ impl LoaderTreeBuilder {
 
     async fn build(mut self, loader_tree: Vc<LoaderTree>) -> Result<LoaderTreeModule> {
         let components = loader_tree.clone().await?.components.await?;
-        match components.global_error {
-            Some(global_error) => {
-                let module = process_module(
-                    &self.context,
-                    &self.server_component_transition,
-                    global_error,
-                );
-                self.inner_assets.insert(GLOBAL_ERROR.into(), module);
-            }
-            None => {}
+        if let Some(global_error) = components.global_error {
+            let module = process_module(
+                &self.context,
+                &self.server_component_transition,
+                global_error,
+            );
+            self.inner_assets.insert(GLOBAL_ERROR.into(), module);
         };
 
         self.walk_tree(loader_tree, true).await?;

--- a/packages/next-swc/crates/next-core/src/loader_tree.rs
+++ b/packages/next-swc/crates/next-core/src/loader_tree.rs
@@ -107,14 +107,8 @@ impl LoaderTreeBuilder {
             let i = self.unique_number();
             let identifier = magic_identifier::mangle(&format!("{name} #{i}"));
 
-            let source = Vc::upcast(FileSource::new(component));
-            let reference_ty = Value::new(ReferenceType::EcmaScriptModules(
-                EcmaScriptModulesReferenceSubType::Undefined,
-            ));
-            let module = self
-                .server_component_transition
-                .process(source, self.context, reference_ty)
-                .module();
+            let module =
+                process_module(&self.context, &self.server_component_transition, component);
 
             writeln!(
                 self.loader_tree_code,
@@ -455,4 +449,20 @@ impl LoaderTreeModule {
             .build(loader_tree)
             .await
     }
+}
+
+pub fn process_module(
+    &context: &Vc<ModuleAssetContext>,
+    &server_component_transition: &Vc<Box<dyn Transition>>,
+    component: Vc<FileSystemPath>,
+) -> Vc<Box<dyn Module>> {
+    let source = Vc::upcast(FileSource::new(component));
+    let reference_ty = Value::new(ReferenceType::EcmaScriptModules(
+        EcmaScriptModulesReferenceSubType::Undefined,
+    ));
+    let module = server_component_transition
+        .process(source, context, reference_ty)
+        .module();
+
+    module
 }

--- a/packages/next-swc/crates/next-core/src/next_app/app_page_entry.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/app_page_entry.rs
@@ -22,7 +22,7 @@ use turbopack_binding::{
 use super::app_entry::AppEntry;
 use crate::{
     app_structure::LoaderTree,
-    loader_tree::{process_module, LoaderTreeModule},
+    loader_tree::LoaderTreeModule,
     next_app::{AppPage, AppPath},
     next_config::NextConfig,
     next_edge::entry::wrap_edge_entry,
@@ -41,8 +41,6 @@ pub async fn get_app_page_entry(
     project_root: Vc<FileSystemPath>,
     next_config: Vc<NextConfig>,
 ) -> Result<Vc<AppEntry>> {
-    const GLOBAL_ERROR: &str = "GLOBAL_ERROR_MODULE";
-
     let config = parse_segment_config_from_loader_tree(loader_tree);
     let is_edge = matches!(config.await?.runtime, Some(NextRuntime::Edge));
     let context = if is_edge {
@@ -51,20 +49,13 @@ pub async fn get_app_page_entry(
         nodejs_context
     };
 
-    let server_component_transition = Vc::upcast(NextServerComponentTransition::new());
-
     let components = loader_tree.clone().await?.components.await?;
     let global_error = match components.global_error {
-        Some(global_error) => {
-            let global_error_module =
-                process_module(&context, &server_component_transition, global_error);
-            let result = global_error_module.ident().path().to_string().await?;
-            println!("global_error: {}", result);
-
-            Some(result)
-        }
-        None => None,
+        Some(value) => value.to_string().await?.clone_value(),
+        None => "next/dist/client/components/error-boundary".into(),
     };
+
+    let server_component_transition = Vc::upcast(NextServerComponentTransition::new());
 
     let base_path = next_config.await?.base_path.clone();
     let loader_tree =
@@ -96,10 +87,8 @@ pub async fn get_app_page_entry(
         indexmap! {
             "VAR_DEFINITION_PAGE" => page.to_string().into(),
             "VAR_DEFINITION_PATHNAME" => pathname.clone(),
-            "VAR_MODULE_GLOBAL_ERROR" => match global_error {
-                Some(global_error) => RcStr::from(global_error.to_string()),
-                None => RcStr::from("next/dist/client/components/error-boundary"),
-            },
+            // TODO(alexkirsz) Support custom global error.
+            "VAR_MODULE_GLOBAL_ERROR" => global_error,
         },
         indexmap! {
             "tree" => loader_tree_code,

--- a/packages/next-swc/crates/next-core/src/next_app/app_page_entry.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/app_page_entry.rs
@@ -81,7 +81,7 @@ pub async fn get_app_page_entry(
         indexmap! {
             "VAR_DEFINITION_PAGE" => page.to_string().into(),
             "VAR_DEFINITION_PATHNAME" => pathname.clone(),
-            "VAR_MODULE_GLOBAL_ERROR" => if inner_assets.get(GLOBAL_ERROR).is_some() {
+            "VAR_MODULE_GLOBAL_ERROR" => if inner_assets.contains_key(GLOBAL_ERROR) {
                 GLOBAL_ERROR.into()
              } else {
                 "next/dist/client/components/error-boundary".into()

--- a/packages/next-swc/crates/next-core/src/next_app/app_page_entry.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/app_page_entry.rs
@@ -49,6 +49,12 @@ pub async fn get_app_page_entry(
         nodejs_context
     };
 
+    let components = loader_tree.clone().await?.components.await?;
+    let global_error = match components.global_error {
+        Some(value) => value.to_string().await?.clone_value(),
+        None => "next/dist/client/components/error-boundary".into(),
+    };
+
     let server_component_transition = Vc::upcast(NextServerComponentTransition::new());
 
     let base_path = next_config.await?.base_path.clone();
@@ -82,7 +88,7 @@ pub async fn get_app_page_entry(
             "VAR_DEFINITION_PAGE" => page.to_string().into(),
             "VAR_DEFINITION_PATHNAME" => pathname.clone(),
             // TODO(alexkirsz) Support custom global error.
-            "VAR_MODULE_GLOBAL_ERROR" => "next/dist/client/components/error-boundary".into(),
+            "VAR_MODULE_GLOBAL_ERROR" => global_error,
         },
         indexmap! {
             "tree" => loader_tree_code,

--- a/packages/next-swc/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/packages/next-swc/crates/next-core/src/next_server_component/server_component_module.rs
@@ -95,17 +95,14 @@ impl ChunkableModule for NextServerComponentModule {
 impl EcmascriptChunkPlaceable for NextServerComponentModule {
     #[turbo_tasks::function]
     fn get_exports(&self) -> Vc<EcmascriptExports> {
-        let exports = BTreeMap::from([(
-            "default".into(),
-            EsmExport::ImportedNamespace(Vc::upcast(NextServerComponentModuleReference::new(
-                Vc::upcast(self.module),
-            ))),
-        )]);
+        let module_reference = Vc::upcast(NextServerComponentModuleReference::new(Vc::upcast(
+            self.module,
+        )));
 
         EcmascriptExports::EsmExports(
             EsmExports {
-                exports,
-                star_exports: Default::default(),
+                exports: Default::default(),
+                star_exports: vec![module_reference],
             }
             .cell(),
         )
@@ -139,9 +136,7 @@ impl EcmascriptChunkItem for BuildServerComponentChunkItem {
         Ok(EcmascriptChunkItemContent {
             inner_code: formatdoc!(
                 r#"
-                    __turbopack_esm__({{
-                        default: () => __turbopack_import__({}),
-                    }});
+                    __turbopack_export_namespace__(__turbopack_import__({}));
                 "#,
                 StringifyJs(&module_id),
             )

--- a/packages/next-swc/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/packages/next-swc/crates/next-core/src/next_server_component/server_component_module.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use anyhow::{bail, Result};
 use indoc::formatdoc;
 use turbo_tasks::{RcStr, Vc};
@@ -12,10 +10,7 @@ use turbopack_binding::turbopack::{
         module::Module,
         reference::ModuleReferences,
     },
-    ecmascript::{
-        chunk::EcmascriptChunkType,
-        references::esm::{EsmExport, EsmExports},
-    },
+    ecmascript::{chunk::EcmascriptChunkType, references::esm::EsmExports},
     turbopack::ecmascript::{
         chunk::{
             EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -1781,15 +1781,14 @@
     },
     "test/e2e/app-dir/global-error/basic/index.test.ts": {
       "passed": [
-        "app dir - global error should catch metadata error in error boundary if presented"
-      ],
-      "failed": [
+        "app dir - global error should catch metadata error in error boundary if presented",
         "app dir - global error should catch metadata error in global-error if no error boundary is presented",
         "app dir - global error should catch the client error thrown in the nested routes",
         "app dir - global error should render global error for error in client components",
         "app dir - global error should render global error for error in server components",
         "app dir - global error should trigger error component when an error happens during rendering"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false
@@ -1797,20 +1796,19 @@
     "test/e2e/app-dir/global-error/catch-all/index.test.ts": {
       "passed": [
         "app dir - global error - with catch-all route should render 404 page correctly",
-        "app dir - global error - with catch-all route should render catch-all route correctly"
-      ],
-      "failed": [
+        "app dir - global error - with catch-all route should render catch-all route correctly",
         "app dir - global error - with catch-all route should render global error correctly"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false
     },
     "test/e2e/app-dir/global-error/layout-error/index.test.ts": {
-      "passed": [],
-      "failed": [
+      "passed": [
         "app dir - global error - layout error should render global error for error in server components"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false


### PR DESCRIPTION
Implements global-error.tsx for Turbopack, this feature was missing.

While adding this @sokra and I found that the server_component_transition was incorrectly wrapping a module around the server component, this is now refactored to re-export the server component instead, making the transition behave as expected. 

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
