### PR TITLE
[Turbopack] Transient Tasks

### DIFF
--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -352,13 +352,27 @@ impl TurboFn {
             parse_quote! {
                 {
                     #assertions
+                    let turbo_tasks_transient = #( turbo_tasks::TaskInput::is_transient(&#inputs) ||)* false;
+                    let turbo_tasks_trait = *#trait_type_id_ident;
+                    let turbo_tasks_name = std::borrow::Cow::Borrowed(stringify!(#ident));
+                    let turbo_tasks_this = #converted_this;
+                    let turbo_tasks_arg = Box::new((#(#inputs,)*)) as Box<dyn turbo_tasks::MagicAny>;
                     <#output as turbo_tasks::task::TaskOutput>::try_from_raw_vc(
-                        turbo_tasks::trait_call(
-                            *#trait_type_id_ident,
-                            std::borrow::Cow::Borrowed(stringify!(#ident)),
-                            #converted_this,
-                            Box::new((#(#inputs,)*)) as Box<dyn turbo_tasks::MagicAny>,
-                        )
+                        if turbo_tasks_transient {
+                            turbo_tasks::transient_trait_call(
+                                turbo_tasks_trait,
+                                turbo_tasks_name,
+                                turbo_tasks_this,
+                                turbo_tasks_arg,
+                            )
+                        } else {
+                            turbo_tasks::trait_call(
+                                turbo_tasks_trait,
+                                turbo_tasks_name,
+                                turbo_tasks_this,
+                                turbo_tasks_arg,
+                            )
+                        }
                     )
                 }
             }
@@ -381,12 +395,24 @@ impl TurboFn {
             parse_quote! {
                 {
                     #assertions
+                    let turbo_tasks_transient = #( turbo_tasks::TaskInput::is_transient(&#inputs) ||)* false;
+                    let turbo_tasks_func = *#native_function_id_ident;
+                    let turbo_tasks_this = #converted_this;
+                    let turbo_tasks_arg = Box::new((#(#inputs,)*)) as Box<dyn turbo_tasks::MagicAny>;
                     <#output as turbo_tasks::task::TaskOutput>::try_from_raw_vc(
-                        turbo_tasks::dynamic_this_call(
-                            *#native_function_id_ident,
-                            #converted_this,
-                            Box::new((#(#inputs,)*)) as Box<dyn turbo_tasks::MagicAny>,
-                        )
+                        if turbo_tasks_transient {
+                            turbo_tasks::transient_dynamic_this_call(
+                                turbo_tasks_func,
+                                turbo_tasks_this,
+                                turbo_tasks_arg,
+                            )
+                        } else {
+                            turbo_tasks::dynamic_this_call(
+                                turbo_tasks_func,
+                                turbo_tasks_this,
+                                turbo_tasks_arg,
+                            )
+                        }
                     )
                 }
             }
@@ -394,11 +420,21 @@ impl TurboFn {
             parse_quote! {
                 {
                     #assertions
+                    let turbo_tasks_transient = #( turbo_tasks::TaskInput::is_transient(&#inputs) ||)* false;
+                    let turbo_tasks_func = *#native_function_id_ident;
+                    let turbo_tasks_arg = Box::new((#(#inputs,)*)) as Box<dyn turbo_tasks::MagicAny>;
                     <#output as turbo_tasks::task::TaskOutput>::try_from_raw_vc(
-                        turbo_tasks::dynamic_call(
-                            *#native_function_id_ident,
-                            Box::new((#(#inputs,)*)) as Box<dyn turbo_tasks::MagicAny>,
-                        )
+                        if turbo_tasks_transient {
+                            turbo_tasks::transient_dynamic_call(
+                                turbo_tasks_func,
+                                turbo_tasks_arg,
+                            )
+                        } else {
+                            turbo_tasks::dynamic_call(
+                                turbo_tasks_func,
+                                turbo_tasks_arg,
+                            )
+                        }
                     )
                 }
             }

--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -353,26 +353,14 @@ impl TurboFn {
                 {
                     #assertions
                     let turbo_tasks_transient = #( turbo_tasks::TaskInput::is_transient(&#inputs) ||)* false;
-                    let turbo_tasks_trait = *#trait_type_id_ident;
-                    let turbo_tasks_name = std::borrow::Cow::Borrowed(stringify!(#ident));
-                    let turbo_tasks_this = #converted_this;
-                    let turbo_tasks_arg = Box::new((#(#inputs,)*)) as Box<dyn turbo_tasks::MagicAny>;
                     <#output as turbo_tasks::task::TaskOutput>::try_from_raw_vc(
-                        if turbo_tasks_transient {
-                            turbo_tasks::transient_trait_call(
-                                turbo_tasks_trait,
-                                turbo_tasks_name,
-                                turbo_tasks_this,
-                                turbo_tasks_arg,
-                            )
-                        } else {
-                            turbo_tasks::trait_call(
-                                turbo_tasks_trait,
-                                turbo_tasks_name,
-                                turbo_tasks_this,
-                                turbo_tasks_arg,
-                            )
-                        }
+                        turbo_tasks::trait_call(
+                            *#trait_type_id_ident,
+                            std::borrow::Cow::Borrowed(stringify!(#ident)),
+                            #converted_this,
+                            Box::new((#(#inputs,)*)) as Box<dyn turbo_tasks::MagicAny>,
+                            turbo_tasks_transient,
+                        )
                     )
                 }
             }
@@ -396,23 +384,13 @@ impl TurboFn {
                 {
                     #assertions
                     let turbo_tasks_transient = #( turbo_tasks::TaskInput::is_transient(&#inputs) ||)* false;
-                    let turbo_tasks_func = *#native_function_id_ident;
-                    let turbo_tasks_this = #converted_this;
-                    let turbo_tasks_arg = Box::new((#(#inputs,)*)) as Box<dyn turbo_tasks::MagicAny>;
                     <#output as turbo_tasks::task::TaskOutput>::try_from_raw_vc(
-                        if turbo_tasks_transient {
-                            turbo_tasks::transient_dynamic_this_call(
-                                turbo_tasks_func,
-                                turbo_tasks_this,
-                                turbo_tasks_arg,
-                            )
-                        } else {
-                            turbo_tasks::dynamic_this_call(
-                                turbo_tasks_func,
-                                turbo_tasks_this,
-                                turbo_tasks_arg,
-                            )
-                        }
+                        turbo_tasks::dynamic_this_call(
+                            *#native_function_id_ident,
+                            #converted_this,
+                            Box::new((#(#inputs,)*)) as Box<dyn turbo_tasks::MagicAny>,
+                            turbo_tasks_transient
+                        )
                     )
                 }
             }
@@ -421,20 +399,12 @@ impl TurboFn {
                 {
                     #assertions
                     let turbo_tasks_transient = #( turbo_tasks::TaskInput::is_transient(&#inputs) ||)* false;
-                    let turbo_tasks_func = *#native_function_id_ident;
-                    let turbo_tasks_arg = Box::new((#(#inputs,)*)) as Box<dyn turbo_tasks::MagicAny>;
                     <#output as turbo_tasks::task::TaskOutput>::try_from_raw_vc(
-                        if turbo_tasks_transient {
-                            turbo_tasks::transient_dynamic_call(
-                                turbo_tasks_func,
-                                turbo_tasks_arg,
-                            )
-                        } else {
-                            turbo_tasks::dynamic_call(
-                                turbo_tasks_func,
-                                turbo_tasks_arg,
-                            )
-                        }
+                        turbo_tasks::dynamic_call(
+                            *#native_function_id_ident,
+                            Box::new((#(#inputs,)*)) as Box<dyn turbo_tasks::MagicAny>,
+                            turbo_tasks_transient,
+                        )
                     )
                 }
             }

--- a/turbopack/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -26,8 +26,8 @@ use turbo_tasks::{
     },
     event::EventListener,
     util::{IdFactoryWithReuse, NoMoveVec},
-    CellId, FunctionId, RawVc, TaskId, TaskIdSet, TraitTypeId, TurboTasksBackendApi, Unused,
-    ValueTypeId, TRANSIENT_TASK_BIT,
+    CellId, FunctionId, RawVc, TaskId, TaskIdSet, TaskInput, TraitTypeId, TurboTasksBackendApi,
+    Unused, ValueTypeId, TRANSIENT_TASK_BIT,
 };
 
 use crate::{
@@ -272,8 +272,13 @@ impl MemoryBackend {
                 drop(entry);
                 unsafe {
                     task_storage.remove(index);
-                    let new_id = Unused::new_unchecked(new_id);
-                    turbo_tasks.reuse_persistent_task_id(new_id);
+                    if new_id.is_transient() {
+                        let new_id = Unused::new_unchecked(new_id);
+                        turbo_tasks.reuse_transient_task_id(new_id);
+                    } else {
+                        let new_id = Unused::new_unchecked(new_id);
+                        turbo_tasks.reuse_persistent_task_id(new_id);
+                    }
                 }
                 task_id
             }

--- a/turbopack/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -74,7 +74,7 @@ impl MemoryBackend {
             persistent_tasks: NoMoveVec::new(),
             transient_tasks: NoMoveVec::new(),
             backend_jobs: NoMoveVec::new(),
-            backend_job_id_factory: IdFactoryWithReuse::new(),
+            backend_job_id_factory: IdFactoryWithReuse::new(1, u32::MAX as u64),
             task_cache: DashMap::with_hasher_and_shard_amount(Default::default(), shard_amount),
             transient_task_cache: DashMap::with_hasher_and_shard_amount(
                 Default::default(),

--- a/turbopack/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -26,8 +26,8 @@ use turbo_tasks::{
     },
     event::EventListener,
     util::{IdFactoryWithReuse, NoMoveVec},
-    CellId, FunctionId, RawVc, TaskId, TaskIdSet, TaskInput, TraitTypeId, TurboTasksBackendApi,
-    Unused, ValueTypeId, TRANSIENT_TASK_BIT,
+    CellId, FunctionId, RawVc, TaskId, TaskIdSet, TraitTypeId, TurboTasksBackendApi, Unused,
+    ValueTypeId, TRANSIENT_TASK_BIT,
 };
 
 use crate::{

--- a/turbopack/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -21,13 +21,13 @@ use tracing::trace_span;
 use turbo_prehash::{BuildHasherExt, PassThroughHash, PreHashed};
 use turbo_tasks::{
     backend::{
-        Backend, BackendJobId, CellContent, PersistentTaskType, TaskCollectiblesMap,
-        TaskExecutionSpec, TransientTaskType, TypedCellContent,
+        Backend, BackendJobId, CachedTaskType, CellContent, TaskCollectiblesMap, TaskExecutionSpec,
+        TransientTaskType, TypedCellContent,
     },
     event::EventListener,
     util::{IdFactoryWithReuse, NoMoveVec},
     CellId, FunctionId, RawVc, TaskId, TaskIdSet, TraitTypeId, TurboTasksBackendApi, Unused,
-    ValueTypeId,
+    ValueTypeId, TRANSIENT_TASK_BIT,
 };
 
 use crate::{
@@ -41,16 +41,19 @@ use crate::{
     task_statistics::TaskStatisticsApi,
 };
 
-fn prehash_task_type(task_type: PersistentTaskType) -> PreHashed<PersistentTaskType> {
+fn prehash_task_type(task_type: CachedTaskType) -> PreHashed<CachedTaskType> {
     BuildHasherDefault::<FxHasher>::prehash(&Default::default(), task_type)
 }
 
 pub struct MemoryBackend {
-    memory_tasks: NoMoveVec<Task, 13>,
+    persistent_tasks: NoMoveVec<Task, 13>,
+    transient_tasks: NoMoveVec<Task, 10>,
     backend_jobs: NoMoveVec<Job>,
     backend_job_id_factory: IdFactoryWithReuse<BackendJobId>,
     task_cache:
-        DashMap<Arc<PreHashed<PersistentTaskType>>, TaskId, BuildHasherDefault<PassThroughHash>>,
+        DashMap<Arc<PreHashed<CachedTaskType>>, TaskId, BuildHasherDefault<PassThroughHash>>,
+    transient_task_cache:
+        DashMap<Arc<PreHashed<CachedTaskType>>, TaskId, BuildHasherDefault<PassThroughHash>>,
     memory_limit: AtomicUsize,
     gc_queue: Option<GcQueue>,
     idle_gc_active: AtomicBool,
@@ -65,14 +68,17 @@ impl Default for MemoryBackend {
 
 impl MemoryBackend {
     pub fn new(memory_limit: usize) -> Self {
+        let shard_amount =
+            (std::thread::available_parallelism().map_or(1, usize::from) * 32).next_power_of_two();
         Self {
-            memory_tasks: NoMoveVec::new(),
+            persistent_tasks: NoMoveVec::new(),
+            transient_tasks: NoMoveVec::new(),
             backend_jobs: NoMoveVec::new(),
             backend_job_id_factory: IdFactoryWithReuse::new(),
-            task_cache: DashMap::with_hasher_and_shard_amount(
+            task_cache: DashMap::with_hasher_and_shard_amount(Default::default(), shard_amount),
+            transient_task_cache: DashMap::with_hasher_and_shard_amount(
                 Default::default(),
-                (std::thread::available_parallelism().map_or(1, usize::from) * 32)
-                    .next_power_of_two(),
+                shard_amount,
             ),
             memory_limit: AtomicUsize::new(memory_limit),
             gc_queue: (memory_limit != usize::MAX).then(GcQueue::new),
@@ -123,16 +129,33 @@ impl MemoryBackend {
         for id in self.task_cache.clone().into_read_only().values() {
             func(*id);
         }
+        for id in self.transient_task_cache.clone().into_read_only().values() {
+            func(*id);
+        }
     }
 
     #[inline(always)]
     pub fn with_task<T>(&self, id: TaskId, func: impl FnOnce(&Task) -> T) -> T {
-        func(self.memory_tasks.get(*id as usize).unwrap())
+        let value = *id;
+        let index = (value & !TRANSIENT_TASK_BIT) as usize;
+        let item = if value & TRANSIENT_TASK_BIT == 0 {
+            self.persistent_tasks.get(index)
+        } else {
+            self.transient_tasks.get(index)
+        };
+        func(item.unwrap())
     }
 
     #[inline(always)]
     pub fn task(&self, id: TaskId) -> &Task {
-        self.memory_tasks.get(*id as usize).unwrap()
+        let value = *id;
+        let index = (value & !TRANSIENT_TASK_BIT) as usize;
+        let item = if value & TRANSIENT_TASK_BIT == 0 {
+            self.persistent_tasks.get(index)
+        } else {
+            self.transient_tasks.get(index)
+        };
+        item.unwrap()
     }
 
     /// Runs the garbage collection until reaching the target memory. An `idle`
@@ -222,18 +245,21 @@ impl MemoryBackend {
         false
     }
 
-    fn insert_and_connect_fresh_task<K: Eq + Hash, H: BuildHasher + Clone>(
+    fn insert_and_connect_fresh_task<K: Eq + Hash, H: BuildHasher + Clone, const N: u32>(
         &self,
         parent_task: TaskId,
         task_cache: &DashMap<K, TaskId, H>,
+        task_storage: &NoMoveVec<Task, N>,
+        task_storage_offset: u32,
         key: K,
         new_id: Unused<TaskId>,
         task: Task,
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) -> TaskId {
         let new_id = new_id.into();
+        let index = (*new_id - task_storage_offset) as usize;
         // Safety: We have a fresh task id that nobody knows about yet
-        unsafe { self.memory_tasks.insert(*new_id as usize, task) };
+        unsafe { task_storage.insert(index, task) };
         let result_task = match task_cache.entry(key) {
             Entry::Vacant(entry) => {
                 // This is the most likely case
@@ -245,7 +271,7 @@ impl MemoryBackend {
                 let task_id = *entry.get();
                 drop(entry);
                 unsafe {
-                    self.memory_tasks.remove(*new_id as usize);
+                    task_storage.remove(index);
                     let new_id = Unused::new_unchecked(new_id);
                     turbo_tasks.reuse_persistent_task_id(new_id);
                 }
@@ -290,6 +316,74 @@ impl MemoryBackend {
 
     pub fn task_statistics(&self) -> &TaskStatisticsApi {
         &self.task_statistics
+    }
+
+    fn track_cache_hit(
+        &self,
+        task_type: &PreHashed<CachedTaskType>,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
+    ) {
+        self.task_statistics().map(|stats| match &**task_type {
+            CachedTaskType::ResolveNative {
+                fn_type: function_id,
+                this: _,
+                arg: _,
+            }
+            | CachedTaskType::Native {
+                fn_type: function_id,
+                this: _,
+                arg: _,
+            } => {
+                stats.increment_cache_hit(*function_id);
+            }
+            CachedTaskType::ResolveTrait {
+                trait_type,
+                method_name: name,
+                this,
+                arg: _,
+            } => {
+                // HACK: Resolve the this argument (`self`) in order to attribute the cache hit
+                // to the concrete trait implementation, rather than the dynamic trait method.
+                // This ensures cache hits and misses are both attributed to the same thing.
+                //
+                // Because this task already resolved, in most cases `self` should either be
+                // resolved, or already in the process of being resolved.
+                //
+                // However, `self` could become unloaded due to cache eviction, and this might
+                // trigger an otherwise unnecessary re-evalutation.
+                //
+                // This is a potentially okay trade-off as long as we don't log statistics by
+                // default. The alternative would be to store function ids on completed
+                // ResolveTrait tasks.
+                let trait_type = *trait_type;
+                let name = name.clone();
+                let this = *this;
+                let stats = Arc::clone(stats);
+                turbo_tasks.run_once(Box::pin(async move {
+                    let function_id =
+                        CachedTaskType::resolve_trait_method(trait_type, name, this).await?;
+                    stats.increment_cache_hit(function_id);
+                    Ok(())
+                }));
+            }
+        });
+    }
+
+    fn track_cache_miss(&self, task_type: &PreHashed<CachedTaskType>) {
+        self.task_statistics().map(|stats| match &**task_type {
+            CachedTaskType::Native {
+                fn_type: function_id,
+                this: _,
+                arg: _,
+            } => {
+                stats.increment_cache_miss(*function_id);
+            }
+            CachedTaskType::ResolveTrait { .. } | CachedTaskType::ResolveNative { .. } => {
+                // these types re-execute themselves as `Native` after
+                // resolving their arguments, skip counting their
+                // executions here to avoid double-counting
+            }
+        });
     }
 }
 
@@ -592,7 +686,7 @@ impl Backend for MemoryBackend {
 
     fn get_or_create_persistent_task(
         &self,
-        task_type: PersistentTaskType,
+        task_type: CachedTaskType,
         parent_task: TaskId,
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) -> TaskId {
@@ -601,68 +695,10 @@ impl Backend for MemoryBackend {
             self.lookup_and_connect_task(parent_task, &self.task_cache, &task_type, turbo_tasks)
         {
             // fast pass without creating a new task
-            self.task_statistics().map(|stats| match &*task_type {
-                PersistentTaskType::ResolveNative {
-                    fn_type: function_id,
-                    this: _,
-                    arg: _,
-                }
-                | PersistentTaskType::Native {
-                    fn_type: function_id,
-                    this: _,
-                    arg: _,
-                } => {
-                    stats.increment_cache_hit(*function_id);
-                }
-                PersistentTaskType::ResolveTrait {
-                    trait_type,
-                    method_name: name,
-                    this,
-                    arg: _,
-                } => {
-                    // HACK: Resolve the this argument (`self`) in order to attribute the cache hit
-                    // to the concrete trait implementation, rather than the dynamic trait method.
-                    // This ensures cache hits and misses are both attributed to the same thing.
-                    //
-                    // Because this task already resolved, in most cases `self` should either be
-                    // resolved, or already in the process of being resolved.
-                    //
-                    // However, `self` could become unloaded due to cache eviction, and this might
-                    // trigger an otherwise unnecessary re-evalutation.
-                    //
-                    // This is a potentially okay trade-off as long as we don't log statistics by
-                    // default. The alternative would be to store function ids on completed
-                    // ResolveTrait tasks.
-                    let trait_type = *trait_type;
-                    let name = name.clone();
-                    let this = *this;
-                    let stats = Arc::clone(stats);
-                    turbo_tasks.run_once(Box::pin(async move {
-                        let function_id =
-                            PersistentTaskType::resolve_trait_method(trait_type, name, this)
-                                .await?;
-                        stats.increment_cache_hit(function_id);
-                        Ok(())
-                    }));
-                }
-            });
+            self.track_cache_hit(&task_type, turbo_tasks);
             task
         } else {
-            self.task_statistics().map(|stats| match &*task_type {
-                PersistentTaskType::Native {
-                    fn_type: function_id,
-                    this: _,
-                    arg: _,
-                } => {
-                    stats.increment_cache_miss(*function_id);
-                }
-                PersistentTaskType::ResolveTrait { .. }
-                | PersistentTaskType::ResolveNative { .. } => {
-                    // these types re-execute themselves as `Native` after
-                    // resolving their arguments, skip counting their
-                    // executions here to avoid double-counting
-                }
-            });
+            self.track_cache_miss(&task_type);
             // It's important to avoid overallocating memory as this will go into the task
             // cache and stay there forever. We can to be as small as possible.
             let (task_type_hash, task_type) = PreHashed::into_parts(task_type);
@@ -678,6 +714,51 @@ impl Backend for MemoryBackend {
             self.insert_and_connect_fresh_task(
                 parent_task,
                 &self.task_cache,
+                &self.persistent_tasks,
+                0,
+                task_type,
+                id,
+                task,
+                turbo_tasks,
+            )
+        }
+    }
+
+    fn get_or_create_transient_task(
+        &self,
+        task_type: CachedTaskType,
+        parent_task: TaskId,
+        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
+    ) -> TaskId {
+        let task_type = prehash_task_type(task_type);
+        if let Some(task) = self.lookup_and_connect_task(
+            parent_task,
+            &self.transient_task_cache,
+            &task_type,
+            turbo_tasks,
+        ) {
+            // fast pass without creating a new task
+            self.track_cache_hit(&task_type, turbo_tasks);
+            task
+        } else {
+            self.track_cache_miss(&task_type);
+            // It's important to avoid overallocating memory as this will go into the task
+            // cache and stay there forever. We can to be as small as possible.
+            let (task_type_hash, task_type) = PreHashed::into_parts(task_type);
+            let task_type = Arc::new(PreHashed::new(task_type_hash, task_type));
+            // slow pass with key lock
+            let id = turbo_tasks.get_fresh_transient_task_id();
+            let task = Task::new_transient(
+                // Safety: That task will hold the value, but we are still in
+                // control of the task
+                *unsafe { id.get_unchecked() },
+                task_type.clone(),
+            );
+            self.insert_and_connect_fresh_task(
+                parent_task,
+                &self.transient_task_cache,
+                &self.transient_tasks,
+                TRANSIENT_TASK_BIT,
                 task_type,
                 id,
                 task,
@@ -717,17 +798,18 @@ impl Backend for MemoryBackend {
     ) -> TaskId {
         let id = turbo_tasks.get_fresh_transient_task_id();
         let id = id.into();
+        let index = (*id - TRANSIENT_TASK_BIT) as usize;
         match task_type {
             TransientTaskType::Root(f) => {
                 let task = Task::new_root(id, move || f() as _);
                 // SAFETY: We have a fresh task id where nobody knows about yet
-                unsafe { self.memory_tasks.insert(*id as usize, task) };
+                unsafe { self.transient_tasks.insert(index, task) };
                 Task::set_root(id, self, turbo_tasks);
             }
             TransientTaskType::Once(f) => {
                 let task = Task::new_once(id, f);
                 // SAFETY: We have a fresh task id where nobody knows about yet
-                unsafe { self.memory_tasks.insert(*id as usize, task) };
+                unsafe { self.transient_tasks.insert(index, task) };
                 Task::set_once(id, self, turbo_tasks);
             }
         };

--- a/turbopack/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -247,7 +247,7 @@ impl MemoryBackend {
                 unsafe {
                     self.memory_tasks.remove(*new_id as usize);
                     let new_id = Unused::new_unchecked(new_id);
-                    turbo_tasks.reuse_task_id(new_id);
+                    turbo_tasks.reuse_persistent_task_id(new_id);
                 }
                 task_id
             }
@@ -668,7 +668,7 @@ impl Backend for MemoryBackend {
             let (task_type_hash, task_type) = PreHashed::into_parts(task_type);
             let task_type = Arc::new(PreHashed::new(task_type_hash, task_type));
             // slow pass with key lock
-            let id = turbo_tasks.get_fresh_task_id();
+            let id = turbo_tasks.get_fresh_persistent_task_id();
             let task = Task::new_persistent(
                 // Safety: That task will hold the value, but we are still in
                 // control of the task
@@ -715,7 +715,7 @@ impl Backend for MemoryBackend {
         task_type: TransientTaskType,
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) -> TaskId {
-        let id = turbo_tasks.get_fresh_task_id();
+        let id = turbo_tasks.get_fresh_transient_task_id();
         let id = id.into();
         match task_type {
             TransientTaskType::Root(f) => {

--- a/turbopack/crates/turbo-tasks-memory/src/task.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/task.rs
@@ -810,6 +810,7 @@ impl Task {
                         native_fn_id,
                         *this,
                         &**arg,
+                        self.id.is_transient(),
                         turbo_tasks,
                     ));
                     drop(entered);
@@ -832,6 +833,7 @@ impl Task {
                         name,
                         *this,
                         &**arg,
+                        self.id.is_transient(),
                         turbo_tasks,
                     ));
                     drop(entered);

--- a/turbopack/crates/turbo-tasks-memory/src/task.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/task.rs
@@ -21,7 +21,7 @@ use tokio::task_local;
 use tracing::Span;
 use turbo_prehash::PreHashed;
 use turbo_tasks::{
-    backend::{CellContent, PersistentTaskType, TaskCollectiblesMap, TaskExecutionSpec},
+    backend::{CachedTaskType, CellContent, TaskCollectiblesMap, TaskExecutionSpec},
     event::{Event, EventListener},
     get_invalidator, registry, CellId, Invalidator, RawVc, TaskId, TaskIdSet, TraitTypeId,
     TurboTasksBackendApi, ValueTypeId,
@@ -71,16 +71,17 @@ pub enum TaskType {
     Once(Box<OnceTaskFn>),
 
     /// A normal persistent task
-    Persistent {
-        ty: Arc<PreHashed<PersistentTaskType>>,
-    },
+    Persistent { ty: Arc<PreHashed<CachedTaskType>> },
+
+    /// A cached transient task
+    Transient { ty: Arc<PreHashed<CachedTaskType>> },
 }
 
 #[derive(Clone)]
 enum TaskTypeForDescription {
     Root,
     Once,
-    Persistent(Arc<PreHashed<PersistentTaskType>>),
+    Persistent(Arc<PreHashed<CachedTaskType>>),
 }
 
 impl TaskTypeForDescription {
@@ -89,6 +90,7 @@ impl TaskTypeForDescription {
             TaskType::Root(..) => Self::Root,
             TaskType::Once(..) => Self::Once,
             TaskType::Persistent { ty, .. } => Self::Persistent(ty.clone()),
+            TaskType::Transient { ty, .. } => Self::Persistent(ty.clone()),
         }
     }
 }
@@ -99,6 +101,7 @@ impl Debug for TaskType {
             Self::Root(..) => f.debug_tuple("Root").finish(),
             Self::Once(..) => f.debug_tuple("Once").finish(),
             Self::Persistent { ty, .. } => Debug::fmt(ty, f),
+            Self::Transient { ty } => Debug::fmt(ty, f),
         }
     }
 }
@@ -109,6 +112,7 @@ impl Display for TaskType {
             Self::Root(..) => f.debug_tuple("Root").finish(),
             Self::Once(..) => f.debug_tuple("Once").finish(),
             Self::Persistent { ty, .. } => Display::fmt(ty, f),
+            Self::Transient { ty } => Display::fmt(ty, f),
         }
     }
 }
@@ -460,11 +464,18 @@ pub enum ReadCellError {
 }
 
 impl Task {
-    pub(crate) fn new_persistent(
-        id: TaskId,
-        task_type: Arc<PreHashed<PersistentTaskType>>,
-    ) -> Self {
+    pub(crate) fn new_persistent(id: TaskId, task_type: Arc<PreHashed<CachedTaskType>>) -> Self {
         let ty = TaskType::Persistent { ty: task_type };
+        Self {
+            id,
+            ty,
+            state: RwLock::new(TaskMetaState::Full(Box::new(TaskState::new()))),
+            graph_modification_in_progress_counter: AtomicU32::new(0),
+        }
+    }
+
+    pub(crate) fn new_transient(id: TaskId, task_type: Arc<PreHashed<CachedTaskType>>) -> Self {
+        let ty = TaskType::Transient { ty: task_type };
         Self {
             id,
             ty,
@@ -508,6 +519,7 @@ impl Task {
     pub(crate) fn is_pure(&self) -> bool {
         match &self.ty {
             TaskType::Persistent { .. } => true,
+            TaskType::Transient { .. } => true,
             TaskType::Root(_) => false,
             TaskType::Once(_) => false,
         }
@@ -516,6 +528,7 @@ impl Task {
     pub(crate) fn is_once(&self) -> bool {
         match &self.ty {
             TaskType::Persistent { .. } => false,
+            TaskType::Transient { .. } => false,
             TaskType::Root(_) => false,
             TaskType::Once(_) => true,
         }
@@ -579,7 +592,7 @@ impl Task {
     }
 
     pub(crate) fn get_function_name(&self) -> Option<Cow<'static, str>> {
-        if let TaskType::Persistent { ty, .. } = &self.ty {
+        if let TaskType::Persistent { ty, .. } | TaskType::Transient { ty, .. } = &self.ty {
             Some(ty.get_name())
         } else {
             None
@@ -595,14 +608,14 @@ impl Task {
             TaskTypeForDescription::Root => format!("[{}] root", id),
             TaskTypeForDescription::Once => format!("[{}] once", id),
             TaskTypeForDescription::Persistent(ty) => match &***ty {
-                PersistentTaskType::Native {
+                CachedTaskType::Native {
                     fn_type: native_fn,
                     this: _,
                     arg: _,
                 } => {
                     format!("[{}] {}", id, registry::get_function(*native_fn).name)
                 }
-                PersistentTaskType::ResolveNative {
+                CachedTaskType::ResolveNative {
                     fn_type: native_fn,
                     this: _,
                     arg: _,
@@ -613,7 +626,7 @@ impl Task {
                         registry::get_function(*native_fn).name
                     )
                 }
-                PersistentTaskType::ResolveTrait {
+                CachedTaskType::ResolveTrait {
                     trait_type,
                     method_name: fn_name,
                     this: _,
@@ -770,8 +783,8 @@ impl Task {
                 mutex.lock().take().expect("Task can only be executed once"),
                 tracing::trace_span!("turbo_tasks::once_task"),
             ),
-            TaskType::Persistent { ty, .. } => match &***ty {
-                PersistentTaskType::Native {
+            TaskType::Persistent { ty, .. } | TaskType::Transient { ty, .. } => match &***ty {
+                CachedTaskType::Native {
                     fn_type: native_fn,
                     this,
                     arg,
@@ -783,7 +796,7 @@ impl Task {
                     drop(entered);
                     (future, span)
                 }
-                PersistentTaskType::ResolveNative {
+                CachedTaskType::ResolveNative {
                     fn_type: ref native_fn_id,
                     this,
                     arg,
@@ -793,7 +806,7 @@ impl Task {
                     let span = func.resolve_span();
                     let entered = span.enter();
                     let turbo_tasks = turbo_tasks.pin();
-                    let future = Box::pin(PersistentTaskType::run_resolve_native(
+                    let future = Box::pin(CachedTaskType::run_resolve_native(
                         native_fn_id,
                         *this,
                         &**arg,
@@ -802,7 +815,7 @@ impl Task {
                     drop(entered);
                     (future, span)
                 }
-                PersistentTaskType::ResolveTrait {
+                CachedTaskType::ResolveTrait {
                     trait_type: trait_type_id,
                     method_name: name,
                     this,
@@ -814,7 +827,7 @@ impl Task {
                     let entered = span.enter();
                     let name = name.clone();
                     let turbo_tasks = turbo_tasks.pin();
-                    let future = Box::pin(PersistentTaskType::run_resolve_trait(
+                    let future = Box::pin(CachedTaskType::run_resolve_trait(
                         trait_type_id,
                         name,
                         *this,

--- a/turbopack/crates/turbo-tasks-memory/tests/task_statistics.rs
+++ b/turbopack/crates/turbo-tasks-memory/tests/task_statistics.rs
@@ -184,13 +184,13 @@ async fn test_no_execution() {
     .await;
 }
 
-// Internally, this function uses `PersistentTaskType::Native`.
+// Internally, this function uses `CachedTaskType::Native`.
 #[turbo_tasks::function]
 fn double(val: u64) -> Vc<u64> {
     Vc::cell(val * 2)
 }
 
-// Internally, this function uses `PersistentTaskType::ResolveNative`.
+// Internally, this function uses `CachedTaskType::ResolveNative`.
 #[turbo_tasks::function]
 async fn double_vc(val: Vc<u64>) -> Result<Vc<u64>> {
     let val = *val.await?;

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -88,7 +88,12 @@ impl VcStorage {
 }
 
 impl TurboTasksCallApi for VcStorage {
-    fn dynamic_call(&self, func: turbo_tasks::FunctionId, arg: Box<dyn MagicAny>) -> RawVc {
+    fn dynamic_call(
+        &self,
+        func: turbo_tasks::FunctionId,
+        arg: Box<dyn MagicAny>,
+        _is_transient: bool,
+    ) -> RawVc {
         self.dynamic_call(func, None, arg)
     }
 
@@ -97,11 +102,17 @@ impl TurboTasksCallApi for VcStorage {
         func: turbo_tasks::FunctionId,
         this_arg: RawVc,
         arg: Box<dyn MagicAny>,
+        _is_transient: bool,
     ) -> RawVc {
         self.dynamic_call(func, Some(this_arg), arg)
     }
 
-    fn native_call(&self, _func: turbo_tasks::FunctionId, _arg: Box<dyn MagicAny>) -> RawVc {
+    fn native_call(
+        &self,
+        _func: turbo_tasks::FunctionId,
+        _arg: Box<dyn MagicAny>,
+        _is_transient: bool,
+    ) -> RawVc {
         unreachable!()
     }
 
@@ -110,6 +121,7 @@ impl TurboTasksCallApi for VcStorage {
         _func: turbo_tasks::FunctionId,
         _this: RawVc,
         _arg: Box<dyn MagicAny>,
+        _is_transient: bool,
     ) -> RawVc {
         unreachable!()
     }
@@ -120,6 +132,7 @@ impl TurboTasksCallApi for VcStorage {
         _trait_fn_name: Cow<'static, str>,
         _this: RawVc,
         _arg: Box<dyn MagicAny>,
+        _is_transient: bool,
     ) -> RawVc {
         unreachable!()
     }

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -27,16 +27,6 @@ use crate::{
     ValueTypeId, VcRead, VcValueTrait, VcValueType,
 };
 
-pub enum TaskType {
-    /// Tasks that only exist for a certain operation and
-    /// won't persist between sessions
-    Transient(TransientTaskType),
-
-    /// Tasks that can persist between sessions and potentially
-    /// shared globally
-    Persistent(CachedTaskType),
-}
-
 type TransientTaskRoot =
     Box<dyn Fn() -> Pin<Box<dyn Future<Output = Result<RawVc>> + Send>> + Send + Sync>;
 

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -292,17 +292,17 @@ impl CachedTaskType {
     /// it can return a `&'static str` in many cases.
     pub fn get_name(&self) -> Cow<'static, str> {
         match self {
-            CachedTaskType::Native {
+            Self::Native {
                 fn_type: native_fn,
                 this: _,
                 arg: _,
             }
-            | CachedTaskType::ResolveNative {
+            | Self::ResolveNative {
                 fn_type: native_fn,
                 this: _,
                 arg: _,
             } => Cow::Borrowed(&registry::get_function(*native_fn).name),
-            CachedTaskType::ResolveTrait {
+            Self::ResolveTrait {
                 trait_type: trait_id,
                 method_name: fn_name,
                 this: _,
@@ -313,9 +313,8 @@ impl CachedTaskType {
 
     pub fn try_get_function_id(&self) -> Option<FunctionId> {
         match self {
-            PersistentTaskType::Native { fn_type, .. }
-            | PersistentTaskType::ResolveNative { fn_type, .. } => Some(*fn_type),
-            PersistentTaskType::ResolveTrait { .. } => None,
+            Self::Native { fn_type, .. } | Self::ResolveNative { fn_type, .. } => Some(*fn_type),
+            Self::ResolveTrait { .. } => None,
         }
     }
 }

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -34,7 +34,7 @@ pub enum TaskType {
 
     /// Tasks that can persist between sessions and potentially
     /// shared globally
-    Persistent(PersistentTaskType),
+    Persistent(CachedTaskType),
 }
 
 type TransientTaskRoot =
@@ -67,7 +67,7 @@ impl Debug for TransientTaskType {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub enum PersistentTaskType {
+pub enum CachedTaskType {
     /// A normal task execution a native (rust) function
     Native {
         fn_type: FunctionId,
@@ -95,7 +95,7 @@ pub enum PersistentTaskType {
     },
 }
 
-impl Display for PersistentTaskType {
+impl Display for CachedTaskType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.get_name())
     }
@@ -144,7 +144,7 @@ mod ser {
                 type Value = FunctionAndArg<'de>;
 
                 fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                    write!(formatter, "a valid PersistentTaskType")
+                    write!(formatter, "a valid CachedTaskType")
                 }
 
                 fn visit_seq<A>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error>
@@ -167,13 +167,13 @@ mod ser {
         }
     }
 
-    impl Serialize for PersistentTaskType {
+    impl Serialize for CachedTaskType {
         fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
         where
             S: ser::Serializer,
         {
             match self {
-                PersistentTaskType::Native { fn_type, this, arg } => {
+                CachedTaskType::Native { fn_type, this, arg } => {
                     let mut s = serializer.serialize_seq(Some(3))?;
                     s.serialize_element::<u8>(&0)?;
                     s.serialize_element(&FunctionAndArg::Borrowed {
@@ -183,7 +183,7 @@ mod ser {
                     s.serialize_element(this)?;
                     s.end()
                 }
-                PersistentTaskType::ResolveNative { fn_type, this, arg } => {
+                CachedTaskType::ResolveNative { fn_type, this, arg } => {
                     let mut s = serializer.serialize_seq(Some(3))?;
                     s.serialize_element::<u8>(&1)?;
                     s.serialize_element(&FunctionAndArg::Borrowed {
@@ -193,7 +193,7 @@ mod ser {
                     s.serialize_element(this)?;
                     s.end()
                 }
-                PersistentTaskType::ResolveTrait {
+                CachedTaskType::ResolveTrait {
                     trait_type,
                     method_name,
                     this,
@@ -218,14 +218,14 @@ mod ser {
         }
     }
 
-    impl<'de> Deserialize<'de> for PersistentTaskType {
+    impl<'de> Deserialize<'de> for CachedTaskType {
         fn deserialize<D: ser::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
             struct Visitor;
             impl<'de> serde::de::Visitor<'de> for Visitor {
-                type Value = PersistentTaskType;
+                type Value = CachedTaskType;
 
                 fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                    write!(formatter, "a valid PersistentTaskType")
+                    write!(formatter, "a valid CachedTaskType")
                 }
 
                 fn visit_seq<A>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error>
@@ -246,7 +246,7 @@ mod ser {
                             let this = seq
                                 .next_element()?
                                 .ok_or_else(|| serde::de::Error::invalid_length(2, &self))?;
-                            Ok(PersistentTaskType::Native { fn_type, this, arg })
+                            Ok(CachedTaskType::Native { fn_type, this, arg })
                         }
                         1 => {
                             let FunctionAndArg::Owned { fn_type, arg } = seq
@@ -258,7 +258,7 @@ mod ser {
                             let this = seq
                                 .next_element()?
                                 .ok_or_else(|| serde::de::Error::invalid_length(2, &self))?;
-                            Ok(PersistentTaskType::ResolveNative { fn_type, this, arg })
+                            Ok(CachedTaskType::ResolveNative { fn_type, this, arg })
                         }
                         2 => {
                             let trait_type = seq
@@ -278,7 +278,7 @@ mod ser {
                             let arg = seq
                                 .next_element_seed(method.arg_deserializer)?
                                 .ok_or_else(|| serde::de::Error::invalid_length(3, &self))?;
-                            Ok(PersistentTaskType::ResolveTrait {
+                            Ok(CachedTaskType::ResolveTrait {
                                 trait_type,
                                 method_name,
                                 this,
@@ -294,7 +294,7 @@ mod ser {
     }
 }
 
-impl PersistentTaskType {
+impl CachedTaskType {
     /// Returns the name of the function in the code. Trait methods are
     /// formatted as `TraitName::method_name`.
     ///
@@ -302,17 +302,17 @@ impl PersistentTaskType {
     /// it can return a `&'static str` in many cases.
     pub fn get_name(&self) -> Cow<'static, str> {
         match self {
-            PersistentTaskType::Native {
+            CachedTaskType::Native {
                 fn_type: native_fn,
                 this: _,
                 arg: _,
             }
-            | PersistentTaskType::ResolveNative {
+            | CachedTaskType::ResolveNative {
                 fn_type: native_fn,
                 this: _,
                 arg: _,
             } => Cow::Borrowed(&registry::get_function(*native_fn).name),
-            PersistentTaskType::ResolveTrait {
+            CachedTaskType::ResolveTrait {
                 trait_type: trait_id,
                 method_name: fn_name,
                 this: _,
@@ -574,7 +574,14 @@ pub trait Backend: Sync + Send {
 
     fn get_or_create_persistent_task(
         &self,
-        task_type: PersistentTaskType,
+        task_type: CachedTaskType,
+        parent_task: TaskId,
+        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
+    ) -> TaskId;
+
+    fn get_or_create_transient_task(
+        &self,
+        task_type: CachedTaskType,
         parent_task: TaskId,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> TaskId;
@@ -607,7 +614,7 @@ pub trait Backend: Sync + Send {
     fn dispose_root_task(&self, task: TaskId, turbo_tasks: &dyn TurboTasksBackendApi<Self>);
 }
 
-impl PersistentTaskType {
+impl CachedTaskType {
     pub async fn run_resolve_native<B: Backend + 'static>(
         fn_id: FunctionId,
         mut this: Option<RawVc>,
@@ -705,7 +712,7 @@ pub(crate) mod tests {
     fn test_get_name() {
         crate::register();
         assert_eq!(
-            PersistentTaskType::Native {
+            CachedTaskType::Native {
                 fn_type: *MOCK_FUNC_TASK_FUNCTION_ID,
                 this: None,
                 arg: Box::new(()),
@@ -714,7 +721,7 @@ pub(crate) mod tests {
             "mock_func_task",
         );
         assert_eq!(
-            PersistentTaskType::ResolveTrait {
+            CachedTaskType::ResolveTrait {
                 trait_type: *MOCKTRAIT_TRAIT_TYPE_ID,
                 method_name: "mock_method_task".into(),
                 this: RawVc::TaskOutput(unsafe { TaskId::new_unchecked(1) }),

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -609,6 +609,7 @@ impl CachedTaskType {
         fn_id: FunctionId,
         mut this: Option<RawVc>,
         arg: &dyn MagicAny,
+        is_transient: bool,
         turbo_tasks: Arc<dyn TurboTasksBackendApi<B>>,
     ) -> Result<RawVc> {
         if let Some(this) = this.as_mut() {
@@ -616,9 +617,9 @@ impl CachedTaskType {
         }
         let arg = registry::get_function(fn_id).arg_meta.resolve(arg).await?;
         Ok(if let Some(this) = this {
-            turbo_tasks.this_call(fn_id, this, arg)
+            turbo_tasks.this_call(fn_id, this, arg, is_transient)
         } else {
-            turbo_tasks.native_call(fn_id, arg)
+            turbo_tasks.native_call(fn_id, arg, is_transient)
         })
     }
 
@@ -636,6 +637,7 @@ impl CachedTaskType {
         name: Cow<'static, str>,
         this: RawVc,
         arg: &dyn MagicAny,
+        is_transient: bool,
         turbo_tasks: Arc<dyn TurboTasksBackendApi<B>>,
     ) -> Result<RawVc> {
         let this = this.resolve().await?;
@@ -646,7 +648,7 @@ impl CachedTaskType {
             .arg_meta
             .resolve(arg)
             .await?;
-        Ok(turbo_tasks.dynamic_this_call(native_fn, this, arg))
+        Ok(turbo_tasks.dynamic_this_call(native_fn, this, arg, is_transient))
     }
 
     /// Shared helper used by [`Self::resolve_trait_method`] and

--- a/turbopack/crates/turbo-tasks/src/id.rs
+++ b/turbopack/crates/turbo-tasks/src/id.rs
@@ -78,6 +78,14 @@ impl Debug for TaskId {
     }
 }
 
+pub const TRANSIENT_TASK_BIT: u32 = 0x8000_0000;
+
+impl TaskId {
+    pub fn is_transient(&self) -> bool {
+        **self & TRANSIENT_TASK_BIT != 0
+    }
+}
+
 macro_rules! make_serializable {
     ($ty:ty, $get_global_name:path, $get_id:path, $visitor_name:ident) => {
         impl Serialize for $ty {

--- a/turbopack/crates/turbo-tasks/src/id_factory.rs
+++ b/turbopack/crates/turbo-tasks/src/id_factory.rs
@@ -23,8 +23,8 @@ impl<T> IdFactory<T> {
 
     pub const fn new_with_range(start: u64, max: u64) -> Self {
         Self {
-            next_id: AtomicU64::new(start as u64),
-            max_id: max as u64,
+            next_id: AtomicU64::new(start),
+            max_id: max,
             _phantom_data: PhantomData,
         }
     }

--- a/turbopack/crates/turbo-tasks/src/id_factory.rs
+++ b/turbopack/crates/turbo-tasks/src/id_factory.rs
@@ -107,7 +107,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Overflow detected")]
     fn test_overflow() {
-        let factory = IdFactory::<NonZeroU8>::new(1, u8::MAX as u64);
+        let factory = IdFactory::<NonZeroU8>::new(1, u16::MAX as u64);
         assert_eq!(factory.get(), NonZeroU8::new(1).unwrap());
         assert_eq!(factory.get(), NonZeroU8::new(2).unwrap());
         for _i in 2..256 {

--- a/turbopack/crates/turbo-tasks/src/id_factory.rs
+++ b/turbopack/crates/turbo-tasks/src/id_factory.rs
@@ -17,22 +17,12 @@ pub struct IdFactory<T> {
 }
 
 impl<T> IdFactory<T> {
-    pub const fn new() -> Self {
-        Self::new_with_range(1, u32::MAX as u64)
-    }
-
-    pub const fn new_with_range(start: u64, max: u64) -> Self {
+    pub const fn new(start: u64, max: u64) -> Self {
         Self {
             next_id: AtomicU64::new(start),
             max_id: max,
             _phantom_data: PhantomData,
         }
-    }
-}
-
-impl<T> Default for IdFactory<T> {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -77,24 +67,11 @@ pub struct IdFactoryWithReuse<T> {
 }
 
 impl<T> IdFactoryWithReuse<T> {
-    pub const fn new() -> Self {
+    pub const fn new(start: u64, max: u64) -> Self {
         Self {
-            factory: IdFactory::new(),
+            factory: IdFactory::new(start, max),
             free_ids: ConcurrentQueue::unbounded(),
         }
-    }
-
-    pub const fn new_with_range(start: u64, max: u64) -> Self {
-        Self {
-            factory: IdFactory::new_with_range(start, max),
-            free_ids: ConcurrentQueue::unbounded(),
-        }
-    }
-}
-
-impl<T> Default for IdFactoryWithReuse<T> {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -130,7 +107,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Overflow detected")]
     fn test_overflow() {
-        let factory = IdFactory::<NonZeroU8>::new();
+        let factory = IdFactory::<NonZeroU8>::new(1, u8::MAX as u64);
         assert_eq!(factory.get(), NonZeroU8::new(1).unwrap());
         assert_eq!(factory.get(), NonZeroU8::new(2).unwrap());
         for _i in 2..256 {

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -90,8 +90,7 @@ pub use magic_any::MagicAny;
 pub use manager::{
     dynamic_call, dynamic_this_call, emit, get_invalidator, mark_finished, mark_stateful,
     prevent_gc, run_once, run_once_with_reason, spawn_blocking, spawn_thread, trait_call,
-    transient_dynamic_call, transient_dynamic_this_call, transient_trait_call, turbo_tasks,
-    CurrentCellRef, Invalidator, TurboTasks, TurboTasksApi, TurboTasksBackendApi,
+    turbo_tasks, CurrentCellRef, Invalidator, TurboTasks, TurboTasksApi, TurboTasksBackendApi,
     TurboTasksCallApi, Unused, UpdateInfo,
 };
 pub use native_function::{FunctionMeta, NativeFunction};

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -90,8 +90,8 @@ pub use magic_any::MagicAny;
 pub use manager::{
     dynamic_call, dynamic_this_call, emit, get_invalidator, mark_finished, mark_stateful,
     prevent_gc, run_once, run_once_with_reason, spawn_blocking, spawn_thread, trait_call,
-    turbo_tasks, CurrentCellRef, Invalidator, TaskIdProvider, TurboTasks, TurboTasksApi,
-    TurboTasksBackendApi, TurboTasksCallApi, Unused, UpdateInfo,
+    turbo_tasks, CurrentCellRef, Invalidator, TurboTasks, TurboTasksApi, TurboTasksBackendApi,
+    TurboTasksCallApi, Unused, UpdateInfo,
 };
 pub use native_function::{FunctionMeta, NativeFunction};
 pub use raw_vc::{CellId, RawVc, ReadRawVcFuture, ResolveTypeError};

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -81,7 +81,7 @@ use auto_hash_map::AutoSet;
 pub use collectibles::CollectiblesSource;
 pub use completion::{Completion, Completions};
 pub use display::ValueToString;
-pub use id::{ExecutionId, FunctionId, TaskId, TraitTypeId, ValueTypeId};
+pub use id::{ExecutionId, FunctionId, TaskId, TraitTypeId, ValueTypeId, TRANSIENT_TASK_BIT};
 pub use invalidation::{
     DynamicEqHash, InvalidationReason, InvalidationReasonKind, InvalidationReasonSet,
 };
@@ -90,7 +90,8 @@ pub use magic_any::MagicAny;
 pub use manager::{
     dynamic_call, dynamic_this_call, emit, get_invalidator, mark_finished, mark_stateful,
     prevent_gc, run_once, run_once_with_reason, spawn_blocking, spawn_thread, trait_call,
-    turbo_tasks, CurrentCellRef, Invalidator, TurboTasks, TurboTasksApi, TurboTasksBackendApi,
+    transient_dynamic_call, transient_dynamic_this_call, transient_trait_call, turbo_tasks,
+    CurrentCellRef, Invalidator, TurboTasks, TurboTasksApi, TurboTasksBackendApi,
     TurboTasksCallApi, Unused, UpdateInfo,
 };
 pub use native_function::{FunctionMeta, NativeFunction};

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -211,7 +211,13 @@ pub trait TurboTasksBackendApi<B: Backend + 'static>: TurboTasksCallApi + Sync +
 
     fn get_fresh_persistent_task_id(&self) -> Unused<TaskId>;
     fn get_fresh_transient_task_id(&self) -> Unused<TaskId>;
+    /// # Safety
+    ///
+    /// The caller must ensure that the task id is not used anymore.
     unsafe fn reuse_persistent_task_id(&self, id: Unused<TaskId>);
+    /// # Safety
+    ///
+    /// The caller must ensure that the task id is not used anymore.
     unsafe fn reuse_transient_task_id(&self, id: Unused<TaskId>);
 
     fn schedule(&self, task: TaskId);

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -323,16 +323,15 @@ impl<B: Backend + 'static> TurboTasks<B> {
     // so we probably want to make sure that all tasks are joined
     // when trying to drop turbo tasks
     pub fn new(backend: B) -> Arc<Self> {
-        let task_id_factory =
-            IdFactoryWithReuse::new_with_range(1, (TRANSIENT_TASK_BIT - 1) as u64);
+        let task_id_factory = IdFactoryWithReuse::new(1, (TRANSIENT_TASK_BIT - 1) as u64);
         let transient_task_id_factory =
-            IdFactoryWithReuse::new_with_range(TRANSIENT_TASK_BIT as u64, u32::MAX as u64);
+            IdFactoryWithReuse::new(TRANSIENT_TASK_BIT as u64, u32::MAX as u64);
         let this = Arc::new_cyclic(|this| Self {
             this: this.clone(),
             backend,
             task_id_factory,
             transient_task_id_factory,
-            execution_id_factory: IdFactory::new(),
+            execution_id_factory: IdFactory::new(1, u64::MAX),
             stopped: AtomicBool::new(false),
             currently_scheduled_tasks: AtomicUsize::new(0),
             currently_scheduled_background_jobs: AtomicUsize::new(0),

--- a/turbopack/crates/turbo-tasks/src/persisted_graph.rs
+++ b/turbopack/crates/turbo-tasks/src/persisted_graph.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use serde::{ser::SerializeSeq, Deserialize, Serialize};
 
 use crate::{
-    backend::{CellContent, PersistentTaskType},
+    backend::{CachedTaskType, CellContent},
     task::shared_reference::TypedSharedReference,
     CellId, RawVc, TaskId,
 };
@@ -160,14 +160,14 @@ pub trait PersistedGraph: Sync + Send {
     /// returns false if that were too many
     fn lookup(
         &self,
-        partial_task_type: &PersistentTaskType,
+        partial_task_type: &CachedTaskType,
         api: &dyn PersistedGraphApi,
     ) -> Result<bool>;
 
     /// lookup one cache entry
     fn lookup_one(
         &self,
-        task_type: &PersistentTaskType,
+        task_type: &CachedTaskType,
         api: &dyn PersistedGraphApi,
     ) -> Result<Option<TaskId>>;
 
@@ -252,9 +252,9 @@ pub trait PersistedGraph: Sync + Send {
 }
 
 pub trait PersistedGraphApi {
-    fn get_or_create_task_type(&self, ty: PersistentTaskType) -> TaskId;
+    fn get_or_create_task_type(&self, ty: CachedTaskType) -> TaskId;
 
-    fn lookup_task_type(&self, id: TaskId) -> &PersistentTaskType;
+    fn lookup_task_type(&self, id: TaskId) -> &CachedTaskType;
 }
 
 /*
@@ -262,8 +262,8 @@ pub trait PersistedGraphApi {
 read:
 
   data: (TaskId) => (TaskData)
-  cache: (PersistentTaskType) => (TaskId)
-  type: (TaskId) => (PersistentTaskType)
+  cache: (CachedTaskType) => (TaskId)
+  type: (TaskId) => (CachedTaskType)
 
 read_dependents:
 
@@ -293,7 +293,7 @@ impl PersistedGraph for () {
 
     fn lookup(
         &self,
-        _partial_task_type: &PersistentTaskType,
+        _partial_task_type: &CachedTaskType,
         _api: &dyn PersistedGraphApi,
     ) -> Result<bool> {
         Ok(false)
@@ -301,7 +301,7 @@ impl PersistedGraph for () {
 
     fn lookup_one(
         &self,
-        _task_type: &PersistentTaskType,
+        _task_type: &CachedTaskType,
         _api: &dyn PersistedGraphApi,
     ) -> Result<Option<TaskId>> {
         Ok(None)

--- a/turbopack/crates/turbo-tasks/src/registry.rs
+++ b/turbopack/crates/turbo-tasks/src/registry.rs
@@ -10,20 +10,20 @@ use crate::{
     NativeFunction, TraitType, ValueType,
 };
 
-static FUNCTION_ID_FACTORY: IdFactory<FunctionId> = IdFactory::new();
+static FUNCTION_ID_FACTORY: IdFactory<FunctionId> = IdFactory::new(1, u32::MAX as u64);
 static FUNCTIONS_BY_NAME: Lazy<DashMap<&'static str, FunctionId>> = Lazy::new(DashMap::new);
 static FUNCTIONS_BY_VALUE: Lazy<DashMap<&'static NativeFunction, FunctionId>> =
     Lazy::new(DashMap::new);
 static FUNCTIONS: Lazy<NoMoveVec<(&'static NativeFunction, &'static str)>> =
     Lazy::new(NoMoveVec::new);
 
-static VALUE_TYPE_ID_FACTORY: IdFactory<ValueTypeId> = IdFactory::new();
+static VALUE_TYPE_ID_FACTORY: IdFactory<ValueTypeId> = IdFactory::new(1, u32::MAX as u64);
 static VALUE_TYPES_BY_NAME: Lazy<DashMap<&'static str, ValueTypeId>> = Lazy::new(DashMap::new);
 static VALUE_TYPES_BY_VALUE: Lazy<DashMap<&'static ValueType, ValueTypeId>> =
     Lazy::new(DashMap::new);
 static VALUE_TYPES: Lazy<NoMoveVec<(&'static ValueType, &'static str)>> = Lazy::new(NoMoveVec::new);
 
-static TRAIT_TYPE_ID_FACTORY: IdFactory<TraitTypeId> = IdFactory::new();
+static TRAIT_TYPE_ID_FACTORY: IdFactory<TraitTypeId> = IdFactory::new(1, u32::MAX as u64);
 static TRAIT_TYPES_BY_NAME: Lazy<DashMap<&'static str, TraitTypeId>> = Lazy::new(DashMap::new);
 static TRAIT_TYPES_BY_VALUE: Lazy<DashMap<&'static TraitType, TraitTypeId>> =
     Lazy::new(DashMap::new);

--- a/turbopack/crates/turbo-tasks/src/task/task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_input.rs
@@ -107,7 +107,7 @@ where
     }
 
     fn is_transient(&self) -> bool {
-        false
+        self.node.get_task_id().is_transient()
     }
 
     async fn resolve(&self) -> Result<Self> {
@@ -124,7 +124,7 @@ where
     }
 
     fn is_transient(&self) -> bool {
-        false
+        self.node.node.get_task_id().is_transient()
     }
 }
 
@@ -189,7 +189,7 @@ where
 
 impl<T> TaskInput for TransientInstance<T>
 where
-    T: Sync + Send,
+    T: Sync + Send + 'static,
 {
     fn is_transient(&self) -> bool {
         true


### PR DESCRIPTION
### What?

use different task ids for persistent and transient tasks

Store transient tasks separately Rename PersistentTaskType -> CachedTaskType

Track which tasks are transient and which are persistent. 

### Why?

We need to track that for persistent caching.

We use a different task id space for transient tasks so they don't use up persistent ids and to easily identify transient tasks.

### How?
