### PR TITLE
chore: typo in bootrap to bootstrap

### DIFF
--- a/packages/next/src/client/next-dev-turbopack.ts
+++ b/packages/next/src/client/next-dev-turbopack.ts
@@ -2,7 +2,7 @@
 import { initialize, version, router, emitter } from './'
 import initHMR from './dev/hot-middleware-client'
 
-import { pageBootrap } from './page-bootstrap'
+import { pageBootstrap } from './page-bootstrap'
 //@ts-expect-error requires "moduleResolution": "node16" in tsconfig.json and not .ts extension
 import { connect } from '@vercel/turbopack-ecmascript-runtime/browser/dev/hmr-client/hmr-client.ts'
 import type { TurbopackMsgToBrowser } from '../server/dev/hot-reloader-types'
@@ -46,7 +46,7 @@ initialize({
       onUpdateError: devClient.handleUpdateError,
     })
 
-    return pageBootrap(assetPrefix)
+    return pageBootstrap(assetPrefix)
   })
   .catch((err) => {
     console.error('Error was not caught', err)

--- a/packages/next/src/client/next-dev.ts
+++ b/packages/next/src/client/next-dev.ts
@@ -2,7 +2,7 @@
 import './webpack'
 import { initialize, version, router, emitter } from './'
 import initHMR from './dev/hot-middleware-client'
-import { pageBootrap } from './page-bootstrap'
+import { pageBootstrap } from './page-bootstrap'
 
 window.next = {
   version,
@@ -16,7 +16,7 @@ window.next = {
 const devClient = initHMR('webpack')
 initialize({ devClient })
   .then(({ assetPrefix }) => {
-    return pageBootrap(assetPrefix)
+    return pageBootstrap(assetPrefix)
   })
   .catch((err) => {
     console.error('Error was not caught', err)

--- a/packages/next/src/client/page-bootstrap.ts
+++ b/packages/next/src/client/page-bootstrap.ts
@@ -16,7 +16,7 @@ import { RuntimeErrorHandler } from './components/react-dev-overlay/internal/hel
 import { REACT_REFRESH_FULL_RELOAD_FROM_ERROR } from './components/react-dev-overlay/shared'
 import { performFullReload } from './components/react-dev-overlay/pages/hot-reloader-client'
 
-export function pageBootrap(assetPrefix: string) {
+export function pageBootstrap(assetPrefix: string) {
   connectHMR({ assetPrefix, path: '/_next/webpack-hmr' })
 
   return hydrate({ beforeRender: displayContent }).then(() => {


### PR DESCRIPTION
The exported function of a filename `page-bootstrap.ts` had typo as `pageBootrap` so fixed to `pageBootstrap`.