### PR TITLE
chore(github): add bitbucket and gitlab hosts

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -31,7 +31,7 @@ jobs:
               "resolved": ".github/comments/resolved.md"
             }
           reproduction-comment: '.github/comments/invalid-link.md'
-          reproduction-hosts: 'github.com,codesandbox.io,stackblitz.com'
+          reproduction-hosts: 'github.com,bitbucket.org,gitlab.com,codesandbox.io,stackblitz.com'
           reproduction-blocklist: 'github.com/vercel/next.js.*,github.com/\\w*/?$,github.com$'
           reproduction-link-section: '### Link to the code that reproduces this issue(.*)### To Reproduce'
           reproduction-invalid-label: 'invalid link'


### PR DESCRIPTION
## Why?

Allow for Bitbucket and GitLab reproduction hosts, so we don't close issues like [this](https://github.com/vercel/next.js/issues/67811).