### PR TITLE
fix: avoid crashing test setup if "packages/next-swc/native" does not exist

### DIFF
--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -90,9 +90,9 @@ async function createNextInstall({
 
         const nativePath = path.join(origRepoDir, 'packages/next-swc/native')
 
-        const hasNativeBinary = fs
-          .readdirSync(nativePath)
-          .some((item) => item.endsWith('.node'))
+        const hasNativeBinary = fs.existsSync(nativePath)
+          ? fs.readdirSync(nativePath).some((item) => item.endsWith('.node'))
+          : false
 
         if (hasNativeBinary) {
           process.env.NEXT_TEST_NATIVE_DIR = nativePath


### PR DESCRIPTION
Follow up to #68624. Fixes a crash during test installation if `next-swc/native` doesn't exist (because it might have been deleted by `pnpm clean`)