### PR TITLE
Docs: Bump min Node.js version to 18.18 (RC Docs)

### DIFF
--- a/docs/01-getting-started/01-installation.mdx
+++ b/docs/01-getting-started/01-installation.mdx
@@ -10,7 +10,7 @@ related:
 
 System Requirements:
 
-- [Node.js 18.17](https://nodejs.org/) or later.
+- [Node.js 18.18](https://nodejs.org/) or later.
 - macOS, Windows (including WSL), and Linux are supported.
 
 ## Automatic Installation


### PR DESCRIPTION
Related: https://github.com/vercel/next.js/pull/67274
Closes: [DOC-3056](https://linear.app/vercel/issue/DOC-3056/bump-nodejs-version-to-18180-for-rc-docs)
