### PR TITLE
Turbopack build: Properly isolate scss/webpack-error test

### DIFF
--- a/test/e2e/app-dir/scss/webpack-error/mock.js
+++ b/test/e2e/app-dir/scss/webpack-error/mock.js
@@ -1,7 +1,0 @@
-let originalLoader
-const M = require('module')
-originalLoader = M._load
-M._load = function hookedLoader(request, parent, isMain) {
-  if (request === 'sass') request = 'sass-begone'
-  return originalLoader(request, parent, isMain)
-}

--- a/test/e2e/app-dir/scss/webpack-error/webpack-error.test.ts
+++ b/test/e2e/app-dir/scss/webpack-error/webpack-error.test.ts
@@ -2,12 +2,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('SCSS Support', () => {
-  const { next } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
     skipDeployment: true,
   })
-  describe('Friendly Webpack Error', () => {
+  // Production only test
+  ;(isNextDev ? describe.skip : describe)('Friendly Webpack Error', () => {
     it('should be a friendly error successfully', async () => {
       const { exitCode, cliOutput } = await next.build()
       expect(exitCode).toBe(1)

--- a/test/e2e/app-dir/scss/webpack-error/webpack-error.test.ts
+++ b/test/e2e/app-dir/scss/webpack-error/webpack-error.test.ts
@@ -1,49 +1,31 @@
 /* eslint-env jest */
-
-import { remove } from 'fs-extra'
-import { nextBuild } from 'next-test-utils'
-import { join } from 'path'
-import { quote as shellQuote } from 'shell-quote'
-// In order for the global isNextStart to be set
-import 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 
 describe('SCSS Support', () => {
-  ;(Boolean((global as any).isNextStart) ? describe : describe.skip)(
-    'production only',
-    () => {
-      describe('Friendly Webpack Error', () => {
-        const appDir = __dirname
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    skipDeployment: true,
+  })
+  describe('Friendly Webpack Error', () => {
+    it('should be a friendly error successfully', async () => {
+      const { exitCode, cliOutput } = await next.build()
+      expect(exitCode).toBe(1)
 
-        const mockFile = join(appDir, 'mock.js')
+      expect(cliOutput).toContain('./styles/global.scss')
+      expect(cliOutput).toContain(
+        "To use Next.js' built-in Sass support, you first need to install `sass`."
+      )
+      expect(cliOutput).toContain(
+        'Run `npm i sass` or `yarn add sass` inside your workspace.'
+      )
+      expect(cliOutput).toContain(
+        'Learn more: https://nextjs.org/docs/messages/install-sass'
+      )
 
-        beforeAll(async () => {
-          await remove(join(appDir, '.next'))
-        })
-        it('should be a friendly error successfully', async () => {
-          const { code, stderr } = await nextBuild(appDir, [], {
-            env: { NODE_OPTIONS: shellQuote([`--require`, mockFile]) },
-            stderr: true,
-          })
-          let cleanScssErrMsg =
-            '\n\n' +
-            './styles/global.scss\n' +
-            "To use Next.js' built-in Sass support, you first need to install `sass`.\n" +
-            'Run `npm i sass` or `yarn add sass` inside your workspace.\n' +
-            '\n' +
-            'Learn more: https://nextjs.org/docs/messages/install-sass\n'
-
-          // eslint-disable-next-line
-          expect(code).toBe(1)
-          // eslint-disable-next-line
-          expect(stderr).toContain('Failed to compile.')
-          // eslint-disable-next-line
-          expect(stderr).toContain(cleanScssErrMsg)
-          // eslint-disable-next-line
-          expect(stderr).not.toContain('css-loader')
-          // eslint-disable-next-line
-          expect(stderr).not.toContain('sass-loader')
-        })
-      })
-    }
-  )
+      expect(cliOutput).toContain('Failed to compile.')
+      expect(cliOutput).not.toContain('css-loader')
+      expect(cliOutput).not.toContain('sass-loader')
+    })
+  })
 })

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -3853,7 +3853,7 @@
     "test/e2e/app-dir/scss/webpack-error/webpack-error.test.ts": {
       "passed": [],
       "failed": [
-        "SCSS Support production only Friendly Webpack Error should be a friendly error successfully"
+        "SCSS Support Friendly Webpack Error should be a friendly error successfully"
       ],
       "pending": [],
       "flakey": [],


### PR DESCRIPTION
When this test was in `test/integration` it tried to hack around Sass always being installed. By leveraging the test isolation helpers we can just opt to not installing `sass` which ensures it matches reality. This doesn't fix the test with  Turbopack enabled yet but it does highlight the real error, instead of showing a strange resolving error about a non-existent sass-begone package.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
