### PR TITLE
Fix duplicate logs for invalid config exports

### DIFF
--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -16,10 +16,7 @@ import { checkCustomRoutes } from '../../lib/load-custom-routes'
 import { tryToParsePath } from '../../lib/try-to-parse-path'
 import { isAPIRoute } from '../../lib/is-api-route'
 import { isEdgeRuntime } from '../../lib/is-edge-runtime'
-import {
-  PHASE_PRODUCTION_BUILD,
-  RSC_MODULE_TYPES,
-} from '../../shared/lib/constants'
+import { RSC_MODULE_TYPES } from '../../shared/lib/constants'
 import type { RSCMeta } from '../webpack/loaders/get-module-build-info'
 import { PAGE_TYPES } from '../../lib/page-types'
 
@@ -448,6 +445,7 @@ function warnAboutExperimentalEdge(apiRoute: string | null) {
 }
 
 export let hadUnsupportedValue = false
+const warnedUnsupportedValueMap = new LRUCache<string, boolean>({ max: 250 })
 
 function warnAboutUnsupportedValue(
   pageFilePath: string,
@@ -455,6 +453,17 @@ function warnAboutUnsupportedValue(
   error: UnsupportedValueError
 ) {
   hadUnsupportedValue = true
+  const isProductionBuild = process.env.NODE_ENV === 'production'
+  if (
+    // we only log for the server compilation so it's not
+    // duplicated due to webpack build worker having fresh
+    // module scope for each compiler
+    process.env.NEXT_COMPILER_NAME !== 'server' ||
+    (isProductionBuild && warnedUnsupportedValueMap.has(pageFilePath))
+  ) {
+    return
+  }
+  warnedUnsupportedValueMap.set(pageFilePath, true)
 
   const message =
     `Next.js can't recognize the exported \`config\` field in ` +
@@ -465,8 +474,9 @@ function warnAboutUnsupportedValue(
     '.\n' +
     'Read More - https://nextjs.org/docs/messages/invalid-page-config'
 
-  // for a build wait to log all errors before exiting
-  if (process.env.NEXT_PHASE !== PHASE_PRODUCTION_BUILD) {
+  // for a build we use `Log.error` instead of throwing
+  // so that all errors can be logged before exiting the process
+  if (isProductionBuild) {
     Log.error(message)
   } else {
     throw new Error(message)

--- a/packages/next/src/build/webpack-build/impl.ts
+++ b/packages/next/src/build/webpack-build/impl.ts
@@ -82,6 +82,7 @@ export async function webpackBuildImpl(
   const nextBuildSpan = NextBuildContext.nextBuildSpan!
   const dir = NextBuildContext.dir!
   const config = NextBuildContext.config!
+  process.env.NEXT_COMPILER_NAME = compilerName || 'server'
 
   const runWebpackSpan = nextBuildSpan.traceChild('run-webpack-compiler')
   const entrypoints = await nextBuildSpan

--- a/test/production/exported-runtimes-value-validation/index.test.ts
+++ b/test/production/exported-runtimes-value-validation/index.test.ts
@@ -23,8 +23,6 @@ describe('Exported runtimes value validation', () => {
       { stdout: true, stderr: true }
     )
 
-    console.log(result.stderr, result.stdout)
-
     // The build should fail to prevent unexpected behavior
     expect(result.code).toBe(1)
 
@@ -67,6 +65,11 @@ describe('Exported runtimes value validation', () => {
         'Next.js can\'t recognize the exported `config` field in route "/array-spread-operator"'
       )
     )
+    // ensure only 1 occurrence of the log
+    expect(
+      result.stderr.match(/field in route "\/array-spread-operator"/g)?.length
+    ).toBe(1)
+
     expect(result.stderr).toEqual(
       expect.stringContaining(
         'Unsupported spread operator in the Array Expression at "config.runtime"'


### PR DESCRIPTION
Fixes from additional comments in https://github.com/vercel/next.js/pull/68638#discussion_r1710142698 to avoid duplicate logging and us failing to dedicate production build mode correctly. 