### PR TITLE
Use posix-compatible syntax for pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,11 +1,11 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 protected_branch='canary'
 
-protected_remote_urls=(
-  'git@github.com:vercel/next.js.git'
-  'https://github.com/vercel/next.js.git' # github blocks password-based auth, but still usable via API token
-)
+# github blocks password-based auth, but still usable via API token
+protected_remote_urls="\
+  git@github.com:vercel/next.js.git
+  https://github.com/vercel/next.js.git"
 
 
 # The pre-push hook [...] receives the name and location of the remote as parameters
@@ -18,7 +18,7 @@ remote_url="$2"
 # if we're pushing to a fork, we don't need to protect canary.
 # check if the remote is one of the protected ones.
 is_remote_protected=0
-for protected_remote_url in "${protected_remote_urls[@]}"; do
+for protected_remote_url in $protected_remote_urls; do
   if [ "$remote_url" = "$protected_remote_url" ]; then
     is_remote_protected=1
     break


### PR DESCRIPTION
### What?

Use POSIX-compatible shell script syntax for the Husky `pre-push` hook. POSIX shell sadly doesn't support arrays, so fall back to using IFS-based string splitting (which is fine here).

### Why?

- Husky ignores the shebang, and simply invokes `sh`: https://github.com/typicode/husky/issues/971
- On Debian-based distributions, [`sh` is provided by `dash`](https://wiki.archlinux.org/title/Dash), which is POSIX compatible, but does not support `bash`-specific features.
- The Husky documentation has a workaround for using bash, but doesn't recommend it: https://typicode.github.io/husky/how-to.html#bash

I do most of my development on a Debian VM, which is how I noticed this.

### Test Plan

On Debian with `dash`, manually invoke it like so:

```
echo local_branch_name from_commit refs/heads/canary to_commit | sh -x .husky/pre-push canary git@github.com:vercel/next.js.git
```