### PR TITLE
Do not limit the number of fetch requests that are logged

### DIFF
--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -176,40 +176,11 @@ function trackFetchMetric(
   }
   staticGenerationStore.fetchMetrics ??= []
 
-  const dedupeFields = ['url', 'status', 'method'] as const
-
-  // don't add metric if one already exists for the fetch
-  if (
-    staticGenerationStore.fetchMetrics.some((metric) =>
-      dedupeFields.every((field) => metric[field] === ctx[field])
-    )
-  ) {
-    return
-  }
   staticGenerationStore.fetchMetrics.push({
     ...ctx,
     end: Date.now(),
     idx: staticGenerationStore.nextFetchId || 0,
   })
-
-  // only store top 10 metrics to avoid storing too many
-  if (staticGenerationStore.fetchMetrics.length > 10) {
-    // sort slowest first as these should be highlighted
-    staticGenerationStore.fetchMetrics.sort((a, b) => {
-      const aDur = a.end - a.start
-      const bDur = b.end - b.start
-
-      if (aDur < bDur) {
-        return 1
-      } else if (aDur > bDur) {
-        return -1
-      }
-      return 0
-    })
-    // now grab top 10
-    staticGenerationStore.fetchMetrics =
-      staticGenerationStore.fetchMetrics.slice(0, 10)
-  }
 }
 
 interface PatchableModule {

--- a/test/e2e/app-dir/logging/app/layout.js
+++ b/test/e2e/app-dir/logging/app/layout.js
@@ -23,6 +23,10 @@ export default function Layout({ children }) {
             /cache-revalidate
           </Link>
           <br />
+          <Link id="nav-many-requests" href={'/many-requests'}>
+            /many-requests
+          </Link>
+          <br />
         </header>
         <div>{children}</div>
       </body>

--- a/test/e2e/app-dir/logging/app/many-requests/page.js
+++ b/test/e2e/app-dir/logging/app/many-requests/page.js
@@ -1,0 +1,14 @@
+export default async function Page() {
+  await Promise.all(
+    new Array(12).fill(undefined).map((_, index) =>
+      index > 5
+        ? fetch(`https://next-data-api-endpoint.vercel.app/api/random?${index}`)
+        : fetch(`https://next-data-api-endpoint.vercel.app/api/random`, {
+            method: 'POST',
+            body: index,
+          })
+    )
+  )
+
+  return <h1>Many Requests</h1>
+}

--- a/test/e2e/app-dir/logging/fetch-logging.test.ts
+++ b/test/e2e/app-dir/logging/fetch-logging.test.ts
@@ -138,6 +138,21 @@ describe('app-dir - logging', () => {
           })
         })
 
+        it('should not limit the number of requests that are logged', async () => {
+          const outputIndex = next.cliOutput.length
+          await next.fetch('/many-requests')
+
+          const expectedUrl = withFullUrlFetches
+            ? 'https://next-data-api-endpoint.vercel.app/api/random'
+            : 'https://next-data-api-en../api/random'
+
+          await retry(() => {
+            const logs = stripAnsi(next.cliOutput.slice(outputIndex))
+            expect(logs).toIncludeRepeated(` │ GET ${expectedUrl}`, 6)
+            expect(logs).toIncludeRepeated(` │ POST ${expectedUrl}`, 6)
+          })
+        })
+
         it('should show cache reason of noStore when use with fetch', async () => {
           const logLength = next.cliOutput.length
           await next.fetch('/no-store')


### PR DESCRIPTION
Previously, we limited the logged fetch requests to the 11 slowest (10 was intended, off-by-one error). There was no indication given to the user, though, that the logged requests may not be a complete representation of all fetch requests made. This lack of transparency could lead to confusion or misinterpretation of the fetch metrics.

Additionally, we had a deduplication logic for logged fetch requests based on `url`, `status`, and `method`. This approach inadvertently caused the logs of POST requests with different request bodies to be deduped.

To improve clarity and provide a more comprehensive overview, we will now log all fetch requests without any arbitrary limits. We have also removed the deduplication logic to ensure that all unique request logs are preserved. This ensures that users have full visibility into the fetch activity and can accurately diagnose and troubleshoot any issues related to fetch performance.

fixes #51699