### PR TITLE
docs: mention `useParams` in incremental adoption guide

### DIFF
--- a/docs/02-app/01-building-your-application/11-upgrading/04-app-router-migration.mdx
+++ b/docs/02-app/01-building-your-application/11-upgrading/04-app-router-migration.mdx
@@ -435,7 +435,7 @@ In `app`, you should use the three new hooks imported from `next/navigation`: [`
 - The new `useRouter` hook is imported from `next/navigation` and has different behavior to the `useRouter` hook in `pages` which is imported from `next/router`.
   - The [`useRouter` hook imported from `next/router`](/docs/pages/api-reference/functions/use-router) is not supported in the `app` directory but can continue to be used in the `pages` directory.
 - The new `useRouter` does not return the `pathname` string. Use the separate `usePathname` hook instead.
-- The new `useRouter` does not return the `query` object. Use the separate `useSearchParams` hook instead.
+- The new `useRouter` does not return the `query` object. Search parameters and dynamic route parameters are now separate. Use the `useSearchParams` and `useParams` hooks instead.
 - You can use `useSearchParams` and `usePathname` together to listen to page changes. See the [Router Events](/docs/app/api-reference/functions/use-router#router-events) section for more details.
 - These new hooks are only supported in Client Components. They cannot be used in Server Components.
 


### PR DESCRIPTION
Replaces https://github.com/vercel/next.js/pull/60104 with merge conflicts (can't edit)