### PR TITLE
Prevent incompability with `'eval-source-map'` and `mangle: false`

### DIFF
--- a/packages/next/webpack.config.js
+++ b/packages/next/webpack.config.js
@@ -173,7 +173,8 @@ module.exports = ({ dev, turbo, bundleType, experimental }) => {
             format: {
               preamble: '',
             },
-            mangle: dev ? false : true,
+            mangle:
+              dev && !process.env.NEXT_SERVER_EVAL_SOURCE_MAPS ? false : true,
           },
         }),
       ],


### PR DESCRIPTION
Setting the terser option `mangle` to `false` for dev server runtime bundles as done in #68641 seems to be incompatible with `'eval-source-map'`, i.e. when running `pnpm dev`. The combination yields strange runtime errors when running an app with the node runtime. E.g.:
```
 ⨯ TypeError: isValidElementType is not a function
    at renderToHTMLImpl (webpack://next/dist/src/server/render.tsx?e2d9:568:10)
    at render (webpack://next/dist/src/server/route-modules/pages/module.ts?84fd:125:12)
```
or
```
TypeError: Cannot read properties of undefined (reading 'contexts')
    at Object.<anonymous> (<snip>/packages/next/src/server/route-modules/pages/vendored/contexts/html-context.ts:1:59)
```
or
```
 ⨯ Error: Cannot find module 'next/dist/server/lib/trace/tracer'
Require stack:
- <snip>/packages/next/dist/compiled/next-server/app-page.runtime.dev.js
- <snip>/test/e2e/app-dir/app/.next/server/app/dashboard/page.js
```

Since using `'eval-source-map'` already fixes showing the original names, we don't need to disable mangling in this case.

**How to reproduce on `canary`:**

- start `pnpm dev`
- start `pnpm next dev test/e2e/app-dir/app`
- open http://localhost:3000/client-component-route
- observe errors