### PR TITLE
Turbopack: JSON5 and package.json for postcss config files

### DIFF
--- a/test/e2e/postcss-config-package/app/pages/_app.js
+++ b/test/e2e/postcss-config-package/app/pages/_app.js
@@ -1,0 +1,7 @@
+import 'tailwindcss/tailwind.css'
+
+function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}
+
+export default MyApp

--- a/test/e2e/postcss-config-package/app/pages/index.js
+++ b/test/e2e/postcss-config-package/app/pages/index.js
@@ -1,0 +1,63 @@
+export default function Home() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen py-2">
+      <main className="flex flex-col items-center justify-center w-full flex-1 px-20 text-center">
+        <h1 className="text-blue-600 text-6xl font-bold">
+          Welcome to{' '}
+          <a className="text-blue-600" href="https://nextjs.org" id="test-link">
+            Next.js!
+          </a>
+        </h1>
+
+        <p className="mt-3 text-2xl">
+          Get started by editing{' '}
+          <code className="p-3 font-mono text-lg bg-gray-100 rounded-md">
+            pages/index.js
+          </code>
+        </p>
+
+        <div className="flex flex-wrap items-center justify-around max-w-4xl mt-6 sm:w-full">
+          <a
+            href="https://nextjs.org/docs"
+            className="p-6 mt-6 text-left border w-96 rounded-xl hover:text-blue-600 focus:text-blue-600"
+          >
+            <h3 className="text-2xl font-bold">Documentation &rarr;</h3>
+            <p className="mt-4 text-xl">
+              Find in-depth information about Next.js features and API.
+            </p>
+          </a>
+
+          <a
+            href="https://nextjs.org/learn"
+            className="p-6 mt-6 text-left border w-96 rounded-xl hover:text-blue-600 focus:text-blue-600"
+          >
+            <h3 className="text-2xl font-bold">Learn &rarr;</h3>
+            <p className="mt-4 text-xl">
+              Learn about Next.js in an interactive course with quizzes!
+            </p>
+          </a>
+
+          <a
+            href="https://github.com/vercel/next.js/tree/canary/examples"
+            className="p-6 mt-6 text-left border w-96 rounded-xl hover:text-blue-600 focus:text-blue-600"
+          >
+            <h3 className="text-2xl font-bold">Examples &rarr;</h3>
+            <p className="mt-4 text-xl">
+              Discover and deploy boilerplate example Next.js projects.
+            </p>
+          </a>
+
+          <a
+            href="https://vercel.com/import?filter=next.js&utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
+            className="p-6 mt-6 text-left border w-96 rounded-xl hover:text-blue-600 focus:text-blue-600"
+          >
+            <h3 className="text-2xl font-bold">Deploy &rarr;</h3>
+            <p className="mt-4 text-xl">
+              Instantly deploy your Next.js site to a public URL with Vercel.
+            </p>
+          </a>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/test/e2e/postcss-config-package/app/tailwind.config.cjs
+++ b/test/e2e/postcss-config-package/app/tailwind.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./pages/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/test/e2e/postcss-config-package/index.test.ts
+++ b/test/e2e/postcss-config-package/index.test.ts
@@ -1,0 +1,35 @@
+import { FileRef, nextTestSetup } from 'e2e-utils'
+import { join } from 'path'
+
+describe('postcss-config-json', () => {
+  const { next } = nextTestSetup({
+    files: new FileRef(join(__dirname, 'app')),
+    dependencies: {
+      autoprefixer: '10.4.19',
+      postcss: '8.4.38',
+      tailwindcss: '3.4.4',
+    },
+    packageJson: {
+      postcss: {
+        plugins: {
+          tailwindcss: {},
+          autoprefixer: {},
+        },
+      },
+    },
+  })
+
+  it('works with postcss config specified in package.json', async () => {
+    let browser = await next.browser('/')
+    try {
+      const text = await browser.elementByCss('.text-6xl').text()
+      expect(text).toMatch(/Welcome to/)
+      const cssBlue = await browser
+        .elementByCss('#test-link')
+        .getComputedCss('color')
+      expect(cssBlue).toBe('rgb(37, 99, 235)')
+    } finally {
+      await browser.close()
+    }
+  })
+})

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1762,6 +1762,17 @@ impl ValueToString for FileJsonContent {
     }
 }
 
