### PR TITLE
chore(turbopack): Enable the rust-analyzer component in rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "nightly-2024-08-01"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"


### PR DESCRIPTION
Discussion: https://vercel.slack.com/archives/C03EWR7LGEN/p1722904371113719

Between @wbinnssmith and myself, we determined that if you don't specify this component here:
- `rustup` won't install rust-analyzer by default (it isn't part of the "minimal" profile)
- `rustacean.nvim` won't install it by default, and will instead just ask you to install it if you run a health check: https://github.com/mrcjkb/rustaceanvim/blob/193f1d7925a61a066f7aa7d5d75f0cfe17dc0a9e/lua/rustaceanvim/health.lua#L210
- The VSCode plugin will look for a rustup-installed version, but since it doesn't exist, it will silently fall back to using its own bundled version, which doesn't match our toolchain version: https://github.com/rust-lang/rust-analyzer/blob/b23142209ef632475915e858f5f20901ef7c12da/editors/code/src/bootstrap.ts#L58-L60

Enabling this component ensures that everyone's IDE (VSCode or Neovim with Rustacean.nvim) uses a version of rust-analyzer that matches the rest of our toolchain. This also ensures reproducibility across the whole team.

Copied the line from https://github.com/vercel/nextpack/blob/main/rust-toolchain.toml

## Tradeoffs

This will install `rust-analyzer` in CI where it's not needed.

## Test Plan

```
rustup component remove rust-analyzer
rustup which rust-analyzer
```

Before this change, the `rustup which` command would fail. With this change, it will auto-install `rust-analyzer`.