### PR TITLE
Turbopack build: Skip babel specific tests

### DIFF
--- a/test/integration/mixed-ssg-serverprops-error/test/index.test.js
+++ b/test/integration/mixed-ssg-serverprops-error/test/index.test.js
@@ -13,53 +13,66 @@ describe('Mixed getStaticProps and getServerSideProps error', () => {
   ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
     'production mode',
     () => {
-      it('should error with getStaticProps but no default export', async () => {
-        // TODO: remove after investigating why dev swc build fails here
-        await fs.writeFile(
-          join(appDir, '.babelrc'),
-          '{ "presets": ["next/babel"] }'
-        )
-        await fs.move(indexPage, indexPageBak)
-        await fs.writeFile(
-          indexPage,
-          `
+      // Uses Babel, not supported in Turbopack.
+      ;(process.env.TURBOPACK ? it.skip : it)(
+        'should error with getStaticProps but no default export',
+        async () => {
+          // TODO: remove after investigating why dev swc build fails here
+          await fs.writeFile(
+            join(appDir, '.babelrc'),
+            '{ "presets": ["next/babel"] }'
+          )
+          await fs.move(indexPage, indexPageBak)
+          await fs.writeFile(
+            indexPage,
+            `
       export function getStaticProps() {
         return {
           props: {}
         }
       }
     `
-        )
-        const { stderr } = await nextBuild(appDir, [], { stderr: true })
-        await fs.remove(join(appDir, '.babelrc'))
-        await fs.remove(indexPage)
-        await fs.move(indexPageBak, indexPage)
-        expect(stderr).toContain(
-          'found page without a React Component as default export in'
-        )
-      })
+          )
+          const { stderr } = await nextBuild(appDir, [], { stderr: true })
+          await fs.remove(join(appDir, '.babelrc'))
+          await fs.remove(indexPage)
+          await fs.move(indexPageBak, indexPage)
+          // eslint-disable-next-line jest/no-standalone-expect
+          expect(stderr).toContain(
+            'found page without a React Component as default export in'
+          )
+        }
+      )
 
-      it('should error when exporting both getStaticProps and getServerSideProps', async () => {
-        // TODO: remove after investigating why dev swc build fails here
-        await fs.writeFile(
-          join(appDir, '.babelrc'),
-          '{ "presets": ["next/babel"] }'
-        )
-        const { stderr } = await nextBuild(appDir, [], { stderr: true })
-        await fs.remove(join(appDir, '.babelrc'))
-        expect(stderr).toContain(SERVER_PROPS_SSG_CONFLICT)
-      })
+      // Uses Babel, not supported in Turbopack.
+      ;(process.env.TURBOPACK ? it.skip : it)(
+        'should error when exporting both getStaticProps and getServerSideProps',
+        async () => {
+          // TODO: remove after investigating why dev swc build fails here
+          await fs.writeFile(
+            join(appDir, '.babelrc'),
+            '{ "presets": ["next/babel"] }'
+          )
+          const { stderr } = await nextBuild(appDir, [], { stderr: true })
+          await fs.remove(join(appDir, '.babelrc'))
+          // eslint-disable-next-line jest/no-standalone-expect
+          expect(stderr).toContain(SERVER_PROPS_SSG_CONFLICT)
+        }
+      )
 
-      it('should error when exporting both getStaticPaths and getServerSideProps', async () => {
-        // TODO: remove after investigating why dev swc build fails here
-        await fs.writeFile(
-          join(appDir, '.babelrc'),
-          '{ "presets": ["next/babel"] }'
-        )
-        await fs.move(indexPage, indexPageBak)
-        await fs.writeFile(
-          indexPage,
-          `
+      // Uses Babel, not supported in Turbopack.
+      ;(process.env.TURBOPACK ? it.skip : it)(
+        'should error when exporting both getStaticPaths and getServerSideProps',
+        async () => {
+          // TODO: remove after investigating why dev swc build fails here
+          await fs.writeFile(
+            join(appDir, '.babelrc'),
+            '{ "presets": ["next/babel"] }'
+          )
+          await fs.move(indexPage, indexPageBak)
+          await fs.writeFile(
+            indexPage,
+            `
       export const getStaticPaths = async () => {
         return {
           props: { world: 'world' }, fallback: true
@@ -74,14 +87,17 @@ describe('Mixed getStaticProps and getServerSideProps error', () => {
 
       export default ({ world }) => <p>Hello {world}</p>
     `
-        )
-        const { stderr, code } = await nextBuild(appDir, [], { stderr: true })
-        await fs.remove(join(appDir, '.babelrc'))
-        await fs.remove(indexPage)
-        await fs.move(indexPageBak, indexPage)
-        expect(code).toBe(1)
-        expect(stderr).toContain(SERVER_PROPS_SSG_CONFLICT)
-      })
+          )
+          const { stderr, code } = await nextBuild(appDir, [], { stderr: true })
+          await fs.remove(join(appDir, '.babelrc'))
+          await fs.remove(indexPage)
+          await fs.move(indexPageBak, indexPage)
+          // eslint-disable-next-line jest/no-standalone-expect
+          expect(code).toBe(1)
+          // eslint-disable-next-line jest/no-standalone-expect
+          expect(stderr).toContain(SERVER_PROPS_SSG_CONFLICT)
+        }
+      )
 
       it('should error when exporting getStaticPaths on a non-dynamic page', async () => {
         await fs.move(indexPage, indexPageBak)

--- a/test/production/next-font/babel-unsupported.test.ts
+++ b/test/production/next-font/babel-unsupported.test.ts
@@ -2,23 +2,27 @@ import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
 import { join } from 'path'
 
-describe('@next/fon babel unsupported', () => {
-  let next: NextInstance
+// Turbopack does not support `.babelrc`. So this test is not relevant for Turbopack.
+;(process.env.TURBOPACK ? describe.skip : describe)(
+  '@next/font babel unsupported',
+  () => {
+    let next: NextInstance
 
-  beforeAll(async () => {
-    next = await createNext({
-      skipStart: true,
-      files: new FileRef(join(__dirname, 'babel-unsupported')),
+    beforeAll(async () => {
+      next = await createNext({
+        skipStart: true,
+        files: new FileRef(join(__dirname, 'babel-unsupported')),
+      })
     })
-  })
-  afterAll(() => next.destroy())
+    afterAll(() => next.destroy())
 
-  test('Build error when using babel', async () => {
-    await expect(next.start()).rejects.toThrow(
-      'next build failed with code/signal 1'
-    )
-    expect(next.cliOutput).toMatch(
-      /"next\/font" requires SWC although Babel is being used due to a custom babel config being present./
-    )
-  })
-})
+    test('Build error when using babel', async () => {
+      await expect(next.start()).rejects.toThrow(
+        'next build failed with code/signal 1'
+      )
+      expect(next.cliOutput).toMatch(
+        /"next\/font" requires SWC although Babel is being used due to a custom babel config being present./
+      )
+    })
+  }
+)

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -12669,12 +12669,12 @@
       "passed": [
         "Mixed getStaticProps and getServerSideProps error production mode should error when exporting getStaticPaths on a non-dynamic page"
       ],
-      "failed": [
+      "failed": [],
+      "pending": [
         "Mixed getStaticProps and getServerSideProps error production mode should error when exporting both getStaticPaths and getServerSideProps",
         "Mixed getStaticProps and getServerSideProps error production mode should error when exporting both getStaticProps and getServerSideProps",
         "Mixed getStaticProps and getServerSideProps error production mode should error with getStaticProps but no default export"
       ],
-      "pending": [],
       "flakey": [],
       "runtimeError": false
     },

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -15956,8 +15956,8 @@
     },
     "test/production/next-font/babel-unsupported.test.ts": {
       "passed": [],
-      "failed": ["@next/fon babel unsupported Build error when using babel"],
-      "pending": [],
+      "failed": [],
+      "pending": ["@next/font babel unsupported Build error when using babel"],
       "flakey": [],
       "runtimeError": false
     },


### PR DESCRIPTION
Ensures the tests that depend on `.babelrc` are skipped. This is not supported in Turbopack without adding the babel-loader, and then `next/babel` is not needed.
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
