### PR TITLE
Docs: Add static indicator diagram

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/devIndicators.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/devIndicators.mdx
@@ -24,7 +24,13 @@ description: Optimized pages include an indicator to let you know if it's being 
 
 Next.js displays a static indicator in the bottom corner of the screen that signals if a route will be prerendered at build time. This makes it easier to understand whether a route is static or dynamic, and for you to identify if a route [opts out of static rendering](#static-route-not-showing-the-indicator).
 
-{/* TODO: Add screenshot - waiting for design */}
+<Image
+  alt="App Folder Structure"
+  srcLight="/docs/light/static-indicator.png"
+  srcDark="/docs/dark/static-indicator.png"
+  width="1600"
+  height="208"
+/>
 
 You can disable the indicator by closing it, or using the config option `next.config.js`:
 


### PR DESCRIPTION
Adds static indicator diagrams to the `devIndicators` docs. [DOC-3152](https://linear.app/vercel/issue/DOC-3152/add-static-indicator-diagrams). 