### PR TITLE
Fix static indicator close button color if user prefers light scheme

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
@@ -410,7 +410,7 @@ export const styles = css`
     margin-left: var(--size-gap-triple);
     border: none;
     background: none;
-    color: var(--color-ansi-bright-white);
+    color: var(--color-font);
     padding: 0;
     transition: opacity 0.25s ease;
     opacity: 0.7;


### PR DESCRIPTION
Using the `--color-font` CSS custom property, we can ensure that the close button of the static indicator is visible, regardless of the user's preferred color scheme.

**Before:**

<img width="394" alt="light before" src="https://github.com/user-attachments/assets/f7dcff4a-1fb1-4284-80fb-32a15682030c">

**After:**

<img width="394" alt="light after" src="https://github.com/user-attachments/assets/562346a3-a1c7-497d-9cc3-daa08cefb700">

**Dark is still the same as before:**

<img width="394" alt="dark" src="https://github.com/user-attachments/assets/b2fe8ddc-fff0-48d4-8763-2420536df3d1">
