### PR TITLE
Add `defineConfig` function to `next/config`

### DIFF
--- a/docs/01-app/03-api-reference/05-config/02-typescript.mdx
+++ b/docs/01-app/03-api-reference/05-config/02-typescript.mdx
@@ -103,6 +103,38 @@ const nextConfig = {
 module.exports = nextConfig
 ```
 
+### Type checking next.config.ts
+
+You can use TypeScript and import types in your Next.js configuration by using `next.config.ts`.
+
+```ts filename="next.config.ts"
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  /* config options here */
+}
+
+export default nextConfig
+```
+
+> **Good to know**: You can import Native ESM modules in `next.config.ts` without any additional configuration. Supports importing extensions like `.cjs`, `.cts`, `.mjs`, and `.mts`.
+
+### Using `defineConfig`
+
+Next.js also provides the `defineConfig` function to streamline the configuration process. This function is offering better type inference and autocompletion in your editor, even if you are not using TypeScript.
+
+```ts filename="next.config.ts"
+import { defineConfig } from 'next/config'
+
+const nextConfig = defineConfig({
+  /* config options here */
+})
+
+export default nextConfig
+```
+
+> **Good to know**: `defineConfig` is experimental, let us know if you encounter any issues.
+
 <AppOnly>
 
 ### Statically Typed Links

--- a/packages/create-next-app/templates/app-empty/js/next.config.mjs
+++ b/packages/create-next-app/templates/app-empty/js/next.config.mjs
@@ -1,4 +1,5 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {};
+const { defineConfig } = require("next/config");
+
+const nextConfig = defineConfig({});
 
 export default nextConfig;

--- a/packages/create-next-app/templates/app-empty/ts/next.config.ts
+++ b/packages/create-next-app/templates/app-empty/ts/next.config.ts
@@ -1,7 +1,7 @@
-import type { NextConfig } from "next";
+const { defineConfig } = require("next/config");
 
-const nextConfig: NextConfig = {
+const nextConfig = defineConfig({
   /* config options here */
-};
+});
 
 export default nextConfig;

--- a/packages/create-next-app/templates/app-tw-empty/js/next.config.mjs
+++ b/packages/create-next-app/templates/app-tw-empty/js/next.config.mjs
@@ -1,4 +1,4 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {};
+const { defineConfig } = require("next/config");
+const nextConfig = defineConfig({});
 
 export default nextConfig;

--- a/packages/create-next-app/templates/app-tw-empty/ts/next.config.ts
+++ b/packages/create-next-app/templates/app-tw-empty/ts/next.config.ts
@@ -1,7 +1,7 @@
-import type { NextConfig } from "next";
+const { defineConfig } = require("next/config");
 
-const nextConfig: NextConfig = {
+const nextConfig = defineConfig({
   /* config options here */
-};
+});
 
 export default nextConfig;

--- a/packages/create-next-app/templates/app-tw/js/next.config.mjs
+++ b/packages/create-next-app/templates/app-tw/js/next.config.mjs
@@ -1,4 +1,5 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {};
+const { defineConfig } = require("next/config");
+
+const nextConfig = defineConfig({});
 
 export default nextConfig;

--- a/packages/create-next-app/templates/app-tw/ts/next.config.ts
+++ b/packages/create-next-app/templates/app-tw/ts/next.config.ts
@@ -1,7 +1,7 @@
-import type { NextConfig } from "next";
+import { defineConfig } from "next/config";
 
-const nextConfig: NextConfig = {
+const nextConfig = defineConfig({
   /* config options here */
-};
+});
 
 export default nextConfig;

--- a/packages/create-next-app/templates/app/js/next.config.mjs
+++ b/packages/create-next-app/templates/app/js/next.config.mjs
@@ -1,4 +1,5 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {};
+const { defineConfig } = require("next/config");
+
+const nextConfig = defineConfig({});
 
 export default nextConfig;

--- a/packages/create-next-app/templates/app/ts/next.config.ts
+++ b/packages/create-next-app/templates/app/ts/next.config.ts
@@ -1,7 +1,7 @@
-import type { NextConfig } from "next";
+import { defineConfig } from "next/config";
 
-const nextConfig: NextConfig = {
+const nextConfig = defineConfig({
   /* config options here */
-};
+});
 
 export default nextConfig;

--- a/packages/create-next-app/templates/default-empty/js/next.config.mjs
+++ b/packages/create-next-app/templates/default-empty/js/next.config.mjs
@@ -1,6 +1,7 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+const { defineConfig } = require("next/config");
+
+const nextConfig = defineConfig({
   reactStrictMode: true,
-};
+});
 
 export default nextConfig;

--- a/packages/create-next-app/templates/default-empty/ts/next.config.ts
+++ b/packages/create-next-app/templates/default-empty/ts/next.config.ts
@@ -1,8 +1,8 @@
-import type { NextConfig } from "next";
+import { defineConfig } from "next/config";
 
-const nextConfig: NextConfig = {
+const nextConfig = defineConfig({
   /* config options here */
   reactStrictMode: true,
-};
+});
 
 export default nextConfig;

--- a/packages/create-next-app/templates/default-tw-empty/js/next.config.mjs
+++ b/packages/create-next-app/templates/default-tw-empty/js/next.config.mjs
@@ -1,6 +1,7 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+const { defineConfig } = require("next/config");
+
+const nextConfig = defineConfig({
   reactStrictMode: true,
-};
+});
 
 export default nextConfig;

--- a/packages/create-next-app/templates/default-tw-empty/ts/next.config.ts
+++ b/packages/create-next-app/templates/default-tw-empty/ts/next.config.ts
@@ -1,8 +1,8 @@
-import type { NextConfig } from "next";
+import { defineConfig } from "next/config";
 
-const nextConfig: NextConfig = {
+const nextConfig = defineConfig({
   /* config options here */
   reactStrictMode: true,
-};
+});
 
 export default nextConfig;

--- a/packages/create-next-app/templates/default-tw/js/next.config.mjs
+++ b/packages/create-next-app/templates/default-tw/js/next.config.mjs
@@ -1,6 +1,7 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+const { defineConfig } = require("next/config");
+
+const nextConfig = defineConfig({
   reactStrictMode: true,
-};
+});
 
 export default nextConfig;

--- a/packages/create-next-app/templates/default-tw/ts/next.config.ts
+++ b/packages/create-next-app/templates/default-tw/ts/next.config.ts
@@ -1,8 +1,8 @@
-import type { NextConfig } from "next";
+import { defineConfig } from "next/config";
 
-const nextConfig: NextConfig = {
+const nextConfig = defineConfig({
   /* config options here */
   reactStrictMode: true,
-};
+});
 
 export default nextConfig;

--- a/packages/create-next-app/templates/default/js/next.config.mjs
+++ b/packages/create-next-app/templates/default/js/next.config.mjs
@@ -1,6 +1,7 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+const { defineConfig } = require("next/config");
+
+const nextConfig = defineConfig({
   reactStrictMode: true,
-};
+});
 
 export default nextConfig;

--- a/packages/create-next-app/templates/default/ts/next.config.ts
+++ b/packages/create-next-app/templates/default/ts/next.config.ts
@@ -1,8 +1,8 @@
-import type { NextConfig } from "next";
+import { defineConfig } from "next/config";
 
-const nextConfig: NextConfig = {
+const nextConfig = defineConfig({
   /* config options here */
   reactStrictMode: true,
-};
+});
 
 export default nextConfig;

--- a/packages/next/src/shared/lib/runtime-config.external.ts
+++ b/packages/next/src/shared/lib/runtime-config.external.ts
@@ -10,6 +10,9 @@ export function setConfig(configValue: any): void {
   runtimeConfig = configValue
 }
 
+/**
+ * Type helper to make it easier to use `next.config.ts`
+ */
 export function defineConfig(config: NextConfig): NextConfig {
   return config
 }

--- a/packages/next/src/shared/lib/runtime-config.external.ts
+++ b/packages/next/src/shared/lib/runtime-config.external.ts
@@ -1,3 +1,5 @@
+import type { NextConfig } from '../../types'
+
 let runtimeConfig: any
 
 export default () => {
@@ -6,4 +8,8 @@ export default () => {
 
 export function setConfig(configValue: any): void {
   runtimeConfig = configValue
+}
+
+export function defineConfig(config: NextConfig): NextConfig {
+  return config
 }

--- a/test/e2e/app-dir/next-config-ts/config-as-async-function/next.config.ts
+++ b/test/e2e/app-dir/next-config-ts/config-as-async-function/next.config.ts
@@ -1,12 +1,12 @@
-import type { NextConfig } from 'next'
+import { defineConfig } from 'next/config'
 
 const nextConfigAsyncFunction = async (phase, { defaultConfig }) => {
-  const nextConfig: NextConfig = {
+  const nextConfig = defineConfig({
     ...defaultConfig,
     env: {
       foo: phase ? 'foo' : 'bar',
     },
-  }
+  })
   return nextConfig
 }
 

--- a/test/e2e/app-dir/next-config-ts/export-as-default/next.config.ts
+++ b/test/e2e/app-dir/next-config-ts/export-as-default/next.config.ts
@@ -1,9 +1,9 @@
-import type { NextConfig } from 'next'
+import { defineConfig } from 'next/config'
 
-const nextConfig: NextConfig = {
+const nextConfig = defineConfig({
   env: {
     foo: 'foo',
   },
-}
+})
 
 export { nextConfig as default }

--- a/test/e2e/app-dir/next-config-ts/export-default/next.config.ts
+++ b/test/e2e/app-dir/next-config-ts/export-default/next.config.ts
@@ -1,7 +1,7 @@
-import type { NextConfig } from 'next'
+import { defineConfig } from 'next/config'
 
-export default {
+export default defineConfig({
   env: {
     foo: 'foo',
   },
-} satisfies NextConfig
+})

--- a/test/e2e/app-dir/next-config-ts/import-alias/next.config.ts
+++ b/test/e2e/app-dir/next-config-ts/import-alias/next.config.ts
@@ -1,12 +1,12 @@
-import type { NextConfig } from 'next'
+import { defineConfig } from 'next/config'
 import { foo } from '@/foo'
 import { bar } from 'bar'
 
-const nextConfig: NextConfig = {
+const nextConfig = defineConfig({
   env: {
     foo,
     bar,
   },
-}
+})
 
 export default nextConfig

--- a/test/e2e/app-dir/next-config-ts/import-from-node-modules/next.config.ts
+++ b/test/e2e/app-dir/next-config-ts/import-from-node-modules/next.config.ts
@@ -1,10 +1,10 @@
-import type { NextConfig } from 'next'
+import { defineConfig } from 'next/config'
 import { foo } from 'foo'
 
-const nextConfig: NextConfig = {
+const nextConfig = defineConfig({
   env: {
     foo,
   },
-}
+})
 
 export default nextConfig

--- a/test/e2e/app-dir/next-config-ts/import-json/next.config.ts
+++ b/test/e2e/app-dir/next-config-ts/import-json/next.config.ts
@@ -1,8 +1,8 @@
-import type { NextConfig } from 'next'
+import { defineConfig } from 'next/config'
 import { foo } from './foo.json'
 
-export default {
+export default defineConfig({
   env: {
     foo,
   },
-} satisfies NextConfig
+})

--- a/test/e2e/app-dir/next-config-ts/nested-imports/next.config.ts
+++ b/test/e2e/app-dir/next-config-ts/nested-imports/next.config.ts
@@ -1,10 +1,10 @@
-import type { NextConfig } from 'next'
+import { defineConfig } from 'next/config'
 import { foobarbaz } from './foo'
 
-const nextConfig: NextConfig = {
+const nextConfig = defineConfig({
   env: {
     foobarbaz,
   },
-}
+})
 
 export default nextConfig

--- a/test/e2e/app-dir/next-config-ts/node-api/next.config.ts
+++ b/test/e2e/app-dir/next-config-ts/node-api/next.config.ts
@@ -1,13 +1,13 @@
-import type { NextConfig } from 'next'
+import { defineConfig } from 'next/config'
 import fs from 'node:fs'
 import { join } from 'node:path'
 
 const foo = fs.readFileSync(join(__dirname, 'foo.txt'), 'utf8')
 
-const nextConfig: NextConfig = {
+const nextConfig = defineConfig({
   env: {
     foo,
   },
-}
+})
 
 export default nextConfig

--- a/test/e2e/app-dir/next-config-ts/pkg-commonjs/next.config.ts
+++ b/test/e2e/app-dir/next-config-ts/pkg-commonjs/next.config.ts
@@ -1,4 +1,4 @@
-import type { NextConfig } from 'next'
+import { defineConfig } from 'next/config'
 import { cjs } from './fixtures/cjs.cjs'
 import { mjs } from './fixtures/mjs.mjs'
 import { cts } from './fixtures/cts.cts'
@@ -6,7 +6,7 @@ import { mts } from './fixtures/mts.mts'
 import { ts } from './fixtures/ts'
 import { commonjs } from './fixtures/commonjs'
 
-const nextConfig: NextConfig = {
+const nextConfig = defineConfig({
   env: {
     cjs,
     mjs,
@@ -15,6 +15,6 @@ const nextConfig: NextConfig = {
     ts,
     commonjs,
   },
-}
+})
 
 export default nextConfig

--- a/test/e2e/app-dir/next-config-ts/pkg-module/next.config.ts
+++ b/test/e2e/app-dir/next-config-ts/pkg-module/next.config.ts
@@ -1,4 +1,4 @@
-import type { NextConfig } from 'next'
+import { defineConfig } from 'next/config'
 import { cjs } from './fixtures/cjs.cjs'
 import { mjs } from './fixtures/mjs.mjs'
 import { cts } from './fixtures/cts.cts'
@@ -6,7 +6,7 @@ import { mts } from './fixtures/mts.mts'
 import { ts } from './fixtures/ts'
 import { esm } from './fixtures/esm'
 
-const nextConfig: NextConfig = {
+const nextConfig = defineConfig({
   env: {
     cjs,
     mjs,
@@ -15,6 +15,6 @@ const nextConfig: NextConfig = {
     ts,
     esm,
   },
-}
+})
 
 export default nextConfig

--- a/test/e2e/app-dir/next-config-ts/type-error/next.config.ts
+++ b/test/e2e/app-dir/next-config-ts/type-error/next.config.ts
@@ -1,12 +1,12 @@
-import type { NextConfig } from 'next'
+import { defineConfig } from 'next/config'
 
 // type error
 let foo: number = 'foo'
 
-const nextConfig: NextConfig = {
+const nextConfig = defineConfig({
   env: {
     foo,
   },
-}
+})
 
 export default nextConfig

--- a/test/e2e/app-dir/next-config/next.config.js
+++ b/test/e2e/app-dir/next-config/next.config.js
@@ -1,11 +1,12 @@
+const { defineConfig } = require('next/config')
+
 // This should work
 console.log(require('webpack').sources.RawSource)
 
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+const nextConfig = defineConfig({
   webpack(config) {
     return config
   },
-}
+})
 
 module.exports = nextConfig


### PR DESCRIPTION
**What did I change?**

<!-- A brief description of the change. -->
I added a `defineConfig` function in `runtime-config.external.ts`.
But to be honest I think it would make more sense if it was in `config-shared.ts` the problem is that you would use 
```ts
// next.config.ts
import { defineConfig } from “next/server"
```
instead of 
```ts
// next.config.ts
import { defineConfig } from “next/config”
```
like vuejs, vitejs, solidjs, cypress or others do.

- [x] e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- [x] Documentation added
- [x] Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


**Why did I change it?**

<!-- A brief description of why the change was made. -->
Fixes: https://x.com/nurodev/status/1813945402049388893

**Preview and Usage**
<img width="584" alt="image" src="https://github.com/user-attachments/assets/8434313f-a3d7-4c4a-bc06-8096ea2f8311">

https://github.com/user-attachments/assets/a034d5a5-cf1b-4724-a3c0-981547286332



