### PR TITLE
Remove remaining uses of removed `swcMinify` config option

### DIFF
--- a/crates/next-build-test/nextConfig.json
+++ b/crates/next-build-test/nextConfig.json
@@ -63,7 +63,6 @@
   },
   "outputFileTracing": true,
   "staticPageGenerationTimeout": 60,
-  "swcMinify": true,
   "modularizeImports": {},
   "experimental": {
     "prerenderEarlyExit": false,


### PR DESCRIPTION
Option was removed in https://github.com/vercel/next.js/pull/65690. 