### PR TITLE
Ensure next-server prepare only execute once

### DIFF
--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -156,6 +156,7 @@ export default class NextNodeServer extends BaseServer<
   protected middlewareManifestPath: string
   private _serverDistDir: string | undefined
   private imageResponseCache?: ResponseCache
+  private registeredInstrumentation: boolean = false
   protected renderWorkersPromises?: Promise<void>
   protected dynamicRoutes?: {
     match: import('../shared/lib/router/utils/route-matcher').RouteMatchFn
@@ -324,6 +325,8 @@ export default class NextNodeServer extends BaseServer<
   }
 
   protected async runInstrumentationHookIfAvailable() {
+    if (this.registeredInstrumentation) return
+    this.registeredInstrumentation = true
     await this.instrumentation?.register?.()
   }
 

--- a/test/e2e/instrumentation-hook/register-once/instrumentation.js
+++ b/test/e2e/instrumentation-hook/register-once/instrumentation.js
@@ -1,5 +1,11 @@
+let count = 0
+
 export function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
+    if (count > 0) {
+      throw new Error('duplicated-register')
+    }
     console.log('register-log')
+    count++
   }
 }

--- a/test/e2e/instrumentation-hook/register-once/register-once.test.ts
+++ b/test/e2e/instrumentation-hook/register-once/register-once.test.ts
@@ -14,4 +14,10 @@ describe('instrumentation-hook - register-once', () => {
     await next.fetch('/foo')
     expect(next.cliOutput).toIncludeRepeated('register-log', 1)
   })
+
+  it('should not error when concurrent requests are made', async () => {
+    await Promise.all([next.fetch('/foo'), next.fetch('/foo')])
+    expect(next.cliOutput).toIncludeRepeated('register-log', 1)
+    expect(next.cliOutput).not.toInclude('duplicated-register')
+  })
 })


### PR DESCRIPTION
### What & Why

Reported by @agadzik that we're still seeing `register()` being called twice in preview deployment even after #67805, the error trace shows it's from `prepreImpl()` call in next server but we're lack of source map to see which exact line it was from.

Came up with this PR that adds another checking to ensure instrumentation `register()` is only called once for setup the instrumentation `register()`

Closes NDX-186



