### PR TITLE
Add a resolved argument to `#[turbo_tasks::function]`

### DIFF
--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args.rs
@@ -1,0 +1,17 @@
+#![feature(arbitrary_self_types)]
+
+use turbo_tasks::{ResolvedVc, Vc};
+
+#[turbo_tasks::value(transparent, resolved)]
+struct IntegersVec(Vec<ResolvedVc<u32>>);
+
+#[turbo_tasks::function(invalid_argument)]
+fn return_contains_resolved_vc() -> Vc<IntegersVec> {
+    Vc::cell(Vec::new())
+}
+
+fn main() {
+    // the macro should be error-tolerent and this function should still be created
+    // despite the earlier compilation error, so this line should not also error
+    let _ = return_contains_resolved_vc();
+}

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args.stderr
@@ -1,0 +1,5 @@
+error: unexpected token, expected one of: "fs", "network", "resolved"
+ --> tests/function/fail_attribute_invalid_args.rs:8:25
+  |
+8 | #[turbo_tasks::function(invalid_argument)]
+  |                         ^^^^^^^^^^^^^^^^

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args_inherent_impl.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args_inherent_impl.rs
@@ -1,0 +1,23 @@
+#![feature(arbitrary_self_types)]
+
+use turbo_tasks::{ResolvedVc, Vc};
+
+#[turbo_tasks::value]
+struct ExampleStruct;
+
+#[turbo_tasks::value(transparent, resolved)]
+struct IntegersVec(Vec<ResolvedVc<u32>>);
+
+#[turbo_tasks::value_impl]
+impl ExampleStruct {
+    #[turbo_tasks::function(invalid_argument)]
+    fn return_contains_resolved_vc(self: Vc<Self>) -> Vc<IntegersVec> {
+        Vc::cell(Vec::new())
+    }
+}
+
+fn main() {
+    // the macro should be error-tolerent and this function should still be created
+    // despite the earlier compilation error, so this line should not also error
+    let _ = ExampleStruct.cell().return_contains_resolved_vc();
+}

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args_inherent_impl.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args_inherent_impl.stderr
@@ -1,0 +1,5 @@
+error: unexpected token, expected one of: "fs", "network", "resolved"
+  --> tests/function/fail_attribute_invalid_args_inherent_impl.rs:13:29
+   |
+13 |     #[turbo_tasks::function(invalid_argument)]
+   |                             ^^^^^^^^^^^^^^^^

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_resolved_inherent_impl.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_resolved_inherent_impl.rs
@@ -1,0 +1,20 @@
+#![feature(arbitrary_self_types)]
+#![allow(dead_code)]
+
+use turbo_tasks::Vc;
+
+#[turbo_tasks::value]
+struct ExampleStruct;
+
+#[turbo_tasks::value(transparent)]
+struct IntegersVec(Vec<Vc<u32>>);
+
+#[turbo_tasks::value_impl]
+impl ExampleStruct {
+    #[turbo_tasks::function(resolved)]
+    fn return_contains_unresolved_vc(self: Vc<Self>) -> Vc<IntegersVec> {
+        Vc::cell(Vec::new())
+    }
+}
+
+fn main() {}

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_resolved_inherent_impl.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_resolved_inherent_impl.stderr
@@ -1,0 +1,21 @@
+error[E0277]: the trait bound `IntegersVec: ResolvedValue` is not satisfied
+  --> tests/function/fail_resolved_inherent_impl.rs:14:29
+   |
+14 |     #[turbo_tasks::function(resolved)]
+   |                             ^^^^^^^^ the trait `ResolvedValue` is not implemented for `IntegersVec`
+   |
+   = help: the following other types implement trait `ResolvedValue`:
+             &T
+             &mut T
+             ()
+             (A, Z, Y, X, W, V, U, T)
+             (B, A, Z, Y, X, W, V, U, T)
+             (C, B, A, Z, Y, X, W, V, U, T)
+             (D, C, B, A, Z, Y, X, W, V, U, T)
+             (E, D, C, B, A, Z, Y, X, W, V, U, T)
+           and $N others
+note: required by a bound in `assert_returns_resolved_value`
+  --> tests/function/fail_resolved_inherent_impl.rs:14:29
+   |
+14 |     #[turbo_tasks::function(resolved)]
+   |                             ^^^^^^^^ required by this bound in `assert_returns_resolved_value`

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_resolved_static.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_resolved_static.rs
@@ -1,0 +1,14 @@
+#![feature(arbitrary_self_types)]
+#![allow(dead_code)]
+
+use turbo_tasks::Vc;
+
+#[turbo_tasks::value(transparent)]
+struct IntegersVec(Vec<Vc<u32>>);
+
+#[turbo_tasks::function(resolved)]
+fn return_contains_unresolved_vc() -> Vc<IntegersVec> {
+    Vc::cell(Vec::new())
+}
+
+fn main() {}

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_resolved_static.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_resolved_static.stderr
@@ -1,0 +1,21 @@
+error[E0277]: the trait bound `IntegersVec: ResolvedValue` is not satisfied
+ --> tests/function/fail_resolved_static.rs:9:25
+  |
+9 | #[turbo_tasks::function(resolved)]
+  |                         ^^^^^^^^ the trait `ResolvedValue` is not implemented for `IntegersVec`
+  |
+  = help: the following other types implement trait `ResolvedValue`:
+            &T
+            &mut T
+            ()
+            (A, Z, Y, X, W, V, U, T)
+            (B, A, Z, Y, X, W, V, U, T)
+            (C, B, A, Z, Y, X, W, V, U, T)
+            (D, C, B, A, Z, Y, X, W, V, U, T)
+            (E, D, C, B, A, Z, Y, X, W, V, U, T)
+          and $N others
+note: required by a bound in `assert_returns_resolved_value`
+ --> tests/function/fail_resolved_static.rs:9:25
+  |
+9 | #[turbo_tasks::function(resolved)]
+  |                         ^^^^^^^^ required by this bound in `assert_returns_resolved_value`

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_resolved_trait_impl.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_resolved_trait_impl.rs
@@ -1,0 +1,25 @@
+#![feature(arbitrary_self_types)]
+#![allow(dead_code)]
+
+use turbo_tasks::Vc;
+
+#[turbo_tasks::value]
+struct ExampleStruct;
+
+#[turbo_tasks::value(transparent)]
+struct IntegersVec(Vec<Vc<u32>>);
+
+#[turbo_tasks::value_trait]
+trait ExampleTrait {
+    fn return_contains_unresolved_vc(self: Vc<Self>) -> Vc<IntegersVec>;
+}
+
+#[turbo_tasks::value_impl]
+impl ExampleTrait for ExampleStruct {
+    #[turbo_tasks::function(resolved)]
+    fn return_contains_unresolved_vc(self: Vc<Self>) -> Vc<IntegersVec> {
+        Vc::cell(Vec::new())
+    }
+}
+
+fn main() {}

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_resolved_trait_impl.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_resolved_trait_impl.stderr
@@ -1,0 +1,21 @@
+error[E0277]: the trait bound `IntegersVec: ResolvedValue` is not satisfied
+  --> tests/function/fail_resolved_trait_impl.rs:19:29
+   |
+19 |     #[turbo_tasks::function(resolved)]
+   |                             ^^^^^^^^ the trait `ResolvedValue` is not implemented for `IntegersVec`
+   |
+   = help: the following other types implement trait `ResolvedValue`:
+             &T
+             &mut T
+             ()
+             (A, Z, Y, X, W, V, U, T)
+             (B, A, Z, Y, X, W, V, U, T)
+             (C, B, A, Z, Y, X, W, V, U, T)
+             (D, C, B, A, Z, Y, X, W, V, U, T)
+             (E, D, C, B, A, Z, Y, X, W, V, U, T)
+           and $N others
+note: required by a bound in `assert_returns_resolved_value`
+  --> tests/function/fail_resolved_trait_impl.rs:19:29
+   |
+19 |     #[turbo_tasks::function(resolved)]
+   |                             ^^^^^^^^ required by this bound in `assert_returns_resolved_value`

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_resolved_inherent_impl.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_resolved_inherent_impl.rs
@@ -1,0 +1,20 @@
+#![feature(arbitrary_self_types)]
+#![allow(dead_code)]
+
+use turbo_tasks::{ResolvedVc, Vc};
+
+#[turbo_tasks::value]
+struct ExampleStruct;
+
+#[turbo_tasks::value(transparent, resolved)]
+struct IntegersVec(Vec<ResolvedVc<u32>>);
+
+#[turbo_tasks::value_impl]
+impl ExampleStruct {
+    #[turbo_tasks::function(resolved)]
+    fn return_contains_resolved_vc(self: Vc<Self>) -> Vc<IntegersVec> {
+        Vc::cell(Vec::new())
+    }
+}
+
+fn main() {}

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_resolved_static.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_resolved_static.rs
@@ -1,0 +1,19 @@
+#![feature(arbitrary_self_types)]
+#![allow(dead_code)]
+
+use turbo_tasks::{ResolvedVc, Vc};
+
+#[turbo_tasks::value(transparent, resolved)]
+struct IntegersVec(Vec<ResolvedVc<u32>>);
+
+#[turbo_tasks::function(resolved)]
+fn return_contains_resolved_vc() -> Vc<IntegersVec> {
+    Vc::cell(Vec::new())
+}
+
+#[turbo_tasks::function(resolved)]
+fn return_contains_resolved_vc_result() -> anyhow::Result<Vc<IntegersVec>> {
+    Ok(Vc::cell(Vec::new()))
+}
+
+fn main() {}

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_resolved_trait_impl.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_resolved_trait_impl.rs
@@ -1,0 +1,25 @@
+#![feature(arbitrary_self_types)]
+#![allow(dead_code)]
+
+use turbo_tasks::{ResolvedVc, Vc};
+
+#[turbo_tasks::value]
+struct ExampleStruct;
+
+#[turbo_tasks::value(transparent, resolved)]
+struct IntegersVec(Vec<ResolvedVc<u32>>);
+
+#[turbo_tasks::value_trait]
+trait ExampleTrait {
+    fn return_contains_resolved_vc(self: Vc<Self>) -> Vc<IntegersVec>;
+}
+
+#[turbo_tasks::value_impl]
+impl ExampleTrait for ExampleStruct {
+    #[turbo_tasks::function(resolved)]
+    fn return_contains_resolved_vc(self: Vc<Self>) -> Vc<IntegersVec> {
+        Vc::cell(Vec::new())
+    }
+}
+
+fn main() {}

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/trybuild.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/trybuild.rs
@@ -6,6 +6,13 @@ fn derive_resolved_value() {
 }
 
 #[test]
