### PR TITLE
refactor: throw if asset-prefix is url in dev

### DIFF
--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -667,6 +667,13 @@ export async function initialize(opts: {
 
         // assetPrefix overrides basePath for HMR path
         if (assetPrefix) {
+          // if assetPrefix is a URL, it can break HMR
+          if (assetPrefix.startsWith('http')) {
+            throw new Error(
+              `assetPrefix is a URL (${assetPrefix}), which is production-only. For more information, see https://nextjs.org/docs/app/api-reference/next-config-js/assetPrefix`
+            )
+          }
+
           hmrPrefix = normalizedAssetPrefix(assetPrefix)
         }
         const isHMRRequest = req.url.startsWith(

--- a/packages/next/src/shared/lib/normalized-asset-prefix.test.ts
+++ b/packages/next/src/shared/lib/normalized-asset-prefix.test.ts
@@ -1,0 +1,29 @@
+import { normalizedAssetPrefix } from './normalized-asset-prefix'
+
+describe('normalizedAssetPrefix', () => {
+  it('should return an empty string when assetPrefix is nullish', () => {
+    expect(normalizedAssetPrefix(undefined)).toBe('')
+  })
+
+  it('should return an empty string when assetPrefix is an empty string', () => {
+    expect(normalizedAssetPrefix('')).toBe('')
+  })
+
+  it('should remove leading slash(es) when assetPrefix has more than one', () => {
+    expect(normalizedAssetPrefix('///path/to/asset')).toBe('/path/to/asset')
+  })
+
+  it('should not remove the leading slash when assetPrefix has only one', () => {
+    expect(normalizedAssetPrefix('/path/to/asset')).toBe('/path/to/asset')
+  })
+
+  it('should add a leading slash when assetPrefix is missing one', () => {
+    expect(normalizedAssetPrefix('path/to/asset')).toBe('/path/to/asset')
+  })
+
+  it('should return a pathname when assetPrefix is a URL', () => {
+    expect(normalizedAssetPrefix('https://example.com/path/to/asset')).toBe(
+      '/path/to/asset'
+    )
+  })
+})


### PR DESCRIPTION
### Why?

User faced broken HMR when set `assetPrefix` as URL, this is anti-pattern for Next.js but we didn't have sufficient warning for this case.

x-ref: https://github.com/vercel/next.js/issues/51162

### How?

Throw if `assetPrefix` was passed as a URL in HMR.

Closes NDX-146