### PR TITLE
fix: NPM Workspace throws`ENOWORKSPACES` error when fetching registry

### DIFF
--- a/packages/next/src/lib/helpers/get-registry.ts
+++ b/packages/next/src/lib/helpers/get-registry.ts
@@ -23,7 +23,11 @@ export function getRegistry(baseDir: string = process.cwd()) {
     if (output.startsWith('http')) {
       registry = output.endsWith('/') ? output : `${output}/`
     }
-  } finally {
-    return registry
+  } catch {
+    // ignore error
+    // e.g. In an npm workspace, `npm config get registry` will throw error code ENOWORKSPACES
+    // x-ref: https://github.com/vercel/next.js/issues/47121#issuecomment-1499044345
   }
+
+  return registry
 }

--- a/packages/next/src/lib/helpers/get-registry.ts
+++ b/packages/next/src/lib/helpers/get-registry.ts
@@ -35,9 +35,9 @@ export function getRegistry(baseDir: string = process.cwd()) {
     }
   } catch (err) {
     if (err instanceof Error) {
-      throw new Error(
-        `Failed to get registry from "${pkgManager}".\n\n${err.message}`
-      )
+      throw new Error(`Failed to get registry from "${pkgManager}".`, {
+        cause: err,
+      })
     }
   }
 

--- a/packages/next/src/lib/helpers/get-registry.ts
+++ b/packages/next/src/lib/helpers/get-registry.ts
@@ -42,11 +42,9 @@ export function getRegistry(baseDir: string = process.cwd()) {
     }
 
     try {
-      // x-ref: https://github.com/npm/cli/issues/6099#issuecomment-1847584792
-      const output = runConfigGetRegistry(pkgManager, [
-        '--workspaces=false',
-        '--include-workspace-root',
-      ])
+      // run command under the context of the root project only
+      // x-ref: https://github.com/npm/statusboard/issues/371#issue-920669998
+      const output = runConfigGetRegistry(pkgManager, ['--no-workspaces'])
 
       if (output.startsWith('http')) {
         registry = addTrailingSlash(output)

--- a/packages/next/src/lib/helpers/get-registry.ts
+++ b/packages/next/src/lib/helpers/get-registry.ts
@@ -34,11 +34,9 @@ export function getRegistry(baseDir: string = process.cwd()) {
       registry = output.endsWith('/') ? output : `${output}/`
     }
   } catch (err) {
-    if (err instanceof Error) {
-      throw new Error(`Failed to get registry from "${pkgManager}".`, {
-        cause: err,
-      })
-    }
+    throw new Error(`Failed to get registry from "${pkgManager}".`, {
+      cause: err,
+    })
   }
 
   return registry

--- a/packages/next/src/lib/helpers/get-registry.ts
+++ b/packages/next/src/lib/helpers/get-registry.ts
@@ -1,3 +1,4 @@
+import isError from '../is-error'
 import { execSync } from 'child_process'
 import { getPkgManager } from './get-pkg-manager'
 import { getFormattedNodeOptionsWithoutInspect } from '../../server/lib/utils'
@@ -23,10 +24,13 @@ export function getRegistry(baseDir: string = process.cwd()) {
     if (output.startsWith('http')) {
       registry = output.endsWith('/') ? output : `${output}/`
     }
-  } catch {
-    // ignore error
-    // e.g. In an npm workspace, `npm config get registry` will throw error code ENOWORKSPACES
+  } catch (error) {
+    // In an npm workspace, `npm config get registry` will throw error code ENOWORKSPACES
+    // As this is NPM specific error, we ignore and use the default NPM registry.
     // x-ref: https://github.com/vercel/next.js/issues/47121#issuecomment-1499044345
+    if (isError(error) && error.code !== 'ENOWORKSPACES') {
+      throw error
+    }
   }
 
   return registry

--- a/packages/next/src/lib/helpers/get-registry.ts
+++ b/packages/next/src/lib/helpers/get-registry.ts
@@ -33,7 +33,13 @@ export function getRegistry(baseDir: string = process.cwd()) {
     if (output.startsWith('http')) {
       registry = output.endsWith('/') ? output : `${output}/`
     }
-  } finally {
-    return registry
+  } catch (err) {
+    if (err instanceof Error) {
+      throw new Error(
+        `Failed to get registry from "${pkgManager}".\n\n${err.message}`
+      )
+    }
   }
+
+  return registry
 }


### PR DESCRIPTION
### Why?

This issue occurs when a project is NPM Workspace, and has no other package managers but NPM is installed.

Next.js runs [npm config get registry](https://github.com/vercel/next.js/blob/e35710f71f8e0f2844add1a97513a65a54a6f2a3/packages/next/src/lib/helpers/get-registry.ts#L13) to fetch the registry.
However, running `npm config get registry` at a NPM Workspace is not allowed resulting a `ENOWORKSPACES` error.

```
$ npm config get registry  
npm error code ENOWORKSPACES
npm error This command does not support workspaces.
```

As we didn't consume the error, it threw when the enabled `next telemetry` [triggered getVersionInfo](https://github.com/vercel/next.js/blame/fb2d2dd01a5f73ac62c4809b7b9c1490617f8705/packages/next/src/server/dev/hot-reloader-webpack.ts#L725-L728) calling `getRegistry` which threw as above.

### How?

Add `--no-workspaces` flag when the pkgManager is `'npm'`.
It is safe for non-workspace projects as it's equivalent to default `--workspaces=false`.

Fixes #47121
Fixes NEXT-832
Fixes NDX-150