### PR TITLE
ast-grep lint fix: don’t call variables `context`

### DIFF
--- a/.config/ast-grep/rules/no-context.yml
+++ b/.config/ast-grep/rules/no-context.yml
@@ -20,8 +20,3 @@ rule:
         - kind: field_identifier
         - inside:
             kind: field_declaration
-ignores:
-  # These are ignored so we can fix these cases incrementally. They will
-  # gradually be fixed and removed from this list.
-  - 'crates/next-api/**/*.rs'
-  - 'crates/next-core/**/*.rs'

--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,5 @@
+# Ignore these files in tools like grep, rg, ast-grep, etc. These files should
+# *not* be ignored by git.
+
+# Not valid text
+turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/error/input/broken.js

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -34,7 +34,7 @@ use crate::{
 #[turbo_tasks::value]
 pub struct InstrumentationEndpoint {
     project: Vc<Project>,
-    context: Vc<Box<dyn AssetContext>>,
+    asset_context: Vc<Box<dyn AssetContext>>,
     source: Vc<Box<dyn Source>>,
     is_edge: bool,
 
@@ -47,7 +47,7 @@ impl InstrumentationEndpoint {
     #[turbo_tasks::function]
     pub fn new(
         project: Vc<Project>,
-        context: Vc<Box<dyn AssetContext>>,
+        asset_context: Vc<Box<dyn AssetContext>>,
         source: Vc<Box<dyn Source>>,
         is_edge: bool,
         app_dir: Option<Vc<FileSystemPath>>,
@@ -55,7 +55,7 @@ impl InstrumentationEndpoint {
     ) -> Vc<Self> {
         Self {
             project,
-            context,
+            asset_context,
             source,
             is_edge,
             app_dir,
@@ -67,7 +67,7 @@ impl InstrumentationEndpoint {
     #[turbo_tasks::function]
     async fn edge_files(&self) -> Result<Vc<OutputAssets>> {
         let userland_module = self
-            .context
+            .asset_context
             .process(
                 self.source,
                 Value::new(ReferenceType::Entry(EntryReferenceSubType::Instrumentation)),
@@ -75,7 +75,7 @@ impl InstrumentationEndpoint {
             .module();
 
         let module = wrap_edge_entry(
-            self.context,
+            self.asset_context,
             self.project.project_path(),
             userland_module,
             "instrumentation".into(),
@@ -89,7 +89,7 @@ impl InstrumentationEndpoint {
             }),
             self.project.next_mode(),
         )
-        .resolve_entries(self.context)
+        .resolve_entries(self.asset_context)
         .await?
         .clone_value();
 
@@ -120,7 +120,7 @@ impl InstrumentationEndpoint {
         let chunking_context = self.project.server_chunking_context(false);
 
         let userland_module = self
-            .context
+            .asset_context
             .process(
                 self.source,
                 Value::new(ReferenceType::Entry(EntryReferenceSubType::Instrumentation)),
@@ -145,7 +145,7 @@ impl InstrumentationEndpoint {
                     }),
                     self.project.next_mode(),
                 )
-                .resolve_entries(self.context),
+                .resolve_entries(self.asset_context),
                 Value::new(AvailabilityInfo::Root),
             )
             .await?;

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -924,11 +924,11 @@ impl Project {
             .as_ref()
             .map(|app_project| app_project.client_transition_name());
 
-        let context = self.middleware_context();
+        let middleware_asset_context = self.middleware_context();
 
         Ok(MiddlewareEndpoint::new(
             self,
-            context,
+            middleware_asset_context,
             source,
             app_dir,
             ecmascript_client_reference_transition_name,
@@ -1038,7 +1038,7 @@ impl Project {
             .as_ref()
             .map(|app_project| app_project.client_transition_name());
 
-        let context = if is_edge {
+        let instrumentation_asset_context = if is_edge {
             self.edge_instrumentation_context()
         } else {
             self.node_instrumentation_context()
@@ -1046,7 +1046,7 @@ impl Project {
 
         Ok(InstrumentationEndpoint::new(
             self,
-            context,
+            instrumentation_asset_context,
             source,
             is_edge,
             app_dir,

--- a/crates/next-core/src/bootstrap.rs
+++ b/crates/next-core/src/bootstrap.rs
@@ -16,14 +16,14 @@ use turbopack_ecmascript::utils::StringifyJs;
 #[turbo_tasks::function]
 pub async fn route_bootstrap(
     asset: Vc<Box<dyn Module>>,
-    context: Vc<Box<dyn AssetContext>>,
+    asset_context: Vc<Box<dyn AssetContext>>,
     base_path: Vc<FileSystemPath>,
     bootstrap_asset: Vc<Box<dyn Source>>,
     config: Vc<BootstrapConfig>,
 ) -> Result<Vc<Box<dyn EvaluatableAsset>>> {
     Ok(bootstrap(
         asset,
-        context,
+        asset_context,
         base_path,
         bootstrap_asset,
         Vc::cell(IndexMap::new()),
@@ -45,7 +45,7 @@ impl BootstrapConfig {
 #[turbo_tasks::function]
 pub async fn bootstrap(
     asset: Vc<Box<dyn Module>>,
-    context: Vc<Box<dyn AssetContext>>,
+    asset_context: Vc<Box<dyn AssetContext>>,
     base_path: Vc<FileSystemPath>,
     bootstrap_asset: Vc<Box<dyn Source>>,
     inner_assets: Vc<InnerAssets>,
@@ -75,7 +75,7 @@ pub async fn bootstrap(
     config.insert("PAGE".to_string(), path.to_string());
     config.insert("PATHNAME".to_string(), pathname);
 
-    let config_asset = context
+    let config_asset = asset_context
         .process(
             Vc::upcast(VirtualSource::new(
                 asset.ident().path().join("bootstrap-config.ts".into()),
@@ -98,7 +98,7 @@ pub async fn bootstrap(
     inner_assets.insert("ENTRY".into(), asset);
     inner_assets.insert("BOOTSTRAP_CONFIG".into(), config_asset);
 
-    let asset = context
+    let asset = asset_context
         .process(
             bootstrap_asset,
             Value::new(ReferenceType::Internal(Vc::cell(inner_assets))),

--- a/crates/next-core/src/middleware.rs
+++ b/crates/next-core/src/middleware.rs
@@ -23,7 +23,7 @@ pub async fn middleware_files(page_extensions: Vc<Vec<RcStr>>) -> Result<Vc<Vec<
 
 #[turbo_tasks::function]
 pub async fn get_middleware_module(
-    context: Vc<Box<dyn AssetContext>>,
+    asset_context: Vc<Box<dyn AssetContext>>,
     project_root: Vc<FileSystemPath>,
     userland_module: Vc<Box<dyn Module>>,
 ) -> Result<Vc<Box<dyn Module>>> {
@@ -46,7 +46,7 @@ pub async fn get_middleware_module(
         INNER.into() => userland_module
     };
 
-    let module = context
+    let module = asset_context
         .process(
             source,
             Value::new(ReferenceType::Internal(Vc::cell(inner_assets))),

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -39,7 +39,7 @@ pub async fn get_app_page_entry(
 ) -> Result<Vc<AppEntry>> {
     let config = parse_segment_config_from_loader_tree(loader_tree);
     let is_edge = matches!(config.await?.runtime, Some(NextRuntime::Edge));
-    let context = if is_edge {
+    let module_asset_context = if is_edge {
         edge_context
     } else {
         nodejs_context
@@ -48,9 +48,13 @@ pub async fn get_app_page_entry(
     let server_component_transition = Vc::upcast(NextServerComponentTransition::new());
 
     let base_path = next_config.await?.base_path.clone();
-    let loader_tree =
-        LoaderTreeModule::build(loader_tree, context, server_component_transition, base_path)
-            .await?;
+    let loader_tree = LoaderTreeModule::build(
+        loader_tree,
+        module_asset_context,
+        server_component_transition,
+        base_path,
+    )
+    .await?;
 
     let LoaderTreeModule {
         inner_assets,
@@ -107,7 +111,7 @@ pub async fn get_app_page_entry(
         AssetContent::file(file.into()),
     );
 
-    let mut rsc_entry = context
+    let mut rsc_entry = module_asset_context
         .process(
             Vc::upcast(source),
             Value::new(ReferenceType::Internal(Vc::cell(inner_assets))),
@@ -116,7 +120,7 @@ pub async fn get_app_page_entry(
 
     if is_edge {
         rsc_entry = wrap_edge_page(
-            Vc::upcast(context),
+            Vc::upcast(module_asset_context),
             project_root,
             rsc_entry,
             page,
@@ -135,7 +139,7 @@ pub async fn get_app_page_entry(
 
 #[turbo_tasks::function]
 async fn wrap_edge_page(
-    context: Vc<Box<dyn AssetContext>>,
+    asset_context: Vc<Box<dyn AssetContext>>,
     project_root: Vc<FileSystemPath>,
     entry: Vc<Box<dyn Module>>,
     page: AppPage,
@@ -185,7 +189,7 @@ async fn wrap_edge_page(
         INNER.into() => entry
     };
 
-    let wrapped = context
+    let wrapped = asset_context
         .process(
             Vc::upcast(source),
             Value::new(ReferenceType::Internal(Vc::cell(inner_assets))),
@@ -193,7 +197,7 @@ async fn wrap_edge_page(
         .module();
 
     Ok(wrap_edge_entry(
-        context,
+        asset_context,
         project_root,
         wrapped,
         AppPath::from(page).to_string().into(),

--- a/crates/next-core/src/next_client/runtime_entry.rs
+++ b/crates/next-core/src/next_client/runtime_entry.rs
@@ -23,18 +23,18 @@ impl RuntimeEntry {
     #[turbo_tasks::function]
     pub async fn resolve_entry(
         self: Vc<Self>,
-        context: Vc<Box<dyn AssetContext>>,
+        asset_context: Vc<Box<dyn AssetContext>>,
     ) -> Result<Vc<EvaluatableAssets>> {
         let (request, path) = match *self.await? {
             RuntimeEntry::Evaluatable(e) => return Ok(EvaluatableAssets::one(e)),
             RuntimeEntry::Source(source) => {
-                return Ok(EvaluatableAssets::one(source.to_evaluatable(context)));
+                return Ok(EvaluatableAssets::one(source.to_evaluatable(asset_context)));
             }
             RuntimeEntry::Request(r, path) => (r, path),
         };
 
         let modules = cjs_resolve(
-            Vc::upcast(PlainResolveOrigin::new(context, path)),
+            Vc::upcast(PlainResolveOrigin::new(asset_context, path)),
             request,
             None,
             IssueSeverity::Error.cell(),
@@ -70,12 +70,12 @@ impl RuntimeEntries {
     #[turbo_tasks::function]
     pub async fn resolve_entries(
         self: Vc<Self>,
-        context: Vc<Box<dyn AssetContext>>,
+        asset_context: Vc<Box<dyn AssetContext>>,
     ) -> Result<Vc<EvaluatableAssets>> {
         let mut runtime_entries = Vec::new();
 
         for reference in &self.await? {
-            let resolved_entries = reference.resolve_entry(context).await?;
+            let resolved_entries = reference.resolve_entry(asset_context).await?;
             runtime_entries.extend(&resolved_entries);
         }
 

--- a/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module_type.rs
+++ b/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module_type.rs
@@ -34,14 +34,14 @@ impl CustomModuleType for CssClientReferenceModuleType {
     async fn create_module(
         &self,
         source: Vc<Box<dyn Source>>,
-        context: Vc<ModuleAssetContext>,
+        module_asset_context: Vc<ModuleAssetContext>,
         _part: Option<Vc<ModulePart>>,
     ) -> Result<Vc<Box<dyn Module>>> {
         let client_module = self
             .client_transition
             .process(
                 source,
-                context,
+                module_asset_context,
                 Value::new(ReferenceType::Css(CssReferenceSubType::Internal)),
             )
             .module();

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
@@ -46,10 +46,10 @@ impl Transition for NextEcmascriptClientReferenceTransition {
     async fn process(
         self: Vc<Self>,
         source: Vc<Box<dyn Source>>,
-        context: Vc<ModuleAssetContext>,
+        module_asset_context: Vc<ModuleAssetContext>,
         _reference_type: Value<ReferenceType>,
     ) -> Result<Vc<ProcessResult>> {
-        let context = self.process_context(context);
+        let module_asset_context = self.process_context(module_asset_context);
 
         let this = self.await?;
 
@@ -70,7 +70,7 @@ impl Transition for NextEcmascriptClientReferenceTransition {
             .client_transition
             .process(
                 client_source,
-                context,
+                module_asset_context,
                 Value::new(ReferenceType::Entry(
                     EntryReferenceSubType::AppClientComponent,
                 )),
@@ -81,7 +81,7 @@ impl Transition for NextEcmascriptClientReferenceTransition {
             .ssr_transition
             .process(
                 source,
-                context,
+                module_asset_context,
                 Value::new(ReferenceType::Entry(
                     EntryReferenceSubType::AppClientComponent,
                 )),
@@ -102,13 +102,13 @@ impl Transition for NextEcmascriptClientReferenceTransition {
 
         // TODO(alexkirsz) This is necessary to remove the transition currently set on
         // the context.
-        let context = context.await?;
+        let module_asset_context = module_asset_context.await?;
         let server_context = ModuleAssetContext::new(
-            context.transitions,
-            context.compile_time_info,
-            context.module_options_context,
-            context.resolve_options_context,
-            context.layer,
+            module_asset_context.transitions,
+            module_asset_context.compile_time_info,
+            module_asset_context.module_options_context,
+            module_asset_context.resolve_options_context,
+            module_asset_context.layer,
         );
 
         Ok(

--- a/crates/next-core/src/next_dynamic/dynamic_transition.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_transition.rs
@@ -32,16 +32,20 @@ impl Transition for NextDynamicTransition {
     async fn process(
         self: Vc<Self>,
         source: Vc<Box<dyn Source>>,
-        context: Vc<ModuleAssetContext>,
+        module_asset_context: Vc<ModuleAssetContext>,
         _reference_type: Value<ReferenceType>,
     ) -> Result<Vc<ProcessResult>> {
-        let context = self.process_context(context);
+        let module_asset_context = self.process_context(module_asset_context);
 
         let this = self.await?;
 
         Ok(match *this
             .client_transition
-            .process(source, context, Value::new(ReferenceType::Undefined))
+            .process(
+                source,
+                module_asset_context,
+                Value::new(ReferenceType::Undefined),
+            )
             .await?
         {
             ProcessResult::Module(client_module) => {

--- a/crates/next-core/src/next_edge/entry.rs
+++ b/crates/next-core/src/next_edge/entry.rs
@@ -11,7 +11,7 @@ use turbopack_ecmascript::utils::StringifyJs;
 
 #[turbo_tasks::function]
 pub async fn wrap_edge_entry(
-    context: Vc<Box<dyn AssetContext>>,
+    asset_context: Vc<Box<dyn AssetContext>>,
     project_root: Vc<FileSystemPath>,
     entry: Vc<Box<dyn Module>>,
     pathname: RcStr,
@@ -38,7 +38,7 @@ pub async fn wrap_edge_entry(
         "MODULE".into() => entry
     };
 
-    let module = context
+    let module = asset_context
         .process(
             Vc::upcast(virtual_source),
             Value::new(ReferenceType::Internal(Vc::cell(inner_assets))),

--- a/crates/next-core/src/next_edge/unsupported.rs
+++ b/crates/next-core/src/next_edge/unsupported.rs
@@ -48,7 +48,7 @@ impl ImportMappingReplacement for NextEdgeUnsupportedModuleReplacer {
     #[turbo_tasks::function]
     async fn result(
         &self,
-        context: Vc<FileSystemPath>,
+        root_path: Vc<FileSystemPath>,
         request: Vc<Request>,
     ) -> Result<Vc<ImportMapResult>> {
         let request = &*request.await?;
@@ -61,7 +61,7 @@ impl ImportMappingReplacement for NextEdgeUnsupportedModuleReplacer {
               "#
             };
             let content = AssetContent::file(File::from(code).into());
-            let source = VirtualSource::new(context, content);
+            let source = VirtualSource::new(root_path, content);
             return Ok(
                 ImportMapResult::Result(ResolveResult::source(Vc::upcast(source)).into()).into(),
             );

--- a/crates/next-core/src/next_font/google/font_fallback.rs
+++ b/crates/next-core/src/next_font/google/font_fallback.rs
@@ -44,16 +44,18 @@ struct Fallback {
 
 #[turbo_tasks::function]
 pub(super) async fn get_font_fallback(
-    context: Vc<FileSystemPath>,
+    lookup_path: Vc<FileSystemPath>,
     options_vc: Vc<NextFontGoogleOptions>,
 ) -> Result<Vc<FontFallback>> {
     let options = options_vc.await?;
     Ok(match &options.fallback {
         Some(fallback) => FontFallback::Manual(fallback.clone()).cell(),
         None => {
-            let metrics_json =
-                load_next_js_templateon(context, "dist/server/capsize-font-metrics.json".into())
-                    .await?;
+            let metrics_json = load_next_js_templateon(
+                lookup_path,
+                "dist/server/capsize-font-metrics.json".into(),
+            )
+            .await?;
             let fallback = lookup_fallback(
                 &options.font_family,
                 metrics_json,
@@ -72,7 +74,7 @@ pub(super) async fn get_font_fallback(
                 .cell(),
                 Err(_) => {
                     NextFontIssue {
-                        path: context,
+                        path: lookup_path,
                         title: StyledString::Text(
                             format!(
                                 "Failed to find font override values for font `{}`",

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -650,9 +650,10 @@ async fn get_mock_stylesheet(
         project_path: _,
         chunking_context,
     } = *execution_context.await?;
-    let context = node_evaluate_asset_context(execution_context, None, None, "next_font".into());
+    let asset_context =
+        node_evaluate_asset_context(execution_context, None, None, "next_font".into());
     let loader_path = mock_fs.root().join("loader.js".into());
-    let mocked_response_asset = context
+    let mocked_response_asset = asset_context
         .process(
             Vc::upcast(VirtualSource::new(
                 loader_path,
@@ -678,7 +679,7 @@ async fn get_mock_stylesheet(
         root,
         env,
         AssetIdent::from_path(loader_path),
-        context,
+        asset_context,
         chunking_context,
         None,
         vec![],

--- a/crates/next-core/src/next_font/local/font_fallback.rs
+++ b/crates/next-core/src/next_font/local/font_fallback.rs
@@ -27,7 +27,7 @@ static BOLD_WEIGHT: f64 = 700.0;
 
 #[turbo_tasks::function]
 pub(super) async fn get_font_fallbacks(
-    context: Vc<FileSystemPath>,
+    lookup_path: Vc<FileSystemPath>,
     options_vc: Vc<NextFontLocalOptions>,
 ) -> Result<Vc<FontFallbacks>> {
     let options = &*options_vc.await?;
@@ -41,7 +41,7 @@ pub(super) async fn get_font_fallbacks(
                 scoped_font_family,
                 local_font_family: Vc::cell("Arial".into()),
                 adjustment: Some(
-                    get_font_adjustment(context, options_vc, &DEFAULT_SANS_SERIF_FONT).await?,
+                    get_font_adjustment(lookup_path, options_vc, &DEFAULT_SANS_SERIF_FONT).await?,
                 ),
             })
             .into(),
@@ -51,7 +51,7 @@ pub(super) async fn get_font_fallbacks(
                 scoped_font_family,
                 local_font_family: Vc::cell("Times New Roman".into()),
                 adjustment: Some(
-                    get_font_adjustment(context, options_vc, &DEFAULT_SERIF_FONT).await?,
+                    get_font_adjustment(lookup_path, options_vc, &DEFAULT_SERIF_FONT).await?,
                 ),
             })
             .into(),
@@ -67,13 +67,16 @@ pub(super) async fn get_font_fallbacks(
 }
 
 async fn get_font_adjustment(
-    context: Vc<FileSystemPath>,
+    lookup_path: Vc<FileSystemPath>,
     options: Vc<NextFontLocalOptions>,
     fallback_font: &DefaultFallbackFont,
 ) -> Result<FontAdjustment> {
     let options = &*options.await?;
     let main_descriptor = pick_font_for_fallback_generation(&options.fonts)?;
-    let font_file = &*context.join(main_descriptor.path.clone()).read().await?;
+    let font_file = &*lookup_path
+        .join(main_descriptor.path.clone())
+        .read()
+        .await?;
     let font_file_rope = match font_file {
         FileContent::NotFound => bail!(FontError::FontFileNotFound(main_descriptor.path.clone())),
         FileContent::Content(file) => file.content(),

--- a/crates/next-core/src/next_image/module.rs
+++ b/crates/next-core/src/next_image/module.rs
@@ -39,10 +39,10 @@ impl StructuredImageModuleType {
     pub(crate) async fn create_module(
         source: Vc<Box<dyn Source>>,
         blur_placeholder_mode: BlurPlaceholderMode,
-        context: Vc<ModuleAssetContext>,
+        module_asset_context: Vc<ModuleAssetContext>,
     ) -> Result<Vc<Box<dyn Module>>> {
-        let static_asset = StaticModuleAsset::new(source, Vc::upcast(context));
-        let module = context
+        let static_asset = StaticModuleAsset::new(source, Vc::upcast(module_asset_context));
+        let module = module_asset_context
             .process(
                 Vc::upcast(
                     StructuredImageFileSource {
@@ -73,9 +73,13 @@ impl CustomModuleType for StructuredImageModuleType {
     fn create_module(
         &self,
         source: Vc<Box<dyn Source>>,
-        context: Vc<ModuleAssetContext>,
+        module_asset_context: Vc<ModuleAssetContext>,
         _part: Option<Vc<ModulePart>>,
     ) -> Vc<Box<dyn Module>> {
-        StructuredImageModuleType::create_module(source, self.blur_placeholder_mode, context)
+        StructuredImageModuleType::create_module(
+            source,
+            self.blur_placeholder_mode,
+            module_asset_context,
+        )
     }
 }

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -180,7 +180,7 @@ async fn process_global_item(
 
 #[turbo_tasks::function]
 async fn wrap_edge_page(
-    context: Vc<Box<dyn AssetContext>>,
+    asset_context: Vc<Box<dyn AssetContext>>,
     project_root: Vc<FileSystemPath>,
     entry: Vc<Box<dyn Module>>,
     page: RcStr,
@@ -237,12 +237,12 @@ async fn wrap_edge_page(
 
     let inner_assets = indexmap! {
         INNER.into() => entry,
-        INNER_DOCUMENT.into() => process_global_item(pages_structure.document(), reference_type.clone(), context),
-        INNER_APP.into() => process_global_item(pages_structure.app(), reference_type.clone(), context),
-        INNER_ERROR.into() => process_global_item(pages_structure.error(), reference_type.clone(), context),
+        INNER_DOCUMENT.into() => process_global_item(pages_structure.document(), reference_type.clone(), asset_context),
+        INNER_APP.into() => process_global_item(pages_structure.app(), reference_type.clone(), asset_context),
+        INNER_ERROR.into() => process_global_item(pages_structure.error(), reference_type.clone(), asset_context),
     };
 
-    let wrapped = context
+    let wrapped = asset_context
         .process(
             Vc::upcast(source),
             Value::new(ReferenceType::Internal(Vc::cell(inner_assets))),
@@ -250,7 +250,7 @@ async fn wrap_edge_page(
         .module();
 
     Ok(wrap_edge_entry(
-        context,
+        asset_context,
         project_root,
         wrapped,
         pathname.clone(),

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -253,15 +253,22 @@ impl AfterResolvePlugin for NextExternalResolvePlugin {
 #[turbo_tasks::value]
 pub(crate) struct NextNodeSharedRuntimeResolvePlugin {
     root: Vc<FileSystemPath>,
-    context: ServerContextType,
+    server_context_type: ServerContextType,
 }
 
 #[turbo_tasks::value_impl]
 impl NextNodeSharedRuntimeResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(root: Vc<FileSystemPath>, context: Value<ServerContextType>) -> Vc<Self> {
-        let context = context.into_value();
-        NextNodeSharedRuntimeResolvePlugin { root, context }.cell()
+    pub fn new(
+        root: Vc<FileSystemPath>,
+        server_context_type: Value<ServerContextType>,
+    ) -> Vc<Self> {
+        let server_context_type = server_context_type.into_value();
+        NextNodeSharedRuntimeResolvePlugin {
+            root,
+            server_context_type,
+        }
+        .cell()
     }
 }
 
@@ -289,7 +296,7 @@ impl AfterResolvePlugin for NextNodeSharedRuntimeResolvePlugin {
 
         let resource_request = format!(
             "next/dist/server/route-modules/{}/vendored/contexts/{}.js",
-            match self.context {
+            match self.server_context_type {
                 ServerContextType::AppRoute { .. } => "app-route",
                 ServerContextType::AppSSR { .. } | ServerContextType::AppRSC { .. } => "app-page",
                 // Use default pages context for all other contexts.


### PR DESCRIPTION
This updates the remaining cases where we were using the generic `context` name for variables, field names, etc.

It also adds an `.ignore` file to prevent files like the non-text `broken.js` from being read by these kinds of tools. This is separate from `.gitignore`.
