### PR TITLE
Expose TS type for onRequestError

### DIFF
--- a/packages/next/src/server/instrumentation/types.ts
+++ b/packages/next/src/server/instrumentation/types.ts
@@ -23,3 +23,7 @@ export type InstrumentationModule = {
   register?(): void
   onRequestError?: InstrumentationOnRequestError
 }
+
+export namespace Instrumentation {
+  export type onRequestError = InstrumentationOnRequestError
+}

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -38,6 +38,8 @@ export type {
   ResolvedViewport,
 } from './lib/metadata/types/metadata-interface'
 
+export type { Instrumentation } from './server/instrumentation/types'
+
 /**
  * Stub route type for typedRoutes before `next dev` or `next build` is run
  * @link https://nextjs.org/docs/app/building-your-application/configuring/typescript#statically-typed-links

--- a/test/e2e/on-request-error/basic/instrumentation.ts
+++ b/test/e2e/on-request-error/basic/instrumentation.ts
@@ -1,8 +1,14 @@
-export function onRequestError(err, request, context) {
+import { type Instrumentation } from 'next'
+
+export const onRequestError: Instrumentation.onRequestError = (
+  err,
+  request,
+  context
+) => {
   fetch(`http://localhost:${process.env.PORT}/write-log`, {
     method: 'POST',
     body: JSON.stringify({
-      message: err.message,
+      message: (err as Error).message,
       request,
       context,
     }),


### PR DESCRIPTION
## What

Expose the TS types for onRequestError API

### API
```ts
type RequestErrorContext = {
    routerKind: 'Pages Router' | 'App Router';
    routePath: string;
    routeType: 'render' | 'route' | 'action' | 'middleware';
    renderSource?: 'react-server-components' | 'react-server-components-payload' | 'server-rendering';
};

export declare namespace Instrumentation {
    type onRequestError = (error: unknown, errorRequest: Readonly<{
    method: string;
    url: string;
    headers: NodeJS.Dict<string | string[]>;
}>, errorContext: Readonly<RequestErrorContext>) => void | Promise<void>;
```

### Usage

```ts
// instrumentation.ts
import { type Instrumentation } from 'next'

export const onRequestError: Instrumentation.onRequestError = (
  err,
  request,
  context
) => {
  //...
}
```