### PR TITLE
docs: add Stack Auth to App Router-enabled auth frameworks

### DIFF
--- a/docs/02-app/index.mdx
+++ b/docs/02-app/index.mdx
@@ -37,6 +37,7 @@ Here are some common authentication solutions that support the App Router:
 
 - [NextAuth.js](https://next-auth.js.org/configuration/nextjs#in-app-router)
 - [Clerk](https://clerk.com/docs/quickstarts/nextjs)
+- [Stack Auth](https://docs.stack-auth.com/getting-started/setup)
 - [Lucia](https://lucia-auth.com/getting-started/nextjs-app)
 - [Auth0](https://github.com/auth0/nextjs-auth0#app-router)
 - [Stytch](https://stytch.com/docs/example-apps/frontend/nextjs)


### PR DESCRIPTION
Following the addition of Stack Auth to the list of authentication frameworks in #68284, this also adds it to the same list for the App Router. Stack is natively built for the App Router, with first-class support for RSC, server actions, PPR, and suspense.