### PR TITLE
Ensure thrown errors that are handled by React are associated with the original component not Next.js error boundaries

### DIFF
--- a/packages/next/src/client/components/not-found-boundary.tsx
+++ b/packages/next/src/client/components/not-found-boundary.tsx
@@ -66,8 +66,9 @@ class NotFoundErrorBoundary extends React.Component<
         notFoundTriggered: true,
       }
     }
-    // Re-throw if error is not for 404
-    throw error
+    return {
+      notFoundTriggered: false,
+    }
   }
 
   static getDerivedStateFromProps(

--- a/packages/next/src/client/components/redirect-boundary.tsx
+++ b/packages/next/src/client/components/redirect-boundary.tsx
@@ -54,8 +54,10 @@ export class RedirectErrorBoundary extends React.Component<
       const redirectType = getRedirectTypeFromError(error)
       return { redirect: url, redirectType }
     }
-    // Re-throw if error is not for redirect
-    throw error
+    return {
+      redirect: null,
+      redirectType: null,
+    }
   }
 
   // Explicit type is needed to avoid the generated `.d.ts` having a wide return type that could be specific the the `@types/react` version.


### PR DESCRIPTION
~If an error is thrown from render, React will provide a default error message that includes which component threw e.g. `The above error occurred in the <Foo> component.`.~

~Due to how our internal error boundaries where implemented, all of these errors were associated with Next.js error boundaries. It always read `The above error occurred in the <NotFoundErrorBoundary> component.` which is confusing since that's neither where the error actually originated from nor a component that's authored by the app developer.~

~The issue was that rethrowing an error from an error boundary is different than rethrowing an error from any other function. In React, you'd just return `this.props.children`:~

We do have to rethrow. It is React that needs a fix to show the original owner stack in the default error handlers.