### PR TITLE
capture test-deploy stderr in cliOutput

### DIFF
--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -957,21 +957,18 @@ describe('Prerender', () => {
       })
     })
 
-    if (!isDeploy) {
-      // relies on runtime logs, which aren't currently captured by `next.cliOutput` in deploys
-      it('should show warning when large amount of page data is returned', async () => {
-        await renderViaHTTP(next.url, '/large-page-data')
-        await check(
-          () => next.cliOutput,
-          /Warning: data for page "\/large-page-data" is 256 kB which exceeds the threshold of 128 kB, this amount of data can reduce performance/
-        )
-        await renderViaHTTP(next.url, '/blocking-fallback/lots-of-data')
-        await check(
-          () => next.cliOutput,
-          /Warning: data for page "\/blocking-fallback\/\[slug\]" \(path "\/blocking-fallback\/lots-of-data"\) is 256 kB which exceeds the threshold of 128 kB, this amount of data can reduce performance/
-        )
-      })
-    }
+    it('should show warning when large amount of page data is returned', async () => {
+      await renderViaHTTP(next.url, '/large-page-data')
+      await check(
+        () => next.cliOutput,
+        /Warning: data for page "\/large-page-data" is 256 kB which exceeds the threshold of 128 kB, this amount of data can reduce performance/
+      )
+      await renderViaHTTP(next.url, '/blocking-fallback/lots-of-data')
+      await check(
+        () => next.cliOutput,
+        /Warning: data for page "\/blocking-fallback\/\[slug\]" \(path "\/blocking-fallback\/lots-of-data"\) is 256 kB which exceeds the threshold of 128 kB, this amount of data can reduce performance/
+      )
+    })
 
     if ((global as any).isNextDev) {
       it('should show warning every time page with large amount of page data is returned', async () => {

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -164,7 +164,8 @@ export class NextDeployInstance extends NextInstance {
     // output other unrelated logs to stderr.
 
     // TODO: Combine with runtime logs (via `vercel logs`)
-    this._cliOutput = buildLogs.stdout
+    // Build logs seem to be piped to stderr, so we'll combine them to make sure we get all the logs.
+    this._cliOutput = buildLogs.stdout + buildLogs.stderr
   }
 
   public get cliOutput() {


### PR DESCRIPTION
This particular test was failing because build logs were being piped to stderr, despite being successful. This ensures `next.cliOutput` captures both `stdout` and `stderr`. 