### PR TITLE
fix: top-level await for `next.config.ts`

### DIFF
--- a/packages/next/src/build/next-config-ts/transpile-config.ts
+++ b/packages/next/src/build/next-config-ts/transpile-config.ts
@@ -57,12 +57,17 @@ export async function transpileConfig({
     // lazy require swc since it loads React before even setting NODE_ENV
     // resulting loading Development React on Production
     const { transform } = require('../swc')
-    const { code } = await transform(nextConfigString, swcOptions)
+    let { code } = await transform(nextConfigString, swcOptions)
 
     // register require hook only if require exists
     if (code.includes('require(')) {
       registerHook(swcOptions)
       hasRequire = true
+    }
+
+    // wrap with async IIFE if await is used
+    if (code.includes('await')) {
+      code = `(async function(){${code}})();`
     }
 
     // filename & extension don't matter here

--- a/test/e2e/app-dir/next-config-ts/top-level-await/app/layout.tsx
+++ b/test/e2e/app-dir/next-config-ts/top-level-await/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/next-config-ts/top-level-await/app/page.tsx
+++ b/test/e2e/app-dir/next-config-ts/top-level-await/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>{process.env.foo}</p>
+}

--- a/test/e2e/app-dir/next-config-ts/top-level-await/index.test.ts
+++ b/test/e2e/app-dir/next-config-ts/top-level-await/index.test.ts
@@ -1,0 +1,12 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('next-config-ts-top-level-await', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should support top-level await', async () => {
+    const $ = await next.render$('/')
+    expect($('p').text()).toBe('foo')
+  })
+})

--- a/test/e2e/app-dir/next-config-ts/top-level-await/next.config.ts
+++ b/test/e2e/app-dir/next-config-ts/top-level-await/next.config.ts
@@ -1,0 +1,14 @@
+import type { NextConfig } from 'next'
+
+async function getFoo() {
+  return 'foo'
+}
+
+// top-level await
+const foo = await getFoo()
+
+export default {
+  env: {
+    foo,
+  },
+} satisfies NextConfig


### PR DESCRIPTION
### Why?

Since we transpile the config to CJS, it couldn't support top-level await

### How?

Wrap with async IIFE if `await` is used. (won't harm other non-top-level awaits)

Fixes #67765
Closes NDX-81