### PR TITLE
refactor(turbo-tasks): Merge CELL_COUNTERS and CURRENT_TASK_ID into CURRENT_TASK_STATE

### DIFF
--- a/turbopack/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -377,7 +377,7 @@ impl Backend for MemoryBackend {
         task_id: TaskId,
         duration: Duration,
         memory_usage: usize,
-        cell_counters: AutoMap<ValueTypeId, u32, BuildHasherDefault<FxHasher>, 8>,
+        cell_counters: &AutoMap<ValueTypeId, u32, BuildHasherDefault<FxHasher>, 8>,
         stateful: bool,
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) -> bool {

--- a/turbopack/crates/turbo-tasks-memory/src/task.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/task.rs
@@ -945,7 +945,7 @@ impl Task {
         duration: Duration,
         memory_usage: usize,
         generation: NonZeroU32,
-        cell_counters: AutoMap<ValueTypeId, u32, BuildHasherDefault<FxHasher>, 8>,
+        cell_counters: &AutoMap<ValueTypeId, u32, BuildHasherDefault<FxHasher>, 8>,
         stateful: bool,
         backend: &MemoryBackend,
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -475,7 +475,7 @@ pub trait Backend: Sync + Send {
         task: TaskId,
         duration: Duration,
         memory_usage: usize,
-        cell_counters: AutoMap<ValueTypeId, u32, BuildHasherDefault<FxHasher>, 8>,
+        cell_counters: &AutoMap<ValueTypeId, u32, BuildHasherDefault<FxHasher>, 8>,
         stateful: bool,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> bool;

--- a/turbopack/crates/turbo-tasks/src/debug/vdbg.rs
+++ b/turbopack/crates/turbo-tasks/src/debug/vdbg.rs
@@ -33,7 +33,7 @@ macro_rules! vdbg {
         {
             use $crate::debug::ValueDebugFormat;
             let depth = $depth;
-            $crate::macro_helpers::spawn_detached(async move {
+            $crate::macro_helpers::spawn_detached_for_testing(async move {
                 $crate::vdbg!(__expand depth ; [ $($valstr $valowned)* ] []);
                 Ok(())
             });

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -81,7 +81,7 @@ use auto_hash_map::AutoSet;
 pub use collectibles::CollectiblesSource;
 pub use completion::{Completion, Completions};
 pub use display::ValueToString;
-pub use id::{FunctionId, TaskId, TraitTypeId, ValueTypeId};
+pub use id::{ExecutionId, FunctionId, TaskId, TraitTypeId, ValueTypeId};
 pub use invalidation::{
     DynamicEqHash, InvalidationReason, InvalidationReasonKind, InvalidationReasonSet,
 };

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -6,7 +6,7 @@ pub use tracing;
 
 pub use super::{
     magic_any::MagicAny,
-    manager::{find_cell_by_type, notify_scheduled_tasks, spawn_detached},
+    manager::{find_cell_by_type, notify_scheduled_tasks, spawn_detached_for_testing},
 };
 use crate::debug::ValueDebugFormatString;
 


### PR DESCRIPTION
## Why?

- These three task locals were pretty much always entered/exited at the same time.
- Syntactically, this lead to some awkwardness, as each scope introduces another level of indentation.
- Each task local adds more entries to the stack traces.
- While entering/exiting each task local's scope is very cheap, it's not free, and it must happen on every task's await points. One task local instead of three reduces the work that needs to happen.

## Benchmarking

Any change in performance is too small to benchmark.

```
cargo bench -p turbopack-bench -p turbopack-cli -- "hmr_to_eval/Turbopack CSR"
```

Manually increased the number of samples and execution time:

```
diff --git a/turbopack/crates/turbopack-bench/src/lib.rs b/turbopack/crates/turbopack-bench/src/lib.rs
index 4e3df12db0..e2f16fb0d6 100644
--- a/turbopack/crates/turbopack-bench/src/lib.rs
+++ b/turbopack/crates/turbopack-bench/src/lib.rs
@@ -127,8 +127,8 @@ enum CodeLocation {

 pub fn bench_hmr_to_eval(c: &mut Criterion, bundlers: &[Box<dyn Bundler>]) {
     let mut g = c.benchmark_group("bench_hmr_to_eval");
-    g.sample_size(10);
-    g.measurement_time(Duration::from_secs(60));
+    g.sample_size(50);
+    g.measurement_time(Duration::from_secs(300));

     bench_hmr_internal(g, CodeLocation::Evaluation, bundlers);
 }
```

Using a machine configured for low-noise: https://github.com/bgw/benchmark-scripts

**Before:**
```
bench_hmr_to_eval/Turbopack CSR/1000 modules
                        time:   [14.713 ms 14.779 ms 14.862 ms]
Found 1 outliers among 50 measurements (2.00%)
  1 (2.00%) high mild
```

**After:**
```
bench_hmr_to_eval/Turbopack CSR/1000 modules
                        time:   [14.732 ms 14.800 ms 14.886 ms]
                        change: [-1.1606% +0.1132% +1.5420%] (p = 0.86 > 0.05)
                        No change in performance detected.
Found 1 outliers among 50 measurements (2.00%)
  1 (2.00%) high mild
```