### PR TITLE
feat(turbopack): Allow type-only import of `usePathname`

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -386,6 +386,15 @@ fn collect_top_level_directives_and_imports(
                 let specifiers = import
                     .specifiers
                     .iter()
+                    .filter(|specifier| {
+                        !matches!(
+                            specifier,
+                            ImportSpecifier::Named(ImportNamedSpecifier {
+                                is_type_only: true,
+                                ..
+                            })
+                        )
+                    })
                     .map(|specifier| match specifier {
                         ImportSpecifier::Named(named) => match &named.imported {
                             Some(imported) => match &imported {

--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -377,7 +377,11 @@ fn collect_top_level_directives_and_imports(
                     }
                 }
             }
-            ModuleItem::ModuleDecl(ModuleDecl::Import(import)) => {
+            ModuleItem::ModuleDecl(ModuleDecl::Import(
+                import @ ImportDecl {
+                    type_only: false, ..
+                },
+            )) => {
                 let source = import.src.value.clone();
                 let specifiers = import
                     .specifiers
@@ -561,7 +565,6 @@ impl ReactServerComponentValidator {
     // assert_invalid_server_lib_apis("react", import)
     // assert_invalid_server_lib_apis("react-dom", import)
     fn assert_invalid_server_lib_apis(&self, import_source: String, import: &ModuleImports) {
-        // keys of invalid_server_lib_apis_mapping
         let invalid_apis = self
             .invalid_server_lib_apis_mapping
             .get(import_source.as_str());

--- a/crates/next-custom-transforms/tests/fixture.rs
+++ b/crates/next-custom-transforms/tests/fixture.rs
@@ -309,6 +309,28 @@ fn shake_exports_fixture_default(input: PathBuf) {
     );
 }
 
+#[fixture("tests/fixture/react-server-components/**/input.ts")]
+fn react_server_components_typescript(input: PathBuf) {
+    use next_custom_transforms::transforms::react_server_components::{Config, Options};
+    let output = input.parent().unwrap().join("output.ts");
+    test_fixture(
+        Syntax::Typescript(Default::default()),
+        &|tr| {
+            server_components(
+                FileName::Real(PathBuf::from("/some-project/src/some-file.js")),
+                Config::WithOptions(Options {
+                    is_react_server_layer: true,
+                }),
+                tr.comments.as_ref().clone(),
+                None,
+            )
+        },
+        &input,
+        &output,
+        Default::default(),
+    );
+}
+
 #[fixture("tests/fixture/react-server-components/server-graph/**/input.js")]
 fn react_server_components_server_graph_fixture(input: PathBuf) {
     use next_custom_transforms::transforms::react_server_components::{Config, Options};

--- a/crates/next-custom-transforms/tests/fixture/react-server-components/pack-3186/input.ts
+++ b/crates/next-custom-transforms/tests/fixture/react-server-components/pack-3186/input.ts
@@ -1,2 +1,2 @@
-// This
+// This fails if the `type` keyword is removed
 import { type usePathname } from 'next/navigation'

--- a/crates/next-custom-transforms/tests/fixture/react-server-components/pack-3186/input.ts
+++ b/crates/next-custom-transforms/tests/fixture/react-server-components/pack-3186/input.ts
@@ -1,0 +1,2 @@
+// This
+import { type usePathname } from 'next/navigation'

--- a/crates/next-custom-transforms/tests/fixture/react-server-components/pack-3186/output.ts
+++ b/crates/next-custom-transforms/tests/fixture/react-server-components/pack-3186/output.ts
@@ -1,2 +1,2 @@
-// This fails if the `type` keyword is removed 
+// This fails if the `type` keyword is removed
 import { type usePathname } from 'next/navigation';

--- a/crates/next-custom-transforms/tests/fixture/react-server-components/pack-3186/output.ts
+++ b/crates/next-custom-transforms/tests/fixture/react-server-components/pack-3186/output.ts
@@ -1,0 +1,2 @@
+// This fails if the `type` keyword is removed 
+import { type usePathname } from 'next/navigation';


### PR DESCRIPTION
### What?

Type-only imports of `usePathaname` from server components are fine.

### Why?

### How?

Closes PACK-3186


