### PR TITLE
Fix race condition with experimental tracing

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2498,6 +2498,8 @@ export default async function build(
 
       if (!isGenerateMode) {
         if (config.experimental.flyingShuttle) {
+          await buildTracesPromise
+
           console.log('stitching builds...')
           const stitchResult = await stitchBuilds(
             {


### PR DESCRIPTION
If we don't await the tracing to finish before we store the trace cache we can have an invalid cache which is missing trace entries. 