### PR TITLE
pre-push: Don't block pushes to canary for forked repos

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,11 +1,22 @@
 #!/usr/bin/env bash
 
-main_branch="canary"
+protected_branch="canary"
+protected_remote_url="git@github.com:vercel/next.js.git"
+
+# The pre-push hook [...] receives the name and location of the remote as parameters
+# https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
+remote_name="$1"
+remote_url="$2"
+
+# if we're pushing to a fork, we don't need to protect canary.
+if [ "$remote_url" != "$protected_remote_url" ]; then
+  exit 0
+fi
 
 branch="$(git rev-parse --abbrev-ref HEAD)"
 
-if [ "$branch" = "$main_branch" ]; then
-  echo "You probably didn't intend to push directly to '$main_branch'." >&2
+if [ "$branch" = "$protected_branch" ]; then
+  echo "You probably didn't intend to push directly to '$protected_branch' on '$remote_name' ($remote_url)." >&2
   echo "If you're sure that that's what you want to do, bypass this check via" >&2
   echo "" >&2
   echo "  git push --no-verify" >&2

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,17 +1,35 @@
 #!/usr/bin/env bash
 
-protected_branch="canary"
-protected_remote_url="git@github.com:vercel/next.js.git"
+protected_branch='canary'
+
+protected_remote_urls=(
+  'git@github.com:vercel/next.js.git'
+  'https://github.com/vercel/next.js.git' # github blocks password-based auth, but still usable via API token
+)
+
 
 # The pre-push hook [...] receives the name and location of the remote as parameters
 # https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
 remote_name="$1"
 remote_url="$2"
 
+
+
 # if we're pushing to a fork, we don't need to protect canary.
-if [ "$remote_url" != "$protected_remote_url" ]; then
+# check if the remote is one of the protected ones.
+is_remote_protected=0
+for protected_remote_url in "${protected_remote_urls[@]}"; do
+  if [ "$remote_url" = "$protected_remote_url" ]; then
+    is_remote_protected=1
+    break
+  fi
+done
+
+if [ "$is_remote_protected" = 0 ]; then
   exit 0
 fi
+
+
 
 # check if the push is targeting canary on the remote
 # https://stackoverflow.com/a/44156933
@@ -23,7 +41,6 @@ while read -r _local_ref _local_sha remote_ref _remote_sha; do
     break
   fi
 done
-
 
 if [ "$push_targets_protected_branch" = "1" ]; then
   echo "You probably didn't intend to push directly to '$protected_branch' on '$remote_name' ($remote_url)." >&2

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -13,9 +13,19 @@ if [ "$remote_url" != "$protected_remote_url" ]; then
   exit 0
 fi
 
-branch="$(git rev-parse --abbrev-ref HEAD)"
+# check if the push is targeting canary on the remote
+# https://stackoverflow.com/a/44156933
+push_targets_protected_branch=0
+protected_ref="refs/heads/$protected_branch"
+while read -r _local_ref _local_sha remote_ref _remote_sha; do
+  if [ "$remote_ref" = "$protected_ref" ]; then
+    push_targets_protected_branch=1
+    break
+  fi
+done
 
-if [ "$branch" = "$protected_branch" ]; then
+
+if [ "$push_targets_protected_branch" = "1" ]; then
   echo "You probably didn't intend to push directly to '$protected_branch' on '$remote_name' ($remote_url)." >&2
   echo "If you're sure that that's what you want to do, bypass this check via" >&2
   echo "" >&2


### PR DESCRIPTION
Our `pre-push` hook blocks accidental pushes to `canary` (see https://github.com/vercel/next.js/pull/66030 for context). This can be a bit annoying if the target remote is a fork -- we don't really need to protect those, we only care about the main repo.

This PR changes the hook to only block pushes if the target remote is `vercel/next.js`.

I also improved the branch checking logic to check if the _remote_ branch is `canary` -- previously, we'd only check the currently checked-out branch name, which means the hook wouldn't catch `git push origin mybranch:canary` (assuming `mybranch` is the currently checked out branch)