### PR TITLE
chore: add flakey tests to manifest

### DIFF
--- a/test/development/app-hmr/hmr.test.ts
+++ b/test/development/app-hmr/hmr.test.ts
@@ -9,7 +9,7 @@ describe(`app-dir-hmr`, () => {
   })
 
   describe('filesystem changes', () => {
-    it('should not continously poll when hitting a not found page', async () => {
+    it('should not continuously poll when hitting a not found page', async () => {
       let requestCount = 0
 
       const browser = await next.browser('/does-not-exist', {

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -1732,7 +1732,12 @@
     ],
     "failed": [],
     "pending": [],
-    "flakey": [],
+    "flakey": [
+      "app-dir-hmr should update server components after navigating to a page with a different runtime",
+      "app-dir-hmr should update server components pages when env files is changed (nodejs)",
+      "app-dir-hmr should update server components pages when env files is changed (edge)",
+      "app-dir-hmr can navigate cleanly to a page that requires a change in the Webpack runtime"
+    ],
     "runtimeError": false
   },
   "test/development/app-render-error-log/app-render-error-log.test.ts": {

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -1726,17 +1726,15 @@
     "passed": [
       "app-dir-hmr filesystem changes should have no unexpected action error for hmr",
       "app-dir-hmr filesystem changes should not break when renaming a folder",
-      "app-dir-hmr filesystem changes should not continously poll when hitting a not found page",
-      "app-dir-hmr filesystem changes should update server components pages when env files is changed (edge)",
-      "app-dir-hmr filesystem changes should update server components pages when env files is changed (nodejs)"
+      "app-dir-hmr filesystem changes should not continuously poll when hitting a not found page"
     ],
     "failed": [],
     "pending": [],
     "flakey": [
-      "app-dir-hmr should update server components after navigating to a page with a different runtime",
-      "app-dir-hmr should update server components pages when env files is changed (nodejs)",
-      "app-dir-hmr should update server components pages when env files is changed (edge)",
-      "app-dir-hmr can navigate cleanly to a page that requires a change in the Webpack runtime"
+      "app-dir-hmr filesystem changes should update server components after navigating to a page with a different runtime",
+      "app-dir-hmr filesystem changes should update server components pages when env files is changed (nodejs)",
+      "app-dir-hmr filesystem changes should update server components pages when env files is changed (edge)",
+      "app-dir-hmr filesystem changes can navigate cleanly to a page that requires a change in the Webpack runtime"
     ],
     "runtimeError": false
   },


### PR DESCRIPTION
cc @eps1lon 

The newly added `app-dir-hmr` tests were missing in manifest and is flakey, so added to the flakey manifest.

x-ref: https://github.com/vercel/next.js/actions/runs/10128418157/job/28009344135?pr=68225