### PR TITLE
refactor: fallback updates

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -200,6 +200,7 @@ import {
 import { storeShuttle } from './flying-shuttle/store-shuttle'
 import { stitchBuilds } from './flying-shuttle/stitch-builds'
 import { inlineStaticEnv } from './flying-shuttle/inline-static-env'
+import { FallbackMode } from '../lib/fallback'
 
 interface ExperimentalBypassForInfo {
   experimentalBypassFor?: RouteHas[]
@@ -2130,9 +2131,15 @@ export default async function build(
                             )
                           }
 
-                          if (workerResult.prerenderFallback === 'blocking') {
+                          if (
+                            workerResult.prerenderFallback ===
+                            FallbackMode.BLOCKING_RENDER
+                          ) {
                             ssgBlockingFallbackPages.add(page)
-                          } else if (workerResult.prerenderFallback === true) {
+                          } else if (
+                            workerResult.prerenderFallback ===
+                            FallbackMode.SERVE_PRERENDER
+                          ) {
                             ssgStaticFallbackPages.add(page)
                           }
                         } else if (workerResult.hasServerProps) {

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2078,7 +2078,11 @@ export default async function build(
                             }
                           }
 
-                          if (workerResult.prerenderFallback) {
+                          if (
+                            workerResult.prerenderFallbackMode !== undefined &&
+                            workerResult.prerenderFallbackMode !==
+                              FallbackMode.NOT_FOUND
+                          ) {
                             // whether or not to allow requests for paths not
                             // returned from generateStaticParams
                             appDynamicParamPaths.add(originalAppPath)
@@ -2132,13 +2136,13 @@ export default async function build(
                           }
 
                           if (
-                            workerResult.prerenderFallback ===
-                            FallbackMode.BLOCKING_RENDER
+                            workerResult.prerenderFallbackMode ===
+                            FallbackMode.BLOCKING_STATIC_RENDER
                           ) {
                             ssgBlockingFallbackPages.add(page)
                           } else if (
-                            workerResult.prerenderFallback ===
-                            FallbackMode.SERVE_PRERENDER
+                            workerResult.prerenderFallbackMode ===
+                            FallbackMode.STATIC_PRERENDER
                           ) {
                             ssgStaticFallbackPages.add(page)
                           }

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -90,6 +90,12 @@ import { formatDynamicImportPath } from '../lib/format-dynamic-import-path'
 import { isInterceptionRouteAppPath } from '../server/lib/interception-routes'
 import { checkIsRoutePPREnabled } from '../server/lib/experimental/ppr'
 import type { Params } from '../client/components/params'
+import { FallbackMode } from '../lib/fallback'
+import {
+  fallbackToStaticPathsResult,
+  parseFallbackAppConfig,
+  parseFallbackStaticPathsResult,
+} from '../lib/fallback'
 
 export type ROUTER_TYPE = 'pages' | 'app'
 
@@ -945,7 +951,7 @@ export type PrerenderedRoute = {
 }
 
 export type StaticPathsResult = {
-  fallback: boolean | 'blocking'
+  fallback: FallbackMode
   prerenderedRoutes: PrerenderedRoute[]
 }
 
@@ -1172,7 +1178,7 @@ export async function buildStaticPaths({
   const seen = new Set<string>()
 
   return {
-    fallback: staticPathsResult.fallback,
+    fallback: parseFallbackStaticPathsResult(staticPathsResult.fallback),
     prerenderedRoutes: prerenderRoutes.filter((route) => {
       if (seen.has(route.path)) return false
 
@@ -1345,6 +1351,7 @@ export async function buildAppStaticPaths({
   requestHeaders,
   maxMemoryCacheSize,
   fetchCacheKeyPrefix,
+  nextConfigOutput,
   ComponentMod,
 }: {
   dir: string
@@ -1357,6 +1364,7 @@ export async function buildAppStaticPaths({
   cacheHandler?: string
   maxMemoryCacheSize?: number
   requestHeaders: IncrementalCache['requestHeaders']
+  nextConfigOutput: 'standalone' | 'export' | undefined
   ComponentMod: AppPageModule
 }): Promise<PartialStaticPathsResult> {
   ComponentMod.patchFetch()
@@ -1479,27 +1487,29 @@ export async function buildAppStaticPaths({
         }
 
         const builtParams = await buildParams()
-        const fallback = !generateParams.some(
-          // TODO: dynamic params should be allowed
-          // to be granular per segment but we need
-          // additional information stored/leveraged in
-          // the prerender-manifest to allow this behavior
-          (generate) => generate.config?.dynamicParams === false
+        const fallback = parseFallbackAppConfig(
+          reduceAppConfig(generateParams, nextConfigOutput)
         )
+
+        if (
+          fallback === FallbackMode.BLOCKING_RENDER &&
+          nextConfigOutput === 'export'
+        ) {
+          throw new Error(
+            '"dynamicParams: true" cannot be used with "output: export". See more info here: https://nextjs.org/docs/app/building-your-application/deploying/static-exports'
+          )
+        }
 
         if (!hadAllParamsGenerated) {
           return {
-            fallback:
-              process.env.NODE_ENV === 'production' && isDynamicRoute(page)
-                ? true
-                : undefined,
+            fallback,
             prerenderedRoutes: undefined,
           }
         }
 
         return buildStaticPaths({
           staticPathsResult: {
-            fallback,
+            fallback: fallbackToStaticPathsResult(fallback),
             paths: builtParams.map((params) => ({ params })),
           },
           page,
@@ -1519,7 +1529,7 @@ type PageIsStaticResult = {
   hasServerProps?: boolean
   hasStaticProps?: boolean
   prerenderedRoutes: PrerenderedRoute[] | undefined
-  prerenderFallback: boolean | 'blocking' | undefined
+  prerenderFallback: FallbackMode | undefined
   isNextImageImported?: boolean
   traceIncludes?: string[]
   traceExcludes?: string[]
@@ -1542,6 +1552,7 @@ export async function isPageStatic({
   originalAppPath,
   isrFlushToDisk,
   maxMemoryCacheSize,
+  nextConfigOutput,
   cacheHandler,
   pprConfig,
 }: {
@@ -1561,7 +1572,7 @@ export async function isPageStatic({
   isrFlushToDisk?: boolean
   maxMemoryCacheSize?: number
   cacheHandler?: string
-  nextConfigOutput: 'standalone' | 'export'
+  nextConfigOutput: 'standalone' | 'export' | undefined
   pprConfig: ExperimentalPPRConfig | undefined
 }): Promise<PageIsStaticResult> {
   const isPageStaticSpan = trace('is-page-static-utils', parentId)
@@ -1576,7 +1587,7 @@ export async function isPageStatic({
 
       let componentsResult: LoadComponentsReturnType
       let prerenderedRoutes: PrerenderedRoute[] | undefined
-      let prerenderFallback: boolean | 'blocking' | undefined
+      let prerenderFallback: FallbackMode | undefined
       let appConfig: AppConfig = {}
       let isClientComponent: boolean = false
       const pathIsEdgeRuntime = isEdgeRuntime(pageRuntime)
@@ -1649,7 +1660,7 @@ export async function isPageStatic({
               ]
             : await collectGenerateParams(tree)
 
-        appConfig = reduceAppConfig(generateParams)
+        appConfig = reduceAppConfig(generateParams, nextConfigOutput)
 
         if (appConfig.dynamic === 'force-static' && pathIsEdgeRuntime) {
           Log.warn(
@@ -1685,6 +1696,7 @@ export async function isPageStatic({
               maxMemoryCacheSize,
               cacheHandler,
               ComponentMod,
+              nextConfigOutput,
             }))
         }
       } else {
@@ -1778,50 +1790,75 @@ export async function isPageStatic({
     })
 }
 
-function reduceAppConfig(generateParams: GenerateParamsResults): AppConfig {
-  return generateParams.reduce(
-    (builtConfig: AppConfig, curGenParams): AppConfig => {
-      const {
-        dynamic,
-        fetchCache,
-        preferredRegion,
-        revalidate: curRevalidate,
-        experimental_ppr,
-      } = curGenParams?.config || {}
+function reduceAppConfig(
+  generateParams: GenerateParamsResults,
+  nextConfigOutput: 'standalone' | 'export' | undefined
+): AppConfig {
+  return generateParams.reduce<AppConfig>((builtConfig, curGenParams) => {
+    const {
+      dynamic,
+      fetchCache,
+      preferredRegion,
+      revalidate: curRevalidate,
+      experimental_ppr,
+      dynamicParams,
+    } = curGenParams?.config || {}
 
-      // TODO: should conflicting configs here throw an error
-      // e.g. if layout defines one region but page defines another
-      if (typeof builtConfig.preferredRegion === 'undefined') {
-        builtConfig.preferredRegion = preferredRegion
-      }
-      if (typeof builtConfig.dynamic === 'undefined') {
-        builtConfig.dynamic = dynamic
-      }
-      if (typeof builtConfig.fetchCache === 'undefined') {
-        builtConfig.fetchCache = fetchCache
-      }
-      // If partial prerendering has been set, only override it if the current value is
-      // provided as it's resolved from root layout to leaf page.
-      if (typeof experimental_ppr !== 'undefined') {
-        builtConfig.experimental_ppr = experimental_ppr
-      }
+    // TODO: should conflicting configs here throw an error
+    // e.g. if layout defines one region but page defines another
+    if (typeof builtConfig.preferredRegion === 'undefined') {
+      builtConfig.preferredRegion = preferredRegion
+    }
+    if (typeof builtConfig.dynamic === 'undefined') {
+      builtConfig.dynamic = dynamic
+    }
+    if (typeof builtConfig.fetchCache === 'undefined') {
+      builtConfig.fetchCache = fetchCache
+    }
+    // If partial prerendering has been set, only override it if the current value is
+    // provided as it's resolved from root layout to leaf page.
+    if (typeof experimental_ppr !== 'undefined') {
+      builtConfig.experimental_ppr = experimental_ppr
+    }
 
-      // any revalidate number overrides false
-      // shorter revalidate overrides longer (initially)
-      if (typeof builtConfig.revalidate === 'undefined') {
-        builtConfig.revalidate = curRevalidate
-      }
+    // any revalidate number overrides false
+    // shorter revalidate overrides longer (initially)
+    if (typeof builtConfig.revalidate === 'undefined') {
+      builtConfig.revalidate = curRevalidate
+    }
+
+    if (
+      typeof curRevalidate === 'number' &&
+      (typeof builtConfig.revalidate !== 'number' ||
+        curRevalidate < builtConfig.revalidate)
+    ) {
+      builtConfig.revalidate = curRevalidate
+    }
+
+    // The default for the dynamicParams will be based on the dynamic config
+    // and the next config output option. If any of these are set or the
+    // output config is set to export, set the dynamicParams to false,
+    // otherwise the default is true.
+    if (typeof builtConfig.dynamicParams === 'undefined') {
       if (
-        typeof curRevalidate === 'number' &&
-        (typeof builtConfig.revalidate !== 'number' ||
-          curRevalidate < builtConfig.revalidate)
+        builtConfig.dynamic === 'error' ||
+        builtConfig.dynamic === 'force-static' ||
+        nextConfigOutput === 'export'
       ) {
-        builtConfig.revalidate = curRevalidate
+        builtConfig.dynamicParams = false
+      } else {
+        builtConfig.dynamicParams = true
       }
-      return builtConfig
-    },
-    {}
-  )
+    }
+
+    // If the dynamicParams is explicitly set to false, we should not
+    // dynamically generate params for this page.
+    if (dynamicParams === false) {
+      builtConfig.dynamicParams = false
+    }
+
+    return builtConfig
+  }, {})
 }
 
 export async function hasCustomGetInitialProps({

--- a/packages/next/src/lib/fallback.ts
+++ b/packages/next/src/lib/fallback.ts
@@ -1,28 +1,26 @@
-import type { AppConfig } from '../build/utils'
-
 /**
  * Describes the different fallback modes that a given page can have.
  */
 export const enum FallbackMode {
   /**
-   * A BLOCKING_RENDER fallback will block the request until the page is\
+   * A BLOCKING_STATIC_RENDER fallback will block the request until the page is
    * generated. No fallback page will be rendered, and users will have to wait
    * to render the page.
    */
-  BLOCKING_RENDER = 'BLOCKING_RENDER',
-
-  /**
-   * When set to NOT_FOUND, pages that are not already prerendered will result
-   * in a not found response.
-   */
-  NOT_FOUND = 'NOT_FOUND',
+  BLOCKING_STATIC_RENDER = 'BLOCKING_STATIC_RENDER',
 
   /**
    * When set to PRERENDER, a fallback page will be sent to users in place of
    * forcing them to wait for the page to be generated. This allows the user to
    * see a rendered page earlier.
    */
-  SERVE_PRERENDER = 'SERVE_PRERENDER',
+  STATIC_PRERENDER = 'STATIC_PRERENDER',
+
+  /**
+   * When set to NOT_FOUND, pages that are not already prerendered will result
+   * in a not found response.
+   */
+  NOT_FOUND = 'NOT_FOUND',
 }
 
 /**
@@ -37,14 +35,20 @@ export type GetStaticPathsFallback = boolean | 'blocking'
  * @returns The fallback mode.
  */
 export function parseFallbackField(
-  fallbackField: string | false | null
-): FallbackMode {
+  fallbackField: string | false | null | undefined
+): FallbackMode | undefined {
   if (typeof fallbackField === 'string') {
-    return FallbackMode.SERVE_PRERENDER
+    return FallbackMode.STATIC_PRERENDER
   } else if (fallbackField === null) {
-    return FallbackMode.BLOCKING_RENDER
-  } else {
+    return FallbackMode.BLOCKING_STATIC_RENDER
+  } else if (fallbackField === false) {
     return FallbackMode.NOT_FOUND
+  } else if (fallbackField === undefined) {
+    return undefined
+  } else {
+    throw new Error(
+      `Invalid fallback option: ${fallbackField}. Fallback option must be a string, null, undefined, or false.`
+    )
   }
 }
 
@@ -58,9 +62,9 @@ export function parseFallbackStaticPathsResult(
   result: GetStaticPathsFallback
 ): FallbackMode {
   if (result === true) {
-    return FallbackMode.SERVE_PRERENDER
+    return FallbackMode.STATIC_PRERENDER
   } else if (result === 'blocking') {
-    return FallbackMode.BLOCKING_RENDER
+    return FallbackMode.BLOCKING_STATIC_RENDER
   } else {
     return FallbackMode.NOT_FOUND
   }
@@ -76,26 +80,12 @@ export function fallbackToStaticPathsResult(
   fallback: FallbackMode
 ): GetStaticPathsFallback {
   switch (fallback) {
-    case FallbackMode.SERVE_PRERENDER:
+    case FallbackMode.STATIC_PRERENDER:
       return true
-    case FallbackMode.BLOCKING_RENDER:
+    case FallbackMode.BLOCKING_STATIC_RENDER:
       return 'blocking'
     case FallbackMode.NOT_FOUND:
     default:
       return false
-  }
-}
-
-/**
- * Parses the fallback field from the app config.
- *
- * @param appConfig The app config.
- * @returns The fallback mode.
- */
-export function parseFallbackAppConfig(appConfig: AppConfig): FallbackMode {
-  if (appConfig.dynamicParams === false) {
-    return FallbackMode.NOT_FOUND
-  } else {
-    return FallbackMode.BLOCKING_RENDER
   }
 }

--- a/packages/next/src/lib/fallback.ts
+++ b/packages/next/src/lib/fallback.ts
@@ -1,0 +1,101 @@
+import type { AppConfig } from '../build/utils'
+
+/**
+ * Describes the different fallback modes that a given page can have.
+ */
+export const enum FallbackMode {
+  /**
+   * A BLOCKING_RENDER fallback will block the request until the page is\
+   * generated. No fallback page will be rendered, and users will have to wait
+   * to render the page.
+   */
+  BLOCKING_RENDER = 'BLOCKING_RENDER',
+
+  /**
+   * When set to NOT_FOUND, pages that are not already prerendered will result
+   * in a not found response.
+   */
+  NOT_FOUND = 'NOT_FOUND',
+
+  /**
+   * When set to PRERENDER, a fallback page will be sent to users in place of
+   * forcing them to wait for the page to be generated. This allows the user to
+   * see a rendered page earlier.
+   */
+  SERVE_PRERENDER = 'SERVE_PRERENDER',
+}
+
+/**
+ * The fallback value returned from the `getStaticPaths` function.
+ */
+export type GetStaticPathsFallback = boolean | 'blocking'
+
+/**
+ * Parses the fallback field from the prerender manifest.
+ *
+ * @param fallbackField The fallback field from the prerender manifest.
+ * @returns The fallback mode.
+ */
+export function parseFallbackField(
+  fallbackField: string | false | null
+): FallbackMode {
+  if (typeof fallbackField === 'string') {
+    return FallbackMode.SERVE_PRERENDER
+  } else if (fallbackField === null) {
+    return FallbackMode.BLOCKING_RENDER
+  } else {
+    return FallbackMode.NOT_FOUND
+  }
+}
+
+/**
+ * Parses the fallback from the static paths result.
+ *
+ * @param result The result from the static paths function.
+ * @returns The fallback mode.
+ */
+export function parseFallbackStaticPathsResult(
+  result: GetStaticPathsFallback
+): FallbackMode {
+  if (result === true) {
+    return FallbackMode.SERVE_PRERENDER
+  } else if (result === 'blocking') {
+    return FallbackMode.BLOCKING_RENDER
+  } else {
+    return FallbackMode.NOT_FOUND
+  }
+}
+
+/**
+ * Converts the fallback mode to a static paths result.
+ *
+ * @param fallback The fallback mode.
+ * @returns The static paths fallback result.
+ */
+export function fallbackToStaticPathsResult(
+  fallback: FallbackMode
+): GetStaticPathsFallback {
+  switch (fallback) {
+    case FallbackMode.SERVE_PRERENDER:
+      return true
+    case FallbackMode.BLOCKING_RENDER:
+      return 'blocking'
+    case FallbackMode.NOT_FOUND:
+    default:
+      return false
+  }
+}
+
+/**
+ * Parses the fallback field from the app config.
+ *
+ * @param appConfig The app config.
+ * @returns The fallback mode.
+ */
+export function parseFallbackAppConfig(appConfig: AppConfig): FallbackMode {
+  if (appConfig.dynamicParams === false) {
+    return FallbackMode.NOT_FOUND
+  } else {
+    return FallbackMode.BLOCKING_RENDER
+  }
+}

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -170,7 +170,7 @@ export default class DevServer extends Server {
       // 5MB
       max: 5 * 1024 * 1024,
       length(value) {
-        return JSON.stringify(value.staticPaths).length
+        return JSON.stringify(value.staticPaths)?.length ?? 0
       },
     })
     this.renderOpts.ampSkipValidation =
@@ -787,13 +787,14 @@ export default class DevServer extends Server {
       []
     )
       .then((res) => {
-        const { prerenderedRoutes: staticPaths = [], fallback } = res.value
+        const { prerenderedRoutes: staticPaths, fallbackMode: fallback } =
+          res.value
         if (!isAppPath && this.nextConfig.output === 'export') {
-          if (fallback === FallbackMode.BLOCKING_RENDER) {
+          if (fallback === FallbackMode.BLOCKING_STATIC_RENDER) {
             throw new Error(
               'getStaticPaths with "fallback: blocking" cannot be used with "output: export". See more info here: https://nextjs.org/docs/advanced-features/static-html-export'
             )
-          } else if (fallback === FallbackMode.SERVE_PRERENDER) {
+          } else if (fallback === FallbackMode.STATIC_PRERENDER) {
             throw new Error(
               'getStaticPaths with "fallback: true" cannot be used with "output: export". See more info here: https://nextjs.org/docs/advanced-features/static-html-export'
             )
@@ -801,11 +802,11 @@ export default class DevServer extends Server {
         }
 
         const value: {
-          staticPaths: string[]
-          fallbackMode: FallbackMode
+          staticPaths: string[] | undefined
+          fallbackMode: FallbackMode | undefined
         } = {
-          staticPaths: staticPaths.map((route) => route.path),
-          fallbackMode: fallback ?? FallbackMode.NOT_FOUND,
+          staticPaths: staticPaths?.map((route) => route.path),
+          fallbackMode: fallback,
         }
         this.staticPathsCache.set(pathname, value)
         return value

--- a/packages/next/src/server/dev/static-paths-worker.ts
+++ b/packages/next/src/server/dev/static-paths-worker.ts
@@ -41,6 +41,7 @@ export async function loadStaticPaths({
   maxMemoryCacheSize,
   requestHeaders,
   cacheHandler,
+  nextConfigOutput,
 }: {
   dir: string
   distDir: string
@@ -56,6 +57,7 @@ export async function loadStaticPaths({
   maxMemoryCacheSize?: number
   requestHeaders: IncrementalCache['requestHeaders']
   cacheHandler?: string
+  nextConfigOutput: 'standalone' | 'export' | undefined
 }): Promise<PartialStaticPathsResult> {
   // update work memory runtime-config
   require('../../shared/lib/runtime-config.external').setConfig(config)
@@ -107,6 +109,7 @@ export async function loadStaticPaths({
       fetchCacheKeyPrefix,
       maxMemoryCacheSize,
       ComponentMod: components.ComponentMod,
+      nextConfigOutput,
     })
   }
 

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -18,6 +18,7 @@ import type {
   NextApiRequest,
   NextApiHandler,
 } from './shared/lib/utils'
+import type { GetStaticPathsFallback } from './lib/fallback'
 
 import type { NextApiRequestCookies } from './server/api-utils'
 
@@ -220,7 +221,7 @@ export type GetStaticPathsResult<
   Params extends ParsedUrlQuery = ParsedUrlQuery,
 > = {
   paths: Array<string | { params: Params; locale?: string }>
-  fallback: boolean | 'blocking'
+  fallback: GetStaticPathsFallback
 }
 
 /**

--- a/test/integration/app-dir-export/test/dynamic-missing-gsp-dev.test.ts
+++ b/test/integration/app-dir-export/test/dynamic-missing-gsp-dev.test.ts
@@ -14,6 +14,16 @@ describe('app dir - with output export - dynamic missing gsp dev', () => {
         })
       })
 
+      it('should error when dynamic route is set to true', async () => {
+        await runTests({
+          isDev: true,
+          dynamicPage: 'undefined',
+          dynamicParams: 'true',
+          expectedErrMsg:
+            '"dynamicParams: true" cannot be used with "output: export". See more info here: https://nextjs.org/docs/app/building-your-application/deploying/static-exports',
+        })
+      })
+
       it('should error when client component has generateStaticParams', async () => {
         const expectedErrMsg = process.env.TURBOPACK_DEV
           ? 'Page "test/integration/app-dir-export/app/another/[slug]/page.js" cannot use both "use client" and export function "generateStaticParams()".'

--- a/test/integration/app-dir-export/test/utils.ts
+++ b/test/integration/app-dir-export/test/utils.ts
@@ -106,6 +106,7 @@ export async function runTests({
   isDev = false,
   trailingSlash = true,
   dynamicPage,
+  dynamicParams,
   dynamicApiRoute,
   generateStaticParamsOpt,
   expectedErrMsg,
@@ -113,6 +114,7 @@ export async function runTests({
   isDev?: boolean
   trailingSlash?: boolean
   dynamicPage?: string
+  dynamicParams?: string
   dynamicApiRoute?: string
   generateStaticParamsOpt?: 'set noop' | 'set client'
   expectedErrMsg?: string
@@ -129,12 +131,18 @@ export async function runTests({
       `const dynamic = ${dynamicPage}`
     )
   }
+
   if (dynamicApiRoute !== undefined) {
     apiJson.replace(
       `const dynamic = 'force-static'`,
       `const dynamic = ${dynamicApiRoute}`
     )
   }
+
+  if (dynamicParams !== undefined) {
+    slugPage.prepend(`export const dynamicParams = ${dynamicParams}\n`)
+  }
+
   if (generateStaticParamsOpt === 'set noop') {
     slugPage.replace('export function generateStaticParams', 'function noop')
   } else if (generateStaticParamsOpt === 'set client') {


### PR DESCRIPTION
This changes the internals to use an enum for the fallback mode instead of passing around `boolean | string` which required knowledge to understand what it meant. The enum values are now more verbose to aid in readability.