### PR TITLE
refactor(turbopack): Remove cast to `EcmascriptModuleAsset`

### DIFF
--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -27,7 +27,7 @@ use turbopack_core::{
     reference_type::EcmaScriptModulesReferenceSubType,
     resolve::{origin::PlainResolveOrigin, parse::Request, pattern::Pattern},
 };
-use turbopack_ecmascript::{parse::ParseResult, resolve::esm_resolve, Parsable};
+use turbopack_ecmascript::{parse::ParseResult, resolve::esm_resolve, EcmascriptParsable};
 
 async fn collect_chunk_group_inner<F, Fu>(
     dynamic_import_entries: IndexMap<Vc<Box<dyn Module>>, DynamicImportedModules>,
@@ -259,7 +259,7 @@ async fn build_dynamic_imports_map_for_module(
     server_module: Vc<Box<dyn Module>>,
 ) -> Result<Vc<OptionDynamicImportsMap>> {
     let Some(ecmascript_asset) =
-        Vc::try_resolve_sidecast::<Box<dyn Parsable>>(server_module).await?
+        Vc::try_resolve_sidecast::<Box<dyn EcmascriptParsable>>(server_module).await?
     else {
         return Ok(Vc::cell(None));
     };

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -27,7 +27,7 @@ use turbopack_core::{
     reference_type::EcmaScriptModulesReferenceSubType,
     resolve::{origin::PlainResolveOrigin, parse::Request, pattern::Pattern},
 };
-use turbopack_ecmascript::{parse::ParseResult, resolve::esm_resolve, EcmascriptModuleAsset};
+use turbopack_ecmascript::{parse::ParseResult, resolve::esm_resolve, Parsable};
 
 async fn collect_chunk_group_inner<F, Fu>(
     dynamic_import_entries: IndexMap<Vc<Box<dyn Module>>, DynamicImportedModules>,

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -259,7 +259,7 @@ async fn build_dynamic_imports_map_for_module(
     server_module: Vc<Box<dyn Module>>,
 ) -> Result<Vc<OptionDynamicImportsMap>> {
     let Some(ecmascript_asset) =
-        Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(server_module).await?
+        Vc::try_resolve_sidecast::<Box<dyn Parsable>>(server_module).await?
     else {
         return Ok(Vc::cell(None));
     };

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -13,19 +13,6 @@ use turbo_tasks::{
     RcStr, TryFlatJoinIterExt, Value, ValueToString, Vc,
 };
 use turbo_tasks_fs::{self, rope::RopeBuilder, File, FileSystemPath};
-use turbopack_core::{
-    asset::{Asset, AssetContent},
-    chunk::{ChunkItemExt, ChunkableModule, ChunkingContext, EvaluatableAsset},
-    context::AssetContext,
-    module::Module,
-    output::OutputAsset,
-    reference::primary_referenced_modules,
-    reference_type::{
-        EcmaScriptModulesReferenceSubType, ReferenceType, TypeScriptReferenceSubType,
-    },
-    virtual_output::VirtualOutputAsset,
-    virtual_source::VirtualSource,
-};
 use turbopack_ecmascript::{
     chunk::EcmascriptChunkPlaceable, parse::ParseResult,
     tree_shake::asset::EcmascriptModulePartAsset, EcmascriptModuleAsset, EcmascriptModuleAssetType,
@@ -299,13 +286,9 @@ pub fn parse_server_actions<C: Comments>(
 #[turbo_tasks::function]
 async fn parse_actions(module: Vc<Box<dyn Module>>) -> Result<Vc<OptionActionMap>> {
     let parsed = if let Some(ecmascript_asset) =
-        Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(module).await?
+        Vc::try_resolve_sidecast::<Box<dyn Parsable>>(module).await?
     {
         ecmascript_asset.failsafe_parse()
-    } else if let Some(ecmascript_asset) =
-        Vc::try_resolve_downcast_type::<EcmascriptModulePartAsset>(module).await?
-    {
-        ecmascript_asset.await?.full_module.failsafe_parse()
     } else {
         return Ok(OptionActionMap::none());
     };

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -278,7 +278,7 @@ async fn parse_actions(module: Vc<Box<dyn Module>>) -> Result<Vc<OptionActionMap
     let parsed = if let Some(ecmascript_asset) =
         Vc::try_resolve_sidecast::<Box<dyn Parsable>>(module).await?
     {
-        ecmascript_asset.failsafe_parse()
+        ecmascript_asset.parse_original()
     } else {
         return Ok(OptionActionMap::none());
     };

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -222,7 +222,7 @@ async fn to_rsc_context(
         module.content(),
     );
     let ty = if let Some(module) = Vc::try_resolve_sidecast::<Box<dyn Parsable>>(module).await? {
-        if *module.await?.ty().await? == EcmascriptModuleAssetType::Ecmascript {
+        if *module.ty().await? == EcmascriptModuleAssetType::Ecmascript {
             ReferenceType::EcmaScriptModules(EcmaScriptModulesReferenceSubType::Undefined)
         } else {
             ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined)

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -27,7 +27,8 @@ use turbopack_core::{
     virtual_source::VirtualSource,
 };
 use turbopack_ecmascript::{
-    chunk::EcmascriptChunkPlaceable, parse::ParseResult, EcmascriptModuleAssetType, Parsable,
+    chunk::EcmascriptChunkPlaceable, parse::ParseResult, EcmascriptModuleAssetType,
+    EcmascriptParsable,
 };
 
 /// Scans the RSC entry point's full module graph looking for exported Server
@@ -233,7 +234,9 @@ async fn to_rsc_context(
         module.ident().with_modifier(action_modifier()),
         module.content(),
     );
-    let ty = if let Some(module) = Vc::try_resolve_sidecast::<Box<dyn Parsable>>(module).await? {
+    let ty = if let Some(module) =
+        Vc::try_resolve_sidecast::<Box<dyn EcmascriptParsable>>(module).await?
+    {
         if *module.ty().await? == EcmascriptModuleAssetType::Ecmascript {
             ReferenceType::EcmaScriptModules(EcmaScriptModulesReferenceSubType::Undefined)
         } else {
@@ -288,7 +291,7 @@ pub fn parse_server_actions<C: Comments>(
 #[turbo_tasks::function]
 async fn parse_actions(module: Vc<Box<dyn Module>>) -> Result<Vc<OptionActionMap>> {
     let parsed = if let Some(ecmascript_asset) =
-        Vc::try_resolve_sidecast::<Box<dyn Parsable>>(module).await?
+        Vc::try_resolve_sidecast::<Box<dyn EcmascriptParsable>>(module).await?
     {
         ecmascript_asset.parse_original()
     } else {

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -13,9 +13,21 @@ use turbo_tasks::{
     RcStr, TryFlatJoinIterExt, Value, ValueToString, Vc,
 };
 use turbo_tasks_fs::{self, rope::RopeBuilder, File, FileSystemPath};
+use turbopack_core::{
+    asset::{Asset, AssetContent},
+    chunk::{ChunkItemExt, ChunkableModule, ChunkingContext, EvaluatableAsset},
+    context::AssetContext,
+    module::Module,
+    output::OutputAsset,
+    reference::primary_referenced_modules,
+    reference_type::{
+        EcmaScriptModulesReferenceSubType, ReferenceType, TypeScriptReferenceSubType,
+    },
+    virtual_output::VirtualOutputAsset,
+    virtual_source::VirtualSource,
+};
 use turbopack_ecmascript::{
-    chunk::EcmascriptChunkPlaceable, parse::ParseResult,
-    tree_shake::asset::EcmascriptModulePartAsset, EcmascriptModuleAsset, EcmascriptModuleAssetType,
+    chunk::EcmascriptChunkPlaceable, parse::ParseResult, EcmascriptModuleAssetType, Parsable,
 };
 
 /// Scans the RSC entry point's full module graph looking for exported Server

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -221,18 +221,8 @@ async fn to_rsc_context(
         module.ident().with_modifier(action_modifier()),
         module.content(),
     );
-    let ty = if let Some(module) =
-        Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(module).await?
-    {
-        if module.await?.ty == EcmascriptModuleAssetType::Ecmascript {
-            ReferenceType::EcmaScriptModules(EcmaScriptModulesReferenceSubType::Undefined)
-        } else {
-            ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined)
-        }
-    } else if let Some(module) =
-        Vc::try_resolve_downcast_type::<EcmascriptModulePartAsset>(module).await?
-    {
-        if module.await?.full_module.await?.ty == EcmascriptModuleAssetType::Ecmascript {
+    let ty = if let Some(module) = Vc::try_resolve_sidecast::<Box<dyn Parsable>>(module).await? {
+        if *module.await?.ty().await? == EcmascriptModuleAssetType::Ecmascript {
             ReferenceType::EcmaScriptModules(EcmaScriptModulesReferenceSubType::Undefined)
         } else {
             ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined)

--- a/crates/next-core/src/next_app/metadata/image.rs
+++ b/crates/next-core/src/next_app/metadata/image.rs
@@ -19,7 +19,6 @@ use turbopack_core::{
 use turbopack_ecmascript::{
     chunk::{EcmascriptChunkPlaceable, EcmascriptExports},
     utils::StringifyJs,
-    EcmascriptModuleAsset,
 };
 
 use crate::next_app::AppPage;

--- a/crates/next-core/src/next_app/metadata/image.rs
+++ b/crates/next-core/src/next_app/metadata/image.rs
@@ -132,7 +132,7 @@ pub async fn dynamic_image_metadata_source(
 #[turbo_tasks::function]
 async fn collect_direct_exports(module: Vc<Box<dyn Module>>) -> Result<Vc<Vec<RcStr>>> {
     let Some(ecmascript_asset) =
-        Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(module).await?
+        Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(module).await?
     else {
         return Ok(Default::default());
     };

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -42,7 +42,6 @@ use crate::{
         get_next_client_resolved_map,
     },
     next_shared::{
-        next_js_special_exports,
         resolve::{
             get_invalid_server_only_resolve_plugin, ModuleFeatureReportResolvePlugin,
             NextSharedRuntimeResolvePlugin,
@@ -284,7 +283,6 @@ pub async fn get_client_module_options_context(
         preset_env_versions: Some(env),
         execution_context: Some(execution_context),
         tree_shaking_mode: tree_shaking_mode_for_user_code,
-        special_exports: Some(next_js_special_exports()),
         enable_postcss_transform,
         side_effect_free_packages: next_config.optimize_package_imports().await?.clone_value(),
         ..Default::default()

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -45,7 +45,6 @@ use crate::{
     next_import_map::get_next_server_import_map,
     next_server::resolve::ExternalPredicate,
     next_shared::{
-        next_js_special_exports,
         resolve::{
             get_invalid_client_only_resolve_plugin, get_invalid_styled_jsx_resolve_plugin,
             ModuleFeatureReportResolvePlugin, NextExternalResolvePlugin,
@@ -493,7 +492,6 @@ pub async fn get_server_module_options_context(
             ..Default::default()
         },
         tree_shaking_mode: tree_shaking_mode_for_user_code,
-        special_exports: Some(next_js_special_exports()),
         side_effect_free_packages: next_config.optimize_package_imports().await?.clone_value(),
         ..Default::default()
     };

--- a/crates/next-core/src/next_shared/mod.rs
+++ b/crates/next-core/src/next_shared/mod.rs
@@ -1,31 +1,3 @@
-use turbo_tasks::{RcStr, Vc};
-
 pub(crate) mod resolve;
 pub(crate) mod transforms;
 pub(crate) mod webpack_rules;
-
-#[turbo_tasks::function]
-pub fn next_js_special_exports() -> Vc<Vec<RcStr>> {
-    Vc::cell(
-        [
-            "config",
-            "middleware",
-            "runtime",
-            "revalidate",
-            "dynamic",
-            "dynamicParams",
-            "fetchCache",
-            "preferredRegion",
-            "maxDuration",
-            "generateStaticParams",
-            "metadata",
-            "generateMetadata",
-            "getServerSideProps",
-            "getInitialProps",
-            "getStaticProps",
-        ]
-        .into_iter()
-        .map(RcStr::from)
-        .collect::<Vec<RcStr>>(),
-    )
-}

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -23,7 +23,7 @@ use turbopack_ecmascript::{
     analyzer::{JsValue, ObjectPart},
     parse::ParseResult,
     utils::StringifyJs,
-    Parsable,
+    EcmascriptParsable,
 };
 
 use crate::{
@@ -370,7 +370,9 @@ fn parse_route_matcher_from_js_value(
 
 #[turbo_tasks::function]
 pub async fn parse_config_from_source(module: Vc<Box<dyn Module>>) -> Result<Vc<NextSourceConfig>> {
-    if let Some(ecmascript_asset) = Vc::try_resolve_sidecast::<Box<dyn Parsable>>(module).await? {
+    if let Some(ecmascript_asset) =
+        Vc::try_resolve_sidecast::<Box<dyn EcmascriptParsable>>(module).await?
+    {
         if let ParseResult::Ok {
             program: Program::Module(module_ast),
             globals,

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -370,9 +370,7 @@ fn parse_route_matcher_from_js_value(
 
 #[turbo_tasks::function]
 pub async fn parse_config_from_source(module: Vc<Box<dyn Module>>) -> Result<Vc<NextSourceConfig>> {
-    if let Some(ecmascript_asset) =
-        Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(module).await?
-    {
+    if let Some(ecmascript_asset) = Vc::try_resolve_sidecast::<Box<dyn Parsable>>(module).await? {
         if let ParseResult::Ok {
             program: Program::Module(module_ast),
             globals,

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -23,7 +23,7 @@ use turbopack_ecmascript::{
     analyzer::{JsValue, ObjectPart},
     parse::ParseResult,
     utils::StringifyJs,
-    EcmascriptModuleAsset,
+    Parsable,
 };
 
 use crate::{

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -9,13 +9,12 @@ use anyhow::{bail, Context, Result};
 use turbo_tasks::{RcStr, TransientInstance, TryJoinIterExt, TurboTasks, Value, Vc};
 use turbo_tasks_fs::FileSystem;
 use turbo_tasks_memory::MemoryBackend;
-use turbopack::ecmascript::EcmascriptModuleAsset;
 use turbopack_cli_utils::issue::{ConsoleUi, LogOptions};
 use turbopack_core::{
     asset::Asset,
     chunk::{
         availability_info::AvailabilityInfo, ChunkableModule, ChunkingContext, ChunkingContextExt,
-        EvaluatableAssets, MinifyType,
+        EvaluatableAsset, EvaluatableAssets, MinifyType,
     },
     environment::{BrowserEnvironment, Environment, ExecutionEnvironment},
     issue::{handle_issues, IssueReporter, IssueSeverity},
@@ -259,7 +258,7 @@ async fn build_internal(
         .map(|entry_module| async move {
             Ok(
                 if let Some(ecmascript) =
-                    Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(entry_module).await?
+                    Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(entry_module).await?
                 {
                     Vc::cell(vec![
                         Vc::try_resolve_downcast_type::<NodeJsChunkingContext>(chunking_context)

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -2,7 +2,6 @@ use anyhow::{anyhow, Result};
 use turbo_tasks::{RcStr, TryJoinIterExt, Value, Vc};
 use turbo_tasks_env::ProcessEnv;
 use turbo_tasks_fs::FileSystemPath;
-use turbopack::ecmascript::EcmascriptModuleAsset;
 use turbopack_browser::{react_refresh::assert_can_resolve_react_refresh, BrowserChunkingContext};
 use turbopack_cli_utils::runtime_entry::{RuntimeEntries, RuntimeEntry};
 use turbopack_core::{

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -6,7 +6,7 @@ use turbopack::ecmascript::EcmascriptModuleAsset;
 use turbopack_browser::{react_refresh::assert_can_resolve_react_refresh, BrowserChunkingContext};
 use turbopack_cli_utils::runtime_entry::{RuntimeEntries, RuntimeEntry};
 use turbopack_core::{
-    chunk::{ChunkableModule, ChunkingContext},
+    chunk::{ChunkableModule, ChunkingContext, EvaluatableAsset},
     environment::Environment,
     file_source::FileSource,
     reference_type::{EntryReferenceSubType, ReferenceType},
@@ -121,13 +121,14 @@ pub async fn create_web_entry_source(
         .into_iter()
         .flatten()
         .map(|module| async move {
-            if let Some(ecmascript) =
-                Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(module).await?
-            {
+            if let (Some(chnkable), Some(entry)) = (
+                Vc::try_resolve_sidecast::<Box<dyn ChunkableModule>>(module).await?,
+                Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(module).await?,
+            ) {
                 Ok((
-                    Vc::upcast(ecmascript),
+                    chnkable,
                     chunking_context,
-                    Some(runtime_entries.with_entry(Vc::upcast(ecmascript))),
+                    Some(runtime_entries.with_entry(entry)),
                 ))
             } else if let Some(chunkable) =
                 Vc::try_resolve_sidecast::<Box<dyn ChunkableModule>>(module).await?

--- a/turbopack/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
@@ -6,7 +6,7 @@ use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
         availability_info::AvailabilityInfo, ChunkItem, ChunkType, ChunkableModule,
-        ChunkingContext, ChunkingContextExt, EvaluatableAssets,
+        ChunkingContext, ChunkingContextExt, EvaluatableAsset, EvaluatableAssets,
     },
     ident::AssetIdent,
     introspect::{
@@ -26,7 +26,6 @@ use crate::{
         EcmascriptChunkType, EcmascriptExports,
     },
     utils::StringifyJs,
-    EcmascriptModuleAsset,
 };
 
 #[turbo_tasks::function]
@@ -129,14 +128,14 @@ impl ChunkGroupFilesChunkItem {
         let this = self.await?;
         let inner = this.inner.await?;
         let chunks = if let Some(ecma) =
-            Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(inner.module).await?
+            Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(inner.module).await?
         {
             inner.chunking_context.evaluated_chunk_group_assets(
                 inner.module.ident(),
                 inner
                     .runtime_entries
                     .unwrap_or_else(EvaluatableAssets::empty)
-                    .with_entry(Vc::upcast(ecma)),
+                    .with_entry(ecma),
                 Value::new(AvailabilityInfo::Root),
             )
         } else {

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -251,7 +251,7 @@ pub struct EcmascriptModuleAsset {
 }
 
 #[turbo_tasks::value_trait]
-pub trait Parsable {
+pub trait EcmascriptParsable {
     fn failsafe_parse(self: Vc<Self>) -> Result<Vc<ParseResult>>;
 
     fn parse_original(self: Vc<Self>) -> Result<Vc<ParseResult>>;
@@ -260,7 +260,7 @@ pub trait Parsable {
 }
 
 #[turbo_tasks::value_trait]
-pub trait Analyzable {
+pub trait EcmascriptAnalyzable {
     fn analyze(self: Vc<Self>) -> Vc<AnalyzeEcmascriptModuleResult>;
 
     /// Generates module contents without an analysis pass. This is useful for
@@ -333,7 +333,7 @@ impl ModuleTypeResult {
 }
 
 #[turbo_tasks::value_impl]
-impl Parsable for EcmascriptModuleAsset {
+impl EcmascriptParsable for EcmascriptModuleAsset {
     #[turbo_tasks::function]
     async fn failsafe_parse(self: Vc<Self>) -> Result<Vc<ParseResult>> {
         let real_result = self.parse();
@@ -362,7 +362,7 @@ impl Parsable for EcmascriptModuleAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl Analyzable for EcmascriptModuleAsset {
+impl EcmascriptAnalyzable for EcmascriptModuleAsset {
     #[turbo_tasks::function]
     fn analyze(self: Vc<Self>) -> Vc<AnalyzeEcmascriptModuleResult> {
         analyse_ecmascript_module(self, None)

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -260,6 +260,11 @@ pub trait Parsable {
     fn failsafe_parse(self: Vc<Self>) -> Result<Vc<ParseResult>>;
 }
 
+#[turbo_tasks::value_trait]
+pub trait Analyzable {
+    fn analyze(self: Vc<Self>) -> Vc<AnalyzeEcmascriptModuleResult>;
+}
+
 /// An optional [EcmascriptModuleAsset]
 #[turbo_tasks::value(transparent)]
 pub struct OptionEcmascriptModuleAsset(Option<Vc<EcmascriptModuleAsset>>);
@@ -337,6 +342,14 @@ impl Parsable for EcmascriptModuleAsset {
 }
 
 #[turbo_tasks::value_impl]
+impl Analyzable for EcmascriptModuleAsset {
+    #[turbo_tasks::function]
+    fn analyze(self: Vc<Self>) -> Vc<AnalyzeEcmascriptModuleResult> {
+        analyse_ecmascript_module(self, None)
+    }
+}
+
+#[turbo_tasks::value_impl]
 impl EcmascriptModuleAsset {
     #[turbo_tasks::function]
     pub fn new(
@@ -384,11 +397,6 @@ impl EcmascriptModuleAsset {
     #[turbo_tasks::function]
     pub async fn source(self: Vc<Self>) -> Result<Vc<Box<dyn Source>>> {
         Ok(self.await?.source)
-    }
-
-    #[turbo_tasks::function]
-    pub fn analyze(self: Vc<Self>) -> Vc<AnalyzeEcmascriptModuleResult> {
-        analyse_ecmascript_module(self, None)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -253,6 +253,8 @@ pub struct EcmascriptModuleAsset {
 #[turbo_tasks::value_trait]
 pub trait Parsable {
     fn failsafe_parse(self: Vc<Self>) -> Result<Vc<ParseResult>>;
+
+    fn ty(self: Vc<Self>) -> Result<Vc<EcmascriptModuleAssetType>>;
 }
 
 #[turbo_tasks::value_trait]
@@ -333,6 +335,11 @@ impl Parsable for EcmascriptModuleAsset {
             state_ref.as_ref().unwrap_or(&real_result_value).clone()
         };
         Ok(ReadRef::cell(result_value))
+    }
+
+    #[turbo_tasks::function]
+    async fn ty(self: Vc<Self>) -> Result<Vc<EcmascriptModuleAssetType>> {
+        Ok(self.await?.ty.cell())
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -254,6 +254,8 @@ pub struct EcmascriptModuleAsset {
 pub trait Parsable {
     fn failsafe_parse(self: Vc<Self>) -> Result<Vc<ParseResult>>;
 
+    fn parse_original(self: Vc<Self>) -> Result<Vc<ParseResult>>;
+
     fn ty(self: Vc<Self>) -> Result<Vc<EcmascriptModuleAssetType>>;
 }
 
@@ -346,6 +348,11 @@ impl Parsable for EcmascriptModuleAsset {
             state_ref.as_ref().unwrap_or(&real_result_value).clone()
         };
         Ok(ReadRef::cell(result_value))
+    }
+
+    #[turbo_tasks::function]
+    async fn parse_original(self: Vc<Self>) -> Result<Vc<ParseResult>> {
+        Ok(self.failsafe_parse())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -142,11 +142,6 @@ pub struct EcmascriptOptions {
     /// If false, they will reference the whole directory. If true, they won't
     /// reference anything and lead to an runtime error instead.
     pub ignore_dynamic_requests: bool,
-
-    /// The list of export names that should make tree shaking bail off. This is
-    /// required because tree shaking can split imports like `export const
-    /// runtime = 'edge'` as a separate module.
-    pub special_exports: Vc<Vec<RcStr>>,
 }
 
 #[turbo_tasks::value(serialization = "auto_for_input")]

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -96,7 +96,6 @@ pub struct EsmAssetReference {
     pub issue_source: Option<Vc<IssueSource>>,
     pub export_name: Option<Vc<ModulePart>>,
     pub import_externals: bool,
-    pub special_exports: Vc<Vec<RcStr>>,
 }
 
 /// A list of [EsmAssetReference]s
@@ -122,7 +121,6 @@ impl EsmAssetReference {
         issue_source: Option<Vc<IssueSource>>,
         annotations: Value<ImportAnnotations>,
         export_name: Option<Vc<ModulePart>>,
-        special_exports: Vc<Vec<RcStr>>,
         import_externals: bool,
     ) -> Vc<Self> {
         Self::cell(EsmAssetReference {
@@ -132,7 +130,6 @@ impl EsmAssetReference {
             annotations: annotations.into_value(),
             export_name,
             import_externals,
-            special_exports,
         })
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -135,7 +135,8 @@ use crate::{
     },
     tree_shake::{find_turbopack_part_id_in_asserts, part_of_module, split},
     utils::AstPathRange,
-    EcmascriptInputTransforms, EcmascriptModuleAsset, SpecifiedModuleType, TreeShakingMode,
+    EcmascriptInputTransforms, EcmascriptModuleAsset, Parsable, SpecifiedModuleType,
+    TreeShakingMode,
 };
 
 #[derive(Clone)]

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -358,7 +358,6 @@ struct AnalysisState<'a> {
     // the object allocation.
     first_import_meta: bool,
     tree_shaking_mode: Option<TreeShakingMode>,
-    special_exports: Vc<Vec<RcStr>>,
     import_externals: bool,
     ignore_dynamic_requests: bool,
 }
@@ -418,7 +417,6 @@ pub(crate) async fn analyse_ecmascript_module_internal(
     let options = raw_module.options;
     let compile_time_info = raw_module.compile_time_info;
     let options = options.await?;
-    let special_exports = options.special_exports;
     let import_externals = options.import_externals;
 
     let origin = Vc::upcast::<Box<dyn ResolveOrigin>>(module);
@@ -435,7 +433,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
 
     let parsed = if let Some(part) = part {
         let parsed = parse(source, ty, transforms);
-        let split_data = split(source.ident(), source, parsed, special_exports);
+        let split_data = split(source.ident(), source, parsed);
         part_of_module(split_data, part)
     } else {
         module.failsafe_parse()
@@ -603,7 +601,6 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                     None
                 }
             },
-            special_exports,
             import_externals,
         );
 
@@ -829,7 +826,6 @@ pub(crate) async fn analyse_ecmascript_module_internal(
         first_import_meta: true,
         tree_shaking_mode: options.tree_shaking_mode,
         import_externals: options.import_externals,
-        special_exports: options.special_exports,
         ignore_dynamic_requests: options.ignore_dynamic_requests,
     };
 
@@ -2040,7 +2036,6 @@ async fn handle_free_var_reference(
                         .map(|export| ModulePart::export(export.clone())),
                     None => None,
                 },
-                state.special_exports,
                 state.import_externals,
             )
             .resolve()

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -135,7 +135,7 @@ use crate::{
     },
     tree_shake::{find_turbopack_part_id_in_asserts, part_of_module, split},
     utils::AstPathRange,
-    EcmascriptInputTransforms, EcmascriptModuleAsset, Parsable, SpecifiedModuleType,
+    EcmascriptInputTransforms, EcmascriptModuleAsset, EcmascriptParsable, SpecifiedModuleType,
     TreeShakingMode,
 };
 

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -20,7 +20,7 @@ use crate::{
         esm::{EsmExport, EsmExports},
     },
     side_effect_optimization::reference::EcmascriptModulePartReference,
-    Analyzable,
+    EcmascriptAnalyzable,
 };
 
 /// A module derived from an original ecmascript module that only contains all
@@ -72,7 +72,7 @@ impl Module for EcmascriptModuleFacadeModule {
         let references = match &*self.ty.await? {
             ModulePart::Evaluation => {
                 let Some(module) =
-                    Vc::try_resolve_sidecast::<Box<dyn Analyzable>>(self.module).await?
+                    Vc::try_resolve_sidecast::<Box<dyn EcmascriptAnalyzable>>(self.module).await?
                 else {
                     bail!(
                         "Expected EcmascriptModuleAsset for a EcmascriptModuleFacadeModule with \
@@ -90,7 +90,7 @@ impl Module for EcmascriptModuleFacadeModule {
             }
             ModulePart::Exports => {
                 let Some(module) =
-                    Vc::try_resolve_sidecast::<Box<dyn Analyzable>>(self.module).await?
+                    Vc::try_resolve_sidecast::<Box<dyn EcmascriptAnalyzable>>(self.module).await?
                 else {
                     bail!(
                         "Expected EcmascriptModuleAsset for a EcmascriptModuleFacadeModule with \

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -20,7 +20,7 @@ use crate::{
         esm::{EsmExport, EsmExports},
     },
     side_effect_optimization::reference::EcmascriptModulePartReference,
-    EcmascriptModuleAsset,
+    Analyzable, EcmascriptModuleAsset,
 };
 
 /// A module derived from an original ecmascript module that only contains all

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -20,7 +20,7 @@ use crate::{
         esm::{EsmExport, EsmExports},
     },
     side_effect_optimization::reference::EcmascriptModulePartReference,
-    Analyzable, EcmascriptModuleAsset,
+    Analyzable,
 };
 
 /// A module derived from an original ecmascript module that only contains all
@@ -72,7 +72,7 @@ impl Module for EcmascriptModuleFacadeModule {
         let references = match &*self.ty.await? {
             ModulePart::Evaluation => {
                 let Some(module) =
-                    Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(self.module).await?
+                    Vc::try_resolve_sidecast::<Box<dyn Analyzable>>(self.module).await?
                 else {
                     bail!(
                         "Expected EcmascriptModuleAsset for a EcmascriptModuleFacadeModule with \
@@ -90,7 +90,7 @@ impl Module for EcmascriptModuleFacadeModule {
             }
             ModulePart::Exports => {
                 let Some(module) =
-                    Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(self.module).await?
+                    Vc::try_resolve_sidecast::<Box<dyn Analyzable>>(self.module).await?
                 else {
                     bail!(
                         "Expected EcmascriptModuleAsset for a EcmascriptModuleFacadeModule with \

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
@@ -13,7 +13,7 @@ use crate::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
         EcmascriptChunkType,
     },
-    EcmascriptModuleContent,
+    Analyzable, EcmascriptModuleContent,
 };
 
 /// The chunk item for [EcmascriptModuleLocalsModule].

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
@@ -13,7 +13,7 @@ use crate::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
         EcmascriptChunkType,
     },
-    Analyzable, EcmascriptModuleContent,
+    EcmascriptAnalyzable, EcmascriptModuleContent,
 };
 
 /// The chunk item for [EcmascriptModuleLocalsModule].

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -19,7 +19,7 @@ use crate::{
         async_module::OptionAsyncModule,
         esm::{EsmExport, EsmExports},
     },
-    Analyzable, EcmascriptModuleAsset,
+    EcmascriptAnalyzable, EcmascriptModuleAsset,
 };
 
 /// A module derived from an original ecmascript module that only contains the

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -19,7 +19,7 @@ use crate::{
         async_module::OptionAsyncModule,
         esm::{EsmExport, EsmExports},
     },
-    EcmascriptModuleAsset,
+    Analyzable, EcmascriptModuleAsset,
 };
 
 /// A module derived from an original ecmascript module that only contains the

--- a/turbopack/crates/turbopack-ecmascript/src/static_code.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/static_code.rs
@@ -8,7 +8,7 @@ use turbopack_core::{
     reference_type::ReferenceType,
 };
 
-use crate::EcmascriptModuleAsset;
+use crate::Analyzable;
 
 /// Static ECMAScript file code, to be used as part of some code.
 ///
@@ -17,7 +17,7 @@ use crate::EcmascriptModuleAsset;
 #[turbo_tasks::value]
 pub struct StaticEcmascriptCode {
     asset_context: Vc<Box<dyn AssetContext>>,
-    asset: Vc<EcmascriptModuleAsset>,
+    asset: Vc<Box<dyn Analyzable>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -34,8 +34,7 @@ impl StaticEcmascriptCode {
                 Value::new(ReferenceType::Runtime),
             )
             .module();
-        let Some(asset) = Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(module).await?
-        else {
+        let Some(asset) = Vc::try_resolve_sidecast::<Box<dyn Analyzable>>(module).await? else {
             bail!("asset is not an Ecmascript module")
         };
         Ok(Self::cell(StaticEcmascriptCode {

--- a/turbopack/crates/turbopack-ecmascript/src/static_code.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/static_code.rs
@@ -8,7 +8,7 @@ use turbopack_core::{
     reference_type::ReferenceType,
 };
 
-use crate::Analyzable;
+use crate::EcmascriptAnalyzable;
 
 /// Static ECMAScript file code, to be used as part of some code.
 ///
@@ -17,7 +17,7 @@ use crate::Analyzable;
 #[turbo_tasks::value]
 pub struct StaticEcmascriptCode {
     asset_context: Vc<Box<dyn AssetContext>>,
-    asset: Vc<Box<dyn Analyzable>>,
+    asset: Vc<Box<dyn EcmascriptAnalyzable>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -34,7 +34,8 @@ impl StaticEcmascriptCode {
                 Value::new(ReferenceType::Runtime),
             )
             .module();
-        let Some(asset) = Vc::try_resolve_sidecast::<Box<dyn Analyzable>>(module).await? else {
+        let Some(asset) = Vc::try_resolve_sidecast::<Box<dyn EcmascriptAnalyzable>>(module).await?
+        else {
             bail!("asset is not an Ecmascript module")
         };
         Ok(Self::cell(StaticEcmascriptCode {

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -17,7 +17,8 @@ use crate::{
     chunk::{EcmascriptChunkPlaceable, EcmascriptExports},
     parse::ParseResult,
     references::analyse_ecmascript_module,
-    Analyzable, AnalyzeEcmascriptModuleResult, EcmascriptModuleAsset, Parsable,
+    Analyzable, AnalyzeEcmascriptModuleResult, EcmascriptModuleAsset, EcmascriptModuleAssetType,
+    Parsable,
 };
 
 /// A reference to part of an ES module.
@@ -39,6 +40,11 @@ impl Parsable for EcmascriptModulePartAsset {
         let parsed = this.full_module.failsafe_parse();
         let split_data = split(this.full_module.ident(), this.full_module.source(), parsed);
         Ok(part_of_module(split_data, this.part))
+    }
+
+    #[turbo_tasks::function]
+    async fn ty(self: Vc<Self>) -> Result<Vc<EcmascriptModuleAssetType>> {
+        Ok(self.await?.full_module.ty())
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -43,6 +43,11 @@ impl Parsable for EcmascriptModulePartAsset {
     }
 
     #[turbo_tasks::function]
+    async fn parse_original(self: Vc<Self>) -> Result<Vc<ParseResult>> {
+        Ok(self.await?.full_module.parse_original())
+    }
+
+    #[turbo_tasks::function]
     async fn ty(self: Vc<Self>) -> Result<Vc<EcmascriptModuleAssetType>> {
         Ok(self.await?.full_module.ty())
     }

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -17,8 +17,8 @@ use crate::{
     chunk::{EcmascriptChunkPlaceable, EcmascriptExports},
     parse::ParseResult,
     references::analyse_ecmascript_module,
-    Analyzable, AnalyzeEcmascriptModuleResult, EcmascriptModuleAsset, EcmascriptModuleAssetType,
-    EcmascriptModuleContent, Parsable,
+    AnalyzeEcmascriptModuleResult, EcmascriptAnalyzable, EcmascriptModuleAsset,
+    EcmascriptModuleAssetType, EcmascriptModuleContent, EcmascriptParsable,
 };
 
 /// A reference to part of an ES module.
@@ -32,7 +32,7 @@ pub struct EcmascriptModulePartAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl Parsable for EcmascriptModulePartAsset {
+impl EcmascriptParsable for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     async fn failsafe_parse(self: Vc<Self>) -> Result<Vc<ParseResult>> {
         let this = self.await?;
@@ -54,7 +54,7 @@ impl Parsable for EcmascriptModulePartAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl Analyzable for EcmascriptModulePartAsset {
+impl EcmascriptAnalyzable for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     async fn analyze(self: Vc<Self>) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
         let this = self.await?;

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -17,7 +17,7 @@ use crate::{
     chunk::{EcmascriptChunkPlaceable, EcmascriptExports},
     parse::ParseResult,
     references::analyse_ecmascript_module,
-    AnalyzeEcmascriptModuleResult, EcmascriptModuleAsset, Parsable,
+    Analyzable, AnalyzeEcmascriptModuleResult, EcmascriptModuleAsset, Parsable,
 };
 
 /// A reference to part of an ES module.
@@ -45,6 +45,16 @@ impl Parsable for EcmascriptModulePartAsset {
             special_exports,
         );
         Ok(part_of_module(split_data, this.part))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Analyzable for EcmascriptModulePartAsset {
+    #[turbo_tasks::function]
+    async fn analyze(self: Vc<Self>) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
+        let this = self.await?;
+        let part = this.part;
+        Ok(analyse_ecmascript_module(this.full_module, Some(part)))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -37,13 +37,7 @@ impl Parsable for EcmascriptModulePartAsset {
         let this = self.await?;
 
         let parsed = this.full_module.failsafe_parse();
-        let special_exports = this.full_module.options().await?.special_exports;
-        let split_data = split(
-            this.full_module.ident(),
-            this.full_module.source(),
-            parsed,
-            special_exports,
-        );
+        let split_data = split(this.full_module.ident(), this.full_module.source(), parsed);
         Ok(part_of_module(split_data, this.part))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -437,12 +437,7 @@ impl PartialEq for SplitResult {
 
 #[turbo_tasks::function]
 pub(super) async fn split_module(asset: Vc<EcmascriptModuleAsset>) -> Result<Vc<SplitResult>> {
-    Ok(split(
-        asset.source().ident(),
-        asset.source(),
-        asset.parse(),
-        asset.options().await?.special_exports,
-    ))
+    Ok(split(asset.source().ident(), asset.source(), asset.parse()))
 }
 
 #[turbo_tasks::function]
@@ -450,7 +445,6 @@ pub(super) async fn split(
     ident: Vc<AssetIdent>,
     source: Vc<Box<dyn Source>>,
     parsed: Vc<ParseResult>,
-    special_exports: Vc<Vec<RcStr>>,
 ) -> Result<Vc<SplitResult>> {
     let parse_result = parsed.await?;
 
@@ -464,7 +458,7 @@ pub(super) async fn split(
             ..
         } => {
             // If the script file is a common js file, we cannot split the module
-            if util::should_skip_tree_shaking(program, &special_exports.await?) {
+            if util::should_skip_tree_shaking(program) {
                 return Ok(SplitResult::Failed {
                     parse_result: parsed,
                 }

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/util.rs
@@ -14,7 +14,6 @@ use swc_core::{
         visit::{noop_visit_type, Visit, VisitWith},
     },
 };
-use turbo_tasks::RcStr;
 
 use crate::TURBOPACK_HELPER;
 
@@ -393,7 +392,7 @@ where
     v.bindings
 }
 
-pub fn should_skip_tree_shaking(m: &Program, special_exports: &[RcStr]) -> bool {
+pub fn should_skip_tree_shaking(m: &Program) -> bool {
     if let Program::Module(m) = m {
         for item in m.body.iter() {
             match item {
@@ -443,30 +442,6 @@ pub fn should_skip_tree_shaking(m: &Program, special_exports: &[RcStr]) -> bool 
                     ..
                 })) => {
                     if value == "use server" {
-                        return true;
-                    }
-                }
-
-                // Skip special reexports that are recognized by next.js
-                ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                    decl: Decl::Var(box VarDecl { decls, .. }),
-                    ..
-                })) => {
-                    for decl in decls {
-                        if let Pat::Ident(name) = &decl.name {
-                            if special_exports.iter().any(|s| **s == *name.sym) {
-                                return true;
-                            }
-                        }
-                    }
-                }
-
-                // Skip special reexports that are recognized by next.js
-                ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                    decl: Decl::Fn(f),
-                    ..
-                })) => {
-                    if special_exports.iter().any(|s| **s == *f.ident.sym) {
                         return true;
                     }
                 }

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -20,7 +20,7 @@ use turbo_tasks_fs::{
 };
 use turbo_tasks_memory::MemoryBackend;
 use turbopack::{
-    ecmascript::{EcmascriptInputTransform, EcmascriptModuleAsset, TreeShakingMode},
+    ecmascript::{EcmascriptInputTransform, TreeShakingMode},
     module_options::{
         CssOptionsContext, EcmascriptOptionsContext, JsxTransformOptions, ModuleOptionsContext,
         ModuleRule, ModuleRuleCondition, ModuleRuleEffect,

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -32,7 +32,7 @@ use turbopack_core::{
     asset::Asset,
     chunk::{
         availability_info::AvailabilityInfo, ChunkableModule, ChunkingContext, ChunkingContextExt,
-        EvaluatableAssetExt, EvaluatableAssets, MinifyType,
+        EvaluatableAsset, EvaluatableAssetExt, EvaluatableAssets, MinifyType,
     },
     compile_time_defines,
     compile_time_info::CompileTimeInfo,
@@ -360,12 +360,12 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         .module();
 
     let chunks = if let Some(ecmascript) =
-        Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(entry_module).await?
+        Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(entry_module).await?
     {
         // TODO: Load runtime entries from snapshots
         match options.runtime {
             Runtime::Browser => chunking_context.evaluated_chunk_group_assets(
-                ecmascript.ident(),
+                entry_module.ident(),
                 runtime_entries
                     .unwrap_or_else(EvaluatableAssets::empty)
                     .with_entry(Vc::upcast(ecmascript)),
@@ -390,7 +390,7 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                                         .into(),
                                 )
                                 .with_extension("entry.js".into()),
-                            Vc::upcast(ecmascript),
+                            entry_module,
                             runtime_entries
                                 .unwrap_or_else(EvaluatableAssets::empty)
                                 .with_entry(Vc::upcast(ecmascript)),

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/output/4c35f_tests_snapshot_basic-tree-shake_dynamic-import_input_index_c9a76e.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/output/4c35f_tests_snapshot_basic-tree-shake_dynamic-import_input_index_c9a76e.js
@@ -1,6 +1,0 @@
-(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
-    "output/4c35f_tests_snapshot_basic-tree-shake_dynamic-import_input_index_c9a76e.js",
-    {},
-    {"otherChunks":["output/4c35f_tests_snapshot_basic-tree-shake_dynamic-import_input_index_92a5f4.js","output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_dynamic-import_input_lib_f9749a.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/index.js [test] (ecmascript)"]}
-]);
-// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/output/4c35f_tests_snapshot_basic-tree-shake_dynamic-import_input_index_c9a76e.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/output/4c35f_tests_snapshot_basic-tree-shake_dynamic-import_input_index_c9a76e.js
@@ -1,0 +1,6 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
+    "output/4c35f_tests_snapshot_basic-tree-shake_dynamic-import_input_index_c9a76e.js",
+    {},
+    {"otherChunks":["output/4c35f_tests_snapshot_basic-tree-shake_dynamic-import_input_index_92a5f4.js","output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_dynamic-import_input_lib_f9749a.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/index.js [test] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/output/4c35f_tests_snapshot_basic-tree-shake_dynamic-import_input_index_c9a76e.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/output/4c35f_tests_snapshot_basic-tree-shake_dynamic-import_input_index_c9a76e.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/output/4c35f_tests_snapshot_basic-tree-shake_dynamic-import_input_index_c9a76e.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/output/4c35f_tests_snapshot_basic-tree-shake_dynamic-import_input_index_c9a76e.js.map
@@ -1,5 +1,0 @@
-{
-  "version": 3,
-  "sources": [],
-  "sections": []
-}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_index_8f30d2.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_index_8f30d2.js
@@ -1,6 +1,0 @@
-(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
-    "output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_index_8f30d2.js",
-    {},
-    {"otherChunks":["output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_e124f3._.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/index.js [test] (ecmascript) <facade>"]}
-]);
-// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_index_8f30d2.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_index_8f30d2.js
@@ -1,0 +1,6 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
+    "output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_index_8f30d2.js",
+    {},
+    {"otherChunks":["output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_e124f3._.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/index.js [test] (ecmascript) <facade>"]}
+]);
+// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_index_8f30d2.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_index_8f30d2.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_index_8f30d2.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_index_8f30d2.js.map
@@ -1,5 +1,0 @@
-{
-  "version": 3,
-  "sources": [],
-  "sections": []
-}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/4c35f_tests_snapshot_basic-tree-shake_export-namespace_input_index_6382de.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/4c35f_tests_snapshot_basic-tree-shake_export-namespace_input_index_6382de.js
@@ -1,6 +1,0 @@
-(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
-    "output/4c35f_tests_snapshot_basic-tree-shake_export-namespace_input_index_6382de.js",
-    {},
-    {"otherChunks":["output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-namespace_input_90a893._.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/index.js [test] (ecmascript) <facade>"]}
-]);
-// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/4c35f_tests_snapshot_basic-tree-shake_export-namespace_input_index_6382de.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/4c35f_tests_snapshot_basic-tree-shake_export-namespace_input_index_6382de.js
@@ -1,0 +1,6 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
+    "output/4c35f_tests_snapshot_basic-tree-shake_export-namespace_input_index_6382de.js",
+    {},
+    {"otherChunks":["output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-namespace_input_90a893._.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/index.js [test] (ecmascript) <facade>"]}
+]);
+// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/4c35f_tests_snapshot_basic-tree-shake_export-namespace_input_index_6382de.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/4c35f_tests_snapshot_basic-tree-shake_export-namespace_input_index_6382de.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/4c35f_tests_snapshot_basic-tree-shake_export-namespace_input_index_6382de.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/4c35f_tests_snapshot_basic-tree-shake_export-namespace_input_index_6382de.js.map
@@ -1,5 +1,0 @@
-{
-  "version": 3,
-  "sources": [],
-  "sections": []
-}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/output/4c35f_tests_snapshot_basic-tree-shake_import-named-all_input_index_10d2db.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/output/4c35f_tests_snapshot_basic-tree-shake_import-named-all_input_index_10d2db.js
@@ -1,6 +1,0 @@
-(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
-    "output/4c35f_tests_snapshot_basic-tree-shake_import-named-all_input_index_10d2db.js",
-    {},
-    {"otherChunks":["output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-named-all_input_fffde0._.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/index.js [test] (ecmascript) <facade>"]}
-]);
-// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/output/4c35f_tests_snapshot_basic-tree-shake_import-named-all_input_index_10d2db.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/output/4c35f_tests_snapshot_basic-tree-shake_import-named-all_input_index_10d2db.js
@@ -1,0 +1,6 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
+    "output/4c35f_tests_snapshot_basic-tree-shake_import-named-all_input_index_10d2db.js",
+    {},
+    {"otherChunks":["output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-named-all_input_fffde0._.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/index.js [test] (ecmascript) <facade>"]}
+]);
+// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/output/4c35f_tests_snapshot_basic-tree-shake_import-named-all_input_index_10d2db.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/output/4c35f_tests_snapshot_basic-tree-shake_import-named-all_input_index_10d2db.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/output/4c35f_tests_snapshot_basic-tree-shake_import-named-all_input_index_10d2db.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/output/4c35f_tests_snapshot_basic-tree-shake_import-named-all_input_index_10d2db.js.map
@@ -1,5 +1,0 @@
-{
-  "version": 3,
-  "sources": [],
-  "sections": []
-}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-named_input_index_e45c55.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-named_input_index_e45c55.js
@@ -1,6 +1,0 @@
-(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
-    "output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-named_input_index_e45c55.js",
-    {},
-    {"otherChunks":["output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-named_input_7d8cea._.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/index.js [test] (ecmascript) <facade>"]}
-]);
-// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-named_input_index_e45c55.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-named_input_index_e45c55.js
@@ -1,0 +1,6 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
+    "output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-named_input_index_e45c55.js",
+    {},
+    {"otherChunks":["output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-named_input_7d8cea._.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/index.js [test] (ecmascript) <facade>"]}
+]);
+// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-named_input_index_e45c55.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-named_input_index_e45c55.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-named_input_index_e45c55.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-named_input_index_e45c55.js.map
@@ -1,5 +1,0 @@
-{
-  "version": 3,
-  "sources": [],
-  "sections": []
-}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/output/4c35f_tests_snapshot_basic-tree-shake_import-namespace_input_index_6d0958.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/output/4c35f_tests_snapshot_basic-tree-shake_import-namespace_input_index_6d0958.js
@@ -1,6 +1,0 @@
-(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
-    "output/4c35f_tests_snapshot_basic-tree-shake_import-namespace_input_index_6d0958.js",
-    {},
-    {"otherChunks":["output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-namespace_input_ab57e2._.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/index.js [test] (ecmascript) <facade>"]}
-]);
-// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/output/4c35f_tests_snapshot_basic-tree-shake_import-namespace_input_index_6d0958.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/output/4c35f_tests_snapshot_basic-tree-shake_import-namespace_input_index_6d0958.js
@@ -1,0 +1,6 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
+    "output/4c35f_tests_snapshot_basic-tree-shake_import-namespace_input_index_6d0958.js",
+    {},
+    {"otherChunks":["output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-namespace_input_ab57e2._.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/index.js [test] (ecmascript) <facade>"]}
+]);
+// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/output/4c35f_tests_snapshot_basic-tree-shake_import-namespace_input_index_6d0958.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/output/4c35f_tests_snapshot_basic-tree-shake_import-namespace_input_index_6d0958.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/output/4c35f_tests_snapshot_basic-tree-shake_import-namespace_input_index_6d0958.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/output/4c35f_tests_snapshot_basic-tree-shake_import-namespace_input_index_6d0958.js.map
@@ -1,5 +1,0 @@
-{
-  "version": 3,
-  "sources": [],
-  "sections": []
-}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_import-side-effect_input_index_ef3f12.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_import-side-effect_input_index_ef3f12.js
@@ -1,6 +1,0 @@
-(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
-    "output/4c35f_tests_snapshot_basic-tree-shake_import-side-effect_input_index_ef3f12.js",
-    {},
-    {"otherChunks":["output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-side-effect_input_98e37c._.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/index.js [test] (ecmascript) <facade>"]}
-]);
-// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_import-side-effect_input_index_ef3f12.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_import-side-effect_input_index_ef3f12.js
@@ -1,0 +1,6 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
+    "output/4c35f_tests_snapshot_basic-tree-shake_import-side-effect_input_index_ef3f12.js",
+    {},
+    {"otherChunks":["output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-side-effect_input_98e37c._.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/input/index.js [test] (ecmascript) <facade>"]}
+]);
+// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_import-side-effect_input_index_ef3f12.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_import-side-effect_input_index_ef3f12.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_import-side-effect_input_index_ef3f12.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_import-side-effect_input_index_ef3f12.js.map
@@ -1,5 +1,0 @@
-{
-  "version": 3,
-  "sources": [],
-  "sections": []
-}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_require-side-effect_input_index_e3ee69.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_require-side-effect_input_index_e3ee69.js
@@ -1,6 +1,0 @@
-(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
-    "output/4c35f_tests_snapshot_basic-tree-shake_require-side-effect_input_index_e3ee69.js",
-    {},
-    {"otherChunks":["output/4c35f_tests_snapshot_basic-tree-shake_require-side-effect_input_a86367._.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/index.js [test] (ecmascript)"]}
-]);
-// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_require-side-effect_input_index_e3ee69.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_require-side-effect_input_index_e3ee69.js
@@ -1,0 +1,6 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
+    "output/4c35f_tests_snapshot_basic-tree-shake_require-side-effect_input_index_e3ee69.js",
+    {},
+    {"otherChunks":["output/4c35f_tests_snapshot_basic-tree-shake_require-side-effect_input_a86367._.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/index.js [test] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_require-side-effect_input_index_e3ee69.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_require-side-effect_input_index_e3ee69.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_require-side-effect_input_index_e3ee69.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_require-side-effect_input_index_e3ee69.js.map
@@ -1,5 +1,0 @@
-{
-  "version": 3,
-  "sources": [],
-  "sections": []
-}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_basic-tree-shake_tree-shake-test-1_input_index_5eb8fa.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_basic-tree-shake_tree-shake-test-1_input_index_5eb8fa.js
@@ -1,6 +1,0 @@
-(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
-    "output/4c35f_tests_snapshot_basic-tree-shake_tree-shake-test-1_input_index_5eb8fa.js",
-    {},
-    {"otherChunks":["output/4c35f_tests_snapshot_basic-tree-shake_tree-shake-test-1_input_index_7bacd6.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js [test] (ecmascript) <facade>"]}
-]);
-// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_basic-tree-shake_tree-shake-test-1_input_index_5eb8fa.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_basic-tree-shake_tree-shake-test-1_input_index_5eb8fa.js
@@ -1,0 +1,6 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
+    "output/4c35f_tests_snapshot_basic-tree-shake_tree-shake-test-1_input_index_5eb8fa.js",
+    {},
+    {"otherChunks":["output/4c35f_tests_snapshot_basic-tree-shake_tree-shake-test-1_input_index_7bacd6.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js [test] (ecmascript) <facade>"]}
+]);
+// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_basic-tree-shake_tree-shake-test-1_input_index_5eb8fa.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_basic-tree-shake_tree-shake-test-1_input_index_5eb8fa.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_basic-tree-shake_tree-shake-test-1_input_index_5eb8fa.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_basic-tree-shake_tree-shake-test-1_input_index_5eb8fa.js.map
@@ -1,5 +1,0 @@
-{
-  "version": 3,
-  "sources": [],
-  "sections": []
-}

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -91,10 +91,8 @@ impl ModuleOptions {
             execution_context,
             ref rules,
             tree_shaking_mode,
-            special_exports,
             ..
         } = *module_options_context.await?;
-        let special_exports = special_exports.unwrap_or_default();
 
         if !rules.is_empty() {
             let path_value = path.await?;
@@ -133,7 +131,6 @@ impl ModuleOptions {
             tree_shaking_mode,
             url_rewrite_behavior: esm_url_rewrite_behavior,
             import_externals,
-            special_exports,
             ignore_dynamic_requests,
             refresh,
             ..Default::default()


### PR DESCRIPTION
### What?

Now we have tree shaking implementation but it uses `EcmascriptModulePartAsset` as the module type. So casting to `EcmascriptModuleAsset` can break the tree shaking.

This PR also removes `special exports` of turbopack, which is cumbersome. The previous analysis logic for those special exports may depend on the value being `EcmascriptModuleAsset`, which is resolved in this PR.

### Why?

Clean code & for future woork.


### How?

Closes PACK-3175