### PR TITLE
fix(turbopack): correctly handle catchall specificity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4056,6 +4056,7 @@ name = "next-swc-napi"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-recursion",
  "backtrace",
  "dhat",
  "fxhash",

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -49,6 +49,7 @@ workspace = true
 
 [dependencies]
 anyhow = "1.0.66"
+async-recursion = { workspace = true }
 backtrace = "0.3"
 fxhash = "0.2.1"
 dhat = { workspace = true, optional = true }

--- a/crates/next-core/src/loader_tree.rs
+++ b/crates/next-core/src/loader_tree.rs
@@ -356,7 +356,7 @@ impl LoaderTreeBuilder {
     }
 
     #[async_recursion]
-    async fn walk_tree(&mut self, loader_tree: Vc<LoaderTree>, root: bool) -> Result<()> {
+    async fn walk_tree(&mut self, loader_tree: &LoaderTree, root: bool) -> Result<()> {
         use std::fmt::Write;
 
         let LoaderTree {
@@ -365,7 +365,7 @@ impl LoaderTreeBuilder {
             parallel_routes,
             components,
             global_metadata,
-        } = &*loader_tree.await?;
+        } = loader_tree;
 
         writeln!(
             self.loader_tree_code,
@@ -402,7 +402,7 @@ impl LoaderTreeBuilder {
         let components_code = replace(&mut self.loader_tree_code, temp_loader_tree_code);
 
         // add parallel_routes
-        for (key, &parallel_route) in parallel_routes.iter() {
+        for (key, parallel_route) in parallel_routes.iter() {
             write!(self.loader_tree_code, "{key}: ", key = StringifyJs(key))?;
             self.walk_tree(parallel_route, false).await?;
             writeln!(self.loader_tree_code, ",")?;
@@ -436,7 +436,7 @@ impl LoaderTreeBuilder {
             self.inner_assets.insert(GLOBAL_ERROR.into(), module);
         };
 
-        self.walk_tree(loader_tree, true).await?;
+        self.walk_tree(&*loader_tree.await?, true).await?;
         Ok(LoaderTreeModule {
             imports: self.imports,
             loader_tree_code: self.loader_tree_code.into(),

--- a/test/e2e/app-dir/catchall-specificity/app/(group)/specific/[[...slug]]/page.tsx
+++ b/test/e2e/app-dir/catchall-specificity/app/(group)/specific/[[...slug]]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Specific Page</div>
+}

--- a/test/e2e/app-dir/catchall-specificity/app/[[...slug]]/page.tsx
+++ b/test/e2e/app-dir/catchall-specificity/app/[[...slug]]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Generic Page</div>
+}

--- a/test/e2e/app-dir/catchall-specificity/app/layout.tsx
+++ b/test/e2e/app-dir/catchall-specificity/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/catchall-specificity/catchall-specificity.test.ts
+++ b/test/e2e/app-dir/catchall-specificity/catchall-specificity.test.ts
@@ -1,0 +1,19 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('catchall-specificity', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should match the generic catchall correctly', async () => {
+    const browser = await next.browser('/foo')
+
+    expect(await browser.elementByCss('body').text()).toContain('Generic Page')
+  })
+
+  it('should match the specific catchall correctly', async () => {
+    const browser = await next.browser('/specific')
+
+    expect(await browser.elementByCss('body').text()).toContain('Specific Page')
+  })
+})

--- a/test/e2e/app-dir/catchall-specificity/next.config.js
+++ b/test/e2e/app-dir/catchall-specificity/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
(generated by graphite)

### What?

Introduce `get_specificity` method to determine the specificity of routes.
This facilitates more accurate route matching for catchall routes by comparing route specificity.
Modify existing route matching logic to incorporate specificity checks and avoid route conflicts.
Add corresponding tests to validate the new specificity handling mechanism.

Fixes #67045
Closes PACK-3154
