### PR TITLE
refactor(cna): use Commander `args` instead of `process.argv`

### DIFF
--- a/packages/create-next-app/create-app.ts
+++ b/packages/create-next-app/create-app.ts
@@ -31,7 +31,7 @@ export async function createApp({
   typescript,
   tailwind,
   eslint,
-  appRouter,
+  app,
   srcDir,
   importAlias,
   skipInstall,
@@ -45,7 +45,7 @@ export async function createApp({
   typescript: boolean
   tailwind: boolean
   eslint: boolean
-  appRouter: boolean
+  app: boolean
   srcDir: boolean
   importAlias: string
   skipInstall: boolean
@@ -54,7 +54,7 @@ export async function createApp({
 }): Promise<void> {
   let repoInfo: RepoInfo | undefined
   const mode: TemplateMode = typescript ? 'ts' : 'js'
-  const template: TemplateType = `${appRouter ? 'app' : 'default'}${tailwind ? '-tw' : ''}${empty ? '-empty' : ''}`
+  const template: TemplateType = `${app ? 'app' : 'default'}${tailwind ? '-tw' : ''}${empty ? '-empty' : ''}`
 
   if (example) {
     let repoUrl: URL | undefined

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -335,17 +335,17 @@ async function run(): Promise<void> {
         opts.app = getPrefOrDefault('app')
       } else {
         const styledAppDir = blue('App Router')
-        const { appRouter } = await prompts({
+        const { app } = await prompts({
           onState: onPromptState,
           type: 'toggle',
-          name: 'appRouter',
+          name: 'app',
           message: `Would you like to use ${styledAppDir}? (recommended)`,
           initial: getPrefOrDefault('app'),
           active: 'Yes',
           inactive: 'No',
         })
-        opts.app = Boolean(appRouter)
-        preferences.app = Boolean(appRouter)
+        opts.app = Boolean(app)
+        preferences.app = Boolean(app)
       }
     }
 
@@ -422,7 +422,7 @@ async function run(): Promise<void> {
       typescript: opts.typescript,
       tailwind: opts.tailwind,
       eslint: opts.eslint,
-      appRouter: opts.app,
+      app: opts.app,
       srcDir: opts.srcDir,
       importAlias: opts.importAlias,
       skipInstall: opts.skipInstall,
@@ -453,7 +453,7 @@ async function run(): Promise<void> {
       typescript: opts.typescript,
       eslint: opts.eslint,
       tailwind: opts.tailwind,
-      appRouter: opts.app,
+      app: opts.app,
       srcDir: opts.srcDir,
       importAlias: opts.importAlias,
       skipInstall: opts.skipInstall,

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -273,7 +273,7 @@ async function run(): Promise<void> {
       }
     }
 
-    if (!opts.includes('--eslint') && !args.includes('--no-eslint')) {
+    if (!opts.eslint && !args.includes('--no-eslint')) {
       if (skipPrompt) {
         opts.eslint = getPrefOrDefault('eslint')
       } else {
@@ -292,7 +292,7 @@ async function run(): Promise<void> {
       }
     }
 
-    if (!opts.includes('--tailwind') && !args.includes('--no-tailwind')) {
+    if (!opts.tailwind && !args.includes('--no-tailwind')) {
       if (skipPrompt) {
         opts.tailwind = getPrefOrDefault('tailwind')
       } else {
@@ -311,7 +311,7 @@ async function run(): Promise<void> {
       }
     }
 
-    if (!opts.includes('--src-dir') && !args.includes('--no-src-dir')) {
+    if (!opts.srcDir && !args.includes('--no-src-dir')) {
       if (skipPrompt) {
         opts.srcDir = getPrefOrDefault('srcDir')
       } else {
@@ -330,7 +330,7 @@ async function run(): Promise<void> {
       }
     }
 
-    if (!opts.includes('--app') && !args.includes('--no-app')) {
+    if (!opts.app && !args.includes('--no-app')) {
       if (skipPrompt) {
         opts.app = getPrefOrDefault('app')
       } else {

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -114,7 +114,7 @@ const program = new Command(packageJson.name)
   .parse(process.argv)
 
 const opts = program.opts()
-// const { args } = program
+const { args } = program
 
 const packageManager: PackageManager = !!opts.useNpm
   ? 'npm'
@@ -273,10 +273,7 @@ async function run(): Promise<void> {
       }
     }
 
-    if (
-      !process.argv.includes('--eslint') &&
-      !process.argv.includes('--no-eslint')
-    ) {
+    if (!opts.includes('--eslint') && !args.includes('--no-eslint')) {
       if (skipPrompt) {
         opts.eslint = getPrefOrDefault('eslint')
       } else {
@@ -295,10 +292,7 @@ async function run(): Promise<void> {
       }
     }
 
-    if (
-      !process.argv.includes('--tailwind') &&
-      !process.argv.includes('--no-tailwind')
-    ) {
+    if (!opts.includes('--tailwind') && !args.includes('--no-tailwind')) {
       if (skipPrompt) {
         opts.tailwind = getPrefOrDefault('tailwind')
       } else {
@@ -317,10 +311,7 @@ async function run(): Promise<void> {
       }
     }
 
-    if (
-      !process.argv.includes('--src-dir') &&
-      !process.argv.includes('--no-src-dir')
-    ) {
+    if (!opts.includes('--src-dir') && !args.includes('--no-src-dir')) {
       if (skipPrompt) {
         opts.srcDir = getPrefOrDefault('srcDir')
       } else {
@@ -339,7 +330,7 @@ async function run(): Promise<void> {
       }
     }
 
-    if (!process.argv.includes('--app') && !process.argv.includes('--no-app')) {
+    if (!opts.includes('--app') && !args.includes('--no-app')) {
       if (skipPrompt) {
         opts.app = getPrefOrDefault('app')
       } else {
@@ -358,7 +349,7 @@ async function run(): Promise<void> {
       }
     }
 
-    if (!opts.turbo && !process.argv.includes('--no-turbo')) {
+    if (!opts.turbo && !args.includes('--no-turbo')) {
       if (skipPrompt) {
         opts.turbo = getPrefOrDefault('turbo')
       } else {
@@ -385,7 +376,7 @@ async function run(): Promise<void> {
       if (skipPrompt) {
         // We don't use preferences here because the default value is @/* regardless of existing preferences
         opts.importAlias = defaults.importAlias
-      } else if (process.argv.includes('--no-import-alias')) {
+      } else if (args.includes('--no-import-alias')) {
         opts.importAlias = defaults.importAlias
       } else {
         const styledImportAlias = blue('import alias')


### PR DESCRIPTION
### Why?

Resolve left-out refactors from #68233

### How?

Used Commander's `args` and `opts` values, which remove a few lines.
Synced the variable name for the `app` value for consistency and possible future destructuring.