### PR TITLE
Fix fetch logging in edge runtime

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/render.ts
@@ -162,6 +162,7 @@ export function getRender({
 
     handler(extendedReq, extendedRes)
     const result = await extendedRes.toResponse()
+    request.fetchMetrics = extendedReq.fetchMetrics
 
     if (event?.waitUntil) {
       // TODO(after):

--- a/test/e2e/app-dir/logging/fetch-logging.test.ts
+++ b/test/e2e/app-dir/logging/fetch-logging.test.ts
@@ -267,7 +267,7 @@ describe('app-dir - logging', () => {
       await next.start()
     })
 
-    runTests({ withFetchesLogging: false })
+    runTests({ withFetchesLogging: true, withFullUrlFetches: true })
   })
 
   describe('with default logging', () => {


### PR DESCRIPTION
Fetch logging in edge runtime was originally implemented in #56108, and then was accidentally broken in #62946.

This restores the previous behaviour, and also fixes the wrong test config, which prevented us from catching the regression.

fixes #50439
fixes #67835