### PR TITLE
[form] pages dir support

### DIFF
--- a/packages/next/src/client/form.tsx
+++ b/packages/next/src/client/form.tsx
@@ -68,7 +68,7 @@ export type FormProps<RouteInferType = any> = InternalFormProps
 export default function Form({
   replace,
   scroll,
-  prefetch: prefetchProp = null,
+  prefetch: prefetchProp,
   ref: externalRef,
   ...props
 }: FormProps) {
@@ -76,7 +76,13 @@ export default function Form({
   const isNavigatingForm = typeof actionProp === 'string'
 
   if (process.env.NODE_ENV === 'development') {
-    if (!(prefetchProp === false || prefetchProp === null)) {
+    if (
+      !(
+        prefetchProp === undefined ||
+        prefetchProp === false ||
+        prefetchProp === null
+      )
+    ) {
       console.error('The `prefetch` prop of <Form> must be `false` or `null`')
     }
   }

--- a/packages/next/src/client/form.tsx
+++ b/packages/next/src/client/form.tsx
@@ -41,6 +41,8 @@ type InternalFormProps = {
    * - `null` (default): For statically generated pages, this will prefetch the full React Server Component data. For dynamic pages, this will prefetch up to the nearest route segment with a [`loading.js`](https://nextjs.org/docs/app/api-reference/file-conventions/loading) file. If there is no loading file, it will not fetch the full tree to avoid fetching too much data.
    * - `false`: This will not prefetch any data.
    *
+   * In pages dir, prefetching is not supported, and passing this prop will emit a warning.
+   *
    * @defaultValue `null`
    */
   prefetch?: false | null

--- a/packages/next/src/client/form.tsx
+++ b/packages/next/src/client/form.tsx
@@ -17,7 +17,6 @@ import {
 import { PrefetchKind } from './components/router-reducer/router-reducer-types'
 import { RouterContext } from '../shared/lib/router-context.shared-runtime'
 import type { NextRouter } from './router'
-import { resolveHref } from './resolve-href'
 
 const DISALLOWED_FORM_PROPS = ['method', 'encType', 'target'] as const
 
@@ -309,13 +308,11 @@ function onFormSubmit(
   event.preventDefault()
 
   const method = replace ? 'replace' : 'push'
-
+  const targetHref = targetUrl.href
   if (isAppRouter(router)) {
-    const targetHref = targetUrl.href
     router[method](targetHref, { scroll })
   } else {
     startTransition(() => {
-      const targetHref = resolveHref(router, targetUrl) // TODO: is this necessary?
       router[method](targetHref, undefined, { scroll })
     })
   }

--- a/packages/next/src/client/form.tsx
+++ b/packages/next/src/client/form.tsx
@@ -1,12 +1,6 @@
 'use client'
 
-import {
-  useEffect,
-  type HTMLProps,
-  type FormEvent,
-  useContext,
-  startTransition,
-} from 'react'
+import { useEffect, type HTMLProps, type FormEvent, useContext } from 'react'
 import { addBasePath } from './add-base-path'
 import { useIntersection } from './use-intersection'
 import { useMergedRef } from './use-merged-ref'
@@ -312,9 +306,15 @@ function onFormSubmit(
   if (isAppRouter(router)) {
     router[method](targetHref, { scroll })
   } else {
-    startTransition(() => {
-      router[method](targetHref, undefined, { scroll })
-    })
+    // TODO(form): Make this use a transition so that pending states work
+    //
+    // Unlike the app router, pages router doesn't use startTransition,
+    // and can't easily be wrapped in one because of implementation details
+    // (e.g. it doesn't use any react state)
+    // But it's important to have this wrapped in a transition because
+    // pending states from e.g. `useFormStatus` rely on that.
+    // So this needs some follow up work.
+    router[method](targetHref, undefined, { scroll })
   }
 }
 

--- a/test/e2e/app-dir/next-form/default/next-form.test.ts
+++ b/test/e2e/app-dir/next-form/default/next-form.test.ts
@@ -12,9 +12,8 @@ describe.each(['app', 'pages'])('%s dir - form', (type) => {
   const pathPrefix = isAppDir ? '' : '/pages-dir'
 
   it(
-    'should soft-navigate on submit' + isAppDir
-      ? ' and show the prefetched loading state'
-      : '',
+    'should soft-navigate on submit' +
+      (isAppDir ? ' and show the prefetched loading state' : ''),
     async () => {
       const session = await next.browser(pathPrefix + '/forms/basic')
       const navigationTracker = await trackMpaNavs(session)

--- a/test/e2e/app-dir/next-form/default/next-form.test.ts
+++ b/test/e2e/app-dir/next-form/default/next-form.test.ts
@@ -1,32 +1,42 @@
 import { nextTestSetup } from 'e2e-utils'
 import { BrowserInterface } from '../../../../lib/next-webdriver'
 
-describe('app dir - form', () => {
+describe.each(['app', 'pages'])('%s dir - form', (type) => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,
   })
 
-  it('should soft-navigate on submit and show the prefetched loading state', async () => {
-    const session = await next.browser('/forms/basic')
-    const navigationTracker = await trackMpaNavs(session)
+  const isAppDir = type === 'app'
+  const pathPrefix = isAppDir ? '' : '/pages-dir'
 
-    const searchInput = await session.elementByCss('input[name="query"]')
-    await searchInput.fill('my search')
+  it(
+    'should soft-navigate on submit' + isAppDir
+      ? ' and show the prefetched loading state'
+      : '',
+    async () => {
+      const session = await next.browser(pathPrefix + '/forms/basic')
+      const navigationTracker = await trackMpaNavs(session)
 
-    const submitButton = await session.elementByCss('[type="submit"]')
-    await submitButton.click()
+      const searchInput = await session.elementByCss('input[name="query"]')
+      await searchInput.fill('my search')
 
-    // we should have prefetched a loading state, so it should be displayed
-    await session.waitForElementByCss('#loading')
+      const submitButton = await session.elementByCss('[type="submit"]')
+      await submitButton.click()
 
-    const result = await session.waitForElementByCss('#search-results').text()
-    expect(result).toMatch(/query: "my search"/)
+      if (isAppDir) {
+        // we should have prefetched a loading state, so it should be displayed
+        await session.waitForElementByCss('#loading')
+      }
 
-    expect(await navigationTracker.didMpaNavigate()).toBe(false)
-  })
+      const result = await session.waitForElementByCss('#search-results').text()
+      expect(result).toMatch(/query: "my search"/)
+
+      expect(await navigationTracker.didMpaNavigate()).toBe(false)
+    }
+  )
 
   it('should soft-navigate to the formAction url of the submitter', async () => {
-    const session = await next.browser('/forms/button-formaction')
+    const session = await next.browser(pathPrefix + '/forms/button-formaction')
     const navigationTracker = await trackMpaNavs(session)
 
     const searchInput = await session.elementByCss('input[name="query"]')
@@ -51,16 +61,20 @@ describe('app dir - form', () => {
         name: 'client action',
         path: '/forms/with-function/action-client',
       },
-      {
-        name: 'server action',
-        path: '/forms/with-function/action-server',
-      },
-      {
-        name: 'server action (closure)',
-        path: '/forms/with-function/action-server-closure',
-      },
+      ...(isAppDir
+        ? [
+            {
+              name: 'server action',
+              path: '/forms/with-function/action-server',
+            },
+            {
+              name: 'server action (closure)',
+              path: '/forms/with-function/action-server-closure',
+            },
+          ]
+        : []),
     ])('runs $name', async ({ path }) => {
-      const session = await next.browser(path)
+      const session = await next.browser(pathPrefix + path)
       const navigationTracker = await trackMpaNavs(session) // actions should not MPA-navigate either.
 
       const searchInput = await session.elementByCss('input[name="query"]')
@@ -81,21 +95,27 @@ describe('app dir - form', () => {
   describe('functions passed to formAction', () => {
     it.each([
       {
+        // TODO(lubieowoce): figure out why the client navigation is failing in pages dir
+        // (see "pages-dir/forms/with-function/button-formaction-client/index.tsx" for more)
         name: 'client action',
         path: '/forms/with-function/button-formaction-client',
       },
-      {
-        name: 'server action',
-        path: '/forms/with-function/button-formaction-server',
-      },
-      {
-        name: 'server action (closure)',
-        path: '/forms/with-function/button-formaction-server-closure',
-      },
+      ...(isAppDir
+        ? [
+            {
+              name: 'server action',
+              path: '/forms/with-function/button-formaction-server',
+            },
+            {
+              name: 'server action (closure)',
+              path: '/forms/with-function/button-formaction-server-closure',
+            },
+          ]
+        : []),
     ])(
       "runs $name from submitter and doesn't warn about unsupported attributes",
       async ({ path }) => {
-        const session = await next.browser(path)
+        const session = await next.browser(pathPrefix + path)
         const navigationTracker = await trackMpaNavs(session) // actions should not MPA-navigate either.
 
         const searchInput = await session.elementByCss('input[name="query"]')
@@ -133,7 +153,8 @@ describe('app dir - form', () => {
       'should warn if submitter sets "$name" to an unsupported value and fall back to default submit behavior',
       async ({ name: attributeName, baseName: attributeBaseName }) => {
         const session = await next.browser(
-          `/forms/button-formaction-unsupported?attribute=${attributeName}`
+          pathPrefix +
+            `/forms/button-formaction-unsupported?attribute=${attributeName}`
         )
 
         const submitButton = await session.elementByCss('[type="submit"]')
@@ -173,7 +194,7 @@ describe('app dir - form', () => {
   })
 
   it('does not push a new history entry if `replace` is passed', async () => {
-    const session = await next.browser(`/forms/with-replace`)
+    const session = await next.browser(pathPrefix + `/forms/with-replace`)
     const navigationTracker = await trackMpaNavs(session)
 
     // apparently this is usually not 1...?
@@ -189,7 +210,9 @@ describe('app dir - form', () => {
   })
 
   it('does not navigate if preventDefault is called in onSubmit', async () => {
-    const session = await next.browser(`/forms/with-onsubmit-preventdefault`)
+    const session = await next.browser(
+      pathPrefix + `/forms/with-onsubmit-preventdefault`
+    )
 
     const submitButton = await session.elementByCss('[type="submit"]')
     await submitButton.click()
@@ -198,12 +221,12 @@ describe('app dir - form', () => {
 
     await session.waitForElementByCss('#redirected-results')
     expect(new URL(await session.url()).pathname).toEqual(
-      '/redirected-from-action'
+      pathPrefix + '/redirected-from-action'
     )
   })
 
   it('url-encodes file inputs, but warns about them', async () => {
-    const session = await next.browser(`/forms/with-file-input`)
+    const session = await next.browser(pathPrefix + `/forms/with-file-input`)
 
     const fileInputSelector = 'input[type="file"]'
     // Fake a file to upload

--- a/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/basic/index.tsx
+++ b/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/basic/index.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react'
+import Form from 'next/form'
+
+export default function Home() {
+  return (
+    <Form action="/pages-dir/search" id="search-form">
+      <input name="query" />
+      <button type="submit">Submit</button>
+    </Form>
+  )
+}

--- a/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/button-formaction-unsupported/index.tsx
+++ b/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/button-formaction-unsupported/index.tsx
@@ -1,0 +1,37 @@
+'use client'
+import * as React from 'react'
+import Form from 'next/form'
+import { useRouter } from 'next/router'
+
+export default function Home() {
+  const searchParams = useRouter().query
+  const attribute = searchParams.attribute as string | undefined
+  return (
+    <div
+      onSubmit={(e) => {
+        // should fire if the form let the event bubble up
+        if (e.defaultPrevented) {
+          console.log('incorrect: default submit behavior was prevented')
+        } else {
+          console.log('correct: default submit behavior was not prevented')
+          e.preventDefault() // this submission will do something stupid, we don't want it to actually go through.
+        }
+      }}
+    >
+      <Form action="/pages-dir/search" id="search-form">
+        <input name="query" />
+        <button
+          type="submit"
+          formAction="/pages-dir/search"
+          formEncType={
+            attribute === 'formEncType' ? 'multipart/form-data' : undefined
+          }
+          formMethod={attribute === 'formMethod' ? 'post' : undefined}
+          formTarget={attribute === 'formTarget' ? 'bloop' : undefined}
+        >
+          Submit
+        </button>
+      </Form>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/button-formaction/index.tsx
+++ b/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/button-formaction/index.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react'
+import Form from 'next/form'
+
+export default function Home() {
+  return (
+    <Form action="/pages-dir/" id="search-form">
+      <input name="query" />
+      <button type="submit" formAction="/pages-dir/search">
+        Submit
+      </button>
+    </Form>
+  )
+}

--- a/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/with-file-input/index.tsx
+++ b/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/with-file-input/index.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react'
+import Form from 'next/form'
+
+export default function Home() {
+  return (
+    <Form action="/pages-dir/search" id="search-form">
+      <input name="query" type="text" />
+      <input name="file" type="file" />
+      <button type="submit">Submit</button>
+    </Form>
+  )
+}

--- a/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/with-function/action-client/index.tsx
+++ b/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/with-function/action-client/index.tsx
@@ -10,13 +10,12 @@ export default function Page() {
   const [, dispatch] = useActionState(() => {
     const to = destination + '?' + new URLSearchParams({ query })
 
-    // TODO(lubieowoce): this doesn't work unless wrapped in a startTransition...
-    //   return startTransition(() => {
-    //     router.push(to)
-    //   })
+    // TODO(form): this doesn't work unless wrapped in a startTransition...
     // why is this necessary here?
     // without it, the URL updates, but we stay on the old page...
-    router.push(to)
+    return React.startTransition(() => {
+      router.push(to)
+    })
   }, undefined)
 
   const [query, setQuery] = useState('')

--- a/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/with-function/action-client/index.tsx
+++ b/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/with-function/action-client/index.tsx
@@ -1,0 +1,34 @@
+'use client'
+import * as React from 'react'
+import { useActionState, useState } from 'react'
+import Form from 'next/form'
+import { useRouter } from 'next/router'
+
+export default function Page() {
+  const destination = '/pages-dir/redirected-from-action'
+  const router = useRouter()
+  const [, dispatch] = useActionState(() => {
+    const to = destination + '?' + new URLSearchParams({ query })
+
+    // TODO(lubieowoce): this doesn't work unless wrapped in a startTransition...
+    //   return startTransition(() => {
+    //     router.push(to)
+    //   })
+    // why is this necessary here?
+    // without it, the URL updates, but we stay on the old page...
+    router.push(to)
+  }, undefined)
+
+  const [query, setQuery] = useState('')
+  return (
+    <Form action={dispatch} id="search-form">
+      <input
+        name="query"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+
+      <button type="submit">Submit (client action)</button>
+    </Form>
+  )
+}

--- a/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/with-function/action-client/index.tsx
+++ b/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/with-function/action-client/index.tsx
@@ -9,13 +9,7 @@ export default function Page() {
   const router = useRouter()
   const [, dispatch] = useActionState(() => {
     const to = destination + '?' + new URLSearchParams({ query })
-
-    // TODO(form): this doesn't work unless wrapped in a startTransition...
-    // why is this necessary here?
-    // without it, the URL updates, but we stay on the old page...
-    return React.startTransition(() => {
-      router.push(to)
-    })
+    router.push(to)
   }, undefined)
 
   const [query, setQuery] = useState('')

--- a/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/with-function/button-formaction-client/index.tsx
+++ b/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/with-function/button-formaction-client/index.tsx
@@ -1,0 +1,32 @@
+'use client'
+import * as React from 'react'
+import { type ComponentProps, useActionState, useState } from 'react'
+import Form from 'next/form'
+import { useRouter } from 'next/router'
+
+export default function Page() {
+  const destination = '/pages-dir/redirected-from-action'
+  const [query, setQuery] = useState('')
+  return (
+    <Form action="/pages-dir/search" id="search-form">
+      <input
+        name="query"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+
+      <NavigateButton to={destination + '?' + new URLSearchParams({ query })}>
+        Submit (client action)
+      </NavigateButton>
+    </Form>
+  )
+}
+
+function NavigateButton({
+  to,
+  ...props
+}: { to: string } & ComponentProps<'button'>) {
+  const router = useRouter()
+  const [, dispatch] = useActionState(() => router.push(to), undefined)
+  return <button type="submit" formAction={dispatch} {...props} />
+}

--- a/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/with-function/button-formaction-client/index.tsx
+++ b/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/with-function/button-formaction-client/index.tsx
@@ -27,6 +27,13 @@ function NavigateButton({
   ...props
 }: { to: string } & ComponentProps<'button'>) {
   const router = useRouter()
-  const [, dispatch] = useActionState(() => router.push(to), undefined)
+  const [, dispatch] = useActionState(() => {
+    // TODO(form): this doesn't work unless wrapped in a startTransition...
+    // why is this necessary here?
+    // without it, the URL updates, but we stay on the old page...
+    React.startTransition(() => {
+      router.push(to)
+    })
+  }, undefined)
   return <button type="submit" formAction={dispatch} {...props} />
 }

--- a/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/with-function/button-formaction-client/index.tsx
+++ b/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/with-function/button-formaction-client/index.tsx
@@ -28,12 +28,7 @@ function NavigateButton({
 }: { to: string } & ComponentProps<'button'>) {
   const router = useRouter()
   const [, dispatch] = useActionState(() => {
-    // TODO(form): this doesn't work unless wrapped in a startTransition...
-    // why is this necessary here?
-    // without it, the URL updates, but we stay on the old page...
-    React.startTransition(() => {
-      router.push(to)
-    })
+    router.push(to)
   }, undefined)
   return <button type="submit" formAction={dispatch} {...props} />
 }

--- a/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/with-onsubmit-preventdefault/index.tsx
+++ b/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/with-onsubmit-preventdefault/index.tsx
@@ -1,0 +1,24 @@
+'use client'
+import * as React from 'react'
+import Form from 'next/form'
+import { useRouter } from 'next/router'
+
+export default function Home() {
+  const router = useRouter()
+  return (
+    <Form
+      action="/pages-dir/search"
+      id="search-form"
+      onSubmit={(e) => {
+        e.preventDefault()
+        // `preventDefault()` should stop <Form> from running its navigation logic.
+        // if it doesn't (which'd be a bug), <Form> would call a `router.push` after this,
+        // and the last push wins, so this would be ignored.
+        router.push('/pages-dir/redirected-from-action')
+      }}
+    >
+      <input name="query" />
+      <button type="submit">Submit</button>
+    </Form>
+  )
+}

--- a/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/with-replace/index.tsx
+++ b/test/e2e/app-dir/next-form/default/pages/pages-dir/forms/with-replace/index.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react'
+import Form from 'next/form'
+
+export default function Home() {
+  return (
+    <Form action="/pages-dir/search" replace id="search-form">
+      <input name="query" />
+      <button type="submit">Submit</button>
+    </Form>
+  )
+}

--- a/test/e2e/app-dir/next-form/default/pages/pages-dir/redirected-from-action/index.tsx
+++ b/test/e2e/app-dir/next-form/default/pages/pages-dir/redirected-from-action/index.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react'
+
+export async function getServerSideProps({ req }) {
+  return {
+    props: {
+      searchParams: Object.fromEntries(
+        new URL(req.url, 'http://n').searchParams.entries()
+      ),
+    },
+  }
+}
+
+export default function RedirectedPage({ searchParams }) {
+  const query = searchParams.query as string
+  return <div id="redirected-results">query: {JSON.stringify(query)}</div>
+}

--- a/test/e2e/app-dir/next-form/default/pages/pages-dir/search/index.tsx
+++ b/test/e2e/app-dir/next-form/default/pages/pages-dir/search/index.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+
+export async function getServerSideProps({ req }) {
+  await sleep(1000)
+  return {
+    props: {
+      searchParams: Object.fromEntries(
+        new URL(req.url, 'http://n').searchParams.entries()
+      ),
+    },
+  }
+}
+
+export default function SearchPage({ searchParams }) {
+  const query = searchParams.query as string
+  return <div id="search-results">query: {JSON.stringify(query)}</div>
+}
+
+function sleep(ms: number) {
+  return new Promise<void>((res) => setTimeout(res, ms))
+}


### PR DESCRIPTION
This PR adds support for using Form with pages dir. The functionality is a bit limited:
- in pages dir, Form doesn't prefetch, because there's no notion of an instant loading state that we could prefetch
- No support for server actions
- pending indicators from `useFormStatus` do not work while navigating to the target page (planning to address this in https://github.com/vercel/next.js/pull/70681)


But other than those things, Form should work. Both of these patterns are supported:
- `<Form action="/foo/bar">`
- `<Form action={clientAction}>` (if using a react version with `useActionState`)