### PR TITLE
fix: dynamic import for `next.config.ts`

### DIFF
--- a/packages/next/src/build/next-config-ts/transpile-config.ts
+++ b/packages/next/src/build/next-config-ts/transpile-config.ts
@@ -71,7 +71,7 @@ export async function transpileConfig({
     }
 
     // filename & extension don't matter here
-    return requireFromString(code, join(cwd, 'next.config.compiled.js'))
+    return await requireFromString(code, join(cwd, 'next.config.compiled.js'))
   } catch (error) {
     throw error
   } finally {

--- a/test/e2e/app-dir/next-config-ts/dynamic-import/app/layout.tsx
+++ b/test/e2e/app-dir/next-config-ts/dynamic-import/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/next-config-ts/dynamic-import/app/page.tsx
+++ b/test/e2e/app-dir/next-config-ts/dynamic-import/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>{process.env.foo}</p>
+}

--- a/test/e2e/app-dir/next-config-ts/dynamic-import/foo.ts
+++ b/test/e2e/app-dir/next-config-ts/dynamic-import/foo.ts
@@ -1,0 +1,1 @@
+export const foo = 'foo'

--- a/test/e2e/app-dir/next-config-ts/dynamic-import/index.test.ts
+++ b/test/e2e/app-dir/next-config-ts/dynamic-import/index.test.ts
@@ -1,6 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 
-describe('next-config-ts-export-default', () => {
+describe('next-config-ts-dynamic-import', () => {
   const { next } = nextTestSetup({
     files: __dirname,
   })

--- a/test/e2e/app-dir/next-config-ts/dynamic-import/index.test.ts
+++ b/test/e2e/app-dir/next-config-ts/dynamic-import/index.test.ts
@@ -1,0 +1,12 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('next-config-ts-export-default', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should support dynamic import', async () => {
+    const $ = await next.render$('/')
+    expect($('p').text()).toBe('foo')
+  })
+})

--- a/test/e2e/app-dir/next-config-ts/dynamic-import/next.config.ts
+++ b/test/e2e/app-dir/next-config-ts/dynamic-import/next.config.ts
@@ -1,0 +1,9 @@
+import type { NextConfig } from 'next'
+
+const { foo } = await import('./foo')
+
+export default {
+  env: {
+    foo,
+  },
+} satisfies NextConfig


### PR DESCRIPTION
### Why?

The dynamic import is transpiled as `Promise().then`, so when we `requireFromString`, it still has unresolved promise.

### How?

Add `await` to the `requireFromString`.

x-ref: #67828

Closes NDX-82