### PR TITLE
[after] fix: make sure the ALS for createCacheScope is a singleton

### DIFF
--- a/packages/next/src/client/components/cache-scope-storage-instance.ts
+++ b/packages/next/src/client/components/cache-scope-storage-instance.ts
@@ -1,0 +1,5 @@
+import { createAsyncLocalStorage } from './async-local-storage'
+import type { CacheScopeStorageAsyncStorage } from './cache-scope-storage.external'
+
+export const cacheScopeAsyncStorage: CacheScopeStorageAsyncStorage =
+  createAsyncLocalStorage()

--- a/packages/next/src/client/components/cache-scope-storage.external.ts
+++ b/packages/next/src/client/components/cache-scope-storage.external.ts
@@ -1,0 +1,10 @@
+import type { AsyncLocalStorage } from 'async_hooks'
+
+// Share the instance module in the next-shared layer
+import { cacheScopeAsyncStorage } from './cache-scope-storage-instance' with { 'turbopack-transition': 'next-shared' }
+
+type CacheMap = Map<Function, unknown>
+
+export type CacheScopeStorageAsyncStorage = AsyncLocalStorage<CacheMap>
+
+export { cacheScopeAsyncStorage }

--- a/packages/next/src/server/after/react-cache-scope.ts
+++ b/packages/next/src/server/after/react-cache-scope.ts
@@ -1,11 +1,11 @@
-import { AsyncLocalStorage } from 'async_hooks'
 import { InvariantError } from '../../shared/lib/invariant-error'
+import { cacheScopeAsyncStorage } from '../../client/components/cache-scope-storage.external'
 
 export function createCacheScope() {
   const storage = createCacheMap()
   return {
     run: <T>(callback: () => T): T => {
-      return CacheScopeStorage.run(storage, () => callback())
+      return cacheScopeAsyncStorage.run(storage, () => callback())
     },
   }
 }
@@ -33,15 +33,12 @@ function createCacheMap(): CacheMap {
 }
 
 function isWithinCacheScope() {
-  return !!CacheScopeStorage.getStore()
+  return !!cacheScopeAsyncStorage.getStore()
 }
-
-const CacheScopeStorage: AsyncLocalStorage<CacheMap> =
-  new AsyncLocalStorage<CacheMap>()
 
 /** forked from packages/react-server/src/flight/ReactFlightServerCache.js */
 function resolveCache(): CacheMap {
-  const store = CacheScopeStorage.getStore()
+  const store = cacheScopeAsyncStorage.getStore()
   if (store) {
     return store
   }


### PR DESCRIPTION
_(This solves a problem encountered in https://github.com/vercel/next.js/pull/68535 where the ALS used for `createCacheScope` was seemingly getting duplicated, but i'm not 100% sure why exactly this works or what the issue was, so i'm leaving this as a draft until i can explain it properly)_