### PR TITLE
Update turbopack manifest for flakey folder rename

### DIFF
--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -1725,14 +1725,15 @@
   "test/development/app-hmr/hmr.test.ts": {
     "passed": [
       "app-dir-hmr filesystem changes should have no unexpected action error for hmr",
-      "app-dir-hmr filesystem changes should not break when renaming a folder",
       "app-dir-hmr filesystem changes should not continously poll when hitting a not found page",
       "app-dir-hmr filesystem changes should update server components pages when env files is changed (edge)",
       "app-dir-hmr filesystem changes should update server components pages when env files is changed (nodejs)"
     ],
     "failed": [],
     "pending": [],
-    "flakey": [],
+    "flakey": [
+      "app-dir-hmr filesystem changes should not break when renaming a folder"
+    ],
     "runtimeError": false
   },
   "test/development/app-render-error-log/app-render-error-log.test.ts": {


### PR DESCRIPTION
This test is flaking pretty hard recently so marking as so in our manifest. 

x-ref: https://github.com/vercel/next.js/actions/runs/10151820867/job/28071977443#step:28:303
x-ref: [slack thread](https://vercel.slack.com/archives/C04KC8A53T7/p1722287367424049)