### PR TITLE
Support `compiler.removeConsole` with Turbopack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3022,6 +3022,7 @@ dependencies = [
  "once_cell",
  "qstring",
  "regex",
+ "remove_console",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/packages/next-swc/crates/next-core/Cargo.toml
+++ b/packages/next-swc/crates/next-core/Cargo.toml
@@ -32,6 +32,7 @@ lazy_static = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 rustc-hash = { workspace = true }
+remove_console = "0.25.15"
 turbopack-binding = { workspace = true, features = [
   "__swc_transform_modularize_imports",
   "__swc_transform_relay",

--- a/packages/next-swc/crates/next-core/src/next_client/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_client/context.rs
@@ -53,6 +53,7 @@ use crate::{
         },
         transforms::{
             emotion::get_emotion_transform_rule, relay::get_relay_transform_rule,
+            remove_console::get_remove_console_transform_rule,
             styled_components::get_styled_components_transform_rule,
             styled_jsx::get_styled_jsx_transform_rule,
             swc_ecma_transform_plugins::get_swc_ecma_transform_plugin_rule,
@@ -249,6 +250,7 @@ pub async fn get_client_module_options_context(
         get_emotion_transform_rule(next_config).await?,
         get_styled_components_transform_rule(next_config).await?,
         get_styled_jsx_transform_rule(next_config, target_browsers).await?,
+        get_remove_console_transform_rule(next_config).await?,
     ]
     .into_iter()
     .flatten()

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -61,7 +61,7 @@ use crate::{
         transforms::{
             emotion::get_emotion_transform_rule, get_ecma_transform_rule,
             next_react_server_components::get_next_react_server_components_transform_rule,
-            relay::get_relay_transform_rule,
+            relay::get_relay_transform_rule, remove_console::get_remove_console_transform_rule,
             styled_components::get_styled_components_transform_rule,
             styled_jsx::get_styled_jsx_transform_rule,
             swc_ecma_transform_plugins::get_swc_ecma_transform_plugin_rule,
@@ -468,6 +468,7 @@ pub async fn get_server_module_options_context(
         get_swc_ecma_transform_plugin_rule(next_config, project_path).await?,
         get_relay_transform_rule(next_config, project_path).await?,
         get_emotion_transform_rule(next_config).await?,
+        get_remove_console_transform_rule(next_config).await?,
     ]
     .into_iter()
     .flatten()

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod next_react_server_components;
 pub(crate) mod next_shake_exports;
 pub(crate) mod next_strip_page_exports;
 pub(crate) mod relay;
+pub(crate) mod remove_console;
 pub(crate) mod server_actions;
 pub(crate) mod styled_components;
 pub(crate) mod styled_jsx;

--- a/packages/next-swc/crates/next-core/src/next_shared/transforms/remove_console.rs
+++ b/packages/next-swc/crates/next-core/src/next_shared/transforms/remove_console.rs
@@ -1,0 +1,74 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use turbo_tasks::Vc;
+use turbopack_binding::{
+    swc::core::{
+        common::{util::take::Take, SyntaxContext},
+        ecma::{
+            ast::{Module, Program},
+            visit::FoldWith,
+        },
+    },
+    turbopack::{
+        ecmascript::{CustomTransformer, TransformContext},
+        turbopack::module_options::ModuleRule,
+    },
+};
+
+use super::get_ecma_transform_rule;
+use crate::next_config::{NextConfig, RemoveConsoleConfig};
+
+/// Returns a rule which applies the remove_console transform.
+pub async fn get_remove_console_transform_rule(
+    next_config: Vc<NextConfig>,
+) -> Result<Option<ModuleRule>> {
+    let enable_mdx_rs = next_config.mdx_rs().await?.is_some();
+
+    let module_rule = next_config
+        .await?
+        .compiler
+        .as_ref()
+        .and_then(|value| value.remove_console.as_ref())
+        .and_then(|config| match config {
+            RemoveConsoleConfig::Boolean(false) => None,
+            RemoveConsoleConfig::Boolean(true) => Some(remove_console::Config::All(true)),
+            RemoveConsoleConfig::Config { exclude } => Some(remove_console::Config::WithOptions(
+                remove_console::Options {
+                    exclude: exclude
+                        .as_deref()
+                        .unwrap_or_default()
+                        .iter()
+                        .map(|v| v.clone().into())
+                        .collect(),
+                },
+            )),
+        })
+        .map(|config| {
+            get_ecma_transform_rule(
+                Box::new(RemoveConsoleTransformer { config }),
+                enable_mdx_rs,
+                true,
+            )
+        });
+
+    Ok(module_rule)
+}
+
+#[derive(Debug)]
+struct RemoveConsoleTransformer {
+    config: remove_console::Config,
+}
+
+#[async_trait]
+impl CustomTransformer for RemoveConsoleTransformer {
+    #[tracing::instrument(level = tracing::Level::TRACE, name = "remove_console", skip_all)]
+    async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
+        let p = std::mem::replace(program, Program::Module(Module::dummy()));
+        *program = p.fold_with(&mut remove_console::remove_console(
+            self.config.clone(),
+            SyntaxContext::empty().apply_mark(ctx.unresolved_mark),
+        ));
+
+        Ok(())
+    }
+}

--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -18,7 +18,7 @@ const unsupportedTurbopackNextConfigOptions = [
   // 'compiler.emotion',
   'compiler.reactRemoveProperties',
   // 'compiler.relay',
-  'compiler.removeConsole',
+  // 'compiler.removeConsole',
   // 'compiler.styledComponents',
   'experimental.fetchCacheKeyPrefix',
 

--- a/test/e2e/app-dir/remove-console/app/client.tsx
+++ b/test/e2e/app-dir/remove-console/app/client.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+export function Client() {
+  console.log('MY LOG MESSAGE')
+  console.error('MY ERROR MESSAGE')
+
+  return <span>client</span>
+}

--- a/test/e2e/app-dir/remove-console/app/layout.tsx
+++ b/test/e2e/app-dir/remove-console/app/layout.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  console.log('MY LOG MESSAGE')
+  console.error('MY ERROR MESSAGE')
+
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/remove-console/app/layout.tsx
+++ b/test/e2e/app-dir/remove-console/app/layout.tsx
@@ -1,8 +1,6 @@
 import { ReactNode } from 'react'
-export default function Root({ children }: { children: ReactNode }) {
-  console.log('MY LOG MESSAGE')
-  console.error('MY ERROR MESSAGE')
 
+export default function Root({ children }: { children: ReactNode }) {
   return (
     <html>
       <body>{children}</body>

--- a/test/e2e/app-dir/remove-console/app/page.tsx
+++ b/test/e2e/app-dir/remove-console/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/remove-console/app/page.tsx
+++ b/test/e2e/app-dir/remove-console/app/page.tsx
@@ -1,3 +1,9 @@
+import { Client } from './client'
+
 export default function Page() {
-  return <p>hello world</p>
+  return (
+    <p>
+      hello <Client />
+    </p>
+  )
 }

--- a/test/e2e/app-dir/remove-console/next.config.js
+++ b/test/e2e/app-dir/remove-console/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  compiler: {
+    removeConsole: { exclude: ['error'] },
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/remove-console/remove-console.test.ts
+++ b/test/e2e/app-dir/remove-console/remove-console.test.ts
@@ -1,0 +1,20 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('remove-console', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should remove console.log', async () => {
+    let stdout = jest.fn()
+    let stderr = jest.fn()
+    next.on('stdout', stdout)
+    next.on('stderr', stderr)
+
+    const $ = await next.render$('/')
+    expect($('p').text()).toBe('hello world')
+
+    expect(stdout).not.toHaveBeenCalledWith('MY LOG MESSAGE\n')
+    expect(stderr).toHaveBeenCalledWith('MY ERROR MESSAGE\n')
+  })
+})

--- a/test/e2e/app-dir/remove-console/remove-console.test.ts
+++ b/test/e2e/app-dir/remove-console/remove-console.test.ts
@@ -6,15 +6,18 @@ describe('remove-console', () => {
   })
 
   it('should remove console.log', async () => {
-    let stdout = jest.fn()
-    let stderr = jest.fn()
-    next.on('stdout', stdout)
-    next.on('stderr', stderr)
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('p').text()).toBe('hello client')
 
-    const $ = await next.render$('/')
-    expect($('p').text()).toBe('hello world')
+    const logs = await browser.log()
 
-    expect(stdout).not.toHaveBeenCalledWith('MY LOG MESSAGE\n')
-    expect(stderr).toHaveBeenCalledWith('MY ERROR MESSAGE\n')
+    expect(logs).not.toContainEqual({
+      source: 'log',
+      message: 'MY LOG MESSAGE',
+    })
+    expect(logs).toContainEqual({
+      source: 'error',
+      message: 'MY ERROR MESSAGE',
+    })
   })
 })


### PR DESCRIPTION
Should `remove_console` and `react_remove_properties` be dependencies of the `next-next` crate
or reuse the dependencies from `next-custom-transforms`?