### PR TITLE
Fix flakiness of `should not cause error when removing loading.js` test

### DIFF
--- a/test/e2e/app-dir/app-compilation/index.test.ts
+++ b/test/e2e/app-dir/app-compilation/index.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { assertNoRedbox, check, waitFor } from 'next-test-utils'
+import { assertNoRedbox, retry } from 'next-test-utils'
 
 describe('app dir', () => {
   const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
@@ -23,30 +23,37 @@ describe('app dir', () => {
     describe('HMR', () => {
       it('should not cause error when removing loading.js', async () => {
         const browser = await next.browser('/page-with-loading')
-        await check(
-          () => browser.elementByCss('h1').text(),
-          'hello from slow page'
-        )
+
+        await retry(async () => {
+          const headline = await browser.elementByCss('h1').text()
+          expect(headline).toBe('hello from slow page')
+        })
+
+        const cliOutputLength = next.cliOutput.length
 
         await next.renameFile(
           'app/page-with-loading/loading.js',
           'app/page-with-loading/_loading.js'
         )
 
-        await waitFor(1000)
+        await retry(async () => {
+          expect(next.cliOutput.slice(cliOutputLength)).toInclude('✓ Compiled')
+        })
 
         // It should not have an error
         await assertNoRedbox(browser)
 
         // HMR should still work
-        const code = await next.readFile('app/page-with-loading/page.js')
         await next.patchFile(
           'app/page-with-loading/page.js',
-          code.replace('hello from slow page', 'hello from new page')
-        )
-        await check(
-          () => browser.elementByCss('h1').text(),
-          'hello from new page'
+          (content) =>
+            content.replace('hello from slow page', 'hello from new page'),
+          async () =>
+            retry(async () => {
+              const headline = await browser.elementByCss('h1').text()
+              expect(headline).toBe('hello from new page')
+              await browser.close()
+            })
         )
       })
     })


### PR DESCRIPTION
x-ref: [Flakiness Metrics](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20env%3Aci%20%40git.repository.id%3Agithub.com%2Fvercel%2Fnext.js%20%40test.service%3Anextjs%20%40test.status%3Afail%20%40test.name%3A%22app%20dir%20HMR%20should%20not%20cause%20error%20when%20removing%20loading.js%22&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&start=1720817553405&end=1721422353405&paused=false)