### PR TITLE
Ensure sync-react updates pnpm overrides

### DIFF
--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -57,7 +57,7 @@ Or, run this command with no arguments to use the most recently published versio
     await fsp.readFile(path.join(cwd, 'package.json'), 'utf-8')
   )
   const devDependencies = pkgJson.devDependencies
-  const resolutions = pkgJson.resolutions
+  const pnpmOverrides = pkgJson.pnpm.overrides
   const baseVersionStr = devDependencies[
     useExperimental ? 'react-experimental-builtin' : 'react-builtin'
   ].replace(/^npm:react@/, '')
@@ -94,9 +94,9 @@ Or, run this command with no arguments to use the most recently published versio
       )
     }
   }
-  for (const [dep, version] of Object.entries(resolutions)) {
+  for (const [dep, version] of Object.entries(pnpmOverrides)) {
     if (version.endsWith(`${baseReleaseLabel}-${baseSha}-${baseDateString}`)) {
-      resolutions[dep] = version.replace(
+      pnpmOverrides[dep] = version.replace(
         `${baseReleaseLabel}-${baseSha}-${baseDateString}`,
         `${newReleaseLabel}-${newSha}-${newDateString}`
       )


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/68186.

We moved `resolutions` to `pnpm.overrides` but didn't update the sync script update `pnpm.overrides` instead of `resolutions`

## test plan

- [x] `p sync-react --version 19.0.0-rc-941e1b4a-20240729` updates `pnpm.overrides`