### PR TITLE
chore: Update `lightningcss`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3402,9 +3402,9 @@ dependencies = [
 
 [[package]]
 name = "lightningcss"
-version = "1.0.0-alpha.57"
+version = "1.0.0-alpha.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10bc10261f46b8df263b80e7779d1748b1880488cd951fbb9e096430cead10e6"
+checksum = "ec380ca49dc7f6a1cafbdd2de5e587958eac0f67ab26b1e56727fcc60a0c3d4d"
 dependencies = [
  "ahash 0.8.9",
  "bitflags 2.5.0",
@@ -3429,10 +3429,11 @@ dependencies = [
 
 [[package]]
 name = "lightningcss-derive"
-version = "1.0.0-alpha.42"
+version = "1.0.0-alpha.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f02a09f0b79d31f1ee13ea55e2f7021037c6b72e0a3ab6c1cb0e9bd7ac8a295"
+checksum = "84c12744d1279367caed41739ef094c325d53fb0ffcd4f9b84a368796f870252"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -4439,9 +4440,9 @@ checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "parcel_selectors"
-version = "0.26.5"
+version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce9c47a67c66fee4a5a42756f9784d92941bd0ab2b653539a9e90521a44b66f0"
+checksum = "512215cb1d3814e276ace4ec2dbc2cac16726ea3fcac20c22ae1197e16fdd72d"
 dependencies = [
  "bitflags 2.5.0",
  "cssparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ indoc = "2.0.0"
 itertools = "0.10.5"
 lazy_static = "1.4.0"
 log = "0.4.17"
-lightningcss = { version = "1.0.0-alpha.57", features = [
+lightningcss = { version = "1.0.0-alpha.58", features = [
   "serde",
   "visitor",
   "into_owned",


### PR DESCRIPTION
### What?

Update `lightningcss` crate of next.js


### Why?

To apply https://github.com/parcel-bundler/lightningcss/pull/784 and https://github.com/parcel-bundler/lightningcss/pull/783

### How?

- Closes PACK-2933
- Closes PACK-3100
- Closes https://github.com/vercel/next.js/issues/66191
- Closes https://github.com/vercel/next.js/issues/64299
