### PR TITLE
Import from internal modules in `next/server`

### DIFF
--- a/packages/next/server.d.ts
+++ b/packages/next/server.d.ts
@@ -4,13 +4,13 @@ declare global {
   var AsyncLocalStorage: typeof NodeAsyncLocalStorage
 }
 
-export { NextFetchEvent } from 'next/dist/server/web/spec-extension/fetch-event'
-export { NextRequest } from 'next/dist/server/web/spec-extension/request'
-export { NextResponse } from 'next/dist/server/web/spec-extension/response'
-export { NextMiddleware, MiddlewareConfig } from 'next/dist/server/web/types'
-export { userAgentFromString } from 'next/dist/server/web/spec-extension/user-agent'
-export { userAgent } from 'next/dist/server/web/spec-extension/user-agent'
-export { URLPattern } from 'next/dist/compiled/@edge-runtime/primitives/url'
-export { ImageResponse } from 'next/dist/server/web/spec-extension/image-response'
-export type { ImageResponseOptions } from 'next/dist/compiled/@vercel/og/types'
-export { unstable_after } from 'next/dist/server/after'
+export { NextFetchEvent } from './dist/server/web/spec-extension/fetch-event'
+export { NextRequest } from './dist/server/web/spec-extension/request'
+export { NextResponse } from './dist/server/web/spec-extension/response'
+export { NextMiddleware, MiddlewareConfig } from './dist/server/web/types'
+export { userAgentFromString } from './dist/server/web/spec-extension/user-agent'
+export { userAgent } from './dist/server/web/spec-extension/user-agent'
+export { URLPattern } from './dist/compiled/@edge-runtime/primitives/url'
+export { ImageResponse } from './dist/server/web/spec-extension/image-response'
+export type { ImageResponseOptions } from './dist/compiled/@vercel/og/types'
+export { unstable_after } from './dist/server/after'

--- a/packages/next/server.js
+++ b/packages/next/server.js
@@ -1,17 +1,15 @@
 const serverExports = {
-  NextRequest: require('next/dist/server/web/spec-extension/request')
-    .NextRequest,
-  NextResponse: require('next/dist/server/web/spec-extension/response')
+  NextRequest: require('./dist/server/web/spec-extension/request').NextRequest,
+  NextResponse: require('./dist/server/web/spec-extension/response')
     .NextResponse,
-  ImageResponse: require('next/dist/server/web/spec-extension/image-response')
+  ImageResponse: require('./dist/server/web/spec-extension/image-response')
     .ImageResponse,
-  userAgentFromString: require('next/dist/server/web/spec-extension/user-agent')
+  userAgentFromString: require('./dist/server/web/spec-extension/user-agent')
     .userAgentFromString,
-  userAgent: require('next/dist/server/web/spec-extension/user-agent')
-    .userAgent,
-  URLPattern: require('next/dist/server/web/spec-extension/url-pattern')
+  userAgent: require('./dist/server/web/spec-extension/user-agent').userAgent,
+  URLPattern: require('./dist/server/web/spec-extension/url-pattern')
     .URLPattern,
-  unstable_after: require('next/dist/server/after').unstable_after,
+  unstable_after: require('./dist/server/after').unstable_after,
 }
 
 // https://nodejs.org/api/esm.html#commonjs-namespaces


### PR DESCRIPTION
Avoids having to leak these internal modules unnecessarily once we add `exports` to `next/package.json`.