### PR TITLE
Remove async module detection from client flight manifest

### DIFF
--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -40,7 +40,6 @@ import {
 import { normalizePathSep } from '../../../shared/lib/page-path/normalize-path-sep'
 import { getProxiedPluginState } from '../../build-context'
 import { PAGE_TYPES } from '../../../lib/page-types'
-import { isWebpackServerOnlyLayer } from '../../utils'
 import { getModuleBuildInfo } from '../loaders/get-module-build-info'
 import { getAssumedSourceType } from '../loaders/next-flight-loader'
 
@@ -95,12 +94,6 @@ const pluginState = getProxiedPluginState({
   // Mapping of resource path to module id for server/edge server.
   serverModuleIds: {} as Record<string, string | number>,
   edgeServerModuleIds: {} as Record<string, string | number>,
-
-  // Collect modules from server/edge compiler in client layer,
-  // and detect if it's been used, and mark it as `async: true` for react.
-  // So that react could unwrap the async module from promise and render module itself.
-  // Use an object to simulate Set lookup
-  ASYNC_CLIENT_MODULES: {} as Record<string, boolean>,
 
   injectedClientEntries: {} as Record<string, string>,
 })
@@ -240,14 +233,6 @@ export class FlightClientEntryPlugin {
       }
 
       traverseModules(compilation, (mod, _chunk, _chunkGroup, modId) => {
-        if (mod && mod.resource && !isWebpackServerOnlyLayer(mod.layer)) {
-          if (compilation.moduleGraph.isAsync(mod)) {
-            // The module must has resolved resource path so it's not a new entry created with loader.
-            // Checking the module layer to make sure it's from client layers (SSR or browser, not RSC).
-            pluginState.ASYNC_CLIENT_MODULES[mod.resource] = true
-          }
-        }
-
         if (modId) recordModule(modId, mod)
       })
     })

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -43,8 +43,6 @@ export type ManifestChunks = Array<string>
 const pluginState = getProxiedPluginState({
   serverModuleIds: {} as Record<string, string | number>,
   edgeServerModuleIds: {} as Record<string, string | number>,
-  // Use an object to simulate Set lookup
-  ASYNC_CLIENT_MODULES: {} as Record<string, boolean>,
 })
 
 export interface ManifestNode {
@@ -304,8 +302,6 @@ export class ClientReferenceManifestPlugin {
         if (!ssrNamedModuleId.startsWith('.'))
           ssrNamedModuleId = `./${ssrNamedModuleId.replace(/\\/g, '/')}`
 
-        const isAsyncModule = !!pluginState.ASYNC_CLIENT_MODULES[mod.resource]
-
         // The client compiler will always use the CJS Next.js build, so here we
         // also add the mapping for the ESM build (Edge runtime) to consume.
         const esmResource = /[\\/]next[\\/]dist[\\/]/.test(resource)
@@ -333,7 +329,7 @@ export class ClientReferenceManifestPlugin {
             id: modId,
             name: '*',
             chunks: requiredChunks,
-            async: isAsyncModule,
+            async: false,
           }
           if (esmResource) {
             const edgeExportName = esmResource
@@ -501,7 +497,5 @@ export class ClientReferenceManifestPlugin {
         )}]=${json}`
       ) as unknown as webpack.sources.RawSource
     }
-
-    pluginState.ASYNC_CLIENT_MODULES = {}
   }
 }


### PR DESCRIPTION
### What

Remove the async client modules collection from shared plugin state, which was used for flight client manifest.


### Why

This was the legacy logic when React RSC renderer requires the `async` property in the flight manifest, but then React dropped that change and all the async modules are handled on the framework side, React won't do any extra await for the modules which are marked as `async: true` in the manifest.

The new async module logic is handled in [this PR](https://github.com/vercel/next.js/pull/66990) now, most critically in [this line](https://github.com/vercel/next.js/pull/66990/files#diff-20be1066bb3785bdd9f255179957039e7ce035324bc7753aefe89ffc6bb6f1edR115). Hence we removed that state for flight manifest.

cc @unstubbable 