### PR TITLE
fix(turbopack): correctly handle catchall specificity

### DIFF
--- a/packages/next-swc/crates/next-core/src/app_structure.rs
+++ b/packages/next-swc/crates/next-core/src/app_structure.rs
@@ -466,6 +466,22 @@ impl LoaderTree {
 
         true
     }
+
+    /// Returns the specificity of the page (i.e. the number of segments
+    /// affecting the path)
+    pub fn get_specificity(&self) -> usize {
+        if &*self.segment == "__PAGE__" {
+            return AppPath::from(self.page.clone()).len();
+        }
+
+        let mut specificity = 0;
+
+        for (_, tree) in &self.parallel_routes {
+            specificity = specificity.max(tree.get_specificity());
+        }
+
+        specificity
+    }
 }
 
 #[derive(
@@ -506,10 +522,6 @@ fn is_parallel_route(name: &str) -> bool {
 
 fn is_group_route(name: &str) -> bool {
     name.starts_with('(') && name.ends_with(')')
-}
-
-fn is_catchall_route(name: &str) -> bool {
-    name.starts_with("[...") && name.ends_with(']')
 }
 
 fn match_parallel_route(name: &str) -> Option<&str> {
@@ -893,7 +905,6 @@ async fn directory_tree_to_loader_tree(
 
         let mut child_app_page = app_page.clone();
         let mut illegal_path_error = None;
-        let is_current_directory_catchall = is_catchall_route(subdir_name);
 
         // When constructing the app_page fails (e. g. due to limitations of the order),
         // we only want to emit the error when there are actual pages below that
@@ -934,31 +945,12 @@ async fn directory_tree_to_loader_tree(
             }
 
             if let Some(current_tree) = tree.parallel_routes.get("children") {
-                if is_current_directory_catchall && subtree.has_only_catchall() {
-                    // there's probably already a more specific page in the
-                    // slot.
-                } else if current_tree.has_only_catchall() {
+                if current_tree.has_only_catchall()
+                    && (!subtree.has_only_catchall()
+                        || current_tree.get_specificity() < subtree.get_specificity())
+                {
                     tree.parallel_routes
                         .insert("children".into(), subtree.clone());
-                } else {
-                    // TODO: Investigate if this is still needed. Emitting the
-                    // error causes the test "should
-                    // gracefully handle when two page
-                    // segments match the `children`
-                    // parallel slot" to fail
-                    // DirectoryTreeIssue {
-                    //     app_dir,
-                    //     message: StyledString::Text(format!(
-                    //         "You cannot have two parallel pages that resolve
-                    // to the same path. \          Route {}
-                    // has multiple matches in {}",
-                    //         for_app_path, app_page
-                    //     ))
-                    //     .cell(),
-                    //     severity: IssueSeverity::Error.cell(),
-                    // }
-                    // .cell()
-                    // .emit();
                 }
             } else {
                 tree.parallel_routes

--- a/test/e2e/app-dir/catchall-specificity/app/(group)/specific/[[...slug]]/page.tsx
+++ b/test/e2e/app-dir/catchall-specificity/app/(group)/specific/[[...slug]]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Specific Page</div>
+}

--- a/test/e2e/app-dir/catchall-specificity/app/[[...slug]]/page.tsx
+++ b/test/e2e/app-dir/catchall-specificity/app/[[...slug]]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Generic Page</div>
+}

--- a/test/e2e/app-dir/catchall-specificity/app/layout.tsx
+++ b/test/e2e/app-dir/catchall-specificity/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/catchall-specificity/catchall-specificity.test.ts
+++ b/test/e2e/app-dir/catchall-specificity/catchall-specificity.test.ts
@@ -1,0 +1,19 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('catchall-specificity', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should match the generic catchall correctly', async () => {
+    const browser = await next.browser('/foo')
+
+    expect(await browser.elementByCss('body').text()).toContain('Generic Page')
+  })
+
+  it('should match the specific catchall correctly', async () => {
+    const browser = await next.browser('/specific')
+
+    expect(await browser.elementByCss('body').text()).toContain('Specific Page')
+  })
+})

--- a/test/e2e/app-dir/catchall-specificity/next.config.js
+++ b/test/e2e/app-dir/catchall-specificity/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
(generated by graphite)

### What?

Introduce `get_specificity` method to determine the specificity of routes.
This facilitates more accurate route matching for catchall routes by comparing route specificity.
Modify existing route matching logic to incorporate specificity checks and avoid route conflicts.
Add corresponding tests to validate the new specificity handling mechanism.

Fixes #67045
Closes PACK-3154
