### PR TITLE
Ensure we always run types-and-precompiled CI check

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -101,7 +101,6 @@ jobs:
   check-types-precompiled:
     name: types and precompiled
     needs: ['changes', 'build-native', 'build-next']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
     with:


### PR DESCRIPTION
We aren't running this check for docs only changes but this can fail if a docs change occurs so this ensures we always run it as https://github.com/vercel/next.js/pull/67839 renamed one of the files we checked but wasn't updated until after merge when we saw it fail on unrelated PRs. 