### PR TITLE
Restore `workspaces` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "nextjs-project",
   "version": "0.0.0",
   "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "new-error": "turbo gen error",
     "new-test": "turbo gen test",


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/68186

Lerna still uses those for some reason.

Fixes 
```
lerna ERR! EWORKSPACES Yarn workspaces need to be defined in the root package.json
```
-- https://github.com/vercel/next.js/actions/runs/10140569484/job/28036160257

## test plan

- [x] passing "deploy preview tarballs" job: https://github.com/vercel/next.js/actions/runs/10143986813/job/28046669603?pr=68267