### PR TITLE
chore: remove asset prefix warning log and update docs

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/assetPrefix.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/assetPrefix.mdx
@@ -23,16 +23,25 @@ description: Learn how to use the assetPrefix config option to configure your CD
 > suited for hosting your application on a sub-path like `/docs`.
 > We do not suggest you use a custom Asset Prefix for this use case.
 
+## Set up a CDN
+
 To set up a [CDN](https://en.wikipedia.org/wiki/Content_delivery_network), you can set up an asset prefix and configure your CDN's origin to resolve to the domain that Next.js is hosted on.
 
-Open `next.config.js` and add the `assetPrefix` config:
+Open `next.config.mjs` and add the `assetPrefix` config based on the [phase](/docs/app/api-reference/next-config-js#async-configuration):
 
-```js filename="next.config.js"
-const isProd = process.env.NODE_ENV === 'production'
+```js filename="next.config.mjs"
+// @ts-check
+import { PHASE_DEVELOPMENT_SERVER } from 'next/constants'
 
-module.exports = {
-  // Use the CDN in production and localhost for development.
-  assetPrefix: isProd ? 'https://cdn.mydomain.com' : undefined,
+export default (phase) => {
+  const isDev = phase === PHASE_DEVELOPMENT_SERVER
+  /**
+   * @type {import('next').NextConfig}
+   */
+  const nextConfig = {
+    assetPrefix: isDev ? undefined : 'https://cdn.mydomain.com',
+  }
+  return nextConfig
 }
 ```
 

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1069,16 +1069,6 @@ export default async function loadConfig(
       }
     }
 
-    if (
-      phase === PHASE_DEVELOPMENT_SERVER &&
-      URL.canParse(userConfig.assetPrefix ?? '')
-    ) {
-      curLog.warn(
-        `Absolute URL assetPrefix "${userConfig.assetPrefix}" may disrupt development HMR.\n` +
-          'See more info here https://nextjs.org/docs/app/api-reference/next-config-js/assetPrefix'
-      )
-    }
-
     if (userConfig.target && userConfig.target !== 'server') {
       throw new Error(
         `The "target" property is no longer supported in ${configFileName}.\n` +

--- a/test/development/app-dir/hmr-asset-prefix-full-url/asset-prefix.test.ts
+++ b/test/development/app-dir/hmr-asset-prefix-full-url/asset-prefix.test.ts
@@ -26,7 +26,7 @@ describe('app-dir assetPrefix full URL', () => {
     })
 
     await retry(async () => {
-      expect(await browser.elementByCss('p').text()).toContain('after edit')
+      expect(await browser.elementByCss('p').text()).toBe('after edit')
     })
   })
 })


### PR DESCRIPTION
### Why?

In https://github.com/vercel/next.js/pull/68622 we fixed a bug that HMR breaks when `assetPrefix` is set to full URL.
The fix was targeted to the edge case where the user may set `localhost` to the `assetPrefix`, and technically, when the request is valid the HMR should work.

However, we do not recommend this pattern as the `assetPrefix` is intended to be used for setting a CDN URL.

### How?

Therefore we modify the docs to gently imply that the `assetPrefix` is for CDN URL.
Also, removed the warning log that could be confusing whether we support it or not.
Setting localhost will still work, but we do not mention about it within the app.
