### PR TITLE
fix(turbopack): don't log errors when they are thrown

### DIFF
--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -246,7 +246,9 @@ export function processIssues(
 
     if (issue.severity !== 'warning') {
       relevantIssues.add(formatted)
-      if (logErrors && isWellKnownError(issue)) {
+
+      // if we throw the issue it will most likely get handed and logged elsewhere
+      if (logErrors && !throwIssue && isWellKnownError(issue)) {
         Log.error(formatted)
       }
     }

--- a/test/development/app-dir/build-error-logs/app/layout.tsx
+++ b/test/development/app-dir/build-error-logs/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/build-error-logs/app/page.tsx
+++ b/test/development/app-dir/build-error-logs/app/page.tsx
@@ -1,0 +1,10 @@
+import { data } from '@/lib/data'
+
+export default function Page() {
+  return (
+    <>
+      <h1>{data.title}</h1>
+      <p>{data.content}</p>
+    </>
+  )
+}

--- a/test/development/app-dir/build-error-logs/build-error-logs.test.ts
+++ b/test/development/app-dir/build-error-logs/build-error-logs.test.ts
@@ -1,0 +1,26 @@
+import { nextTestSetup } from 'e2e-utils'
+import stripAnsi from 'strip-ansi'
+
+describe('build-error-logs', () => {
+  const { next, isTurbopack } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should only log error a single time', async () => {
+    await next.fetch('/')
+    const output = stripAnsi(next.cliOutput)
+
+    expect(output).toContain('Module not found')
+
+    const moduleNotFoundLogs = output
+      .split('\n')
+      .filter((line) => line.includes('Module not found'))
+
+    if (isTurbopack) {
+      expect(moduleNotFoundLogs).toHaveLength(1)
+    } else {
+      // FIXME: next with webpack still logs the same error too many times
+      expect(moduleNotFoundLogs).toHaveLength(3)
+    }
+  })
+})

--- a/test/development/app-dir/build-error-logs/next.config.js
+++ b/test/development/app-dir/build-error-logs/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
### What?
Disables logging when an error is thrown anyway (which will be logged upstream).

Reduces the errors logged when there is a compiler error to 1, currently it shows 3 times.


Closes PACK-3170
