### PR TITLE
refactor client router initialization

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -13,7 +13,6 @@ import {
   AppRouterContext,
   LayoutRouterContext,
   GlobalLayoutRouterContext,
-  MissingSlotContext,
 } from '../../shared/lib/app-router-context.shared-runtime'
 import type {
   CacheNode,
@@ -45,8 +44,7 @@ import {
   useUnwrapState,
   type ReduxDevtoolsSyncFn,
 } from './use-reducer-with-devtools'
-import { ErrorBoundary } from './error-boundary'
-import { createInitialRouterState } from './router-reducer/create-initial-router-state'
+import { ErrorBoundary, type ErrorComponent } from './error-boundary'
 import { isBot } from '../../shared/lib/router/utils/is-bot'
 import { addBasePath } from '../add-base-path'
 import { AppRouterAnnouncer } from './app-router-announcer'
@@ -56,17 +54,9 @@ import { unresolvedThenable } from './unresolved-thenable'
 import { removeBasePath } from '../remove-base-path'
 import { hasBasePath } from '../has-base-path'
 import { getSelectedParams } from './router-reducer/compute-changed-path'
-import type {
-  FlightRouterState,
-  InitialRSCPayload,
-} from '../../server/app-render/types'
+import type { FlightRouterState } from '../../server/app-render/types'
 import { useServerActionDispatcher } from '../app-call-server'
-const isServer = typeof window === 'undefined'
-
-// Ensure the initialParallelRoutes are not combined because of double-rendering in the browser with Strict Mode.
-let initialParallelRoutes: CacheNode['parallelRoutes'] = isServer
-  ? null!
-  : new Map()
+import type { AppRouterActionQueue } from '../../shared/lib/router/action-queue'
 
 const globalMutable: {
   pendingMpaPath?: string
@@ -206,36 +196,14 @@ function Head({
  * The global router that wraps the application components.
  */
 function Router({
-  initialRSCPayload,
+  actionQueue,
+  assetPrefix,
 }: {
-  initialRSCPayload: Omit<InitialRSCPayload, 'G'>
+  actionQueue: AppRouterActionQueue
+  assetPrefix: string
 }) {
-  const initialState = useMemo(
-    () =>
-      createInitialRouterState({
-        buildId: initialRSCPayload.b,
-        initialFlightData: initialRSCPayload.f,
-        initialCanonicalUrl: initialRSCPayload.c,
-        initialParallelRoutes,
-        location: !isServer ? window.location : null,
-        couldBeIntercepted: initialRSCPayload.i,
-      }),
-    [
-      initialRSCPayload.b,
-      initialRSCPayload.c,
-      initialRSCPayload.f,
-      initialRSCPayload.i,
-    ]
-  )
-  const [reducerState, dispatch, sync] =
-    useReducerWithReduxDevtools(initialState)
-
-  useEffect(() => {
-    // Ensure initialParallelRoutes is cleaned up from memory once it's used.
-    initialParallelRoutes = null!
-  }, [])
-
-  const { canonicalUrl } = useUnwrapState(reducerState)
+  const [state, dispatch, sync] = useReducerWithReduxDevtools(actionQueue)
+  const { canonicalUrl } = useUnwrapState(state)
   // Add memoized pathname/query for useSearchParams and usePathname.
   const { searchParams, pathname } = useMemo(() => {
     const url = new URL(
@@ -341,7 +309,7 @@ function Router({
 
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    const { cache, prefetchCache, tree } = useUnwrapState(reducerState)
+    const { cache, prefetchCache, tree } = useUnwrapState(state)
 
     // This hook is in a conditional but that is ok because `process.env.NODE_ENV` never changes
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -400,7 +368,7 @@ function Router({
   // probably safe because we know this is a singleton component and it's never
   // in <Offscreen>. At least I hope so. (It will run twice in dev strict mode,
   // but that's... fine?)
-  const { pushRef } = useUnwrapState(reducerState)
+  const { pushRef } = useUnwrapState(state)
   if (pushRef.mpaNavigation) {
     // if there's a re-render, we don't want to trigger another redirect if one is already in flight to the same URL
     if (globalMutable.pendingMpaPath !== canonicalUrl) {
@@ -493,14 +461,14 @@ function Router({
      * By default dispatches ACTION_RESTORE, however if the history entry was not pushed/replaced by app-router it will reload the page.
      * That case can happen when the old router injected the history entry.
      */
-    const onPopState = ({ state }: PopStateEvent) => {
-      if (!state) {
+    const onPopState = (event: PopStateEvent) => {
+      if (!event.state) {
         // TODO-APP: this case only happens when pushState/replaceState was called outside of Next.js. It should probably reload the page in this case.
         return
       }
 
       // This case happens when the history entry was pushed by the `pages` router.
-      if (!state.__NA) {
+      if (!event.state.__NA) {
         window.location.reload()
         return
       }
@@ -511,7 +479,7 @@ function Router({
         dispatch({
           type: ACTION_RESTORE,
           url: new URL(window.location.href),
-          tree: state.__PRIVATE_NEXTJS_INTERNALS_TREE,
+          tree: event.state.__PRIVATE_NEXTJS_INTERNALS_TREE,
         })
       })
     }
@@ -525,8 +493,8 @@ function Router({
     }
   }, [dispatch])
 
-  const { cache, tree, nextUrl, focusAndScrollRef } =
-    useUnwrapState(reducerState)
+  const { cache, tree, nextUrl, focusAndScrollRef, buildId } =
+    useUnwrapState(state)
 
   const matchingHead = useMemo(() => {
     return findHeadInCache(cache, tree[1])
@@ -550,19 +518,13 @@ function Router({
 
   const globalLayoutRouterContext = useMemo(() => {
     return {
-      buildId: initialRSCPayload.b,
+      buildId,
       changeByServerResponse,
       tree,
       focusAndScrollRef,
       nextUrl,
     }
-  }, [
-    initialRSCPayload.b,
-    changeByServerResponse,
-    tree,
-    focusAndScrollRef,
-    nextUrl,
-  ])
+  }, [buildId, changeByServerResponse, tree, focusAndScrollRef, nextUrl])
 
   let head
   if (matchingHead !== null) {
@@ -590,32 +552,17 @@ function Router({
     if (typeof window !== 'undefined') {
       const DevRootNotFoundBoundary: typeof import('./dev-root-not-found-boundary').DevRootNotFoundBoundary =
         require('./dev-root-not-found-boundary').DevRootNotFoundBoundary
-      content = (
-        <DevRootNotFoundBoundary>
-          {initialRSCPayload.m ? (
-            <MissingSlotContext.Provider value={initialRSCPayload.m}>
-              {content}
-            </MissingSlotContext.Provider>
-          ) : (
-            content
-          )}
-        </DevRootNotFoundBoundary>
-      )
+      content = <DevRootNotFoundBoundary>{content}</DevRootNotFoundBoundary>
     }
     const HotReloader: typeof import('./react-dev-overlay/app/hot-reloader-client').default =
       require('./react-dev-overlay/app/hot-reloader-client').default
 
-    content = (
-      <HotReloader assetPrefix={initialRSCPayload.p}>{content}</HotReloader>
-    )
+    content = <HotReloader assetPrefix={assetPrefix}>{content}</HotReloader>
   }
 
   return (
     <>
-      <HistoryUpdater
-        appRouterState={useUnwrapState(reducerState)}
-        sync={sync}
-      />
+      <HistoryUpdater appRouterState={useUnwrapState(state)} sync={sync} />
       <RuntimeStyles />
       <PathParamsContext.Provider value={pathParams}>
         <PathnameContext.Provider value={pathname}>
@@ -637,14 +584,17 @@ function Router({
 }
 
 export default function AppRouter({
-  initialRSCPayload,
+  actionQueue,
+  globalErrorComponent,
+  assetPrefix,
 }: {
-  initialRSCPayload: InitialRSCPayload
+  actionQueue: AppRouterActionQueue
+  globalErrorComponent: ErrorComponent
+  assetPrefix: string
 }) {
-  const { G: globalErrorComponent, ...rest } = initialRSCPayload
   return (
     <ErrorBoundary errorComponent={globalErrorComponent}>
-      <Router initialRSCPayload={rest} />
+      <Router actionQueue={actionQueue} assetPrefix={assetPrefix} />
     </ErrorBoundary>
   )
 }

--- a/test/e2e/app-dir/next-after-app/index.test.ts
+++ b/test/e2e/app-dir/next-after-app/index.test.ts
@@ -131,11 +131,14 @@ describe.each(runtimes)('unstable_after() in %s runtime', (runtimeValue) => {
   describe('interrupted RSC renders', () => {
     it('runs callbacks if redirect() was called', async () => {
       await next.browser('/interrupted/calls-redirect')
-      expect(getLogs()).toContainEqual({
-        source: '[page] /interrupted/calls-redirect',
-      })
-      expect(getLogs()).toContainEqual({
-        source: '[page] /interrupted/redirect-target',
+
+      await retry(() => {
+        expect(getLogs()).toContainEqual({
+          source: '[page] /interrupted/calls-redirect',
+        })
+        expect(getLogs()).toContainEqual({
+          source: '[page] /interrupted/redirect-target',
+        })
       })
     })
 


### PR DESCRIPTION
Previously, the `AppRouter` component was responsible for creating the initial router state, while the `ActionQueue` was initialized in `app-index`. This led to a weird inversion of control: `ActionQueue` could technically have `null` state, which was invalid and guarded by an invariant. To account for this, the state was lazily initialized on the first `dispatch`. We also had to have separate exports & `isServer` conditions since `AppRouter` is also rendered during SSR.

With the refactor in #64594, the render stream no longer includes the `AppRouter` component. This means that we can initialize the client router state in `app-index` using `initialRSCPayload`, and create the `ActionQueue` with that initial state. That way `AppRouter` always has an initialized `ActionQueue`. 

Closes NDX-92