### PR TITLE
Ensure client components are in experimental trace

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1786,6 +1786,7 @@ export default async function getBaseWebpackConfig(
             traceIgnores: [],
             flyingShuttle: !!config.experimental.flyingShuttle,
             compilerType,
+            swcLoaderConfig: swcDefaultLoader,
           }
         ),
       // Moment.js is an extremely popular library that bundles large locale files


### PR DESCRIPTION
This ensures we properly trace client components with the experimental tracing as currently the trace plugin is failing to detect these dependencies due to the `flight-client-module` proxy transform taking place before the trace entrypoints plugin is applied. To avoid this issue it grabs the original source and only applies the swc loader for now which handles the majority case. We can investigate in the future applying other loaders as well to handle more edge cases. 

Closes: NDX-135
Closes: NDX-134