### PR TITLE
Add failing test for unexpected remount with `history.replaceState`

### DIFF
--- a/test/e2e/app-dir/history-replace-state/app/input.tsx
+++ b/test/e2e/app-dir/history-replace-state/app/input.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import * as React from 'react'
+
+export function Input() {
+  const [query, setQuery] = React.useState('')
+
+  React.useEffect(() => {
+    if (!query) {
+      return
+    }
+
+    window.history.replaceState({ query }, null, `?q=${query}`)
+  }, [query])
+
+  return (
+    <input
+      onChange={(event) => setQuery(event.currentTarget.value)}
+      value={query}
+    />
+  )
+}

--- a/test/e2e/app-dir/history-replace-state/app/layout.tsx
+++ b/test/e2e/app-dir/history-replace-state/app/layout.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react'
+
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/history-replace-state/app/loading.tsx
+++ b/test/e2e/app-dir/history-replace-state/app/loading.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react'
+
+export default function Loading() {
+  return <p>Loading...</p>
+}

--- a/test/e2e/app-dir/history-replace-state/app/page.tsx
+++ b/test/e2e/app-dir/history-replace-state/app/page.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react'
+import { Input } from './input'
+
+export default function Page() {
+  return (
+    <main>
+      <label>
+        Enter a query: <Input />
+      </label>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/history-replace-state/history-replace-state.test.ts
+++ b/test/e2e/app-dir/history-replace-state/history-replace-state.test.ts
@@ -1,0 +1,14 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('history-replace-state', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should not remount component', async () => {
+    const browser = await next.browser('/')
+    await await browser.elementByCss('input').type('a')
+    // When the input is remounted, its value is cleared.
+    expect(await browser.elementByCss('input').getValue()).toBe('a')
+  })
+})

--- a/test/e2e/app-dir/history-replace-state/next.config.js
+++ b/test/e2e/app-dir/history-replace-state/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    ppr: true,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
The issue occurs under these circumstances:
- a loading file exists
- PPR is enabled (so that React experimental channel is used)
- `window.history.replaceState` is called