### PR TITLE
Re-enable and fix `create-next-app` integration tests

### DIFF
--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -41,7 +41,12 @@ const program = new Command(packageJson.name)
   .argument('[project-directory]')
   .usage(`${green('[project-directory]')} [options]`)
   .action((name) => {
-    projectPath = name
+    // Commander does not implicitly support negated options. When they are used
+    // by the user they will be interpreted as the positional argument (name) in
+    // the action handler. See https://github.com/tj/commander.js/pull/1355
+    if (name && !name.startsWith('--no-')) {
+      projectPath = name
+    }
   })
   .option(
     '--ts, --typescript',

--- a/test/integration/create-next-app/examples.test.ts
+++ b/test/integration/create-next-app/examples.test.ts
@@ -11,7 +11,7 @@ import {
   useTempDir,
 } from './utils'
 
-describe.skip('create-next-app --example', () => {
+describe('create-next-app --example', () => {
   let nextInstall: Awaited<ReturnType<typeof createNextInstall>>
   beforeAll(async () => {
     nextInstall = await createNextInstall({

--- a/test/integration/create-next-app/examples.test.ts
+++ b/test/integration/create-next-app/examples.test.ts
@@ -1,5 +1,3 @@
-import { trace } from 'next/dist/trace'
-import { createNextInstall } from '../../lib/create-next-install'
 import {
   EXAMPLE_PATH,
   EXAMPLE_REPO,
@@ -12,19 +10,26 @@ import {
 } from './utils'
 
 describe('create-next-app --example', () => {
-  let nextInstall: Awaited<ReturnType<typeof createNextInstall>>
-  beforeAll(async () => {
-    nextInstall = await createNextInstall({
-      parentSpan: trace('test'),
-      keepRepoDir: Boolean(process.env.NEXT_TEST_SKIP_CLEANUP),
-    })
+  let nextTgzFilename: string
+
+  beforeAll(() => {
+    if (!process.env.NEXT_TEST_PKG_PATHS) {
+      throw new Error('This test needs to be run with `node run-tests.js`.')
+    }
+
+    const pkgPaths = new Map<string, string>(
+      JSON.parse(process.env.NEXT_TEST_PKG_PATHS)
+    )
+
+    nextTgzFilename = pkgPaths.get('next')
   })
+
   it('should create on valid Next.js example name', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'valid-example'
       const res = await run(
         [projectName, '--example', 'basic-css'],
-        nextInstall.installDir,
+        nextTgzFilename,
         {
           cwd,
         }
@@ -49,7 +54,7 @@ describe('create-next-app --example', () => {
       const projectName = 'github-url'
       const res = await run(
         [projectName, '--example', FULL_EXAMPLE_PATH],
-        nextInstall.installDir,
+        nextTgzFilename,
         {
           cwd,
         }
@@ -81,7 +86,7 @@ describe('create-next-app --example', () => {
           // GH#39665
           'https://github.com/vercel/nextjs-portfolio-starter/',
         ],
-        nextInstall.installDir,
+        nextTgzFilename,
         {
           cwd,
         }
@@ -115,7 +120,7 @@ describe('create-next-app --example', () => {
           '--example-path',
           EXAMPLE_PATH,
         ],
-        nextInstall.installDir,
+        nextTgzFilename,
         {
           cwd,
         }
@@ -150,7 +155,7 @@ describe('create-next-app --example', () => {
           '--example-path',
           EXAMPLE_PATH,
         ],
-        nextInstall.installDir,
+        nextTgzFilename,
         {
           cwd,
         }
@@ -188,7 +193,7 @@ describe('create-next-app --example', () => {
             '__internal-testing-retry',
             '--import-alias=@/*',
           ],
-          nextInstall.installDir,
+          nextTgzFilename,
           {
             cwd,
             input: '\n', // 'Yes' to retry
@@ -220,7 +225,7 @@ describe('create-next-app --example', () => {
           'default',
           '--import-alias=@/*',
         ],
-        nextInstall.installDir,
+        nextTgzFilename,
         {
           cwd,
         }
@@ -241,7 +246,7 @@ describe('create-next-app --example', () => {
       const projectName = 'invalid-example'
       const res = await run(
         [projectName, '--example', 'not a real example'],
-        nextInstall.installDir,
+        nextTgzFilename,
         {
           cwd,
           reject: false,
@@ -270,7 +275,7 @@ describe('create-next-app --example', () => {
           '--no-tailwind',
           '--example',
         ],
-        nextInstall.installDir,
+        nextTgzFilename,
         {
           cwd,
           reject: false,

--- a/test/integration/create-next-app/index.test.ts
+++ b/test/integration/create-next-app/index.test.ts
@@ -6,18 +6,22 @@ import {
   projectFilesShouldExist,
   projectFilesShouldNotExist,
 } from './utils'
-import { createNextInstall } from '../../lib/create-next-install'
-import { trace } from 'next/dist/trace'
-
-let nextInstall: Awaited<ReturnType<typeof createNextInstall>>
-beforeAll(async () => {
-  nextInstall = await createNextInstall({
-    parentSpan: trace('test'),
-    keepRepoDir: Boolean(process.env.NEXT_TEST_SKIP_CLEANUP),
-  })
-})
 
 describe('create-next-app', () => {
+  let nextTgzFilename: string
+
+  beforeAll(() => {
+    if (!process.env.NEXT_TEST_PKG_PATHS) {
+      throw new Error('This test needs to be run with `node run-tests.js`.')
+    }
+
+    const pkgPaths = new Map<string, string>(
+      JSON.parse(process.env.NEXT_TEST_PKG_PATHS)
+    )
+
+    nextTgzFilename = pkgPaths.get('next')
+  })
+
   it('should not create if the target directory is not empty', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'non-empty-dir'
@@ -36,7 +40,7 @@ describe('create-next-app', () => {
           '--no-src-dir',
           '--no-import-alias',
         ],
-        nextInstall.installDir,
+        nextTgzFilename,
         {
           cwd,
           reject: false,
@@ -77,7 +81,7 @@ describe('create-next-app', () => {
           '--no-src-dir',
           '--no-import-alias',
         ],
-        nextInstall.installDir,
+        nextTgzFilename,
         {
           cwd,
           reject: false,
@@ -108,7 +112,7 @@ describe('create-next-app', () => {
           '--no-import-alias',
           '--skip-install',
         ],
-        nextInstall.installDir,
+        nextTgzFilename,
         {
           cwd,
         }

--- a/test/integration/create-next-app/index.test.ts
+++ b/test/integration/create-next-app/index.test.ts
@@ -17,7 +17,7 @@ beforeAll(async () => {
   })
 })
 
-describe.skip('create-next-app', () => {
+describe('create-next-app', () => {
   it('should not create if the target directory is not empty', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'non-empty-dir'
@@ -71,6 +71,7 @@ describe.skip('create-next-app', () => {
           projectName,
           '--ts',
           '--app',
+          '--no-turbo',
           '--eslint',
           '--no-tailwind',
           '--no-src-dir',

--- a/test/integration/create-next-app/lib/utils.ts
+++ b/test/integration/create-next-app/lib/utils.ts
@@ -4,7 +4,7 @@
  * This file contains utilities for  `create-next-app` testing.
  */
 
-import { ChildProcess, execSync, spawn, SpawnOptions } from 'child_process'
+import { execSync, spawn, SpawnOptions } from 'child_process'
 import { existsSync } from 'fs'
 import { join, resolve } from 'path'
 import glob from 'glob'
@@ -55,24 +55,6 @@ export const createNextApp = (
       ...cloneEnv,
       ...options.env,
     },
-  })
-}
-
-/**
- * Return a Promise that resolves when the process exits with code 0 and rejects
- * otherwise.
- */
-export const spawnExitPromise = (childProcess: ChildProcess) => {
-  return new Promise((resolve, reject) => {
-    childProcess
-      .on('exit', (code) => {
-        if (code === 0) {
-          resolve(code)
-        } else {
-          reject(code)
-        }
-      })
-      .on('error', reject)
   })
 }
 

--- a/test/integration/create-next-app/package-manager/bun.test.ts
+++ b/test/integration/create-next-app/package-manager/bun.test.ts
@@ -1,5 +1,3 @@
-import { trace } from 'next/dist/trace'
-import { createNextInstall } from '../../../lib/create-next-install'
 import {
   command,
   DEFAULT_FILES,
@@ -12,21 +10,25 @@ import {
 const lockFile = 'bun.lockb'
 const files = [...DEFAULT_FILES, lockFile]
 
-beforeEach(async () => {
-  await command('bun', ['--version'])
-    // install bun if not available
-    .catch(() => command('npm', ['i', '-g', 'bun']))
-})
+describe('create-next-app with package manager bun', () => {
+  let nextTgzFilename: string
 
-let nextInstall: Awaited<ReturnType<typeof createNextInstall>>
-beforeAll(async () => {
-  nextInstall = await createNextInstall({
-    parentSpan: trace('test'),
-    keepRepoDir: Boolean(process.env.NEXT_TEST_SKIP_CLEANUP),
+  beforeAll(async () => {
+    if (!process.env.NEXT_TEST_PKG_PATHS) {
+      throw new Error('This test needs to be run with `node run-tests.js`.')
+    }
+
+    const pkgPaths = new Map<string, string>(
+      JSON.parse(process.env.NEXT_TEST_PKG_PATHS)
+    )
+
+    nextTgzFilename = pkgPaths.get('next')
+
+    await command('bun', ['--version'])
+      // install bun if not available
+      .catch(() => command('npm', ['i', '-g', 'bun']))
   })
-})
 
-describe.skip('create-next-app with package manager bun', () => {
   it('should use bun for --use-bun flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'use-bun'
@@ -42,7 +44,7 @@ describe.skip('create-next-app with package manager bun', () => {
           '--no-tailwind',
           '--no-import-alias',
         ],
-        nextInstall.installDir,
+        nextTgzFilename,
         {
           cwd,
         }
@@ -71,7 +73,7 @@ describe.skip('create-next-app with package manager bun', () => {
           '--no-tailwind',
           '--no-import-alias',
         ],
-        nextInstall.installDir,
+        nextTgzFilename,
         {
           cwd,
           env: { npm_config_user_agent: 'bun' },
@@ -92,7 +94,7 @@ describe.skip('create-next-app with package manager bun', () => {
       const projectName = 'use-bun-with-example'
       const res = await run(
         [projectName, '--use-bun', '--example', FULL_EXAMPLE_PATH],
-        nextInstall.installDir,
+        nextTgzFilename,
         { cwd }
       )
 
@@ -110,7 +112,7 @@ describe.skip('create-next-app with package manager bun', () => {
       const projectName = 'user-agent-bun-with-example'
       const res = await run(
         [projectName, '--example', FULL_EXAMPLE_PATH],
-        nextInstall.installDir,
+        nextTgzFilename,
         {
           cwd,
           env: { npm_config_user_agent: 'bun' },

--- a/test/integration/create-next-app/package-manager/npm.test.ts
+++ b/test/integration/create-next-app/package-manager/npm.test.ts
@@ -19,7 +19,7 @@ beforeAll(async () => {
   })
 })
 
-describe.skip('create-next-app with package manager npm', () => {
+describe('create-next-app with package manager npm', () => {
   it('should use npm for --use-npm flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'use-npm'

--- a/test/integration/create-next-app/package-manager/npm.test.ts
+++ b/test/integration/create-next-app/package-manager/npm.test.ts
@@ -1,4 +1,3 @@
-import { trace } from 'next/dist/trace'
 import {
   DEFAULT_FILES,
   FULL_EXAMPLE_PATH,
@@ -6,20 +5,25 @@ import {
   run,
   useTempDir,
 } from '../utils'
-import { createNextInstall } from '../../../lib/create-next-install'
 
 const lockFile = 'package-lock.json'
 const files = [...DEFAULT_FILES, lockFile]
 
-let nextInstall: Awaited<ReturnType<typeof createNextInstall>>
-beforeAll(async () => {
-  nextInstall = await createNextInstall({
-    parentSpan: trace('test'),
-    keepRepoDir: Boolean(process.env.NEXT_TEST_SKIP_CLEANUP),
-  })
-})
-
 describe('create-next-app with package manager npm', () => {
+  let nextTgzFilename: string
+
+  beforeAll(() => {
+    if (!process.env.NEXT_TEST_PKG_PATHS) {
+      throw new Error('This test needs to be run with `node run-tests.js`.')
+    }
+
+    const pkgPaths = new Map<string, string>(
+      JSON.parse(process.env.NEXT_TEST_PKG_PATHS)
+    )
+
+    nextTgzFilename = pkgPaths.get('next')
+  })
+
   it('should use npm for --use-npm flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'use-npm'
@@ -35,7 +39,7 @@ describe('create-next-app with package manager npm', () => {
           '--no-tailwind',
           '--no-import-alias',
         ],
-        nextInstall.installDir,
+        nextTgzFilename,
         {
           cwd,
         }
@@ -64,7 +68,7 @@ describe('create-next-app with package manager npm', () => {
           '--no-tailwind',
           '--no-import-alias',
         ],
-        nextInstall.installDir,
+        nextTgzFilename,
         {
           cwd,
           env: { npm_config_user_agent: 'npm' },
@@ -85,7 +89,7 @@ describe('create-next-app with package manager npm', () => {
       const projectName = 'use-npm-with-example'
       const res = await run(
         [projectName, '--use-npm', '--example', FULL_EXAMPLE_PATH],
-        nextInstall.installDir,
+        nextTgzFilename,
         { cwd }
       )
 
@@ -103,7 +107,7 @@ describe('create-next-app with package manager npm', () => {
       const projectName = 'user-agent-npm-with-example'
       const res = await run(
         [projectName, '--example', FULL_EXAMPLE_PATH],
-        nextInstall.installDir,
+        nextTgzFilename,
         {
           cwd,
           env: { npm_config_user_agent: 'npm' },

--- a/test/integration/create-next-app/package-manager/pnpm.test.ts
+++ b/test/integration/create-next-app/package-manager/pnpm.test.ts
@@ -1,5 +1,3 @@
-import { trace } from 'next/dist/trace'
-import { createNextInstall } from '../../../lib/create-next-install'
 import {
   command,
   DEFAULT_FILES,
@@ -12,22 +10,28 @@ import {
 const lockFile = 'pnpm-lock.yaml'
 const files = [...DEFAULT_FILES, lockFile]
 
-let nextInstall: Awaited<ReturnType<typeof createNextInstall>>
-beforeAll(async () => {
-  nextInstall = await createNextInstall({
-    parentSpan: trace('test'),
-    keepRepoDir: Boolean(process.env.NEXT_TEST_SKIP_CLEANUP),
-  })
-})
-
-beforeEach(async () => {
-  await command('pnpm', ['--version'])
-    // install pnpm if not available
-    .catch(() => command('corepack', ['prepare', '--activate', 'pnpm@latest']))
-    .catch(() => command('npm', ['i', '-g', 'pnpm']))
-})
-
 describe('create-next-app with package manager pnpm', () => {
+  let nextTgzFilename: string
+
+  beforeAll(async () => {
+    if (!process.env.NEXT_TEST_PKG_PATHS) {
+      throw new Error('This test needs to be run with `node run-tests.js`.')
+    }
+
+    const pkgPaths = new Map<string, string>(
+      JSON.parse(process.env.NEXT_TEST_PKG_PATHS)
+    )
+
+    nextTgzFilename = pkgPaths.get('next')
+
+    await command('pnpm', ['--version'])
+      // install pnpm if not available
+      .catch(() =>
+        command('corepack', ['prepare', '--activate', 'pnpm@latest'])
+      )
+      .catch(() => command('npm', ['i', '-g', 'pnpm']))
+  })
+
   it('should use pnpm for --use-pnpm flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'use-pnpm'
@@ -43,7 +47,7 @@ describe('create-next-app with package manager pnpm', () => {
           '--no-tailwind',
           '--no-import-alias',
         ],
-        nextInstall.installDir,
+        nextTgzFilename,
         {
           cwd,
         }
@@ -72,7 +76,7 @@ describe('create-next-app with package manager pnpm', () => {
           '--no-tailwind',
           '--no-import-alias',
         ],
-        nextInstall.installDir,
+        nextTgzFilename,
         {
           cwd,
           env: { npm_config_user_agent: 'pnpm' },
@@ -93,7 +97,7 @@ describe('create-next-app with package manager pnpm', () => {
       const projectName = 'use-pnpm-with-example'
       const res = await run(
         [projectName, '--use-pnpm', '--example', FULL_EXAMPLE_PATH],
-        nextInstall.installDir,
+        nextTgzFilename,
         { cwd }
       )
 
@@ -111,7 +115,7 @@ describe('create-next-app with package manager pnpm', () => {
       const projectName = 'user-agent-pnpm-with-example'
       const res = await run(
         [projectName, '--example', FULL_EXAMPLE_PATH],
-        nextInstall.installDir,
+        nextTgzFilename,
         {
           cwd,
           env: { npm_config_user_agent: 'pnpm' },

--- a/test/integration/create-next-app/package-manager/pnpm.test.ts
+++ b/test/integration/create-next-app/package-manager/pnpm.test.ts
@@ -27,7 +27,7 @@ beforeEach(async () => {
     .catch(() => command('npm', ['i', '-g', 'pnpm']))
 })
 
-describe.skip('create-next-app with package manager pnpm', () => {
+describe('create-next-app with package manager pnpm', () => {
   it('should use pnpm for --use-pnpm flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'use-pnpm'

--- a/test/integration/create-next-app/package-manager/pnpm.test.ts
+++ b/test/integration/create-next-app/package-manager/pnpm.test.ts
@@ -1,5 +1,4 @@
 import {
-  command,
   DEFAULT_FILES,
   FULL_EXAMPLE_PATH,
   projectFilesShouldExist,
@@ -23,13 +22,6 @@ describe('create-next-app with package manager pnpm', () => {
     )
 
     nextTgzFilename = pkgPaths.get('next')
-
-    await command('pnpm', ['--version'])
-      // install pnpm if not available
-      .catch(() =>
-        command('corepack', ['prepare', '--activate', 'pnpm@latest'])
-      )
-      .catch(() => command('npm', ['i', '-g', 'pnpm']))
   })
 
   it('should use pnpm for --use-pnpm flag', async () => {

--- a/test/integration/create-next-app/package-manager/yarn.test.ts
+++ b/test/integration/create-next-app/package-manager/yarn.test.ts
@@ -10,17 +10,28 @@ import {
 const lockFile = 'yarn.lock'
 const files = [...DEFAULT_FILES, lockFile]
 
-// Don't install local next build here as yarn will error with:
-// Usage Error: This project is configured to use pnpm
-
-beforeEach(async () => {
-  await command('yarn', ['--version'])
-    // install yarn if not available
-    .catch(() => command('corepack', ['prepare', '--activate', 'yarn@1.22.19']))
-    .catch(() => command('npm', ['i', '-g', 'yarn']))
-})
-
 describe('create-next-app with package manager yarn', () => {
+  let nextTgzFilename: string
+
+  beforeAll(async () => {
+    if (!process.env.NEXT_TEST_PKG_PATHS) {
+      throw new Error('This test needs to be run with `node run-tests.js`.')
+    }
+
+    const pkgPaths = new Map<string, string>(
+      JSON.parse(process.env.NEXT_TEST_PKG_PATHS)
+    )
+
+    nextTgzFilename = pkgPaths.get('next')
+
+    await command('yarn', ['--version'])
+      // install yarn if not available
+      .catch(() =>
+        command('corepack', ['prepare', '--activate', 'yarn@1.22.19'])
+      )
+      .catch(() => command('npm', ['i', '-g', 'yarn']))
+  })
+
   it('should use yarn for --use-yarn flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'use-yarn'
@@ -36,7 +47,7 @@ describe('create-next-app with package manager yarn', () => {
           '--no-tailwind',
           '--no-import-alias',
         ],
-        'canary',
+        nextTgzFilename,
         {
           cwd,
         }
@@ -65,7 +76,7 @@ describe('create-next-app with package manager yarn', () => {
           '--no-tailwind',
           '--no-import-alias',
         ],
-        'canary',
+        nextTgzFilename,
         {
           cwd,
           env: { npm_config_user_agent: 'yarn' },
@@ -86,7 +97,7 @@ describe('create-next-app with package manager yarn', () => {
       const projectName = 'use-yarn-with-example'
       const res = await run(
         [projectName, '--use-yarn', '--example', FULL_EXAMPLE_PATH],
-        'canary',
+        nextTgzFilename,
         { cwd }
       )
 
@@ -104,7 +115,7 @@ describe('create-next-app with package manager yarn', () => {
       const projectName = 'user-agent-yarn-with-example'
       const res = await run(
         [projectName, '--example', FULL_EXAMPLE_PATH],
-        'canary',
+        nextTgzFilename,
         {
           cwd,
           env: { npm_config_user_agent: 'yarn' },

--- a/test/integration/create-next-app/package-manager/yarn.test.ts
+++ b/test/integration/create-next-app/package-manager/yarn.test.ts
@@ -20,7 +20,7 @@ beforeEach(async () => {
     .catch(() => command('npm', ['i', '-g', 'yarn']))
 })
 
-describe.skip('create-next-app with package manager yarn', () => {
+describe('create-next-app with package manager yarn', () => {
   it('should use yarn for --use-yarn flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'use-yarn'

--- a/test/integration/create-next-app/prompts.test.ts
+++ b/test/integration/create-next-app/prompts.test.ts
@@ -13,7 +13,7 @@ beforeAll(async () => {
   // ).get('next')
 })
 
-describe.skip('create-next-app prompts', () => {
+describe('create-next-app prompts', () => {
   it('should prompt user for choice if directory name is absent', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'no-dir-name'
@@ -29,7 +29,8 @@ describe.skip('create-next-app prompts', () => {
         ],
         {
           cwd,
-        }
+        },
+        testVersion
       )
 
       await new Promise<void>((resolve) => {

--- a/test/integration/create-next-app/prompts.test.ts
+++ b/test/integration/create-next-app/prompts.test.ts
@@ -1,19 +1,22 @@
-import { join } from 'path'
 import { check } from 'next-test-utils'
+import { join } from 'path'
 import { createNextApp, projectFilesShouldExist, useTempDir } from './utils'
 
-let testVersion
-beforeAll(async () => {
-  // TODO: investigate moving this post publish or create deployed GH#57025
-  // tarballs to avoid these failing while a publish is in progress
-  testVersion = 'canary'
-  // const span = new Span({ name: 'parent' })
-  // testVersion = (
-  //   await createNextInstall({ onlyPackages: true, parentSpan: span })
-  // ).get('next')
-})
-
 describe('create-next-app prompts', () => {
+  let nextTgzFilename: string
+
+  beforeAll(() => {
+    if (!process.env.NEXT_TEST_PKG_PATHS) {
+      throw new Error('This test needs to be run with `node run-tests.js`.')
+    }
+
+    const pkgPaths = new Map<string, string>(
+      JSON.parse(process.env.NEXT_TEST_PKG_PATHS)
+    )
+
+    nextTgzFilename = pkgPaths.get('next')
+  })
+
   it('should prompt user for choice if directory name is absent', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'no-dir-name'
@@ -30,7 +33,7 @@ describe('create-next-app prompts', () => {
         {
           cwd,
         },
-        testVersion
+        nextTgzFilename
       )
 
       await new Promise<void>((resolve) => {
@@ -69,7 +72,7 @@ describe('create-next-app prompts', () => {
         {
           cwd,
         },
-        testVersion
+        nextTgzFilename
       )
 
       await new Promise<void>((resolve) => {
@@ -105,7 +108,7 @@ describe('create-next-app prompts', () => {
         {
           cwd,
         },
-        testVersion
+        nextTgzFilename
       )
 
       await new Promise<void>((resolve) => {
@@ -141,7 +144,7 @@ describe('create-next-app prompts', () => {
         {
           cwd,
         },
-        testVersion
+        nextTgzFilename
       )
 
       await new Promise<void>(async (resolve) => {

--- a/test/integration/create-next-app/templates/app.test.ts
+++ b/test/integration/create-next-app/templates/app.test.ts
@@ -1,30 +1,31 @@
 import { join } from 'node:path'
 import {
-  createNextApp,
   projectShouldHaveNoGitChanges,
   shouldBeTemplateProject,
-  spawnExitPromise,
   tryNextDev,
+  run,
   useTempDir,
 } from '../utils'
 
-let testVersion: string
-beforeAll(async () => {
-  if (testVersion) return
-  // TODO: investigate moving this post publish or create deployed GH#57025
-  // tarballs to avoid these failing while a publish is in progress
-  testVersion = 'canary'
-  // const span = new Span({ name: 'parent' })
-  // testVersion = (
-  //   await createNextInstall({ onlyPackages: true, parentSpan: span })
-  // ).get('next')
-})
-
 describe('create-next-app --app (App Router)', () => {
+  let nextTgzFilename: string
+
+  beforeAll(() => {
+    if (!process.env.NEXT_TEST_PKG_PATHS) {
+      throw new Error('This test needs to be run with `node run-tests.js`.')
+    }
+
+    const pkgPaths = new Map<string, string>(
+      JSON.parse(process.env.NEXT_TEST_PKG_PATHS)
+    )
+
+    nextTgzFilename = pkgPaths.get('next')
+  })
+
   it('should create JavaScript project with --js flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'app-js'
-      const childProcess = createNextApp(
+      const { exitCode } = await run(
         [
           projectName,
           '--js',
@@ -35,13 +36,12 @@ describe('create-next-app --app (App Router)', () => {
           '--no-tailwind',
           '--no-import-alias',
         ],
+        nextTgzFilename,
         {
           cwd,
-        },
-        testVersion
+        }
       )
 
-      const exitCode = await spawnExitPromise(childProcess)
       expect(exitCode).toBe(0)
       shouldBeTemplateProject({ cwd, projectName, template: 'app', mode: 'js' })
       await tryNextDev({
@@ -54,7 +54,7 @@ describe('create-next-app --app (App Router)', () => {
   it('should create TypeScript project with --ts flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'app-ts'
-      const cp = createNextApp(
+      const { exitCode } = await run(
         [
           projectName,
           '--ts',
@@ -65,13 +65,12 @@ describe('create-next-app --app (App Router)', () => {
           '--no-tailwind',
           '--no-import-alias',
         ],
+        nextTgzFilename,
         {
           cwd,
-        },
-        testVersion
+        }
       )
 
-      const exitCode = await spawnExitPromise(cp)
       expect(exitCode).toBe(0)
       shouldBeTemplateProject({ cwd, projectName, template: 'app', mode: 'ts' })
       await tryNextDev({ cwd, projectName })
@@ -82,7 +81,7 @@ describe('create-next-app --app (App Router)', () => {
   it('should create project inside "src" directory with --src-dir flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'app-src-dir'
-      const childProcess = createNextApp(
+      const { exitCode } = await run(
         [
           projectName,
           '--ts',
@@ -93,14 +92,13 @@ describe('create-next-app --app (App Router)', () => {
           '--no-tailwind',
           '--no-import-alias',
         ],
+        nextTgzFilename,
         {
           cwd,
           stdio: 'inherit',
-        },
-        testVersion
+        }
       )
 
-      const exitCode = await spawnExitPromise(childProcess)
       expect(exitCode).toBe(0)
       shouldBeTemplateProject({
         cwd,
@@ -119,7 +117,7 @@ describe('create-next-app --app (App Router)', () => {
   it('should create TailwindCSS project with --tailwind flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'app-tw'
-      const childProcess = createNextApp(
+      const { exitCode } = await run(
         [
           projectName,
           '--ts',
@@ -130,13 +128,12 @@ describe('create-next-app --app (App Router)', () => {
           '--tailwind',
           '--no-import-alias',
         ],
+        nextTgzFilename,
         {
           cwd,
-        },
-        testVersion
+        }
       )
 
-      const exitCode = await spawnExitPromise(childProcess)
       expect(exitCode).toBe(0)
       shouldBeTemplateProject({
         cwd,
@@ -155,7 +152,7 @@ describe('create-next-app --app (App Router)', () => {
   it('should create an empty project with --empty flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'app-empty'
-      const childProcess = createNextApp(
+      const { exitCode } = await run(
         [
           projectName,
           '--ts',
@@ -167,13 +164,12 @@ describe('create-next-app --app (App Router)', () => {
           '--no-tailwind',
           '--no-import-alias',
         ],
+        nextTgzFilename,
         {
           cwd,
-        },
-        testVersion
+        }
       )
 
-      const exitCode = await spawnExitPromise(childProcess)
       const isEmpty = true
       expect(exitCode).toBe(0)
       shouldBeTemplateProject({
@@ -194,7 +190,7 @@ describe('create-next-app --app (App Router)', () => {
   it('should create an empty TailwindCSS project with --empty flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'app-tw-empty'
-      const childProcess = createNextApp(
+      const { exitCode } = await run(
         [
           projectName,
           '--ts',
@@ -206,13 +202,12 @@ describe('create-next-app --app (App Router)', () => {
           '--empty',
           '--no-import-alias',
         ],
+        nextTgzFilename,
         {
           cwd,
-        },
-        testVersion
+        }
       )
 
-      const exitCode = await spawnExitPromise(childProcess)
       const isEmpty = true
       expect(exitCode).toBe(0)
       shouldBeTemplateProject({
@@ -233,7 +228,7 @@ describe('create-next-app --app (App Router)', () => {
   it('should enable turbopack dev with --turbo flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'app-turbo'
-      const childProcess = createNextApp(
+      const { exitCode } = await run(
         [
           projectName,
           '--ts',
@@ -244,13 +239,12 @@ describe('create-next-app --app (App Router)', () => {
           '--no-tailwind',
           '--no-import-alias',
         ],
+        nextTgzFilename,
         {
           cwd,
-        },
-        testVersion
+        }
       )
 
-      const exitCode = await spawnExitPromise(childProcess)
       expect(exitCode).toBe(0)
       const projectRoot = join(cwd, projectName)
       const pkgJson = require(join(projectRoot, 'package.json'))

--- a/test/integration/create-next-app/templates/app.test.ts
+++ b/test/integration/create-next-app/templates/app.test.ts
@@ -20,7 +20,7 @@ beforeAll(async () => {
   // ).get('next')
 })
 
-describe.skip('create-next-app --app (App Router)', () => {
+describe('create-next-app --app (App Router)', () => {
   it('should create JavaScript project with --js flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'app-js'
@@ -29,6 +29,7 @@ describe.skip('create-next-app --app (App Router)', () => {
           projectName,
           '--js',
           '--app',
+          '--no-turbo',
           '--eslint',
           '--no-src-dir',
           '--no-tailwind',
@@ -58,6 +59,7 @@ describe.skip('create-next-app --app (App Router)', () => {
           projectName,
           '--ts',
           '--app',
+          '--no-turbo',
           '--eslint',
           '--no-src-dir',
           '--no-tailwind',
@@ -85,6 +87,7 @@ describe.skip('create-next-app --app (App Router)', () => {
           projectName,
           '--ts',
           '--app',
+          '--no-turbo',
           '--eslint',
           '--src-dir',
           '--no-tailwind',
@@ -121,6 +124,7 @@ describe.skip('create-next-app --app (App Router)', () => {
           projectName,
           '--ts',
           '--app',
+          '--no-turbo',
           '--eslint',
           '--src-dir',
           '--tailwind',
@@ -156,6 +160,7 @@ describe.skip('create-next-app --app (App Router)', () => {
           projectName,
           '--ts',
           '--app',
+          '--no-turbo',
           '--eslint',
           '--src-dir',
           '--empty',
@@ -194,6 +199,7 @@ describe.skip('create-next-app --app (App Router)', () => {
           projectName,
           '--ts',
           '--app',
+          '--no-turbo',
           '--eslint',
           '--src-dir',
           '--tailwind',

--- a/test/integration/create-next-app/templates/pages.test.ts
+++ b/test/integration/create-next-app/templates/pages.test.ts
@@ -19,7 +19,7 @@ beforeAll(async () => {
   // ).get('next')
 })
 
-describe.skip('create-next-app --no-app (Pages Router)', () => {
+describe('create-next-app --no-app (Pages Router)', () => {
   it('should create JavaScript project with --js flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'pages-js'
@@ -28,6 +28,7 @@ describe.skip('create-next-app --no-app (Pages Router)', () => {
           projectName,
           '--js',
           '--no-app',
+          '--no-turbo',
           '--eslint',
           '--no-src-dir',
           '--no-tailwind',
@@ -62,6 +63,7 @@ describe.skip('create-next-app --no-app (Pages Router)', () => {
           projectName,
           '--ts',
           '--no-app',
+          '--no-turbo',
           '--eslint',
           '--no-src-dir',
           '--no-tailwind',
@@ -93,6 +95,7 @@ describe.skip('create-next-app --no-app (Pages Router)', () => {
           projectName,
           '--ts',
           '--no-app',
+          '--no-turbo',
           '--eslint',
           '--src-dir',
           '--no-tailwind',
@@ -128,6 +131,7 @@ describe.skip('create-next-app --no-app (Pages Router)', () => {
           projectName,
           '--ts',
           '--no-app',
+          '--no-turbo',
           '--eslint',
           '--src-dir',
           '--tailwind',
@@ -164,6 +168,7 @@ describe.skip('create-next-app --no-app (Pages Router)', () => {
           projectName,
           '--ts',
           '--no-app',
+          '--no-turbo',
           '--eslint',
           '--src-dir',
           '--no-tailwind',
@@ -203,6 +208,7 @@ describe.skip('create-next-app --no-app (Pages Router)', () => {
           projectName,
           '--ts',
           '--no-app',
+          '--no-turbo',
           '--eslint',
           '--src-dir',
           '--tailwind',

--- a/test/integration/create-next-app/templates/pages.test.ts
+++ b/test/integration/create-next-app/templates/pages.test.ts
@@ -1,29 +1,31 @@
 import { join } from 'node:path'
 import {
-  createNextApp,
   projectShouldHaveNoGitChanges,
+  run,
   shouldBeTemplateProject,
-  spawnExitPromise,
   tryNextDev,
   useTempDir,
 } from '../utils'
 
-let testVersion: string
-beforeAll(async () => {
-  // TODO: investigate moving this post publish or create deployed GH#57025
-  // tarballs to avoid these failing while a publish is in progress
-  testVersion = 'canary'
-  // const span = new Span({ name: 'parent' })
-  // testVersion = (
-  //   await createNextInstall({ onlyPackages: true, parentSpan: span })
-  // ).get('next')
-})
-
 describe('create-next-app --no-app (Pages Router)', () => {
+  let nextTgzFilename: string
+
+  beforeAll(() => {
+    if (!process.env.NEXT_TEST_PKG_PATHS) {
+      throw new Error('This test needs to be run with `node run-tests.js`.')
+    }
+
+    const pkgPaths = new Map<string, string>(
+      JSON.parse(process.env.NEXT_TEST_PKG_PATHS)
+    )
+
+    nextTgzFilename = pkgPaths.get('next')
+  })
+
   it('should create JavaScript project with --js flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'pages-js'
-      const childProcess = createNextApp(
+      const { exitCode } = await run(
         [
           projectName,
           '--js',
@@ -34,12 +36,11 @@ describe('create-next-app --no-app (Pages Router)', () => {
           '--no-tailwind',
           '--no-import-alias',
         ],
+        nextTgzFilename,
         {
           cwd,
-        },
-        testVersion
+        }
       )
-      const exitCode = await spawnExitPromise(childProcess)
       expect(exitCode).toBe(0)
       shouldBeTemplateProject({
         cwd,
@@ -58,7 +59,7 @@ describe('create-next-app --no-app (Pages Router)', () => {
   it('should create TypeScript project with --ts flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'pages-ts'
-      const childProcess = createNextApp(
+      const { exitCode } = await run(
         [
           projectName,
           '--ts',
@@ -69,12 +70,11 @@ describe('create-next-app --no-app (Pages Router)', () => {
           '--no-tailwind',
           '--no-import-alias',
         ],
+        nextTgzFilename,
         {
           cwd,
-        },
-        testVersion
+        }
       )
-      const exitCode = await spawnExitPromise(childProcess)
       expect(exitCode).toBe(0)
       shouldBeTemplateProject({
         cwd,
@@ -90,7 +90,7 @@ describe('create-next-app --no-app (Pages Router)', () => {
   it('should create project inside "src" directory with --src-dir flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'pages-src-dir'
-      const childProcess = createNextApp(
+      const { exitCode } = await run(
         [
           projectName,
           '--ts',
@@ -101,12 +101,11 @@ describe('create-next-app --no-app (Pages Router)', () => {
           '--no-tailwind',
           '--no-import-alias',
         ],
+        nextTgzFilename,
         {
           cwd,
-        },
-        testVersion
+        }
       )
-      const exitCode = await spawnExitPromise(childProcess)
       expect(exitCode).toBe(0)
       shouldBeTemplateProject({
         cwd,
@@ -126,7 +125,7 @@ describe('create-next-app --no-app (Pages Router)', () => {
   it('should create TailwindCSS project with --tailwind flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'pages-tw'
-      const childProcess = createNextApp(
+      const { exitCode } = await run(
         [
           projectName,
           '--ts',
@@ -137,13 +136,12 @@ describe('create-next-app --no-app (Pages Router)', () => {
           '--tailwind',
           '--no-import-alias',
         ],
+        nextTgzFilename,
         {
           cwd,
-        },
-        testVersion
+        }
       )
 
-      const exitCode = await spawnExitPromise(childProcess)
       expect(exitCode).toBe(0)
       shouldBeTemplateProject({
         cwd,
@@ -163,7 +161,7 @@ describe('create-next-app --no-app (Pages Router)', () => {
   it('should create an empty project with --empty flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'pages-empty'
-      const childProcess = createNextApp(
+      const { exitCode } = await run(
         [
           projectName,
           '--ts',
@@ -175,13 +173,12 @@ describe('create-next-app --no-app (Pages Router)', () => {
           '--empty',
           '--no-import-alias',
         ],
+        nextTgzFilename,
         {
           cwd,
-        },
-        testVersion
+        }
       )
 
-      const exitCode = await spawnExitPromise(childProcess)
       const isEmpty = true
       expect(exitCode).toBe(0)
       shouldBeTemplateProject({
@@ -203,7 +200,7 @@ describe('create-next-app --no-app (Pages Router)', () => {
   it('should create an empty TailwindCSS project with --empty flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'pages-tw-empty'
-      const childProcess = createNextApp(
+      const { exitCode } = await run(
         [
           projectName,
           '--ts',
@@ -215,13 +212,12 @@ describe('create-next-app --no-app (Pages Router)', () => {
           '--empty',
           '--no-import-alias',
         ],
+        nextTgzFilename,
         {
           cwd,
-        },
-        testVersion
+        }
       )
 
-      const exitCode = await spawnExitPromise(childProcess)
       const isEmpty = true
       expect(exitCode).toBe(0)
       shouldBeTemplateProject({
@@ -243,7 +239,7 @@ describe('create-next-app --no-app (Pages Router)', () => {
   it('should enable turbopack dev with --turbo flag', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'pages-turbo'
-      const childProcess = createNextApp(
+      const { exitCode } = await run(
         [
           projectName,
           '--ts',
@@ -254,13 +250,12 @@ describe('create-next-app --no-app (Pages Router)', () => {
           '--no-tailwind',
           '--no-import-alias',
         ],
+        nextTgzFilename,
         {
           cwd,
-        },
-        testVersion
+        }
       )
 
-      const exitCode = await spawnExitPromise(childProcess)
       expect(exitCode).toBe(0)
       const projectRoot = join(cwd, projectName)
       const pkgJson = require(join(projectRoot, 'package.json'))

--- a/test/integration/create-next-app/utils.ts
+++ b/test/integration/create-next-app/utils.ts
@@ -86,6 +86,5 @@ export {
   shouldBeTemplateProject,
   shouldBeJavascriptProject,
   shouldBeTypescriptProject,
-  spawnExitPromise,
 } from './lib/utils'
 export { useTempDir } from '../../lib/use-temp-dir'


### PR DESCRIPTION
These tests were disabled as part of #65845, probably due to mismatching peer dependency errors. This has been resolved in the meantime.

As part of this PR we're also fixing how the tests are installing Next.js in preparation for running `create-next-app`:

The `run-tests.js` script already calls `createNextInstall` and does all the heavy lifting. Calling it again in the `create-next-app` integration tests is wasteful.

In addition, the built `next` tarball is exposed by `run-tests.js` via the `NEXT_TEST_PKG_PATHS` env variable. We need to provide the filename of the tgz as `NEXT_PRIVATE_TEST_VERSION` so that `create-next-app` uses it in the generated `package.json` as the `next` dependency "version".

With the previous approach, the installation was pointing `next` at the `installDir`, which has its own version of React installed. This created runtime errors (`TypeError: Cannot read properties of null (reading 'useContext')`) when running `next dev` in a pages project that was created with `create-next-app`.

Some of the tests were even downloading a published `canary` version of `next` instead of using the version from the current branch. This has been fixed as well.
