### PR TITLE
Add telemetry for React Compiler usage

### DIFF
--- a/packages/next/src/telemetry/events/version.ts
+++ b/packages/next/src/telemetry/events/version.ts
@@ -35,6 +35,9 @@ type EventCliSessionStarted = {
   pagesDir: boolean | null
   staticStaleTime: number | null
   dynamicStaleTime: number | null
+  reactCompiler: boolean
+  reactCompilerCompilationMode: string | null
+  reactCompilerPanicThreshold: string | null
 }
 
 function hasBabelConfig(dir: string): boolean {
@@ -83,6 +86,9 @@ export function eventCliSession(
     | 'reactStrictMode'
     | 'staticStaleTime'
     | 'dynamicStaleTime'
+    | 'reactCompiler'
+    | 'reactCompilerCompilationMode'
+    | 'reactCompilerPanicThreshold'
   >
 ): { eventName: string; payload: EventCliSessionStarted }[] {
   // This should be an invariant, if it fails our build tooling is broken.
@@ -126,6 +132,15 @@ export function eventCliSession(
     pagesDir: event.pagesDir,
     staticStaleTime: nextConfig.experimental.staleTimes?.static ?? null,
     dynamicStaleTime: nextConfig.experimental.staleTimes?.dynamic ?? null,
+    reactCompiler: Boolean(nextConfig.experimental.reactCompiler),
+    reactCompilerCompilationMode:
+      typeof nextConfig.experimental.reactCompiler !== 'boolean'
+        ? nextConfig.experimental.reactCompiler?.compilationMode ?? null
+        : null,
+    reactCompilerPanicThreshold:
+      typeof nextConfig.experimental.reactCompiler !== 'boolean'
+        ? nextConfig.experimental.reactCompiler?.panicThreshold ?? null
+        : null,
   }
   return [{ eventName: EVENT_VERSION, payload }]
 }

--- a/test/integration/telemetry/next.config.reactCompiler-base
+++ b/test/integration/telemetry/next.config.reactCompiler-base
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    reactCompiler: true
+  }
+}

--- a/test/integration/telemetry/next.config.reactCompiler-options
+++ b/test/integration/telemetry/next.config.reactCompiler-options
@@ -1,0 +1,8 @@
+module.exports = {
+  experimental: {
+    reactCompiler: {
+      compilationMode: 'annotation',
+      panicThreshold: 'CRITICAL_ERRORS'
+    }
+  }
+}

--- a/test/integration/telemetry/test/config.test.js
+++ b/test/integration/telemetry/test/config.test.js
@@ -571,6 +571,90 @@ describe('config telemetry', () => {
           invocationCount: 1,
         })
       })
+
+      it('emits telemetry for default React Compiler options', async () => {
+        const { stderr } = await nextBuild(appDir, [], {
+          stderr: true,
+          env: { NEXT_TELEMETRY_DEBUG: 1 },
+        })
+
+        try {
+          const event = /NEXT_CLI_SESSION_STARTED[\s\S]+?{([\s\S]+?)}/
+            .exec(stderr)
+            .pop()
+
+          expect(event).toMatch(/"reactCompiler": false/)
+          expect(event).toMatch(/"reactCompilerCompilationMode": null/)
+          expect(event).toMatch(/"reactCompilerPanicThreshold": null/)
+        } catch (err) {
+          require('console').error('failing stderr', stderr, err)
+          throw err
+        }
+      })
+
+      it('emits telemetry for enabled React Compiler', async () => {
+        await fs.rename(
+          path.join(appDir, 'next.config.reactCompiler-base'),
+          path.join(appDir, 'next.config.js')
+        )
+
+        let stderr
+        try {
+          const app = await nextBuild(appDir, [], {
+            stderr: true,
+            env: { NEXT_TELEMETRY_DEBUG: 1 },
+          })
+          stderr = app.stderr
+          const event = /NEXT_CLI_SESSION_STARTED[\s\S]+?{([\s\S]+?)}/
+            .exec(stderr)
+            .pop()
+
+          expect(event).toMatch(/"reactCompiler": true/)
+          expect(event).toMatch(/"reactCompilerCompilationMode": null/)
+          expect(event).toMatch(/"reactCompilerPanicThreshold": null/)
+        } catch (err) {
+          require('console').error('failing stderr', stderr, err)
+          throw err
+        } finally {
+          await fs.rename(
+            path.join(appDir, 'next.config.js'),
+            path.join(appDir, 'next.config.reactCompiler-base')
+          )
+        }
+      })
+
+      it('emits telemetry for configured React Compiler options', async () => {
+        await fs.rename(
+          path.join(appDir, 'next.config.reactCompiler-options'),
+          path.join(appDir, 'next.config.js')
+        )
+
+        let stderr
+        try {
+          const app = await nextBuild(appDir, [], {
+            stderr: true,
+            env: { NEXT_TELEMETRY_DEBUG: 1 },
+          })
+          stderr = app.stderr
+          const event = /NEXT_CLI_SESSION_STARTED[\s\S]+?{([\s\S]+?)}/
+            .exec(stderr)
+            .pop()
+
+          expect(event).toMatch(/"reactCompiler": true/)
+          expect(event).toMatch(/"reactCompilerCompilationMode": "annotation"/)
+          expect(event).toMatch(
+            /"reactCompilerPanicThreshold": "CRITICAL_ERRORS"/
+          )
+        } catch (err) {
+          require('console').error('failing stderr', stderr, err)
+          throw err
+        } finally {
+          await fs.rename(
+            path.join(appDir, 'next.config.js'),
+            path.join(appDir, 'next.config.reactCompiler-options')
+          )
+        }
+      })
     }
   )
 })


### PR DESCRIPTION
Closes https://linear.app/vercel/issue/NDX-173
This'll help give feedback for React Compiler adoption.

Followed https://github.com/vercel/next.js/pull/36289 so let me know if I missed some places that handle telemetry.

Fields added in https://github.com/vercel/next-telemetry/pull/116