### PR TITLE
HOTFIX: pages doc `next-config-js` was moved from `03` to `04`

### DIFF
--- a/scripts/validate-externals-doc.js
+++ b/scripts/validate-externals-doc.js
@@ -58,7 +58,7 @@ const appRouterValid = validate(
   `docs/02-app/02-api-reference/05-next-config-js/serverExternalPackages.mdx`
 )
 const pagesRouterValid = validate(
-  `docs/03-pages/02-api-reference/03-next-config-js/serverExternalPackages.mdx`
+  `docs/03-pages/02-api-reference/04-next-config-js/serverExternalPackages.mdx`
 )
 
 if (appRouterValid && pagesRouterValid) {


### PR DESCRIPTION
### Why?

`types-and-precompiled` is failing on CI: 
https://github.com/vercel/next.js/actions/runs/10186089792/job/28178038314

### How?

The script `validate-externals-doc.js` was validating the `docs/.../03-next-config-js/...mdx` page, but the page was moved to `docs/.../04-next-config-js/...mdx` in https://github.com/vercel/next.js/pull/67839