### PR TITLE
Improve error message when preview builds were not found in deploy tests

### DIFF
--- a/scripts/test-new-tests.mjs
+++ b/scripts/test-new-tests.mjs
@@ -102,6 +102,13 @@ async function main() {
           )
           await new Promise((resolve) => setTimeout(resolve, timeout))
         } else {
+          if (res.status === 404) {
+            throw new Error(
+              `Artifacts not found for commit ${commitSha}. ` +
+                `This can happen if the preview builds either failed or didn't succeed yet. ` +
+                `Once the "Deploy Preview tarball" job has finished, a retry should fix this error.`
+            )
+          }
           throw new Error(
             `Failed to verify artifacts for commit ${commitSha}: ${res.status}`
           )


### PR DESCRIPTION
When the preview builds are not found it's almost certainly either because the build failed or didn't succeed yet (at least I can't think of another reason). We can add that to the error message so that people know what to do (see https://github.com/vercel/next.js/pull/68070#issuecomment-2259898401)