### PR TITLE
Turbopack build: Fix re-export-all-exports-from-page-disallowed test

### DIFF
--- a/test/integration/re-export-all-exports-from-page-disallowed/.babelrc
+++ b/test/integration/re-export-all-exports-from-page-disallowed/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["next/babel"]
-}

--- a/test/integration/re-export-all-exports-from-page-disallowed/pages/about.js
+++ b/test/integration/re-export-all-exports-from-page-disallowed/pages/about.js
@@ -7,8 +7,7 @@ export async function getStaticProps() {
   const text = fs
     .readFileSync(
       findUp.sync('world.txt', {
-        // eslint-disable-next-line no-eval
-        cwd: eval(`__dirname`),
+        cwd: process.cwd(),
       }),
       'utf8'
     )

--- a/test/integration/re-export-all-exports-from-page-disallowed/test/index.test.js
+++ b/test/integration/re-export-all-exports-from-page-disallowed/test/index.test.js
@@ -15,7 +15,7 @@ describe('Re-export all exports from page is disallowed', () => {
         })
         expect(code).toBe(1)
         expect(stderr).toInclude('pages/contact.js')
-        expect(stderr).toInclude(':3:1')
+        expect(stderr).toInclude('3:1')
         expect(stderr).toInclude(
           "Using `export * from '...'` in a page is disallowed. Please use `export { default } from '...'` instead."
         )

--- a/test/integration/re-export-all-exports-from-page-disallowed/test/index.test.js
+++ b/test/integration/re-export-all-exports-from-page-disallowed/test/index.test.js
@@ -11,15 +11,17 @@ describe('Re-export all exports from page is disallowed', () => {
       it('shows error when a page re-export all exports', async () => {
         const { code, stderr } = await nextBuild(appDir, undefined, {
           stderr: true,
+          cwd: appDir,
         })
         expect(code).toBe(1)
-        expect(stderr).toMatch(/\/export-all-in-page/)
-
-        expect(stderr.split('\n\n')[1]).toMatchInlineSnapshot(`
-      "./pages/contact.js:3:1
-      Syntax error: Using \`export * from '...'\` in a page is disallowed. Please use \`export { default } from '...'\` instead.
-      Read more: https://nextjs.org/docs/messages/export-all-in-page"
-    `)
+        expect(stderr).toInclude('pages/contact.js')
+        expect(stderr).toInclude(':3:1')
+        expect(stderr).toInclude(
+          "Using `export * from '...'` in a page is disallowed. Please use `export { default } from '...'` instead."
+        )
+        expect(stderr).toInclude(
+          'Read more: https://nextjs.org/docs/messages/export-all-in-page'
+        )
       })
 
       it('builds without error when no `export * from "..."` is used in pages', async () => {
@@ -28,6 +30,7 @@ describe('Re-export all exports from page is disallowed', () => {
         try {
           const { code, stderr } = await nextBuild(appDir, undefined, {
             stderr: true,
+            cwd: appDir,
           })
           expect(code).toBe(0)
           expect(stderr).not.toMatch(/\/export-all-in-page/)

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -14067,11 +14067,11 @@
       "runtimeError": false
     },
     "test/integration/re-export-all-exports-from-page-disallowed/test/index.test.js": {
-      "passed": [],
-      "failed": [
+      "passed": [
         "Re-export all exports from page is disallowed production mode builds without error when no `export * from \"...\"` is used in pages",
         "Re-export all exports from page is disallowed production mode shows error when a page re-export all exports"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false


### PR DESCRIPTION
The test itself needed to be reworked a bit as it made incorrect assumptions for example that the loglines would be exactly in one place, instead of validating against the full output. Also found that it tried to break out webpack bundling using `eval("__dirname")` which you can't break out of like that in Turbopack as Turbopack adds `__dirname` as part of the module wrapper. Switched it to using `process.cwd()` which matches our recommendation for runtime files.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
