### PR TITLE
Turbopack: Implement HMR for module-scoped environment variable changes

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -157,6 +157,7 @@ export async function createHotReloaderTurbopack(
   opts.onCleanup(() => project.onExit())
   const entrypointsSubscription = project.entrypointsSubscribe()
 
+  const currentWrittenEntrypoints: Map<EntryKey, WrittenEndpoint> = new Map()
   const currentEntrypoints: Entrypoints = {
     global: {
       app: undefined,
@@ -193,35 +194,47 @@ export async function createHotReloaderTurbopack(
 
   function clearRequireCache(
     key: EntryKey,
-    writtenEndpoint: WrittenEndpoint
+    writtenEndpoint: WrittenEndpoint,
+    {
+      force,
+    }: {
+      // Always clear the cache, don't check if files have changed
+      force?: boolean
+    } = {}
   ): void {
-    // Figure out if the server files have changed
-    let hasChange = false
-    for (const { path, contentHash } of writtenEndpoint.serverPaths) {
-      // We ignore source maps
-      if (path.endsWith('.map')) continue
-      const localKey = `${key}:${path}`
-      const localHash = serverPathState.get(localKey)
-      const globalHash = serverPathState.get(path)
-      if (
-        (localHash && localHash !== contentHash) ||
-        (globalHash && globalHash !== contentHash)
-      ) {
-        hasChange = true
-        serverPathState.set(key, contentHash)
+    if (force) {
+      for (const { path, contentHash } of writtenEndpoint.serverPaths) {
         serverPathState.set(path, contentHash)
-      } else {
-        if (!localHash) {
+      }
+    } else {
+      // Figure out if the server files have changed
+      let hasChange = false
+      for (const { path, contentHash } of writtenEndpoint.serverPaths) {
+        // We ignore source maps
+        if (path.endsWith('.map')) continue
+        const localKey = `${key}:${path}`
+        const localHash = serverPathState.get(localKey)
+        const globalHash = serverPathState.get(path)
+        if (
+          (localHash && localHash !== contentHash) ||
+          (globalHash && globalHash !== contentHash)
+        ) {
+          hasChange = true
           serverPathState.set(key, contentHash)
-        }
-        if (!globalHash) {
           serverPathState.set(path, contentHash)
+        } else {
+          if (!localHash) {
+            serverPathState.set(key, contentHash)
+          }
+          if (!globalHash) {
+            serverPathState.set(path, contentHash)
+          }
         }
       }
-    }
 
-    if (!hasChange) {
-      return
+      if (!hasChange) {
+        return
+      }
     }
 
     const hasAppPaths = writtenEndpoint.serverPaths.some(({ path: p }) =>
@@ -477,6 +490,7 @@ export async function createHotReloaderTurbopack(
 
           hooks: {
             handleWrittenEndpoint: (id, result) => {
+              currentWrittenEntrypoints.set(id, result)
               clearRequireCache(id, result)
             },
             propagateServerField: propagateServerField.bind(null, opts),
@@ -754,6 +768,10 @@ export async function createHotReloaderTurbopack(
       reloadAfterInvalidation,
     }) {
       if (reloadAfterInvalidation) {
+        for (const [key, entrypoint] of currentWrittenEntrypoints) {
+          clearRequireCache(key, entrypoint, { force: true })
+        }
+
         await clearAllModuleContexts()
         this.send({
           action: HMR_ACTIONS_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
@@ -822,6 +840,7 @@ export async function createHotReloaderTurbopack(
               subscribeToChanges,
               handleWrittenEndpoint: (id, result) => {
                 clearRequireCache(id, result)
+                currentWrittenEntrypoints.set(id, result)
                 assetMapper.setPathsForKey(id, result.clientPaths)
               },
             },
@@ -879,6 +898,7 @@ export async function createHotReloaderTurbopack(
           hooks: {
             subscribeToChanges,
             handleWrittenEndpoint: (id, result) => {
+              currentWrittenEntrypoints.set(id, result)
               clearRequireCache(id, result)
               assetMapper.setPathsForKey(id, result.clientPaths)
             },

--- a/test/development/app-hmr/app/env/edge-module-var/page.jsx
+++ b/test/development/app-hmr/app/env/edge-module-var/page.jsx
@@ -1,0 +1,7 @@
+const MY_DEVICE = process.env.MY_DEVICE?.slice()
+
+export default function Page() {
+  return <p>{MY_DEVICE}</p>
+}
+
+export const runtime = 'edge'

--- a/test/development/app-hmr/app/env/node-module-var/page.jsx
+++ b/test/development/app-hmr/app/env/node-module-var/page.jsx
@@ -1,0 +1,5 @@
+const MY_DEVICE = process.env.MY_DEVICE?.slice()
+
+export default function Page() {
+  return <p>{MY_DEVICE}</p>
+}


### PR DESCRIPTION
While we currently refetch RSC updates on changes to the environment (e.g. `.env` files), we never cleared the require cache to re-evaluate RSCs with the new environment. This implements that.

Test Plan: Added tests. `TURBOPACK=1 pnpm test-dev test/development/app-hmr/hmr.test.ts`
