### PR TITLE
Ensure we copy map file as well for experimental tracing

### DIFF
--- a/packages/next/src/build/flying-shuttle/detect-changed-entries.ts
+++ b/packages/next/src/build/flying-shuttle/detect-changed-entries.ts
@@ -275,11 +275,7 @@ export async function detectChangedEntries({
   }
 
   for (const entry of appPaths || []) {
-    let normalizedEntry = getPageFromPath(entry, pageExtensions)
-
-    if (normalizedEntry === '/not-found') {
-      normalizedEntry = '/_not-found'
-    }
+    const normalizedEntry = getPageFromPath(entry, pageExtensions)
     await detectChange({ entry, normalizedEntry, type: 'app' })
   }
 

--- a/packages/next/src/build/flying-shuttle/stitch-builds.ts
+++ b/packages/next/src/build/flying-shuttle/stitch-builds.ts
@@ -114,6 +114,17 @@ export async function stitchBuilds(
       path.join(shuttleDir, entryFile),
       path.join(distDir, entryFile)
     )
+    // copy map file as well if it exists
+    await fs.promises
+      .copyFile(
+        path.join(shuttleDir, `${entryFile}.map`),
+        path.join(distDir, `${entryFile}.map`)
+      )
+      .catch((err) => {
+        if (err.code !== 'ENOENT') {
+          throw err
+        }
+      })
   }
   const copySema = new Sema(8)
 

--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -282,7 +282,7 @@ export function getDefineEnv({
   }
   const serializedDefineEnv = serializeDefineEnv(defineEnv)
 
-  if (Boolean(config.experimental.flyingShuttle)) {
+  if (!dev && Boolean(config.experimental.flyingShuttle)) {
     // we delay inlining these values until after the build
     // with flying shuttle enabled so we can update them
     // without invalidating entries


### PR DESCRIPTION
These files can be present if server source maps flag is enabled so need copying as well. Also removes incorrect `_not-found` special case which will need revisiting and updating define-env check to not apply in dev. 

x-ref: [slack thread](https://vercel.slack.com/archives/C056QDZARTM/p1723119830912809)