### PR TITLE
test: refactor unclear tests to composed matchers

### DIFF
--- a/test/integration/jsconfig-baseurl/test/index.test.js
+++ b/test/integration/jsconfig-baseurl/test/index.test.js
@@ -10,7 +10,7 @@ import {
   launchApp,
   killApp,
   nextBuild,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -54,15 +54,13 @@ describe('jsconfig.json baseurl', () => {
           contents.replace('components/world', 'components/worldd')
         )
 
-        const found = await check(
-          async () => {
-            await renderViaHTTP(appPort, '/hello')
-            return stripAnsi(output)
-          },
-          /Module not found: Can't resolve 'components\/worldd'/,
-          false
-        )
-        expect(found).toBe(true)
+        await retry(async () => {
+          await renderViaHTTP(appPort, '/hello')
+          const strippedOutput = stripAnsi(output)
+          expect(strippedOutput).toMatch(
+            /Module not found: Can't resolve 'components\/worldd'/
+          )
+        })
       } finally {
         await fs.writeFile(basicPage, contents)
       }

--- a/test/integration/jsconfig-paths/test/index.test.js
+++ b/test/integration/jsconfig-paths/test/index.test.js
@@ -11,7 +11,7 @@ import {
   launchApp,
   nextBuild,
   killApp,
-  check,
+  retry,
   File,
 } from 'next-test-utils'
 import * as JSON5 from 'json5'
@@ -69,15 +69,12 @@ function runTests() {
       try {
         await fs.writeFile(basicPage, contents.replace('@c/world', '@c/worldd'))
 
-        const found = await check(
-          async () => {
-            await renderViaHTTP(appPort, '/basic-alias')
-            return stripAnsi(output)
-          },
-          /Module not found: Can't resolve '@c\/worldd'/,
-          false
-        )
-        expect(found).toBe(true)
+        await retry(async () => {
+          await renderViaHTTP(appPort, '/basic-alias')
+          expect(stripAnsi(output)).toMatch(
+            /Module not found: Can't resolve '@c\/worldd'/
+          )
+        })
       } finally {
         await fs.writeFile(basicPage, contents)
       }

--- a/test/integration/link-ref/test/index.test.js
+++ b/test/integration/link-ref/test/index.test.js
@@ -35,16 +35,16 @@ const noError = async (pathname) => {
 const didPrefetch = async (pathname) => {
   const browser = await webdriver(appPort, pathname)
   const links = await browser.elementsByCss('link[rel=prefetch]')
-  let found = false
 
-  for (const link of links) {
-    const href = await link.getAttribute('href')
-    if (href.includes('index')) {
-      found = true
-      break
-    }
-  }
-  expect(found).toBe(true)
+  const hrefs = await Promise.all(
+    links.map(async (link) => {
+      return await link.getAttribute('href')
+    })
+  )
+
+  // expect one of the href contain string "index"
+  expect(hrefs).toContain(expect.stringContaining('index'))
+
   await browser.close()
 }
 

--- a/test/integration/link-ref/test/index.test.js
+++ b/test/integration/link-ref/test/index.test.js
@@ -40,9 +40,7 @@ const didPrefetch = async (pathname) => {
     const links = await browser.elementsByCss('link[rel=prefetch]')
 
     const hrefs = await Promise.all(
-      links.map(async (link) => {
-        return await link.getAttribute('href')
-      })
+      links.map((link) => link.getAttribute('href'))
     )
 
     // expect one of the href contain string "index"

--- a/test/integration/link-ref/test/index.test.js
+++ b/test/integration/link-ref/test/index.test.js
@@ -43,7 +43,9 @@ const didPrefetch = async (pathname) => {
   )
 
   // expect one of the href contain string "index"
-  expect(hrefs).toContain(expect.stringContaining('index'))
+  expect(hrefs).toEqual(
+    expect.arrayContaining([expect.stringContaining('index')])
+  )
 
   await browser.close()
 }

--- a/test/integration/preload-viewport/test/index.test.js
+++ b/test/integration/preload-viewport/test/index.test.js
@@ -267,7 +267,7 @@ describe('Prefetching Links in viewport', () => {
               links.map(async (link) => await link.getAttribute('href'))
             )
             expect(hrefs).toEqual(
-              expect.arrayContaining([expect.stringContaining('another')])
+              expect.not.arrayContaining([expect.stringContaining('another')])
             )
           })
 
@@ -350,7 +350,9 @@ describe('Prefetching Links in viewport', () => {
             const srcProps = await Promise.all(
               scripts.map(async (script) => await script.getAttribute('src'))
             )
-            expect(srcProps).toContain(expect.stringContaining('another'))
+            expect(srcProps).toEqual(
+              expect.arrayContaining([expect.stringContaining('another')])
+            )
           })
         } finally {
           if (browser) await browser.close()
@@ -381,8 +383,8 @@ describe('Prefetching Links in viewport', () => {
           const hrefs = await Promise.all(
             links.map(async (link) => await link.getAttribute('href'))
           )
-          expect(hrefs).not.toEqual(
-            expect.arrayContaining([expect.stringContaining('another')])
+          expect(hrefs).toEqual(
+            expect.not.arrayContaining([expect.stringContaining('another')])
           )
         })
       })

--- a/test/integration/preload-viewport/test/index.test.js
+++ b/test/integration/preload-viewport/test/index.test.js
@@ -2,6 +2,7 @@
 
 import {
   check,
+  retry,
   findPort,
   killApp,
   nextBuild,
@@ -101,20 +102,14 @@ describe('Prefetching Links in viewport', () => {
         try {
           browser = await webdriver(appPort, '/')
 
-          await check(async () => {
+          await retry(async () => {
             const links = await browser.elementsByCss('link[rel=prefetch]')
-            let found = false
 
-            for (const link of links) {
-              const href = await link.getAttribute('href')
-              if (href.includes('first')) {
-                found = true
-                break
-              }
-            }
-            expect(found).toBe(true)
-            return 'success'
-          }, 'success')
+            const hrefs = await Promise.all(
+              links.map(async (link) => await link.getAttribute('href'))
+            )
+            expect(hrefs).toContain(expect.stringContaining('first'))
+          })
         } finally {
           if (browser) await browser.close()
         }
@@ -157,21 +152,14 @@ describe('Prefetching Links in viewport', () => {
         try {
           browser = await webdriver(appPort, '/rewrite-prefetch')
 
-          await check(async () => {
+          await retry(async () => {
             const links = await browser.elementsByCss('link[rel=prefetch]')
-            let found = false
 
-            for (const link of links) {
-              const href = await link.getAttribute('href')
-              if (href.includes('%5Bslug%5D')) {
-                found = true
-                break
-              }
-            }
-            expect(found).toBe(true)
-            return 'success'
-          }, 'success')
-
+            const hrefs = await Promise.all(
+              links.map(async (link) => await link.getAttribute('href'))
+            )
+            expect(hrefs).toContain(expect.stringContaining('%5Bslug%5D'))
+          })
           const hrefs = await browser.eval(
             `Object.keys(window.next.router.sdc)`
           )
@@ -211,19 +199,15 @@ describe('Prefetching Links in viewport', () => {
         try {
           browser = await webdriver(appPort, '/')
           await browser.elementByCss('#scroll-to-another').click()
-          await waitFor(2 * 1000)
 
-          const links = await browser.elementsByCss('link[rel=prefetch]')
-          let found = false
+          await retry(async () => {
+            const links = await browser.elementsByCss('link[rel=prefetch]')
 
-          for (const link of links) {
-            const href = await link.getAttribute('href')
-            if (href.includes('another')) {
-              found = true
-              break
-            }
-          }
-          expect(found).toBe(true)
+            const hrefs = await Promise.all(
+              links.map(async (link) => await link.getAttribute('href'))
+            )
+            expect(hrefs).toContain(expect.stringContaining('another'))
+          })
         } finally {
           if (browser) await browser.close()
         }
@@ -234,36 +218,27 @@ describe('Prefetching Links in viewport', () => {
         try {
           browser = await webdriver(appPort, '/')
           await browser.elementByCss('#scroll-to-another').click()
-          await waitFor(2 * 1000)
 
-          const links = await browser.elementsByCss('link[rel=prefetch]')
-          let foundLink = false
+          await retry(async () => {
+            const links = await browser.elementsByCss('link[rel=prefetch]')
 
-          for (const link of links) {
-            const href = await link.getAttribute('href')
-            if (href.includes('another')) {
-              foundLink = true
-              break
-            }
-          }
-          expect(foundLink).toBe(true)
+            const hrefs = await Promise.all(
+              links.map(async (link) => await link.getAttribute('href'))
+            )
+            expect(hrefs).toContain(expect.stringContaining('another'))
+          })
 
           await browser.elementByCss('#link-another').moveTo()
-          await waitFor(2 * 1000)
 
-          const scripts = await browser.elementsByCss(
+          await retry(async () => {
             // Mouse hover is a high-priority fetch
-            'script:not([async])'
-          )
-          let scriptFound = false
-          for (const aScript of scripts) {
-            const href = await aScript.getAttribute('src')
-            if (href.includes('another')) {
-              scriptFound = true
-              break
-            }
-          }
-          expect(scriptFound).toBe(true)
+            const scripts = await browser.elementsByCss('script:not([async])')
+
+            const srcProps = await Promise.all(
+              scripts.map(async (script) => await script.getAttribute('src'))
+            )
+            expect(srcProps).toContain(expect.stringContaining('another'))
+          })
         } finally {
           if (browser) await browser.close()
         }
@@ -273,19 +248,15 @@ describe('Prefetching Links in viewport', () => {
         let browser
         try {
           browser = await webdriver(appPort, '/prefetch-disabled')
-          await waitFor(2 * 1000)
 
-          const links = await browser.elementsByCss('link[rel=prefetch]')
-          let foundLink = false
+          await retry(async () => {
+            const links = await browser.elementsByCss('link[rel=prefetch]')
 
-          for (const link of links) {
-            const href = await link.getAttribute('href')
-            if (href.includes('another')) {
-              foundLink = true
-              break
-            }
-          }
-          expect(foundLink).toBe(false)
+            const hrefs = await Promise.all(
+              links.map(async (link) => await link.getAttribute('href'))
+            )
+            expect(hrefs).toContain(expect.stringContaining('another'))
+          })
 
           async function hasAnotherScript() {
             const scripts = await browser.elementsByCss(
@@ -358,21 +329,16 @@ describe('Prefetching Links in viewport', () => {
         try {
           browser = await webdriver(appPort, '/invalid-ref')
           await browser.elementByCss('#btn-link').moveTo()
-          await waitFor(2 * 1000)
 
-          const scripts = await browser.elementsByCss(
+          await retry(async () => {
             // Mouse hover is a high-priority fetch
-            'script:not([async])'
-          )
-          let scriptFound = false
-          for (const aScript of scripts) {
-            const href = await aScript.getAttribute('src')
-            if (href.includes('another')) {
-              scriptFound = true
-              break
-            }
-          }
-          expect(scriptFound).toBe(true)
+            const scripts = await browser.elementsByCss('script:not([async])')
+
+            const srcProps = await Promise.all(
+              scripts.map(async (script) => await script.getAttribute('src'))
+            )
+            expect(srcProps).toContain(expect.stringContaining('another'))
+          })
         } finally {
           if (browser) await browser.close()
         }
@@ -397,17 +363,13 @@ describe('Prefetching Links in viewport', () => {
       it('should not prefetch when prefetch is explicitly set to false', async () => {
         const browser = await webdriver(appPort, '/opt-out')
 
-        const links = await browser.elementsByCss('link[rel=prefetch]')
-        let found = false
-
-        for (const link of links) {
-          const href = await link.getAttribute('href')
-          if (href.includes('another')) {
-            found = true
-            break
-          }
-        }
-        expect(found).toBe(false)
+        await retry(async () => {
+          const links = await browser.elementsByCss('link[rel=prefetch]')
+          const hrefs = await Promise.all(
+            links.map(async (link) => await link.getAttribute('href'))
+          )
+          expect(hrefs).not.toContain(expect.stringContaining('another'))
+        })
       })
 
       // Turbopack handling of chunks is different, by default it does not include a script tag for the page itself.
@@ -467,20 +429,13 @@ describe('Prefetching Links in viewport', () => {
         // want to be re-fetched/re-observed.
         const browser = await webdriver(appPort, '/')
 
-        await check(async () => {
+        await retry(async () => {
           const links = await browser.elementsByCss('link[rel=prefetch]')
-          let found = false
-
-          for (const link of links) {
-            const href = await link.getAttribute('href')
-            if (href.includes('first')) {
-              found = true
-              break
-            }
-          }
-          expect(found).toBe(true)
-          return 'success'
-        }, 'success')
+          const hrefs = await Promise.all(
+            links.map(async (link) => await link.getAttribute('href'))
+          )
+          expect(hrefs).toContain(expect.stringContaining('first'))
+        })
 
         await browser.eval(`(function() {
       window.calledPrefetch = false

--- a/test/integration/preload-viewport/test/index.test.js
+++ b/test/integration/preload-viewport/test/index.test.js
@@ -108,7 +108,9 @@ describe('Prefetching Links in viewport', () => {
             const hrefs = await Promise.all(
               links.map(async (link) => await link.getAttribute('href'))
             )
-            expect(hrefs).toContain(expect.stringContaining('first'))
+            expect(hrefs).toEqual(
+              expect.arrayContaining([expect.stringContaining('first')])
+            )
           })
         } finally {
           if (browser) await browser.close()
@@ -158,7 +160,10 @@ describe('Prefetching Links in viewport', () => {
             const hrefs = await Promise.all(
               links.map(async (link) => await link.getAttribute('href'))
             )
-            expect(hrefs).toContain(expect.stringContaining('%5Bslug%5D'))
+
+            expect(hrefs).toEqual(
+              expect.arrayContaining([expect.stringContaining('%5Bslug%5D')])
+            )
           })
           const hrefs = await browser.eval(
             `Object.keys(window.next.router.sdc)`
@@ -206,7 +211,9 @@ describe('Prefetching Links in viewport', () => {
             const hrefs = await Promise.all(
               links.map(async (link) => await link.getAttribute('href'))
             )
-            expect(hrefs).toContain(expect.stringContaining('another'))
+            expect(hrefs).toEqual(
+              expect.arrayContaining([expect.stringContaining('another')])
+            )
           })
         } finally {
           if (browser) await browser.close()
@@ -225,7 +232,9 @@ describe('Prefetching Links in viewport', () => {
             const hrefs = await Promise.all(
               links.map(async (link) => await link.getAttribute('href'))
             )
-            expect(hrefs).toContain(expect.stringContaining('another'))
+            expect(hrefs).toEqual(
+              expect.arrayContaining([expect.stringContaining('another')])
+            )
           })
 
           await browser.elementByCss('#link-another').moveTo()
@@ -237,7 +246,9 @@ describe('Prefetching Links in viewport', () => {
             const srcProps = await Promise.all(
               scripts.map(async (script) => await script.getAttribute('src'))
             )
-            expect(srcProps).toContain(expect.stringContaining('another'))
+            expect(srcProps).toEqual(
+              expect.arrayContaining([expect.stringContaining('another')])
+            )
           })
         } finally {
           if (browser) await browser.close()
@@ -255,7 +266,9 @@ describe('Prefetching Links in viewport', () => {
             const hrefs = await Promise.all(
               links.map(async (link) => await link.getAttribute('href'))
             )
-            expect(hrefs).toContain(expect.stringContaining('another'))
+            expect(hrefs).toEqual(
+              expect.arrayContaining([expect.stringContaining('another')])
+            )
           })
 
           async function hasAnotherScript() {
@@ -368,7 +381,9 @@ describe('Prefetching Links in viewport', () => {
           const hrefs = await Promise.all(
             links.map(async (link) => await link.getAttribute('href'))
           )
-          expect(hrefs).not.toContain(expect.stringContaining('another'))
+          expect(hrefs).not.toEqual(
+            expect.arrayContaining([expect.stringContaining('another')])
+          )
         })
       })
 
@@ -434,7 +449,9 @@ describe('Prefetching Links in viewport', () => {
           const hrefs = await Promise.all(
             links.map(async (link) => await link.getAttribute('href'))
           )
-          expect(hrefs).toContain(expect.stringContaining('first'))
+          expect(hrefs).toEqual(
+            expect.arrayContaining([expect.stringContaining('first')])
+          )
         })
 
         await browser.eval(`(function() {

--- a/test/integration/preload-viewport/test/index.test.js
+++ b/test/integration/preload-viewport/test/index.test.js
@@ -106,7 +106,7 @@ describe('Prefetching Links in viewport', () => {
             const links = await browser.elementsByCss('link[rel=prefetch]')
 
             const hrefs = await Promise.all(
-              links.map(async (link) => await link.getAttribute('href'))
+              links.map((link) => link.getAttribute('href'))
             )
             expect(hrefs).toEqual(
               expect.arrayContaining([expect.stringContaining('first')])
@@ -158,7 +158,7 @@ describe('Prefetching Links in viewport', () => {
             const links = await browser.elementsByCss('link[rel=prefetch]')
 
             const hrefs = await Promise.all(
-              links.map(async (link) => await link.getAttribute('href'))
+              links.map((link) => link.getAttribute('href'))
             )
 
             expect(hrefs).toEqual(
@@ -209,7 +209,7 @@ describe('Prefetching Links in viewport', () => {
             const links = await browser.elementsByCss('link[rel=prefetch]')
 
             const hrefs = await Promise.all(
-              links.map(async (link) => await link.getAttribute('href'))
+              links.map((link) => link.getAttribute('href'))
             )
             expect(hrefs).toEqual(
               expect.arrayContaining([expect.stringContaining('another')])
@@ -230,7 +230,7 @@ describe('Prefetching Links in viewport', () => {
             const links = await browser.elementsByCss('link[rel=prefetch]')
 
             const hrefs = await Promise.all(
-              links.map(async (link) => await link.getAttribute('href'))
+              links.map((link) => link.getAttribute('href'))
             )
             expect(hrefs).toEqual(
               expect.arrayContaining([expect.stringContaining('another')])
@@ -244,7 +244,7 @@ describe('Prefetching Links in viewport', () => {
             const scripts = await browser.elementsByCss('script:not([async])')
 
             const srcProps = await Promise.all(
-              scripts.map(async (script) => await script.getAttribute('src'))
+              scripts.map((script) => script.getAttribute('src'))
             )
             expect(srcProps).toEqual(
               expect.arrayContaining([expect.stringContaining('another')])
@@ -264,7 +264,7 @@ describe('Prefetching Links in viewport', () => {
             const links = await browser.elementsByCss('link[rel=prefetch]')
 
             const hrefs = await Promise.all(
-              links.map(async (link) => await link.getAttribute('href'))
+              links.map((link) => link.getAttribute('href'))
             )
             expect(hrefs).toEqual(
               expect.not.arrayContaining([expect.stringContaining('another')])
@@ -348,7 +348,7 @@ describe('Prefetching Links in viewport', () => {
             const scripts = await browser.elementsByCss('script:not([async])')
 
             const srcProps = await Promise.all(
-              scripts.map(async (script) => await script.getAttribute('src'))
+              scripts.map((script) => script.getAttribute('src'))
             )
             expect(srcProps).toEqual(
               expect.arrayContaining([expect.stringContaining('another')])
@@ -381,7 +381,7 @@ describe('Prefetching Links in viewport', () => {
         await retry(async () => {
           const links = await browser.elementsByCss('link[rel=prefetch]')
           const hrefs = await Promise.all(
-            links.map(async (link) => await link.getAttribute('href'))
+            links.map((link) => link.getAttribute('href'))
           )
           expect(hrefs).toEqual(
             expect.not.arrayContaining([expect.stringContaining('another')])
@@ -449,7 +449,7 @@ describe('Prefetching Links in viewport', () => {
         await retry(async () => {
           const links = await browser.elementsByCss('link[rel=prefetch]')
           const hrefs = await Promise.all(
-            links.map(async (link) => await link.getAttribute('href'))
+            links.map((link) => link.getAttribute('href'))
           )
           expect(hrefs).toEqual(
             expect.arrayContaining([expect.stringContaining('first')])


### PR DESCRIPTION
### What

Improve the test matcher for string matching while searching in array case, those flaky tests were giving unclear failing messages without enough context to help investigate the flakeness.

### Why

Example of existing unclear flaky failure
```
pnpm test test/integration/link-ref/test/index.test.js
• Invalid hrefs > production mode > should preload with child ref with React.createRef
Expand output
● Invalid hrefs › production mode › should preload with child ref with React.createRef
expect(received).toBe(expected) // [Object.is](http://object.is/) equality

Expected: true
Received: false
```

While looking at the test, assertions like `expect(found).toBe(true)` could fail without telling us what are the context, what is the original input before narrowing down as a boolean value. After changing to a composed testing matcher, we're able to see what href links are giving us the unexpected result

```ts
expect(hrefs).toEqual(
    expect.arrayContaining([expect.stringContaining('index')])
  )
```

For example, if we're looking for a string pattern `first-1` in the link hrefs, but it only got `first`, the failure message would look like this. This will help us identify the root cause easier with more context.

```
 ● Prefetching Links in viewport › production mode › should prefetch with link in viewport onload

   expect(received).toEqual(expected) // deep equality

   Expected: ArrayContaining [StringContaining "first1"]
   Received: ["/_next/static/chunks/pages/first-c9300691290bda9a.js"]

     109 |               links.map(async (link) => await link.getAttribute('href'))
     110 |             )
   > 111 |             expect(hrefs).toEqual(
         |                           ^
     112 |               expect.arrayContaining([expect.stringContaining('first1')])
```