### PR TITLE
Ensure we hard error on invalid middleware config export

### DIFF
--- a/packages/next/src/build/analysis/extract-const-value.ts
+++ b/packages/next/src/build/analysis/extract-const-value.ts
@@ -12,6 +12,7 @@ import type {
   RegExpLiteral,
   StringLiteral,
   TemplateLiteral,
+  TsSatisfiesExpression,
   VariableDeclaration,
 } from '@swc/core'
 
@@ -63,6 +64,10 @@ function isRegExpLiteral(node: Node): node is RegExpLiteral {
 
 function isTemplateLiteral(node: Node): node is TemplateLiteral {
   return node.type === 'TemplateLiteral'
+}
+
+function isTsSatisfiesExpression(node: Node): node is TsSatisfiesExpression {
+  return node.type === 'TsSatisfiesExpression'
 }
 
 export class UnsupportedValueError extends Error {
@@ -194,6 +199,8 @@ function extractValue(node: Node, path?: string[]): any {
     const [{ cooked, raw }] = node.quasis
 
     return cooked ?? raw
+  } else if (isTsSatisfiesExpression(node)) {
+    return extractValue(node.expression)
   } else {
     throw new UnsupportedValueError(
       `Unsupported node type "${node.type}"`,

--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -444,29 +444,20 @@ function warnAboutExperimentalEdge(apiRoute: string | null) {
   apiRouteWarnings.set(apiRoute, 1)
 }
 
-const warnedUnsupportedValueMap = new LRUCache<string, boolean>({ max: 250 })
-
 function warnAboutUnsupportedValue(
   pageFilePath: string,
   page: string | undefined,
   error: UnsupportedValueError
 ) {
-  if (warnedUnsupportedValueMap.has(pageFilePath)) {
-    return
-  }
-
-  Log.warn(
+  throw new Error(
     `Next.js can't recognize the exported \`config\` field in ` +
       (page ? `route "${page}"` : `"${pageFilePath}"`) +
       ':\n' +
       error.message +
       (error.path ? ` at "${error.path}"` : '') +
       '.\n' +
-      'The default config will be used instead.\n' +
       'Read More - https://nextjs.org/docs/messages/invalid-page-config'
   )
-
-  warnedUnsupportedValueMap.set(pageFilePath, true)
 }
 
 /**

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -100,7 +100,10 @@ import {
 } from '../telemetry/events'
 import type { EventBuildFeatureUsage } from '../telemetry/events'
 import { Telemetry } from '../telemetry/storage'
-import { getPageStaticInfo } from './analysis/get-page-static-info'
+import {
+  getPageStaticInfo,
+  hadUnsupportedValue,
+} from './analysis/get-page-static-info'
 import { createPagesMapping, getPageFromPath, sortByPageExts } from './entries'
 import { PAGE_TYPES } from '../lib/page-types'
 import { generateBuildId } from './generate-build-id'
@@ -2302,6 +2305,13 @@ export default async function build(
               })
             })
         )
+
+        if (hadUnsupportedValue) {
+          Log.error(
+            `Invalid config value exports detected, these can cause unexpected behavior from the configs not being applied. Please fix them to continue`
+          )
+          process.exit(1)
+        }
 
         const errorPageResult = await errorPageStaticResult
         const nonStaticErrorPage =

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -293,7 +293,9 @@ describe('middleware - development errors', () => {
 
       await check(() => {
         expect(next.cliOutput).toContain(`Expected '{', got '}'`)
-        expect(next.cliOutput.split(`Expected '{', got '}'`).length).toEqual(2)
+        expect(
+          next.cliOutput.split(`Expected '{', got '}'`).length
+        ).toBeGreaterThanOrEqual(2)
         return 'success'
       }, 'success')
     })

--- a/test/production/exported-runtimes-value-validation/index.test.ts
+++ b/test/production/exported-runtimes-value-validation/index.test.ts
@@ -86,7 +86,7 @@ describe('Exported runtimes value validation', () => {
     // Unknown Expression Type
     expect(result.stderr).toEqual(
       expect.stringContaining(
-        'Next.js can\'t recognize the exported `config` field in route "/unsupported-value-type"'
+        "Next.js can't recognize the exported `config` field in route"
       )
     )
     expect(result.stderr).toEqual(

--- a/test/production/exported-runtimes-value-validation/index.test.ts
+++ b/test/production/exported-runtimes-value-validation/index.test.ts
@@ -25,7 +25,7 @@ describe('Exported runtimes value validation', () => {
 
     console.log(result.stderr, result.stdout)
 
-    // The build should fail if we have invalid config
+    // The build should fail to prevent unexpected behavior
     expect(result.code).toBe(1)
 
     // Template Literal with Expressions
@@ -86,7 +86,7 @@ describe('Exported runtimes value validation', () => {
     // Unknown Expression Type
     expect(result.stderr).toEqual(
       expect.stringContaining(
-        "Next.js can't recognize the exported `config` field in route"
+        'Next.js can\'t recognize the exported `config` field in route "/unsupported-value-type"'
       )
     )
     expect(result.stderr).toEqual(
@@ -97,7 +97,7 @@ describe('Exported runtimes value validation', () => {
     // Unknown Object Key
     expect(result.stderr).toEqual(
       expect.stringContaining(
-        "Next.js can't recognize the exported `config` field in route"
+        'Next.js can\'t recognize the exported `config` field in route "/unsupported-object-key"'
       )
     )
     expect(result.stderr).toEqual(

--- a/test/production/exported-runtimes-value-validation/index.test.ts
+++ b/test/production/exported-runtimes-value-validation/index.test.ts
@@ -25,8 +25,8 @@ describe('Exported runtimes value validation', () => {
 
     console.log(result.stderr, result.stdout)
 
-    // The build should still succeed with invalid config being ignored
-    expect(result.code).toBe(0)
+    // The build should fail if we have invalid config
+    expect(result.code).toBe(1)
 
     // Template Literal with Expressions
     expect(result.stderr).toEqual(
@@ -97,7 +97,7 @@ describe('Exported runtimes value validation', () => {
     // Unknown Object Key
     expect(result.stderr).toEqual(
       expect.stringContaining(
-        'Next.js can\'t recognize the exported `config` field in route "/unsupported-object-key"'
+        "Next.js can't recognize the exported `config` field in route"
       )
     )
     expect(result.stderr).toEqual(

--- a/test/production/middleware-typescript/app/middleware.ts
+++ b/test/production/middleware-typescript/app/middleware.ts
@@ -25,7 +25,7 @@ export const middleware: NextMiddleware = function (request) {
 }
 
 export const config = {
-  matcher: [],
+  matcher: ['/:path*'],
   regions: [],
   unstable_allowDynamicGlobs: undefined,
 } satisfies MiddlewareConfig


### PR DESCRIPTION
Currently we only log warnings when we fail to parse config values and then fall back to their defaults, this is very dangerous as this can cause unexpected behavior and the warning log can be easy to miss. To prevent this unexpected behavior this updates to treat these as errors instead and fails the build if any invalid config exports are provided.  

x-ref: NDX-190