### PR TITLE
fix app router prefetch deduping

### DIFF
--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -148,8 +148,11 @@ function prefetch(
   }
 
   // We should only dedupe requests when experimental.optimisticClientCache is
-  // disabled.
-  if (!options.bypassPrefetchedCheck) {
+  // disabled & when we're not using the app router. App router handles
+  // reusing an existing prefetch entry (if it exists) for the same URL.
+  // If we dedupe in here, we will cause a race where different prefetch kinds
+  // to the same URL (ie auto vs true) will cause one to be ignored.
+  if (!options.bypassPrefetchedCheck && !isAppRouter) {
     const locale =
       // Let the link's locale prop override the default router locale.
       typeof options.locale !== 'undefined'

--- a/test/e2e/app-dir/app-prefetch/app/prefetch-race/page.js
+++ b/test/e2e/app-dir/app-prefetch/app/prefetch-race/page.js
@@ -1,0 +1,19 @@
+import Link from 'next/link'
+import React from 'react'
+
+export default function Page() {
+  return (
+    <>
+      <div>
+        <Link href="/force-dynamic/test-page">
+          /force-dynamic/test-page (prefetch: auto)
+        </Link>
+      </div>
+      <div>
+        <Link href="/force-dynamic/test-page" prefetch>
+          /force-dynamic/test-page (prefetch: true)
+        </Link>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
The `Link` component has built in prefetch deduping behavior that was added for pages router, since pages only supports a single kind of prefetch.

Both pages & app routers share the `Link` component, meaning the deduping behavior was enabled for both. However, app router supports different [prefetch types](https://nextjs.org/docs/app/api-reference/components/link#prefetch). This means that if a page contains a link to a URL with auto prefetching, followed by a URL with `prefetch={true}`, the full prefetch would not be applied because it was short-circuited by `Link`.

Closes NDX-124