### PR TITLE
Improve performance of test cleanup step

### DIFF
--- a/test/e2e/new-link-behavior/material-ui.test.ts
+++ b/test/e2e/new-link-behavior/material-ui.test.ts
@@ -1,36 +1,30 @@
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 import path from 'path'
 
 const appDir = path.join(__dirname, 'material-ui')
 
 describe('New Link Behavior with material-ui', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(path.join(appDir, 'pages')),
-        src: new FileRef(path.join(appDir, 'src')),
-        'next.config.js': new FileRef(path.join(appDir, 'next.config.js')),
-      },
-      dependencies: {
-        '@emotion/cache': 'latest',
-        '@emotion/react': 'latest',
-        '@emotion/server': 'latest',
-        '@emotion/styled': 'latest',
-        '@mui/icons-material': 'latest',
-        '@mui/material': 'latest',
-        next: 'latest',
-        'prop-types': 'latest',
-        // Use minimum peer dep version instead of v9 of eslint to avoid breaking changes
-        eslint: '8.56.0',
-        'eslint-config-next': 'latest',
-      },
-    })
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(path.join(appDir, 'pages')),
+      src: new FileRef(path.join(appDir, 'src')),
+      'next.config.js': new FileRef(path.join(appDir, 'next.config.js')),
+    },
+    dependencies: {
+      '@emotion/cache': 'latest',
+      '@emotion/react': 'latest',
+      '@emotion/server': 'latest',
+      '@emotion/styled': 'latest',
+      '@mui/icons-material': 'latest',
+      '@mui/material': 'latest',
+      next: 'latest',
+      'prop-types': 'latest',
+      // Use minimum peer dep version instead of v9 of eslint to avoid breaking changes
+      eslint: '8.56.0',
+      'eslint-config-next': 'latest',
+    },
   })
-  afterAll(() => next.destroy())
 
   it('should render MuiLink with <a>', async () => {
     const browser = await webdriver(next.url, `/`)

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -1,6 +1,6 @@
 import os from 'os'
 import path from 'path'
-import { existsSync, promises as fs } from 'fs'
+import { existsSync, promises as fs, rmSync } from 'fs'
 import treeKill from 'tree-kill'
 import type { NextConfig } from 'next'
 import { FileRef, isNextDeploy } from '../e2e-utils'
@@ -416,6 +416,8 @@ export class NextInstance {
 
   public async destroy(): Promise<void> {
     try {
+      require('console').time('destroyed next instance')
+
       if (this.isDestroyed) {
         throw new Error(`next instance already destroyed`)
       }
@@ -446,9 +448,9 @@ export class NextInstance {
       }
 
       if (!process.env.NEXT_TEST_SKIP_CLEANUP) {
-        await fs.rm(this.testDir, { recursive: true, force: true })
+        rmSync(this.testDir, { recursive: true, force: true })
       }
-      require('console').log(`destroyed next instance`)
+      require('console').timeEnd(`destroyed next instance`)
     } catch (err) {
       require('console').error('Error while destroying', err)
     }

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -448,6 +448,7 @@ export class NextInstance {
       }
 
       if (!process.env.NEXT_TEST_SKIP_CLEANUP) {
+        // Faster than `await fs.rm`. Benchmark before change.
         rmSync(this.testDir, { recursive: true, force: true })
       }
       require('console').timeEnd(`destroyed next instance`)


### PR DESCRIPTION
Saw this material-ui test flaking quite often for both Turbopack and Turbopack build, however the test itself was passing, it failed on the `destroy` step of the test isolation, specifically when cleaning up the test directory when the suite is done. Looked into it and switched the `await fs.rm()` to `rmSync` instead, holding quite good results, this test now runs in 30 seconds instead of 60+ seconds.

No changes to the test manifest as it's already marked as passing but would flake from time to time. 

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
