### PR TITLE
Stop mangling server runtime in dev

### DIFF
--- a/packages/next/webpack.config.js
+++ b/packages/next/webpack.config.js
@@ -173,6 +173,7 @@ module.exports = ({ dev, turbo, bundleType, experimental }) => {
             format: {
               preamble: '',
             },
+            mangle: dev ? false : true,
           },
         }),
       ],


### PR DESCRIPTION
The server runtimes are currently all bundled in production mode with full optimizaitons. This can make certain things hard in dev mode because while most of your app will be unmangled anything that runs from the server runtime will be runnign without useful debug information like original function names. This PR updates the runtime configs to no longer mangle the output.