### PR TITLE
opt out of content map hashing during builds

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -183,8 +183,10 @@ impl ProjectContainer {
     #[turbo_tasks::function]
     pub fn new(options: ProjectOptions) -> Vc<Self> {
         ProjectContainer {
+            // we only need to enable versioning in dev mode, since build
+            // is assumed to be operating over a static snapshot
+            versioned_content_map: VersionedContentMap::new(options.dev),
             options_state: State::new(options),
-            versioned_content_map: VersionedContentMap::new(),
         }
         .cell()
     }


### PR DESCRIPTION
### TL;DR

Add an option to enable or disable versioning in `VersionedContentMap`, and disable the versioning calculations during builds.

### What changed?

- Modified the `ProjectContainer::new` function to pass the `dev` flag to the `VersionedContentMap` constructor.
- Updated `VersionedContentMap` to include an `enable_versioning` boolean flag which controls versioning behavior.
- Added a `Dummy` struct to bypass versioning when `enable_versioning` is `false`.

### How to test?

- Run existing unit tests to ensure no regressions. 

### Why make this change?

This change improves performance during builds by avoiding unnecessary versioning calculations (lots of hashing) during build operations, which assume a static snapshot of the codebase.