### PR TITLE
benchmark and publish data for shadcn/ui

### DIFF
--- a/.github/workflows/next_swc_benchmark.yml
+++ b/.github/workflows/next_swc_benchmark.yml
@@ -1,0 +1,26 @@
+name: next_swc Benchmark
+on:
+  workflow_dispatch: {}
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pages: [0, 1, 12]
+    steps:
+      - uses: actions/checkout
+      - name: Install heaptrack
+        run: apt install heaptrack
+      - name: Build binary
+        run: cargo build --profile release-with-debug --manifest-path $GITHUB_WORKSPACE/packages/next-swc/crates/next-build-test/Cargo.toml
+      - name: Run benchmark
+        run: bash bench.sh 29de71d77fd3db93c33cc3886c64a32ad889278f ${{ matrix.pages }}
+      - name: Print results
+        run: tail -n 7 result.log
+      - name: Upload reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: report
+          path: |
+            result.log
+            heaptrack.*


### PR DESCRIPTION
WIP: need to see the CI working here

### What?

Add a ci job for the shadcn ui benchmark I put together a few back so we can check the exec time / memory usage. TBD run this on custom runners.

### Why?

shadcn/ui is a midsize project and it would be nice to have a number to work towards for production builds of nextjs.

### How?

We use the next-build-test binary which sidesteps the node side of things. shadcn ui is currently pinned so that we can get a reasonably consistent view. 


Closes PACK-3657