### PR TITLE
Stop importing from `next/dist/bin/next`

### DIFF
--- a/test/production/build-spinners/index.test.ts
+++ b/test/production/build-spinners/index.test.ts
@@ -108,11 +108,10 @@ describe('build-spinners', () => {
 
     const appDir = next.testDir
 
-    const nextBin = resolveFrom(appDir, 'next/dist/bin/next')
     const ptyPath = resolveFrom(appDir, 'node-pty')
     const pty = require(ptyPath)
     const output = []
-    const ptyProcess = pty.spawn(process.execPath, [nextBin, 'build'], {
+    const ptyProcess = pty.spawn('pnpm', ['next', 'build'], {
       name: 'xterm-color',
       cols: 80,
       rows: 30,


### PR DESCRIPTION
This is technically a private path that can move between any release.
The supported API is running `next` from your package manager so tests should reflect that.