### PR TITLE
Restructure trace experiment manifest

### DIFF
--- a/packages/next/src/build/flying-shuttle/detect-changed-entries.ts
+++ b/packages/next/src/build/flying-shuttle/detect-changed-entries.ts
@@ -71,16 +71,6 @@ export async function hasShuttle(
     _hasShuttle = false
   }
 
-  for (const key of Object.keys(currentShuttleManifest.nextPublicEnv || {})) {
-    if (
-      currentShuttleManifest.nextPublicEnv[key] !==
-      foundShuttleManifest.nextPublicEnv?.[key]
-    ) {
-      console.log(`Mismatching public env ${key}`)
-      _hasShuttle = false
-    }
-  }
-
   if (!deepEqual(currentShuttleManifest.config, foundShuttleManifest.config)) {
     _hasShuttle = false
     console.log(

--- a/packages/next/src/build/flying-shuttle/detect-changed-entries.ts
+++ b/packages/next/src/build/flying-shuttle/detect-changed-entries.ts
@@ -3,12 +3,38 @@ import path from 'path'
 import crypto from 'crypto'
 import { getPageFromPath } from '../entries'
 import { Sema } from 'next/dist/compiled/async-sema'
-import { generateShuttleManifest } from './store-shuttle'
+import { generateShuttleManifest, type ShuttleManifest } from './store-shuttle'
 import type { NextConfigComplete } from '../../server/config-shared'
 
 export interface DetectedEntriesResult {
   app: string[]
   pages: string[]
+}
+
+function deepEqual(obj1: any, obj2: any) {
+  if (obj1 === obj2) return true
+
+  if (
+    typeof obj1 !== 'object' ||
+    obj1 === null ||
+    typeof obj2 !== 'object' ||
+    obj2 === null
+  ) {
+    return false
+  }
+
+  let keys1 = Object.keys(obj1)
+  let keys2 = Object.keys(obj2)
+
+  if (keys1.length !== keys2.length) return false
+
+  for (let key of keys1) {
+    if (!keys2.includes(key) || !deepEqual(obj1[key], obj2[key])) {
+      return false
+    }
+  }
+
+  return true
 }
 
 let _hasShuttle: undefined | boolean = undefined
@@ -19,44 +45,51 @@ export async function hasShuttle(
   if (typeof _hasShuttle === 'boolean') {
     return _hasShuttle
   }
-  let foundShuttleManifest:
-    | ReturnType<typeof generateShuttleManifest>
-    | undefined
+  let foundShuttleManifest: ShuttleManifest
 
   try {
     foundShuttleManifest = JSON.parse(
-      await fs.promises
-        .readFile(path.join(shuttleDir, 'shuttle-manifest.json'), 'utf8')
-        .catch(() => '{}')
+      await fs.promises.readFile(
+        path.join(shuttleDir, 'shuttle-manifest.json'),
+        'utf8'
+      )
     )
     _hasShuttle = true
   } catch (err: unknown) {
     _hasShuttle = false
+    console.log(`Failed to read shuttle manifest`)
     return _hasShuttle
   }
-  const currentShuttleManifest = generateShuttleManifest(config)
+  const currentShuttleManifest = JSON.parse(generateShuttleManifest(config))
 
-  if (
-    currentShuttleManifest.nextVersion !== foundShuttleManifest?.nextVersion
-  ) {
+  if (currentShuttleManifest.nextVersion !== foundShuttleManifest.nextVersion) {
     // we don't allow using shuttle from differing Next.js version
     // as it could have internal changes
     console.log(
-      `shuttle has differing Next.js version ${foundShuttleManifest?.nextVersion} versus current ${currentShuttleManifest.nextVersion}, skipping.`
+      `shuttle has differing Next.js version ${foundShuttleManifest.nextVersion} versus current ${currentShuttleManifest.nextVersion}, skipping.`
     )
     _hasShuttle = false
   }
 
-  if (
-    _hasShuttle !== false &&
-    currentShuttleManifest.globalHash !== foundShuttleManifest?.globalHash
-  ) {
-    // if the global hash was invalidated we bypass the cache to be safe
-    console.log(
-      `shuttle has differing global hash ${foundShuttleManifest?.globalHash} versus current ${currentShuttleManifest.globalHash}, skipping.`
-    )
-    _hasShuttle = false
+  for (const key of Object.keys(currentShuttleManifest.nextPublicEnv || {})) {
+    if (
+      currentShuttleManifest.nextPublicEnv[key] !==
+      foundShuttleManifest.nextPublicEnv?.[key]
+    ) {
+      console.log(`Mismatching public env ${key}`)
+      _hasShuttle = false
+    }
   }
+
+  if (!deepEqual(currentShuttleManifest.config, foundShuttleManifest.config)) {
+    _hasShuttle = false
+    console.log(
+      `Mismatching shuttle configs`,
+      currentShuttleManifest.config,
+      foundShuttleManifest.config
+    )
+  }
+
   return _hasShuttle
 }
 

--- a/packages/next/src/build/flying-shuttle/store-shuttle.ts
+++ b/packages/next/src/build/flying-shuttle/store-shuttle.ts
@@ -1,9 +1,9 @@
 import fs from 'fs'
 import path from 'path'
-import crypto from 'crypto'
 import { recursiveCopy } from '../../lib/recursive-copy'
 import { version as nextVersion } from 'next/package.json'
 import type { NextConfigComplete } from '../../server/config-shared'
+import { getNextPublicEnvironmentVariables } from '../webpack/plugins/define-env-plugin'
 import {
   BUILD_MANIFEST,
   APP_BUILD_MANIFEST,
@@ -12,58 +12,33 @@ import {
   PAGES_MANIFEST,
   ROUTES_MANIFEST,
 } from '../../shared/lib/constants'
-import { getNextPublicEnvironmentVariables } from '../webpack/plugins/define-env-plugin'
+
+export interface ShuttleManifest {
+  nextVersion: string
+  nextPublicEnv: Record<string, string>
+  config: Record<string, any>
+}
 
 export function generateShuttleManifest(config: NextConfigComplete) {
-  // NEXT_PUBLIC_ changes for now since they are inlined
-  // and specific next config values that can impact the build
-  const globalHash = crypto.createHash('sha256')
-  const nextPublicEnv = getNextPublicEnvironmentVariables()
-  // sort for deterministic order
-  const publicEnvKeys = Object.keys(nextPublicEnv).sort()
-
-  for (const key of publicEnvKeys) {
-    globalHash.update(`${key}=${nextPublicEnv[key]}`)
-  }
-
-  // TODO: make this opt-out list instead?
-  // also ensure this list is complete this is minimal set
-  const configsToInvalidateOn = [
-    'basePath',
-    'env',
-    'i18n',
-    'images',
-    'productionBrowserSourceMaps',
-    'webpack',
-    'sassOptions',
-    'trailingSlash',
-    'experimental.flyingShuttle',
-    'experimental.ppr',
-    'experimental.reactCompiler',
-  ].sort()
-
-  for (const key of configsToInvalidateOn) {
-    let value = config[key]
-
-    if (key.includes('.')) {
-      value = config
-
-      const keyParts = key.split('.')
-      for (let i = 0; i < keyParts.length; i++) {
-        value = value[keyParts[i]]
-      }
-    }
-
-    let serializedConfig =
-      typeof value === 'function' ? value.toString() : JSON.stringify(value)
-
-    globalHash.update(`${key}=${serializedConfig}`)
-  }
-
-  return {
+  return JSON.stringify({
     nextVersion,
-    globalHash: globalHash.digest('hex'),
-  }
+    nextPublicEnv: getNextPublicEnvironmentVariables() as Record<string, any>,
+    config: {
+      env: config.env,
+      i18n: config.i18n,
+      basePath: config.basePath,
+      sassOptions: config.sassOptions,
+      trailingSlash: config.trailingSlash,
+      productionBrowserSourceMaps: config.productionBrowserSourceMaps,
+
+      experimental: {
+        ppr: config.experimental.ppr,
+        reactCompiler: config.experimental.reactCompiler,
+        serverSourceMaps: config.experimental.serverSourceMaps,
+        serverMinification: config.experimental.serverMinification,
+      },
+    },
+  } satisfies ShuttleManifest)
 }
 
 // we can create a new shuttle with the outputs before env values have
@@ -80,10 +55,9 @@ export async function storeShuttle({
   await fs.promises.rm(shuttleDir, { force: true, recursive: true })
   await fs.promises.mkdir(shuttleDir, { recursive: true })
 
-  const shuttleManifest = generateShuttleManifest(config)
   await fs.promises.writeFile(
     path.join(shuttleDir, 'shuttle-manifest.json'),
-    JSON.stringify(shuttleManifest)
+    generateShuttleManifest(config)
   )
 
   // copy all server entries

--- a/packages/next/src/build/flying-shuttle/store-shuttle.ts
+++ b/packages/next/src/build/flying-shuttle/store-shuttle.ts
@@ -3,7 +3,6 @@ import path from 'path'
 import { recursiveCopy } from '../../lib/recursive-copy'
 import { version as nextVersion } from 'next/package.json'
 import type { NextConfigComplete } from '../../server/config-shared'
-import { getNextPublicEnvironmentVariables } from '../webpack/plugins/define-env-plugin'
 import {
   BUILD_MANIFEST,
   APP_BUILD_MANIFEST,
@@ -15,14 +14,12 @@ import {
 
 export interface ShuttleManifest {
   nextVersion: string
-  nextPublicEnv: Record<string, string>
   config: Record<string, any>
 }
 
 export function generateShuttleManifest(config: NextConfigComplete) {
   return JSON.stringify({
     nextVersion,
-    nextPublicEnv: getNextPublicEnvironmentVariables() as Record<string, any>,
     config: {
       env: config.env,
       i18n: config.i18n,

--- a/test/e2e/app-dir/app/flying-shuttle.test.ts
+++ b/test/e2e/app-dir/app/flying-shuttle.test.ts
@@ -23,14 +23,12 @@ import { nextTestSetup, isNextStart } from 'e2e-utils'
         NEXT_PRIVATE_FLYING_SHUTTLE: 'true',
       },
     })
-    let initialNextPublic: Record<string, any> = {}
     let initialConfig: Record<string, any> = {}
 
     beforeAll(async () => {
       const manifest = await next.readJSON(
         '.next/cache/shuttle/shuttle-manifest.json'
       )
-      initialNextPublic = manifest.nextPublicEnv
       initialConfig = manifest.config
     })
 
@@ -42,7 +40,6 @@ import { nextTestSetup, isNextStart } from 'e2e-utils'
       expect(manifest).toEqual({
         nextVersion,
         config: initialConfig,
-        nextPublicEnv: initialNextPublic,
       })
     }
 

--- a/test/e2e/app-dir/app/flying-shuttle.test.ts
+++ b/test/e2e/app-dir/app/flying-shuttle.test.ts
@@ -23,13 +23,15 @@ import { nextTestSetup, isNextStart } from 'e2e-utils'
         NEXT_PRIVATE_FLYING_SHUTTLE: 'true',
       },
     })
-    let initialGlobalHash: string = ''
+    let initialNextPublic: Record<string, any> = {}
+    let initialConfig: Record<string, any> = {}
 
     beforeAll(async () => {
       const manifest = await next.readJSON(
         '.next/cache/shuttle/shuttle-manifest.json'
       )
-      initialGlobalHash = manifest.globalHash
+      initialNextPublic = manifest.nextPublicEnv
+      initialConfig = manifest.config
     })
 
     async function checkShuttleManifest() {
@@ -39,7 +41,8 @@ import { nextTestSetup, isNextStart } from 'e2e-utils'
 
       expect(manifest).toEqual({
         nextVersion,
-        globalHash: initialGlobalHash,
+        config: initialConfig,
+        nextPublicEnv: initialNextPublic,
       })
     }
 
@@ -91,17 +94,6 @@ import { nextTestSetup, isNextStart } from 'e2e-utils'
           expect(typeof traceFile.fileHashes[key]).toBe('string')
         }
       }
-    })
-
-    it('should have shuttle-manifest.json', async () => {
-      const manifest = await next.readJSON(
-        '.next/cache/shuttle/shuttle-manifest.json'
-      )
-
-      expect(manifest).toEqual({
-        nextVersion,
-        globalHash: expect.stringMatching(/[\w\d]{1,}/),
-      })
     })
 
     it('should hard navigate on chunk load failure', async () => {


### PR DESCRIPTION
This restructures the experimental trace manifest to output the values instead of just hashes for better debugging experience and removes public env from the manifest for now.  