### PR TITLE
fix(create-next-app): support renamed repositories

### DIFF
--- a/packages/create-next-app/helpers/examples.ts
+++ b/packages/create-next-app/helpers/examples.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { Readable } from 'node:stream'
+import { sep } from 'node:path'
 import { pipeline } from 'node:stream/promises'
 import { x } from 'tar'
 
@@ -99,6 +100,7 @@ export async function downloadAndExtractRepo(
   root: string,
   { username, name, branch, filePath }: RepoInfo
 ) {
+  let rootPath: string | null = null
   await pipeline(
     await downloadTarStream(
       `https://codeload.github.com/${username}/${name}/tar.gz/${branch}`
@@ -106,12 +108,18 @@ export async function downloadAndExtractRepo(
     x({
       cwd: root,
       strip: filePath ? filePath.split('/').length + 1 : 1,
-      filter: (p) =>
-        p.startsWith(
-          `${name}-${branch.replace(/\//g, '-')}${
-            filePath ? `/${filePath}/` : '/'
-          }`
-        ),
+      filter: (p: string) => {
+        // Determine the unpacked root path dynamically instead of hardcoding to the fetched repo's name / branch.
+        // This avoids the condition when the repository has been renamed, and the old repository name is used to fetch the example.
+        // The tar download will work as it is redirected automatically, but the root directory of the extracted
+        // example will be the new, renamed name instead of the name used to fetch the example, breaking the filter.
+        if (rootPath === null) {
+          const pathSegments = p.split(sep)
+          rootPath = pathSegments.length ? pathSegments[0] : null
+        }
+
+        return p.startsWith(`${rootPath}${filePath ? `/${filePath}/` : '/'}`)
+      },
     })
   )
 }


### PR DESCRIPTION
### What?

Fix bug in `create-next-app` that prevents using an example from a renamed repository. 

Right now we assume the tar of the downloaded repository will always match the format `{repo}-{branch}`. However, if a repository is specified that has been renamed, and the _old_ name is used, the download will work as it is automatically redirected, but the filter will break as it will be expecting the old name. For example:

If you request:
```
npx create-next-app@latest -e https://github.com/tknickman/turbo/tree/main/examples/basic my-cool-example
```

You will get an empty directory, with the following console output:
```
Creating a new Next.js app in /Users/knickman/Developer/vercel/tmp/my-cool-example.

Downloading files from repo https://github.com/tknickman/turbo/tree/main/examples/basic. This might take a moment.

Initialized a git repository.

Success! Created my-cool-example at /Users/knickman/Developer/vercel/tmp/my-cool-example
```

This happens because the repo `https://github.com/tknickman/turbo` has been renamed to `https://github.com/tknickman/turborepo`. The tar download works, as it follows the redirect. But the file that is created is `turborepo-main` instead of `turbo-main` (what we expect because we inferred the name from the url). This results in all files being filtered out, and an empty directory being created. 

### Why?

Repositories can be seamlessly renamed on Github (we've done this ourselves with `vercel/turborepo` > `vercel/turbo` etc.) `create-next-app` should support this as well to ensure old code examples work as expected

### How?

instead of hardcoding the expected result of the repo download, we infer it dynamically as part of the filter process. 

