### PR TITLE
[form] typedRoutes support for action prop

### DIFF
--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
@@ -500,6 +500,24 @@ declare module 'next/navigation' {
 
   export declare function useRouter(): AppRouterInstance;
 }
+
+declare module 'next/form' {
+  import type { FormProps as OriginalFormProps } from 'next/dist/client/form.js'
+
+  type FormRestProps = Omit<OriginalFormProps, 'action'>
+
+  export type FormProps<RouteInferType> = {
+    /**
+     * \`action\` can be either a \`string\` or a function.
+     * - If \`action\` is a string, it will be interpreted as a path or URL to navigate to when the form is submitted.
+     *   The path will be prefetched when the form becomes visible.
+     * - If \`action\` is a function, it will be called when the form is submitted. See the [React docs](https://react.dev/reference/react-dom/components/form#props) for more.
+     */
+    action: __next_route_internal_types__.RouteImpl<RouteInferType> | ((formData: FormData) => void)
+  } & FormRestProps
+
+  export default function Form<RouteType>(props: FormProps<RouteType>): JSX.Element
+}
 `
 }
 

--- a/packages/next/src/client/form.tsx
+++ b/packages/next/src/client/form.tsx
@@ -13,7 +13,7 @@ const DISALLOWED_FORM_PROPS = ['method', 'encType', 'target'] as const
 type HTMLFormProps = HTMLProps<HTMLFormElement>
 type DisallowedFormProps = (typeof DISALLOWED_FORM_PROPS)[number]
 
-export type FormProps = {
+type InternalFormProps = {
   /**
    * `action` can be either a `string` or a function.
    * - If `action` is a string, it will be interpreted as a path or URL to navigate to when the form is submitted.
@@ -36,6 +36,11 @@ export type FormProps = {
    */
   scroll?: boolean
 } & Omit<HTMLFormProps, 'action' | DisallowedFormProps>
+
+// `RouteInferType` is a stub here to avoid breaking `typedRoutes` when the type
+// isn't generated yet. It will be replaced when the webpack plugin runs.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export type FormProps<RouteInferType = any> = InternalFormProps
 
 export default function Form({
   replace,

--- a/test/integration/app-types/app-types.test.js
+++ b/test/integration/app-types/app-types.test.js
@@ -62,6 +62,21 @@ const appDir = __dirname
         )
       })
 
+      it('should generate route types correctly and report form errors', async () => {
+        // Make sure all errors were reported and other Forms passed type checking
+        const errorLines = [
+          ...errors.matchAll(
+            /\.\/src\/app\/type-checks\/form\/page\.tsx:(\d+):/g
+          ),
+        ].map(([, line]) => +line)
+
+        const ST = 8
+        const ED = 10
+        expect(errorLines).toEqual(
+          Array.from({ length: ED - ST + 1 }, (_, i) => i + ST)
+        )
+      })
+
       it('should type check invalid entry exports', () => {
         // Can't export arbitrary things.
         expect(errors).toContain(`"foo" is not a valid Page export field.`)

--- a/test/integration/app-types/src/app/type-checks/form/page.tsx
+++ b/test/integration/app-types/src/app/type-checks/form/page.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react'
+import type { Route } from 'next'
+import Form from 'next/form'
+
+export default function Page() {
+  const invalidRoutes = (
+    <>
+      <Form action="/wrong-link"></Form>
+      <Form action="/blog/a?1/b"></Form>
+      <Form action={`/blog/${'a/b/c'}`}></Form>
+    </>
+  )
+
+  const validRoutes = (
+    <>
+      <Form action="/dashboard/another"></Form>
+      <Form action="/about"></Form>
+      <Form action="/redirect"></Form>
+      <Form action={`/blog/${'a/b'}`}></Form>
+      <Form action={'/invalid' as Route}></Form>
+      <Form
+        action={async (formData) => {
+          'use server'
+          console.log('function action', formData.get('myInput'))
+        }}
+      ></Form>
+    </>
+  )
+
+  return (
+    <>
+      {invalidRoutes}
+      {validRoutes}
+    </>
+  )
+}


### PR DESCRIPTION
This PR adds `typedRoutes` support for Form's `action` prop. The implementation closely follows the way it's done for Link.