### PR TITLE
rename fetchServerResponse response properties

### DIFF
--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -102,11 +102,11 @@ export function createInitialRouterState({
     createPrefetchCacheEntryForInitialLoad({
       url,
       data: {
-        f: initialFlightData,
-        c: undefined,
-        i: !!couldBeIntercepted,
+        flightData: initialFlightData,
+        canonicalUrl: undefined,
+        couldBeIntercepted: !!couldBeIntercepted,
         // TODO: the server should probably send a value for this. Default to false for now.
-        p: false,
+        isPrerender: false,
       },
       tree: initialState.tree,
       prefetchCache: initialState.prefetchCache,

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -57,10 +57,10 @@ function urlToUrlWithoutFlightMarker(url: string): URL {
 
 function doMpaNavigation(url: string): FetchServerResponseResult {
   return {
-    f: urlToUrlWithoutFlightMarker(url).toString(),
-    c: undefined,
-    i: false,
-    p: false,
+    flightData: urlToUrlWithoutFlightMarker(url).toString(),
+    canonicalUrl: undefined,
+    couldBeIntercepted: false,
+    isPrerender: false,
   }
 }
 
@@ -206,10 +206,10 @@ export async function fetchServerResponse(
     }
 
     return {
-      f: response.f,
-      c: canonicalUrl,
-      i: interception,
-      p: isPrerender,
+      flightData: response.f,
+      canonicalUrl: canonicalUrl,
+      couldBeIntercepted: interception,
+      isPrerender: isPrerender,
     }
   } catch (err) {
     console.error(
@@ -220,10 +220,10 @@ export async function fetchServerResponse(
     // TODO-APP: Add a test for the case where a CORS request fails, e.g. external url redirect coming from the response.
     // See https://github.com/vercel/next.js/issues/43605#issuecomment-1451617521 for a reproduction.
     return {
-      f: url.toString(),
-      c: undefined,
-      i: false,
-      p: false,
+      flightData: url.toString(),
+      canonicalUrl: undefined,
+      couldBeIntercepted: false,
+      isPrerender: false,
     }
   }
 }

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -353,7 +353,7 @@ export function listenForDynamicRequest(
   responsePromise: Promise<FetchServerResponseResult>
 ) {
   responsePromise.then(
-    ({ f: flightData }: FetchServerResponseResult) => {
+    ({ flightData }: FetchServerResponseResult) => {
       for (const flightDataPath of flightData) {
         const segmentPath = flightDataPath.slice(0, -3)
         const serverRouterState = flightDataPath[flightDataPath.length - 3]

--- a/packages/next/src/client/components/router-reducer/prefetch-cache-utils.ts
+++ b/packages/next/src/client/components/router-reducer/prefetch-cache-utils.ts
@@ -247,7 +247,7 @@ export function createPrefetchCacheEntryForInitialLoad({
   // prefetch cache so that we can skip an extra prefetch request later, since we already have the data.
   const kind = PrefetchKind.AUTO
   // if the prefetch corresponds with an interception route, we use the nextUrl to prefix the cache key
-  const prefetchCacheKey = data.i
+  const prefetchCacheKey = data.couldBeIntercepted
     ? createPrefetchCacheKey(url, kind, nextUrl)
     : createPrefetchCacheKey(url, kind)
 
@@ -300,7 +300,7 @@ function createLazyPrefetchEntry({
       // (which is currently directly influenced by the server response)
       let newCacheKey
 
-      if (prefetchResponse.i) {
+      if (prefetchResponse.couldBeIntercepted) {
         // Determine if we need to prefix the cache key with the nextUrl
         newCacheKey = prefixExistingPrefetchCacheEntry({
           url,
@@ -313,7 +313,7 @@ function createLazyPrefetchEntry({
       // If the prefetch was a cache hit, we want to update the existing cache entry to reflect that it was a full prefetch.
       // This is because we know that a static response will contain the full RSC payload, and can be updated to respect the `static`
       // staleTime.
-      if (prefetchResponse.p) {
+      if (prefetchResponse.isPrerender) {
         const existingCacheEntry = prefetchCache.get(
           // if we prefixed the cache key due to route interception, we want to use the new key. Otherwise we use the original key
           newCacheKey ?? prefetchCacheKey

--- a/packages/next/src/client/components/router-reducer/reducers/hmr-refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/hmr-refresh-reducer.ts
@@ -42,7 +42,7 @@ function hmrRefreshReducerImpl(
   })
 
   return cache.lazyData.then(
-    ({ f: flightData, c: canonicalUrlOverride }) => {
+    ({ flightData, canonicalUrl: canonicalUrlOverride }) => {
       // Handle case when navigating to page in `pages` from `app`
       if (typeof flightData === 'string') {
         return handleExternalUrl(

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -137,7 +137,7 @@ function navigateReducer_noPPR(
   prefetchQueue.bump(data)
 
   return data.then(
-    ({ f: flightData, c: canonicalUrlOverride }) => {
+    ({ flightData, canonicalUrl: canonicalUrlOverride }) => {
       let isFirstRead = false
       // we only want to mark this once
       if (!prefetchValues.lastUsedTime) {
@@ -353,7 +353,7 @@ function navigateReducer_PPR(
   prefetchQueue.bump(data)
 
   return data.then(
-    ({ f: flightData, c: canonicalUrlOverride }) => {
+    ({ flightData, canonicalUrl: canonicalUrlOverride }) => {
       let isFirstRead = false
       // we only want to mark this once
       if (!prefetchValues.lastUsedTime) {
@@ -450,6 +450,7 @@ function navigateReducer_PPR(
               head,
               mutable.onlyHashChange
             )
+
             if (task !== null) {
               // We've created a new Cache Node tree that contains a prefetched
               // version of the next page. This can be rendered instantly.
@@ -480,14 +481,17 @@ function navigateReducer_PPR(
                 // root multiple times per navigation, like if the server sends us
                 // a different response than we expected. For now, we revert back
                 // to the lazy fetching mechanism in that case.)
-                listenForDynamicRequest(
-                  task,
-                  fetchServerResponse(url, {
-                    flightRouterState: currentTree,
-                    nextUrl: state.nextUrl,
-                    buildId: state.buildId,
-                  })
-                )
+                const dynamicRequest = fetchServerResponse(url, {
+                  flightRouterState: currentTree,
+                  nextUrl: state.nextUrl,
+                  buildId: state.buildId,
+                })
+
+                listenForDynamicRequest(task, dynamicRequest)
+                // We store the dynamic request on the `lazyData` property of the CacheNode
+                // because we're not going to await the dynamic request here. Since we're not blocking
+                // on the dynamic request, `layout-router` will
+                // task.node.lazyData = dynamicRequest
 
                 mutable.cache = newCache
               }

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -49,7 +49,7 @@ export function refreshReducer(
   })
 
   return cache.lazyData.then(
-    async ({ f: flightData, c: canonicalUrlOverride }) => {
+    async ({ flightData, canonicalUrl: canonicalUrlOverride }) => {
       // Handle case when navigating to page in `pages` from `app`
       if (typeof flightData === 'string') {
         return handleExternalUrl(

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
@@ -19,7 +19,7 @@ export function serverPatchReducer(
   action: ServerPatchAction
 ): ReducerState {
   const {
-    serverResponse: { f: flightData, c: canonicalUrlOverride },
+    serverResponse: { flightData, canonicalUrl: canonicalUrlOverride },
   } = action
 
   const mutable: Mutable = {}

--- a/packages/next/src/client/components/router-reducer/refetch-inactive-parallel-segments.ts
+++ b/packages/next/src/client/components/router-reducer/refetch-inactive-parallel-segments.ts
@@ -71,7 +71,7 @@ async function refreshInactiveParallelSegmentsImpl({
         nextUrl: includeNextUrl ? state.nextUrl : null,
         buildId: state.buildId,
       }
-    ).then(({ f: flightData }) => {
+    ).then(({ flightData }) => {
       if (typeof flightData !== 'string') {
         for (const flightDataPath of flightData) {
           // we only pass the new cache as this function is called after clearing the router cache

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -237,14 +237,10 @@ export type ActionFlightResponse = {
 }
 
 export type FetchServerResponseResult = {
-  /** flightData */
-  f: FlightData
-  /** canonicalUrl */
-  c: URL | undefined
-  /** couldBeIntercepted */
-  i: boolean
-  /** isPrerender */
-  p: boolean
+  flightData: FlightData
+  canonicalUrl: URL | undefined
+  couldBeIntercepted: boolean
+  isPrerender: boolean
 }
 
 export type RSCPayload =


### PR DESCRIPTION
This was mirroring the single-key responses that we do on the responses from the server, but since this is never serialized or passed from server -> client, there's no reason to make it harder to read!