### PR TITLE
Fix `next lint` with async eslint-formatters

### DIFF
--- a/packages/next/src/lib/eslint/customFormatter.ts
+++ b/packages/next/src/lib/eslint/customFormatter.ts
@@ -94,16 +94,16 @@ function formatMessage(
   return output
 }
 
-export function formatResults(
+export async function formatResults(
   baseDir: string,
   results: LintResult[],
-  format: (r: LintResult[]) => string
-): {
+  format: (r: LintResult[]) => string | Promise<string>
+): Promise<{
   output: string
   outputWithMessages: string
   totalNextPluginErrorCount: number
   totalNextPluginWarningCount: number
-} {
+}> {
   let totalNextPluginErrorCount = 0
   let totalNextPluginWarningCount = 0
   let resultsWithMessages = results.filter(({ messages }) => messages?.length)
@@ -117,7 +117,7 @@ export function formatResults(
 
   // Use user defined formatter or Next.js's built-in custom formatter
   const output = format
-    ? format(resultsWithMessages)
+    ? await format(resultsWithMessages)
     : resultsWithMessages
         .map(({ messages, filePath }) =>
           formatMessage(baseDir, messages, filePath)

--- a/packages/next/src/lib/eslint/runLintCheck.ts
+++ b/packages/next/src/lib/eslint/runLintCheck.ts
@@ -229,7 +229,7 @@ async function lint(
     if (reportErrorsOnly) results = await ESLint.getErrorResults(results) // Only return errors if --quiet flag is used
 
     if (formatter) selectedFormatter = await eslint.loadFormatter(formatter)
-    const formattedResult = formatResults(
+    const formattedResult = await formatResults(
       baseDir,
       results,
       selectedFormatter?.format

--- a/test/integration/eslint/formatter-async/format.js
+++ b/test/integration/eslint/formatter-async/format.js
@@ -1,0 +1,7 @@
+module.exports = async function (results) {
+  // wait 1ms
+  await new Promise((resolve) => setTimeout(resolve, 1))
+
+  // return results as JSON
+  return 'Async results:\n' + JSON.stringify(results)
+}

--- a/test/integration/eslint/test/next-lint.test.js
+++ b/test/integration/eslint/test/next-lint.test.js
@@ -27,6 +27,7 @@ const dirNoConfig = join(__dirname, '../no-config')
 const dirFileLinting = join(__dirname, '../file-linting')
 const mjsCjsLinting = join(__dirname, '../mjs-cjs-linting')
 const dirTypescript = join(__dirname, '../with-typescript')
+const formatterAsync = join(__dirname, '../formatter-async/format.js')
 
 describe('Next Lint', () => {
   describe('First Time Setup ', () => {
@@ -439,6 +440,21 @@ describe('Next Lint', () => {
     expect(output).toContain('warning: Synchronous scripts should not be used.')
     expect(stdout).toContain('<script src="https://example.com" />')
     expect(stdout).toContain('2 warnings found')
+  })
+
+  test('format flag supports async formatters', async () => {
+    const { stdout, stderr } = await nextLint(
+      dirMaxWarnings,
+      ['-f', formatterAsync],
+      {
+        stdout: true,
+        stderr: true,
+      }
+    )
+
+    const output = stdout + stderr
+    expect(output).toContain('Async results:')
+    expect(stdout).toContain('Synchronous scripts should not be used.')
   })
 
   test('file flag can selectively lint only a single file', async () => {


### PR DESCRIPTION
Custom eslint-formatters can be async since ESLint v8.4.0. Running `next lint` with an async formatter only outputted `[object Promise]`.

I have updated the `format` parameter signature to match the one from ESLint (see  [LoadedFormatter type](https://eslint.org/docs/latest/integrate/nodejs-api#-loadedformatter-type)) and added the now necessary `await`s.

I've also added a test and verified the test is failing against the current canary.