### PR TITLE
test: fix invalid URL in app-types test

### DIFF
--- a/test/integration/app-types/app-types.test.js
+++ b/test/integration/app-types/app-types.test.js
@@ -40,8 +40,8 @@ const appDir = __dirname
           ),
         ].map(([, line]) => +line)
 
-        const ST = 17
-        const ED = 34
+        const ST = 18
+        const ED = 35
         expect(errorLines).toEqual(
           Array.from({ length: ED - ST + 1 }, (_, i) => i + ST)
         )

--- a/test/integration/app-types/src/app/type-checks/link/page.tsx
+++ b/test/integration/app-types/src/app/type-checks/link/page.tsx
@@ -1,4 +1,5 @@
-import type { Route, Metadata } from 'next'
+'use client'
+import type { Route } from 'next'
 import Link from 'next/link'
 
 export function Card<T extends string>({ href }: { href: Route<T> | URL }) {
@@ -62,7 +63,7 @@ export default function page() {
       <Link href="/redirect">test</Link>
       <Link href="/redirect/v1/guides/x/page">test</Link>
       <Link href="/redirect/guides/x/page">test</Link>
-      <Link href={new URL('/about')}>test</Link>
+      <Link href={new URL('https://nextjs.org')}>test</Link>
       <Link href="https://nextjs.org">test</Link>
       <Link href="http://nextjs.org">test</Link>
       <Link href="#id">test</Link>
@@ -77,8 +78,4 @@ export default function page() {
       {shouldPass}
     </>
   )
-}
-
-export const metadata: Metadata = {
-  title: 'test',
 }


### PR DESCRIPTION
This PR fixes a test that typechecks, but crashes when actually running the page, because
1. `new URL("/relative")` will throw (so we change it to absolute)
2. We cannot pass a URL object from RSC to a client component (so we just make the page 'use client', which also requires removing `metadata`, but that wasn't used for anything)

See https://github.com/vercel/next.js/pull/68323#discussion_r1698468251, where this was split from