### PR TITLE
Remove extraneous configs from cache manifest

### DIFF
--- a/packages/next/src/build/flying-shuttle/store-shuttle.ts
+++ b/packages/next/src/build/flying-shuttle/store-shuttle.ts
@@ -26,13 +26,10 @@ export function generateShuttleManifest(config: NextConfigComplete) {
       basePath: config.basePath,
       sassOptions: config.sassOptions,
       trailingSlash: config.trailingSlash,
-      productionBrowserSourceMaps: config.productionBrowserSourceMaps,
 
       experimental: {
         ppr: config.experimental.ppr,
         reactCompiler: config.experimental.reactCompiler,
-        serverSourceMaps: config.experimental.serverSourceMaps,
-        serverMinification: config.experimental.serverMinification,
       },
     },
   } satisfies ShuttleManifest)


### PR DESCRIPTION
As discussed we can tolerate sharing cache between source maps enabled and not e.g. sharing cache from main -> preview so this drops those related configs from the cache manifest.