### PR TITLE
Log fetch requests during client-side navigation

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -435,7 +435,9 @@ async function generateDynamicFlightRenderResult(
     }
   )
 
-  return new FlightRenderResult(flightReadableStream)
+  return new FlightRenderResult(flightReadableStream, {
+    fetchMetrics: ctx.staticGenerationStore.fetchMetrics,
+  })
 }
 
 type RenderToStreamResult = {

--- a/packages/next/src/server/app-render/flight-render-result.ts
+++ b/packages/next/src/server/app-render/flight-render-result.ts
@@ -1,11 +1,14 @@
 import { RSC_CONTENT_TYPE_HEADER } from '../../client/components/app-router-headers'
-import RenderResult from '../render-result'
+import RenderResult, { type RenderResultMetadata } from '../render-result'
 
 /**
  * Flight Response is always set to RSC_CONTENT_TYPE_HEADER to ensure it does not get interpreted as HTML.
  */
 export class FlightRenderResult extends RenderResult {
-  constructor(response: string | ReadableStream<Uint8Array>) {
-    super(response, { contentType: RSC_CONTENT_TYPE_HEADER, metadata: {} })
+  constructor(
+    response: string | ReadableStream<Uint8Array>,
+    metadata: RenderResultMetadata = {}
+  ) {
+    super(response, { contentType: RSC_CONTENT_TYPE_HEADER, metadata })
   }
 }

--- a/packages/next/src/server/base-http/index.ts
+++ b/packages/next/src/server/base-http/index.ts
@@ -19,7 +19,7 @@ export type FetchMetric = {
   method: string
   status: number
   cacheReason: string
-  cacheStatus: 'hit' | 'miss' | 'skip'
+  cacheStatus: 'hit' | 'miss' | 'skip' | 'hmr'
   cacheWarning?: string
 }
 

--- a/packages/next/src/server/base-http/index.ts
+++ b/packages/next/src/server/base-http/index.ts
@@ -20,6 +20,7 @@ export type FetchMetric = {
   status: number
   cacheReason: string
   cacheStatus: 'hit' | 'miss' | 'skip'
+  cacheWarning?: string
 }
 
 export type FetchMetrics = Array<FetchMetric>

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -11,7 +11,6 @@ import {
   NEXT_CACHE_TAG_MAX_ITEMS,
   NEXT_CACHE_TAG_MAX_LENGTH,
 } from '../../lib/constants'
-import * as Log from '../../build/output/log'
 import { markCurrentScopeAsDynamic } from '../app-render/dynamic-rendering'
 import type { FetchMetric } from '../base-http'
 import { createDedupeFetch } from './dedupe-fetch'
@@ -328,6 +327,7 @@ function createPatchedFetcher(
 
         let currentFetchCacheConfig = getRequestMeta('cache')
         let cacheReason = ''
+        let cacheWarning: string | undefined
 
         if (
           typeof currentFetchCacheConfig === 'string' &&
@@ -336,9 +336,7 @@ function createPatchedFetcher(
           // when providing fetch with a Request input, it'll automatically set a cache value of 'default'
           // we only want to warn if the user is explicitly setting a cache value
           if (!(isRequestInput && currentFetchCacheConfig === 'default')) {
-            Log.warn(
-              `fetch for ${fetchUrl} on ${staticGenerationStore.route} specified "cache: ${currentFetchCacheConfig}" and "revalidate: ${currentFetchRevalidate}", only one should be specified.`
-            )
+            cacheWarning = `Specified "cache: ${currentFetchCacheConfig}" and "revalidate: ${currentFetchRevalidate}", only one should be specified.`
           }
           currentFetchCacheConfig = undefined
         }
@@ -587,6 +585,7 @@ function createPatchedFetcher(
                   finalRevalidate === 0 || cacheReasonOverride
                     ? 'skip'
                     : 'miss',
+                cacheWarning,
                 status: res.status,
                 method: clonedInit.method || 'GET',
               })
@@ -713,6 +712,7 @@ function createPatchedFetcher(
               url: fetchUrl,
               cacheReason,
               cacheStatus: 'hit',
+              cacheWarning,
               status: cachedFetchData.status || 200,
               method: init?.method || 'GET',
             })

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -646,6 +646,7 @@ function createPatchedFetcher(
         let handleUnlock = () => Promise.resolve()
         let cacheReasonOverride
         let isForegroundRevalidate = false
+        let isHmrRefreshCache = false
 
         if (cacheKey && staticGenerationStore.incrementalCache) {
           let cachedFetchData: CachedFetchData | undefined
@@ -656,6 +657,8 @@ function createPatchedFetcher(
           ) {
             cachedFetchData =
               requestStore.serverComponentsHmrCache.get(cacheKey)
+
+            isHmrRefreshCache = true
           }
 
           if (isCacheableRevalidate && !cachedFetchData) {
@@ -711,7 +714,7 @@ function createPatchedFetcher(
               start: fetchStart,
               url: fetchUrl,
               cacheReason,
-              cacheStatus: 'hit',
+              cacheStatus: isHmrRefreshCache ? 'hmr' : 'hit',
               cacheWarning,
               status: cachedFetchData.status || 200,
               method: init?.method || 'GET',

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -12,7 +12,6 @@ import type { MiddlewareManifest } from '../build/webpack/plugins/middleware-plu
 import type RenderResult from './render-result'
 import type { FetchEventResult } from './web/types'
 import type { PrerenderManifest } from '../build'
-import type { FetchMetric } from './base-http'
 import type { PagesManifest } from '../build/webpack/plugins/pages-manifest-plugin'
 import type { NextParsedUrlQuery, NextUrlWithParsedQuery } from './request-meta'
 import type { Params } from '../shared/lib/router/utils/route-matcher'
@@ -1167,26 +1166,6 @@ export default class NextNodeServer extends BaseServer<
           )
 
           if (fetchMetrics.length && enabledVerboseLogging) {
-            const calcNestedLevel = (
-              prevMetrics: FetchMetric[],
-              start: number
-            ): string => {
-              let nestedLevel = 0
-
-              for (let i = 0; i < prevMetrics.length; i++) {
-                const metric = prevMetrics[i]
-                const prevMetric = prevMetrics[i - 1]
-
-                if (
-                  metric.end <= start &&
-                  !(prevMetric && prevMetric.start < metric.end)
-                ) {
-                  nestedLevel += 1
-                }
-              }
-              return nestedLevel === 0 ? ' ' : ' │ '.repeat(nestedLevel)
-            }
-
             for (let i = 0; i < fetchMetrics.length; i++) {
               const metric = fetchMetrics[i]
               let { cacheStatus, cacheReason } = metric
@@ -1229,26 +1208,15 @@ export default class NextNodeServer extends BaseServer<
               }
 
               const status = cacheColor(`(cache ${cacheStatus})`)
-              const newLineLeadingChar = '│'
-              const nestedIndent = calcNestedLevel(
-                fetchMetrics.slice(0, i + 1),
-                metric.start
-              )
+              const indentation = '│ '
 
               writeStdoutLine(
-                `${newLineLeadingChar}${nestedIndent}${white(
+                `${indentation}${white(
                   metric.method
                 )} ${white(url)} ${metric.status} in ${duration}ms ${status}`
               )
               if (cacheReasonStr) {
-                const nextNestedIndent = calcNestedLevel(
-                  fetchMetrics.slice(0, i + 1),
-                  metric.start
-                )
-
-                writeStdoutLine(
-                  `${newLineLeadingChar}${nextNestedIndent}${newLineLeadingChar} ${cacheReasonStr}`
-                )
+                writeStdoutLine(`${indentation}${indentation}${cacheReasonStr}`)
               }
             }
           }

--- a/test/e2e/app-dir/logging/fetch-logging.test.ts
+++ b/test/e2e/app-dir/logging/fetch-logging.test.ts
@@ -210,6 +210,24 @@ describe('app-dir - logging', () => {
             expect(logs).toIncludeRepeated(` │ GET ${expectedUrl}`, 7)
           })
         })
+
+        it('should not log requests for HMR refreshes', async () => {
+          const browser = await next.browser('/default-cache')
+          let headline = await browser.waitForElementByCss('h1').text()
+          expect(headline).toBe('Default Cache')
+          const outputIndex = next.cliOutput.length
+
+          await next.patchFile(
+            'app/default-cache/page.js',
+            (content) => content.replace('Default Cache', 'Hello!'),
+            async () => {
+              headline = await browser.waitForElementByCss('h1').text()
+              expect(headline).toBe('Hello!')
+              const logs = stripAnsi(next.cliOutput.slice(outputIndex))
+              expect(logs).not.toInclude(` │ GET `)
+            }
+          )
+        })
       }
     } else {
       // No fetches logging enabled

--- a/test/e2e/app-dir/logging/fetch-logging.test.ts
+++ b/test/e2e/app-dir/logging/fetch-logging.test.ts
@@ -126,13 +126,12 @@ describe('app-dir - logging', () => {
           const outputIndex = next.cliOutput.length
           await next.fetch('/default-cache')
 
+          const expectedUrl = withFullUrlFetches
+            ? 'https://next-data-api-endpoint.vercel.app/api/random'
+            : 'https://next-data-api-en../api/random'
+
           await retry(() => {
             const logs = stripAnsi(next.cliOutput.slice(outputIndex))
-
-            const expectedUrl = withFullUrlFetches
-              ? 'https://next-data-api-endpoint.vercel.app/api/random'
-              : 'https://next-data-api-en../api/random'
-
             expect(logs).toIncludeRepeated(' GET /default-cache', 1)
             expect(logs).toIncludeRepeated(` │ GET ${expectedUrl}`, 7)
             expect(logs).toIncludeRepeated(' │ │ Cache skipped reason', 3)
@@ -194,6 +193,22 @@ describe('app-dir - logging', () => {
           expect(logs).toContain('GET /headers')
           expect(logs).not.toContain('/_next/static')
           expect(logs).not.toContain('?_rsc')
+        })
+
+        it('should log requests for client-side navigations', async () => {
+          const outputIndex = next.cliOutput.length
+          const browser = await next.browser('/')
+          await browser.elementById('nav-default-cache').click()
+          await browser.waitForElementByCss('h1')
+
+          const expectedUrl = withFullUrlFetches
+            ? 'https://next-data-api-endpoint.vercel.app/api/random'
+            : 'https://next-data-api-en../api/random'
+
+          await retry(() => {
+            const logs = stripAnsi(next.cliOutput.slice(outputIndex))
+            expect(logs).toIncludeRepeated(` │ GET ${expectedUrl}`, 7)
+          })
         })
       }
     } else {

--- a/test/e2e/app-dir/logging/fetch-logging.test.ts
+++ b/test/e2e/app-dir/logging/fetch-logging.test.ts
@@ -128,10 +128,14 @@ describe('app-dir - logging', () => {
 
           await retry(() => {
             const logs = stripAnsi(next.cliOutput.slice(outputIndex))
-            expect(logs).toContain(' GET /default-cache')
-            expect(logs).toContain(' │ GET ')
-            expect(logs).toContain(' │ │ Cache skipped reason')
-            expect(logs).toContain(' │ │ GET ')
+
+            const expectedUrl = withFullUrlFetches
+              ? 'https://next-data-api-endpoint.vercel.app/api/random'
+              : 'https://next-data-api-en../api/random'
+
+            expect(logs).toIncludeRepeated(' GET /default-cache', 1)
+            expect(logs).toIncludeRepeated(` │ GET ${expectedUrl}`, 7)
+            expect(logs).toIncludeRepeated(' │ │ Cache skipped reason', 3)
           })
         })
 

--- a/test/e2e/app-dir/logging/fetch-warning.test.ts
+++ b/test/e2e/app-dir/logging/fetch-warning.test.ts
@@ -1,8 +1,8 @@
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 
 describe('app-dir - fetch warnings', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next, skipped, isNextDev } = nextTestSetup({
     skipDeployment: true,
     files: __dirname,
   })
@@ -20,33 +20,40 @@ describe('app-dir - fetch warnings', () => {
     await next.fetch('/cache-revalidate')
   })
 
-  it('should log when request input is a string', async () => {
-    await check(() => {
-      return next.cliOutput.includes(
-        'fetch for https://next-data-api-endpoint.vercel.app/api/random?request-string on /cache-revalidate specified "cache: force-cache" and "revalidate: 3", only one should be specified'
-      )
-        ? 'success'
-        : 'fail'
-    }, 'success')
-  })
+  if (isNextDev) {
+    it('should log when request input is a string', async () => {
+      await retry(() => {
+        expect(next.cliOutput).toInclude(`
+   │ GET https://next-data-api-endpoint.vercel.app/api/random?request-string
+   │ │ ⚠ Specified "cache: force-cache" and "revalidate: 3", only one should be specified.
+  `)
+      })
+    })
 
-  it('should log when request input is a Request instance', async () => {
-    await check(() => {
-      return next.cliOutput.includes(
-        'fetch for https://next-data-api-endpoint.vercel.app/api/random?request-input-cache-override on /cache-revalidate specified "cache: force-cache" and "revalidate: 3", only one should be specified.'
-      )
-        ? 'success'
-        : 'fail'
-    }, 'success')
-  })
+    it('should log when request input is a Request instance', async () => {
+      await retry(() => {
+        expect(next.cliOutput).toInclude(`
+   │ GET https://next-data-api-endpoint.vercel.app/api/random?request-input-cache-override
+   │ │ ⚠ Specified "cache: force-cache" and "revalidate: 3", only one should be specified.
+  `)
+      })
+    })
 
-  it('should not log when overriding cache within the Request object', async () => {
-    await check(() => {
-      return next.cliOutput.includes(
-        `fetch for https://next-data-api-endpoint.vercel.app/api/random?request-input on /cache-revalidate specified "cache: default" and "revalidate: 3", only one should be specified.`
-      )
-        ? 'fail'
-        : 'success'
-    }, 'success')
-  })
+    it('should not log when overriding cache within the Request object', async () => {
+      await retry(() => {
+        expect(next.cliOutput).not.toInclude(`
+        │ GET https://next-data-api-endpoint.vercel.app/api/random?request-input
+        │ │ ⚠ Specified "cache: force-cache" and "revalidate: 3", only one should be specified.
+        `)
+      })
+    })
+  } else {
+    it('should not log fetch warnings in production', async () => {
+      await retry(() => {
+        expect(next.cliOutput).not.toInclude(
+          '⚠ Specified "cache: force-cache" and "revalidate: 3", only one should be specified.'
+        )
+      })
+    })
+  }
 })

