### PR TITLE
Ensure instrumentation register only call once

### DIFF
--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -290,9 +290,6 @@ export default class DevServer extends Server {
     const telemetry = new Telemetry({ distDir: this.distDir })
 
     await super.prepareImpl()
-    await this.startServerSpan
-      .traceChild('run-instrumentation-hook')
-      .traceAsyncFn(() => this.runInstrumentationHookIfAvailable())
     await this.matchers.reload()
 
     // Store globals again to preserve changes made by the instrumentation hook.
@@ -623,10 +620,10 @@ export default class DevServer extends Server {
     return instrumentationModule
   }
 
-  private async runInstrumentationHookIfAvailable() {
-    if (this.instrumentation) {
-      await this.instrumentation.register?.()
-    }
+  protected async runInstrumentationHookIfAvailable() {
+    await this.startServerSpan
+      .traceChild('run-instrumentation-hook')
+      .traceAsyncFn(() => this.instrumentation?.register?.())
   }
 
   protected async ensureEdgeFunction({

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -306,15 +306,11 @@ export default class NextNodeServer extends BaseServer<
     // development.
   }
 
-  private isProductionInstrumentationEnabled = () => {
-    return (
+  protected async loadInstrumentationModule() {
+    if (
       !this.serverOptions.dev &&
       !!this.nextConfig.experimental.instrumentationHook
-    )
-  }
-
-  protected async loadInstrumentationModule() {
-    if (this.isProductionInstrumentationEnabled()) {
+    ) {
       try {
         this.instrumentation = await dynamicRequire(
           resolve(
@@ -336,10 +332,11 @@ export default class NextNodeServer extends BaseServer<
 
   protected async prepareImpl() {
     await super.prepareImpl()
+    await this.runInstrumentationHookIfAvailable()
+  }
 
-    if (this.isProductionInstrumentationEnabled()) {
-      await this.instrumentation?.register?.()
-    }
+  protected async runInstrumentationHookIfAvailable() {
+    await this.instrumentation?.register?.()
   }
 
   protected loadEnvConfig({

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -306,11 +306,15 @@ export default class NextNodeServer extends BaseServer<
     // development.
   }
 
-  protected async loadInstrumentationModule() {
-    if (
+  private isProductionInstrumentationEnabled = () => {
+    return (
       !this.serverOptions.dev &&
-      this.nextConfig.experimental.instrumentationHook
-    ) {
+      !!this.nextConfig.experimental.instrumentationHook
+    )
+  }
+
+  protected async loadInstrumentationModule() {
+    if (this.isProductionInstrumentationEnabled()) {
       try {
         this.instrumentation = await dynamicRequire(
           resolve(
@@ -333,8 +337,8 @@ export default class NextNodeServer extends BaseServer<
   protected async prepareImpl() {
     await super.prepareImpl()
 
-    if (this.instrumentation) {
-      await this.instrumentation.register?.()
+    if (this.isProductionInstrumentationEnabled()) {
+      await this.instrumentation?.register?.()
     }
   }
 

--- a/test/e2e/instrumentation-hook/register-once/instrumentation.js
+++ b/test/e2e/instrumentation-hook/register-once/instrumentation.js
@@ -1,0 +1,5 @@
+export function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    console.log('register-log')
+  }
+}

--- a/test/e2e/instrumentation-hook/register-once/next.config.js
+++ b/test/e2e/instrumentation-hook/register-once/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    instrumentationHook: true,
+  },
+}

--- a/test/e2e/instrumentation-hook/register-once/pages/foo.js
+++ b/test/e2e/instrumentation-hook/register-once/pages/foo.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'foo'
+}

--- a/test/e2e/instrumentation-hook/register-once/register-once.test.ts
+++ b/test/e2e/instrumentation-hook/register-once/register-once.test.ts
@@ -12,6 +12,6 @@ describe('instrumentation-hook - register-once', () => {
 
   it('should only register once', async () => {
     await next.fetch('/foo')
-    expect(next.cliOutput.split('register-log').length).toBe(2)
+    expect(next.cliOutput).toIncludeRepeated('register-log', 1)
   })
 })

--- a/test/e2e/instrumentation-hook/register-once/register-once.test.ts
+++ b/test/e2e/instrumentation-hook/register-once/register-once.test.ts
@@ -1,0 +1,17 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('instrumentation-hook - register-once', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should only register once', async () => {
+    await next.fetch('/foo')
+    expect(next.cliOutput.split('register-log').length).toBe(2)
+  })
+})


### PR DESCRIPTION
### What

Ensure instrumentation.js register only called once

### Why

In #67539 we accidentally make it call twice in both next-dev-ser and next-server. Adding a condition to ensure the one in next-server is only called in production runtime.