### PR TITLE
Fix `pnpm build --filter next` on a clean repository

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -160,6 +160,7 @@
     "@jest/types": "29.5.0",
     "@mswjs/interceptors": "0.23.0",
     "@napi-rs/triples": "1.2.0",
+    "@next/font": "15.0.0-canary.111",
     "@next/polyfill-module": "15.0.0-canary.111",
     "@next/polyfill-nomodule": "15.0.0-canary.111",
     "@next/react-refresh-utils": "15.0.0-canary.111",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -977,6 +977,9 @@ importers:
       '@napi-rs/triples':
         specifier: 1.2.0
         version: 1.2.0
+      '@next/font':
+        specifier: 15.0.0-canary.111
+        version: link:../font
       '@next/polyfill-module':
         specifier: 15.0.0-canary.111
         version: link:../next-polyfill-module


### PR DESCRIPTION
`next` uses `@next/font` during type emission (referenced in `packages/next/types/$$compiled.internal.d.ts`). However, we currently don't build `@next/font` before `next` since it's not declared dependency.

Added to `devDependencies` since that's what `@next/font` is to `next`. In prod, we use the vendored version.