### PR TITLE
Normalize vendored entrypoints

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1604,7 +1604,7 @@ export default async function getBaseWebpackConfig(
                               'next/dist/compiled/assert'
                             ),
                             buffer: require.resolve(
-                              'next/dist/compiled/buffer/'
+                              'next/dist/compiled/buffer'
                             ),
                             constants: require.resolve(
                               'next/dist/compiled/constants-browserify'
@@ -1641,7 +1641,7 @@ export default async function getBaseWebpackConfig(
                             string_decoder: require.resolve(
                               'next/dist/compiled/string_decoder'
                             ),
-                            sys: require.resolve('next/dist/compiled/util/'),
+                            sys: require.resolve('next/dist/compiled/util'),
                             timers: require.resolve(
                               'next/dist/compiled/timers-browserify'
                             ),
@@ -1649,8 +1649,8 @@ export default async function getBaseWebpackConfig(
                               'next/dist/compiled/tty-browserify'
                             ),
                             // Handled in separate alias
-                            // url: require.resolve('url/'),
-                            util: require.resolve('next/dist/compiled/util/'),
+                            // url: require.resolve('url'),
+                            util: require.resolve('next/dist/compiled/util'),
                             vm: require.resolve(
                               'next/dist/compiled/vm-browserify'
                             ),
@@ -1658,7 +1658,7 @@ export default async function getBaseWebpackConfig(
                               'next/dist/compiled/browserify-zlib'
                             ),
                             events: require.resolve(
-                              'next/dist/compiled/events/'
+                              'next/dist/compiled/events'
                             ),
                             setImmediate: require.resolve(
                               'next/dist/compiled/setimmediate'


### PR DESCRIPTION
Some entrypoint imports are inconsistent i.e. same resolved file but different import sources. All of the inconsistencies stem from trailing slashes. We now only import without trailing slashes.