### PR TITLE
make sure all the crates in turbopack are considered when caching

### DIFF
--- a/packages/next-swc/turbo.json
+++ b/packages/next-swc/turbo.json
@@ -6,6 +6,7 @@
       "inputs": [
         "../../.cargo/**",
         "../../crates/**",
+        "../../turbopack/crates/**",
         "../../Cargo.toml",
         "../../Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
@@ -17,6 +18,7 @@
       "inputs": [
         "../../.cargo/**",
         "../../crates/**",
+        "../../turbopack/crates/**",
         "../../**/Cargo.toml",
         "../../**/Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
@@ -28,6 +30,7 @@
       "inputs": [
         "../../.cargo/**",
         "../../crates/**",
+        "../../turbopack/crates/**",
         "../../**/Cargo.toml",
         "../../**/Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
@@ -39,6 +42,7 @@
       "inputs": [
         "../../.cargo/**",
         "../../crates/**",
+        "../../turbopack/crates/**",
         "../../**/Cargo.toml",
         "../../**/Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
@@ -50,6 +54,7 @@
       "inputs": [
         "../../.cargo/**",
         "../../crates/**",
+        "../../turbopack/crates/**",
         "../../**/Cargo.toml",
         "../../**/Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
@@ -61,6 +66,7 @@
       "inputs": [
         "../../.cargo/**",
         "../../crates/**",
+        "../../turbopack/crates/**",
         "../../**/Cargo.toml",
         "../../**/Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
@@ -72,6 +78,7 @@
       "inputs": [
         "../../.cargo/**",
         "../../crates/**",
+        "../../turbopack/crates/**",
         "../../**/Cargo.toml",
         "../../**/Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
@@ -90,6 +97,7 @@
       "inputs": [
         "../../.cargo/**",
         "../../crates/**",
+        "../../turbopack/crates/**",
         "../../**/Cargo.toml",
         "../../**/Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
@@ -101,6 +109,7 @@
       "inputs": [
         "../../.cargo/**",
         "../../crates/**",
+        "../../turbopack/crates/**",
         "../../**/Cargo.toml",
         "../../**/Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
@@ -111,6 +120,7 @@
       "inputs": [
         "../../.cargo/**",
         "../../crates/**",
+        "../../turbopack/crates/**",
         "../../**/Cargo.toml",
         "../../**/Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
@@ -121,6 +131,7 @@
       "inputs": [
         "../../.cargo/**",
         "../../crates/**",
+        "../../turbopack/crates/**",
         "../../**/Cargo.toml",
         "../../**/Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",


### PR DESCRIPTION
### What?

We use turbo to build the native portion of nextjs / turbopack which relies on turborepo for caching, with manually specified inputs. When moving the project we missed adding the new crates folder to the `turbo.json` file, leading to erroneous cache hits.

### Why?

Erroneous cache hits = bad.

### How?

Add the new path to the turbo.json file for next-swc. I did not include the `turbopack/packages` folder, since it is not used in native builds.
