### PR TITLE
[turbopack] Implement resolution for local Vcs

### DIFF
--- a/turbopack/crates/turbo-tasks/src/persisted_graph.rs
+++ b/turbopack/crates/turbo-tasks/src/persisted_graph.rs
@@ -41,7 +41,7 @@ struct SerializableTaskCell(Option<Option<TypedSharedReference>>);
 impl From<SerializableTaskCell> for TaskCell {
     fn from(val: SerializableTaskCell) -> Self {
         match val.0 {
-            Some(d) => TaskCell::Content(CellContent(d.map(|d| d.untyped().1))),
+            Some(d) => TaskCell::Content(d.map(TypedSharedReference::into_untyped).into()),
             None => TaskCell::NeedComputation,
         }
     }
@@ -56,7 +56,7 @@ impl Serialize for TaskCells {
         for (cell_id, cell) in &self.0 {
             let task_cell = SerializableTaskCell(match cell {
                 TaskCell::Content(CellContent(opt)) => {
-                    Some(opt.as_ref().map(|d| d.typed(cell_id.type_id)))
+                    Some(opt.clone().map(|d| d.into_typed(cell_id.type_id)))
                 }
                 TaskCell::NeedComputation => None,
             });

--- a/turbopack/crates/turbo-tasks/src/read_ref.rs
+++ b/turbopack/crates/turbo-tasks/src/read_ref.rs
@@ -251,7 +251,7 @@ where
         };
         Vc {
             node: <T::CellMode as VcCellMode<T>>::raw_cell(
-                SharedReference::new(value).typed(type_id),
+                SharedReference::new(value).into_typed(type_id),
             ),
             _t: PhantomData,
         }

--- a/turbopack/crates/turbo-tasks/src/task/shared_reference.rs
+++ b/turbopack/crates/turbo-tasks/src/task/shared_reference.rs
@@ -2,6 +2,7 @@ use std::{
     any::Any,
     fmt::{Debug, Display},
     hash::Hash,
+    ops::Deref,
 };
 
 use anyhow::Result;
@@ -36,14 +37,26 @@ impl SharedReference {
         }
     }
 
-    pub(crate) fn typed(&self, type_id: ValueTypeId) -> TypedSharedReference {
-        TypedSharedReference(type_id, self.clone())
+    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
+        self.0.downcast_ref()
+    }
+
+    pub fn into_typed(self, type_id: ValueTypeId) -> TypedSharedReference {
+        TypedSharedReference(type_id, self)
     }
 }
 
 impl TypedSharedReference {
-    pub(crate) fn untyped(&self) -> (ValueTypeId, SharedReference) {
-        (self.0, self.1.clone())
+    pub fn into_untyped(self) -> SharedReference {
+        self.1
+    }
+}
+
+impl Deref for TypedSharedReference {
+    type Target = SharedReference;
+
+    fn deref(&self) -> &Self::Target {
+        &self.1
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -25,7 +25,6 @@ pub use self::{
     traits::{Dynamic, TypedForInput, Upcast, VcValueTrait, VcValueType},
 };
 use crate::{
-    backend::CellContent,
     debug::{ValueDebug, ValueDebugFormat, ValueDebugFormatString},
     manager::create_local_cell,
     registry,
@@ -282,10 +281,8 @@ where
         // cells aren't stored across executions, so there can be no concept of
         // "updating" the cell across multiple executions.
         let (execution_id, local_cell_id) = create_local_cell(
-            CellContent(Some(SharedReference::new(triomphe::Arc::new(
-                T::Read::target_to_repr(inner),
-            ))))
-            .into_typed(T::get_value_type_id()),
+            SharedReference::new(triomphe::Arc::new(T::Read::target_to_repr(inner)))
+                .into_typed(T::get_value_type_id()),
         );
         Vc {
             node: RawVc::LocalCell(execution_id, local_cell_id),


### PR DESCRIPTION
*This is a migrated PR. This was in the turbo repository before the next.js merge.*
**Migrated From:** https://github.com/vercel/turbo/pull/8826

### Description

Builds on the minimal implementation of local Vcs in #68469

At some point, we need to return local Vcs or pass them to another function as an argument. However, local Vcs are only valid within the context of the current task.

The solution is that we need to convert local `Vc`s to non-local `Vc`s, and the easiest way to do that is to `.resolve()` it!

This PR creates the new non-local cell on the current task, re-using the SharedReference the was used for the local cell, along with it's type id information.

`RawVc` lacks information about the compile-time type `T`. Even `Vc` may know the real type of `T` if the `Vc` has been downcast to `Vc<Box<dyn ...>>`. To solve for this, we perform a lookup of the `VcCellMode::raw_cell` method using the type id (I added `raw_cell` in #68467).

### Testing Instructions

```
cargo nextest r -p turbo-tasks -p turbo-tasks-memory
```