### PR TITLE
Add app-action deploy test to manifest

### DIFF
--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -1,6 +1,11 @@
 {
   "version": 2,
   "suites": {
+    "test/e2e/app-dir/actions/app-action.test.ts": {
+      "failed": [
+        "app-dir action handling fetch actions should invalidate client cache when path is revalidated"
+      ]
+    },
     "test/e2e/app-dir/app-static/app-static.test.ts": {
       "failed": [
         "app-dir static/dynamic handling new tags have been specified on subsequent fetch should not fetch from memory cache",


### PR DESCRIPTION
This test is currently a known failure case in deploy mode which is being investigated but we should disable to reduce noise while it's investigated. 

x-ref: [slack thread](https://vercel.slack.com/archives/C07BVA6HM17/p1722011813463959)
x-ref: [slack thread](https://vercel.slack.com/archives/C02K2HCH5V4/p1722035835457319)
x-ref: https://github.com/vercel/next.js/actions/runs/10153430071/job/28077706487