### PR TITLE
Add `--yes` option to `create-next-app`

### DIFF
--- a/docs/02-app/02-api-reference/06-create-next-app.mdx
+++ b/docs/02-app/02-api-reference/06-create-next-app.mdx
@@ -95,24 +95,24 @@ Options:
 
   --use-npm
 
-    Explicitly tell the CLI to bootstrap the app using npm
+    Explicitly tell the CLI to bootstrap the application using npm
 
   --use-pnpm
 
-    Explicitly tell the CLI to bootstrap the app using pnpm
+    Explicitly tell the CLI to bootstrap the application using pnpm
 
   --use-yarn
 
-    Explicitly tell the CLI to bootstrap the app using Yarn
+    Explicitly tell the CLI to bootstrap the application using Yarn
 
   --use-bun
 
-    Explicitly tell the CLI to bootstrap the app using Bun
+    Explicitly tell the CLI to bootstrap the application using Bun
 
   -e, --example [name]|[github-url]
 
     An example to bootstrap the app with. You can use an example name
-    from the official Next.js repo or a public GitHub URL. The URL can use
+    from the official Next.js repo or a GitHub URL. The URL can use
     any branch and/or subdirectory
 
   --example-path <path-to-example>
@@ -130,7 +130,12 @@ Options:
 
     Explicitly tell the CLI to skip installing packages
 
-  -h, --help                           output usage information
+  --yes
+
+    Use previous preferences or defaults for all options that were not
+    explicitly specified, without prompting.
+
+  -h, --help                           display help for command
 ```
 
 ### Why use Create Next App?

--- a/packages/create-next-app/README.md
+++ b/packages/create-next-app/README.md
@@ -31,7 +31,7 @@ You can also pass command line arguments to set up a new project
 non-interactively. See `create-next-app --help`:
 
 ```bash
-Usage: create-next-app <project-directory> [options]
+Usage: create-next-app [project-directory] [options]
 
 Options:
   -V, --version                        output the version number
@@ -67,26 +67,30 @@ Options:
 
     Specify import alias to use (default "@/*").
 
+  --empty
+
+    Initialize an empty project.
+
   --use-npm
 
-    Explicitly tell the CLI to bootstrap the app using npm
+    Explicitly tell the CLI to bootstrap the application using npm
 
   --use-pnpm
 
-    Explicitly tell the CLI to bootstrap the app using pnpm
+    Explicitly tell the CLI to bootstrap the application using pnpm
 
   --use-yarn
 
-    Explicitly tell the CLI to bootstrap the app using Yarn
+    Explicitly tell the CLI to bootstrap the application using Yarn
 
   --use-bun
 
-    Explicitly tell the CLI to bootstrap the app using Bun
+    Explicitly tell the CLI to bootstrap the application using Bun
 
   -e, --example [name]|[github-url]
 
     An example to bootstrap the app with. You can use an example name
-    from the official Next.js repo or a public GitHub URL. The URL can use
+    from the official Next.js repo or a GitHub URL. The URL can use
     any branch and/or subdirectory
 
   --example-path <path-to-example>
@@ -100,7 +104,16 @@ Options:
 
     Explicitly tell the CLI to reset any stored preferences
 
-  -h, --help                           output usage information
+  --skip-install
+
+    Explicitly tell the CLI to skip installing packages
+
+  --yes
+
+    Use previous preferences or defaults for all options that were not
+    explicitly specified, without prompting.
+
+  -h, --help                           display help for command
 ```
 
 ### Why use Create Next App?

--- a/test/integration/create-next-app/prompts.test.ts
+++ b/test/integration/create-next-app/prompts.test.ts
@@ -174,4 +174,46 @@ describe('create-next-app prompts', () => {
       `)
     })
   })
+
+  it('should not prompt user for choice and use defaults if --yes is defined', async () => {
+    await useTempDir(async (cwd) => {
+      const projectName = 'yes-we-can'
+      const childProcess = createNextApp(
+        [projectName, '--yes'],
+        {
+          cwd,
+        },
+        nextTgzFilename
+      )
+
+      await new Promise<void>((resolve) => {
+        childProcess.on('exit', async (exitCode) => {
+          expect(exitCode).toBe(0)
+          projectFilesShouldExist({
+            cwd,
+            projectName,
+            files: [
+              'app',
+              '.eslintrc.json',
+              'package.json',
+              'tailwind.config.ts',
+              'tsconfig.json',
+            ],
+          })
+          resolve()
+        })
+      })
+
+      const pkg = require(join(cwd, projectName, 'package.json'))
+      expect(pkg.name).toBe(projectName)
+      const tsConfig = require(join(cwd, projectName, 'tsconfig.json'))
+      expect(tsConfig.compilerOptions.paths).toMatchInlineSnapshot(`
+        {
+          "@/*": [
+            "./*",
+          ],
+        }
+      `)
+    })
+  })
 })


### PR DESCRIPTION
> **YES,**
> **WE**
> **CNA.**

This is a small improvement for power users that run `create-next-app` frequently, using the same preferences. By specifying the `--yes` option along with the project name, they won't be prompted for any preferences. Instead, the previously used preferences are automatically chosen, using the defaults as fallback.