### PR TITLE
Ensure experimental trace invalidates correctly

### DIFF
--- a/packages/next/src/build/flying-shuttle/stitch-builds.ts
+++ b/packages/next/src/build/flying-shuttle/stitch-builds.ts
@@ -31,9 +31,11 @@ import {
   ROUTES_MANIFEST,
 } from '../../shared/lib/constants'
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
+import type { NextConfigComplete } from '../../server/config-shared'
 
 export async function stitchBuilds(
   {
+    config,
     distDir,
     shuttleDir,
     buildId,
@@ -43,6 +45,7 @@ export async function stitchBuilds(
     encryptionKey,
     edgePreviewProps,
   }: {
+    config: NextConfigComplete
     buildId: string
     distDir: string
     shuttleDir: string
@@ -64,7 +67,7 @@ export async function stitchBuilds(
 ): Promise<{
   pagesManifest?: PagesManifest
 }> {
-  if (!(await hasShuttle(shuttleDir))) {
+  if (!(await hasShuttle(config, shuttleDir))) {
     // no shuttle directory nothing to stitch
     return {}
   }

--- a/packages/next/src/build/flying-shuttle/store-shuttle.ts
+++ b/packages/next/src/build/flying-shuttle/store-shuttle.ts
@@ -12,13 +12,14 @@ import {
   PAGES_MANIFEST,
   ROUTES_MANIFEST,
 } from '../../shared/lib/constants'
+import { getNextPublicEnvironmentVariables } from '../webpack/plugins/define-env-plugin'
 
 export function generateShuttleManifest(config: NextConfigComplete) {
   // NEXT_PUBLIC_ changes for now since they are inlined
   // and specific next config values that can impact the build
   const globalHash = crypto.createHash('sha256')
 
-  for (const key in process.env) {
+  for (const key in getNextPublicEnvironmentVariables()) {
     if (key.startsWith('NEXT_PUBLIC_')) {
       globalHash.update(`${key}=${process.env[key]}`)
     }

--- a/packages/next/src/build/flying-shuttle/store-shuttle.ts
+++ b/packages/next/src/build/flying-shuttle/store-shuttle.ts
@@ -13,10 +13,12 @@ import {
   ROUTES_MANIFEST,
 } from '../../shared/lib/constants'
 
-export function getShuttleManifest(config: NextConfigComplete) {
+export function generateShuttleManifest(config: NextConfigComplete) {
+  // NEXT_PUBLIC_ changes for now since they are inlined
+  // and specific next config values that can impact the build
   const globalHash = crypto.createHash('sha256')
 
-  for (const key of Object.keys(process.env || {})) {
+  for (const key in process.env) {
     if (key.startsWith('NEXT_PUBLIC_')) {
       globalHash.update(`${key}=${process.env[key]}`)
     }
@@ -24,7 +26,7 @@ export function getShuttleManifest(config: NextConfigComplete) {
 
   const omittedConfigKeys = ['headers', 'rewrites', 'redirects']
 
-  for (const key of Object.keys(config)) {
+  for (const key in config) {
     if (omittedConfigKeys.includes(key)) {
       continue
     }
@@ -38,7 +40,6 @@ export function getShuttleManifest(config: NextConfigComplete) {
 
   return {
     nextVersion,
-    // NEXT_PUBLIC_ changes for now and specific next config values
     globalHash: globalHash.digest('hex'),
   }
 }
@@ -57,7 +58,7 @@ export async function storeShuttle({
   await fs.promises.rm(shuttleDir, { force: true, recursive: true })
   await fs.promises.mkdir(shuttleDir, { recursive: true })
 
-  const shuttleManifest = getShuttleManifest(config)
+  const shuttleManifest = generateShuttleManifest(config)
   await fs.promises.writeFile(
     path.join(shuttleDir, 'shuttle-manifest.json'),
     JSON.stringify(shuttleManifest)

--- a/packages/next/src/build/flying-shuttle/store-shuttle.ts
+++ b/packages/next/src/build/flying-shuttle/store-shuttle.ts
@@ -1,5 +1,9 @@
 import fs from 'fs'
 import path from 'path'
+import crypto from 'crypto'
+import { recursiveCopy } from '../../lib/recursive-copy'
+import { version as nextVersion } from 'next/package.json'
+import type { NextConfigComplete } from '../../server/config-shared'
 import {
   BUILD_MANIFEST,
   APP_BUILD_MANIFEST,
@@ -8,19 +12,56 @@ import {
   PAGES_MANIFEST,
   ROUTES_MANIFEST,
 } from '../../shared/lib/constants'
-import { recursiveCopy } from '../../lib/recursive-copy'
+
+export function getShuttleManifest(config: NextConfigComplete) {
+  const globalHash = crypto.createHash('sha256')
+
+  for (const key of Object.keys(process.env || {})) {
+    if (key.startsWith('NEXT_PUBLIC_')) {
+      globalHash.update(`${key}=${process.env[key]}`)
+    }
+  }
+
+  const omittedConfigKeys = ['headers', 'rewrites', 'redirects']
+
+  for (const key of Object.keys(config)) {
+    if (omittedConfigKeys.includes(key)) {
+      continue
+    }
+    let serializedConfig =
+      typeof config[key] === 'function'
+        ? config[key].toString()
+        : JSON.stringify(config[key])
+
+    globalHash.update(`${key}=${serializedConfig}`)
+  }
+
+  return {
+    nextVersion,
+    // NEXT_PUBLIC_ changes for now and specific next config values
+    globalHash: globalHash.digest('hex'),
+  }
+}
 
 // we can create a new shuttle with the outputs before env values have
 // been inlined, can be done after stitching takes place
 export async function storeShuttle({
+  config,
   distDir,
   shuttleDir,
 }: {
   distDir: string
   shuttleDir: string
+  config: NextConfigComplete
 }) {
   await fs.promises.rm(shuttleDir, { force: true, recursive: true })
   await fs.promises.mkdir(shuttleDir, { recursive: true })
+
+  const shuttleManifest = getShuttleManifest(config)
+  await fs.promises.writeFile(
+    path.join(shuttleDir, 'shuttle-manifest.json'),
+    JSON.stringify(shuttleManifest)
+  )
 
   // copy all server entries
   await recursiveCopy(

--- a/packages/next/src/build/flying-shuttle/store-shuttle.ts
+++ b/packages/next/src/build/flying-shuttle/store-shuttle.ts
@@ -20,9 +20,7 @@ export function generateShuttleManifest(config: NextConfigComplete) {
   const globalHash = crypto.createHash('sha256')
 
   for (const key in getNextPublicEnvironmentVariables()) {
-    if (key.startsWith('NEXT_PUBLIC_')) {
-      globalHash.update(`${key}=${process.env[key]}`)
-    }
+    globalHash.update(`${key}=${process.env[key]}`)
   }
 
   const omittedConfigKeys = ['headers', 'rewrites', 'redirects']

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -869,6 +869,7 @@ export default async function build(
           pageExtensions: config.pageExtensions,
           distDir,
           shuttleDir,
+          config,
         })
         console.log({ changedPagePathsResult })
         pagesPaths = changedPagePathsResult.changed.pages
@@ -960,6 +961,7 @@ export default async function build(
             pageExtensions: config.pageExtensions,
             distDir,
             shuttleDir,
+            config,
           })
           console.log({ changedAppPathsResult })
           appPaths = changedAppPathsResult.changed.app
@@ -2518,6 +2520,7 @@ export default async function build(
 
           console.log('storing shuttle')
           await storeShuttle({
+            config,
             distDir,
             shuttleDir,
           })

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2484,6 +2484,7 @@ export default async function build(
           console.log('stitching builds...')
           const stitchResult = await stitchBuilds(
             {
+              config,
               buildId,
               distDir,
               shuttleDir,

--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -58,7 +58,7 @@ interface SerializedDefineEnv {
 /**
  * Collects all environment variables that are using the `NEXT_PUBLIC_` prefix.
  */
-function getNextPublicEnvironmentVariables(): DefineEnv {
+export function getNextPublicEnvironmentVariables(): DefineEnv {
   const defineEnv: DefineEnv = {}
   for (const key in process.env) {
     if (key.startsWith('NEXT_PUBLIC_')) {


### PR DESCRIPTION
This ensures we invalidate the experimental trace result when Next.js versions mismatch or our global hash differs as these changes should re-build everything to be safe we aren't missing an important change. 

Closes: NDX-104