### PR TITLE
reveal hidden bugs in unstable_after tests for dev+edge

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1744,12 +1744,7 @@ export default abstract class Server<
       return builtinRequestContext.waitUntil
     }
 
-    if (process.env.__NEXT_TEST_MODE) {
-      // we're in a test, use a no-op.
-      return Server.noopWaitUntil
-    }
-
-    if (this.minimalMode || process.env.NEXT_RUNTIME === 'edge') {
+    if (this.minimalMode) {
       // we're built for a serverless environment, and `waitUntil` is not available,
       // but using a noop would likely lead to incorrect behavior,
       // because we have no way of keeping the invocation alive.

--- a/test/development/app-dir/server-components-hmr-cache/components/shared-page.tsx
+++ b/test/development/app-dir/server-components-hmr-cache/components/shared-page.tsx
@@ -7,10 +7,15 @@ import { RefreshButton } from './refresh-button'
 export async function SharedPage({ runtime }: { runtime: string }) {
   const value = await fetchRandomValue(`render-${runtime}`)
 
-  after(async () => {
-    const value = await fetchRandomValue(`after-${runtime}`)
-    console.log('After:', value)
-  })
+  // FIXME(lubieowoce): reenable this when after() is fixed in edge runtime
+  // (disabling it like this makes tests that don't care about `after()` work,
+  //  and the tests that do care about it will look for logs, so they'll fail anyway)
+  if (process.env.NEXT_RUNTIME !== 'edge') {
+    after(async () => {
+      const value = await fetchRandomValue(`after-${runtime}`)
+      console.log('After:', value)
+    })
+  }
 
   return (
     <>

--- a/test/lib/development-sandbox.ts
+++ b/test/lib/development-sandbox.ts
@@ -33,7 +33,7 @@ export function waitForHydration(browser: BrowserInterface): Promise<void> {
 
 export async function sandbox(
   next: NextInstance,
-  initialFiles?: Map<string, string>,
+  initialFiles?: Map<string, string | ((contents: string) => string)>,
   initialUrl: string = '/',
   webDriverOptions: any = undefined
 ) {


### PR DESCRIPTION
The `unstable_after` tests had a bunch of issues:
- The `next.patch` calls we do to set the runtime to either `node` or `edge` were being trampled over by `sandbox()`, which resets everything to default, so many tests weren't actually running in `edge`
- Due to bugs fixed further up the stack, `unstable_after` always throws in dev mode on edge runtime pages (thanks @unstubbable for discovering this), but a sneaky `if` in `base-server` was hiding that, so the tests passed

This PR changes the tests that are currently broken for edge to use `it.failing` to accurately reflect the current state 