### PR TITLE
Add a GlobalInformation struct

### DIFF
--- a/crates/next-api/src/global_information.rs
+++ b/crates/next-api/src/global_information.rs
@@ -1,0 +1,13 @@
+use anyhow::Result;
+use turbo_tasks::Vc;
+use turbopack_core::chunk::global_information::{GlobalInformation, OptionGlobalInformation};
+
+use crate::project::Project;
+
+#[turbo_tasks::function]
+pub async fn build_global_information(
+    _project: Vc<Project>,
+) -> Result<Vc<OptionGlobalInformation>> {
+    let global_information = GlobalInformation {};
+    Ok(Vc::cell(Some(global_information)))
+}

--- a/crates/next-api/src/lib.rs
+++ b/crates/next-api/src/lib.rs
@@ -6,6 +6,7 @@ mod app;
 mod dynamic_imports;
 pub mod entrypoints;
 mod font;
+pub mod global_information;
 mod instrumentation;
 mod loadable_manifest;
 mod middleware;

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -14,7 +14,7 @@ use turbopack::{
 };
 use turbopack_browser::{react_refresh::assert_can_resolve_react_refresh, BrowserChunkingContext};
 use turbopack_core::{
-    chunk::ChunkingContext,
+    chunk::{global_information::OptionGlobalInformation, ChunkingContext},
     compile_time_info::{
         CompileTimeDefineValue, CompileTimeDefines, CompileTimeInfo, FreeVarReference,
         FreeVarReferences,
@@ -353,6 +353,7 @@ pub async fn get_client_chunking_context(
     asset_prefix: Vc<Option<RcStr>>,
     environment: Vc<Environment>,
     mode: Vc<NextMode>,
+    global_information: Vc<OptionGlobalInformation>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
     let next_mode = mode.await?;
     let mut builder = BrowserChunkingContext::builder(
@@ -363,6 +364,7 @@ pub async fn get_client_chunking_context(
         get_client_assets_path(client_root),
         environment,
         next_mode.runtime_type(),
+        global_information,
     )
     .chunk_base_path(asset_prefix)
     .minify_type(next_mode.minify_type())

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -6,7 +6,7 @@ use turbo_tasks_fs::FileSystemPath;
 use turbopack::resolve_options_context::ResolveOptionsContext;
 use turbopack_browser::BrowserChunkingContext;
 use turbopack_core::{
-    chunk::ChunkingContext,
+    chunk::{global_information::OptionGlobalInformation, ChunkingContext},
     compile_time_info::{
         CompileTimeDefineValue, CompileTimeDefines, CompileTimeInfo, FreeVarReference,
         FreeVarReferences,
@@ -178,6 +178,7 @@ pub async fn get_edge_chunking_context_with_client_assets(
     client_root: Vc<FileSystemPath>,
     asset_prefix: Vc<Option<RcStr>>,
     environment: Vc<Environment>,
+    global_information: Vc<OptionGlobalInformation>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
     let output_root = node_root.join("server/edge".into());
     let next_mode = mode.await?;
@@ -190,6 +191,7 @@ pub async fn get_edge_chunking_context_with_client_assets(
             client_root.join("static/media".into()),
             environment,
             next_mode.runtime_type(),
+            global_information,
         )
         .asset_base_path(asset_prefix)
         .minify_type(next_mode.minify_type())
@@ -203,6 +205,7 @@ pub async fn get_edge_chunking_context(
     project_path: Vc<FileSystemPath>,
     node_root: Vc<FileSystemPath>,
     environment: Vc<Environment>,
+    global_information: Vc<OptionGlobalInformation>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
     let output_root = node_root.join("server/edge".into());
     let next_mode = mode.await?;
@@ -215,6 +218,7 @@ pub async fn get_edge_chunking_context(
             output_root.join("assets".into()),
             environment,
             next_mode.runtime_type(),
+            global_information,
         )
         // Since one can't read files in edge directly, any asset need to be fetched
         // instead. This special blob url is handled by the custom fetch

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -14,6 +14,7 @@ use turbopack::{
     transition::Transition,
 };
 use turbopack_core::{
+    chunk::global_information::OptionGlobalInformation,
     compile_time_info::{
         CompileTimeDefineValue, CompileTimeDefines, CompileTimeInfo, FreeVarReferences,
     },
@@ -921,6 +922,7 @@ pub async fn get_server_chunking_context_with_client_assets(
     client_root: Vc<FileSystemPath>,
     asset_prefix: Vc<Option<RcStr>>,
     environment: Vc<Environment>,
+    global_information: Vc<OptionGlobalInformation>,
 ) -> Result<Vc<NodeJsChunkingContext>> {
     let next_mode = mode.await?;
     // TODO(alexkirsz) This should return a trait that can be implemented by the
@@ -934,6 +936,7 @@ pub async fn get_server_chunking_context_with_client_assets(
         client_root.join("static/media".into()),
         environment,
         next_mode.runtime_type(),
+        global_information,
     )
     .asset_prefix(asset_prefix)
     .minify_type(next_mode.minify_type())
@@ -946,6 +949,7 @@ pub async fn get_server_chunking_context(
     project_path: Vc<FileSystemPath>,
     node_root: Vc<FileSystemPath>,
     environment: Vc<Environment>,
+    global_information: Vc<OptionGlobalInformation>,
 ) -> Result<Vc<NodeJsChunkingContext>> {
     let next_mode = mode.await?;
     // TODO(alexkirsz) This should return a trait that can be implemented by the
@@ -959,6 +963,7 @@ pub async fn get_server_chunking_context(
         node_root.join("server/assets".into()),
         environment,
         next_mode.runtime_type(),
+        global_information,
     )
     .minify_type(next_mode.minify_type())
     .build())

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -6,6 +6,7 @@ use turbopack_core::{
     chunk::{
         availability_info::AvailabilityInfo,
         chunk_group::{make_chunk_group, MakeChunkGroupResult},
+        global_information::OptionGlobalInformation,
         Chunk, ChunkGroupResult, ChunkItem, ChunkableModule, ChunkingContext,
         EntryChunkGroupResult, EvaluatableAssets, MinifyType, ModuleId,
     },
@@ -122,6 +123,8 @@ pub struct BrowserChunkingContext {
     minify_type: MinifyType,
     /// Whether to use manifest chunks for lazy compilation
     manifest_chunks: bool,
+    /// Global information
+    global_information: Vc<OptionGlobalInformation>,
 }
 
 impl BrowserChunkingContext {
@@ -133,6 +136,7 @@ impl BrowserChunkingContext {
         asset_root_path: Vc<FileSystemPath>,
         environment: Vc<Environment>,
         runtime_type: RuntimeType,
+        global_information: Vc<OptionGlobalInformation>,
     ) -> BrowserChunkingContextBuilder {
         BrowserChunkingContextBuilder {
             chunking_context: BrowserChunkingContext {
@@ -151,6 +155,7 @@ impl BrowserChunkingContext {
                 runtime_type,
                 minify_type: MinifyType::NoMinify,
                 manifest_chunks: false,
+                global_information,
             },
         }
     }

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -196,6 +196,7 @@ async fn build_internal(
                 NodeEnv::Development => RuntimeType::Development,
                 NodeEnv::Production => RuntimeType::Production,
             },
+            Vc::cell(None),
         )
         .minify_type(minify_type)
         .build(),

--- a/turbopack/crates/turbopack-cli/src/dev/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/mod.rs
@@ -255,6 +255,7 @@ async fn source(
         build_output_root.join("assets".into()),
         node_build_environment(),
         RuntimeType::Development,
+        Vc::cell(None),
     )
     .build();
 

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -44,6 +44,7 @@ pub fn get_client_chunking_context(
             server_root.join("/_assets".into()),
             environment,
             RuntimeType::Development,
+            Vc::cell(None),
         )
         .hot_module_replacement()
         .build(),

--- a/turbopack/crates/turbopack-core/src/chunk/global_information.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/global_information.rs
@@ -1,0 +1,6 @@
+#[turbo_tasks::value]
+#[derive(Clone, Debug)]
+pub struct GlobalInformation {}
+
+#[turbo_tasks::value(transparent)]
+pub struct OptionGlobalInformation(Option<GlobalInformation>);

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod chunking_context;
 pub(crate) mod containment_tree;
 pub(crate) mod data;
 pub(crate) mod evaluate;
+pub mod global_information;
 pub mod optimize;
 
 use std::{

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -8,6 +8,7 @@ use turbopack_core::{
     chunk::{
         availability_info::AvailabilityInfo,
         chunk_group::{make_chunk_group, MakeChunkGroupResult},
+        global_information::OptionGlobalInformation,
         Chunk, ChunkGroupResult, ChunkItem, ChunkableModule, ChunkingContext,
         EntryChunkGroupResult, EvaluatableAssets, MinifyType, ModuleId,
     },
@@ -84,6 +85,8 @@ pub struct NodeJsChunkingContext {
     minify_type: MinifyType,
     /// Whether to use manifest chunks for lazy compilation
     manifest_chunks: bool,
+    /// Global information
+    global_information: Vc<OptionGlobalInformation>,
 }
 
 impl NodeJsChunkingContext {
@@ -96,6 +99,7 @@ impl NodeJsChunkingContext {
         asset_root_path: Vc<FileSystemPath>,
         environment: Vc<Environment>,
         runtime_type: RuntimeType,
+        global_information: Vc<OptionGlobalInformation>,
     ) -> NodeJsChunkingContextBuilder {
         NodeJsChunkingContextBuilder {
             chunking_context: NodeJsChunkingContext {
@@ -109,6 +113,7 @@ impl NodeJsChunkingContext {
                 runtime_type,
                 minify_type: MinifyType::NoMinify,
                 manifest_chunks: false,
+                global_information,
             },
         }
     }

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -329,6 +329,7 @@ async fn run_test(prepared_test: Vc<PreparedTest>) -> Result<Vc<RunTestResult>> 
         static_root_path,
         env,
         RuntimeType::Development,
+        Vc::cell(None),
     )
     .build();
 

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -328,6 +328,7 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                 static_root_path,
                 env,
                 options.runtime_type,
+                Vc::cell(None),
             )
             .build(),
         ),
@@ -340,6 +341,7 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                 static_root_path,
                 env,
                 options.runtime_type,
+                Vc::cell(None),
             )
             .minify_type(options.minify_type)
             .build(),


### PR DESCRIPTION
A `GlobalInformation` struct is added, which is made available through the `ChunkingContext` trait. Constructing a new `GlobalInformation` takes a `Project` parameter, which gives the constructor access to global information. `ChunkingContext` builder methods now also take a `GlobalInformation` object.

Closes PACK-3946