### PR TITLE
Update devlow to 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@types/trusted-types": "2.0.3",
     "@typescript-eslint/eslint-plugin": "7.16.0",
     "@typescript-eslint/parser": "7.16.0",
-    "@vercel/devlow-bench": "0.3.1",
+    "@vercel/devlow-bench": "0.3.2",
     "@vercel/fetch": "6.1.1",
     "@vercel/og": "0.6.2",
     "abort-controller": "3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,8 +192,8 @@ importers:
         specifier: 7.16.0
         version: 7.16.0(eslint@8.56.0)(typescript@5.5.3)
       '@vercel/devlow-bench':
-        specifier: 0.3.1
-        version: 0.3.1(encoding@0.1.13)
+        specifier: 0.3.2
+        version: 0.3.2(encoding@0.1.13)
       '@vercel/fetch':
         specifier: 6.1.1
         version: 6.1.1(@types/node-fetch@2.6.1)(node-fetch@2.6.7(encoding@0.1.13))
@@ -5201,8 +5201,8 @@ packages:
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
-  '@vercel/devlow-bench@0.3.1':
-    resolution: {integrity: sha512-RbKloNKAj55/JYqhx2QtqVFWKr1f7zvuBVGs8oPksCO6oZkSnvgJhcgjftOpFAzJKUSQ+oUOYIO9oWdjDUjgFw==}
+  '@vercel/devlow-bench@0.3.2':
+    resolution: {integrity: sha512-S5sZLbMpmpmelVoYxXj6aR79sgLDM6Szdow3erbv9Kh7IKLtgldNwRMqMleEaKZZznFx+l3mBrlHs/Cae2pbQg==}
     hasBin: true
 
   '@vercel/fetch-cached-dns@2.0.2':
@@ -19766,7 +19766,7 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vercel/devlow-bench@0.3.1(encoding@0.1.13)':
+  '@vercel/devlow-bench@0.3.2(encoding@0.1.13)':
     dependencies:
       '@datadog/datadog-api-client': 1.25.0(encoding@0.1.13)
       chalk: 2.4.2
@@ -23648,7 +23648,7 @@ snapshots:
       function-bind: 1.1.2
       has-proto: 1.0.1
       has-symbols: 1.0.3
-      hasown: 2.0.0
+      hasown: 2.0.2
 
   get-nonce@1.0.1: {}
 
@@ -26355,7 +26355,7 @@ snapshots:
       decamelize: 1.2.0
       loud-rejection: 1.6.0
       map-obj: 1.0.1
-      minimist: 1.2.6
+      minimist: 1.2.8
       normalize-package-data: 2.5.0
       object-assign: 4.1.1
       read-pkg-up: 1.0.1


### PR DESCRIPTION
This includes https://github.com/vercel/turbo/pull/8602, which adds git data to datapoints.
