### PR TITLE
allow to run trace-server on a different port

### DIFF
--- a/turbopack/crates/turbopack-trace-server/src/lib.rs
+++ b/turbopack/crates/turbopack-trace-server/src/lib.rs
@@ -24,7 +24,7 @@ pub fn start_turbopack_trace_server(path: PathBuf) {
     let store = Arc::new(StoreContainer::new());
     let reader = TraceReader::spawn(store.clone(), path);
 
-    serve(store);
+    serve(store, 5747);
 
     reader.join().unwrap();
 }

--- a/turbopack/crates/turbopack-trace-server/src/main.rs
+++ b/turbopack/crates/turbopack-trace-server/src/main.rs
@@ -23,15 +23,14 @@ mod viewer;
 fn main() {
     let args: HashSet<String> = std::env::args().skip(1).collect();
 
-    let arg = args
-        .iter()
-        .next()
-        .expect("missing argument: trace file path");
+    let mut iter = args.iter();
+    let arg = iter.next().expect("missing argument: trace file path");
+    let port = iter.next().map_or(5747, |s| s.parse().unwrap());
 
     let store = Arc::new(StoreContainer::new());
     let reader = TraceReader::spawn(store.clone(), arg.into());
 
-    serve(store);
+    serve(store, port);
 
     reader.join().unwrap();
 }

--- a/turbopack/crates/turbopack-trace-server/src/server.rs
+++ b/turbopack/crates/turbopack-trace-server/src/server.rs
@@ -1,5 +1,5 @@
 use std::{
-    net::{TcpListener, TcpStream},
+    net::{SocketAddr, SocketAddrV4, TcpListener, TcpStream},
     sync::{Arc, Mutex},
     thread::spawn,
 };
@@ -115,8 +115,12 @@ struct ConnectionState {
     last_update_generation: usize,
 }
 
-pub fn serve(store: Arc<StoreContainer>) {
-    let server = TcpListener::bind("127.0.0.1:5747").unwrap();
+pub fn serve(store: Arc<StoreContainer>, port: u16) {
+    let server = TcpListener::bind(SocketAddr::V4(SocketAddrV4::new(
+        std::net::Ipv4Addr::new(127, 0, 0, 1),
+        port,
+    )))
+    .unwrap();
     for stream in server.incoming() {
         let store = store.clone();
 


### PR DESCRIPTION
### Why?

Sometimes it's useful to view multiple traces at the same time

`https://turbo-trace-viewer.vercel.app/?port=1234`
