### PR TITLE
Fix for `typedRoutes` when setting `pageExtensions` - for typedRoutes MDX support

### DIFF
--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
@@ -622,6 +622,7 @@ export class NextTypesPlugin {
       const IS_LAYOUT = /[/\\]layout\.[^./\\]+$/.test(mod.resource)
       const IS_PAGE = !IS_LAYOUT && /[/\\]page\.[^.]+$/.test(mod.resource)
       const IS_ROUTE = !IS_PAGE && /[/\\]route\.[^.]+$/.test(mod.resource)
+      const IS_IMPORTABLE = /\.(js|jsx|ts|tsx|mjs|cjs)$/.test(mod.resource)
       const relativePathToApp = path.relative(this.appDir, mod.resource)
 
       if (!this.dev) {
@@ -641,6 +642,10 @@ export class NextTypesPlugin {
       )
 
       const assetPath = path.join(assetDirRelative, typePath)
+
+      // Typescript won’t allow relative-importing (for example) a .mdx file using the .js extension
+      // so for now we only generate “type guard files” for files that typescript can transform
+      if (!IS_IMPORTABLE) return
 
       if (IS_LAYOUT) {
         const slots = await collectNamedSlots(mod.resource)

--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
@@ -603,7 +603,11 @@ export class NextTypesPlugin {
     const handleModule = async (mod: webpack.NormalModule, assets: any) => {
       if (!mod.resource) return
 
-      if (!/\.(js|jsx|ts|tsx|mjs)$/.test(mod.resource)) return
+      const pageExtensionsRegex = new RegExp(
+        `\\.(${this.pageExtensions.join('|')})$`
+      )
+
+      if (!pageExtensionsRegex.test(mod.resource)) return
 
       if (!mod.resource.startsWith(this.appDir + path.sep)) {
         if (!this.dev) {
@@ -628,12 +632,12 @@ export class NextTypesPlugin {
 
       const typePath = path.join(
         appTypesBasePath,
-        relativePathToApp.replace(/\.(js|jsx|ts|tsx|mjs)$/, '.ts')
+        relativePathToApp.replace(pageExtensionsRegex, '.ts')
       )
       const relativeImportPath = normalizePathSep(
         path
           .join(this.getRelativePathFromAppTypesDir(relativePathToApp))
-          .replace(/\.(js|jsx|ts|tsx|mjs)$/, '')
+          .replace(pageExtensionsRegex, '')
       )
 
       const assetPath = path.join(assetDirRelative, typePath)

--- a/test/integration/app-types/mdx-components.ts
+++ b/test/integration/app-types/mdx-components.ts
@@ -1,0 +1,3 @@
+export function useMDXComponents(components: unknown) {
+  return components
+}

--- a/test/integration/app-types/next.config.js
+++ b/test/integration/app-types/next.config.js
@@ -1,7 +1,14 @@
-export default {
+import createMdx from '@next/mdx'
+
+const withMdx = createMdx()
+
+export default withMdx({
   experimental: {
     typedRoutes: true,
   },
+
+  pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'mdx'],
+
   async rewrites() {
     return [
       {
@@ -40,4 +47,4 @@ export default {
       },
     ]
   },
-}
+})

--- a/test/integration/app-types/src/app/mdx-test/page.mdx
+++ b/test/integration/app-types/src/app/mdx-test/page.mdx
@@ -1,0 +1,1 @@
+# I’m a MDX page

--- a/test/integration/app-types/src/app/type-checks/link/page.tsx
+++ b/test/integration/app-types/src/app/type-checks/link/page.tsx
@@ -41,6 +41,7 @@ export default function page() {
       <Card href="/aaa" />
       <Card href="/blog/a/b?1" />
       <Link href="/about">test</Link>
+      <Link href="/mdx-test" />
       <Link href="/aaa#aaa">test</Link>
       <Link href="/aaa?q=1">test</Link>
       <Link href="/blog/a/b">test</Link>


### PR DESCRIPTION
### What?

**Fixes MDX support for `typedRoutes`**

Updates the `next-types` webpack plugin to consider the full array of user-defined `pageExtensions` when deciding whether to include a file as a route (rather than using the hardcoded pattern `js|jsx|ts|tsx|mjs`).

### Why?

Without this PR, `typedRoutes` produces false-positive type errors when linking to MDX pages, because MDX pages aren’t included in the generated types - see #67822.

But it’s not specific to MDX—this bug affects any file type that’s added via [`pageExtensions`](https://nextjs.org/docs/app/api-reference/next-config-js/pageExtensions) outside of `js`, `jsx`, `ts`, `tsx`, or `mjs`.

### How?

Constructs a page-extension regex from `options.pageExtensions`, instead of hardcoding the regex `/\.(js|jsx|ts|tsx|mjs)$/`

### Fixes

Fixes #67822
Fixes #62335 
Supersedes #62402

Tests updated to cover this case

cc @shuding 