### PR TITLE
Handle more cases with env inlining

### DIFF
--- a/packages/next/src/build/flying-shuttle/inline-static-env.ts
+++ b/packages/next/src/build/flying-shuttle/inline-static-env.ts
@@ -33,21 +33,14 @@ export async function inlineStaticEnv({ distDir }: { distDir: string }) {
 
         await fs.promises.writeFile(
           filepath,
-          content
-            // if a NEXT_PUBLIC_ reference is present but the value isn't
-            // provided in the env it won't be replaced so we normalize
-            // it to globalThis to avoid minify/mangling for future inlining
-            .replace(/[\w]{1,}\.env\.NEXT_PUBLIC_[\w]{1,}/g, (match) => {
-              return `globalThis.${match.split('.').pop()}`
-            })
-            .replace(/globalThis\.[\w]{1,}/g, (match) => {
-              let normalizedMatch = `process.env.${match.substring('globalThis.'.length)}`
+          content.replace(/[\w]{1,}\.env\.NEXT_PUBLIC_[\w]{1,}/g, (match) => {
+            let normalizedMatch = `process.env.${match.split('.').pop()}`
 
-              if (staticEnv[normalizedMatch]) {
-                return JSON.stringify(staticEnv[normalizedMatch])
-              }
-              return match
-            })
+            if (staticEnv[normalizedMatch]) {
+              return JSON.stringify(staticEnv[normalizedMatch])
+            }
+            return match
+          })
         )
         inlineSema.release()
       })

