### PR TITLE
feat: allow for custom gtm script host

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/12-third-party-libraries.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/12-third-party-libraries.mdx
@@ -175,6 +175,7 @@ docs](https://developers.google.com/tag-platform/tag-manager/datalayer).
 | `dataLayerName` | Optional | Name of the data layer. Defaults to `dataLayer`.                         |
 | `auth`          | Optional | Value of authentication parameter (`gtm_auth`) for environment snippets. |
 | `preview`       | Optional | Value of preview parameter (`gtm_preview`) for environment snippets.     |
+| `host`          | Optional | A custom GTM host url for use with server-side tagging.                  |
 
 ### Google Analytics
 

--- a/packages/third-parties/src/google/gtm.tsx
+++ b/packages/third-parties/src/google/gtm.tsx
@@ -8,7 +8,14 @@ import type { GTMParams } from '../types/google'
 let currDataLayerName: string | undefined = undefined
 
 export function GoogleTagManager(props: GTMParams) {
-  const { gtmId, dataLayerName = 'dataLayer', auth, preview, dataLayer, trackingHost = 'https://www.googletagmanager.com' } = props
+  const {
+    gtmId,
+    dataLayerName = 'dataLayer',
+    auth,
+    preview,
+    dataLayer,
+    host = 'https://www.googletagmanager.com',
+  } = props
 
   if (currDataLayerName === undefined) {
     currDataLayerName = dataLayerName
@@ -47,7 +54,7 @@ export function GoogleTagManager(props: GTMParams) {
       <Script
         id="_next-gtm"
         data-ntpc="GTM"
-        src={`${trackingHost}/gtm.js?id=${gtmId}${gtmLayer}${gtmAuth}${gtmPreview}`}
+        src={`${host}/gtm.js?id=${gtmId}${gtmLayer}${gtmAuth}${gtmPreview}`}
       />
     </>
   )

--- a/packages/third-parties/src/google/gtm.tsx
+++ b/packages/third-parties/src/google/gtm.tsx
@@ -8,7 +8,7 @@ import type { GTMParams } from '../types/google'
 let currDataLayerName: string | undefined = undefined
 
 export function GoogleTagManager(props: GTMParams) {
-  const { gtmId, dataLayerName = 'dataLayer', auth, preview, dataLayer } = props
+  const { gtmId, dataLayerName = 'dataLayer', auth, preview, dataLayer, trackingHost = 'https://www.googletagmanager.com' } = props
 
   if (currDataLayerName === undefined) {
     currDataLayerName = dataLayerName
@@ -47,7 +47,7 @@ export function GoogleTagManager(props: GTMParams) {
       <Script
         id="_next-gtm"
         data-ntpc="GTM"
-        src={`https://www.googletagmanager.com/gtm.js?id=${gtmId}${gtmLayer}${gtmAuth}${gtmPreview}`}
+        src={`${trackingHost}/gtm.js?id=${gtmId}${gtmLayer}${gtmAuth}${gtmPreview}`}
       />
     </>
   )

--- a/packages/third-parties/src/types/google.ts
+++ b/packages/third-parties/src/types/google.ts
@@ -18,6 +18,7 @@ export type GTMParams = {
   dataLayerName?: string
   auth?: string
   preview?: string
+  host?: string
 }
 
 export type GAParams = {


### PR DESCRIPTION
### What?

This PR adds the option to provide a custom GTM script domain to `@next/third-parties/google`

### Why?

- Most modern browsers have already deprecated 3rd party cookies. 
- GTM offers [a new way of handling cookies](https://developers.google.com/tag-platform/tag-manager/server-side/dependency-serving?tag=gtm#step_2_update_the_script_source_domain_) as 1st party, via a proxy server. 
- This proxy server can also serve the gtm.js script under a 1st party domain.

### How?

By adding an option for the host url (`trackingHost`) to the `GoogleTagManager` initialisation function.
Defaults to the original `googletagmanager.com` host