### PR TITLE
Update flakey module-errors test

### DIFF
--- a/test/integration/edge-runtime-module-errors/test/module-imports.test.js
+++ b/test/integration/edge-runtime-module-errors/test/module-imports.test.js
@@ -4,13 +4,13 @@
 import { remove } from 'fs-extra'
 import { join } from 'path'
 import {
-  check,
   fetchViaHTTP,
   findPort,
   killApp,
   launchApp,
   nextBuild,
   nextStart,
+  retry,
 } from 'next-test-utils'
 import {
   context,
@@ -85,14 +85,12 @@ describe('Edge runtime code with imports', () => {
 
     it('throws unsupported module error in dev at runtime and highlights the faulty line', async () => {
       context.app = await launchApp(context.appDir, context.appPort, appOption)
-      const res = await fetchViaHTTP(context.appPort, url)
-      expect(res.status).toBe(500)
-
-      const text = await res.text()
-      await check(async () => {
+      await retry(async () => {
+        const res = await fetchViaHTTP(context.appPort, url)
+        expect(res.status).toBe(500)
+        const text = await res.text()
         expectUnsupportedModuleDevError(moduleName, importStatement, text)
-        return 'success'
-      }, 'success')
+      })
     })
     ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
       'production mode',
@@ -152,14 +150,13 @@ describe('Edge runtime code with imports', () => {
 
     it('throws not-found module error in dev at runtime and highlights the faulty line', async () => {
       context.app = await launchApp(context.appDir, context.appPort, appOption)
-      const res = await fetchViaHTTP(context.appPort, url)
-      expect(res.status).toBe(500)
+      await retry(async () => {
+        const res = await fetchViaHTTP(context.appPort, url)
+        expect(res.status).toBe(500)
 
-      const text = await res.text()
-      await check(async () => {
+        const text = await res.text()
         expectModuleNotFoundDevError(moduleName, importStatement, text)
-        return 'success'
-      }, 'success')
+      })
     })
     ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
       'production mode',
@@ -218,14 +215,13 @@ describe('Edge runtime code with imports', () => {
 
     it('throws not-found module error in dev at runtime and highlights the faulty line', async () => {
       context.app = await launchApp(context.appDir, context.appPort, appOption)
-      const res = await fetchViaHTTP(context.appPort, url)
-      expect(res.status).toBe(500)
+      await retry(async () => {
+        const res = await fetchViaHTTP(context.appPort, url)
+        expect(res.status).toBe(500)
 
-      const text = await res.text()
-      await check(async () => {
+        const text = await res.text()
         expectModuleNotFoundDevError(moduleName, importStatement, text)
-        return 'success'
-      }, 'success')
+      })
     })
     ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
       'production mode',
@@ -285,9 +281,11 @@ describe('Edge runtime code with imports', () => {
 
     it('does not throw in dev at runtime', async () => {
       context.app = await launchApp(context.appDir, context.appPort, appOption)
-      const res = await fetchViaHTTP(context.appPort, url)
-      expect(res.status).toBe(200)
-      expectNoError(moduleName)
+      await retry(async () => {
+        const res = await fetchViaHTTP(context.appPort, url)
+        expect(res.status).toBe(200)
+        expectNoError(moduleName)
+      })
     })
     ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
       'production mode',


### PR DESCRIPTION
Looks like this can have a race condition of editing the test file and booting the dev server

x-ref: https://github.com/vercel/next.js/actions/runs/10231169480/job/28307684614?pr=68492
x-ref: https://github.com/vercel/next.js/actions/runs/10230130942/job/28304603462?pr=68449