### PR TITLE
refactor(cna): add `--reset` alias for `--reset-preferences`

### DIFF
--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -65,8 +65,8 @@ const program = new Command(packageJson.name)
     ).choices(['npm', 'pnpm', 'yarn', 'bun'])
   )
   .option(
-    '--reset-preferences',
-    'Explicitly tell the CLI to reset any stored preferences.'
+    '--reset, --reset-preferences',
+    'Reset the preferences saved for create-next-app.'
   )
   .option(
     '--skip-install',
@@ -122,9 +122,20 @@ async function run(): Promise<void> {
   const conf = new Conf({ projectName: 'create-next-app' })
 
   if (opts.resetPreferences) {
-    conf.clear()
-    console.log(`Preferences reset successfully`)
-    return
+    const { resetPreferences } = await prompts({
+      onState: onPromptState,
+      type: 'toggle',
+      name: 'resetPreferences',
+      message: 'Would you like to reset the saved preferences?',
+      initial: false,
+      active: 'Yes',
+      inactive: 'No',
+    })
+    if (resetPreferences) {
+      conf.clear()
+      console.log('The preferences have been reset successfully!')
+    }
+    process.exit(0)
   }
 
   if (typeof projectPath === 'string') {

--- a/test/integration/create-next-app/prompts.test.ts
+++ b/test/integration/create-next-app/prompts.test.ts
@@ -216,4 +216,38 @@ describe('create-next-app prompts', () => {
       `)
     })
   })
+
+  it('should prompt user to confirm reset preferences', async () => {
+    await useTempDir(async (cwd) => {
+      const childProcess = createNextApp(
+        ['--reset'],
+        {
+          cwd,
+        },
+        nextTgzFilename
+      )
+
+      await new Promise<void>(async (resolve) => {
+        childProcess.on('exit', async (exitCode) => {
+          expect(exitCode).toBe(0)
+          resolve()
+        })
+        let output = ''
+        childProcess.stdout.on('data', (data) => {
+          output += data
+          process.stdout.write(data)
+        })
+        await check(
+          () => output,
+          /Would you like to reset the saved preferences/
+        )
+        // cursor forward, choose 'Yes' for reset preferences
+        childProcess.stdin.write('\u001b[C\n')
+        await check(
+          () => output,
+          /The preferences have been reset successfully/
+        )
+      })
+    })
+  })
 })


### PR DESCRIPTION
### Why?

1. `--reset-preferences` is pretty long to type.
2. A safety `Do you really want to reset?` message is missing, is instant. 

### How?

Added alias `--reset`, and added prompt to ask Yes or No.
Added tests.