### PR TITLE
Drop @babel/plugin-transform-classes by default

### DIFF
--- a/packages/next/src/build/babel/preset.ts
+++ b/packages/next/src/build/babel/preset.ts
@@ -161,7 +161,10 @@ export default (
         },
       ],
       require('./plugins/react-loadable-plugin'),
-      [
+      // only enable this plugin if custom config for it was provided
+      // otherwise we will only enable it if their browserslist triggers
+      // preset-env to pull it in
+      options['class-properties'] && [
         require('next/dist/compiled/babel/plugin-proposal-class-properties'),
         options['class-properties'] || {},
       ],


### PR DESCRIPTION
We shouldn't include this by default in our plugins list anymore and this should be handled by browserslist instead via `@babel/preset-env` if browsers old enough that need this are configured. Additionally we'll leave this configured if specific config is being provided for it to avoid unexpected dropping. 

Closes: https://github.com/vercel/next.js/issues/65540
Closes: NEXT-3598