+#[turbo_tasks::value_impl]
+impl FileJsonContent {
+    #[turbo_tasks::function]
+    pub async fn content(self: Vc<Self>) -> Result<Vc<Value>> {
+        match &*self.await? {
+            FileJsonContent::Content(json) => Ok(Vc::cell(json.clone())),
+            FileJsonContent::Unparseable(e) => Err(anyhow!("File is not valid JSON: {}", e)),
+            FileJsonContent::NotFound => Err(anyhow!("File not found")),
+        }
+    }
+}
 impl FileJsonContent {
     pub fn unparseable(message: &'static str) -> Self {
         FileJsonContent::Unparseable(Box::new(UnparseableJson {

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -19,7 +19,7 @@ use turbopack_core::{
         Issue, IssueDescriptionExt, IssueSeverity, IssueStage, OptionStyledString, StyledString,
     },
     reference_type::{EntryReferenceSubType, InnerAssets, ReferenceType},
-    resolve::{find_context_file, options::ImportMapping, FindContextFileResult},
+    resolve::{find_context_file_or_package_key, options::ImportMapping, FindContextFileResult},
     source::Source,
     source_transform::SourceTransform,
     virtual_source::VirtualSource,
@@ -225,12 +225,69 @@ async fn extra_configs_changed(
     Ok(Vc::<Completions>::cell(configs).completed())
 }
 
+#[turbo_tasks::value]
+pub struct JsonKeySource {
+    pub path: Vc<FileSystemPath>,
+    pub key: Vc<RcStr>,
+}
+
+#[turbo_tasks::value_impl]
+impl JsonKeySource {
+    #[turbo_tasks::function]
+    pub fn new(path: Vc<FileSystemPath>, key: Vc<RcStr>) -> Vc<Self> {
+        Self::cell(JsonKeySource { path, key })
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Source for JsonKeySource {
+    #[turbo_tasks::function]
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(AssetIdent::from_path(
+            self.path
+                .append(".".into())
+                .append(self.key.await?.clone_value())
+                .append(".json".into()),
+        )
+        .with_modifier(self.key))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for JsonKeySource {
+    #[turbo_tasks::function]
+    async fn content(&self) -> Result<Vc<AssetContent>> {
+        let file_type = &*self.path.get_type().await?;
+        match file_type {
+            FileSystemEntryType::File => {
+                let json = self.path.read_json().content().await?;
+                let key = &**self.key.await?;
+                let Some(value) = json.get(key) else {
+                    return Err(anyhow::anyhow!("Invalid file type {:?}", file_type));
+                };
+                Ok(AssetContent::file(File::from(value.to_string()).into()))
+            }
+            FileSystemEntryType::NotFound => {
+                Ok(AssetContent::File(FileContent::NotFound.cell()).cell())
+            }
+            _ => Err(anyhow::anyhow!("Invalid file type {:?}", file_type)),
+        }
+    }
+}
+
 #[turbo_tasks::function]
 pub(crate) async fn config_loader_source(
     project_path: Vc<FileSystemPath>,
     postcss_config_path: Vc<FileSystemPath>,
 ) -> Result<Vc<Box<dyn Source>>> {
     let postcss_config_path_value = &*postcss_config_path.await?;
+
+    if postcss_config_path_value.file_name() == "package.json" {
+        return Ok(Vc::upcast(JsonKeySource::new(
+            postcss_config_path,
+            Vc::cell("postcss".into()),
+        )));
+    }
 
     // We can only load js files with `import()`.
     if !postcss_config_path_value.path.ends_with(".js") {
@@ -298,15 +355,23 @@ async fn find_config_in_location(
     location: PostCssConfigLocation,
     source: Vc<Box<dyn Source>>,
 ) -> Result<Option<Vc<FileSystemPath>>> {
-    if let FindContextFileResult::Found(config_path, _) =
-        *find_context_file(project_path, postcss_configs()).await?
+    if let FindContextFileResult::Found(config_path, _) = *find_context_file_or_package_key(
+        project_path,
+        postcss_configs(),
+        Value::new("postcss".into()),
+    )
+    .await?
     {
         return Ok(Some(config_path));
     }
 
     if matches!(location, PostCssConfigLocation::ProjectPathOrLocalPath) {
-        if let FindContextFileResult::Found(config_path, _) =
-            *find_context_file(source.ident().path().parent(), postcss_configs()).await?
+        if let FindContextFileResult::Found(config_path, _) = *find_context_file_or_package_key(
+            source.ident().path().parent(),
+            postcss_configs(),
+            Value::new("postcss".into()),
+        )
+        .await?
         {
             return Ok(Some(config_path));
         }


### PR DESCRIPTION
Use JSON5 for parsing the PostCSS config files

Webpack also uses JSON5: https://github.com/vercel/next.js/blob/17f2cb65c2aacc6b52ed6d34e98a839ee465c35d/packages/next/src/lib/find-config.ts#L96

Not sure if a new `Source` is the best way to do this

Closes PACK-3103
Closes PACK-2657
Closes https://github.com/vercel/next.js/issues/67218
Closes #67221