### PR TITLE
docs(cookies): fix link to Dynamic Function

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/cookies.mdx
+++ b/docs/02-app/02-api-reference/04-functions/cookies.mdx
@@ -10,7 +10,7 @@ related:
 
 The `cookies` function allows you to read the HTTP incoming request cookies from a [Server Component](/docs/app/building-your-application/rendering/server-components) or write outgoing request cookies in a [Server Action](/docs/app/building-your-application/data-fetching/server-actions-and-mutations) or [Route Handler](/docs/app/building-your-application/routing/route-handlers).
 
-> **Good to know**: `cookies()` is a **[Dynamic Function](/docs/app/building-your-application/rendering/server-components#server-rendering-strategies#dynamic-functions)** whose returned values cannot be known ahead of time. Using it in a layout or page will opt a route into **[dynamic rendering](/docs/app/building-your-application/rendering/server-components#dynamic-rendering)** at request time.
+> **Good to know**: `cookies()` is a **[Dynamic Function](/docs/app/building-your-application/rendering/server-components#dynamic-functions)** whose returned values cannot be known ahead of time. Using it in a layout or page will opt a route into **[dynamic rendering](/docs/app/building-your-application/rendering/server-components#dynamic-rendering)** at request time.
 
 ## `cookies().get(name)`
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f315327c-ddc1-4ce4-a00a-695c21e47fa0)

There is an invalid link on the cookies page (https://nextjs.org/docs/app/api-reference/functions/cookies). Currently it links to the incorrect section. The correct link should be https://nextjs.org/docs/app/building-your-application/rendering/server-components#dynamic-functions