--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -140,13 +140,14 @@ export function getDefineEnv({
   middlewareMatchers,
 }: DefineEnvPluginOptions): SerializedDefineEnv {
   const nextPublicEnv = getNextPublicEnvironmentVariables()
+  const nextConfigEnv = getNextConfigEnv(config)
 
   const defineEnv: DefineEnv = {
     // internal field to identify the plugin config
     __NEXT_DEFINE_ENV: true,
 
     ...nextPublicEnv,
-    ...getNextConfigEnv(config),
+    ...nextConfigEnv,
     ...(!isEdgeServer
       ? {}
       : {
@@ -286,10 +287,10 @@ export function getDefineEnv({
     // with flying shuttle enabled so we can update them
     // without invalidating entries
     for (const key in nextPublicEnv) {
-      // we inline as the key itself to avoid process.env
-      // mangling by webpack/minifier making replacing unsafe
-      serializedDefineEnv[key] =
-        `globalThis.${key.substring('process.env.'.length)}`
+      if (key in nextConfigEnv) {
+        continue
+      }
+      serializedDefineEnv[key] = key
     }
   }
 

--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -141,17 +141,6 @@ export function getDefineEnv({
 }: DefineEnvPluginOptions): SerializedDefineEnv {
   const nextPublicEnv = getNextPublicEnvironmentVariables()
 
-  if (Boolean(config.experimental.flyingShuttle)) {
-    // we delay inlining these values until after the build
-    // with flying shuttle enabled so we can update them
-    // without invalidating entries
-    for (const key in nextPublicEnv) {
-      // we inline as the key itself to avoid process.env
-      // mangling by webpack/minifier making replacing unsafe
-      nextPublicEnv[key] = key
-    }
-  }
-
   const defineEnv: DefineEnv = {
     // internal field to identify the plugin config
     __NEXT_DEFINE_ENV: true,
@@ -290,7 +279,21 @@ export function getDefineEnv({
         }
       : undefined),
   }
-  return serializeDefineEnv(defineEnv)
+  const serializedDefineEnv = serializeDefineEnv(defineEnv)
+
+  if (Boolean(config.experimental.flyingShuttle)) {
+    // we delay inlining these values until after the build
+    // with flying shuttle enabled so we can update them
+    // without invalidating entries
+    for (const key in nextPublicEnv) {
+      // we inline as the key itself to avoid process.env
+      // mangling by webpack/minifier making replacing unsafe
+      serializedDefineEnv[key] =
+        `globalThis.${key.substring('process.env.'.length)}`
+    }
+  }
+
+  return serializedDefineEnv
 }
 
 export function getDefineEnvPlugin(options: DefineEnvPluginOptions) {

--- a/test/e2e/app-dir/app/app/dashboard/deployments/[id]/page.js
+++ b/test/e2e/app-dir/app/app/dashboard/deployments/[id]/page.js
@@ -23,6 +23,7 @@ export default function DeploymentsPage(props) {
     <>
       <p>hello from app/dashboard/deployments/[id]. ID is: {data.id}</p>
       <p id="my-env">{process.env.NEXT_PUBLIC_TEST_ID}</p>
+      <p id="my-other-env">{`${process.env.NEXT_PUBLIC_TEST_ID}-suffix`}</p>
     </>
   )
 }

--- a/test/e2e/app-dir/app/app/dashboard/deployments/[id]/page.js
+++ b/test/e2e/app-dir/app/app/dashboard/deployments/[id]/page.js
@@ -22,8 +22,8 @@ export default function DeploymentsPage(props) {
   return (
     <>
       <p>hello from app/dashboard/deployments/[id]. ID is: {data.id}</p>
-      <p id="my-env">{process.env.NEXT_PUBLIC_TEST_ID}</p>
-      <p id="my-other-env">{`${process.env.NEXT_PUBLIC_TEST_ID}-suffix`}</p>
+      <span id="my-env">{process.env.NEXT_PUBLIC_TEST_ID}</span>
+      <span id="my-other-env">{`${process.env.NEXT_PUBLIC_TEST_ID}-suffix`}</span>
     </>
   )
 }

--- a/test/e2e/app-dir/app/flying-shuttle.test.ts
+++ b/test/e2e/app-dir/app/flying-shuttle.test.ts
@@ -171,7 +171,11 @@ import { nextTestSetup, isNextStart } from 'e2e-utils'
       const index$ = await next.render$('/')
       const deployments$ = await next.render$('/dashboard/deployments/123')
       expect(index$('#my-env').text()).toContain(testEnvId)
+      expect(index$('#my-other-env').text()).toContain(`${testEnvId}-suffix`)
       expect(deployments$('#my-env').text()).toContain(testEnvId)
+      expect(deployments$('#my-other-env').text()).toContain(
+        `${testEnvId}-suffix`
+      )
 
       const testPaths = [
         { path: '/', content: 'hello from pages/index', type: 'pages' },

--- a/test/e2e/app-dir/app/pages/index.js
+++ b/test/e2e/app-dir/app/pages/index.js
@@ -17,6 +17,7 @@ export default function Page() {
       <p id="react-version">{React.version}</p>
       <Button>Click me!</Button>
       <p id="my-env">{process.env.NEXT_PUBLIC_TEST_ID}</p>
+      <p id="my-other-env">{`${process.env.NEXT_PUBLIC_TEST_ID}-suffix`}</p>
     </>
   )
 }

--- a/test/e2e/app-dir/app/pages/index.js
+++ b/test/e2e/app-dir/app/pages/index.js
@@ -16,8 +16,8 @@ export default function Page() {
       <Link href="/dashboard">Dashboard</Link>
       <p id="react-version">{React.version}</p>
       <Button>Click me!</Button>
-      <p id="my-env">{process.env.NEXT_PUBLIC_TEST_ID}</p>
-      <p id="my-other-env">{`${process.env.NEXT_PUBLIC_TEST_ID}-suffix`}</p>
+      <span id="my-env">{process.env.NEXT_PUBLIC_TEST_ID}</span>
+      <span id="my-other-env">{`${process.env.NEXT_PUBLIC_TEST_ID}-suffix`}</span>
     </>
   )
 }


### PR DESCRIPTION
This ensures we are able to properly replace even when an env variable value wasn't initially provided and also ensures an env that is interpolated in a string properly replaces. We don't use the stringified version of `process.env` as that can cause issues with interpolation and such. 