### PR TITLE
chore(next-swc): avoid deleting .gitignore when running "clean" script

### DIFF
--- a/packages/next-swc/.gitignore
+++ b/packages/next-swc/.gitignore
@@ -1,0 +1,2 @@
+# Ignore build artifacts
+native/*

--- a/packages/next-swc/native/.gitignore
+++ b/packages/next-swc/native/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore


### PR DESCRIPTION
### What/Why

Running `pnpm clean` always removes the `packages/next-swc/native/.gitignore` file in `next-swc`, which is annoying because that's meant to stay checked in. This PR moves the `.gitignore` file out from the `native` directory to avoid this.

How to reproduce this problem:

```console
$ pnpm clean
<snip>

$ git status
<snip>
Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	deleted:    packages/next-swc/native/.gitignore
```
This is because the `clean` script just removes the entire `native` directory:
https://github.com/vercel/next.js/blob/a5e2a02f5a988d50a35fc2932b069dff5200e2c6/packages/next-swc/package.json#L6

so moving the `.gitignore` file out from there avoids this.