### PR TITLE
docs(tailwind-css): add `tailwind.config.ts` code block

### DIFF
--- a/docs/02-app/01-building-your-application/05-styling/02-tailwind-css.mdx
+++ b/docs/02-app/01-building-your-application/05-styling/02-tailwind-css.mdx
@@ -31,7 +31,27 @@ npx tailwindcss init -p
 
 Inside `tailwind.config.js`, add paths to the files that will use Tailwind CSS class names:
 
-```js filename="tailwind.config.js"
+```ts filename="tailwind.config.ts" switcher
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx,mdx}', // Note the addition of the `app` directory.
+    './pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './components/**/*.{js,ts,jsx,tsx,mdx}',
+
+    // Or if using `src` directory:
+    './src/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+export default config;
+```
+
+```js filename="tailwind.config.js" switcher
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [

--- a/docs/02-app/01-building-your-application/05-styling/02-tailwind-css.mdx
+++ b/docs/02-app/01-building-your-application/05-styling/02-tailwind-css.mdx
@@ -32,7 +32,7 @@ npx tailwindcss init -p
 Inside your Tailwind configuration file, add paths to the files that will use Tailwind class names:
 
 ```ts filename="tailwind.config.ts" switcher
-import type { Config } from "tailwindcss";
+import type { Config } from 'tailwindcss'
 
 const config: Config = {
   content: [
@@ -47,8 +47,8 @@ const config: Config = {
     extend: {},
   },
   plugins: [],
-};
-export default config;
+}
+export default config
 ```
 
 ```js filename="tailwind.config.js" switcher

--- a/docs/02-app/01-building-your-application/05-styling/02-tailwind-css.mdx
+++ b/docs/02-app/01-building-your-application/05-styling/02-tailwind-css.mdx
@@ -29,7 +29,7 @@ npx tailwindcss init -p
 
 ## Configuring Tailwind
 
-Inside `tailwind.config.js`, add paths to the files that will use Tailwind CSS class names:
+Inside your Tailwind configuration file, add paths to the files that will use Tailwind class names:
 
 ```ts filename="tailwind.config.ts" switcher
 import type { Config } from "tailwindcss";


### PR DESCRIPTION
`create-next-app` has been generating `tailwind.config.ts` for TypeScript project since PR #47795. This PR adds a example code block for `tailwind.config.ts` file on the [Styling: Tailwind CSS page](https://nextjs.org/docs/app/building-your-application/styling/tailwind-css).