### PR TITLE
fix retrieval of deploy test build logs

### DIFF
--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -23,6 +23,7 @@ describe('Prerender', () => {
   let next: NextInstance
 
   beforeAll(async () => {
+    console.log('changing test to validate')
     next = await createNext({
       files: {
         pages: new FileRef(join(__dirname, 'prerender/pages')),

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -23,7 +23,6 @@ describe('Prerender', () => {
   let next: NextInstance
 
   beforeAll(async () => {
-    console.log('changing test to validate')
     next = await createNext({
       files: {
         pages: new FileRef(join(__dirname, 'prerender/pages')),
@@ -958,18 +957,21 @@ describe('Prerender', () => {
       })
     })
 
-    it('should show warning when large amount of page data is returned', async () => {
-      await renderViaHTTP(next.url, '/large-page-data')
-      await check(
-        () => next.cliOutput,
-        /Warning: data for page "\/large-page-data" is 256 kB which exceeds the threshold of 128 kB, this amount of data can reduce performance/
-      )
-      await renderViaHTTP(next.url, '/blocking-fallback/lots-of-data')
-      await check(
-        () => next.cliOutput,
-        /Warning: data for page "\/blocking-fallback\/\[slug\]" \(path "\/blocking-fallback\/lots-of-data"\) is 256 kB which exceeds the threshold of 128 kB, this amount of data can reduce performance/
-      )
-    })
+    if (!isDeploy) {
+      // relies on runtime logs, which aren't currently captured by `next.cliOutput` in deploys
+      it('should show warning when large amount of page data is returned', async () => {
+        await renderViaHTTP(next.url, '/large-page-data')
+        await check(
+          () => next.cliOutput,
+          /Warning: data for page "\/large-page-data" is 256 kB which exceeds the threshold of 128 kB, this amount of data can reduce performance/
+        )
+        await renderViaHTTP(next.url, '/blocking-fallback/lots-of-data')
+        await check(
+          () => next.cliOutput,
+          /Warning: data for page "\/blocking-fallback\/\[slug\]" \(path "\/blocking-fallback\/lots-of-data"\) is 256 kB which exceeds the threshold of 128 kB, this amount of data can reduce performance/
+        )
+      })
+    }
 
     if ((global as any).isNextDev) {
       it('should show warning every time page with large amount of page data is returned', async () => {

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -147,32 +147,24 @@ export class NextDeployInstance extends NextInstance {
 
     require('console').log(`Got buildId: ${this._buildId}`)
 
-    // Use the vercel logs command to get the CLI output from the build.
-    const logs = await execa(
+    // Use the vercel inspect command to get the CLI output from the build.
+    const buildLogs = await execa(
       'vercel',
-      [
-        'logs',
-        this._url,
-        '--output',
-        'raw',
-        // The default # of lines to show in the output is 100, but some of our tests have noisy output,
-        // so bump to 1000
-        '-n',
-        1000,
-        ...vercelFlags,
-      ],
+      ['inspect', '--logs', this._url, ...vercelFlags],
       {
         env: vercelEnv,
         reject: false,
       }
     )
-    if (logs.exitCode !== 0) {
-      throw new Error(`Failed to get build output logs: ${logs.stderr}`)
+    if (buildLogs.exitCode !== 0) {
+      throw new Error(`Failed to get build output logs: ${buildLogs.stderr}`)
     }
 
     // Use the stdout from the logs command as the CLI output. The CLI will
     // output other unrelated logs to stderr.
-    this._cliOutput = logs.stdout
+
+    // TODO: Combine with runtime logs (via `vercel logs`)
+    this._cliOutput = buildLogs.stdout
   }
 
   public get cliOutput() {


### PR DESCRIPTION
`vercel logs` now retrieves runtime logs in watch mode. This causes the `createNext` step to hang as it never resolves.

These logs are intended to be build logs, which is available under `vercel inspect --logs`. I removed some arguments that are no longer valid for that CLI function.

Separately, it looks like we're able to add runtime logs to `next.cliOutput`, which I'll do in a future PR. 

Related:
- https://github.com/vercel/vercel/pull/11788

[Failure example](https://github.com/vercel/next.js/actions/runs/10012728881/job/27679225925)

["Success" example](https://github.com/vercel/next.js/actions/runs/10013211758/job/27680965374?pr=67971)