### PR TITLE
chore(turbopack): Add `comment_width = 100` to rustfmt.toml

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,11 +1,13 @@
 max_width = 100
 
+comment_width = 100
+wrap_comments = true
+
 tab_spaces = 4
 hard_tabs = false
 
 format_strings = true
 use_field_init_shorthand = true
-wrap_comments = true
 
 imports_granularity = "Crate"
 group_imports = "StdExternalCrate"

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -109,10 +109,9 @@ pub(crate) async fn collect_evaluated_chunk_group(
 /// If an import is specified as dynamic, next.js does few things:
 /// - Runs a next_dynamic [transform to the source file](https://github.com/vercel/next.js/blob/ae1b89984d26b2af3658001fa19a19e1e77c312d/packages/next-swc/crates/next-transform-dynamic/src/lib.rs#L22)
 ///   - This transform will [inject `loadableGenerated` property](https://github.com/vercel/next.js/blob/ae1b89984d26b2af3658001fa19a19e1e77c312d/packages/next-swc/crates/next-transform-dynamic/tests/fixture/wrapped-import/output-webpack-dev.js#L5),
-///     which contains the list of the import ids in the form of `${origin} ->
-///     ${imported}`.
-/// - Emits `react-loadable-manifest.json` which contains the mapping of the
-///   import ids to the chunk ids.
+///     which contains the list of the import ids in the form of `${origin} -> ${imported}`.
+/// - Emits `react-loadable-manifest.json` which contains the mapping of the import ids to the chunk
+///   ids.
 ///   - Webpack: [implementation](https://github.com/vercel/next.js/blob/ae1b89984d26b2af3658001fa19a19e1e77c312d/packages/next/src/build/webpack/plugins/react-loadable-plugin.ts)
 ///   - Turbopack: [implementation 1](https://github.com/vercel/next.js/pull/56389/files#diff-3cac9d9bfe73e0619e6407f21f6fe652da0719d0ec9074ff813ad3e416d0eb1a),
 ///     [implementation 2](https://github.com/vercel/next.js/pull/56389/files#diff-791951bbe1fa09bcbad9be9173412d0848168f7d658758f11b6e8888a021552c),
@@ -124,8 +123,8 @@ pub(crate) async fn collect_evaluated_chunk_group(
 ///    - Server embeds those into __NEXT_DATA__ and [send to the client.](https://github.com/vercel/next.js/blob/ad42b610c25b72561ad367b82b1c7383fd2a5dd2/packages/next/src/server/render.tsx#L1453)
 ///    - When client boots up, pass it to the [client preload](https://github.com/vercel/next.js/blob/ad42b610c25b72561ad367b82b1c7383fd2a5dd2/packages/next/src/client/index.tsx#L943)
 ///    - Loadable runtime [injects preload fn](https://github.com/vercel/next.js/blob/ad42b610c25b72561ad367b82b1c7383fd2a5dd2/packages/next/src/shared/lib/loadable.shared-runtime.tsx#L281)
-///      to wait until all the dynamic components are being loaded, this ensures
-///      hydration mismatch won't occur
+///      to wait until all the dynamic components are being loaded, this ensures hydration mismatch
+///      won't occur
 #[tracing::instrument(level = Level::INFO, name = "collecting next/dynamic imports", skip_all)]
 pub(crate) async fn collect_next_dynamic_imports(
     server_entries: impl IntoIterator<Item = Vc<Box<dyn Module>>>,
@@ -133,8 +132,7 @@ pub(crate) async fn collect_next_dynamic_imports(
 ) -> Result<IndexMap<Vc<Box<dyn Module>>, DynamicImportedModules>> {
     // Traverse referenced modules graph, collect all of the dynamic imports:
     // - Read the Program AST of the Module, this is the origin (A)
-    //  - If there's `dynamic(import(B))`, then B is the module that is being
-    //    imported
+    //  - If there's `dynamic(import(B))`, then B is the module that is being imported
     // Returned import mappings are in the form of
     // (Module<A>, Vec<(B, Module<B>)>) (where B is the raw import source string,
     // and Module<B> is the actual resolved Module)

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -22,8 +22,8 @@ use crate::{
 /// Computes the entry for a Next.js app route.
 /// # Arguments
 ///
-/// * `original_segment_config` - A next segment config to be specified
-///   explicitly for the given source.
+/// * `original_segment_config` - A next segment config to be specified explicitly for the given
+///   source.
 /// For some cases `source` may not be the original but the handler (dynamic
 /// metadata) which will lose segment config.
 #[turbo_tasks::function]

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -9,8 +9,8 @@ use turbopack_core::{
 use turbopack_ecmascript::chunk::EcmascriptChunkPlaceable;
 
 /// An [EcmascriptClientReferenceModule] is a marker module, used by the
-/// [super::ecmascript_client_reference_proxy_module::EcmascriptClientReferenceProxyModule] to indicate which client reference
-/// should appear in the client reference manifest.
+/// [super::ecmascript_client_reference_proxy_module::EcmascriptClientReferenceProxyModule] to
+/// indicate which client reference should appear in the client reference manifest.
 #[turbo_tasks::value]
 pub struct EcmascriptClientReferenceModule {
     pub server_ident: Vc<AssetIdent>,
@@ -24,8 +24,8 @@ impl EcmascriptClientReferenceModule {
     ///
     /// # Arguments
     ///
-    /// * `server_ident` - The identifier of the server module, used to identify
-    ///   the client reference.
+    /// * `server_ident` - The identifier of the server module, used to identify the client
+    ///   reference.
     /// * `client_module` - The client module.
     /// * `ssr_module` - The SSR module.
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_font/local/font_fallback.rs
+++ b/crates/next-core/src/next_font/local/font_fallback.rs
@@ -145,8 +145,8 @@ fn calc_average_width(font: &mut Font<DynamicFontTableProvider>) -> Option<f32> 
 /// font file:
 /// - Most of the text will have normal weight, use the one closest to 400
 /// - Most of the text will have normal style, prefer normal over italic
-/// - If two font files have the same distance from normal weight, the thinner
-///   one will most likely be the bulk of the text
+/// - If two font files have the same distance from normal weight, the thinner one will most likely
+///   be the bulk of the text
 fn pick_font_for_fallback_generation(
     font_descriptors: &FontDescriptors,
 ) -> Result<&FontDescriptor> {

--- a/crates/next-core/src/next_font/util.rs
+++ b/crates/next-core/src/next_font/util.rs
@@ -43,8 +43,8 @@ pub(crate) enum FontFamilyType {
 }
 
 /// Returns a uniquely scoped version of the font family, e.g.`__Roboto_c123b8`
-/// * `ty` - Whether to generate a scoped classname for the main font or its
-///   fallback equivalent, e.g. `__Roboto_Fallback_c123b8`
+/// * `ty` - Whether to generate a scoped classname for the main font or its fallback equivalent,
+///   e.g. `__Roboto_Fallback_c123b8`
 /// * `font_family_name` - The font name to scope, e.g. `Roboto`
 /// * `request_hash` - The hash value of the font request
 #[turbo_tasks::function]

--- a/crates/next-custom-transforms/src/transforms/dynamic.rs
+++ b/crates/next-custom-transforms/src/transforms/dynamic.rs
@@ -66,12 +66,11 @@ pub enum NextDynamicMode {
     /// the React Loadable Webpack plugin.
     Webpack,
     /// In Turbopack mode:
-    /// * in development, each `dynamic()` call will generate a key containing
-    ///   both the imported module id and the chunks it needs. This removes the
-    ///   need for a manifest entry
-    /// * during build, each `dynamic()` call will import the module through the
-    ///   given transition, which takes care of adding an entry to the manifest
-    ///   and returning an asset that exports the entry's key.
+    /// * in development, each `dynamic()` call will generate a key containing both the imported
+    ///   module id and the chunks it needs. This removes the need for a manifest entry
+    /// * during build, each `dynamic()` call will import the module through the given transition,
+    ///   which takes care of adding an entry to the manifest and returning an asset that exports
+    ///   the entry's key.
     Turbopack { dynamic_transition_name: String },
 }
 

--- a/crates/next-custom-transforms/src/transforms/strip_page_exports.rs
+++ b/crates/next-custom-transforms/src/transforms/strip_page_exports.rs
@@ -51,8 +51,7 @@ impl PageMode {
 }
 
 /// A transform that either:
-/// * strips Next.js data exports (getServerSideProps, getStaticProps,
-///   getStaticPaths); or
+/// * strips Next.js data exports (getServerSideProps, getStaticProps, getStaticPaths); or
 /// * strips the default export.
 ///
 /// Note: This transform requires running `resolver` **before** running it.

--- a/turbopack/crates/turbo-tasks-fs/src/glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/glob.rs
@@ -35,8 +35,8 @@ enum GlobPart {
 // - file*.js = File(file), AnyFile, File(.js)
 // - dir/file.js = File(dir), PathSeparator, File(file.js)
 // - **/*.js = AnyDirectories, PathSeparator, AnyFile, File(.js)
-// - {a/**,*}/file = Alternatives([File(a), PathSeparator, AnyDirectories],
-//   [AnyFile]), PathSeparator, File(file)
+// - {a/**,*}/file = Alternatives([File(a), PathSeparator, AnyDirectories], [AnyFile]),
+//   PathSeparator, File(file)
 
 // Note: a/**/b does match a/b, so we need some special logic about path
 // separators

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -282,10 +282,9 @@ impl DiskFileSystem {
     ///
     /// * `name` - Name of the filesystem.
     /// * `root` - Path to the given filesystem's root.
-    /// * `ignored_subpaths` - A list of subpaths that should not trigger
-    ///   invalidation. This should be a full path, since it is possible that
-    ///   root & project dir is different and requires to ignore specific
-    ///   subpaths from each.
+    /// * `ignored_subpaths` - A list of subpaths that should not trigger invalidation. This should
+    ///   be a full path, since it is possible that root & project dir is different and requires to
+    ///   ignore specific subpaths from each.
     #[turbo_tasks::function]
     pub async fn new(name: RcStr, root: RcStr, ignored_subpaths: Vec<RcStr>) -> Result<Vc<Self>> {
         mark_stateful();
@@ -1043,8 +1042,7 @@ impl FileSystemPath {
     ///
     /// * [`None`], if there is no file name;
     /// * The entire file name if there is no embedded `.`;
-    /// * The entire file name if the file name begins with `.` and has no other
-    ///   `.`s within;
+    /// * The entire file name if the file name begins with `.` and has no other `.`s within;
     /// * Otherwise, the portion of the file name before the final `.`
     #[turbo_tasks::function]
     pub async fn file_stem(self: Vc<Self>) -> Result<Vc<Option<RcStr>>> {

--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -111,13 +111,12 @@ impl DiskWatcher {
     /// `notify` provides 2 different debouncer implementations, `-full`
     /// provides below differences for the easy of use:
     ///
-    /// - Only emits a single Rename event if the rename From and To events can
-    ///   be matched
+    /// - Only emits a single Rename event if the rename From and To events can be matched
     /// - Merges multiple Rename events
-    /// - Takes Rename events into account and updates paths for events that
-    ///   occurred before the rename event, but which haven't been emitted, yet
-    /// - Optionally keeps track of the file system IDs all files and stitches
-    ///   rename events together (FSevents, Windows)
+    /// - Takes Rename events into account and updates paths for events that occurred before the
+    ///   rename event, but which haven't been emitted, yet
+    /// - Optionally keeps track of the file system IDs all files and stitches rename events
+    ///   together (FSevents, Windows)
     /// - Emits only one Remove event when deleting a directory (inotify)
     /// - Doesn't emit duplicate create events
     /// - Doesn't emit Modify events after a Create event

--- a/turbopack/crates/turbo-tasks-macros-shared/src/expand.rs
+++ b/turbopack/crates/turbo-tasks-macros-shared/src/expand.rs
@@ -10,12 +10,11 @@ use syn::{
 ///
 /// Requires several Fn helpers which perform expand different structures:
 ///
-/// - [expand_named] handles the expansion of a struct or enum variant with
-///   named fields (e.g. `struct Foo { bar: u32 }`, `Foo::Bar { baz: u32 }`).
-/// - [expand_unnamed] handles the expansion of a struct or enum variant with
-///   unnamed fields (e.g. `struct Foo(u32)`, `Foo::Bar(u32)`).
-/// - [expand_unit] handles the expansion of a unit struct or enum (e.g. `struct
-///   Foo;`, `Foo::Bar`).
+/// - [expand_named] handles the expansion of a struct or enum variant with named fields (e.g.
+///   `struct Foo { bar: u32 }`, `Foo::Bar { baz: u32 }`).
+/// - [expand_unnamed] handles the expansion of a struct or enum variant with unnamed fields (e.g.
+///   `struct Foo(u32)`, `Foo::Bar(u32)`).
+/// - [expand_unit] handles the expansion of a unit struct or enum (e.g. `struct Foo;`, `Foo::Bar`).
 ///
 /// These helpers should themselves call [generate_destructuring] to generate
 /// the destructure necessary to access the fields of the value.

--- a/turbopack/crates/turbo-tasks-macros/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/lib.rs
@@ -91,13 +91,10 @@ pub fn derive_task_input(input: TokenStream) -> TokenStream {
 ///
 /// Possible values:
 ///
-/// - "auto" (default): Derives the serialization traits and enabled
-///   serialization.
-/// - "auto_for_input": Same as "auto", but also adds the marker trait
-///   [turbo_tasks::TypedForInput].
-/// - "custom": Prevents deriving the serialization traits, but still enables
-///   serialization (you need to manually implement [serde::Serialize] and
-///   [serde::Deserialize]).
+/// - "auto" (default): Derives the serialization traits and enabled serialization.
+/// - "auto_for_input": Same as "auto", but also adds the marker trait [turbo_tasks::TypedForInput].
+/// - "custom": Prevents deriving the serialization traits, but still enables serialization (you
+///   need to manually implement [serde::Serialize] and [serde::Deserialize]).
 /// - "custom_for_input":Same as "auto", but also adds the marker trait
 ///   [turbo_tasks::TypedForInput].
 /// - "none": Disables serialization and prevents deriving the traits.

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -5,12 +5,12 @@
 //! - functions: Unit of execution, invalidation and reexecution.
 //! - values: Data created, stored and returned by functions.
 //! - traits: Traits that define a set of functions on values.
-//! - collectibles: Values emitted in functions that bubble up the call graph
-//!   and can be collected in parent functions.
+//! - collectibles: Values emitted in functions that bubble up the call graph and can be collected
+//!   in parent functions.
 //!
 //! It also defines some derived elements from that:
-//! - cells: The locations in functions where values are stored. The content of
-//!   a cell can change after the reexecution of a function.
+//! - cells: The locations in functions where values are stored. The content of a cell can change
+//!   after the reexecution of a function.
 //! - Vcs: A reference to a cell in a function or a return value of a function.
 //! - task: An instance of a function together with its arguments.
 //!

--- a/turbopack/crates/turbo-tasks/src/vc/default.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/default.rs
@@ -8,11 +8,9 @@ use crate::{self as turbo_tasks};
 /// `T::value_default()`.
 ///
 /// There are two ways to implement this trait:
-/// 1. Annotating with `#[turbo_tasks::value_impl]`: this will make
-///    `Vc::default()` always return the same underlying value (i.e. a
-///    singleton).
-/// 2. No annotations: this will make `Vc::default()` always return a different
-///    value.
+/// 1. Annotating with `#[turbo_tasks::value_impl]`: this will make `Vc::default()` always return
+///    the same underlying value (i.e. a singleton).
+/// 2. No annotations: this will make `Vc::default()` always return a different value.
 #[turbo_tasks::value_trait]
 pub trait ValueDefault {
     fn value_default() -> Vc<Self>;

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -173,11 +173,10 @@ where
 
 // This is the magic that makes `Vc<T>` accept `self: Vc<Self>` methods through
 // `arbitrary_self_types`, while not allowing any other receiver type:
-// * `Vc<T>` dereferences to `*const *mut *const T`, which means that it is
-//   valid under the `arbitrary_self_types` rules.
-// * `*const *mut *const T` is not a valid receiver for any attribute access on
-//   `T`, which means that the only applicable items will be the methods
-//   declared on `self: Vc<Self>`.
+// * `Vc<T>` dereferences to `*const *mut *const T`, which means that it is valid under the
+//   `arbitrary_self_types` rules.
+// * `*const *mut *const T` is not a valid receiver for any attribute access on `T`, which means
+//   that the only applicable items will be the methods declared on `self: Vc<Self>`.
 //
 // If we had used `type Target = T` instead, `vc_t.some_attr_defined_on_t` would
 // have been accepted by the compiler.

--- a/turbopack/crates/turbopack-cli-utils/src/issue.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/issue.rs
@@ -217,15 +217,13 @@ pub struct LogOptions {
 /// When a source repulls emitted issues due to a recomputation somewhere in its
 /// graph, there are a few possibilities:
 ///
-/// 1. An issue from this pull is brand new to all sources, in which case it
-///    will be logged and the issue's count is inremented.
-/// 2. An issue from this pull is brand new to this source but another source
-///    has already pulled it, in which case it will be logged and the issue's
-///    count is incremented.
-/// 3. The previous pull from this source had already seen the issue, in which
-///    case the issue will be skipped and the issue's count remains constant.
-/// 4. An issue seen in a previous pull was not repulled, and the issue's count
-///    is decremented.
+/// 1. An issue from this pull is brand new to all sources, in which case it will be logged and the
+///    issue's count is inremented.
+/// 2. An issue from this pull is brand new to this source but another source has already pulled it,
+///    in which case it will be logged and the issue's count is incremented.
+/// 3. The previous pull from this source had already seen the issue, in which case the issue will
+///    be skipped and the issue's count remains constant.
+/// 4. An issue seen in a previous pull was not repulled, and the issue's count is decremented.
 ///
 /// Once an issue's count reaches zero, it's removed. If it is ever seen again,
 /// it is considered new and will be relogged.

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -104,8 +104,7 @@ pub trait ChunkingContext {
 
     /// Generates an output chunk that:
     /// * evaluates the given assets; and
-    /// * exports the result of evaluating the given module as a CommonJS
-    ///   default export.
+    /// * exports the result of evaluating the given module as a CommonJS default export.
     fn entry_chunk_group(
         self: Vc<Self>,
         path: Vc<FileSystemPath>,

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -492,10 +492,8 @@ impl IssueSource {
     /// Arguments:
     ///
     /// * `source`: The source code in which to look up the byte offsets.
-    /// * `start`: Byte offset into the source that the text begins. 0-based
-    ///   index and inclusive.
-    /// * `end`: Byte offset into the source that the text ends. 0-based index
-    ///   and exclusive.
+    /// * `start`: Byte offset into the source that the text begins. 0-based index and inclusive.
+    /// * `end`: Byte offset into the source that the text ends. 0-based index and exclusive.
     pub async fn from_byte_offset(
         source: Vc<Box<dyn Source>>,
         start: usize,
@@ -748,8 +746,8 @@ pub trait IssueReporter {
     ///
     /// * `issues` - A [ReadRef] of [CapturedIssues]. Typically obtained with
     ///   `source.peek_issues_with_path()`.
-    /// * `source` - The root [Vc] from which issues are traced. Can be used by
-    ///   implementers to determine which issues are new.
+    /// * `source` - The root [Vc] from which issues are traced. Can be used by implementers to
+    ///   determine which issues are new.
     /// * `min_failing_severity` - The minimum Vc<[IssueSeverity]>
     ///  The minimum issue severity level considered to fatally end the program.
     fn report_issues(

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -372,24 +372,21 @@ impl Display for LogicalProperty {
 /// TODO: Use `Arc`
 /// There are 4 kinds of values: Leaves, Nested, Operations, and Placeholders
 /// (see [JsValueMetaKind] for details). Values are processed in two phases:
-/// - Analyze phase: We convert AST into [JsValue]s. We don't have contextual
-///   information so we need to insert placeholders to represent that.
-/// - Link phase: We try to reduce a value to a constant value. The link phase
-///   has 5 substeps that are executed on each node in the graph depth-first.
-///   When a value is modified, we need to visit the new children again.
-/// - Replace variables with their values. This replaces [JsValue::Variable]. No
-///   variable should be remaining after that.
-/// - Replace placeholders with contextual information. This usually replaces
-///   [JsValue::FreeVar] and [JsValue::Module]. Some [JsValue::Call] on well-
-///   known functions might also be replaced. No free vars or modules should be
+/// - Analyze phase: We convert AST into [JsValue]s. We don't have contextual information so we need
+///   to insert placeholders to represent that.
+/// - Link phase: We try to reduce a value to a constant value. The link phase has 5 substeps that
+///   are executed on each node in the graph depth-first. When a value is modified, we need to visit
+///   the new children again.
+/// - Replace variables with their values. This replaces [JsValue::Variable]. No variable should be
 ///   remaining after that.
-/// - Replace operations on well-known objects and functions. This handles
-///   [JsValue::Call] and [JsValue::Member] on well-known objects and functions.
-/// - Replace all built-in functions with their values when they are
-///   compile-time constant.
-/// - For optimization, any nested operations are replaced with
-///   [JsValue::Unknown]. So only one layer of operation remains. Any remaining
-///   operation or placeholder can be treated as unknown.
+/// - Replace placeholders with contextual information. This usually replaces [JsValue::FreeVar] and
+///   [JsValue::Module]. Some [JsValue::Call] on well- known functions might also be replaced. No
+///   free vars or modules should be remaining after that.
+/// - Replace operations on well-known objects and functions. This handles [JsValue::Call] and
+///   [JsValue::Member] on well-known objects and functions.
+/// - Replace all built-in functions with their values when they are compile-time constant.
+/// - For optimization, any nested operations are replaced with [JsValue::Unknown]. So only one
+///   layer of operation remains. Any remaining operation or placeholder can be treated as unknown.
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum JsValue {
     // LEAF VALUES
@@ -1774,11 +1771,10 @@ impl JsValue {
     /// When the value has a user-defineable name, return the length of it (in
     /// segments). Otherwise returns None.
     /// - any free var has itself as user-defineable name.
-    /// - any member access adds the identifier as segement to the name of the
-    ///   object.
+    /// - any member access adds the identifier as segement to the name of the object.
     /// - some well-known objects/functions have a user-defineable names.
-    /// - member calls without arguments also have a user-defineable name which
-    ///   is the property with `()` appended.
+    /// - member calls without arguments also have a user-defineable name which is the property with
+    ///   `()` appended.
     pub fn get_defineable_name_len(&self) -> Option<usize> {
         match self {
             JsValue::FreeVar(_) => Some(1),

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -90,15 +90,13 @@ pub(crate) struct ItemData {
 
     /// Variables read by this module item eventually
     ///
-    /// - e.g. variables read in the body of function declarations are
-    ///   considered as eventually read
-    /// - This is only used when reads are not trigger directly by this module
-    ///   item, but require a side effect to be triggered. We don’t know when
-    ///   this is executed.
-    /// - Note: This doesn’t mean they are only read “after” initial evaluation.
-    ///   They might also be read “during” initial evaluation on any module item
-    ///   with SIDE_EFFECTS. This kind of interaction is handled by the module
-    ///   item with SIDE_EFFECTS.
+    /// - e.g. variables read in the body of function declarations are considered as eventually
+    ///   read
+    /// - This is only used when reads are not trigger directly by this module item, but require a
+    ///   side effect to be triggered. We don’t know when this is executed.
+    /// - Note: This doesn’t mean they are only read “after” initial evaluation. They might also be
+    ///   read “during” initial evaluation on any module item with SIDE_EFFECTS. This kind of
+    ///   interaction is handled by the module item with SIDE_EFFECTS.
     pub eventual_read_vars: IndexSet<Id, FxBuildHasher>,
 
     /// Side effects that are triggered on local variables during evaluation

--- a/turbopack/crates/turbopack-node/src/pool.rs
+++ b/turbopack/crates/turbopack-node/src/pool.rs
@@ -714,8 +714,8 @@ pub struct NodeJsPool {
 }
 
 impl NodeJsPool {
-    /// * debug: Whether to automatically enable Node's `--inspect-brk` when
-    ///   spawning it. Note: automatically overrides concurrency to 1.
+    /// * debug: Whether to automatically enable Node's `--inspect-brk` when spawning it. Note:
+    ///   automatically overrides concurrency to 1.
     pub(super) fn new(
         cwd: PathBuf,
         entrypoint: PathBuf,

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -331,8 +331,8 @@ impl PostCssTransformedAsset {
         // i.e, this is possible
         // - root
         //  - node_modules
-        //     - somepkg/(some.module.css, postcss.config.js) // this could be symlinked
-        //       local, or actual remote pkg or anything
+        //     - somepkg/(some.module.css, postcss.config.js) // this could be symlinked local, or
+        //       actual remote pkg or anything
         //  - packages // root of workspace pkgs
         //     - pkg1/(postcss.config.js) // The actual config we're looking for
         //

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -287,8 +287,7 @@ impl ChunkingContext for NodeJsChunkingContext {
 
     /// Generates an output chunk that:
     /// * evaluates the given assets; and
-    /// * exports the result of evaluating the given module as a CommonJS
-    ///   default export.
+    /// * exports the result of evaluating the given module as a CommonJS default export.
     #[turbo_tasks::function]
     pub async fn entry_chunk_group(
         self: Vc<Self>,

--- a/turbopack/crates/turbopack-trace-utils/src/trace_writer.rs
+++ b/turbopack/crates/turbopack-trace-utils/src/trace_writer.rs
@@ -12,12 +12,10 @@ impl TraceWriter {
     /// This is a non-blocking writer that writes a file in a background thread.
     /// This is inspired by tracing-appender non_blocking, but has some
     /// differences:
-    /// * It allows writing an owned Vec<u8> instead of a reference, so avoiding
-    ///   additional allocation.
-    /// * It uses an unbounded channel to avoid slowing down the application at
-    ///   all (memory) cost.
-    /// * It issues less writes by buffering the data into chunks of ~1MB, when
-    ///   possible.
+    /// * It allows writing an owned Vec<u8> instead of a reference, so avoiding additional
+    ///   allocation.
+    /// * It uses an unbounded channel to avoid slowing down the application at all (memory) cost.
+    /// * It issues less writes by buffering the data into chunks of ~1MB, when possible.
     pub fn new<W: Write + Send + 'static>(mut writer: W) -> (Self, TraceWriterGuard) {
         let (data_tx, data_rx) = unbounded::<Vec<u8>>();
         let (return_tx, return_rx) = bounded::<Vec<u8>>(1024 * 10);


### PR DESCRIPTION
The default `comment_width` is `80`, which is a mismatch with the `max_width` of `100`.

Previous discussion: https://vercel.slack.com/archives/C03EWR7LGEN/p1716332166435329

Ran `cargo fmt` after making this change. It seems to mostly just fix bullet points. Other places it likely can't differentiate between wrapped text and intentional newlines.

I don't plan on going through and manually re-wrapping of all of the comments, but over time this should get fixed as people change comments.