### PR TITLE
fix(next): properly pass layout-level `maxDuration` config to the children page segments on build

### DIFF
--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -117,7 +117,7 @@ export async function getStaticInfoIncludingLayouts({
     pageFilePath,
     isDev,
     page,
-    // TODO: sync types for pages: PAGE_TYPES, ROUTE_TYPES, 'app' | 'pages', etc.
+    // TODO: sync types for pages: PAGE_TYPES, ROUTER_TYPE, 'app' | 'pages', etc.
     pageType: isInsideAppDir ? PAGE_TYPES.APP : PAGE_TYPES.PAGES,
   })
 

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -100,11 +100,13 @@ import {
 } from '../telemetry/events'
 import type { EventBuildFeatureUsage } from '../telemetry/events'
 import { Telemetry } from '../telemetry/storage'
+import { hadUnsupportedValue } from './analysis/get-page-static-info'
 import {
-  getPageStaticInfo,
-  hadUnsupportedValue,
-} from './analysis/get-page-static-info'
-import { createPagesMapping, getPageFromPath, sortByPageExts } from './entries'
+  createPagesMapping,
+  getPageFromPath,
+  getStaticInfoIncludingLayouts,
+  sortByPageExts,
+} from './entries'
 import { PAGE_TYPES } from '../lib/page-types'
 import { generateBuildId } from './generate-build-id'
 import { isWriteable } from './is-writeable'
@@ -2018,13 +2020,19 @@ export default async function build(
                       pagePath
                     )
 
+                const isInsideAppDir = pageType === 'app'
                 const staticInfo = pagePath
-                  ? await getPageStaticInfo({
+                  ? await getStaticInfoIncludingLayouts({
+                      isInsideAppDir,
                       pageFilePath,
-                      nextConfig: config,
-                      // TODO: fix type mismatch
-                      pageType:
-                        pageType === 'app' ? PAGE_TYPES.APP : PAGE_TYPES.PAGES,
+                      pageExtensions: config.pageExtensions,
+                      appDir,
+                      config,
+                      isDev: false,
+                      // If this route is an App Router page route, inherit the
+                      // route segment configs (e.g. `runtime`) from the layout by
+                      // passing the `originalAppPath`, which should end with `/page`.
+                      page: isInsideAppDir ? originalAppPath! : page,
                     })
                   : undefined
 

--- a/test/e2e/app-dir/with-exported-function-config/app/app-layout/inner/page.tsx
+++ b/test/e2e/app-dir/with-exported-function-config/app/app-layout/inner/page.tsx
@@ -1,0 +1,6 @@
+export default function Page() {
+  return <p>app-layout</p>
+}
+
+// overwrite ../layout's maxDuration
+export const maxDuration = 2

--- a/test/e2e/app-dir/with-exported-function-config/app/app-layout/layout.tsx
+++ b/test/e2e/app-dir/with-exported-function-config/app/app-layout/layout.tsx
@@ -1,0 +1,5 @@
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}
+
+export const maxDuration = 1

--- a/test/e2e/app-dir/with-exported-function-config/app/app-layout/page.tsx
+++ b/test/e2e/app-dir/with-exported-function-config/app/app-layout/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>app-layout</p>
+}

--- a/test/e2e/app-dir/with-exported-function-config/with-exported-function-config.test.ts
+++ b/test/e2e/app-dir/with-exported-function-config/with-exported-function-config.test.ts
@@ -16,11 +16,9 @@ describe('with-exported-function-config', () => {
           '/api/page-route': {
             maxDuration: 1,
           },
-          // TODO: remove this comment.
-          // The `maxDuration` for `/app-layout/inner` is present, but `/app-layout` is not.
-          // This occurs because the `maxDuration` defined in `layout.tsx` is not overridden
-          // at `/app-layout`, and `/app-layout/inner` has it's own `maxDuration` defined just
-          // like other routes.
+          '/app-layout': {
+            maxDuration: 1,
+          },
           '/app-layout/inner': {
             maxDuration: 2,
           },
@@ -45,11 +43,6 @@ describe('with-exported-function-config', () => {
         },
         version: 1,
       })
-
-      // TODO: remove the test below, it is to show the current behavior
-      expect(functionsConfigManifest.functions).not.toHaveProperty(
-        '/app-layout'
-      )
     }
   })
 })

