### PR TITLE
Ensure webpack cache does not conflict with experimental tracing

### DIFF
--- a/packages/next/src/build/flying-shuttle/stitch-builds.ts
+++ b/packages/next/src/build/flying-shuttle/stitch-builds.ts
@@ -78,19 +78,6 @@ export async function stitchBuilds(
     pagesManifest?: PagesManifest
   } = {}
 
-  // we need to copy the chunks from the shuttle folder
-  // to the distDir (we copy all server split chunks currently)
-  await recursiveCopy(
-    path.join(shuttleDir, 'server'),
-    path.join(distDir, 'server'),
-    {
-      filter(item) {
-        // we copy page chunks separately to not copy stale entries
-        return !item.match(/^[/\\](pages|app)[/\\]/)
-      },
-      overwrite: true,
-    }
-  )
   // copy static chunks (this includes stale chunks but won't be loaded)
   // unless referenced
   await recursiveCopy(

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1785,6 +1785,26 @@ export default async function build(
 
       const postCompileSpinner = createSpinner('Collecting page data')
 
+      if (config.experimental.flyingShuttle) {
+        // we need to copy the chunks from the shuttle folder
+        // to the distDir (we copy all server split chunks currently)
+        // this has to come before we require any page chunks as webpack
+        // cache could reference previous runtimes/chunks
+        if (await fileExists(path.join(shuttleDir, 'server'))) {
+          await recursiveCopy(
+            path.join(shuttleDir, 'server'),
+            path.join(distDir, 'server'),
+            {
+              filter(item) {
+                // we copy page chunks separately to not copy stale entries
+                return !item.match(/^[/\\](pages|app)[/\\]/)
+              },
+              overwrite: true,
+            }
+          )
+        }
+      }
+
       const buildManifestPath = path.join(distDir, BUILD_MANIFEST)
       const appBuildManifestPath = path.join(distDir, APP_BUILD_MANIFEST)
 

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2088,6 +2088,7 @@ export default async function getBaseWebpackConfig(
     imageLoaderFile: config.images.loaderFile,
     clientTraceMetadata: config.experimental.clientTraceMetadata,
     serverSourceMaps: config.experimental.serverSourceMaps,
+    flyingShuttle: config.experimental.flyingShuttle,
   })
 
   const cache: any = {

--- a/test/e2e/app-dir/app/next.config.js
+++ b/test/e2e/app-dir/app/next.config.js
@@ -8,14 +8,6 @@ module.exports = {
     parallelServerBuildTraces: true,
     webpackBuildWorker: true,
   },
-  webpack(cfg) {
-    if (process.env.NEXT_PRIVATE_FLYING_SHUTTLE) {
-      // disable the webpack cache to make sure we're
-      // deterministic without
-      cfg.cache = false
-    }
-    return cfg
-  },
   // output: 'standalone',
   rewrites: async () => {
     return {


### PR DESCRIPTION
This ensures we merge the previous chunks before we require any page chunks as the webpack cache could create outputs that still reference previous runtime chunks. This is tested in our existing `flying-shuttle` test suite by removing the manual webpack cache disabling.

Closes: NDX-126