### PR TITLE
refac(cna): don't assign internal flag as app name

### DIFF
--- a/packages/create-next-app/create-app.ts
+++ b/packages/create-next-app/create-app.ts
@@ -31,7 +31,7 @@ export async function createApp({
   typescript,
   tailwind,
   eslint,
-  appRouter,
+  app,
   srcDir,
   importAlias,
   skipInstall,
@@ -45,7 +45,7 @@ export async function createApp({
   typescript: boolean
   tailwind: boolean
   eslint: boolean
-  appRouter: boolean
+  app: boolean
   srcDir: boolean
   importAlias: string
   skipInstall: boolean
@@ -54,7 +54,7 @@ export async function createApp({
 }): Promise<void> {
   let repoInfo: RepoInfo | undefined
   const mode: TemplateMode = typescript ? 'ts' : 'js'
-  const template: TemplateType = `${appRouter ? 'app' : 'default'}${tailwind ? '-tw' : ''}${empty ? '-empty' : ''}`
+  const template: TemplateType = `${app ? 'app' : 'default'}${tailwind ? '-tw' : ''}${empty ? '-empty' : ''}`
 
   if (example) {
     let repoUrl: URL | undefined

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -411,6 +411,10 @@ async function run(): Promise<void> {
   const createAppParams = {
     appPath,
     packageManager,
+    // Proceed to default app if the example value is "default".
+    // x-ref: https://github.com/vercel/next.js/pull/12109
+    example: example && example !== 'default' ? example : undefined,
+    examplePath: opts.examplePath,
     typescript: opts.typescript,
     tailwind: opts.tailwind,
     eslint: opts.eslint,
@@ -435,7 +439,7 @@ async function run(): Promise<void> {
       throw reason
     }
 
-    const res = await prompts({
+    const { builtin } = await prompts({
       onState: onPromptState,
       type: 'confirm',
       name: 'builtin',
@@ -444,7 +448,8 @@ async function run(): Promise<void> {
         `Do you want to use the default template instead?`,
       initial: true,
     })
-    if (!res.builtin) {
+
+    if (!builtin) {
       throw reason
     }
 

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -216,35 +216,26 @@ async function run(): Promise<void> {
     process.exit(1)
   }
 
-  if (opts.example) {
-    const example = typeof opts.example === 'string' && opts.example.trim()
+  if (opts.example === true) {
+    console.error(
+      'Please provide an example name or url, otherwise remove the example option.'
+    )
+    process.exit(1)
+  }
 
-    if (!example || opts.example === true) {
-      console.error(
-        'Please provide an example name or url, otherwise remove the example option.'
-      )
-      process.exit(1)
-    }
+  const example = typeof opts.example === 'string' && opts.example.trim()
 
+  // If the example value is "default", skip the example prompt.
+  // x-ref: https://github.com/vercel/next.js/pull/12109
+  if (example && example !== 'default') {
     try {
-      // If the example value is "default", serve the default example.
-      // Previously, providing "default" would skip the example prompt.
-      // x-ref: https://github.com/vercel/next.js/pull/12109
-      if (example === 'default') {
-        await createApp({
-          appPath,
-          packageManager,
-          ...defaults,
-        })
-      } else {
-        await createApp({
-          appPath,
-          packageManager,
-          example,
-          examplePath: opts.examplePath,
-          ...defaults,
-        })
-      }
+      await createApp({
+        appPath,
+        packageManager,
+        example,
+        examplePath: opts.examplePath,
+        ...defaults,
+      })
     } catch (reason) {
       if (!(reason instanceof DownloadError)) {
         throw reason

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -99,9 +99,9 @@ const program = new Command(packageJson.name)
       // by the user they will be interpreted as the positional argument (name) in
       // the action handler. See https://github.com/tj/commander.js/pull/1355
       // Also, the internal flags we used cannot be used as the app name.
-      ['--no-', '--use-', '--dry-run'].some((flag) => {
-        return !name.startsWith(flag)
-      })
+      !name.startsWith('--no-') &&
+      !name.startsWith('--use-') &&
+      name !== '--dry-run'
     ) {
       appName = name.trim()
     }

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -241,7 +241,7 @@ async function run(): Promise<void> {
         throw reason
       }
 
-      const res = await prompts({
+      const { builtin } = await prompts({
         onState: onPromptState,
         type: 'confirm',
         name: 'builtin',
@@ -251,7 +251,7 @@ async function run(): Promise<void> {
         initial: true,
       })
 
-      if (!res.builtin) {
+      if (!builtin) {
         throw reason
       }
 
@@ -269,7 +269,7 @@ async function run(): Promise<void> {
         turbo: opts.turbo,
       })
     }
-
+    conf.set('preferences', preferences)
     process.exit(0)
   }
 
@@ -315,10 +315,7 @@ async function run(): Promise<void> {
     }
   }
 
-  if (
-    !process.argv.includes('--eslint') &&
-    !process.argv.includes('--no-eslint')
-  ) {
+  if (!opts.eslint && !args.includes('--no-eslint')) {
     if (skipPrompt) {
       opts.eslint = getPrefOrDefault('eslint')
     } else {
@@ -337,10 +334,7 @@ async function run(): Promise<void> {
     }
   }
 
-  if (
-    !process.argv.includes('--tailwind') &&
-    !process.argv.includes('--no-tailwind')
-  ) {
+  if (!opts.tailwind && !args.includes('--no-tailwind')) {
     if (skipPrompt) {
       opts.tailwind = getPrefOrDefault('tailwind')
     } else {
@@ -359,10 +353,7 @@ async function run(): Promise<void> {
     }
   }
 
-  if (
-    !process.argv.includes('--src-dir') &&
-    !process.argv.includes('--no-src-dir')
-  ) {
+  if (!opts.srcDir && !args.includes('--no-src-dir')) {
     if (skipPrompt) {
       opts.srcDir = getPrefOrDefault('srcDir')
     } else {
@@ -381,7 +372,7 @@ async function run(): Promise<void> {
     }
   }
 
-  if (!process.argv.includes('--app') && !process.argv.includes('--no-app')) {
+  if (!opts.app && !args.includes('--no-app')) {
     if (skipPrompt) {
       opts.app = getPrefOrDefault('app')
     } else {
@@ -400,7 +391,7 @@ async function run(): Promise<void> {
     }
   }
 
-  if (!opts.turbo && !process.argv.includes('--no-turbo')) {
+  if (!opts.turbo && !args.includes('--no-turbo')) {
     if (skipPrompt) {
       opts.turbo = getPrefOrDefault('turbo')
     } else {
@@ -427,7 +418,7 @@ async function run(): Promise<void> {
     if (skipPrompt) {
       // We don't use preferences here because the default value is @/* regardless of existing preferences
       opts.importAlias = defaults.importAlias
-    } else if (process.argv.includes('--no-import-alias')) {
+    } else if (args.includes('--no-import-alias')) {
       opts.importAlias = defaults.importAlias
     } else {
       const styledImportAlias = blue('import alias')

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -138,6 +138,11 @@ async function run(): Promise<void> {
     process.exit(0)
   }
 
+  const isDryRun = args.includes('--dry-run')
+  if (isDryRun) {
+    console.log('Running a dry run, skipping installation.')
+  }
+
   if (typeof projectPath === 'string') {
     projectPath = projectPath.trim()
   }
@@ -415,7 +420,7 @@ async function run(): Promise<void> {
   }
 
   try {
-    await createApp({
+    const createAppParams = {
       appPath,
       packageManager,
       example: example && example !== 'default' ? example : undefined,
@@ -429,7 +434,15 @@ async function run(): Promise<void> {
       skipInstall: opts.skipInstall,
       empty: opts.empty,
       turbo: opts.turbo,
-    })
+    }
+
+    if (isDryRun) {
+      console.log('Dry Run Result:')
+      console.log(JSON.stringify(createAppParams, null, 2))
+      return
+    }
+
+    await createApp(createAppParams)
   } catch (reason) {
     if (!(reason instanceof DownloadError)) {
       throw reason

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -225,231 +225,185 @@ async function run(): Promise<void> {
 
   const example = typeof opts.example === 'string' && opts.example.trim()
 
-  // If the example value is "default", skip the example prompt.
-  // x-ref: https://github.com/vercel/next.js/pull/12109
-  if (example && example !== 'default') {
-    try {
-      await createApp({
-        appPath,
-        packageManager,
-        example,
-        examplePath: opts.examplePath,
-        ...defaults,
-      })
-    } catch (reason) {
-      if (!(reason instanceof DownloadError)) {
-        throw reason
-      }
-
-      const { builtin } = await prompts({
-        onState: onPromptState,
-        type: 'confirm',
-        name: 'builtin',
-        message:
-          `Could not download "${example}" because of a connectivity issue between your machine and GitHub.\n` +
-          `Do you want to use the default template instead?`,
-        initial: true,
-      })
-
-      if (!builtin) {
-        throw reason
-      }
-
-      await createApp({
-        appPath,
-        packageManager,
-        typescript: opts.typescript,
-        eslint: opts.eslint,
-        tailwind: opts.tailwind,
-        app: opts.app,
-        srcDir: opts.srcDir,
-        importAlias: opts.importAlias,
-        skipInstall: opts.skipInstall,
-        empty: opts.empty,
-        turbo: opts.turbo,
-      })
-    }
-    conf.set('preferences', preferences)
-    process.exit(0)
-  }
-
   /**
    * If the user does not provide the necessary flags, prompt them for their
    * preferences, unless `--yes` option was specified, or when running in CI.
    */
   const skipPrompt = ciInfo.isCI || opts.yes
 
-  if (!opts.typescript && !opts.javascript) {
-    if (skipPrompt) {
-      // default to TypeScript in CI as we can't prompt to
-      // prevent breaking setup flows
-      opts.typescript = getPrefOrDefault('typescript')
-    } else {
-      const styledTypeScript = blue('TypeScript')
-      const { typescript } = await prompts(
-        {
+  if (!example) {
+    if (!opts.typescript && !opts.javascript) {
+      if (skipPrompt) {
+        // default to TypeScript in CI as we can't prompt to
+        // prevent breaking setup flows
+        opts.typescript = getPrefOrDefault('typescript')
+      } else {
+        const styledTypeScript = blue('TypeScript')
+        const { typescript } = await prompts(
+          {
+            type: 'toggle',
+            name: 'typescript',
+            message: `Would you like to use ${styledTypeScript}?`,
+            initial: getPrefOrDefault('typescript'),
+            active: 'Yes',
+            inactive: 'No',
+          },
+          {
+            /**
+             * User inputs Ctrl+C or Ctrl+D to exit the prompt. We should close the
+             * process and not write to the file system.
+             */
+            onCancel: () => {
+              console.error('Exiting.')
+              process.exit(1)
+            },
+          }
+        )
+        /**
+         * Depending on the prompt response, set the appropriate program flags.
+         */
+        opts.typescript = Boolean(typescript)
+        opts.javascript = !Boolean(typescript)
+        preferences.typescript = Boolean(typescript)
+      }
+    }
+
+    if (!opts.eslint && !args.includes('--no-eslint')) {
+      if (skipPrompt) {
+        opts.eslint = getPrefOrDefault('eslint')
+      } else {
+        const styledEslint = blue('ESLint')
+        const { eslint } = await prompts({
+          onState: onPromptState,
           type: 'toggle',
-          name: 'typescript',
-          message: `Would you like to use ${styledTypeScript}?`,
-          initial: getPrefOrDefault('typescript'),
+          name: 'eslint',
+          message: `Would you like to use ${styledEslint}?`,
+          initial: getPrefOrDefault('eslint'),
           active: 'Yes',
           inactive: 'No',
-        },
-        {
-          /**
-           * User inputs Ctrl+C or Ctrl+D to exit the prompt. We should close the
-           * process and not write to the file system.
-           */
-          onCancel: () => {
-            console.error('Exiting.')
-            process.exit(1)
-          },
-        }
-      )
-      /**
-       * Depending on the prompt response, set the appropriate program flags.
-       */
-      opts.typescript = Boolean(typescript)
-      opts.javascript = !Boolean(typescript)
-      preferences.typescript = Boolean(typescript)
+        })
+        opts.eslint = Boolean(eslint)
+        preferences.eslint = Boolean(eslint)
+      }
     }
-  }
 
-  if (!opts.eslint && !args.includes('--no-eslint')) {
-    if (skipPrompt) {
-      opts.eslint = getPrefOrDefault('eslint')
-    } else {
-      const styledEslint = blue('ESLint')
-      const { eslint } = await prompts({
-        onState: onPromptState,
-        type: 'toggle',
-        name: 'eslint',
-        message: `Would you like to use ${styledEslint}?`,
-        initial: getPrefOrDefault('eslint'),
-        active: 'Yes',
-        inactive: 'No',
-      })
-      opts.eslint = Boolean(eslint)
-      preferences.eslint = Boolean(eslint)
+    if (!opts.tailwind && !args.includes('--no-tailwind')) {
+      if (skipPrompt) {
+        opts.tailwind = getPrefOrDefault('tailwind')
+      } else {
+        const tw = blue('Tailwind CSS')
+        const { tailwind } = await prompts({
+          onState: onPromptState,
+          type: 'toggle',
+          name: 'tailwind',
+          message: `Would you like to use ${tw}?`,
+          initial: getPrefOrDefault('tailwind'),
+          active: 'Yes',
+          inactive: 'No',
+        })
+        opts.tailwind = Boolean(tailwind)
+        preferences.tailwind = Boolean(tailwind)
+      }
     }
-  }
 
-  if (!opts.tailwind && !args.includes('--no-tailwind')) {
-    if (skipPrompt) {
-      opts.tailwind = getPrefOrDefault('tailwind')
-    } else {
-      const tw = blue('Tailwind CSS')
-      const { tailwind } = await prompts({
-        onState: onPromptState,
-        type: 'toggle',
-        name: 'tailwind',
-        message: `Would you like to use ${tw}?`,
-        initial: getPrefOrDefault('tailwind'),
-        active: 'Yes',
-        inactive: 'No',
-      })
-      opts.tailwind = Boolean(tailwind)
-      preferences.tailwind = Boolean(tailwind)
+    if (!opts.srcDir && !args.includes('--no-src-dir')) {
+      if (skipPrompt) {
+        opts.srcDir = getPrefOrDefault('srcDir')
+      } else {
+        const styledSrcDir = blue('`src/` directory')
+        const { srcDir } = await prompts({
+          onState: onPromptState,
+          type: 'toggle',
+          name: 'srcDir',
+          message: `Would you like your code inside a ${styledSrcDir}?`,
+          initial: getPrefOrDefault('srcDir'),
+          active: 'Yes',
+          inactive: 'No',
+        })
+        opts.srcDir = Boolean(srcDir)
+        preferences.srcDir = Boolean(srcDir)
+      }
     }
-  }
 
-  if (!opts.srcDir && !args.includes('--no-src-dir')) {
-    if (skipPrompt) {
-      opts.srcDir = getPrefOrDefault('srcDir')
-    } else {
-      const styledSrcDir = blue('`src/` directory')
-      const { srcDir } = await prompts({
-        onState: onPromptState,
-        type: 'toggle',
-        name: 'srcDir',
-        message: `Would you like your code inside a ${styledSrcDir}?`,
-        initial: getPrefOrDefault('srcDir'),
-        active: 'Yes',
-        inactive: 'No',
-      })
-      opts.srcDir = Boolean(srcDir)
-      preferences.srcDir = Boolean(srcDir)
+    if (!opts.app && !args.includes('--no-app')) {
+      if (skipPrompt) {
+        opts.app = getPrefOrDefault('app')
+      } else {
+        const styledAppDir = blue('App Router')
+        const { app } = await prompts({
+          onState: onPromptState,
+          type: 'toggle',
+          name: 'app',
+          message: `Would you like to use ${styledAppDir}? (recommended)`,
+          initial: getPrefOrDefault('app'),
+          active: 'Yes',
+          inactive: 'No',
+        })
+        opts.app = Boolean(app)
+        preferences.app = Boolean(app)
+      }
     }
-  }
 
-  if (!opts.app && !args.includes('--no-app')) {
-    if (skipPrompt) {
-      opts.app = getPrefOrDefault('app')
-    } else {
-      const styledAppDir = blue('App Router')
-      const { app } = await prompts({
-        onState: onPromptState,
-        type: 'toggle',
-        name: 'app',
-        message: `Would you like to use ${styledAppDir}? (recommended)`,
-        initial: getPrefOrDefault('app'),
-        active: 'Yes',
-        inactive: 'No',
-      })
-      opts.app = Boolean(app)
-      preferences.app = Boolean(app)
+    if (!opts.turbo && !args.includes('--no-turbo')) {
+      if (skipPrompt) {
+        opts.turbo = getPrefOrDefault('turbo')
+      } else {
+        const styledTurbo = blue('Turbopack')
+        const { turbo } = await prompts({
+          onState: onPromptState,
+          type: 'toggle',
+          name: 'turbo',
+          message: `Would you like to use ${styledTurbo} for ${`next dev`}?`,
+          initial: getPrefOrDefault('turbo'),
+          active: 'Yes',
+          inactive: 'No',
+        })
+        opts.turbo = Boolean(turbo)
+        preferences.turbo = Boolean(turbo)
+      }
     }
-  }
 
-  if (!opts.turbo && !args.includes('--no-turbo')) {
-    if (skipPrompt) {
-      opts.turbo = getPrefOrDefault('turbo')
-    } else {
-      const styledTurbo = blue('Turbopack')
-      const { turbo } = await prompts({
-        onState: onPromptState,
-        type: 'toggle',
-        name: 'turbo',
-        message: `Would you like to use ${styledTurbo} for ${`next dev`}?`,
-        initial: getPrefOrDefault('turbo'),
-        active: 'Yes',
-        inactive: 'No',
-      })
-      opts.turbo = Boolean(turbo)
-      preferences.turbo = Boolean(turbo)
-    }
-  }
-
-  const importAliasPattern = /^[^*"]+\/\*\s*$/
-  if (
-    typeof opts.importAlias !== 'string' ||
-    !importAliasPattern.test(opts.importAlias)
-  ) {
-    if (skipPrompt) {
-      // We don't use preferences here because the default value is @/* regardless of existing preferences
-      opts.importAlias = defaults.importAlias
-    } else if (args.includes('--no-import-alias')) {
-      opts.importAlias = defaults.importAlias
-    } else {
-      const styledImportAlias = blue('import alias')
-
-      const { customizeImportAlias } = await prompts({
-        onState: onPromptState,
-        type: 'toggle',
-        name: 'customizeImportAlias',
-        message: `Would you like to customize the ${styledImportAlias} (${defaults.importAlias} by default)?`,
-        initial: getPrefOrDefault('customizeImportAlias'),
-        active: 'Yes',
-        inactive: 'No',
-      })
-
-      if (!customizeImportAlias) {
+    const importAliasPattern = /^[^*"]+\/\*\s*$/
+    if (
+      typeof opts.importAlias !== 'string' ||
+      !importAliasPattern.test(opts.importAlias)
+    ) {
+      if (skipPrompt) {
         // We don't use preferences here because the default value is @/* regardless of existing preferences
         opts.importAlias = defaults.importAlias
+      } else if (args.includes('--no-import-alias')) {
+        opts.importAlias = defaults.importAlias
       } else {
-        const { importAlias } = await prompts({
+        const styledImportAlias = blue('import alias')
+
+        const { customizeImportAlias } = await prompts({
           onState: onPromptState,
-          type: 'text',
-          name: 'importAlias',
-          message: `What ${styledImportAlias} would you like configured?`,
-          initial: getPrefOrDefault('importAlias'),
-          validate: (value) =>
-            importAliasPattern.test(value)
-              ? true
-              : 'Import alias must follow the pattern <prefix>/*',
+          type: 'toggle',
+          name: 'customizeImportAlias',
+          message: `Would you like to customize the ${styledImportAlias} (${defaults.importAlias} by default)?`,
+          initial: getPrefOrDefault('customizeImportAlias'),
+          active: 'Yes',
+          inactive: 'No',
         })
-        opts.importAlias = importAlias
-        preferences.importAlias = importAlias
+
+        if (!customizeImportAlias) {
+          // We don't use preferences here because the default value is @/* regardless of existing preferences
+          opts.importAlias = defaults.importAlias
+        } else {
+          const { importAlias } = await prompts({
+            onState: onPromptState,
+            type: 'text',
+            name: 'importAlias',
+            message: `What ${styledImportAlias} would you like configured?`,
+            initial: getPrefOrDefault('importAlias'),
+            validate: (value) =>
+              importAliasPattern.test(value)
+                ? true
+                : 'Import alias must follow the pattern <prefix>/*',
+          })
+          opts.importAlias = importAlias
+          preferences.importAlias = importAlias
+        }
       }
     }
   }
@@ -474,7 +428,40 @@ async function run(): Promise<void> {
     return
   }
 
-  await createApp(createAppParams)
+  try {
+    await createApp(createAppParams)
+  } catch (reason) {
+    if (!(reason instanceof DownloadError)) {
+      throw reason
+    }
+
+    const res = await prompts({
+      onState: onPromptState,
+      type: 'confirm',
+      name: 'builtin',
+      message:
+        `Could not download "${example}" because of a connectivity issue between your machine and GitHub.\n` +
+        `Do you want to use the default template instead?`,
+      initial: true,
+    })
+    if (!res.builtin) {
+      throw reason
+    }
+
+    await createApp({
+      appPath,
+      packageManager,
+      typescript: opts.typescript,
+      eslint: opts.eslint,
+      tailwind: opts.tailwind,
+      app: opts.app,
+      srcDir: opts.srcDir,
+      importAlias: opts.importAlias,
+      skipInstall: opts.skipInstall,
+      empty: opts.empty,
+      turbo: opts.turbo,
+    })
+  }
   conf.set('preferences', preferences)
 }
 

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -16,7 +16,7 @@ import { getPkgManager } from './helpers/get-pkg-manager'
 import { isFolderEmpty } from './helpers/is-folder-empty'
 import { validateNpmName } from './helpers/validate-pkg'
 
-let projectPath: string = ''
+let appName: string = ''
 
 const handleSigTerm = () => process.exit(0)
 
@@ -97,7 +97,7 @@ const program = new Command(packageJson.name)
     // by the user they will be interpreted as the positional argument (name) in
     // the action handler. See https://github.com/tj/commander.js/pull/1355
     if (name && !name.startsWith('--no-')) {
-      projectPath = name.trim()
+      appName = name.trim()
     }
   })
   .allowUnknownOption()
@@ -163,7 +163,7 @@ async function run(): Promise<void> {
     console.log('Running a dry run, skipping installation.')
   }
 
-  if (!projectPath) {
+  if (!appName) {
     const { path } = await prompts({
       onState: onPromptState,
       type: 'text',
@@ -180,10 +180,10 @@ async function run(): Promise<void> {
     })
 
     if (typeof path === 'string') {
-      projectPath = path.trim()
+      appName = path.trim()
     }
 
-    if (!projectPath) {
+    if (!appName) {
       console.log(
         '\nPlease specify the project directory:\n' +
           `  ${cyan(opts.name())} ${green('<project-directory>')}\n` +
@@ -194,9 +194,6 @@ async function run(): Promise<void> {
       process.exit(1)
     }
   }
-
-  const appPath = resolve(projectPath)
-  const appName = basename(appPath)
 
   const validation = validateNpmName(appName)
   if (!validation.valid) {
@@ -212,6 +209,7 @@ async function run(): Promise<void> {
     process.exit(1)
   }
 
+  const appPath = resolve(appName)
   if (existsSync(appPath) && !isFolderEmpty(appPath, appName)) {
     process.exit(1)
   }

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -267,7 +267,15 @@ async function run(): Promise<void> {
       await createApp({
         appPath,
         packageManager,
-        ...defaults,
+        typescript: opts.typescript,
+        eslint: opts.eslint,
+        tailwind: opts.tailwind,
+        app: opts.app,
+        srcDir: opts.srcDir,
+        importAlias: opts.importAlias,
+        skipInstall: opts.skipInstall,
+        empty: opts.empty,
+        turbo: opts.turbo,
       })
     }
 

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -93,10 +93,16 @@ const program = new Command(packageJson.name)
 `
   )
   .action((name) => {
-    // Commander does not implicitly support negated options. When they are used
-    // by the user they will be interpreted as the positional argument (name) in
-    // the action handler. See https://github.com/tj/commander.js/pull/1355
-    if (name && !name.startsWith('--no-')) {
+    if (
+      name &&
+      // Commander does not implicitly support negated options. When they are used
+      // by the user they will be interpreted as the positional argument (name) in
+      // the action handler. See https://github.com/tj/commander.js/pull/1355
+      // Also, the internal flags we used cannot be used as the app name.
+      ['--no-', '--use-', '--dry-run'].some((flag) => {
+        return !name.startsWith(flag)
+      })
+    ) {
       appName = name.trim()
     }
   })

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -65,8 +65,8 @@ const program = new Command(packageJson.name)
     ).choices(['npm', 'pnpm', 'yarn', 'bun'])
   )
   .option(
-    '--reset-preferences',
-    'Explicitly tell the CLI to reset any stored preferences.'
+    '--reset, --reset-preferences',
+    'Reset the preferences saved for create-next-app.'
   )
   .option(
     '--skip-install',
@@ -122,9 +122,20 @@ async function run(): Promise<void> {
   const conf = new Conf({ projectName: 'create-next-app' })
 
   if (opts.resetPreferences) {
-    conf.clear()
-    console.log(`Preferences reset successfully`)
-    return
+    const { resetPreferences } = await prompts({
+      onState: onPromptState,
+      type: 'toggle',
+      name: 'resetPreferences',
+      message: 'Would you like to reset the saved preferences?',
+      initial: false,
+      active: 'Yes',
+      inactive: 'No',
+    })
+    if (resetPreferences) {
+      conf.clear()
+      console.log('The preferences have been reset successfully!')
+    }
+    process.exit(0)
   }
 
   if (typeof projectPath === 'string') {

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -37,115 +37,58 @@ const onPromptState = (state: {
 }
 
 const program = new Command(packageJson.name)
-  .version(packageJson.version)
-  .argument('[project-directory]')
-  .usage(`${green('[project-directory]')} [options]`)
-  .action((name) => {
-    // Commander does not implicitly support negated options. When they are used
-    // by the user they will be interpreted as the positional argument (name) in
-    // the action handler. See https://github.com/tj/commander.js/pull/1355
-    if (name && !name.startsWith('--no-')) {
-      projectPath = name
-    }
-  })
-  .option(
-    '--ts, --typescript',
-    `
-
-  Initialize as a TypeScript project. (default)
-`
+  .version(
+    packageJson.version,
+    '-v, --version',
+    'Output the current version of create-next-app.'
   )
+  .argument('[directory]')
+  .usage('[directory] [options]')
+  .helpOption('-h, --help', 'Display this help message.')
+  .option('--ts, --typescript', 'Initialize as a TypeScript project. (default)')
+  .option('--js, --javascript', 'Initialize as a JavaScript project.')
+  .option('--tailwind', 'Initialize with Tailwind CSS config. (default)')
+  .option('--eslint', 'Initialize with ESLint config.')
+  .option('--app', 'Initialize as an App Router project.')
+  .option('--src-dir', "Initialize inside a 'src/' directory.")
+  .option('--turbo', 'Enable Turbopack by default for development.')
   .option(
-    '--js, --javascript',
-    `
-
-  Initialize as a JavaScript project.
-`
+    '--import-alias <prefix/*>',
+    'Specify import alias to use (default "@/*").'
   )
-  .option(
-    '--tailwind',
-    `
-
-  Initialize with Tailwind CSS config. (default)
-`
-  )
-  .option(
-    '--eslint',
-    `
-
-  Initialize with ESLint config.
-`
-  )
-  .option(
-    '--app',
-    `
-
-  Initialize as an App Router project.
-`
-  )
-  .option(
-    '--src-dir',
-    `
-
-  Initialize inside a \`src/\` directory.
-`
-  )
-  .option(
-    '--turbo',
-    `
-    
-  Enable Turbopack by default for development.
-`
-  )
-  .option(
-    '--import-alias <alias-to-configure>',
-    `
-
-  Specify import alias to use (default "@/*").
-`
-  )
-  .option(
-    '--empty',
-    `
-
-  Initialize an empty project.
-`
-  )
+  .option('--empty', 'Initialize an empty project.')
   .option(
     '--use-npm',
-    `
-
-  Explicitly tell the CLI to bootstrap the application using npm
-`
+    'Explicitly tell the CLI to bootstrap the application using npm.'
   )
   .option(
     '--use-pnpm',
-    `
-
-  Explicitly tell the CLI to bootstrap the application using pnpm
-`
+    'Explicitly tell the CLI to bootstrap the application using pnpm.'
   )
   .option(
     '--use-yarn',
-    `
-
-  Explicitly tell the CLI to bootstrap the application using Yarn
-`
+    'Explicitly tell the CLI to bootstrap the application using Yarn.'
   )
   .option(
     '--use-bun',
-    `
-
-  Explicitly tell the CLI to bootstrap the application using Bun
-`
+    'Explicitly tell the CLI to bootstrap the application using Bun.'
   )
   .option(
-    '-e, --example [name]|[github-url]',
+    '--reset-preferences',
+    'Explicitly tell the CLI to reset any stored preferences.'
+  )
+  .option(
+    '--skip-install',
+    'Explicitly tell the CLI to skip installing packages.'
+  )
+  .option('--yes', 'Use saved preferences or defaults for unprovided options.')
+  .option(
+    '-e, --example <example-name|github-url>',
     `
 
   An example to bootstrap the app with. You can use an example name
-  from the official Next.js repo or a GitHub URL. The URL can use
-  any branch and/or subdirectory
+  from the official Next.js repo or a public GitHub URL. The URL can use
+  any branch and/or subdirectory.
 `
   )
   .option(
@@ -158,28 +101,14 @@ const program = new Command(packageJson.name)
   --example-path foo/bar
 `
   )
-  .option(
-    '--reset-preferences',
-    `
-
-  Explicitly tell the CLI to reset any stored preferences
-`
-  )
-  .option(
-    '--skip-install',
-    `
-
-  Explicitly tell the CLI to skip installing packages
-`
-  )
-  .option(
-    '--yes',
-    `
-
-  Use previous preferences or defaults for all options that were not
-  explicitly specified, without prompting.
-`
-  )
+  .action((name) => {
+    // Commander does not implicitly support negated options. When they are used
+    // by the user they will be interpreted as the positional argument (name) in
+    // the action handler. See https://github.com/tj/commander.js/pull/1355
+    if (name && !name.startsWith('--no-')) {
+      projectPath = name
+    }
+  })
   .allowUnknownOption()
   .parse(process.argv)
   .opts()

--- a/test/integration/create-next-app/examples.test.ts
+++ b/test/integration/create-next-app/examples.test.ts
@@ -216,15 +216,7 @@ describe('create-next-app --example', () => {
     await useTempDir(async (cwd) => {
       const projectName = 'example-default'
       const res = await run(
-        [
-          projectName,
-          '--js',
-          '--no-tailwind',
-          '--eslint',
-          '--example',
-          'default',
-          '--import-alias=@/*',
-        ],
+        [projectName, '--example', 'default'],
         nextTgzFilename,
         {
           cwd,
@@ -235,8 +227,8 @@ describe('create-next-app --example', () => {
       shouldBeTemplateProject({
         cwd,
         projectName,
-        template: 'default',
-        mode: 'js',
+        template: 'app-tw',
+        mode: 'ts',
       })
     })
   })

--- a/test/integration/create-next-app/examples.test.ts
+++ b/test/integration/create-next-app/examples.test.ts
@@ -216,7 +216,15 @@ describe('create-next-app --example', () => {
     await useTempDir(async (cwd) => {
       const projectName = 'example-default'
       const res = await run(
-        [projectName, '--example', 'default'],
+        [
+          projectName,
+          '--js',
+          '--no-tailwind',
+          '--eslint',
+          '--example',
+          'default',
+          '--import-alias=@/*',
+        ],
         nextTgzFilename,
         {
           cwd,
@@ -227,8 +235,8 @@ describe('create-next-app --example', () => {
       shouldBeTemplateProject({
         cwd,
         projectName,
-        template: 'app-tw',
-        mode: 'ts',
+        template: 'default',
+        mode: 'js',
       })
     })
   })

--- a/test/integration/create-next-app/package-manager/bun.test.ts
+++ b/test/integration/create-next-app/package-manager/bun.test.ts
@@ -29,7 +29,37 @@ describe('create-next-app with package manager bun', () => {
       .catch(() => command('npm', ['i', '-g', 'bun']))
   })
 
-  it('should use bun for --use-bun flag', async () => {
+  it('should use bun for legacy --use-bun flag', async () => {
+    await useTempDir(async (cwd) => {
+      const projectName = 'use-bun-flag'
+      const res = await run(
+        [
+          projectName,
+          '--ts',
+          '--app',
+          '--use-bun',
+          '--no-turbo',
+          '--no-eslint',
+          '--no-src-dir',
+          '--no-tailwind',
+          '--no-import-alias',
+        ],
+        nextTgzFilename,
+        {
+          cwd,
+        }
+      )
+
+      expect(res.exitCode).toBe(0)
+      projectFilesShouldExist({
+        cwd,
+        projectName,
+        files,
+      })
+    })
+  })
+
+  it('should use bun for --use bun', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'use-bun'
       const res = await run(
@@ -37,7 +67,7 @@ describe('create-next-app with package manager bun', () => {
           projectName,
           '--ts',
           '--app',
-          '--use-bun',
+          '--use=bun',
           '--no-turbo',
           '--no-eslint',
           '--no-src-dir',
@@ -89,11 +119,29 @@ describe('create-next-app with package manager bun', () => {
     })
   })
 
-  it('should use bun for --use-bun flag with example', async () => {
+  it('should use bun for legacy --use-bun flag with example', async () => {
+    await useTempDir(async (cwd) => {
+      const projectName = 'use-bun-flag-with-example'
+      const res = await run(
+        [projectName, '--use-bun', '--example', FULL_EXAMPLE_PATH],
+        nextTgzFilename,
+        { cwd }
+      )
+
+      expect(res.exitCode).toBe(0)
+      projectFilesShouldExist({
+        cwd,
+        projectName,
+        files,
+      })
+    })
+  })
+
+  it('should use bun for --use bun with example', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'use-bun-with-example'
       const res = await run(
-        [projectName, '--use-bun', '--example', FULL_EXAMPLE_PATH],
+        [projectName, '--use=bun', '--example', FULL_EXAMPLE_PATH],
         nextTgzFilename,
         { cwd }
       )

--- a/test/integration/create-next-app/package-manager/npm.test.ts
+++ b/test/integration/create-next-app/package-manager/npm.test.ts
@@ -24,7 +24,37 @@ describe('create-next-app with package manager npm', () => {
     nextTgzFilename = pkgPaths.get('next')
   })
 
-  it('should use npm for --use-npm flag', async () => {
+  it('should use npm for legacy --use-npm flag', async () => {
+    await useTempDir(async (cwd) => {
+      const projectName = 'use-npm-flag'
+      const res = await run(
+        [
+          projectName,
+          '--ts',
+          '--app',
+          '--use-npm',
+          '--no-turbo',
+          '--no-eslint',
+          '--no-src-dir',
+          '--no-tailwind',
+          '--no-import-alias',
+        ],
+        nextTgzFilename,
+        {
+          cwd,
+        }
+      )
+
+      expect(res.exitCode).toBe(0)
+      projectFilesShouldExist({
+        cwd,
+        projectName,
+        files,
+      })
+    })
+  })
+
+  it('should use npm for --use npm', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'use-npm'
       const res = await run(
@@ -32,7 +62,7 @@ describe('create-next-app with package manager npm', () => {
           projectName,
           '--ts',
           '--app',
-          '--use-npm',
+          '--use=npm',
           '--no-turbo',
           '--no-eslint',
           '--no-src-dir',
@@ -84,11 +114,29 @@ describe('create-next-app with package manager npm', () => {
     })
   })
 
-  it('should use npm for --use-npm flag with example', async () => {
+  it('should use npm for legacy --use-npm flag with example', async () => {
+    await useTempDir(async (cwd) => {
+      const projectName = 'use-npm-flag-with-example'
+      const res = await run(
+        [projectName, '--use-npm', '--example', FULL_EXAMPLE_PATH],
+        nextTgzFilename,
+        { cwd }
+      )
+
+      expect(res.exitCode).toBe(0)
+      projectFilesShouldExist({
+        cwd,
+        projectName,
+        files,
+      })
+    })
+  })
+
+  it('should use npm for --use npm with example', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'use-npm-with-example'
       const res = await run(
-        [projectName, '--use-npm', '--example', FULL_EXAMPLE_PATH],
+        [projectName, '--use=npm', '--example', FULL_EXAMPLE_PATH],
         nextTgzFilename,
         { cwd }
       )

--- a/test/integration/create-next-app/package-manager/pnpm.test.ts
+++ b/test/integration/create-next-app/package-manager/pnpm.test.ts
@@ -24,7 +24,37 @@ describe('create-next-app with package manager pnpm', () => {
     nextTgzFilename = pkgPaths.get('next')
   })
 
-  it('should use pnpm for --use-pnpm flag', async () => {
+  it('should use pnpm for legacy --use-pnpm flag', async () => {
+    await useTempDir(async (cwd) => {
+      const projectName = 'use-pnpm-flag'
+      const res = await run(
+        [
+          projectName,
+          '--ts',
+          '--app',
+          '--use-pnpm',
+          '--no-turbo',
+          '--no-eslint',
+          '--no-src-dir',
+          '--no-tailwind',
+          '--no-import-alias',
+        ],
+        nextTgzFilename,
+        {
+          cwd,
+        }
+      )
+
+      expect(res.exitCode).toBe(0)
+      projectFilesShouldExist({
+        cwd,
+        projectName,
+        files,
+      })
+    })
+  })
+
+  it('should use pnpm for --use pnpm', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'use-pnpm'
       const res = await run(
@@ -32,7 +62,7 @@ describe('create-next-app with package manager pnpm', () => {
           projectName,
           '--ts',
           '--app',
-          '--use-pnpm',
+          '--use=pnpm',
           '--no-turbo',
           '--no-eslint',
           '--no-src-dir',
@@ -84,11 +114,29 @@ describe('create-next-app with package manager pnpm', () => {
     })
   })
 
-  it('should use pnpm for --use-pnpm flag with example', async () => {
+  it('should use pnpm for legacy --use-pnpm flag with example', async () => {
+    await useTempDir(async (cwd) => {
+      const projectName = 'use-pnpm-flag-with-example'
+      const res = await run(
+        [projectName, '--use-pnpm', '--example', FULL_EXAMPLE_PATH],
+        nextTgzFilename,
+        { cwd }
+      )
+
+      expect(res.exitCode).toBe(0)
+      projectFilesShouldExist({
+        cwd,
+        projectName,
+        files,
+      })
+    })
+  })
+
+  it('should use pnpm for --use pnpm with example', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'use-pnpm-with-example'
       const res = await run(
-        [projectName, '--use-pnpm', '--example', FULL_EXAMPLE_PATH],
+        [projectName, '--use=pnpm', '--example', FULL_EXAMPLE_PATH],
         nextTgzFilename,
         { cwd }
       )

--- a/test/integration/create-next-app/package-manager/yarn.test.ts
+++ b/test/integration/create-next-app/package-manager/yarn.test.ts
@@ -32,7 +32,37 @@ describe('create-next-app with package manager yarn', () => {
       .catch(() => command('npm', ['i', '-g', 'yarn']))
   })
 
-  it('should use yarn for --use-yarn flag', async () => {
+  it('should use yarn for legacy --use-yarn flag', async () => {
+    await useTempDir(async (cwd) => {
+      const projectName = 'use-yarn-flag'
+      const res = await run(
+        [
+          projectName,
+          '--ts',
+          '--app',
+          '--use-yarn',
+          '--no-turbo',
+          '--no-eslint',
+          '--no-src-dir',
+          '--no-tailwind',
+          '--no-import-alias',
+        ],
+        nextTgzFilename,
+        {
+          cwd,
+        }
+      )
+
+      expect(res.exitCode).toBe(0)
+      projectFilesShouldExist({
+        cwd,
+        projectName,
+        files,
+      })
+    })
+  })
+
+  it('should use yarn for --use yarn', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'use-yarn'
       const res = await run(
@@ -40,7 +70,7 @@ describe('create-next-app with package manager yarn', () => {
           projectName,
           '--ts',
           '--app',
-          '--use-yarn',
+          '--use=yarn',
           '--no-turbo',
           '--no-eslint',
           '--no-src-dir',
@@ -92,11 +122,29 @@ describe('create-next-app with package manager yarn', () => {
     })
   })
 
-  it('should use yarn for --use-yarn flag with example', async () => {
+  it('should use yarn for legacy --use-yarn flag with example', async () => {
+    await useTempDir(async (cwd) => {
+      const projectName = 'use-yarn-flag-with-example'
+      const res = await run(
+        [projectName, '--use-yarn', '--example', FULL_EXAMPLE_PATH],
+        nextTgzFilename,
+        { cwd }
+      )
+
+      expect(res.exitCode).toBe(0)
+      projectFilesShouldExist({
+        cwd,
+        projectName,
+        files,
+      })
+    })
+  })
+
+  it('should use yarn for --use yarn with example', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'use-yarn-with-example'
       const res = await run(
-        [projectName, '--use-yarn', '--example', FULL_EXAMPLE_PATH],
+        [projectName, '--use=yarn', '--example', FULL_EXAMPLE_PATH],
         nextTgzFilename,
         { cwd }
       )

--- a/test/integration/create-next-app/prompts.test.ts
+++ b/test/integration/create-next-app/prompts.test.ts
@@ -216,4 +216,38 @@ describe('create-next-app prompts', () => {
       `)
     })
   })
+
+  it('should prompt user to confirm reset preferences', async () => {
+    await useTempDir(async (cwd) => {
+      const childProcess = createNextApp(
+        ['--reset'],
+        {
+          cwd,
+        },
+        nextTgzFilename
+      )
+
+      await new Promise<void>(async (resolve) => {
+        childProcess.on('exit', async (exitCode) => {
+          expect(exitCode).toBe(0)
+          resolve()
+        })
+        let output = ''
+        childProcess.stdout.on('data', (data) => {
+          output += data
+          process.stdout.write(data)
+        })
+        await check(
+          () => output,
+          /Would you like to reset the saved preferences/
+        )
+        // cursor forward, choose 'Yes' for reset preferences
+        childProcess.stdin.write('\u001b[C\n')
+        await check(
+          () => output,
+          /The preferences have been reset successfully/
+        )
+      })
+    })
+  })
 })


### PR DESCRIPTION
### Why?

Since new internal flags were added at https://github.com/vercel/next.js/pull/68229 and https://github.com/vercel/next.js/pull/68233, we should not assign them as the app name.

### How?

Added `--use-` and `--dry-run` along with `--no-`.

### RFC

What if we not allow an app name to start with `--`?