### PR TITLE
docs: fix typo

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/cssChunking.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/cssChunking.mdx
@@ -35,6 +35,6 @@ module.exports = nextConfig
 - **`'loose'` (default)**: Next.js will try to merge CSS files whenever possible, determining explicit and implicit dependencies between files from import order to reduce the number of chunks and therefore the number of requests.
 - **`'strict'`**: Next.js will load CSS files in the correct order they are imported into your files, which can lead to more chunks and requests.
 
-You may consider using `'strict'` if you run into unexpected CSS behavior. For example, if you import `a.css` and `b.css` in different files using a different `import` order (`a` before `b`, or `b` before `a`), `'loose'` will merge the files in any other and assume there are no dependencies between them. However, if `b.css` depends on `a.css`, you may want to use `'strict'` to prevent the files from being merged, and instead, load them in the order they are imported - which can result in more chunks and requests.
+You may consider using `'strict'` if you run into unexpected CSS behavior. For example, if you import `a.css` and `b.css` in different files using a different `import` order (`a` before `b`, or `b` before `a`), `'loose'` will merge the files in any order and assume there are no dependencies between them. However, if `b.css` depends on `a.css`, you may want to use `'strict'` to prevent the files from being merged, and instead, load them in the order they are imported - which can result in more chunks and requests.
 
 For most applications, we recommend `'loose'` as it leads to fewer requests and better performance.


### PR DESCRIPTION
## Why?

Fixing `other` → `order` typo.

- x-ref: https://github.com/vercel/next.js/pull/67691#discussion_r1691162768