### PR TITLE
Add warning to next 14.2.x when turbo is enabled

### DIFF
--- a/packages/next/src/server/lib/app-info-log.ts
+++ b/packages/next/src/server/lib/app-info-log.ts
@@ -45,6 +45,12 @@ export function logStartInfo({
     }
   }
 
+  if (process.env.TURBOPACK) {
+    Log.warn(
+      '- Turbo: consider updating to the latest rc version of Next.js for better support'
+    )
+  }
+
   // New line after the bootstrap info
   Log.info('')
 }


### PR DESCRIPTION
### What?

We are getting numerous reports of people struggling with turbo issues when on 14.2.x branch. We know this is not expected to work, but there is nothing to warn users.

### Why?

Better UX for early adopters who want to use turbo in next 14, but who may not know about the existence of the 15 rc branch.

### How?

A warning on startup that notifies turbo users about the rc.
