### PR TITLE
refactor static workers to help with parallelization & cache sharing

### DIFF
--- a/packages/next/src/build/worker.ts
+++ b/packages/next/src/build/worker.ts
@@ -5,5 +5,4 @@ export {
   hasCustomGetInitialProps,
   isPageStatic,
 } from './utils'
-import exportPage from '../export/worker'
-export { exportPage }
+export { exportPages } from '../export/worker'

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -3,7 +3,7 @@ import type {
   ExportAppOptions,
   WorkerRenderOptsPartial,
 } from './types'
-import type { PrerenderManifest } from '../build'
+import { createStaticWorker, type PrerenderManifest } from '../build'
 import type { PagesManifest } from '../build/webpack/plugins/pages-manifest-plugin'
 
 import { bold, yellow } from '../lib/picocolors'
@@ -49,7 +49,6 @@ import type { MiddlewareManifest } from '../build/webpack/plugins/middleware-plu
 import { isAppRouteRoute } from '../lib/is-app-route-route'
 import { isAppPageRoute } from '../lib/is-app-page-route'
 import isError from '../lib/is-error'
-import { needsExperimentalReact } from '../lib/needs-experimental-react'
 import { formatManifest } from '../build/manifests/formatter/format-manifest'
 import { validateRevalidate } from '../server/lib/patch-fetch'
 import { TurborepoAccessTraceResult } from '../build/turborepo-access-trace'
@@ -60,7 +59,7 @@ export class ExportError extends Error {
   code = 'NEXT_EXPORT_ERROR'
 }
 
