### PR TITLE
Enable global optimizations by building all endpoints in a single project.buildGlobal call (next build)

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -12,7 +12,7 @@ use next_api::{
         DefineEnv, DraftModeOptions, Instrumentation, Middleware, PartialProjectOptions, Project,
         ProjectContainer, ProjectOptions,
     },
-    route::{Endpoint, Route, WrittenEndpoint},
+    route::{Endpoint, Route},
 };
 use next_core::tracing_presets::{
     TRACING_NEXT_OVERVIEW_TARGETS, TRACING_NEXT_TARGETS, TRACING_NEXT_TURBOPACK_TARGETS,
@@ -49,9 +49,9 @@ use url::Url;
 
 use super::{
     endpoint::{
-        get_written_endpoint_with_issues, AnnotatedWrittenRoute, ExternalEndpoint,
-        NapiAnnotatedWrittenRoute, NapiWrittenEndpoint, NapiWrittenGlobalEndpoints,
-        WrittenEndpointWithIssues,
+        get_written_endpoint_with_issues, AnnotatedWrittenRouteWithIssues, ExternalEndpoint,
+        NapiAnnotatedWrittenRouteWithIssues, NapiWrittenEndpointWithIssues,
+        NapiWrittenGlobalEndpoints,
     },
     utils::{
         get_diagnostics, get_issues, subscribe, NapiDiagnostic, NapiIssue, RootTask,
@@ -1092,24 +1092,21 @@ pub async fn project_trace_source(
 #[napi]
 pub async fn project_build_global(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
-) -> napi::Result<TurbopackResult<NapiWrittenGlobalEndpoints>> {
+) -> napi::Result<NapiWrittenGlobalEndpoints> {
     let container = project.container;
     let turbo_tasks = project.turbo_tasks.clone();
 
     let (
-        annotated_written_routes,
-        app_endpoint,
-        document_endpoint,
-        error_endpoint,
-        issues_global,
-        diagnostics_global,
+        annotated_written_routes_with_issues,
+        app_endpoint_with_issues,
+        document_endpoint_with_issues,
+        error_endpoint_with_issues,
     ) = turbo_tasks
         .run_once(async move {
             let entrypoints = container.entrypoints().await?;
 
-            let mut annotated_written_routes: Vec<AnnotatedWrittenRoute> = vec![];
-            let mut issues_global = vec![];
-            let mut diagnostics_global = vec![];
+            let mut annotated_written_routes_with_issues: Vec<AnnotatedWrittenRouteWithIssues> =
+                vec![];
 
             for (path, route) in entrypoints.routes.iter() {
                 match route {
@@ -1117,145 +1114,110 @@ pub async fn project_build_global(
                         ref html_endpoint,
                         data_endpoint: _,
                     } => {
-                        let WrittenEndpointWithIssues {
-                            written,
-                            issues,
-                            diagnostics,
-                        } = &*get_written_endpoint_with_issues(*html_endpoint)
-                            .strongly_consistent()
-                            .await?;
-                        annotated_written_routes.push(AnnotatedWrittenRoute {
-                            written_route: written.clone_value(),
-                            route_type: "page".to_string(),
-                            page: path.to_string(),
-                        });
-                        issues_global.extend(issues.iter().cloned());
-                        diagnostics_global.extend(diagnostics.iter().cloned());
+                        let written_endpoint_with_issues =
+                            &*get_written_endpoint_with_issues(*html_endpoint)
+                                .strongly_consistent()
+                                .await?;
+                        annotated_written_routes_with_issues.push(
+                            AnnotatedWrittenRouteWithIssues {
+                                written_route_with_issues: written_endpoint_with_issues.clone(),
+                                route_type: "page".to_string(),
+                                page: path.to_string(),
+                            },
+                        );
                     }
                     Route::PageApi { ref endpoint } => {
-                        let WrittenEndpointWithIssues {
-                            written,
-                            issues,
-                            diagnostics,
-                        } = &*get_written_endpoint_with_issues(*endpoint)
-                            .strongly_consistent()
-                            .await?;
-                        annotated_written_routes.push(AnnotatedWrittenRoute {
-                            written_route: written.clone_value(),
-                            route_type: "page-api".to_string(),
-                            page: path.to_string(),
-                        });
-                        issues_global.extend(issues.iter().cloned());
-                        diagnostics_global.extend(diagnostics.iter().cloned());
+                        let written_endpoint_with_issues =
+                            &*get_written_endpoint_with_issues(*endpoint)
+                                .strongly_consistent()
+                                .await?;
+                        annotated_written_routes_with_issues.push(
+                            AnnotatedWrittenRouteWithIssues {
+                                written_route_with_issues: written_endpoint_with_issues.clone(),
+                                route_type: "page-api".to_string(),
+                                page: path.to_string(),
+                            },
+                        );
                     }
                     Route::AppPage(routes) => {
                         // TODO: Look at this... probably have to ask
                         for module in routes {
                             let html_endpoint: Vc<Box<dyn Endpoint>> = module.html_endpoint;
-                            let WrittenEndpointWithIssues {
-                                written,
-                                issues,
-                                diagnostics,
-                            } = &*get_written_endpoint_with_issues(html_endpoint)
-                                .strongly_consistent()
-                                .await?;
-                            annotated_written_routes.push(AnnotatedWrittenRoute {
-                                written_route: written.clone_value(),
-                                route_type: "app-page".to_string(),
-                                page: module.original_name.to_string(),
-                            });
-                            issues_global.extend(issues.iter().cloned());
-                            diagnostics_global.extend(diagnostics.iter().cloned());
+                            let written_endpoint_with_issues =
+                                &*get_written_endpoint_with_issues(html_endpoint)
+                                    .strongly_consistent()
+                                    .await?;
+                            annotated_written_routes_with_issues.push(
+                                AnnotatedWrittenRouteWithIssues {
+                                    written_route_with_issues: written_endpoint_with_issues.clone(),
+                                    route_type: "app-page".to_string(),
+                                    page: module.original_name.to_string(),
+                                },
+                            );
                         }
                     }
                     Route::AppRoute {
                         original_name,
                         ref endpoint,
                     } => {
-                        let WrittenEndpointWithIssues {
-                            written,
-                            issues,
-                            diagnostics,
-                        } = &*get_written_endpoint_with_issues(*endpoint)
-                            .strongly_consistent()
-                            .await?;
-                        annotated_written_routes.push(AnnotatedWrittenRoute {
-                            written_route: written.clone_value(),
-                            route_type: "app-route".to_string(),
-                            page: original_name.to_string(),
-                        });
-                        issues_global.extend(issues.iter().cloned());
-                        diagnostics_global.extend(diagnostics.iter().cloned());
+                        let written_endpoint_with_issues =
+                            &*get_written_endpoint_with_issues(*endpoint)
+                                .strongly_consistent()
+                                .await?;
+                        annotated_written_routes_with_issues.push(
+                            AnnotatedWrittenRouteWithIssues {
+                                written_route_with_issues: written_endpoint_with_issues.clone(),
+                                route_type: "app-route".to_string(),
+                                page: original_name.to_string(),
+                            },
+                        );
                     }
                     Route::Conflict => {}
                 };
             }
 
-            let WrittenEndpointWithIssues {
-                written: app_endpoint,
-                issues: issues_global_app,
-                diagnostics: diagnostics_global_app,
-            } = &*get_written_endpoint_with_issues(entrypoints.pages_app_endpoint)
-                .strongly_consistent()
-                .await?;
-            issues_global.extend(issues_global_app.iter().cloned());
-            diagnostics_global.extend(diagnostics_global_app.iter().cloned());
+            let app_endpoint_with_issues =
+                &*get_written_endpoint_with_issues(entrypoints.pages_app_endpoint)
+                    .strongly_consistent()
+                    .await?;
 
-            let WrittenEndpointWithIssues {
-                written: document_endpoint,
-                issues: issues_global_document,
-                diagnostics: diagnostics_global_document,
-            } = &*get_written_endpoint_with_issues(entrypoints.pages_document_endpoint)
-                .strongly_consistent()
-                .await?;
-            issues_global.extend(issues_global_document.iter().cloned());
-            diagnostics_global.extend(diagnostics_global_document.iter().cloned());
+            let document_endpoint_with_issues =
+                &*get_written_endpoint_with_issues(entrypoints.pages_document_endpoint)
+                    .strongly_consistent()
+                    .await?;
 
-            let WrittenEndpointWithIssues {
-                written: error_endpoint,
-                issues: issues_global_error,
-                diagnostics: diagnostics_global_error,
-            } = &*get_written_endpoint_with_issues(entrypoints.pages_error_endpoint)
-                .strongly_consistent()
-                .await?;
-            issues_global.extend(issues_global_error.iter().cloned());
-            diagnostics_global.extend(diagnostics_global_error.iter().cloned());
+            let error_endpoint_with_issues =
+                &*get_written_endpoint_with_issues(entrypoints.pages_error_endpoint)
+                    .strongly_consistent()
+                    .await?;
 
             Ok((
-                annotated_written_routes,
-                app_endpoint.clone(),
-                document_endpoint.clone(),
-                error_endpoint.clone(),
-                issues_global,
-                diagnostics_global,
+                annotated_written_routes_with_issues,
+                app_endpoint_with_issues.clone(),
+                document_endpoint_with_issues.clone(),
+                error_endpoint_with_issues.clone(),
             ))
         })
         .await
         .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))?;
 
     let napi_written_global_endpoints = NapiWrittenGlobalEndpoints {
-        annotated_written_routes: annotated_written_routes
+        annotated_written_routes: annotated_written_routes_with_issues
             .iter()
-            .map(|annotated_written_route| {
-                NapiAnnotatedWrittenRoute::from(annotated_written_route.to_owned())
+            .map(|annotated_written_route_with_issues| {
+                NapiAnnotatedWrittenRouteWithIssues::from(
+                    annotated_written_route_with_issues.to_owned(),
+                )
             })
             .collect(),
-        app_endpoint: NapiWrittenEndpoint::from(app_endpoint.clone_value()),
-        document_endpoint: NapiWrittenEndpoint::from(document_endpoint.clone_value()),
-        error_endpoint: NapiWrittenEndpoint::from(error_endpoint.clone_value()),
+        app_endpoint: NapiWrittenEndpointWithIssues::from(app_endpoint_with_issues.clone()),
+        document_endpoint: NapiWrittenEndpointWithIssues::from(
+            document_endpoint_with_issues.clone(),
+        ),
+        error_endpoint: NapiWrittenEndpointWithIssues::from(error_endpoint_with_issues.clone()),
     };
 
-    Ok(TurbopackResult {
-        result: napi_written_global_endpoints,
-        issues: issues_global
-            .iter()
-            .map(|i| NapiIssue::from(&**i))
-            .collect(),
-        diagnostics: diagnostics_global
-            .iter()
-            .map(|d| NapiDiagnostic::from(d))
-            .collect(),
-    })
+    Ok(napi_written_global_endpoints)
 }
 
 #[napi]

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -669,7 +669,7 @@ export interface Project {
     TurbopackResult<HmrIdentifiers>
   >
 
-  buildGlobal(): Promise<TurbopackResult<WrittenGlobalEndpoints>>
+  buildGlobal(): Promise<WrittenGlobalEndpoints>
 
   getSourceForAsset(filePath: string): Promise<string | null>
 
@@ -773,15 +773,21 @@ export type WrittenEndpoint =
       config: EndpointConfig
     }
 
+export type WrittenEndpointWithIssues = {
+  writtenEndpoint: WrittenEndpoint
+  issues: Issue[]
+  diagnostics: Diagnostics[]
+}
+
 export type WrittenGlobalEndpoints = {
   annotatedWrittenRoutes: {
-    writtenRoute: WrittenEndpoint
+    writtenRouteWithIssues: WrittenEndpointWithIssues
     routeType: string
     page: string
   }[]
-  appEndpoint: WrittenEndpoint
-  documentEndpoint: WrittenEndpoint
-  errorEndpoint: WrittenEndpoint
+  appEndpoint: WrittenEndpointWithIssues
+  documentEndpoint: WrittenEndpointWithIssues
+  errorEndpoint: WrittenEndpointWithIssues
 }
 
 function rustifyEnv(env: Record<string, string>): RustifiedEnv {

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -669,6 +669,8 @@ export interface Project {
     TurbopackResult<HmrIdentifiers>
   >
 
+  buildGlobal(): Promise<TurbopackResult<WrittenGlobalEndpoints>>
+
   getSourceForAsset(filePath: string): Promise<string | null>
 
   traceSource(
@@ -770,6 +772,17 @@ export type WrittenEndpoint =
       serverPaths: ServerPath[]
       config: EndpointConfig
     }
+
+export type WrittenGlobalEndpoints = {
+  annotatedWrittenRoutes: {
+    writtenRoute: WrittenEndpoint
+    routeType: string
+    page: string
+  }[]
+  appEndpoint: WrittenEndpoint
+  documentEndpoint: WrittenEndpoint
+  errorEndpoint: WrittenEndpoint
+}
 
 function rustifyEnv(env: Record<string, string>): RustifiedEnv {
   return Object.entries(env)
@@ -1069,6 +1082,9 @@ function bindingToApi(
         async (callback) =>
           binding.projectHmrIdentifiersSubscribe(this._nativeProject, callback)
       )
+    }
+    buildGlobal(): Promise<TurbopackResult<WrittenGlobalEndpoints>> {
+      return binding.projectBuildGlobal(this._nativeProject)
     }
 
     traceSource(

--- a/packages/next/src/build/turbopack-utils.ts
+++ b/packages/next/src/build/turbopack-utils.ts
@@ -1,38 +1,72 @@
 import type { CustomRoutes } from '../lib/load-custom-routes'
-import {} from '../server/dev/turbopack-utils'
+import {
+  processIssues,
+  type EntryIssuesMap,
+} from '../server/dev/turbopack-utils'
 import { getEntryKey } from '../server/dev/turbopack/entry-key'
 import type { TurbopackManifestLoader } from '../server/dev/turbopack/manifest-loader'
 import type { Entrypoints } from '../server/dev/turbopack/types'
 import type { SetupOpts } from '../server/lib/router-utils/setup-dev-bundler'
-import type { WrittenEndpoint } from './swc'
+import type { WrittenEndpointWithIssues } from './swc'
 
 export async function handleRouteType({
   page,
   writtenEndpoint,
   routeType,
+  globalAppEndpoint,
+  globalDocumentEndpoint,
+  currentEntryIssues,
   entrypoints,
   manifestLoader,
   devRewrites,
   productionRewrites,
+  logErrors,
 }: {
   page: string
-  writtenEndpoint: WrittenEndpoint
+  writtenEndpoint: WrittenEndpointWithIssues
   routeType: string
+  globalAppEndpoint: WrittenEndpointWithIssues
+  globalDocumentEndpoint: WrittenEndpointWithIssues
+  currentEntryIssues: EntryIssuesMap
   entrypoints: Entrypoints
   manifestLoader: TurbopackManifestLoader
   devRewrites: SetupOpts['fsChecker']['rewrites'] | undefined
   productionRewrites: CustomRoutes['rewrites'] | undefined
+  logErrors: boolean
 }) {
   switch (routeType) {
     case 'page': {
       const serverKey = getEntryKey('pages', 'server', page)
 
       try {
+        if (entrypoints.global.app) {
+          const key = getEntryKey('pages', 'server', '_app')
+
+          processIssues(
+            currentEntryIssues,
+            key,
+            globalAppEndpoint,
+            false,
+            logErrors
+          )
+        }
         await manifestLoader.loadBuildManifest('_app')
         await manifestLoader.loadPagesManifest('_app')
+
+        if (entrypoints.global.document) {
+          const key = getEntryKey('pages', 'server', '_document')
+
+          processIssues(
+            currentEntryIssues,
+            key,
+            globalDocumentEndpoint,
+            false,
+            logErrors
+          )
+        }
         await manifestLoader.loadPagesManifest('_document')
 
-        const type = writtenEndpoint?.type
+        const type = writtenEndpoint?.writtenEndpoint.type
 
         await manifestLoader.loadBuildManifest(page)
         await manifestLoader.loadPagesManifest(page)
@@ -50,6 +84,14 @@ export async function handleRouteType({
           productionRewrites,
           entrypoints,
         })
+
+        processIssues(
+          currentEntryIssues,
+          serverKey,
+          writtenEndpoint,
+          false,
+          logErrors
+        )
       } finally {
       }
 
@@ -58,7 +100,7 @@ export async function handleRouteType({
     case 'page-api': {
       const key = getEntryKey('pages', 'server', page)
 
-      const type = writtenEndpoint?.type
+      const type = writtenEndpoint?.writtenEndpoint.type
 
       await manifestLoader.loadPagesManifest(page)
       if (type === 'edge') {
@@ -73,12 +115,15 @@ export async function handleRouteType({
         productionRewrites,
         entrypoints,
       })
+
+      processIssues(currentEntryIssues, key, writtenEndpoint, true, logErrors)
+
       break
     }
     case 'app-page': {
       const key = getEntryKey('app', 'server', page)
 
-      const type = writtenEndpoint?.type
+      const type = writtenEndpoint?.writtenEndpoint.type
 
       if (type === 'edge') {
         await manifestLoader.loadMiddlewareManifest(page, 'app')
@@ -98,12 +143,14 @@ export async function handleRouteType({
         entrypoints,
       })
 
+      processIssues(currentEntryIssues, key, writtenEndpoint, false, logErrors)
+
       break
     }
     case 'app-route': {
       const key = getEntryKey('app', 'server', page)
 
-      const type = writtenEndpoint?.type
+      const type = writtenEndpoint?.writtenEndpoint.type
 
       await manifestLoader.loadAppPathsManifest(page)
 
@@ -118,6 +165,7 @@ export async function handleRouteType({
         productionRewrites,
         entrypoints,
       })
+      processIssues(currentEntryIssues, key, writtenEndpoint, true, logErrors)
 
       break
     }
@@ -128,20 +176,61 @@ export async function handleRouteType({
 }
 
 export async function handlePagesErrorRoute({
+  globalAppEndpoint,
+  globalDocumentEndpoint,
+  globalErrorEndpoint,
+  currentEntryIssues,
   entrypoints,
   manifestLoader,
   devRewrites,
   productionRewrites,
+  logErrors,
 }: {
+  globalAppEndpoint: WrittenEndpointWithIssues
+  globalDocumentEndpoint: WrittenEndpointWithIssues
+  globalErrorEndpoint: WrittenEndpointWithIssues
+  currentEntryIssues: EntryIssuesMap
   entrypoints: Entrypoints
   manifestLoader: TurbopackManifestLoader
   devRewrites: SetupOpts['fsChecker']['rewrites'] | undefined
   productionRewrites: CustomRoutes['rewrites'] | undefined
+  logErrors: boolean
 }) {
+  if (entrypoints.global.app) {
+    const key = getEntryKey('pages', 'server', '_app')
+
+    processIssues(currentEntryIssues, key, globalAppEndpoint, false, logErrors)
+  }
+
   await manifestLoader.loadBuildManifest('_app')
   await manifestLoader.loadPagesManifest('_app')
   await manifestLoader.loadFontManifest('_app')
+
+  if (entrypoints.global.document) {
+    const key = getEntryKey('pages', 'server', '_document')
+
+    processIssues(
+      currentEntryIssues,
+      key,
+      globalDocumentEndpoint,
+      false,
+      logErrors
+    )
+  }
+
   await manifestLoader.loadPagesManifest('_document')
+
+  if (entrypoints.global.error) {
+    const key = getEntryKey('pages', 'server', '_error')
+
+    processIssues(
+      currentEntryIssues,
+      key,
+      globalErrorEndpoint,
+      false,
+      logErrors
+    )
+  }
   await manifestLoader.loadBuildManifest('_error')
   await manifestLoader.loadPagesManifest('_error')
   await manifestLoader.loadFontManifest('_error')

--- a/packages/next/src/build/turbopack-utils.ts
+++ b/packages/next/src/build/turbopack-utils.ts
@@ -1,0 +1,154 @@
+import type { CustomRoutes } from '../lib/load-custom-routes'
+import {} from '../server/dev/turbopack-utils'
+import { getEntryKey } from '../server/dev/turbopack/entry-key'
+import type { TurbopackManifestLoader } from '../server/dev/turbopack/manifest-loader'
+import type { Entrypoints } from '../server/dev/turbopack/types'
+import type { SetupOpts } from '../server/lib/router-utils/setup-dev-bundler'
+import type { WrittenEndpoint } from './swc'
+
+export async function handleRouteType({
+  page,
+  writtenEndpoint,
+  routeType,
+  entrypoints,
+  manifestLoader,
+  devRewrites,
+  productionRewrites,
+}: {
+  page: string
+  writtenEndpoint: WrittenEndpoint
+  routeType: string
+  entrypoints: Entrypoints
+  manifestLoader: TurbopackManifestLoader
+  devRewrites: SetupOpts['fsChecker']['rewrites'] | undefined
+  productionRewrites: CustomRoutes['rewrites'] | undefined
+}) {
+  switch (routeType) {
+    case 'page': {
+      const serverKey = getEntryKey('pages', 'server', page)
+
+      try {
+        await manifestLoader.loadBuildManifest('_app')
+        await manifestLoader.loadPagesManifest('_app')
+        await manifestLoader.loadPagesManifest('_document')
+
+        const type = writtenEndpoint?.type
+
+        await manifestLoader.loadBuildManifest(page)
+        await manifestLoader.loadPagesManifest(page)
+        if (type === 'edge') {
+          await manifestLoader.loadMiddlewareManifest(page, 'pages')
+        } else {
+          manifestLoader.deleteMiddlewareManifest(serverKey)
+        }
+        await manifestLoader.loadFontManifest('/_app', 'pages')
+        await manifestLoader.loadFontManifest(page, 'pages')
+        await manifestLoader.loadLoadableManifest(page, 'pages')
+
+        await manifestLoader.writeManifests({
+          devRewrites,
+          productionRewrites,
+          entrypoints,
+        })
+      } finally {
+      }
+
+      break
+    }
+    case 'page-api': {
+      const key = getEntryKey('pages', 'server', page)
+
+      const type = writtenEndpoint?.type
+
+      await manifestLoader.loadPagesManifest(page)
+      if (type === 'edge') {
+        await manifestLoader.loadMiddlewareManifest(page, 'pages')
+      } else {
+        manifestLoader.deleteMiddlewareManifest(key)
+      }
+      await manifestLoader.loadLoadableManifest(page, 'pages')
+
+      await manifestLoader.writeManifests({
+        devRewrites,
+        productionRewrites,
+        entrypoints,
+      })
+      break
+    }
+    case 'app-page': {
+      const key = getEntryKey('app', 'server', page)
+
+      const type = writtenEndpoint?.type
+
+      if (type === 'edge') {
+        await manifestLoader.loadMiddlewareManifest(page, 'app')
+      } else {
+        manifestLoader.deleteMiddlewareManifest(key)
+      }
+
+      await manifestLoader.loadAppBuildManifest(page)
+      await manifestLoader.loadBuildManifest(page, 'app')
+      await manifestLoader.loadAppPathsManifest(page)
+      await manifestLoader.loadActionManifest(page)
+      await manifestLoader.loadLoadableManifest(page, 'app')
+      await manifestLoader.loadFontManifest(page, 'app')
+      await manifestLoader.writeManifests({
+        devRewrites,
+        productionRewrites,
+        entrypoints,
+      })
+
+      break
+    }
+    case 'app-route': {
+      const key = getEntryKey('app', 'server', page)
+
+      const type = writtenEndpoint?.type
+
+      await manifestLoader.loadAppPathsManifest(page)
+
+      if (type === 'edge') {
+        await manifestLoader.loadMiddlewareManifest(page, 'app')
+      } else {
+        manifestLoader.deleteMiddlewareManifest(key)
+      }
+
+      await manifestLoader.writeManifests({
+        devRewrites,
+        productionRewrites,
+        entrypoints,
+      })
+
+      break
+    }
+    default: {
+      throw new Error(`unknown route type ${routeType} for ${page}`)
+    }
+  }
+}
+
+export async function handlePagesErrorRoute({
+  entrypoints,
+  manifestLoader,
+  devRewrites,
+  productionRewrites,
+}: {
+  entrypoints: Entrypoints
+  manifestLoader: TurbopackManifestLoader
+  devRewrites: SetupOpts['fsChecker']['rewrites'] | undefined
+  productionRewrites: CustomRoutes['rewrites'] | undefined
+}) {
+  await manifestLoader.loadBuildManifest('_app')
+  await manifestLoader.loadPagesManifest('_app')
+  await manifestLoader.loadFontManifest('_app')
+  await manifestLoader.loadPagesManifest('_document')
+  await manifestLoader.loadBuildManifest('_error')
+  await manifestLoader.loadPagesManifest('_error')
+  await manifestLoader.loadFontManifest('_error')
+
+  await manifestLoader.writeManifests({
+    devRewrites,
+    productionRewrites,
+    entrypoints,
+  })
+}


### PR DESCRIPTION
### What?
Introduced the `project.buildGlobal()` binding (`project_build_global` in Rust) to use in production builds, which constructs and writes to disk all endpoints in one call, allowing for global optimizations.

### Why?
For global optimizations (e.g. module ids) to be performed, global information needs to be constructed before writing endpoints to disk. This is not possible in the current architecture of production builds, where `write_to_disk` is individually called for each endpoint from Node.

### How?
- Introduced `project_build_global`.
- Added a `turbopack-utils.ts` file to `next.js/packages/next/src/build/`, with modified versions of `handleRouteType` and `handlePagesErrorRoute` specific for production builds. The main difference w.r.t. their development counterparts is that they take the written endpoint as a parameter instead of writing it themselves.

### Notes
`project_build_global` currently calls `write_to_disk` for all routes and the app, document and error endopints. Should this method also build the middleware and instrumentation endpoints? Or should leave their construction as is now (built by `handleEntrypoints`, called a few lines before building the rest of the endpoints). It would depend on whether we will perform global optimizations in middleware and instrumentation endpoints, I guess.
