### PR TITLE
only perform VersionedContentMap bookkeeping in dev

### DIFF
--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -60,6 +60,8 @@ impl VersionedContentMap {
 
 #[turbo_tasks::value_impl]
 impl VersionedContentMap {
+    /// Inserts output assets into the map and returns a completion that when
+    /// awaited will emit the assets that were inserted.
     #[turbo_tasks::function]
     pub async fn insert_output_assets(
         self: Vc<Self>,


### PR DESCRIPTION
### What?

We have a data structure VersionedContentMap that is used in dev mode to manage hmr and source maps. This is irrelevant in prod so we can just short circuit it altogether and bail when attempting to call these during builds.

### Why?

VersionedContentMap does a lot of hashing to account for files changing during development. In production, this is pointless as we assume a static snapshot of the repo.

### How?

Replace it with an Option and bail in the case of not being configured.