+fn function() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/function/pass_*.rs");
+    t.compile_fail("tests/function/fail_*.rs");
+}
+
+#[test]
 fn value() {
     let t = trybuild::TestCases::new();
     t.pass("tests/value/pass_*.rs");

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/value/pass_resolved.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/value/pass_resolved.rs
@@ -5,7 +5,7 @@ struct MyValue {
     value: i32,
 }
 
-fn expects_resolved<T: turbo_tasks::ResolvedValue>(value: T) {}
+fn expects_resolved<T: turbo_tasks::ResolvedValue>(_value: T) {}
 
 fn main() {
     let v = MyValue { value: 0 };

--- a/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
@@ -4,7 +4,7 @@ use quote::quote;
 use syn::{parse_macro_input, parse_quote, ExprPath, ItemFn};
 use turbo_tasks_macros_shared::{get_native_function_id_ident, get_native_function_ident};
 
-use crate::func::{DefinitionContext, NativeFn, TurboFn};
+use crate::func::{DefinitionContext, FunctionArguments, NativeFn, TurboFn};
 
 /// This macro generates the virtual function that powers turbo tasks.
 /// An annotated task is replaced with a stub function that returns a
@@ -25,8 +25,9 @@ use crate::func::{DefinitionContext, NativeFn, TurboFn};
 ///     // access filesystem
 /// }
 /// ```
-pub fn function(_args: TokenStream, input: TokenStream) -> TokenStream {
+pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as ItemFn);
+    let mut errors = Vec::new();
 
     let ItemFn {
         attrs,
@@ -35,7 +36,12 @@ pub fn function(_args: TokenStream, input: TokenStream) -> TokenStream {
         block,
     } = &item;
 
-    let Some(turbo_fn) = TurboFn::new(sig, DefinitionContext::NakedFn) else {
+    let args = syn::parse::<FunctionArguments>(args);
+    if let Err(err) = &args {
+        errors.push(err.to_compile_error());
+    }
+    let Some(turbo_fn) = TurboFn::new(sig, DefinitionContext::NakedFn, args.unwrap_or_default())
+    else {
         return quote! {
             // An error occurred while parsing the function signature.
         }
@@ -78,6 +84,8 @@ pub fn function(_args: TokenStream, input: TokenStream) -> TokenStream {
 
         #[doc(hidden)]
         pub(crate) static #native_function_id_ident: #native_function_id_ty = #native_function_id_def;
+
+        #(#errors)*
     }
     .into()
 }

--- a/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -10,7 +10,7 @@ use turbo_tasks_macros_shared::{
     get_trait_type_id_ident, get_trait_type_ident, ValueTraitArguments,
 };
 
-use crate::func::{DefinitionContext, NativeFn, TurboFn};
+use crate::func::{DefinitionContext, FunctionArguments, NativeFn, TurboFn};
 
 pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
     let ValueTraitArguments { debug, resolved } = parse_macro_input!(args as ValueTraitArguments);
@@ -85,7 +85,14 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
 
         let ident = &sig.ident;
 
-        let Some(turbo_fn) = TurboFn::new(sig, DefinitionContext::ValueTrait) else {
+        // Value trait method declarations don't have `#[turbo_tasks::function]`
+        // annotations on them, though their `impl`s do. It may make sense to require it
+        // in the future when defining a default implementation.
+        let Some(turbo_fn) = TurboFn::new(
+            sig,
+            DefinitionContext::ValueTrait,
+            FunctionArguments::default(),
+        ) else {
             return quote! {
                 // An error occurred while parsing the function signature.
             }

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -17,9 +17,16 @@ use std::{
 
 use auto_hash_map::{AutoMap, AutoSet};
 use indexmap::{IndexMap, IndexSet};
+use serde::{Deserialize, Serialize};
 
-use crate::{vc::Vc, RcStr};
+use crate::{
+    trace::{TraceRawVcs, TraceRawVcsContext},
+    vc::Vc,
+    RcStr,
+};
 
+#[derive(Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct ResolvedVc<T>
 where
     T: ?Sized + Send,
@@ -77,6 +84,15 @@ where
         f.debug_struct("ResolvedVc")
             .field("node", &self.node.node)
             .finish()
+    }
+}
+
+impl<T> TraceRawVcs for ResolvedVc<T>
+where
+    T: ?Sized + Send,
+{
+    fn trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
+        TraceRawVcs::trace_raw_vcs(&self.node, trace_context);
     }
 }
 


### PR DESCRIPTION
### What & Why?

We want to enforce that values that functions return contain only `ResolvedVc` and not `Vc` (though the outermost `Vc` is okay). We can do that using the `ResolvedValue` marker trait (https://github.com/vercel/turbo/pull/8678).

This PR allows enforcing that by passing a `resolved` argument to the `#[turbo_tasks::function(...)]` macro.

This enforcement behavior is currently opt-in, but the goal is eventually to make it opt-out, so that most functions can easily be converted to use local tasks.

Bigger picture: https://www.notion.so/vercel/Resolved-Vcs-Vc-Lifetimes-Local-Vcs-and-Vc-Refcounts-49d666d3f9594017b5b312b87ddc5bff

### How?

The key part of the macro is this bit:

```
fn assert_returns_resolved_value<
    ReturnType,
    Rv,
>() where
    ReturnType: turbo_tasks::task::TaskOutput<Return = Vc<Rv>>,
    Rv: turbo_tasks::ResolvedValue + Send,
{}
assert_returns_resolved_value::<#return_type, _>()
```

That creates no-op code that successfully compiles when the return value (inside of the outermost `Vc`) is a `ResolvedValue`, but fails when it isn't. This is the same trick that the [`static_assertions` library](https://docs.rs/static_assertions/latest/static_assertions/macro.assert_type_eq_all.html) uses.

### Test Plan

Lots of [trybuild](https://github.com/dtolnay/trybuild) tests!

```
cargo nextest r -p turbo-tasks-macros-tests
```

**Hint:** Use `TRYBUILD=overwrite` when intentionally changing the tests.
