### PR TITLE
Ensure bail out on ssr error in static generation

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1236,8 +1236,8 @@ async function renderToStream(
     // and should omit the error reporter in the SSR layer instead
     undefined
   )
-  function onServerRenderError(err: DigestedError) {
-    const renderSource = renderErrorsByDigest.has(err.digest)
+  function onServerRenderError(err: DigestedError, isRSCError: boolean) {
+    const renderSource = isRSCError
       ? 'react-server-components'
       : 'server-rendering'
     return renderOpts.onInstrumentationRequestError?.(
@@ -1646,8 +1646,8 @@ async function prerenderToStream(
     // and should omit the error reporter in the SSR layer instead
     undefined
   )
-  function onServerRenderError(err: DigestedError) {
-    const renderSource = reactServerErrorsByDigest.has(err.digest)
+  function onServerRenderError(err: DigestedError, isRSCError: boolean) {
+    const renderSource = isRSCError
       ? 'react-server-components'
       : 'server-rendering'
     return renderOpts.onInstrumentationRequestError?.(

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1232,12 +1232,12 @@ async function renderToStream(
   )
 
   // Including both RSC errors and SSR errors
-  const renderErrorsByDigest: Map<string, DigestedError> = new Map()
+  const reactServerErrorsByDigest: Map<string, DigestedError> = new Map()
   const silenceLogger = false
   const serverComponentsErrorHandler = createHTMLReactServerErrorHandler(
     !!renderOpts.dev,
     !!renderOpts.nextExport,
-    renderErrorsByDigest,
+    reactServerErrorsByDigest,
     silenceLogger,
     // RSC rendering error will report as SSR error
     // @TODO we should report RSC errors where they happen for instrumentation purposes
@@ -1264,7 +1264,7 @@ async function renderToStream(
   const htmlRendererErrorHandler = createHTMLErrorHandler(
     !!renderOpts.dev,
     !!renderOpts.nextExport,
-    renderErrorsByDigest,
+    reactServerErrorsByDigest,
     allCapturedErrors,
     silenceLogger,
     onHTMLRenderRSCError,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1223,12 +1223,13 @@ async function renderToStream(
     renderOpts.page
   )
 
-  const reactServerErrorsByDigest: Map<string, DigestedError> = new Map()
+  // Including both RSC errors and SSR errors
+  const renderErrorsByDigest: Map<string, DigestedError> = new Map()
   const silenceLogger = false
   const serverComponentsErrorHandler = createHTMLReactServerErrorHandler(
     !!renderOpts.dev,
     !!renderOpts.nextExport,
-    reactServerErrorsByDigest,
+    renderErrorsByDigest,
     silenceLogger,
     // RSC rendering error will report as SSR error
     // @TODO we should report RSC errors where they happen for instrumentation purposes
@@ -1236,7 +1237,7 @@ async function renderToStream(
     undefined
   )
   function onServerRenderError(err: DigestedError) {
-    const renderSource = reactServerErrorsByDigest.has(err.digest)
+    const renderSource = renderErrorsByDigest.has(err.digest)
       ? 'react-server-components'
       : 'server-rendering'
     return renderOpts.onInstrumentationRequestError?.(
@@ -1249,7 +1250,7 @@ async function renderToStream(
   const htmlRendererErrorHandler = createHTMLErrorHandler(
     !!renderOpts.dev,
     !!renderOpts.nextExport,
-    reactServerErrorsByDigest,
+    renderErrorsByDigest,
     allCapturedErrors,
     silenceLogger,
     onServerRenderError
@@ -1635,6 +1636,7 @@ async function prerenderToStream(
   const reactServerErrorsByDigest: Map<string, DigestedError> = new Map()
   // We don't report errors during prerendering through our instrumentation hooks
   const silenceLogger = !!renderOpts.experimental.isRoutePPREnabled
+  console.log('silenceLogger', silenceLogger)
   const serverComponentsErrorHandler = createHTMLReactServerErrorHandler(
     !!renderOpts.dev,
     !!renderOpts.nextExport,
@@ -1649,6 +1651,12 @@ async function prerenderToStream(
     const renderSource = reactServerErrorsByDigest.has(err.digest)
       ? 'react-server-components'
       : 'server-rendering'
+    console.log(
+      'onServerRenderError',
+      renderSource,
+      'renderOpts.nextExport',
+      renderOpts.nextExport
+    )
     return renderOpts.onInstrumentationRequestError?.(
       err,
       req,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -969,15 +969,14 @@ async function renderToHTMLOrFlightImpl(
       }
     }
 
-    let buildFailingError: unknown
     // If we encountered any unexpected errors during build we fail the
     // prerendering phase and the build.
     if (response.digestErrorsMap.size) {
-      buildFailingError = response.digestErrorsMap.values().next().value
+      const buildFailingError = response.digestErrorsMap.values().next().value
       if (buildFailingError) throw buildFailingError
     }
     if (response.ssrErrors.length) {
-      buildFailingError = response.ssrErrors.filter((err) =>
+      const buildFailingError = response.ssrErrors.filter((err) =>
         isUserLandError(err)
       )[0]
       if (buildFailingError) throw buildFailingError

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -976,11 +976,11 @@ async function renderToHTMLOrFlightImpl(
       if (buildFailingError) throw buildFailingError
     }
     if (response.ssrErrors.length) {
-      const buildFailingError = response.ssrErrors.filter(
+      const buildFailingError = response.ssrErrors.find(
         (err) =>
           isUserLandError(err) &&
           !response.digestErrorsMap.has((err as any).digest)
-      )[0]
+      )
       if (buildFailingError) throw buildFailingError
     }
 

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1636,7 +1636,6 @@ async function prerenderToStream(
   const reactServerErrorsByDigest: Map<string, DigestedError> = new Map()
   // We don't report errors during prerendering through our instrumentation hooks
   const silenceLogger = !!renderOpts.experimental.isRoutePPREnabled
-  console.log('silenceLogger', silenceLogger)
   const serverComponentsErrorHandler = createHTMLReactServerErrorHandler(
     !!renderOpts.dev,
     !!renderOpts.nextExport,
@@ -1651,12 +1650,6 @@ async function prerenderToStream(
     const renderSource = reactServerErrorsByDigest.has(err.digest)
       ? 'react-server-components'
       : 'server-rendering'
-    console.log(
-      'onServerRenderError',
-      renderSource,
-      'renderOpts.nextExport',
-      renderOpts.nextExport
-    )
     return renderOpts.onInstrumentationRequestError?.(
       err,
       req,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -975,11 +975,10 @@ async function renderToHTMLOrFlightImpl(
       const buildFailingError = response.digestErrorsMap.values().next().value
       if (buildFailingError) throw buildFailingError
     }
+    // Pick first userland SSR error, which is also not a RSC error.
     if (response.ssrErrors.length) {
-      const buildFailingError = response.ssrErrors.find(
-        (err) =>
-          isUserLandError(err) &&
-          !response.digestErrorsMap.has((err as any).digest)
+      const buildFailingError = response.ssrErrors.find((err) =>
+        isUserLandError(err)
       )
       if (buildFailingError) throw buildFailingError
     }
@@ -1232,7 +1231,6 @@ async function renderToStream(
     renderOpts.page
   )
 
-  // Including both RSC errors and SSR errors
   const reactServerErrorsByDigest: Map<string, DigestedError> = new Map()
   const silenceLogger = false
   const serverComponentsErrorHandler = createHTMLReactServerErrorHandler(

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -976,8 +976,10 @@ async function renderToHTMLOrFlightImpl(
       if (buildFailingError) throw buildFailingError
     }
     if (response.ssrErrors.length) {
-      const buildFailingError = response.ssrErrors.filter((err) =>
-        isUserLandError(err)
+      const buildFailingError = response.ssrErrors.filter(
+        (err) =>
+          isUserLandError(err) &&
+          !response.digestErrorsMap.has((err as any).digest)
       )[0]
       if (buildFailingError) throw buildFailingError
     }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1233,16 +1233,6 @@ async function renderToStream(
 
   const reactServerErrorsByDigest: Map<string, DigestedError> = new Map()
   const silenceLogger = false
-  const serverComponentsErrorHandler = createHTMLReactServerErrorHandler(
-    !!renderOpts.dev,
-    !!renderOpts.nextExport,
-    reactServerErrorsByDigest,
-    silenceLogger,
-    // RSC rendering error will report as SSR error
-    // @TODO we should report RSC errors where they happen for instrumentation purposes
-    // and should omit the error reporter in the SSR layer instead
-    undefined
-  )
   function onHTMLRenderRSCError(err: DigestedError) {
     return renderOpts.onInstrumentationRequestError?.(
       err,
@@ -1250,6 +1240,13 @@ async function renderToStream(
       createErrorContext(ctx, 'react-server-components')
     )
   }
+  const serverComponentsErrorHandler = createHTMLReactServerErrorHandler(
+    !!renderOpts.dev,
+    !!renderOpts.nextExport,
+    reactServerErrorsByDigest,
+    silenceLogger,
+    onHTMLRenderRSCError
+  )
 
   function onHTMLRenderSSRError(err: DigestedError) {
     return renderOpts.onInstrumentationRequestError?.(
@@ -1266,7 +1263,6 @@ async function renderToStream(
     reactServerErrorsByDigest,
     allCapturedErrors,
     silenceLogger,
-    onHTMLRenderRSCError,
     onHTMLRenderSSRError
   )
 
@@ -1651,16 +1647,6 @@ async function prerenderToStream(
   const reactServerErrorsByDigest: Map<string, DigestedError> = new Map()
   // We don't report errors during prerendering through our instrumentation hooks
   const silenceLogger = !!renderOpts.experimental.isRoutePPREnabled
-  const serverComponentsErrorHandler = createHTMLReactServerErrorHandler(
-    !!renderOpts.dev,
-    !!renderOpts.nextExport,
-    reactServerErrorsByDigest,
-    silenceLogger,
-    // RSC rendering error will report as SSR error
-    // @TODO we should report RSC errors where they happen for instrumentation purposes
-    // and should omit the error reporter in the SSR layer instead
-    undefined
-  )
   function onHTMLRenderRSCError(err: DigestedError) {
     return renderOpts.onInstrumentationRequestError?.(
       err,
@@ -1668,6 +1654,13 @@ async function prerenderToStream(
       createErrorContext(ctx, 'react-server-components')
     )
   }
+  const serverComponentsErrorHandler = createHTMLReactServerErrorHandler(
+    !!renderOpts.dev,
+    !!renderOpts.nextExport,
+    reactServerErrorsByDigest,
+    silenceLogger,
+    onHTMLRenderRSCError
+  )
 
   function onHTMLRenderSSRError(err: DigestedError) {
     return renderOpts.onInstrumentationRequestError?.(
@@ -1683,7 +1676,6 @@ async function prerenderToStream(
     reactServerErrorsByDigest,
     allCapturedErrors,
     silenceLogger,
-    onHTMLRenderRSCError,
     onHTMLRenderSSRError
   )
 

--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -139,7 +139,7 @@ export function createHTMLErrorHandler(
   dev: boolean,
   isNextExport: boolean,
   reactServerErrors: Map<string, DigestedError>,
-  allCapturedError: Array<unknown>,
+  allCapturedErrors: Array<unknown>,
   silenceLogger: boolean,
   onHTMLRenderError: (err: any) => void
 ): ErrorHandler {
@@ -155,6 +155,7 @@ export function createHTMLErrorHandler(
       } else {
         // The error is not from react-server but has a digest
         // from other means so we don't need to produce a new one
+        reactServerErrors.set(err.digest, err)
       }
     } else {
       err.digest = stringHash(
@@ -162,7 +163,7 @@ export function createHTMLErrorHandler(
       ).toString()
     }
 
-    allCapturedError.push(err)
+    allCapturedErrors.push(err)
 
     // If the response was closed, we don't need to log the error.
     if (isAbortError(err)) return

--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -145,16 +145,15 @@ export function createHTMLErrorHandler(
   onHTMLRenderRSCError: (err: any) => void
 ): ErrorHandler {
   return (err: any, errorInfo: any) => {
-    let isRSCError = false
+    const isRSCError = reactServerErrors.has(err.digest)
     // If the error already has a digest, respect the original digest,
     // so it won't get re-generated into another new error.
 
     if (err.digest) {
-      if (reactServerErrors.has(err.digest)) {
+      if (isRSCError) {
         // This error is likely an obfuscated error from react-server.
         // We recover the original error here.
         err = reactServerErrors.get(err.digest)
-        isRSCError = true
       }
     } else {
       err.digest = stringHash(

--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -141,8 +141,8 @@ export function createHTMLErrorHandler(
   reactServerErrors: Map<string, DigestedError>,
   allCapturedErrors: Array<unknown>,
   silenceLogger: boolean,
-  onHTMLRenderSSRError: (err: any) => void,
-  onHTMLRenderRSCError: (err: any) => void
+  onHTMLRenderRSCError: (err: any) => void,
+  onHTMLRenderSSRError: (err: any) => void
 ): ErrorHandler {
   return (err: any, errorInfo: any) => {
     let isRSCError = false

--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -152,16 +152,15 @@ export function createHTMLErrorHandler(
         // This error is likely an obfuscated error from react-server.
         // We recover the original error here.
         err = reactServerErrors.get(err.digest)
-      } else {
-        // The error is not from react-server but has a digest
-        // from other means so we don't need to produce a new one
-        reactServerErrors.set(err.digest, err)
       }
     } else {
       err.digest = stringHash(
         err.message + (errorInfo?.stack || err.stack || '')
       ).toString()
     }
+
+    // In SSR rendering, we always collect the error
+    reactServerErrors.set(err.digest, err)
 
     allCapturedErrors.push(err)
 

--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -141,9 +141,10 @@ export function createHTMLErrorHandler(
   reactServerErrors: Map<string, DigestedError>,
   allCapturedErrors: Array<unknown>,
   silenceLogger: boolean,
-  onHTMLRenderError: (err: any) => void
+  onHTMLRenderError: (err: any, isRSCError: boolean) => void
 ): ErrorHandler {
   return (err: any, errorInfo: any) => {
+    let isRSCError = false
     // If the error already has a digest, respect the original digest,
     // so it won't get re-generated into another new error.
 
@@ -152,6 +153,7 @@ export function createHTMLErrorHandler(
         // This error is likely an obfuscated error from react-server.
         // We recover the original error here.
         err = reactServerErrors.get(err.digest)
+        isRSCError = true
       }
     } else {
       err.digest = stringHash(
@@ -204,7 +206,7 @@ export function createHTMLErrorHandler(
       }
 
       if (!silenceLogger) {
-        onHTMLRenderError(err)
+        onHTMLRenderError(err, isRSCError)
       }
     }
 

--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -159,9 +159,6 @@ export function createHTMLErrorHandler(
       ).toString()
     }
 
-    // In SSR rendering, we always collect the error
-    reactServerErrors.set(err.digest, err)
-
     allCapturedErrors.push(err)
 
     // If the response was closed, we don't need to log the error.
@@ -172,6 +169,9 @@ export function createHTMLErrorHandler(
 
     // If this is a navigation error, we don't need to log the error.
     if (isNextRouterError(err)) return err.digest
+
+    // In SSR rendering, we always collect the error
+    reactServerErrors.set(err.digest, err)
 
     // If this error occurs, we know that we should be stopping the static
     // render. This is only thrown in static generation when PPR is not enabled,

--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -145,15 +145,19 @@ export function createHTMLErrorHandler(
   onHTMLRenderRSCError: (err: any) => void
 ): ErrorHandler {
   return (err: any, errorInfo: any) => {
-    const isRSCError = reactServerErrors.has(err.digest)
+    let isRSCError = false
     // If the error already has a digest, respect the original digest,
     // so it won't get re-generated into another new error.
 
     if (err.digest) {
-      if (isRSCError) {
+      if (reactServerErrors.has(err.digest)) {
+        isRSCError = true
         // This error is likely an obfuscated error from react-server.
         // We recover the original error here.
         err = reactServerErrors.get(err.digest)
+      } else {
+        // The error is not from react-server but has a digest
+        // from other means so we don't need to produce a new one
       }
     } else {
       err.digest = stringHash(

--- a/test/production/app-dir/client-page-error-bailout/app/layout.js
+++ b/test/production/app-dir/client-page-error-bailout/app/layout.js
@@ -1,0 +1,7 @@
+export default function Root({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/client-page-error-bailout/app/page.js
+++ b/test/production/app-dir/client-page-error-bailout/app/page.js
@@ -1,0 +1,5 @@
+'use client'
+
+export default function Page() {
+  throw new Error('client-page-error')
+}

--- a/test/production/app-dir/client-page-error-bailout/client-page-error-bailout.test.ts
+++ b/test/production/app-dir/client-page-error-bailout/client-page-error-bailout.test.ts
@@ -1,0 +1,29 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('app-dir - client-page-error-bailout', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  let stderr = ''
+  beforeAll(() => {
+    const onLog = (log: string) => {
+      stderr += log
+    }
+
+    next.on('stderr', onLog)
+  })
+
+  it('should bail out in static generation build', async () => {
+    await next.build()
+    expect(stderr).toContain(
+      'Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error'
+    )
+    expect(stderr).toContain('Error: client-page-error')
+  })
+})


### PR DESCRIPTION
### What

It's regression introduced in #67703 where throwing error in client component page is not bailing out anymore in static generation. It was supposed to bail out the build, found by @gnoff 

Closes NDX-52

### Why

We're throwing the all the collected render errors for both RSC and SSR rendering error. But in #67703 we accidentally removed the collection of SSR rendering error into digested errors map

```js
   if (response.digestErrorsMap.size) {
      const buildFailingError = response.digestErrorsMap.values().next().value
      throw buildFailingError
    }
```

We add another check after above for SSR errors, if they're presented we'll bail with the 1st SSR error.