### PR TITLE
refactor: use render results for fallbacks

### DIFF
--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -9,7 +9,7 @@ import {
   MiddlewareNotFoundError,
 } from '../shared/lib/utils'
 import type { MiddlewareManifest } from '../build/webpack/plugins/middleware-plugin'
-import type RenderResult from './render-result'
+import RenderResult from './render-result'
 import type { FetchEventResult } from './web/types'
 import type { PrerenderManifest } from '../build'
 import type { PagesManifest } from '../build/webpack/plugins/pages-manifest-plugin'
@@ -794,13 +794,14 @@ export default class NextNodeServer extends BaseServer<
     ) as NextFontManifest
   }
 
-  protected getFallback(page: string): Promise<string> {
+  protected async getFallback(page: string): Promise<RenderResult> {
     page = normalizePagePath(page)
     const cacheFs = this.getCacheFilesystem()
-    return cacheFs.readFile(
-      join(this.serverDistDir, 'pages', `${page}.html`),
-      'utf8'
-    )
+
+    // For Pages, we just have to return the fallback HTML.
+    const filename = join(this.serverDistDir, 'pages', page)
+    const html = await cacheFs.readFile(`${filename}.html`, 'utf8')
+    return RenderResult.fromStatic(html)
   }
 
   protected handleNextImageRequest: NodeRouteHandler = async (

--- a/packages/next/src/server/web-server.ts
+++ b/packages/next/src/server/web-server.ts
@@ -1,5 +1,5 @@
 import type { WebNextRequest, WebNextResponse } from './base-http/web'
-import type RenderResult from './render-result'
+import RenderResult from './render-result'
 import type { NextParsedUrlQuery, NextUrlWithParsedQuery } from './request-meta'
 import type { Params } from '../client/components/params'
 import type { LoadComponentsReturnType } from './load-components'
@@ -358,7 +358,7 @@ export default class NextWebServer extends BaseServer<
   }
 
   protected async getFallback() {
-    return ''
+    return RenderResult.fromStatic('')
   }
 
   protected getFontManifest() {


### PR DESCRIPTION
To simplify the fallback interface, this changes the return type of the fallback return from a `Promise<string>` to a `Promise<RenderResult>`. This paves the way for us to leverage the incremental cache more directly for the server implementations.
