### PR TITLE
Align the typeEnv value type with default process env value type

### DIFF
--- a/packages/next/src/server/lib/experimental/create-env-definitions.test.ts
+++ b/packages/next/src/server/lib/experimental/create-env-definitions.test.ts
@@ -17,10 +17,10 @@ describe('create-env-definitions', () => {
       declare global {
         namespace NodeJS {
           interface ProcessEnv {
-            FROM_DEV_ENV_LOCAL: string
-            FROM_ENV_LOCAL: string
-            FROM_ENV: string
-            FROM_NEXT_CONFIG: string
+            FROM_DEV_ENV_LOCAL?: string
+            FROM_ENV_LOCAL?: string
+            FROM_ENV?: string
+            FROM_NEXT_CONFIG?: string
           }
         }
       }

--- a/packages/next/src/server/lib/experimental/create-env-definitions.ts
+++ b/packages/next/src/server/lib/experimental/create-env-definitions.ts
@@ -10,7 +10,7 @@ export async function createEnvDefinitions({
   env: Env
 }) {
   const envKeysStr = Object.keys(env)
-    .map((key) => `      ${key}: string`)
+    .map((key) => `      ${key}?: string`)
     .join('\n')
 
   const definitionStr = `// Type definitions for Next.js environment variables

--- a/test/development/app-dir/typed-env/typed-env.test.ts
+++ b/test/development/app-dir/typed-env/typed-env.test.ts
@@ -13,15 +13,15 @@ describe('typed-env', () => {
       },
 
       // should not include from production-specific env
-      // e.g. FROM_PROD_ENV_LOCAL: string
+      // e.g. FROM_PROD_ENV_LOCAL?: string
       `// Type definitions for Next.js environment variables
 declare global {
   namespace NodeJS {
     interface ProcessEnv {
-      FROM_DEV_ENV_LOCAL: string
-      FROM_ENV_LOCAL: string
-      FROM_ENV: string
-      FROM_NEXT_CONFIG: string
+      FROM_DEV_ENV_LOCAL?: string
+      FROM_ENV_LOCAL?: string
+      FROM_ENV?: string
+      FROM_NEXT_CONFIG?: string
     }
   }
 }
@@ -35,15 +35,15 @@ export {}`
         return await next.readFile('.next/types/env.d.ts')
       },
       // env.d.ts is written from original .env
-      /FROM_ENV: string/
+      /FROM_ENV/
     )
 
     // modify .env
     await next.patchFile('.env', 'MODIFIED_ENV="MODIFIED_ENV"')
 
     // should not include from original .env
-    // e.g. FROM_ENV: string
-    // but have MODIFIED_ENV: string
+    // e.g. FROM_ENV?: string
+    // but have MODIFIED_ENV?: string
     await check(
       async () => {
         return await next.readFile('.next/types/env.d.ts')
@@ -52,10 +52,10 @@ export {}`
 declare global {
   namespace NodeJS {
     interface ProcessEnv {
-      FROM_DEV_ENV_LOCAL: string
-      FROM_ENV_LOCAL: string
-      MODIFIED_ENV: string
-      FROM_NEXT_CONFIG: string
+      FROM_DEV_ENV_LOCAL?: string
+      FROM_ENV_LOCAL?: string
+      MODIFIED_ENV?: string
+      FROM_NEXT_CONFIG?: string
     }
   }
 }


### PR DESCRIPTION
### What

Align the typeEnv value type with default process env value type `string | undefined`

### Why?

When the `experimental.typedEnv` is enabled, we generate a `env.d.ts` file during the Dev Server.
The type for the loaded env values will be `string` on Dev (type inference).

Since we do not generate the `env.d.ts` file during the build time, there could be confusion from the difference of env types between the Dev and Build.

The reason we don't want to strongly type as `string` or `readonly string` is because the multiple environment: Dev, Preview, Production, where the env could be different.

If we type in one place based on the loaded .env file, the environment (like deployment preview or deployment production) might not have these values in env files or they only have the env vars in Node.js `process.env`.

So the type file in build could be unpredictable, after discussion we decided to keep the original type for values, but the keys of envs are still be able to hint during development.


### How?

Temporarily infer the type as `string | undefined`.
The `typedEnv` will serve as the intellisense (type hint).

Closes NDX-84