### PR TITLE
Remove obsolete `deleteAppClientCache()` call from webpack plugin

### DIFF
--- a/packages/next/src/build/webpack/plugins/nextjs-require-cache-hot-reloader.ts
+++ b/packages/next/src/build/webpack/plugins/nextjs-require-cache-hot-reloader.ts
@@ -94,16 +94,10 @@ export class NextJsRequireCacheHotReloader implements WebpackPluginInstance {
       // we need to make sure to clear all server entries from cache
       // since they can have a stale webpack-runtime cache
       // which needs to always be in-sync
-      let hasAppEntry = false
       const entries = [...compilation.entries.keys()].filter((entry) => {
         const isAppPath = entry.toString().startsWith('app/')
-        if (isAppPath) hasAppEntry = true
         return entry.toString().startsWith('pages/') || isAppPath
       })
-
-      if (hasAppEntry) {
-        deleteAppClientCache()
-      }
 
       for (const page of entries) {
         const outputPath = path.join(


### PR DESCRIPTION
The first iteration of `deleteAppClientCache()` was introduced in #41510. Its purpose was to remove stale client components (for SSR) from React's cache. Since React didn't (and still doesn't) offer an API for that, this was accomplished by deleting `react-server-dom-webpack` from the require cache.

With the bundling that was introduced in #55362, `deleteAppClientCache()` was changed to delete the whole server runtimes (e.g. `app-page.runtime.dev.js`) from the require cache. This has the unfortunate side effect that also React's other module scope cache (back then `ReactCurrentCache`, now `ReactSharedInternals.A`) is reset between compilations. As a result, when fetching data from a route handler in a page, the fetch cache didn't work properly. This issue was masked though by response buffering for the static generation cache. In #68447 the response buffering will be removed which [uncovered the issue](https://github.com/vercel/next.js/actions/runs/10217197012/job/28270497496).

React had two module-scoped caches for client components:
- `chunkCache` – caches the loaded JS chunks, as specified in the SSR manifest
- `asyncModuleCache` – caches the required modules, if marked as `async` in the SSR manifest

The `asyncModuleCache` was subsequently dropped in https://github.com/facebook/react/pull/26985.

In addition, with Webpack, we don't create any client component chunks for SSR (removed from the manifest in #50959). So there's no need anymore to delete server runtime bundles from the require cache, and we can remove `deleteAppClientCache()` from the `NextJsRequireCacheHotReloader`.

For Turbopack, the exported `deleteAppClientCache` function is still used because Turbopack does create SSR client component chunks. Ideally, React would offer an API to clear the chunk cache. But for now we can keep this logic, since Turbopack also handles this a bit more sophisticated than the Webpack plugin, so that the aforementioned fetch issue does not occur there.

This PR in conjunction with https://github.com/vercel/next.js/pull/68193 should then also fix the issue that was reported in #52126.