### PR TITLE
Use the shared Next.js `installDir` on Windows as well

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -398,21 +398,16 @@ ${tests.map((t) => t.file).join('\n')}
 ${ENDGROUP}`)
   console.log(`total: ${tests.length}`)
 
-  const hasIsolatedTests = tests.some((test) => {
-    return configuredTestTypes.some(
-      (type) => typeof type === 'string' && test.file.startsWith(type)
-    )
-  })
-
   if (
     !options.dry &&
     process.env.NEXT_TEST_MODE !== 'deploy' &&
-    ((options.type && options.type !== 'unit') || hasIsolatedTests)
+    ((options.type && options.type !== 'unit') ||
+      tests.some((test) => !testFilters.unit.test(test.file)))
   ) {
-    // for isolated next tests: e2e, dev, prod we create
-    // a starter Next.js install to re-use to speed up tests
-    // to avoid having to run yarn each time
-    console.log(`${GROUP}Creating Next.js install for isolated tests`)
+    // For isolated next tests (e2e, dev, prod) and integration tests we create
+    // a starter Next.js install to re-use to speed up tests to avoid having to
+    // run `pnpm install` each time.
+    console.log(`${GROUP}Creating shared Next.js install`)
     const reactVersion = process.env.NEXT_TEST_REACT_VERSION || '19.0.0-rc.0'
     const { installDir, pkgPaths, tmpRepoDir } = await createNextInstall({
       parentSpan: mockTrace(),

--- a/run-tests.js
+++ b/run-tests.js
@@ -400,8 +400,7 @@ ${ENDGROUP}`)
 
   const hasIsolatedTests = tests.some((test) => {
     return configuredTestTypes.some(
-      (type) =>
-        type !== testFilters.unit && test.file.startsWith(`test/${type}`)
+      (type) => typeof type === 'string' && test.file.startsWith(type)
     )
   })
 

--- a/run-tests.js
+++ b/run-tests.js
@@ -407,7 +407,6 @@ ${ENDGROUP}`)
 
   if (
     !options.dry &&
-    process.platform !== 'win32' &&
     process.env.NEXT_TEST_MODE !== 'deploy' &&
     ((options.type && options.type !== 'unit') || hasIsolatedTests)
   ) {


### PR DESCRIPTION
It seems that this now [works in Azure](https://dev.azure.com/nextjs/next.js/_build/results?buildId=92732&view=logs&j=14d0eb3f-bc66-5450-3353-28256327ad6c&t=7e988112-57f9-5e14-1c8c-05f6c2b0ea47), so we don't need to differentiate based on the platform anymore. Using the shared `createNextInstall` is a requirement for #68084. To make this work, we need to also fix an accidental breakage of `hasIsolatedTests` from #53406.