### PR TITLE
fix: merged middleware cookies should preserve options

### DIFF
--- a/packages/next/src/server/async-storage/with-request-store.ts
+++ b/packages/next/src/server/async-storage/with-request-store.ts
@@ -104,7 +104,7 @@ function mergeMiddlewareCookies(
 
     // Transfer cookies from ResponseCookies to RequestCookies
     for (const cookie of responseCookies.getAll()) {
-      existingCookies.set(cookie.name, cookie.value ?? '')
+      existingCookies.set(cookie)
     }
   }
 }

--- a/test/e2e/app-dir/app-middleware/app-middleware.test.ts
+++ b/test/e2e/app-dir/app-middleware/app-middleware.test.ts
@@ -161,6 +161,33 @@ describe('app-dir with middleware', () => {
         /Cookie 2: \d+\.\d+/
       )
     })
+
+    // Cleanup
+    await browser.deleteCookies()
+  })
+
+  it('should respect cookie options of merged middleware cookies', async () => {
+    const browser = await next.browser('/rsc-cookies/cookie-options')
+
+    const totalCookies = await browser.elementById('total-cookies').text()
+
+    // a secure cookie was set in middleware
+    expect(totalCookies).toBe('Total Cookie Length: 1')
+
+    // we don't expect to be able to read it
+    expect(await browser.eval('document.cookie')).toBeFalsy()
+
+    await browser.elementById('submit-server-action').click()
+
+    await retry(() => {
+      expect(next.cliOutput).toMatch(/\[Cookie From Action\]: \d+\.\d+/)
+    })
+
+    // ensure that we still can't read the secure cookie
+    expect(await browser.eval('document.cookie')).toBeFalsy()
+
+    // Cleanup
+    await browser.deleteCookies()
   })
 
   it('should be possible to read cookies that are set during the middleware handling of a server action', async () => {
@@ -186,6 +213,8 @@ describe('app-dir with middleware', () => {
     await retry(() => {
       expect(next.cliOutput).toMatch(/\[Cookie From Action\]: \d+\.\d+/)
     })
+
+    await browser.deleteCookies()
   })
 })
 

--- a/test/e2e/app-dir/app-middleware/app/rsc-cookies/cookie-options/page.js
+++ b/test/e2e/app-dir/app-middleware/app/rsc-cookies/cookie-options/page.js
@@ -1,0 +1,25 @@
+import { cookies } from 'next/headers'
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <p id="total-cookies">Total Cookie Length: {cookies().size}</p>
+      <Link href="/rsc-cookies-delete">To Delete Cookies Route</Link>
+
+      <form
+        action={async () => {
+          'use server'
+          console.log(
+            '[Cookie From Action]:',
+            cookies().get('rsc-secure-cookie').value
+          )
+        }}
+      >
+        <button type="submit" id="submit-server-action">
+          server action
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-middleware/middleware.js
+++ b/test/e2e/app-dir/app-middleware/middleware.js
@@ -52,6 +52,16 @@ export async function middleware(request) {
     return res
   }
 
+  if (request.nextUrl.pathname === '/rsc-cookies/cookie-options') {
+    const res = NextResponse.next()
+    res.cookies.set('rsc-secure-cookie', `${Math.random()}`, {
+      secure: true,
+      httpOnly: true,
+    })
+
+    return res
+  }
+
   if (request.nextUrl.pathname === '/rsc-cookies-delete') {
     const res = NextResponse.next()
     res.cookies.delete('rsc-cookie-value-1')


### PR DESCRIPTION
This ensures that cookies merged via `x-middleware-set-cookie` preserve the options that are passed to them. Currently we're only selectively merging in `name` and `value` but really we can just copy the `ResponseCookie` in kind rather than enumerating on select properties. 