### PR TITLE
[turbopack] Replace uses of globby in scripts with glob

### DIFF
--- a/scripts/pack-next.cjs
+++ b/scripts/pack-next.cjs
@@ -4,6 +4,7 @@ const {
   booleanArg,
   exec,
   execAsyncWithOutput,
+  glob,
   packageFiles,
 } = require('./pack-util.cjs')
 const fs = require('fs')
@@ -17,8 +18,6 @@ const NEXT_PACKAGES = `${CWD}/packages`
 const noBuild = booleanArg(args, '--no-build')
 
 ;(async () => {
-  const { globby } = await import('globby')
-
   // the debuginfo on macos is much smaller, so we don't typically need to strip
   const DEFAULT_PACK_NEXT_COMPRESS =
     process.platform === 'darwin' ? 'none' : 'strip'
@@ -47,7 +46,10 @@ const noBuild = booleanArg(args, '--no-build')
   const NEXT_BA_TARBALL = `${TARBALLS}/next-bundle-analyzer.tar`
 
   async function nextSwcBinaries() {
-    return await globby([`${NEXT_PACKAGES}/next-swc/native/*.node`])
+    return await glob('next-swc/native/*.node', {
+      cwd: NEXT_PACKAGES,
+      absolute: true,
+    })
   }
 
   // We use neither:


### PR DESCRIPTION
Replace uses of `globby` (which is not in the `package.json`) with `glob` (which is in the `package.json`).

These scripts were part of the nextpack repository (RIP), and @wbinnssmith copied them over in #68471 

Tested by running `pnpm pack-next`, inspecting the `tarballs` directory, installing the tarballs into shadcn-ui, and building with turbopack.

`globby` and `glob` share the same API, but Next.js pulls in a pretty old version of `glob`, so some of the newer APIs don't exist, and it doesn't natively use promises: https://github.com/isaacs/node-glob/tree/v7.1.6

We could upgrade `glob` without too much pain... It's only used for `devDependencies`.