### PR TITLE
apply no-html-link-for-pages rule to app directory

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -93,6 +93,8 @@ export = defineRule({
     }
 
     const pageUrls = getUrlFromPagesDirectories('/', foundPagesDirs)
+    const appUrls = getUrlFromPagesDirectories('/', foundAppDirs)
+
     return {
       JSXOpeningElement(node) {
         if (node.name.name !== 'a') {
@@ -134,7 +136,7 @@ export = defineRule({
           return
         }
 
-        pageUrls.forEach((pageUrl) => {
+        ;[...pageUrls, ...appUrls].forEach((pageUrl) => {
           if (pageUrl.test(normalizeURL(hrefPath))) {
             context.report({
               node,

--- a/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
+++ b/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
@@ -251,6 +251,13 @@ describe('no-html-link-for-pages', function () {
     assert.deepEqual(report, [])
   })
 
+  it('valid link element with app linter', function () {
+    const report = withAppLinter.verify(validCode, linterConfig, {
+      filename: 'foo.js',
+    })
+    assert.deepEqual(report, [])
+  })
+
   it('valid link element with multiple directories', function () {
     const report = withCustomPagesLinter.verify(
       validCode,
@@ -319,6 +326,21 @@ describe('no-html-link-for-pages', function () {
 
   it('invalid static route', function () {
     const [report] = withCustomPagesLinter.verify(
+      invalidStaticCode,
+      linterConfigWithCustomDirectory,
+      {
+        filename: 'foo.js',
+      }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+
+  it('invalid static route with app directory linter', function () {
+    const [report] = withAppLinter.verify(
       invalidStaticCode,
       linterConfigWithCustomDirectory,
       {


### PR DESCRIPTION
fixes #53473

### Fixing a bug

- Related issues linked using `fixes #53473`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md
