### PR TITLE
Ensure "[Fast Refresh] rebuilding" logs have a matching "[Fast Refresh] done" log in Webpack

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
@@ -59,7 +59,6 @@ function onFastRefresh(
   updatedModules: ReadonlyArray<string>
 ) {
   dispatcher.onBuildOk()
-
   reportHmrLatency(sendMessage, updatedModules)
 
   dispatcher.onRefresh()
@@ -161,6 +160,7 @@ function tryApplyUpdates(
 ) {
   if (!isUpdateAvailable() || !canApplyUpdates()) {
     dispatcher.onBuildOk()
+    reportHmrLatency(sendMessage, [])
     return
   }
 
@@ -430,7 +430,6 @@ function processMessage(
         router.hmrRefresh()
         dispatcher.onRefresh()
       })
-      reportHmrLatency(sendMessage, [])
 
       if (process.env.__NEXT_TEST_MODE) {
         if (self.__NEXT_HMR_CB) {

--- a/test/development/app-hmr/hmr.test.ts
+++ b/test/development/app-hmr/hmr.test.ts
@@ -138,11 +138,6 @@ describe(`app-dir-hmr`, () => {
     })
 
     it('should update server components pages when env files is changed (nodejs)', async () => {
-      // If "should update server components after navigating to a page with a different runtime" failed, the dev server is in a corrupted state.
-      // Restart fixes this.
-      await next.stop()
-      await next.start()
-
       const envContent = await next.readFile(envFile)
       const browser = await next.browser('/env/node')
       expect(await browser.elementByCss('p').text()).toBe('mac')
@@ -191,10 +186,6 @@ describe(`app-dir-hmr`, () => {
     })
 
     it('should update server components pages when env files is changed (edge)', async () => {
-      // Restart to work around a bug highlighted in the flakiness of "should update server components after navigating to a page with a different runtime"
-      await next.stop()
-      await next.start()
-
       const envContent = await next.readFile(envFile)
       const browser = await next.browser('/env/edge')
       expect(await browser.elementByCss('p').text()).toBe('mac')

--- a/test/development/app-hmr/hmr.test.ts
+++ b/test/development/app-hmr/hmr.test.ts
@@ -55,8 +55,6 @@ describe(`app-dir-hmr`, () => {
     })
 
     it('should update server components after navigating to a page with a different runtime', async () => {
-      const envContent = await next.readFile(envFile)
-
       const browser = await next.browser('/env/node')
       await browser.loadPage(`${next.url}/env/edge`)
       await browser.eval('window.__TEST_NO_RELOAD = true')
@@ -134,12 +132,15 @@ describe(`app-dir-hmr`, () => {
           ])
         }
       } finally {
-        await next.patchFile(envFile, envContent)
+        // TOOD: use sandbox instead
+        await next.patchFile(envFile, 'MY_DEVICE="mac"')
+        await retry(async () => {
+          expect(await browser.elementByCss('p').text()).toBe('mac')
+        })
       }
     })
 
     it('should update server components pages when env files is changed (nodejs)', async () => {
-      const envContent = await next.readFile(envFile)
       const browser = await next.browser('/env/node')
       expect(await browser.elementByCss('p').text()).toBe('mac')
       await next.patchFile(envFile, 'MY_DEVICE="ipad"')
@@ -182,12 +183,15 @@ describe(`app-dir-hmr`, () => {
           )
         }
       } finally {
-        await next.patchFile(envFile, envContent)
+        // TOOD: use sandbox instead
+        await next.patchFile(envFile, 'MY_DEVICE="mac"')
+        await retry(async () => {
+          expect(await browser.elementByCss('p').text()).toBe('mac')
+        })
       }
     })
 
     it('should update server components pages when env files is changed (edge)', async () => {
-      const envContent = await next.readFile(envFile)
       const browser = await next.browser('/env/edge')
       expect(await browser.elementByCss('p').text()).toBe('mac')
       await next.patchFile(envFile, 'MY_DEVICE="ipad"')
@@ -230,7 +234,11 @@ describe(`app-dir-hmr`, () => {
           )
         }
       } finally {
-        await next.patchFile(envFile, envContent)
+        // TOOD: use sandbox instead
+        await next.patchFile(envFile, 'MY_DEVICE="mac"')
+        await retry(async () => {
+          expect(await browser.elementByCss('p').text()).toBe('mac')
+        })
       }
     })
 

--- a/test/development/app-hmr/hmr.test.ts
+++ b/test/development/app-hmr/hmr.test.ts
@@ -61,6 +61,7 @@ describe(`app-dir-hmr`, () => {
       await browser.loadPage(`${next.url}/env/edge`)
       await browser.eval('window.__TEST_NO_RELOAD = true')
 
+      expect(await browser.elementByCss('p').text()).toBe('mac')
       await next.patchFile(envFile, 'MY_DEVICE="ipad"')
 
       try {


### PR DESCRIPTION
Fixes a bug where we sometimes didn't report HMR latency when using Webpack. This reverts https://github.com/vercel/next.js/pull/67699 for Turbopack specifically but Turbopack has already issues in other cases with not reporting latency. We also never released https://github.com/vercel/next.js/pull/67699 so we're not regressing on stable behavior.

This stack is mainly for unblocking the React sync which has only issues with Webpack. That was also the motivation for https://github.com/vercel/next.js/pull/67699. If we want to fix the Turbopack HMR latency reporting, we should dedicate a separate task to it.

Related NDX-61