--- a/test/e2e/app-dir/logging/fetch-warning.test.ts
+++ b/test/e2e/app-dir/logging/fetch-warning.test.ts
@@ -24,27 +24,24 @@ describe('app-dir - fetch warnings', () => {
     it('should log when request input is a string', async () => {
       await retry(() => {
         expect(next.cliOutput).toInclude(`
-   │ GET https://next-data-api-endpoint.vercel.app/api/random?request-string
-   │ │ ⚠ Specified "cache: force-cache" and "revalidate: 3", only one should be specified.
-  `)
+ │ GET https://next-data-api-endpoint.vercel.app/api/random?request-string
+ │ │ ⚠ Specified "cache: force-cache" and "revalidate: 3", only one should be specified.`)
       })
     })
 
     it('should log when request input is a Request instance', async () => {
       await retry(() => {
         expect(next.cliOutput).toInclude(`
-   │ GET https://next-data-api-endpoint.vercel.app/api/random?request-input-cache-override
-   │ │ ⚠ Specified "cache: force-cache" and "revalidate: 3", only one should be specified.
-  `)
+ │ GET https://next-data-api-endpoint.vercel.app/api/random?request-input-cache-override
+ │ │ ⚠ Specified "cache: force-cache" and "revalidate: 3", only one should be specified.`)
       })
     })
 
     it('should not log when overriding cache within the Request object', async () => {
       await retry(() => {
         expect(next.cliOutput).not.toInclude(`
-        │ GET https://next-data-api-endpoint.vercel.app/api/random?request-input
-        │ │ ⚠ Specified "cache: force-cache" and "revalidate: 3", only one should be specified.
-        `)
+ │ GET https://next-data-api-endpoint.vercel.app/api/random?request-input
+ │ │ ⚠ Specified "cache: force-cache" and "revalidate: 3", only one should be specified.`)
       })
     })
   } else {

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -8,7 +8,7 @@ import { ChildProcess } from 'child_process'
 import { createNextInstall } from '../create-next-install'
 import { Span } from 'next/dist/trace'
 import webdriver from '../next-webdriver'
-import { renderViaHTTP, fetchViaHTTP, findPort } from 'next-test-utils'
+import { renderViaHTTP, fetchViaHTTP, findPort, retry } from 'next-test-utils'
 import cheerio from 'cheerio'
 import { once } from 'events'
 import { BrowserInterface } from '../browsers/base'
@@ -490,18 +490,30 @@ export class NextInstance {
 
   public async patchFile(
     filename: string,
-    content: string | ((contents: string) => string)
+    content: string | ((content: string) => string),
+    retryWithTempContent?: (context: { newFile: boolean }) => Promise<void>
   ): Promise<{ newFile: boolean }> {
     const outputPath = path.join(this.testDir, filename)
     const newFile = !existsSync(outputPath)
     await fs.mkdir(path.dirname(outputPath), { recursive: true })
+    const previousContent = newFile ? undefined : await this.readFile(filename)
 
     await fs.writeFile(
       outputPath,
-      typeof content === 'function'
-        ? content(await this.readFile(filename))
-        : content
+      typeof content === 'function' ? content(previousContent) : content
     )
+
+    if (retryWithTempContent) {
+      try {
+        await retry(() => retryWithTempContent({ newFile }))
+      } finally {
+        if (previousContent === undefined) {
+          await fs.rm(outputPath)
+        } else {
+          await fs.writeFile(outputPath, previousContent)
+        }
+      }
+    }
 
     return { newFile }
   }


### PR DESCRIPTION
When the config `logging.fetches` (see https://nextjs.org/docs/app/api-reference/next-config-js/logging) is defined, any fetch requests that are done in server components should be logged. This is currently not the case for client-side navigations in the app router. This PR fixes that, and also cleans up the log format a bit. In addition, cached requests for the purpose of HMR refreshes (see #67527) are explicitly omitted from the logs.

**Before**

<img width="963" alt="fetch logs before" src="https://github.com/user-attachments/assets/f3d50495-1168-4e75-933e-635931f6efb0">

**After**

<img width="908" alt="fetch logs after" src="https://github.com/user-attachments/assets/0933964c-1e02-4f14-b059-1ce536abec71">

Note that warnings for conflicting fetch cache configs are now co-located with the logged fetch metrics. If `logging.fetches` is not enabled, the warnings are still logged, as was the case before. They are now only logged in dev mode though, which was not the case before.