-export async function exportAppImpl(
+async function exportAppImpl(
   dir: string,
   options: Readonly<ExportAppOptions>,
   span: Span
@@ -364,7 +363,7 @@ export async function exportAppImpl(
     reactMaxHeadersLength: nextConfig.reactMaxHeadersLength,
   }
 
-  const { serverRuntimeConfig, publicRuntimeConfig } = nextConfig
+  const { publicRuntimeConfig } = nextConfig
 
   if (Object.keys(publicRuntimeConfig).length > 0) {
     renderOpts.runtimeConfig = publicRuntimeConfig
@@ -486,9 +485,6 @@ export async function exportAppImpl(
     }
   }
 
-  const progress =
-    !options.silent &&
-    createProgress(filteredPaths.length, options.statusMessage || 'Exporting')
   const pagesDataDir = options.buildExport
     ? outDir
     : join(outDir, '_next/data', buildId)
@@ -511,120 +507,75 @@ export async function exportAppImpl(
     )
   }
 
-  const failedExportAttemptsByPage: Map<string, number> = new Map()
-  const maxAttempts = nextConfig.experimental.staticGenerationRetryCount ?? 1
-  const results = await Promise.all(
-    filteredPaths.map(async (path) => {
-      const pathMap = exportPathMap[path]
-      const exportPage = pathMap._isAppDir
-        ? options.exportAppPageWorker
-        : options.exportPageWorker
+  const failedExportAttemptsByPage: Map<string, boolean> = new Map()
 
-      if (!exportPage) {
-        throw new Error(
-          'Invariant: Undefined export worker for app dir, this is a bug in Next.js.'
-        )
-      }
+  // Chunk filtered pages into smaller groups, and call the export worker on each group.
+  // We've set an arbitrary minimum of 25 pages per chunk to ensure that even setups
+  // with only a few static pages can leverage a shared incremental cache.
+  const chunks = []
+  const minChunkSize = 25
 
-      const pageExportSpan = span.traceChild('export-page')
-      pageExportSpan.setAttribute('path', path)
-      const { page } = exportPathMap[path]
-      const pageKey = page !== path ? `${page}: ${path}` : path
-
-      let result
-
-      for (let attempt = 0; attempt < maxAttempts; attempt++) {
-        try {
-          result = await pageExportSpan.traceAsyncFn(async () => {
-            return await exportPage({
-              dir,
-              path,
-              pathMap,
-              distDir,
-              outDir,
-              pagesDataDir,
-              renderOpts,
-              ampValidatorPath:
-                nextConfig.experimental.amp?.validator || undefined,
-              trailingSlash: nextConfig.trailingSlash,
-              serverRuntimeConfig,
-              subFolders,
-              buildExport: options.buildExport,
-              optimizeFonts: nextConfig.optimizeFonts as FontConfig,
-              optimizeCss: nextConfig.experimental.optimizeCss,
-              disableOptimizedLoading:
-                nextConfig.experimental.disableOptimizedLoading,
-              parentSpanId: pageExportSpan.getId(),
-              httpAgentOptions: nextConfig.httpAgentOptions,
-              debugOutput: options.debugOutput,
-              cacheMaxMemorySize: nextConfig.cacheMaxMemorySize,
-              fetchCache: true,
-              fetchCacheKeyPrefix: nextConfig.experimental.fetchCacheKeyPrefix,
-              cacheHandler: nextConfig.cacheHandler,
-              enableExperimentalReact: needsExperimentalReact(nextConfig),
-              enabledDirectories,
-            })
-          })
-
-          // If there was an error in the export, throw it immediately. In the catch block, we might retry the export,
-          // or immediately fail the build, depending on user configuration. We might also continue on and attempt other pages.
-          if (result && 'error' in result) {
-            throw new ExportError()
-          }
-
-          // If the export succeeds, break out of the retry loop
-          break
-        } catch (err) {
-          // The only error that should be caught here is an ExportError, as `exportPage` doesn't throw and instead returns an object with an `error` property.
-          // This is an overly cautious check to ensure that we don't accidentally catch an unexpected error.
-          if (!(err instanceof ExportError)) {
-            throw err
-          }
-
-          const currentCount = failedExportAttemptsByPage.get(pageKey) ?? 0
-          failedExportAttemptsByPage.set(pageKey, currentCount + 1)
-
-          // We've reached the maximum number of attempts
-          if (attempt >= maxAttempts - 1) {
-            // Log a message if we've reached the maximum number of attempts.
-            // We only care to do this if maxAttempts was configured.
-            if (maxAttempts > 0) {
-              Log.info(
-                `Failed to build ${pageKey} after ${maxAttempts} attempts.`
-              )
-            }
-            // If prerenderEarlyExit is enabled, we'll exit the build immediately.
-            if (nextConfig.experimental.prerenderEarlyExit) {
-              throw new ExportError(
-                `Export encountered an error on ${pageKey}, exiting the build.`
-              )
-            } else {
-              // Otherwise, this is a no-op. The build will continue, and a summary of failed pages will be displayed at the end.
-            }
-          } else {
-            // Otherwise, we have more attempts to make. Wait before retrying
-            Log.info(
-              `Failed to build ${pageKey} (attempt ${attempt + 1} of ${maxAttempts}). Retrying again shortly.`
-            )
-            await new Promise((r) => setTimeout(r, Math.random() * 500))
-          }
-        }
-      }
-
-      // if we eventually succeeded, remove the page from the failed attempts map
-      if (
-        failedExportAttemptsByPage.has(pageKey) &&
-        result &&
-        !('error' in result)
-      ) {
-        failedExportAttemptsByPage.delete(pageKey)
-      }
-
-      if (progress) progress()
-
-      return { result, path }
-    })
+  // Calculate the number of workers needed to ensure each chunk has at least minChunkSize pages
+  const numWorkers = Math.min(
+    options.numWorkers,
+    Math.ceil(filteredPaths.length / minChunkSize)
   )
+
+  // Calculate the chunk size based on the number of workers
+  const chunkSize = Math.ceil(filteredPaths.length / numWorkers)
+
+  let currentChunk = []
+  for (let i = 0; i < filteredPaths.length; i++) {
+    currentChunk.push(filteredPaths[i])
+
+    // If the current chunk reaches the calculated chunk size or we're at the end of the list
+    if (currentChunk.length >= chunkSize || i === filteredPaths.length - 1) {
+      chunks.push(currentChunk)
+      currentChunk = []
+    }
+  }
+
+  // Evenly distribute remaining pages among existing chunks
+  let remainingPages = chunks.flat().slice(numWorkers * chunkSize)
+  for (let i = 0; remainingPages.length > 0; i = (i + 1) % chunks.length) {
+    if (remainingPages.length > 0) {
+      const page = remainingPages.shift()
+      if (page) {
+        chunks[i].push(page)
+      }
+    }
+  }
+
+  const progress = createProgress(
+    filteredPaths.length,
+    options.statusMessage || 'Exporting'
+  )
+
+  const worker = createStaticWorker(nextConfig, progress)
+
+  const results = (
+    await Promise.all(
+      chunks.map((paths) =>
+        worker.exportPages({
+          paths,
+          exportPathMap,
+          parentSpanId: span.getId(),
+          pagesDataDir,
+          renderOpts,
+          options,
+          dir,
+          distDir,
+          outDir,
+          enabledDirectories,
+          nextConfig,
+          cacheHandler: nextConfig.cacheHandler,
+          cacheMaxMemorySize: nextConfig.cacheMaxMemorySize,
+          fetchCache: true,
+          fetchCacheKeyPrefix: nextConfig.experimental.fetchCacheKeyPrefix,
+        })
+      )
+    )
+  ).flat()
 
   let hadValidationError = false
 
@@ -635,8 +586,12 @@ export async function exportAppImpl(
     turborepoAccessTraceResults: new Map(),
   }
 
-  for (const { result, path } of results) {
-    if (!result || 'error' in result) continue
+  for (const { result, path, pageKey } of results) {
+    if (!result) continue
+    if ('error' in result) {
+      failedExportAttemptsByPage.set(pageKey, true)
+      continue
+    }
 
     const { page } = exportPathMap[path]
 
@@ -808,7 +763,7 @@ export async function exportAppImpl(
     await telemetry.flush()
   }
 
-  await options.endWorker()
+  await worker.end()
 
   return collector
 }

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -510,9 +510,11 @@ async function exportAppImpl(
   const failedExportAttemptsByPage: Map<string, boolean> = new Map()
 
   // Chunk filtered pages into smaller groups, and call the export worker on each group.
-  // We've set an arbitrary minimum of 25 pages per chunk to ensure that even setups
-  // with only a few static pages can leverage a shared incremental cache.
-  const minChunkSize = 25
+  // We've set a default minimum of 25 pages per chunk to ensure that even setups
+  // with only a few static pages can leverage a shared incremental cache, however this
+  // value can be configured.
+  const minChunkSize =
+    nextConfig.experimental.staticGenerationMinPagesPerWorker ?? 25
   // Calculate the number of workers needed to ensure each chunk has at least minChunkSize pages
   const numWorkers = Math.min(
     options.numWorkers,

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -31,6 +31,9 @@ export const enum ExportedAppPageFiles {
   POSTPONED = 'POSTPONED',
 }
 
+/**
+ * Renders & exports a page associated with the /app directory
+ */
 export async function exportAppPage(
   req: MockedRequest,
   res: MockedResponse,

--- a/packages/next/src/export/routes/pages.ts
+++ b/packages/next/src/export/routes/pages.ts
@@ -27,7 +27,10 @@ export const enum ExportedPagesFiles {
   AMP_DATA = 'AMP_PAGE_DATA',
 }
 
-export async function exportPages(
+/**
+ * Renders & exports a page associated with the /pages directory
+ */
+export async function exportPagesPage(
   req: MockedRequest,
   res: MockedResponse,
   path: string,

--- a/packages/next/src/export/types.ts
+++ b/packages/next/src/export/types.ts
@@ -41,9 +41,26 @@ export type FileWriter = (
 
 type PathMap = ExportPathMap[keyof ExportPathMap]
 
+export interface ExportPagesInput {
+  paths: string[]
+  exportPathMap: ExportPathMap
+  parentSpanId: number
+  dir: string
+  distDir: string
+  outDir: string
+  pagesDataDir: string
+  renderOpts: WorkerRenderOptsPartial
+  nextConfig: NextConfigComplete
+  cacheMaxMemorySize: NextConfigComplete['cacheMaxMemorySize'] | undefined
+  fetchCache: boolean | undefined
+  cacheHandler: string | undefined
+  fetchCacheKeyPrefix: string | undefined
+  enabledDirectories: NextEnabledDirectories
+  options: ExportAppOptions
+}
+
 export interface ExportPageInput {
   path: string
-  dir: string
   pathMap: PathMap
   distDir: string
   outDir: string
@@ -57,16 +74,11 @@ export interface ExportPageInput {
   optimizeFonts: FontConfig
   optimizeCss: any
   disableOptimizedLoading: any
-  parentSpanId: any
+  parentSpanId: number
   httpAgentOptions: NextConfigComplete['httpAgentOptions']
   debugOutput?: boolean
-  cacheMaxMemorySize?: NextConfigComplete['cacheMaxMemorySize']
-  fetchCache?: boolean
-  cacheHandler?: string
-  fetchCacheKeyPrefix?: string
   nextConfigOutput?: NextConfigComplete['output']
   enableExperimentalReact?: boolean
-  enabledDirectories: NextEnabledDirectories
 }
 
 export type ExportedPageFile = {
@@ -97,16 +109,18 @@ export type ExportPageResult = ExportRouteResult & {
   turborepoAccessTraceResult?: SerializableTurborepoAccessTraceResult
 }
 
+export type ExportPagesResult = {
+  result: ExportPageResult | undefined
+  path: string
+  pageKey: string
+}[]
+
 export type WorkerRenderOptsPartial = PagesRenderOptsPartial &
   AppRenderOptsPartial
 
 export type WorkerRenderOpts = WorkerRenderOptsPartial &
   RequestLifecycleOpts &
   LoadComponentsReturnType
-
-export type ExportWorker = (
-  input: ExportPageInput
-) => Promise<ExportPageResult | undefined>
 
 export interface ExportAppOptions {
   outdir: string
@@ -116,11 +130,9 @@ export interface ExportAppOptions {
   pages?: string[]
   buildExport: boolean
   statusMessage?: string
-  exportPageWorker?: ExportWorker
-  exportAppPageWorker?: ExportWorker
-  endWorker: () => Promise<void>
   nextConfig?: NextConfigComplete
   hasOutdirFromCli?: boolean
+  numWorkers: number
 }
 
 export type ExportPageMetadata = {

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -1,10 +1,12 @@
 import type {
+  ExportPagesInput,
   ExportPageInput,
   ExportPageResult,
   ExportRouteResult,
   ExportedPageFile,
   FileWriter,
   WorkerRenderOpts,
+  ExportPagesResult,
 } from './types'
 
 import '../server/node-environment'
@@ -29,7 +31,7 @@ import { isAppRouteRoute } from '../lib/is-app-route-route'
 import { hasNextSupport } from '../telemetry/ci-info'
 import { exportAppRoute } from './routes/app-route'
 import { exportAppPage } from './routes/app-page'
-import { exportPages } from './routes/pages'
+import { exportPagesPage } from './routes/pages'
 import { getParams } from './helpers/get-params'
 import { createIncrementalCache } from './helpers/create-incremental-cache'
 import { isPostpone } from '../server/lib/router-utils/is-postpone'
@@ -40,6 +42,8 @@ import {
   TurborepoAccessTraceResult,
 } from '../build/turborepo-access-trace'
 import type { Params } from '../client/components/params'
+import { needsExperimentalReact } from '../lib/needs-experimental-react'
+import { ExportError } from '.'
 
 const envConfig = require('../shared/lib/runtime-config.external')
 
@@ -47,12 +51,15 @@ const envConfig = require('../shared/lib/runtime-config.external')
   nextExport: true,
 }
 
+class TimeoutError extends Error {
+  code = 'NEXT_EXPORT_TIMEOUT_ERROR'
+}
+
 async function exportPageImpl(
   input: ExportPageInput,
   fileWriter: FileWriter
 ): Promise<ExportRouteResult | undefined> {
   const {
-    dir,
     path,
     pathMap,
     distDir,
@@ -64,14 +71,9 @@ async function exportPageImpl(
     optimizeCss,
     disableOptimizedLoading,
     debugOutput = false,
-    cacheMaxMemorySize,
-    fetchCache,
-    fetchCacheKeyPrefix,
-    cacheHandler,
     enableExperimentalReact,
     ampValidatorPath,
     trailingSlash,
-    enabledDirectories,
   } = input
 
   if (enableExperimentalReact) {
@@ -221,23 +223,6 @@ async function exportPageImpl(
 
     await fs.mkdir(baseDir, { recursive: true })
 
-    // If the fetch cache was enabled, we need to create an incremental
-    // cache instance for this page.
-    const incrementalCache =
-      isAppDir && fetchCache
-        ? await createIncrementalCache({
-            cacheHandler,
-            cacheMaxMemorySize,
-            fetchCacheKeyPrefix,
-            distDir,
-            dir,
-            enabledDirectories,
-            // skip writing to disk in minimal mode for now, pending some
-            // changes to better support it
-            flushToDisk: !hasNextSupport,
-          })
-        : undefined
-
     // Handle App Routes.
     if (isAppDir && isAppRouteRoute(page)) {
       return await exportAppRoute(
@@ -245,7 +230,7 @@ async function exportPageImpl(
         res,
         params,
         page,
-        incrementalCache,
+        input.renderOpts.incrementalCache,
         distDir,
         htmlFilepath,
         fileWriter,
@@ -284,10 +269,6 @@ async function exportPageImpl(
 
     // Handle App Pages
     if (isAppDir) {
-      // Set the incremental cache on the renderOpts, that's how app page's
-      // consume it.
-      renderOpts.incrementalCache = incrementalCache
-
       return await exportAppPage(
         req,
         res,
@@ -303,7 +284,7 @@ async function exportPageImpl(
       )
     }
 
-    return await exportPages(
+    return await exportPagesPage(
       req,
       res,
       path,
@@ -335,9 +316,148 @@ async function exportPageImpl(
   }
 }
 
-export default async function exportPage(
+export async function exportPages(
+  input: ExportPagesInput
+): Promise<ExportPagesResult> {
+  const {
+    exportPathMap,
+    paths,
+    dir,
+    distDir,
+    outDir,
+    cacheHandler,
+    cacheMaxMemorySize,
+    fetchCacheKeyPrefix,
+    enabledDirectories,
+    pagesDataDir,
+    renderOpts,
+    nextConfig,
+    options,
+  } = input
+
+  // If the fetch cache was enabled, we need to create an incremental
+  // cache instance for this page.
+  const incrementalCache = await createIncrementalCache({
+    cacheHandler,
+    cacheMaxMemorySize,
+    fetchCacheKeyPrefix,
+    distDir,
+    dir,
+    enabledDirectories: enabledDirectories,
+    // skip writing to disk in minimal mode for now, pending some
+    // changes to better support it
+    flushToDisk: !hasNextSupport,
+  })
+
+  renderOpts.incrementalCache = incrementalCache
+
+  let maxAttempts = nextConfig.experimental.staticGenerationRetryCount ?? 1
+
+  return Promise.all(
+    paths.map(async (path) => {
+      const pathMap = exportPathMap[path]
+
+      const { page } = exportPathMap[path]
+      const pageKey = page !== path ? `${page}: ${path}` : path
+
+      let result
+
+      for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        try {
+          result = await Promise.race<ExportPageResult | undefined>([
+            exportPage({
+              path,
+              pathMap,
+              distDir,
+              outDir,
+              pagesDataDir,
+              renderOpts,
+              ampValidatorPath:
+                nextConfig.experimental.amp?.validator || undefined,
+              trailingSlash: nextConfig.trailingSlash,
+              serverRuntimeConfig: nextConfig.serverRuntimeConfig,
+              subFolders: nextConfig.trailingSlash && !options.buildExport,
+              buildExport: options.buildExport,
+              optimizeFonts: nextConfig.optimizeFonts,
+              optimizeCss: nextConfig.experimental.optimizeCss,
+              disableOptimizedLoading:
+                nextConfig.experimental.disableOptimizedLoading,
+              parentSpanId: input.parentSpanId,
+              httpAgentOptions: nextConfig.httpAgentOptions,
+              debugOutput: options.debugOutput,
+              enableExperimentalReact: needsExperimentalReact(nextConfig),
+            }),
+            // If exporting the page takes longer than the timeout, reject the promise.
+            new Promise((_, reject) => {
+              setTimeout(() => {
+                reject(new TimeoutError())
+              }, nextConfig.staticPageGenerationTimeout * 1000)
+            }),
+          ])
+
+          // If there was an error in the export, throw it immediately. In the catch block, we might retry the export,
+          // or immediately fail the build, depending on user configuration. We might also continue on and attempt other pages.
+          if (result && 'error' in result) {
+            throw new ExportError()
+          }
+
+          // If the export succeeds, break out of the retry loop
+          break
+        } catch (err) {
+          // The only error that should be caught here is an ExportError, as `exportPage` doesn't throw and instead returns an object with an `error` property.
+          // This is an overly cautious check to ensure that we don't accidentally catch an unexpected error.
+          if (!(err instanceof ExportError || err instanceof TimeoutError)) {
+            throw err
+          }
+
+          if (err instanceof TimeoutError) {
+            // If the export times out, we will restart the worker up to 3 times.
+            maxAttempts = 3
+          }
+
+          // We've reached the maximum number of attempts
+          if (attempt >= maxAttempts - 1) {
+            // Log a message if we've reached the maximum number of attempts.
+            // We only care to do this if maxAttempts was configured.
+            if (maxAttempts > 0) {
+              console.info(
+                `Failed to build ${pageKey} after ${maxAttempts} attempts.`
+              )
+            }
+            // If prerenderEarlyExit is enabled, we'll exit the build immediately.
+            if (nextConfig.experimental.prerenderEarlyExit) {
+              throw new ExportError(
+                `Export encountered an error on ${pageKey}, exiting the build.`
+              )
+            } else {
+              // Otherwise, this is a no-op. The build will continue, and a summary of failed pages will be displayed at the end.
+            }
+          } else {
+            // Otherwise, we have more attempts to make. Wait before retrying
+            if (err instanceof TimeoutError) {
+              console.info(
+                `Failed to build ${pageKey} (attempt ${attempt + 1} of ${maxAttempts}) because it took more than ${nextConfig.staticPageGenerationTimeout} seconds. Retrying again shortly.`
+              )
+            } else {
+              console.info(
+                `Failed to build ${pageKey} (attempt ${attempt + 1} of ${maxAttempts}). Retrying again shortly.`
+              )
+            }
+            await new Promise((r) => setTimeout(r, Math.random() * 500))
+          }
+        }
+      }
+
+      return { result, path, pageKey }
+    })
+  )
+}
+
+async function exportPage(
   input: ExportPageInput
 ): Promise<ExportPageResult | undefined> {
+  trace('export-page', input.parentSpanId).setAttribute('path', input.path)
+
   // Configure the http agent.
   setHttpClientAndAgentOptions({
     httpAgentOptions: input.httpAgentOptions,
@@ -375,6 +495,9 @@ export default async function exportPage(
   if ('error' in result) {
     return { error: result.error, duration: Date.now() - start, files: [] }
   }
+
+  // Notify the parent process that we processed a page (used by the progress activity indicator)
+  process.send?.([3, { type: 'activity' }])
 
   // Otherwise we can return the result.
   return {

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -352,7 +352,7 @@ export async function exportPages(
   renderOpts.incrementalCache = incrementalCache
 
   const maxConcurrency =
-    nextConfig.experimental.staticGenerationMaxConcurrency ?? 2
+    nextConfig.experimental.staticGenerationMaxConcurrency ?? 8
   const results: ExportPagesResult = []
 
   const exportPageWithRetry = async (path: string, maxAttempts: number) => {

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -438,6 +438,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
             .optional(),
         ]),
         staticGenerationRetryCount: z.number().int().optional(),
+        staticGenerationMaxConcurrency: z.number().int().optional(),
         typedEnv: z.boolean().optional(),
         serverComponentsHmrCache: z.boolean().optional(),
       })

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -439,6 +439,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         ]),
         staticGenerationRetryCount: z.number().int().optional(),
         staticGenerationMaxConcurrency: z.number().int().optional(),
+        staticGenerationMinPagesPerWorker: z.number().int().optional(),
         typedEnv: z.boolean().optional(),
         serverComponentsHmrCache: z.boolean().optional(),
       })

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -511,6 +511,11 @@ export interface ExperimentalConfig {
   staticGenerationMaxConcurrency?: number
 
   /**
+   * The minimum number of pages to be chunked into each export worker.
+   */
+  staticGenerationMinPagesPerWorker?: number
+
+  /**
    * Allows previously fetched data to be re-used when editing server components.
    */
   serverComponentsHmrCache?: boolean
@@ -1050,7 +1055,8 @@ export const defaultConfig: NextConfig = {
     after: false,
     staticGenerationRetryCount: undefined,
     serverComponentsHmrCache: true,
-    staticGenerationMaxConcurrency: 2,
+    staticGenerationMaxConcurrency: 8,
+    staticGenerationMinPagesPerWorker: 25,
   },
   bundlePagesRouterDependencies: false,
 }

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -506,6 +506,11 @@ export interface ExperimentalConfig {
   staticGenerationRetryCount?: number
 
   /**
+   * The amount of pages to export per worker during static generation.
+   */
+  staticGenerationMaxConcurrency?: number
+
+  /**
    * Allows previously fetched data to be re-used when editing server components.
    */
   serverComponentsHmrCache?: boolean
@@ -1045,6 +1050,7 @@ export const defaultConfig: NextConfig = {
     after: false,
     staticGenerationRetryCount: undefined,
     serverComponentsHmrCache: true,
+    staticGenerationMaxConcurrency: 2,
   },
   bundlePagesRouterDependencies: false,
 }

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -375,14 +375,20 @@ function createPatchedFetcher(
          * - OR the fetch comes after a configuration that triggered dynamic rendering (e.g., reading cookies())
          *   and the fetch was considered uncacheable (e.g., POST method or has authorization headers)
          */
+        const hasNoExplicitCacheConfig =
+          // eslint-disable-next-line eqeqeq
+          pageFetchCacheMode == undefined &&
+          // eslint-disable-next-line eqeqeq
+          currentFetchCacheConfig == undefined &&
+          // eslint-disable-next-line eqeqeq
+          currentFetchRevalidate == undefined
         const autoNoCache =
           // this condition is hit for null/undefined
           // eslint-disable-next-line eqeqeq
-          (pageFetchCacheMode == undefined &&
-            // eslint-disable-next-line eqeqeq
-            currentFetchCacheConfig == undefined &&
-            // eslint-disable-next-line eqeqeq
-            currentFetchRevalidate == undefined) ||
+          (hasNoExplicitCacheConfig &&
+            // we disable automatic no caching behavior during build time SSG so that we can still
+            // leverage the fetch cache between SSG workers
+            !staticGenerationStore.isPrerendering) ||
           ((hasUnCacheableHeader || isUnCacheableMethod) &&
             staticGenerationStore.revalidate === 0)
 

--- a/packages/next/types/compiled.d.ts
+++ b/packages/next/types/compiled.d.ts
@@ -47,6 +47,17 @@ declare module 'next/dist/compiled/superstruct' {
   export type Describe<T> = any
 }
 
+declare module 'next/dist/compiled/jest-worker' {
+  export class Worker {
+    constructor(...args: any[])
+    end(): any
+  }
+}
+
+declare module 'next/dist/compiled/amphtml-validator' {
+  export type ValidationError = any
+}
+
 declare module 'react-server-dom-webpack/server.edge'
 
 declare module 'VAR_MODULE_GLOBAL_ERROR'

--- a/test/e2e/app-dir/app-fetch-deduping/app-fetch-deduping.test.ts
+++ b/test/e2e/app-dir/app-fetch-deduping/app-fetch-deduping.test.ts
@@ -1,9 +1,52 @@
-import { waitFor } from 'next-test-utils'
+import { findPort, waitFor } from 'next-test-utils'
+import http from 'http'
 import { outdent } from 'outdent'
-import { isNextDev, nextTestSetup } from 'e2e-utils'
+import { isNextDev, isNextStart, nextTestSetup } from 'e2e-utils'
 
 describe('app-fetch-deduping', () => {
-  if (isNextDev) {
+  if (isNextStart) {
+    describe('during static generation', () => {
+      const { next } = nextTestSetup({ files: __dirname, skipStart: true })
+      let externalServerPort: number
+      let externalServer: http.Server
+      let requests = []
+
+      beforeAll(async () => {
+        externalServerPort = await findPort()
+        externalServer = http.createServer((req, res) => {
+          requests.push(req.url)
+          res.end(`Request ${req.url} received at ${Date.now()}`)
+        })
+
+        await new Promise<void>((resolve, reject) => {
+          externalServer.listen(externalServerPort, () => {
+            resolve()
+          })
+
+          externalServer.once('error', (err) => {
+            reject(err)
+          })
+        })
+      })
+
+      beforeEach(() => {
+        requests = []
+      })
+
+      afterAll(() => externalServer.close())
+
+      it('dedupes requests amongst static workers', async () => {
+        await next.patchFileFast(
+          'next.config.js',
+          `module.exports = {
+            env: { TEST_SERVER_PORT: "${externalServerPort}" },
+          }`
+        )
+        await next.build()
+        expect(requests.length).toBe(1)
+      })
+    })
+  } else if (isNextDev) {
     describe('during next dev', () => {
       const { next } = nextTestSetup({ files: __dirname })
       function invocation(cliOutput: string): number {

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -2102,10 +2102,10 @@ describe('app-dir static/dynamic handling', () => {
       expect(indexFetchMetrics[0]).toMatchObject({
         url: 'https://next-data-api-endpoint.vercel.app/api/random?page',
         status: 200,
-        cacheStatus: 'skip',
+        cacheStatus: expect.any(String),
         start: expect.any(Number),
         end: expect.any(Number),
-        cacheReason: 'auto no cache',
+        cacheReason: expect.any(String),
       })
 
       const otherPageMetrics =
@@ -2117,10 +2117,10 @@ describe('app-dir static/dynamic handling', () => {
           expect.objectContaining({
             url: 'https://next-data-api-endpoint.vercel.app/api/random?layout',
             status: 200,
-            cacheStatus: 'hit',
+            cacheStatus: expect.any(String),
             start: expect.any(Number),
             end: expect.any(Number),
-            cacheReason: 'revalidate: 10',
+            cacheReason: expect.any(String),
           }),
         ])
       )

--- a/test/integration/build-output/test/index.test.js
+++ b/test/integration/build-output/test/index.test.js
@@ -168,19 +168,23 @@ describe('Build Output', () => {
               / \/slow-static\/.+\/.+(?: \(\d+ ms\))?| \[\+\d+ more paths\]/g
             )
 
-            // Check that there are some paths printed
-            expect(matches.length).toBeGreaterThan(0)
-
-            // Check that each match (except the last one) contains a duration
-            // This explicitly doesn't check for specific paths as workers
-            // process paths in a non-deterministic order
-            matches.slice(0, -1).forEach((match) => {
-              expect(match).toMatch(/ \(\d+ ms\)/)
-            })
-
-            // Check that the last match is "[+2 more paths]"
-            const lastMatch = matches[matches.length - 1]
-            expect(lastMatch).toBe(' [+2 more paths]')
+            for (const check of [
+              // summary
+              expect.stringMatching(
+                /\/\[propsDuration\]\/\[renderDuration\] \(\d+ ms\)/
+              ),
+              // ordered by duration, includes duration
+              expect.stringMatching(/\/2000\/10 \(\d+ ms\)$/),
+              expect.stringMatching(/\/10\/1000 \(\d+ ms\)$/),
+              expect.stringMatching(/\/300\/10 \(\d+ ms\)$/),
+              // max of 7 preview paths
+              ' [+2 more paths]',
+            ]) {
+              // the order isn't guaranteed on the timing tests as while() is being
+              // used in the render so can block the thread of other renders sharing
+              // the same worker
+              expect(matches).toContainEqual(check)
+            }
           })
 
           it('should not emit extracted comments', async () => {

--- a/test/integration/build-output/test/index.test.js
+++ b/test/integration/build-output/test/index.test.js
@@ -168,23 +168,19 @@ describe('Build Output', () => {
               / \/slow-static\/.+\/.+(?: \(\d+ ms\))?| \[\+\d+ more paths\]/g
             )
 
-            for (const check of [
-              // summary
-              expect.stringMatching(
-                /\/\[propsDuration\]\/\[renderDuration\] \(\d+ ms\)/
-              ),
-              // ordered by duration, includes duration
-              expect.stringMatching(/\/2000\/10 \(\d+ ms\)$/),
-              expect.stringMatching(/\/10\/1000 \(\d+ ms\)$/),
-              expect.stringMatching(/\/300\/10 \(\d+ ms\)$/),
-              // max of 7 preview paths
-              ' [+2 more paths]',
-            ]) {
-              // the order isn't guaranteed on the timing tests as while() is being
-              // used in the render so can block the thread of other renders sharing
-              // the same worker
-              expect(matches).toContainEqual(check)
-            }
+            // Check that there are some paths printed
+            expect(matches.length).toBeGreaterThan(0)
+
+            // Check that each match (except the last one) contains a duration
+            // This explicitly doesn't check for specific paths as workers
+            // process paths in a non-deterministic order
+            matches.slice(0, -1).forEach((match) => {
+              expect(match).toMatch(/ \(\d+ ms\)/)
+            })
+
+            // Check that the last match is "[+2 more paths]"
+            const lastMatch = matches[matches.length - 1]
+            expect(lastMatch).toBe(' [+2 more paths]')
           })
 
           it('should not emit extracted comments', async () => {

--- a/test/production/app-dir/worker-restart/worker-restart.test.ts
+++ b/test/production/app-dir/worker-restart/worker-restart.test.ts
@@ -13,16 +13,13 @@ describe('worker-restart', () => {
 
     const output = stdout + stderr
     expect(output).toContain(
-      'Sending SIGTERM signal to static worker due to timeout of 10 seconds. Subsequent errors may be a result of the worker exiting.'
+      'Failed to build /bad-page/page: /bad-page (attempt 1 of 3) because it took more than 10 seconds. Retrying again shortly.'
     )
     expect(output).toContain(
-      'Static worker exited with code: null and signal: SIGTERM'
+      'Failed to build /bad-page/page: /bad-page (attempt 2 of 3) because it took more than 10 seconds. Retrying again shortly.'
     )
     expect(output).toContain(
-      'Restarted static page generation for /bad-page because it took more than 10 seconds'
-    )
-    expect(output).toContain(
-      'Static page generation for /bad-page is still timing out after 3 attempts'
+      'Failed to build /bad-page/page: /bad-page after 3 attempts'
     )
     expect(output).not.toContain(
       'Error: Farm is ended, no more calls can be done to it'


### PR DESCRIPTION
### What
During SSG, the fetch cache isn't shared between renders of different pages within a single export worker. This means that if **Page A** fetches `/foo` and **Page B** also fetches `/foo`, they will not be deduped and instead will be fetched from origin within each worker. Additionally, we currently only prerender 1 path per worker, which doesn't allow us to take advantage of concurrency or smarter groupings.

### Why
Currently the export worker is set up to handle indivdual pages. We fire off an exportPage request to all of the known paths and jest-worker handles concurrency & parallelization.

### How
This refactors the export worker to accept an array of paths. For this iteration, it doesn't attempt to do any smart grouping of paths (ie ones that share a layout, etc), it just tries to create reasonably sized groups. It will chunk a minimum of 25 pages per worker, and each worker will process `experimental.staticGenerationMaxConcurrency` (defaults to 2, tbd on final numbers here) exports at a time. 

This lets us set up the `IncrementalCache` inside of the worker before we process pages. As we process pages, the incremental cache will be populated with entries, and subsequent requests will leverage the cache rules therein. 

This also disables the auto no-cache behavior that we introduced with Next 15 during SSG. Unless a fetch is explicitly opting out of caching, we'll attempt to cache it during SSG so another worker can re-use it.

Closes NDX-78
Closes NDX-19