### PR TITLE
chore: port more nextpack scripts

### DIFF
--- a/contributing/core/developing.md
+++ b/contributing/core/developing.md
@@ -65,6 +65,18 @@ Or without running the build:
 pnpm pack-next --no-build --release && pnpm unpack-next path/to/project
 ```
 
+Without going through a tarball (only works if you've added the overrides from `pack-next`):
+
+```bash
+pnpm patch-next path/to/project
+```
+
+Supports the same arguments:
+
+```bash
+pnpm patch-next --no-build --release path/to/project
+```
+
 ### Explanation of the scripts
 
 ```bash
@@ -84,4 +96,28 @@ Afterwards, you'll need to unpack the tarball into your test project. You can ei
 ```bash
 # Unpack the tarballs generated with pack-next into project's node_modules
 $ pnpm unpack-next path/to/project
+```
+
+## Recover disk space
+
+Rust builds quickly add up to a lot of disk space, you can clean up old artifacts with this command:
+
+```bash
+pnpm sweep
+```
+
+It will also clean up other caches (pnpm store, cargo, etc.) and run `git gc` for you.
+
+### MacOS disk compression
+
+If you want to automatically use APFS disk compression on macOS for `node_modules/` and `target/` you can install a launch agent with:
+
+```bash
+./scripts/LaunchAgents/install-macos-agents.sh
+```
+
+Or run it manually with:
+
+```bash
+./scripts/macos-compress.sh
 ```

--- a/package.json
+++ b/package.json
@@ -60,8 +60,10 @@
     "prepare": "husky",
     "sync-react": "node ./scripts/sync-react.js",
     "update-google-fonts": "node ./scripts/update-google-fonts.js",
+    "patch-next": "node scripts/patch-next.cjs",
     "unpack-next": "node scripts/unpack-next.cjs",
