### PR TITLE
fix: imageLoader return URL for cloudinary

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/images.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/images.mdx
@@ -95,7 +95,7 @@ export default function cloudfrontLoader({ src, width, quality }) {
 // Demo: https://res.cloudinary.com/demo/image/upload/w_300,c_limit,q_auto/turtles.jpg
 export default function cloudinaryLoader({ src, width, quality }) {
   const params = ['f_auto', 'c_limit', `w_${width}`, `q_${quality || 'auto'}`]
-  return `https://example.com/${params.join(',')}${src}`
+  return `https://example.com/${params.join(',')}/${src}`
 }
 ```
 


### PR DESCRIPTION
## Description

Return URL typo under cloudinary for 
https://nextjs.org/docs/pages/api-reference/next-config-js/images