### PR TITLE
Ensure we only handle app nav failure for actual error

### DIFF
--- a/packages/next/src/client/components/error-boundary.tsx
+++ b/packages/next/src/client/components/error-boundary.tsx
@@ -91,7 +91,7 @@ export class ErrorBoundaryHandler extends React.Component<
     // the error boundary and instead should fallback
     // to a hard navigation to attempt recovering
     if (process.env.__NEXT_APP_NAV_FAIL_HANDLING) {
-      if (handleHardNavError(error)) {
+      if (error && handleHardNavError(error)) {
         // clear error so we don't render anything
         return {
           error: null,

--- a/packages/next/src/client/components/nav-failure-handler.ts
+++ b/packages/next/src/client/components/nav-failure-handler.ts
@@ -3,6 +3,7 @@ import { createHrefFromUrl } from './router-reducer/create-href-from-url'
 
 export function handleHardNavError(error: unknown): boolean {
   if (
+    error &&
     typeof window !== 'undefined' &&
     window.next.__pendingUrl &&
     createHrefFromUrl(new URL(window.location.href)) !==


### PR DESCRIPTION
We were seeing `null` errors in the app navigation failure handling so this ensures we check the error is a truthy value and only handle for that case. 

![CleanShot 2024-07-29 at 11 45 42@2x](https://github.com/user-attachments/assets/91d0e9ad-bedd-4c4b-9e0e-dc8b2e589671)
