### PR TITLE
Fix store only case for tracing

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1790,7 +1790,7 @@ export default async function build(
 
       const postCompileSpinner = createSpinner('Collecting page data')
 
-      if (config.experimental.flyingShuttle) {
+      if (isFullFlyingShuttle) {
         // we need to copy the chunks from the shuttle folder
         // to the distDir (we copy all server split chunks currently)
         // this has to come before we require any page chunks as webpack

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1202,7 +1202,7 @@ export default async function build(
         )
         const filterPaths: string[] = []
 
-        if (flyingShuttle) {
+        if (isFullFlyingShuttle) {
           filterPaths.push(
             ...[
               // client filter always has all app paths


### PR DESCRIPTION
While testing noticed we were incorrectly copying from the cache when in `store-only` mode so this fixes that condition to ensure we skip that case properly. 