### PR TITLE
refactor(turbopack): make loader tree operations more synchronous

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4056,6 +4056,7 @@ name = "next-swc-napi"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-recursion",
  "backtrace",
  "dhat",
  "fxhash",

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -49,6 +49,7 @@ workspace = true
 
 [dependencies]
 anyhow = "1.0.66"
+async-recursion = { workspace = true }
 backtrace = "0.3"
 fxhash = "0.2.1"
 dhat = { workspace = true, optional = true }

--- a/crates/next-core/src/loader_tree.rs
+++ b/crates/next-core/src/loader_tree.rs
@@ -356,7 +356,7 @@ impl LoaderTreeBuilder {
     }
 
     #[async_recursion]
-    async fn walk_tree(&mut self, loader_tree: Vc<LoaderTree>, root: bool) -> Result<()> {
+    async fn walk_tree(&mut self, loader_tree: &LoaderTree, root: bool) -> Result<()> {
         use std::fmt::Write;
 
         let LoaderTree {
@@ -365,7 +365,7 @@ impl LoaderTreeBuilder {
             parallel_routes,
             components,
             global_metadata,
-        } = &*loader_tree.await?;
+        } = loader_tree;
 
         writeln!(
             self.loader_tree_code,
@@ -402,7 +402,7 @@ impl LoaderTreeBuilder {
         let components_code = replace(&mut self.loader_tree_code, temp_loader_tree_code);
 
         // add parallel_routes
-        for (key, &parallel_route) in parallel_routes.iter() {
+        for (key, parallel_route) in parallel_routes.iter() {
             write!(self.loader_tree_code, "{key}: ", key = StringifyJs(key))?;
             self.walk_tree(parallel_route, false).await?;
             writeln!(self.loader_tree_code, ",")?;
@@ -436,7 +436,7 @@ impl LoaderTreeBuilder {
             self.inner_assets.insert(GLOBAL_ERROR.into(), module);
         };
 
-        self.walk_tree(loader_tree, true).await?;
+        self.walk_tree(&*loader_tree.await?, true).await?;
         Ok(LoaderTreeModule {
             imports: self.imports,
             loader_tree_code: self.loader_tree_code.into(),


### PR DESCRIPTION
(generated by graphite)

### TL;DR

This PR refactors `LoaderTree` to remove unnecessary `.await` calls by making it non-async. This results in a more efficient and cleaner codebase by reducing async overhead and improving readability.

### What changed?
- Refactored `LoaderTree` to remove `.await` calls and handle the tree traversal synchronously.
- Updated functions to call the appropriate synchronous methods.

### Why make this change?
This change aims to reduce the number of async `.await` calls, which can introduce overhead and unnecessarily complicate the code. By making `LoaderTree` synchronous, the code becomes more streamlined and efficient.
