### PR TITLE
Remove invalid line from memory usage doc

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/13-memory-usage.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/13-memory-usage.mdx
@@ -82,7 +82,6 @@ const nextConfig = {
       config.cache = Object.freeze({
         type: 'memory',
       })
-      config.cache.maxMemoryGenerations = 0
     }
     // Important: return the modified config
     return config


### PR DESCRIPTION
This line is invalid as you can't augment a frozen object and also since we're disabling webpack cache for a build there shouldn't be multiple memory generations anyways

x-ref: [slack thread](https://vercel.slack.com/archives/C06K82ECH8S/p1722890647302349?thread_ts=1722878511.521699&cid=C06K82ECH8S)