-    "swc-build-native": "pnpm --filter=@next/swc build-native"
+    "swc-build-native": "pnpm --filter=@next/swc build-native",
+    "sweep": "node scripts/sweep.cjs"
   },
   "devDependencies": {
     "@actions/core": "1.10.1",

--- a/scripts/LaunchAgents/build.turbo.compress.plist
+++ b/scripts/LaunchAgents/build.turbo.compress.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <!-- Periodically compress text-heavy directories -->
+	<dict>
+		<key>Label</key>
+		<string>build.turbo.compress</string>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/build.turbo.compress/log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/build/turbo.compress/error</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PATH</key>
+      <string>/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+
+    <key>ProgramArguments</key>
+    <array>
+      <string>/bin/sh</string>
+      <string>-c</string>
+      <string>cd $(defaults read build.turbo.repopath -string) &amp;&amp; ./scripts/macos-compress.sh</string>
+    </array>
+
+    <key>StartInterval</key>
+    <integer>10800</integer> <!-- 3 hours -->
+	</dict>
+</plist>

--- a/scripts/LaunchAgents/install-macos-agents.sh
+++ b/scripts/LaunchAgents/install-macos-agents.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Optionally automates compressing target/ and other directories.
+# Only intended for and needed on macOS.
+
+set -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+NEXT_DIR=$(realpath "$SCRIPT_DIR/../..")
+
+defaults write build.turbo.repopath -string "$NEXT_DIR"
+
+for filename in "$SCRIPT_DIR"/*.plist; do
+  PLIST_FILE="$HOME/Library/LaunchAgents/$(basename "$filename")"
+  ln -sf "$filename" "$PLIST_FILE"
+  launchctl unload "$PLIST_FILE" || true
+  launchctl load "$PLIST_FILE"
+done

--- a/scripts/build-native.cjs
+++ b/scripts/build-native.cjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+const { NEXT_DIR, booleanArg, execAsyncWithOutput } = require('./pack-util.cjs')
+const { rmSync } = require('fs')
+const path = require('path')
+
+const args = process.argv.slice(2)
+
+// strip --no-build when called from pack-next.cjs
+booleanArg(args, '--no-build')
+
+const targetDir = path.join(NEXT_DIR, 'target')
+
+module.exports = (async () => {
+  for (let i = 0; i < 2; i++) {
+    try {
+      await execAsyncWithOutput(
+        'Build native modules',
+        ['pnpm', 'run', 'swc-build-native', '--', ...args],
+        {
+          shell: process.platform === 'win32' ? 'powershell.exe' : false,
+          env: {
+            COLOR: 'always',
+            TTY: '1',
+            ...process.env,
+          },
+        }
+      )
+    } catch (e) {
+      if (
+        e.stderr
+          .toString()
+          .includes('the compiler unexpectedly panicked. this is a bug.')
+      ) {
+        rmSync(path.join(targetDir, 'release/incremental'), {
+          recursive: true,
+          force: true,
+        })
+        rmSync(path.join(targetDir, 'debug/incremental'), {
+          recursive: true,
+          force: true,
+        })
+        continue
+      }
+      delete e.stdout
+      delete e.stderr
+      throw e
+    }
+    break
+  }
+})()

--- a/scripts/macos-compress.sh
+++ b/scripts/macos-compress.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Optionally automates compressing target/ and other directories.
+# Only intended for and needed on macOS.
+#
+
+set -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+NEXT_DIR=$(realpath "$SCRIPT_DIR/..")
+
+# Basic timestamp prefix for logging
+PS4='+ $(date "+%Y-%m-%d +%H:%M:%S") '
+
+set -x
+
+if ! command -v afsctool &> /dev/null; then
+  echo "afsctool is required. Install it with 'brew install afsctool'."
+  exit 1
+fi
+
+afsctool -c "$NEXT_DIR/target" "$NEXT_DIR/node_modules"

--- a/scripts/pack-next.cjs
+++ b/scripts/pack-next.cjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const {
+  NEXT_DIR,
   booleanArg,
   exec,
   execAsyncWithOutput,
@@ -12,9 +13,8 @@ const fsPromises = require('fs/promises')
 
 const args = process.argv.slice(2)
 
-const CWD = process.cwd()
-const TARBALLS = `${CWD}/tarballs`
-const NEXT_PACKAGES = `${CWD}/packages`
+const TARBALLS = `${NEXT_DIR}/tarballs`
+const NEXT_PACKAGES = `${NEXT_DIR}/packages`
 const noBuild = booleanArg(args, '--no-build')
 
 ;(async () => {
@@ -37,7 +37,7 @@ const noBuild = booleanArg(args, '--no-build')
     await Promise.all(binaries.map((bin) => fsPromises.rm(bin)))
   }
 
-  exec('Build native modules', 'pnpm run swc-build-native')
+  await require('./build-native.cjs')
 
   const NEXT_TARBALL = `${TARBALLS}/next.tar`
   const NEXT_SWC_TARBALL = `${TARBALLS}/next-swc.tar`

--- a/scripts/pack-util.cjs
+++ b/scripts/pack-util.cjs
@@ -7,17 +7,29 @@ const { promisify } = require('util')
 const glob = promisify(globOrig)
 exports.glob = glob
 
+const NEXT_DIR = join(__dirname, '..')
+
+exports.NEXT_DIR = NEXT_DIR
+
+/**
+ * @param {string} title
+ * @param {string | string[]} command
+ * @param {ExecSyncOptions} [opts]
+ * @returns {string}
+ */
 function exec(title, command, opts) {
   if (Array.isArray(command)) {
     logCommand(title, command)
     return execFileSync(command[0], command.slice(1), {
       stdio: 'inherit',
+      cwd: NEXT_DIR,
       ...opts,
     })
   } else {
     logCommand(title, command)
     return execSync(command, {
       stdio: 'inherit',
+      cwd: NEXT_DIR,
       ...opts,
     })
   }
@@ -25,11 +37,17 @@ function exec(title, command, opts) {
 
 exports.exec = exec
 
+/**
+ * @param {string} title
+ * @param {string | string[]} command
+ * @param {SpawnOptions} [opts]
+ */
 function execAsyncWithOutput(title, command, opts) {
   logCommand(title, command)
   const proc = spawn(command[0], command.slice(1), {
     encoding: 'utf8',
     stdio: ['inherit', 'pipe', 'pipe'],
+    cwd: NEXT_DIR,
     ...opts,
   })
   const stdout = []
@@ -63,11 +81,18 @@ function execAsyncWithOutput(title, command, opts) {
 
 exports.execAsyncWithOutput = execAsyncWithOutput
 
+/**
+ * @param {string | string[]} command
+ */
 function prettyCommand(command) {
   if (Array.isArray(command)) command = command.join(' ')
   return command.replace(/ -- .*/, ' -- …')
 }
 
+/**
+ * @param {string} title
+ * @param {string | string[]} [command]
+ */
 function logCommand(title, command) {
   if (command) {
     const pretty = prettyCommand(command)
@@ -79,6 +104,11 @@ function logCommand(title, command) {
 
 exports.logCommand = logCommand
 
+/**
+ * @param {string[]} args
+ * @param {string} name
+ * @returns {boolean}
+ */
 function booleanArg(args, name) {
   const index = args.indexOf(name)
   if (index === -1) return false
@@ -90,6 +120,11 @@ exports.booleanArg = booleanArg
 
 const DEFAULT_GLOBS = ['**', '!target', '!node_modules', '!crates', '!.turbo']
 const FORCED_GLOBS = ['package.json', 'README*', 'LICENSE*', 'LICENCE*']
+
+/**
+ * @param {string} path
+ * @returns {Promise<string[]>}
+ */
 async function packageFiles(path) {
   const { files = DEFAULT_GLOBS, main, bin } = require(`${path}/package.json`)
 
@@ -119,4 +154,5 @@ async function packageFiles(path) {
     return true
   })
 }
+
 exports.packageFiles = packageFiles

--- a/scripts/patch-next.cjs
+++ b/scripts/patch-next.cjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+const {
+  NEXT_DIR,
+  exec,
+  logCommand,
+  booleanArg,
+  packageFiles,
+} = require('./pack-util.cjs')
+const fs = require('fs')
+const path = require('path')
+
+/** @type {string[]} */
+const argv = process.argv
+const args = argv.slice(2)
+
+const NEXT_PACKAGES = `${NEXT_DIR}/packages`
+
+const PROJECT_DIR = path.resolve(args[0])
+
+const noBuild = booleanArg(args, '--no-build')
+const noNativeBuild = booleanArg(args, '--no-native-build')
+
+async function execFn(title, fn) {
+  logCommand(title, fn.toString())
+  return fn()
+}
+
+function realPathIfAny(path) {
+  try {
+    return fs.realpathSync(path)
+  } catch {
+    return null
+  }
+}
+
+async function copy(src, dst) {
+  const realDst = realPathIfAny(dst)
+  if (!realDst) {
+    return
+  }
+
+  const files = await packageFiles(src)
+
+  for (const file of files) {
+    fs.cpSync(path.join(src, file), path.join(realDst, file), {
+      recursive: true,
+    })
+  }
+}
+
+;(async () => {
+  if (!noBuild) {
+    exec('Install Next.js build dependencies', 'pnpm i')
+    exec('Build Next.js', 'pnpm run build')
+  }
+
+  if (!noNativeBuild) {
+    process.argv = [...process.argv.slice(0, 2), ...args.slice(1)]
+
+    await require('./build-native.cjs')
+  }
+
+  await execFn('Patching next', () =>
+    copy(`${NEXT_PACKAGES}/next`, `${PROJECT_DIR}/node_modules/next`)
+  )
+  await execFn('Patching @next/swc', () =>
+    copy(`${NEXT_PACKAGES}/next-swc`, `${PROJECT_DIR}/node_modules/@next/swc`)
+  )
+  await execFn('Patching @next/mdx', () =>
+    copy(`${NEXT_PACKAGES}/next-mdx`, `${PROJECT_DIR}/node_modules/@next/mdx`)
+  )
+  await execFn('Patching @next/bundle-analyzer', () =>
+    copy(
+      `${NEXT_PACKAGES}/next-bundle-analyzer`,
+      `${PROJECT_DIR}/node_modules/@next/bundle-anlyzer`
+    )
+  )
+})()

--- a/scripts/sweep.cjs
+++ b/scripts/sweep.cjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+const { existsSync, rmSync, readdirSync } = require('fs')
+const { join } = require('path')
+const { NEXT_DIR, exec, logCommand } = require('./pack-util.cjs')
+
+const sweepInstalled = existsSync(`${process.env.CARGO_HOME}/bin/cargo-sweep`)
+const cacheInstalled = existsSync(`${process.env.CARGO_HOME}/bin/cargo-cache`)
+
+function removeNestedNext(directory) {
+  const items = readdirSync(directory, { withFileTypes: true })
+
+  for (const item of items) {
+    const fullPath = join(directory, item.name)
+    if (item.isDirectory()) {
+      if (item.name === 'node_modules' || item.name === '.git') {
+        // skip
+      } else if (item.name === '.next') {
+        console.log(`removing ${fullPath}`)
+        rmSync(fullPath, { recursive: true, force: true })
+      } else {
+        removeNestedNext(fullPath)
+      }
+    }
+  }
+}
+
+logCommand(`Remove .next directories`)
+removeNestedNext(NEXT_DIR)
+
+logCommand(`Remove .cache directories`)
+rmSync(join(NEXT_DIR, 'node_modules/.cache'), { recursive: true, force: true })
+
+rmSync('target/rust-analyzer/debug/incremental', {
+  recursive: true,
+  force: true,
+})
+function removeDirs(title, prefix) {
+  logCommand(title)
+  rmSync(`${prefix}target/tmp`, { recursive: true, force: true })
+  rmSync(`${prefix}target/release/incremental`, {
+    recursive: true,
+    force: true,
+  })
+  rmSync(`${prefix}target/debug/incremental`, { recursive: true, force: true })
+}
+removeDirs('Remove incremental dirs', '')
+
+exec('Prune pnpm', 'pnpm prune', {
+  env: {
+    ...process.env,
+    // We don't need to download the native build as we are not going to use it
+    NEXT_SKIP_NATIVE_POSTINSTALL: '1',
+  },
+})
+exec('Prune pnpm store', 'pnpm store prune')
+
+if (!sweepInstalled) exec('Install cargo-sweep', 'cargo install cargo-sweep')
+
+if (existsSync('target')) {
+  exec('Sweep', 'cargo sweep --maxsize 20000')
+}
+
+function chunkArray(array, chunkSize) {
+  const chunks = []
+  for (let i = 0; i < array.length; i += chunkSize) {
+    chunks.push(array.slice(i, i + chunkSize))
+  }
+  return chunks
+}
+// git tag -d $(git tag -l)
+const tags = exec('Get tags', `git tag -l`, {
+  stdio: ['inherit', 'pipe', 'inherit'],
+})
+  .toString()
+  .trim()
+  .split('\n')
+for (const someTags of chunkArray(tags, 100)) {
+  exec('Delete local tags', `git tag -d ${someTags.join(' ')}`)
+}
+exec('Fetch & prune', 'git fetch -p')
+
+exec('Git GC', 'git gc --prune=1day')
+
+if (!cacheInstalled) exec('Install cargo-cache', 'cargo install cargo-cache')
+exec('Optimize cargo cache', 'cargo cache -e')

--- a/scripts/unpack-next.cjs
+++ b/scripts/unpack-next.cjs
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
 
-const { exec } = require('./pack-util.cjs')
+const { NEXT_DIR, exec } = require('./pack-util.cjs')
 const fs = require('fs')
 const path = require('path')
 
-const CWD = process.cwd()
-const TARBALLS = `${CWD}/tarballs`
+const TARBALLS = `${NEXT_DIR}/tarballs`
 
 const PROJECT_DIR = path.resolve(process.argv[2])
 


### PR DESCRIPTION
### What?

Ports a few more useful scripts from nextpack, namely:

- `patch-next`
- `sweep`
- `build-native` (to clean up incremental artifacts on compiler panics)
- the macOS compression agent
