### PR TITLE
fix: #68259 set authors in openGraph of metadata to empty string will be crash with SSR

### DIFF
--- a/packages/next/src/lib/metadata/generate/meta.tsx
+++ b/packages/next/src/lib/metadata/generate/meta.tsx
@@ -100,6 +100,9 @@ export function MultiMeta({
   if (typeof contents === 'undefined' || contents === null) {
     return null
   }
+  if (!Array.isArray(contents)) {
+    contents = [contents]
+  }
 
   return MetaFilter(
     contents.map((content) => {

--- a/packages/next/src/lib/metadata/resolvers/resolve-opengraph.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-opengraph.ts
@@ -166,6 +166,11 @@ export const resolveOpenGraph: FieldResolverExtraArgs<
     )
   }
 
+  /* 
+  warning: force type assertion maybe merge authors of openGraph with string type from Metadata into ResolvedOpenGraph, 
+  but it's not support a string type for authors of openGraph.
+  is there any other field that has the same issue?
+   */
   const resolved = {
     ...openGraph,
     title: resolveTitle(openGraph.title, titleTemplate),


### PR DESCRIPTION
### Fixing a bug https://github.com/vercel/next.js/issues/68259

According to the official Next.js documentation, developers can set the authors field in the openGraph metadata, and the type accepts either a string or a URL. However, when I attempted to do this, server-side rendering would crash with the error “r.map is not a function” because the actual code execution forcefully asserts that this authors field is of type string[]. This pull request fixes this issue and provides a warning comment.

Feel free to let me know if you need any adjustments!