### PR TITLE
Stabilize outputFileTracing configs

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/output.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/output.mdx
@@ -54,31 +54,27 @@ Additionally, a minimal `server.js` file is also output which can be used instea
 
 ## Caveats
 
-- While tracing in monorepo setups, the project directory is used for tracing by default. For `next build packages/web-app`, `packages/web-app` would be the tracing root and any files outside of that folder will not be included. To include files outside of this folder you can set `experimental.outputFileTracingRoot` in your `next.config.js`.
+- While tracing in monorepo setups, the project directory is used for tracing by default. For `next build packages/web-app`, `packages/web-app` would be the tracing root and any files outside of that folder will not be included. To include files outside of this folder you can set `outputFileTracingRoot` in your `next.config.js`.
 
 ```js filename="packages/web-app/next.config.js"
 module.exports = {
-  experimental: {
-    // this includes files from the monorepo base two directories up
-    outputFileTracingRoot: path.join(__dirname, '../../'),
-  },
+  // this includes files from the monorepo base two directories up
+  outputFileTracingRoot: path.join(__dirname, '../../'),
 }
 ```
 
-- There are some cases in which Next.js might fail to include required files, or might incorrectly include unused files. In those cases, you can leverage `experimental.outputFileTracingExcludes` and `experimental.outputFileTracingIncludes` respectively in `next.config.js`. Each config accepts an object with [minimatch globs](https://www.npmjs.com/package/minimatch) for the key to match specific pages and a value of an array with globs relative to the project's root to either include or exclude in the trace.
+- There are some cases in which Next.js might fail to include required files, or might incorrectly include unused files. In those cases, you can leverage `outputFileTracingExcludes` and `outputFileTracingIncludes` respectively in `next.config.js`. Each config accepts an object with [minimatch globs](https://www.npmjs.com/package/minimatch) for the key to match specific pages and a value of an array with globs relative to the project's root to either include or exclude in the trace.
 
 ```js filename="next.config.js"
 module.exports = {
-  experimental: {
-    outputFileTracingExcludes: {
-      '/api/hello': ['./un-necessary-folder/**/*'],
-    },
-    outputFileTracingIncludes: {
-      '/api/another': ['./necessary-folder/**/*'],
-      '/api/login/\\[\\[\\.\\.\\.slug\\]\\]': [
-        './node_modules/aws-crt/dist/bin/**/*',
-      ],
-    },
+  outputFileTracingExcludes: {
+    '/api/hello': ['./un-necessary-folder/**/*'],
+  },
+  outputFileTracingIncludes: {
+    '/api/another': ['./necessary-folder/**/*'],
+    '/api/login/\\[\\[\\.\\.\\.slug\\]\\]': [
+      './node_modules/aws-crt/dist/bin/**/*',
+    ],
   },
 }
 ```
@@ -114,8 +110,8 @@ module.exports = {
       logAll?: boolean
       // control the context directory of the turbotrace
       // files outside of the context directory will not be traced
-      // set the `experimental.outputFileTracingRoot` has the same effect
-      // if the `experimental.outputFileTracingRoot` and this option are both set, the `experimental.turbotrace.contextDirectory` will be used
+      // set the `outputFileTracingRoot` has the same effect
+      // if the `outputFileTracingRoot` and this option are both set, the `experimental.turbotrace.contextDirectory` will be used
       contextDirectory?: string
       // if there is `process.cwd()` expression in your code, you can set this option to tell `turbotrace` the value of `process.cwd()` while tracing.
       // for example the require(process.cwd() + '/package.json') will be traced as require('/path/to/cwd/package.json')

--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -205,7 +205,7 @@ export async function collectBuildTraces({
   }
 
   const { outputFileTracingIncludes = {}, outputFileTracingExcludes = {} } =
-    config.experimental
+    config
   const excludeGlobKeys = Object.keys(outputFileTracingExcludes)
   const includeGlobKeys = Object.keys(outputFileTracingIncludes)
 
@@ -319,7 +319,6 @@ export async function collectBuildTraces({
 
         ...(isStandalone ? [] : TRACE_IGNORES),
         ...additionalIgnores,
-        ...(config.experimental.outputFileTracingIgnores || []),
       ]
 
       const sharedIgnoresFn = makeIgnoreFn(sharedIgnores)

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1262,8 +1262,7 @@ export default async function build(
         buildStage: 'start',
       })
 
-      const outputFileTracingRoot =
-        config.experimental.outputFileTracingRoot || dir
+      const outputFileTracingRoot = config.outputFileTracingRoot || dir
 
       const pagesManifestPath = path.join(
         distDir,
@@ -1387,7 +1386,7 @@ export default async function build(
         const project = await bindings.turbo.createProject(
           {
             projectPath: dir,
-            rootPath: config.experimental.outputFileTracingRoot || dir,
+            rootPath: config.outputFileTracingRoot || dir,
             nextConfig: config,
             jsConfig: await getTurbopackJsConfig(dir, config),
             watch: false,

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1828,11 +1828,11 @@ export default async function getBaseWebpackConfig(
             appDir: appDir,
             pagesDir: pagesDir,
             esmExternals: config.experimental.esmExternals,
-            outputFileTracingRoot: config.experimental.outputFileTracingRoot,
+            outputFileTracingRoot: config.outputFileTracingRoot,
             appDirEnabled: hasAppDir,
             turbotrace: config.experimental.turbotrace,
             optOutBundlingPackages,
-            traceIgnores: config.experimental.outputFileTracingIgnores || [],
+            traceIgnores: [],
             flyingShuttle: !!config.experimental.flyingShuttle,
             compilerType,
           }

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -307,14 +307,6 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         // The critter option is unknown, use z.any() here
         optimizeCss: z.union([z.boolean(), z.any()]).optional(),
         optimisticClientCache: z.boolean().optional(),
-        outputFileTracingRoot: z.string().optional(),
-        outputFileTracingExcludes: z
-          .record(z.string(), z.array(z.string()))
-          .optional(),
-        outputFileTracingIgnores: z.array(z.string()).optional(),
-        outputFileTracingIncludes: z
-          .record(z.string(), z.array(z.string()))
-          .optional(),
         parallelServerCompiles: z.boolean().optional(),
         parallelServerBuildTraces: z.boolean().optional(),
         ppr: z
@@ -565,6 +557,13 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
       .optional(),
     optimizeFonts: z.boolean().optional(),
     output: z.enum(['standalone', 'export']).optional(),
+    outputFileTracingRoot: z.string().optional(),
+    outputFileTracingExcludes: z
+      .record(z.string(), z.array(z.string()))
+      .optional(),
+    outputFileTracingIncludes: z
+      .record(z.string(), z.array(z.string()))
+      .optional(),
     pageExtensions: z.array(z.string()).min(1).optional(),
     poweredByHeader: z.boolean().optional(),
     productionBrowserSourceMaps: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -278,10 +278,6 @@ export interface ExperimentalConfig {
   esmExternals?: boolean | 'loose'
   fullySpecified?: boolean
   urlImports?: NonNullable<webpack.Configuration['experiments']>['buildHttp']
-  outputFileTracingRoot?: string
-  outputFileTracingExcludes?: Record<string, string[]>
-  outputFileTracingIgnores?: string[]
-  outputFileTracingIncludes?: Record<string, string[]>
   swcTraceProfiling?: boolean
   forceSwcTransforms?: boolean
 
@@ -887,6 +883,24 @@ export interface NextConfig extends Record<string, any> {
    * @see https://nextjs.org/docs/app/api-reference/next-config-js/serverExternalPackages
    */
   serverExternalPackages?: string[]
+
+  /**
+   * This is the repo root usually and only files above this
+   * directory are traced and included.
+   */
+  outputFileTracingRoot?: string
+
+  /**
+   * This allows manually excluding traced files if too many
+   * are included incorrectly on a per-page basis.
+   */
+  outputFileTracingExcludes?: Record<string, string[]>
+
+  /**
+   * This allows manually including traced files if some
+   * were not detected on a per-page basis.
+   */
+  outputFileTracingIncludes?: Record<string, string[]>
 }
 
 export const defaultConfig: NextConfig = {
@@ -944,6 +958,7 @@ export const defaultConfig: NextConfig = {
   staticPageGenerationTimeout: 60,
   output: !!process.env.NEXT_PRIVATE_STANDALONE ? 'standalone' : undefined,
   modularizeImports: undefined,
+  outputFileTracingRoot: process.env.NEXT_PRIVATE_OUTPUT_TRACE_ROOT || '',
   experimental: {
     appNavFailHandling: Boolean(process.env.NEXT_PRIVATE_FLYING_SHUTTLE),
     flyingShuttle: Boolean(process.env.NEXT_PRIVATE_FLYING_SHUTTLE),
@@ -978,7 +993,6 @@ export const defaultConfig: NextConfig = {
     craCompat: false,
     esmExternals: true,
     fullySpecified: false,
-    outputFileTracingRoot: process.env.NEXT_PRIVATE_OUTPUT_TRACE_ROOT || '',
     swcTraceProfiling: false,
     forceSwcTransforms: false,
     swcPlugins: undefined,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -335,25 +335,6 @@ function assignDefaults(
     )
   }
 
-  // TODO: remove after next minor (current v13.1.1)
-  if (Array.isArray(result.experimental?.outputFileTracingIgnores)) {
-    if (!result.experimental) {
-      result.experimental = {}
-    }
-    if (!result.experimental.outputFileTracingExcludes) {
-      result.experimental.outputFileTracingExcludes = {}
-    }
-    if (!result.experimental.outputFileTracingExcludes['**/*']) {
-      result.experimental.outputFileTracingExcludes['**/*'] = []
-    }
-    result.experimental.outputFileTracingExcludes['**/*'].push(
-      ...(result.experimental.outputFileTracingIgnores || [])
-    )
-    Log.warn(
-      `\`outputFileTracingIgnores\` has been moved to \`experimental.outputFileTracingExcludes\`. Please update your ${configFileName} file accordingly.`
-    )
-  }
-
   if (result.basePath !== '') {
     if (result.basePath === '/') {
       throw new Error(
@@ -546,6 +527,27 @@ function assignDefaults(
     configFileName,
     silent
   )
+  warnOptionHasBeenMovedOutOfExperimental(
+    result,
+    'outputFileTracingRoot',
+    'outputFileTracingRoot',
+    configFileName,
+    silent
+  )
+  warnOptionHasBeenMovedOutOfExperimental(
+    result,
+    'outputFileTracingIncludes',
+    'outputFileTracingIncludes',
+    configFileName,
+    silent
+  )
+  warnOptionHasBeenMovedOutOfExperimental(
+    result,
+    'outputFileTracingExcludes',
+    'outputFileTracingExcludes',
+    configFileName,
+    silent
+  )
 
   if ((result.experimental as any).outputStandalone) {
     if (!silent) {
@@ -592,15 +594,13 @@ function assignDefaults(
   )
 
   if (
-    result.experimental?.outputFileTracingRoot &&
-    !isAbsolute(result.experimental.outputFileTracingRoot)
+    result?.outputFileTracingRoot &&
+    !isAbsolute(result.outputFileTracingRoot)
   ) {
-    result.experimental.outputFileTracingRoot = resolve(
-      result.experimental.outputFileTracingRoot
-    )
+    result.outputFileTracingRoot = resolve(result.outputFileTracingRoot)
     if (!silent) {
       Log.warn(
-        `experimental.outputFileTracingRoot should be absolute, using: ${result.experimental.outputFileTracingRoot}`
+        `experimental.outputFileTracingRoot should be absolute, using: ${result.outputFileTracingRoot}`
       )
     }
   }
@@ -611,7 +611,7 @@ function assignDefaults(
   }
 
   // use the closest lockfile as tracing root
-  if (!result.experimental?.outputFileTracingRoot) {
+  if (!result?.outputFileTracingRoot) {
     let rootDir = findRootDir(dir)
 
     if (rootDir) {
@@ -621,9 +621,8 @@ function assignDefaults(
       if (!defaultConfig.experimental) {
         defaultConfig.experimental = {}
       }
-      result.experimental.outputFileTracingRoot = rootDir
-      defaultConfig.experimental.outputFileTracingRoot =
-        result.experimental.outputFileTracingRoot
+      result.outputFileTracingRoot = rootDir
+      defaultConfig.outputFileTracingRoot = result.outputFileTracingRoot
     }
   }
 

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -128,7 +128,7 @@ export async function createHotReloaderTurbopack(
   const project = await bindings.turbo.createProject(
     {
       projectPath: dir,
-      rootPath: opts.nextConfig.experimental.outputFileTracingRoot || dir,
+      rootPath: opts.nextConfig.outputFileTracingRoot || dir,
       nextConfig: opts.nextConfig,
       jsConfig: await getTurbopackJsConfig(dir, nextConfig),
       watch: true,

--- a/test/integration/build-trace-extra-entries-turbo/app/next.config.js
+++ b/test/integration/build-trace-extra-entries-turbo/app/next.config.js
@@ -19,15 +19,15 @@ module.exports = {
     }
     return cfg
   },
+  outputFileTracingIncludes: {
+    '/index': ['include-me/*'],
+    '/route1': ['include-me/*'],
+  },
+  outputFileTracingExcludes: {
+    '/index': ['public/exclude-me/**/*'],
+    '/route1': ['public/exclude-me/**/*'],
+  },
   experimental: {
-    outputFileTracingIncludes: {
-      '/index': ['include-me/*'],
-      '/route1': ['include-me/*'],
-    },
-    outputFileTracingExcludes: {
-      '/index': ['public/exclude-me/**/*'],
-      '/route1': ['public/exclude-me/**/*'],
-    },
     turbotrace: {
       contextDirectory: path.join(__dirname, '..', '..', '..', '..'),
     },

--- a/test/integration/build-trace-extra-entries/app/next.config.js
+++ b/test/integration/build-trace-extra-entries/app/next.config.js
@@ -19,14 +19,12 @@ module.exports = {
     }
     return cfg
   },
-  experimental: {
-    outputFileTracingIncludes: {
-      '/index': ['include-me/**/*'],
-      '/route1': ['include-me/**/*'],
-    },
-    outputFileTracingExcludes: {
-      '/index': ['public/exclude-me/**/*'],
-      '/route1': ['public/exclude-me/**/*'],
-    },
+  outputFileTracingIncludes: {
+    '/index': ['include-me/**/*'],
+    '/route1': ['include-me/**/*'],
+  },
+  outputFileTracingExcludes: {
+    '/index': ['public/exclude-me/**/*'],
+    '/route1': ['public/exclude-me/**/*'],
   },
 }

--- a/test/integration/turbotrace-with-webpack-worker/app/next.config.js
+++ b/test/integration/turbotrace-with-webpack-worker/app/next.config.js
@@ -19,13 +19,13 @@ module.exports = {
     }
     return cfg
   },
+  outputFileTracingIncludes: {
+    '/index': ['include-me/*'],
+  },
+  outputFileTracingExcludes: {
+    '/index': ['public/exclude-me/**/*'],
+  },
   experimental: {
-    outputFileTracingIncludes: {
-      '/index': ['include-me/*'],
-    },
-    outputFileTracingExcludes: {
-      '/index': ['public/exclude-me/**/*'],
-    },
     turbotrace: {
       contextDirectory: path.join(__dirname, '..', '..', '..', '..'),
       memoryLimit: 2048,


### PR DESCRIPTION
These configs have been being validated for quite a while now and they are pretty crucial to handle edge-cases without our output tracing setup since we can't always trace 100% of cases. No functional changes are made here expect removal of long deprecated `experimental.outputFileTracingIgnores` and upgrading from experimental for `outputFileTracingRoot`, `outputFileTracingIncludes`, and `outputFileTracingExcludes`.

Closes: NDX-166  