### PR TITLE
Remove stray heading in error page

### DIFF
--- a/errors/missing-root-layout-tags.mdx
+++ b/errors/missing-root-layout-tags.mdx
@@ -2,8 +2,6 @@
 title: Missing Root Layout tags
 ---
 
-## ``
-
 #### Why This Error Occurred
 
 You forgot to define the `<html>` and/or `<body>` tags in your Root Layout.


### PR DESCRIPTION
It currently looks like this

<img width="1236" alt="Bildschirmfoto 2024-07-22 um 10 09 05" src="https://github.com/user-attachments/assets/6ddb73b7-18f3-4e60-9505-0befb0014253">
