### PR TITLE
Add docs to mention glob behavior of trace includes/excludes

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/output.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/output.mdx
@@ -75,10 +75,15 @@ module.exports = {
     },
     outputFileTracingIncludes: {
       '/api/another': ['./necessary-folder/**/*'],
+      '/api/login/\\[\\[\\.\\.\\.slug\\]\\]': [
+        './node_modules/aws-crt/dist/bin/**/*',
+      ],
     },
   },
 }
 ```
+
+Note: the key for `outputFileTracingIncludes`/`outputFileTracingExcludes` is a [glob](https://www.npmjs.com/package/picomatch#basic-globbing) so needs to have special characters escaped.
 
 - Currently, Next.js does not do anything with the emitted `.nft.json` files. The files must be read by your deployment platform, for example [Vercel](https://vercel.com), to create a minimal deployment. In a future release, a new command is planned to utilize these `.nft.json` files.
 

--- a/docs/02-app/02-api-reference/05-next-config-js/output.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/output.mdx
@@ -83,7 +83,7 @@ module.exports = {
 }
 ```
 
-Note: the key for `outputFileTracingIncludes`/`outputFileTracingExcludes` is a [glob](https://www.npmjs.com/package/picomatch#basic-globbing) so needs to have special characters escaped.
+**Note:** The key of `outputFileTracingIncludes`/`outputFileTracingExcludes` is a [glob](https://www.npmjs.com/package/picomatch#basic-globbing), so special characters need to be escaped.
 
 - Currently, Next.js does not do anything with the emitted `.nft.json` files. The files must be read by your deployment platform, for example [Vercel](https://vercel.com), to create a minimal deployment. In a future release, a new command is planned to utilize these `.nft.json` files.
 


### PR DESCRIPTION
This updates our docs related to `outputFileTracingIncludes`/`outputFileTracingExcludes` to mention the key is a glob and needs to be escaped accordingly as it can cause confusion. 

x-ref: NEXT-3648