--- a/test/e2e/app-dir/with-exported-function-config/with-exported-function-config.test.ts
+++ b/test/e2e/app-dir/with-exported-function-config/with-exported-function-config.test.ts
@@ -11,34 +11,32 @@ describe('with-exported-function-config', () => {
         await next.readFile('.next/server/functions-config-manifest.json')
       )
 
-      expect(functionsConfigManifest).toMatchInlineSnapshot(`
-        {
-          "functions": {
-            "/api/page-route": {
-              "maxDuration": 1,
-            },
-            "/app-route": {
-              "maxDuration": 1,
-            },
-            "/app-route-edge": {
-              "maxDuration": 2,
-            },
-            "/app-ssr": {
-              "maxDuration": 3,
-            },
-            "/app-ssr-edge": {
-              "maxDuration": 4,
-            },
-            "/page": {
-              "maxDuration": 2,
-            },
-            "/page-ssr": {
-              "maxDuration": 3,
-            },
+      expect(functionsConfigManifest).toEqual({
+        functions: {
+          '/api/page-route': {
+            maxDuration: 1,
           },
-          "version": 1,
-        }
-      `)
+          '/app-route': {
+            maxDuration: 1,
+          },
+          '/app-route-edge': {
+            maxDuration: 2,
+          },
+          '/app-ssr': {
+            maxDuration: 3,
+          },
+          '/app-ssr-edge': {
+            maxDuration: 4,
+          },
+          '/page': {
+            maxDuration: 2,
+          },
+          '/page-ssr': {
+            maxDuration: 3,
+          },
+        },
+        version: 1,
+      })
     }
   })
 })

--- a/test/e2e/app-dir/with-exported-function-config/with-exported-function-config.test.ts
+++ b/test/e2e/app-dir/with-exported-function-config/with-exported-function-config.test.ts
@@ -16,6 +16,14 @@ describe('with-exported-function-config', () => {
           '/api/page-route': {
             maxDuration: 1,
           },
+          // TODO: remove this comment.
+          // The `maxDuration` for `/app-layout/inner` is present, but `/app-layout` is not.
+          // This occurs because the `maxDuration` defined in `layout.tsx` is not overridden
+          // at `/app-layout`, and `/app-layout/inner` has it's own `maxDuration` defined just
+          // like other routes.
+          '/app-layout/inner': {
+            maxDuration: 2,
+          },
           '/app-route': {
             maxDuration: 1,
           },
@@ -37,6 +45,11 @@ describe('with-exported-function-config', () => {
         },
         version: 1,
       })
+
+      // TODO: remove the test below, it is to show the current behavior
+      expect(functionsConfigManifest.functions).not.toHaveProperty(
+        '/app-layout'
+      )
     }
   })
 })


### PR DESCRIPTION
> [!NOTE]
> This PR is recommended to [hide whitespace](https://github.blog/news-insights/product-news/ignore-white-space-in-code-review/) when reviewing.

### What?

Fixed layouts to properly pass route segment config `maxDuration` to their children page segments.

```tsx
// layout.tsx

export const maxDuration = 5

```

### Why?

- We separately handle the route segment configs on different places.
- `maxDuration` was missing logic to get value from the layouts unlike [other route segment configs](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/utils.ts#L1636-L1652).

### How?

- Instead of explicit logic for the `maxDuration`, get the route segment configs from the layout on the page's static info.
- Ensure to inherit the value from the layout only if is a page segment.

#### See Changes by Commits

- current: 522b9537d5d249e39e606f4f69459ac9f9519ded
- expected: 12496d445703bb23dc4beb14ed13dcbec458a539
- fix: 196e0e86ee11b9319c899123e16d3a632dbbe37c

Fixes NDX-196