### PR TITLE
split out versioned content map and content map

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -332,7 +332,7 @@ impl ProjectContainer {
         file_path: Vc<FileSystemPath>,
     ) -> Result<Vc<Box<dyn VersionedContent>>> {
         let this = self.await?;
-        Ok(this.versioned_content_map.get(file_path))
+        Ok(this.versioned_content_map.get_asset(file_path))
     }
 
     #[turbo_tasks::function]
@@ -1096,7 +1096,7 @@ impl Project {
         Ok(self
             .await?
             .versioned_content_map
-            .get(self.client_relative_path().join(identifier)))
+            .get_asset(self.client_relative_path().join(identifier)))
     }
 
     #[turbo_tasks::function]


### PR DESCRIPTION
### What?

This splits out the VersionedContentMap to make it clear which parts of the code require considerations when doing versioning calculations.

### Why?

A later PR will add some code to just the versioning codepath and it's easier to reason with in two parts.

### How?

Wrapper type which delegates back into the ContentMap.

This PR contains no behavioral changes and is safe to apply as long as the code compiles.
