### PR TITLE
fix(turbopack): correctly handle catchall specificity

### DIFF
--- a/test/e2e/app-dir/catchall-specificity/app/(group)/specific/[[...slug]]/page.tsx
+++ b/test/e2e/app-dir/catchall-specificity/app/(group)/specific/[[...slug]]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Specific Page</div>
+}

--- a/test/e2e/app-dir/catchall-specificity/app/[[...slug]]/page.tsx
+++ b/test/e2e/app-dir/catchall-specificity/app/[[...slug]]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Generic Page</div>
+}

--- a/test/e2e/app-dir/catchall-specificity/app/layout.tsx
+++ b/test/e2e/app-dir/catchall-specificity/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/catchall-specificity/catchall-specificity.test.ts
+++ b/test/e2e/app-dir/catchall-specificity/catchall-specificity.test.ts
@@ -1,0 +1,19 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('catchall-specificity', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should match the generic catchall correctly', async () => {
+    const browser = await next.browser('/foo')
+
+    expect(await browser.elementByCss('body').text()).toContain('Generic Page')
+  })
+
+  it('should match the specific catchall correctly', async () => {
+    const browser = await next.browser('/specific')
+
+    expect(await browser.elementByCss('body').text()).toContain('Specific Page')
+  })
+})

--- a/test/e2e/app-dir/catchall-specificity/next.config.js
+++ b/test/e2e/app-dir/catchall-specificity/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
(generated by graphite)

### What?

Introduce `get_specificity` method to determine the specificity of routes.
This facilitates more accurate route matching for catchall routes by comparing route specificity.
Modify existing route matching logic to incorporate specificity checks and avoid route conflicts.
Add corresponding tests to validate the new specificity handling mechanism.

Fixes #67045
Closes PACK-3154

