### PR TITLE
Add note about bubbling

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/05-error-handling.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/05-error-handling.mdx
@@ -211,7 +211,7 @@ export default function Error({ error, reset }) {
 }
 ```
 
-You can bubble up errors to the next parent error boundary by throwing while rendering the `Error` component.
+If you want errors to bubble up to the parent error boundary, you can `throw` when rendering the `error` component.
 
 ### Handling Errors in Nested Routes
 

--- a/docs/02-app/01-building-your-application/01-routing/05-error-handling.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/05-error-handling.mdx
@@ -211,6 +211,8 @@ export default function Error({ error, reset }) {
 }
 ```
 
+You can bubble up errors to the next parent error boundary by throwing while rendering the `Error` component.
+
 ### Handling Errors in Nested Routes
 
 Errors will bubble up to the nearest parent error boundary. This allows for granular error handling by placing `error.tsx` files at different levels in the [route hierarchy](/docs/app/building-your-application/routing#component-hierarchy).


### PR DESCRIPTION
Adds a little note about bubbling errors via `error.js`. Error bubbling is a basic part of error handling.

I'm not sure how to phrase this correctly, what do we call the "render" part of a component nowadays? (I tried to find it in React docs but couldn't)

cc @leerob and @timneutkens 