### PR TITLE
misc: tweak fetch patch restoration timing during HMR to allow for userland fetch patching

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -92,7 +92,8 @@ const sessionId = Math.floor(Number.MAX_SAFE_INTEGER * Math.random())
 export async function createHotReloaderTurbopack(
   opts: SetupOpts,
   serverFields: ServerFields,
-  distDir: string
+  distDir: string,
+  resetFetch: () => void
 ): Promise<NextJsHotReloaderInterface> {
   const buildId = 'development'
   const { nextConfig, dir } = opts
@@ -235,6 +236,8 @@ export async function createHotReloaderTurbopack(
         return
       }
     }
+
+    resetFetch()
 
     const hasAppPaths = writtenEndpoint.serverPaths.some(({ path: p }) =>
       p.startsWith('server/app')

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -249,6 +249,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
   private pagesMapping: { [key: string]: string } = {}
   private appDir?: string
   private telemetry: Telemetry
+  private resetFetch: () => void
   private versionInfo: VersionInfo = {
     staleness: 'unknown',
     installed: '0.0.0',
@@ -274,6 +275,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       rewrites,
       appDir,
       telemetry,
+      resetFetch,
     }: {
       config: NextConfigComplete
       pagesDir?: string
@@ -284,6 +286,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       rewrites: CustomRoutes['rewrites']
       appDir?: string
       telemetry: Telemetry
+      resetFetch: () => void
     }
   ) {
     this.hasAmpEntrypoints = false
@@ -301,6 +304,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
     this.edgeServerStats = null
     this.serverPrevDocumentHash = null
     this.telemetry = telemetry
+    this.resetFetch = resetFetch
 
     this.config = config
     this.previewProps = previewProps
@@ -1365,6 +1369,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
         changedCSSImportPages.size ||
         reloadAfterInvalidation
       ) {
+        this.resetFetch()
         this.refreshServerComponents()
       }
 

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -162,7 +162,6 @@ export default class DevServer extends Server {
     this.bundlerService = options.bundlerService
     this.startServerSpan =
       options.startServerSpan ?? trace('start-next-dev-server')
-    this.storeGlobals()
     this.renderOpts.dev = true
     this.renderOpts.ErrorDebug = ReactDevOverlay
     this.staticPathsCache = new LRUCache({
@@ -293,9 +292,6 @@ export default class DevServer extends Server {
 
     await super.prepareImpl()
     await this.matchers.reload()
-
-    // Store globals again to preserve changes made by the instrumentation hook.
-    this.storeGlobals()
 
     this.ready?.resolve()
     this.ready = undefined
@@ -825,14 +821,6 @@ export default class DevServer extends Server {
     return nextInvoke as NonNullable<typeof result>
   }
 
-  private storeGlobals(): void {
-    this.originalFetch = global.fetch
-  }
-
-  private restorePatchedGlobals(): void {
-    global.fetch = this.originalFetch ?? global.fetch
-  }
-
   protected async ensurePage(opts: {
     page: string
     clientOnly: boolean
@@ -880,11 +868,6 @@ export default class DevServer extends Server {
       }
 
       this.nextFontManifest = super.getNextFontManifest()
-      // before we re-evaluate a route module, we want to restore globals that might
-      // have been patched previously to their original state so that we don't
-      // patch on top of the previous patch, which would keep the context of the previous
-      // patched global in memory, creating a memory leak.
-      this.restorePatchedGlobals()
 
       return await super.findPageComponents({
         page,

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -37,8 +37,7 @@ type PatchedFetcher = Fetcher & {
 export const NEXT_PATCH_SYMBOL = Symbol.for('next-patch')
 
 function isFetchPatched() {
-  // @ts-ignore
-  return globalThis[NEXT_PATCH_SYMBOL] === true
+  return (globalThis as Record<symbol, unknown>)[NEXT_PATCH_SYMBOL] === true
 }
 
 export function validateRevalidate(
@@ -811,8 +810,7 @@ export function createPatchedFetcher(
   patched.__nextPatched = true as const
   patched.__nextGetStaticStore = () => staticGenerationAsyncStorage
   patched._nextOriginalFetch = originFetch
-  // @ts-ignore
-  globalThis[NEXT_PATCH_SYMBOL] = true
+  ;(globalThis as Record<symbol, unknown>)[NEXT_PATCH_SYMBOL] = true
 
   return patched
 }

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -34,11 +34,11 @@ type PatchedFetcher = Fetcher & {
   readonly _nextOriginalFetch: Fetcher
 }
 
-const nextPatchSymbol = Symbol.for('next-patch')
+export const NEXT_PATCH_SYMBOL = Symbol.for('next-patch')
 
 function isFetchPatched() {
   // @ts-ignore
-  return globalThis[nextPatchSymbol] === true
+  return globalThis[NEXT_PATCH_SYMBOL] === true
 }
 
 export function validateRevalidate(
@@ -812,7 +812,7 @@ export function createPatchedFetcher(
   patched.__nextGetStaticStore = () => staticGenerationAsyncStorage
   patched._nextOriginalFetch = originFetch
   // @ts-ignore
-  globalThis[nextPatchSymbol] = true
+  globalThis[NEXT_PATCH_SYMBOL] = true
 
   return patched
 }

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -46,6 +46,7 @@ import {
   type AppIsrManifestAction,
 } from '../dev/hot-reloader-types'
 import { normalizedAssetPrefix } from '../../shared/lib/normalized-asset-prefix'
+import { NEXT_PATCH_SYMBOL } from './patch-fetch'
 
 const debug = setupDebug('next:router-server:main')
 const isNextFont = (pathname: string | null) =>
@@ -109,6 +110,8 @@ export async function initialize(opts: {
 
   let devBundlerService: DevBundlerService | undefined
 
+  let originalFetch = globalThis.fetch
+
   if (opts.dev) {
     const { Telemetry } =
       require('../../telemetry/storage') as typeof import('../../telemetry/storage')
@@ -120,6 +123,12 @@ export async function initialize(opts: {
 
     const { setupDevBundler } =
       require('./router-utils/setup-dev-bundler') as typeof import('./router-utils/setup-dev-bundler')
+
+    const resetFetch = () => {
+      global.fetch = originalFetch
+      // @ts-ignore
+      global[NEXT_PATCH_SYMBOL] = false
+    }
 
     const setupDevBundlerSpan = opts.startServerSpan
       ? opts.startServerSpan.traceChild('setup-dev-bundler')
@@ -138,6 +147,7 @@ export async function initialize(opts: {
         turbo: !!process.env.TURBOPACK,
         port: opts.port,
         onCleanup: opts.onCleanup,
+        resetFetch,
       })
     )
 
@@ -591,12 +601,12 @@ export async function initialize(opts: {
   let requestHandler: WorkerRequestHandler = requestHandlerImpl
   if (config.experimental.testProxy) {
     // Intercept fetch and other testmode apis.
-    const {
-      wrapRequestHandlerWorker,
-      interceptTestApis,
-    } = require('next/dist/experimental/testmode/server')
+    const { wrapRequestHandlerWorker, interceptTestApis } =
+      require('next/dist/experimental/testmode/server') as typeof import('next/src/experimental/testmode/server')
     requestHandler = wrapRequestHandlerWorker(requestHandler)
     interceptTestApis()
+    // We treat the intercepted fetch as "original" fetch that should be reset to during HMR.
+    originalFetch = globalThis.fetch
   }
   requestHandlers[opts.dir] = requestHandler
 

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -125,9 +125,8 @@ export async function initialize(opts: {
       require('./router-utils/setup-dev-bundler') as typeof import('./router-utils/setup-dev-bundler')
 
     const resetFetch = () => {
-      global.fetch = originalFetch
-      // @ts-ignore
-      global[NEXT_PATCH_SYMBOL] = false
+      globalThis.fetch = originalFetch
+      ;(globalThis as Record<symbol, unknown>)[NEXT_PATCH_SYMBOL] = false
     }
 
     const setupDevBundlerSpan = opts.startServerSpan

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -122,6 +122,7 @@ export type ServerFields = {
     typeof import('./filesystem').buildCustomRoute
   >[]
   setAppIsrStatus?: (key: string, value: false | number | null) => void
+  resetFetch?: () => void
 }
 
 async function verifyTypeScript(opts: SetupOpts) {
@@ -181,8 +182,13 @@ async function startWatcher(opts: SetupOpts) {
     logging: nextConfig.logging !== false,
   })
 
+  const originalFetch = global.fetch
+  const resetFetch = () => {
+    global.fetch = originalFetch
+  }
+
   const hotReloader: NextJsHotReloaderInterface = opts.turbo
-    ? await createHotReloaderTurbopack(opts, serverFields, distDir)
+    ? await createHotReloaderTurbopack(opts, serverFields, distDir, resetFetch)
     : new HotReloaderWebpack(opts.dir, {
         appDir,
         pagesDir,
@@ -193,6 +199,7 @@ async function startWatcher(opts: SetupOpts) {
         telemetry: opts.telemetry,
         rewrites: opts.fsChecker.rewrites,
         previewProps: opts.fsChecker.prerenderManifest.preview,
+        resetFetch: resetFetch,
       })
 
   await hotReloader.start()

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -89,6 +89,7 @@ import { normalizeMetadataPageToRoute } from '../../../lib/metadata/get-metadata
 import { createEnvDefinitions } from '../experimental/create-env-definitions'
 import { JsConfigPathsPlugin } from '../../../build/webpack/plugins/jsconfig-paths-plugin'
 import { store as consoleStore } from '../../../build/output/store'
+import { NEXT_PATCH_SYMBOL } from '../patch-fetch'
 
 export type SetupOpts = {
   renderServer: LazyRenderServerInstance
@@ -185,6 +186,8 @@ async function startWatcher(opts: SetupOpts) {
   const originalFetch = global.fetch
   const resetFetch = () => {
     global.fetch = originalFetch
+    // @ts-ignore
+    global[NEXT_PATCH_SYMBOL] = false
   }
 
   const hotReloader: NextJsHotReloaderInterface = opts.turbo

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -89,7 +89,6 @@ import { normalizeMetadataPageToRoute } from '../../../lib/metadata/get-metadata
 import { createEnvDefinitions } from '../experimental/create-env-definitions'
 import { JsConfigPathsPlugin } from '../../../build/webpack/plugins/jsconfig-paths-plugin'
 import { store as consoleStore } from '../../../build/output/store'
-import { NEXT_PATCH_SYMBOL } from '../patch-fetch'
 
 export type SetupOpts = {
   renderServer: LazyRenderServerInstance
@@ -105,6 +104,7 @@ export type SetupOpts = {
   nextConfig: NextConfigComplete
   port: number
   onCleanup: (listener: () => Promise<void>) => void
+  resetFetch: () => void
 }
 
 export type ServerFields = {
@@ -154,7 +154,7 @@ export async function propagateServerField(
 }
 
 async function startWatcher(opts: SetupOpts) {
-  const { nextConfig, appDir, pagesDir, dir } = opts
+  const { nextConfig, appDir, pagesDir, dir, resetFetch } = opts
   const { useFileSystemPublicRoutes } = nextConfig
   const usingTypeScript = await verifyTypeScript(opts)
 
@@ -183,13 +183,6 @@ async function startWatcher(opts: SetupOpts) {
     logging: nextConfig.logging !== false,
   })
 
-  const originalFetch = global.fetch
-  const resetFetch = () => {
-    global.fetch = originalFetch
-    // @ts-ignore
-    global[NEXT_PATCH_SYMBOL] = false
-  }
-
   const hotReloader: NextJsHotReloaderInterface = opts.turbo
     ? await createHotReloaderTurbopack(opts, serverFields, distDir, resetFetch)
     : new HotReloaderWebpack(opts.dir, {
@@ -202,7 +195,7 @@ async function startWatcher(opts: SetupOpts) {
         telemetry: opts.telemetry,
         rewrites: opts.fsChecker.rewrites,
         previewProps: opts.fsChecker.prerenderManifest.preview,
-        resetFetch: resetFetch,
+        resetFetch,
       })
 
   await hotReloader.start()

--- a/test/development/app-dir/dev-fetch-hmr/app/layout.tsx
+++ b/test/development/app-dir/dev-fetch-hmr/app/layout.tsx
@@ -4,25 +4,17 @@ import { ReactNode } from 'react'
 const magicNumber = Math.random()
 const originalFetch = globalThis.fetch
 
-console.log('monkey patching fetch')
-
-// @ts-ignore
 globalThis.fetch = async (
   resource: URL | RequestInfo,
   options?: RequestInit
 ) => {
-  let url: string
-  if (typeof resource === 'string') {
-    url = resource
-  } else {
-    url = resource instanceof URL ? resource.href : resource.url
-  }
+  const request = new Request(resource)
 
-  if (url === 'http://fake.url/secret') {
+  if (request.url === 'http://fake.url/secret') {
     return new Response('monkey patching is fun')
   }
 
-  if (url === 'http://fake.url/magic-number') {
+  if (request.url === 'http://fake.url/magic-number') {
     return new Response(magicNumber.toString())
   }
 

--- a/test/development/app-dir/dev-fetch-hmr/app/layout.tsx
+++ b/test/development/app-dir/dev-fetch-hmr/app/layout.tsx
@@ -4,6 +4,8 @@ import { ReactNode } from 'react'
 const magicNumber = Math.random()
 const originalFetch = globalThis.fetch
 
+console.log('monkey patching fetch')
+
 // @ts-ignore
 globalThis.fetch = async (
   resource: URL | RequestInfo,
@@ -16,12 +18,12 @@ globalThis.fetch = async (
     url = resource instanceof URL ? resource.href : resource.url
   }
 
-  if (url === 'secret') {
-    return 'monkey patching is fun'
+  if (url === 'http://fake.url/secret') {
+    return new Response('monkey patching is fun')
   }
 
-  if (url === 'magic-number') {
-    return magicNumber
+  if (url === 'http://fake.url/magic-number') {
+    return new Response(magicNumber.toString())
   }
 
   return originalFetch(resource, options)

--- a/test/development/app-dir/dev-fetch-hmr/app/layout.tsx
+++ b/test/development/app-dir/dev-fetch-hmr/app/layout.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { ReactNode } from 'react'
+
+const magicNumber = Math.random()
+const originalFetch = globalThis.fetch
+
+// @ts-ignore
+globalThis.fetch = async (
+  resource: URL | RequestInfo,
+  options?: RequestInit
+) => {
+  let url: string
+  if (typeof resource === 'string') {
+    url = resource
+  } else {
+    url = resource instanceof URL ? resource.href : resource.url
+  }
+
+  if (url === 'secret') {
+    return 'monkey patching is fun'
+  }
+
+  if (url === 'magic-number') {
+    return magicNumber
+  }
+
+  return originalFetch(resource, options)
+}
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/dev-fetch-hmr/app/layout.tsx
+++ b/test/development/app-dir/dev-fetch-hmr/app/layout.tsx
@@ -4,10 +4,16 @@ import { ReactNode } from 'react'
 const magicNumber = Math.random()
 const originalFetch = globalThis.fetch
 
-globalThis.fetch = async (
+if (originalFetch.name === 'monkeyPatchedFetch') {
+  throw new Error(
+    'Patching over already patched fetch. This creates a memory leak.'
+  )
+}
+
+globalThis.fetch = async function monkeyPatchedFetch(
   resource: URL | RequestInfo,
   options?: RequestInit
-) => {
+) {
   const request = new Request(resource)
 
   if (request.url === 'http://fake.url/secret') {

--- a/test/development/app-dir/dev-fetch-hmr/app/page.tsx
+++ b/test/development/app-dir/dev-fetch-hmr/app/page.tsx
@@ -1,0 +1,11 @@
+export default async function Page() {
+  // touch to trigger HMR
+  const secret = (await fetch('secret')) as any
+  const magicNumber = (await fetch('magic-number')) as any
+  return (
+    <>
+      <div id="secret">{secret}</div>
+      <div id="magic-number">{magicNumber}</div>
+    </>
+  )
+}

--- a/test/development/app-dir/dev-fetch-hmr/app/page.tsx
+++ b/test/development/app-dir/dev-fetch-hmr/app/page.tsx
@@ -1,7 +1,12 @@
 export default async function Page() {
   // touch to trigger HMR
-  const secret = (await fetch('secret')) as any
-  const magicNumber = (await fetch('magic-number')) as any
+  const secret = (await fetch('http://fake.url/secret').then((res) =>
+    res.text()
+  )) as any
+  const magicNumber = (await fetch('http://fake.url/magic-number').then((res) =>
+    res.text()
+  )) as any
+
   return (
     <>
       <div id="secret">{secret}</div>

--- a/test/development/app-dir/dev-fetch-hmr/app/page.tsx
+++ b/test/development/app-dir/dev-fetch-hmr/app/page.tsx
@@ -1,5 +1,4 @@
 export default async function Page() {
-  // touch to trigger HMR
   const secret = (await fetch('http://fake.url/secret').then((res) =>
     res.text()
   )) as any
@@ -9,6 +8,7 @@ export default async function Page() {
 
   return (
     <>
+      <div id="update">touch to trigger HMR</div>
       <div id="secret">{secret}</div>
       <div id="magic-number">{magicNumber}</div>
     </>

--- a/test/development/app-dir/dev-fetch-hmr/dev-fetch-hmr.test.ts
+++ b/test/development/app-dir/dev-fetch-hmr/dev-fetch-hmr.test.ts
@@ -1,0 +1,34 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+import cheerio from 'cheerio'
+
+describe('dev-fetch-hmr', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should retain module level fetch patching', async () => {
+    const html = await next.render('/')
+    expect(html).toContain('monkey patching is fun')
+
+    const magicNumber = cheerio.load(html)('#magic-number').text()
+
+    const html2 = await next.render('/')
+    expect(html2).toContain('monkey patching is fun')
+    const magicNumber2 = cheerio.load(html2)('#magic-number').text()
+    expect(magicNumber).toBe(magicNumber2)
+
+    // trigger HMR
+    await next.patchFile('app/page.tsx', (content) =>
+      content.replace('touch to trigger HMR', 'touch to trigger HMR 2')
+    )
+
+    await retry(async () => {
+      const html3 = await next.render('/')
+      const magicNumber3 = cheerio.load(html3)('#magic-number').text()
+      expect(html3).toContain('monkey patching is fun')
+      expect(magicNumber).not.toEqual(magicNumber3)
+    })
+  })
+})

--- a/test/development/app-dir/dev-fetch-hmr/dev-fetch-hmr.test.ts
+++ b/test/development/app-dir/dev-fetch-hmr/dev-fetch-hmr.test.ts
@@ -17,7 +17,10 @@ describe('dev-fetch-hmr', () => {
     const html2 = await next.render('/')
     expect(html2).toContain('monkey patching is fun')
     const magicNumber2 = cheerio.load(html2)('#magic-number').text()
-    expect(magicNumber).toBe(magicNumber2)
+    // Module was not re-evaluated
+    expect(magicNumber2).toBe(magicNumber)
+    const update = cheerio.load(html2)('#update').text()
+    expect(update).toBe('touch to trigger HMR')
 
     // trigger HMR
     await next.patchFile('app/page.tsx', (content) =>
@@ -26,9 +29,12 @@ describe('dev-fetch-hmr', () => {
 
     await retry(async () => {
       const html3 = await next.render('/')
+      const update2 = cheerio.load(html3)('#update').text()
+      expect(update2).toBe('touch to trigger HMR 2')
       const magicNumber3 = cheerio.load(html3)('#magic-number').text()
       expect(html3).toContain('monkey patching is fun')
-      expect(magicNumber).not.toEqual(magicNumber3)
+      // Module was re-evaluated
+      expect(magicNumber3).not.toEqual(magicNumber)
     })
   })
 })

--- a/test/development/app-dir/dev-fetch-hmr/next.config.js
+++ b/test/development/app-dir/dev-fetch-hmr/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/development/app-dir/dev-fetch-hmr/tsconfig.json
+++ b/test/development/app-dir/dev-fetch-hmr/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors


### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

## This PR

In this PR, I update the fetch patching logic that restores the original fetch during development after a request to only happen when a server components gets actually reloaded.

This also makes the fetch patching check more lax so that other users can patch fetch if they want to (seems fair 💀).

## Context 

- In #43859, I added some logic to restore the original fetch after handling a request during development. I did this because when a server component gets modified in dev, we nuke the require cache to be able to re-instantiate the newly modified component in a fresh environment (temu fast refresh).  The problem I found at the time was that we would keep applying the fetch patch on top of the other, leading to the memory of the original fetch environment being retained by the newly patched fetch, which led to huge memory problems.
- MSW is a library that helps people easily mock network requests via patching fetch on the server or using a server worker in the browser

## Why

I was investigating how we could make MSW work better with @kettanaito and I wrote a quick example of initialising MSW at the top level of a layout in order to intercept fetch calls. 

Nothing complicated, just this: 
```
if (process.env.NEXT_RUNTIME === 'nodejs') {
  const { server } = require('../mocks/node')
  server.listen()
}
```

Turns out, this breaks on a second page load because the MSW patching gets undone, even though we have not modified the file itself, which is slightly problematic.

I fixed this by changing the timing, but I also realised testing it that any fetch patch that remained would still get overridden by a check in `patch-fetch.ts` where we verify via a special property that we patched fetch correctly. If you patch fetch on top of that, it breaks because on the second render, we'd patch again.

As a result, I also changed the `isPatched` check to be a global check that should only be invalidated during dev HMR

## test plan

- wrote a simple test that checks that patching is doable
- verified manually that the fetch still does not leak

