### PR TITLE
Refactored module IDs optimization

### DIFF
--- a/crates/next-api/src/global_module_id_strategy.rs
+++ b/crates/next-api/src/global_module_id_strategy.rs
@@ -26,6 +26,10 @@ impl GlobalModuleIdStrategyBuilder {
 
         let entrypoints = project.entrypoints().await?;
 
+        preprocessed_module_ids.push(preprocess_module_ids(entrypoints.pages_error_endpoint));
+        preprocessed_module_ids.push(preprocess_module_ids(entrypoints.pages_app_endpoint));
+        preprocessed_module_ids.push(preprocess_module_ids(entrypoints.pages_document_endpoint));
+
         for (_, route) in entrypoints.routes.iter() {
             match route {
                 Route::Page {
@@ -42,6 +46,8 @@ impl GlobalModuleIdStrategyBuilder {
                     for page_route in page_routes {
                         preprocessed_module_ids
                             .push(preprocess_module_ids(page_route.html_endpoint));
+                        preprocessed_module_ids
+                            .push(preprocess_module_ids(page_route.rsc_endpoint));
                     }
                 }
                 Route::AppRoute {

--- a/crates/next-api/src/global_module_id_strategy.rs
+++ b/crates/next-api/src/global_module_id_strategy.rs
@@ -24,6 +24,8 @@ impl GlobalModuleIdStrategyBuilder {
     pub async fn build(project: Vc<Project>) -> Result<Vc<Box<dyn ModuleIdStrategy>>> {
         let mut preprocessed_module_ids = Vec::new();
 
+        preprocessed_module_ids.push(children_modules_idents(project.client_main_modules()));
+
         let entrypoints = project.entrypoints().await?;
 
         preprocessed_module_ids.push(preprocess_module_ids(entrypoints.pages_error_endpoint));

--- a/crates/next-api/src/global_module_id_strategy.rs
+++ b/crates/next-api/src/global_module_id_strategy.rs
@@ -1,0 +1,75 @@
+use anyhow::Result;
+use turbo_tasks::Vc;
+use turbopack_core::chunk::{
+    global_module_id_strategy::{
+        children_modules_idents, merge_preprocessed_module_ids, PreprocessedChildrenIdents,
+    },
+    module_id_strategies::{GlobalModuleIdStrategy, ModuleIdStrategy},
+};
+
+use crate::{
+    project::Project,
+    route::{Endpoint, Route},
+};
+
+#[turbo_tasks::value]
+pub struct GlobalModuleIdStrategyBuilder;
+
+// NOTE(LichuAcu) To access all entrypoints, we need to access an instance of `Project`, but
+// `Project` is not available in `turbopack-core`, so we need need this
+// `GlobalModuleIdStrategyBuilder` in `next-api`.
+#[turbo_tasks::value_impl]
+impl GlobalModuleIdStrategyBuilder {
+    #[turbo_tasks::function]
+    pub async fn build(project: Vc<Project>) -> Result<Vc<Box<dyn ModuleIdStrategy>>> {
+        let mut preprocessed_module_ids = Vec::new();
+
+        let entrypoints = project.entrypoints().await?;
+
+        for (_, route) in entrypoints.routes.iter() {
+            match route {
+                Route::Page {
+                    html_endpoint,
+                    data_endpoint,
+                } => {
+                    preprocessed_module_ids.push(preprocess_module_ids(*html_endpoint));
+                    preprocessed_module_ids.push(preprocess_module_ids(*data_endpoint));
+                }
+                Route::PageApi { endpoint } => {
+                    preprocessed_module_ids.push(preprocess_module_ids(*endpoint));
+                }
+                Route::AppPage(page_routes) => {
+                    for page_route in page_routes {
+                        preprocessed_module_ids
+                            .push(preprocess_module_ids(page_route.html_endpoint));
+                    }
+                }
+                Route::AppRoute {
+                    original_name: _,
+                    endpoint,
+                } => {
+                    preprocessed_module_ids.push(preprocess_module_ids(*endpoint));
+                }
+                Route::Conflict => {
+                    tracing::info!("WARN: conflict");
+                }
+            }
+        }
+
+        let module_id_map = merge_preprocessed_module_ids(preprocessed_module_ids).await?;
+
+        Ok(Vc::upcast(
+            GlobalModuleIdStrategy::new(module_id_map).await?,
+        ))
+    }
+}
+
+// NOTE(LichuAcu) We can't move this function to `turbopack-core` because we need access to
+// `Endpoint`, which is not available there.
+#[turbo_tasks::function]
+async fn preprocess_module_ids(
+    endpoint: Vc<Box<dyn Endpoint>>,
+) -> Result<Vc<PreprocessedChildrenIdents>> {
+    let root_modules = endpoint.root_modules();
+    Ok(children_modules_idents(root_modules))
+}

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -15,7 +15,7 @@ use turbopack_core::{
         EntryChunkGroupResult,
     },
     context::AssetContext,
-    module::Module,
+    module::{Module, Modules},
     output::{OutputAsset, OutputAssets},
     reference_type::{EntryReferenceSubType, ReferenceType},
     source::Source,
@@ -235,5 +235,10 @@ impl Endpoint for InstrumentationEndpoint {
     #[turbo_tasks::function]
     fn client_changed(self: Vc<Self>) -> Vc<Completion> {
         Completion::immutable()
+    }
+
+    #[turbo_tasks::function]
+    fn root_modules(self: Vc<Self>) -> Result<Vc<Modules>> {
+        Err(anyhow::anyhow!("Not implemented."))
     }
 }

--- a/crates/next-api/src/lib.rs
+++ b/crates/next-api/src/lib.rs
@@ -6,6 +6,7 @@ mod app;
 mod dynamic_imports;
 pub mod entrypoints;
 mod font;
+pub mod global_module_id_strategy;
 mod instrumentation;
 mod loadable_manifest;
 mod middleware;

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -14,7 +14,7 @@ use turbopack_core::{
     asset::AssetContent,
     chunk::{availability_info::AvailabilityInfo, ChunkingContextExt},
     context::AssetContext,
-    module::Module,
+    module::{Module, Modules},
     output::OutputAssets,
     reference_type::{EntryReferenceSubType, ReferenceType},
     source::Source,
@@ -236,5 +236,10 @@ impl Endpoint for MiddlewareEndpoint {
     #[turbo_tasks::function]
     fn client_changed(self: Vc<Self>) -> Vc<Completion> {
         Completion::immutable()
+    }
+
+    #[turbo_tasks::function]
+    fn root_modules(self: Vc<Self>) -> Result<Vc<Modules>> {
+        Err(anyhow::anyhow!("Not implemented."))
     }
 }

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -46,7 +46,7 @@ use turbopack_core::{
     context::AssetContext,
     file_source::FileSource,
     issue::IssueSeverity,
-    module::Module,
+    module::{Module, Modules},
     output::{OutputAsset, OutputAssets},
     reference_type::{EcmaScriptModulesReferenceSubType, EntryReferenceSubType, ReferenceType},
     resolve::{origin::PlainResolveOrigin, parse::Request, pattern::Pattern},
@@ -615,42 +615,55 @@ impl PageEndpoint {
     }
 
     #[turbo_tasks::function]
+    async fn client_chunks_modules(self: Vc<Self>) -> Result<Vc<ClientChunksModules>> {
+        let this = self.await?;
+
+        let client_module_context = this.pages_project.client_module_context();
+        let client_module =
+            create_page_loader_entry_module(client_module_context, self.source(), this.pathname);
+
+        let client_main_module = esm_resolve(
+            Vc::upcast(PlainResolveOrigin::new(
+                client_module_context,
+                this.pages_project.project().project_path().join("_".into()),
+            )),
+            Request::parse(Value::new(Pattern::Constant(
+                match *this.pages_project.project().next_mode().await? {
+                    NextMode::Development => "next/dist/client/next-dev-turbopack.js",
+                    NextMode::Build => "next/dist/client/next-turbopack.js",
+                }
+                .into(),
+            ))),
+            Value::new(EcmaScriptModulesReferenceSubType::Undefined),
+            IssueSeverity::Error.cell(),
+            None,
+        )
+        .first_module()
+        .await?
+        .context("expected Next.js client runtime to resolve to a module")?;
+
+        Ok(ClientChunksModules {
+            client_module,
+            client_main_module,
+        }
+        .cell())
+    }
+
+    #[turbo_tasks::function]
     async fn client_chunks(self: Vc<Self>) -> Result<Vc<OutputAssets>> {
         async move {
             let this = self.await?;
 
-            let client_module_context = this.pages_project.client_module_context();
-            let client_module = create_page_loader_entry_module(
-                client_module_context,
-                self.source(),
-                this.pathname,
-            );
+            let ClientChunksModules {
+                client_module,
+                client_main_module,
+            } = *self.client_chunks_modules().await?;
 
             let Some(client_module) =
                 Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(client_module).await?
             else {
                 bail!("expected an ECMAScript module asset");
             };
-
-            let client_main_module = esm_resolve(
-                Vc::upcast(PlainResolveOrigin::new(
-                    client_module_context,
-                    this.pages_project.project().project_path().join("_".into()),
-                )),
-                Request::parse(Value::new(Pattern::Constant(
-                    match *this.pages_project.project().next_mode().await? {
-                        NextMode::Development => "next/dist/client/next-dev-turbopack.js",
-                        NextMode::Build => "next/dist/client/next-turbopack.js",
-                    }
-                    .into(),
-                ))),
-                Value::new(EcmaScriptModulesReferenceSubType::Undefined),
-                IssueSeverity::Error.cell(),
-                None,
-            )
-            .first_module()
-            .await?
-            .context("expected Next.js client runtime to resolve to a module")?;
 
             let Some(client_main_module) =
                 Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(client_main_module).await?
@@ -694,14 +707,83 @@ impl PageEndpoint {
     }
 
     #[turbo_tasks::function]
+    async fn internal_ssr_chunk_module(self: Vc<Self>) -> Result<Vc<InternalSsrChunkModule>> {
+        let this = self.await?;
+
+        let (reference_type, project_root, module_context, edge_module_context) = match this.ty {
+            PageEndpointType::Html | PageEndpointType::SsrOnly => (
+                Value::new(ReferenceType::Entry(EntryReferenceSubType::Page)),
+                this.pages_project.project().project_path(),
+                this.pages_project.ssr_module_context(),
+                this.pages_project.edge_ssr_module_context(),
+            ),
+            PageEndpointType::Data => (
+                Value::new(ReferenceType::Entry(EntryReferenceSubType::Page)),
+                this.pages_project.project().project_path(),
+                this.pages_project.ssr_data_module_context(),
+                this.pages_project.edge_ssr_data_module_context(),
+            ),
+            PageEndpointType::Api => (
+                Value::new(ReferenceType::Entry(EntryReferenceSubType::PagesApi)),
+                this.pages_project.project().project_path(),
+                this.pages_project.api_module_context(),
+                this.pages_project.edge_api_module_context(),
+            ),
+        };
+
+        let ssr_module = module_context
+            .process(self.source(), reference_type.clone())
+            .module();
+
+        let config = parse_config_from_source(ssr_module).await?;
+        let is_edge = matches!(config.runtime, NextRuntime::Edge);
+
+        let ssr_module = if is_edge {
+            create_page_ssr_entry_module(
+                this.pathname,
+                reference_type,
+                project_root,
+                Vc::upcast(edge_module_context),
+                self.source(),
+                this.original_name,
+                this.pages_structure,
+                config.runtime,
+                this.pages_project.project().next_config(),
+            )
+        } else {
+            let pathname = &**this.pathname.await?;
+
+            // `/_app` and `/_document` never get rendered directly so they don't need to be
+            // wrapped in the route module.
+            if pathname == "/_app" || pathname == "/_document" {
+                ssr_module
+            } else {
+                create_page_ssr_entry_module(
+                    this.pathname,
+                    reference_type,
+                    project_root,
+                    Vc::upcast(module_context),
+                    self.source(),
+                    this.original_name,
+                    this.pages_structure,
+                    config.runtime,
+                    this.pages_project.project().next_config(),
+                )
+            }
+        };
+
+        Ok(InternalSsrChunkModule {
+            ssr_module,
+            runtime: config.runtime,
+        }
+        .cell())
+    }
+
+    #[turbo_tasks::function]
     async fn internal_ssr_chunk(
         self: Vc<Self>,
         ty: SsrChunkType,
-        reference_type: Value<ReferenceType>,
         node_path: Vc<FileSystemPath>,
-        project_root: Vc<FileSystemPath>,
-        module_context: Vc<ModuleAssetContext>,
-        edge_module_context: Vc<ModuleAssetContext>,
         chunking_context: Vc<NodeJsChunkingContext>,
         edge_chunking_context: Vc<Box<dyn ChunkingContext>>,
         runtime_entries: Vc<EvaluatableAssets>,
@@ -710,26 +792,14 @@ impl PageEndpoint {
         async move {
             let this = self.await?;
 
-            let ssr_module = module_context
-                .process(self.source(), reference_type.clone())
-                .module();
+            let InternalSsrChunkModule {
+                ssr_module,
+                runtime,
+            } = *self.internal_ssr_chunk_module().await?;
 
-            let config = parse_config_from_source(ssr_module).await?;
-            let is_edge = matches!(config.runtime, NextRuntime::Edge);
+            let is_edge = matches!(runtime, NextRuntime::Edge);
 
             if is_edge {
-                let ssr_module = create_page_ssr_entry_module(
-                    this.pathname,
-                    reference_type,
-                    project_root,
-                    Vc::upcast(edge_module_context),
-                    self.source(),
-                    this.original_name,
-                    this.pages_structure,
-                    config.runtime,
-                    this.pages_project.project().next_config(),
-                );
-
                 let mut evaluatable_assets = edge_runtime_entries.await?.clone_value();
                 let evaluatable = Vc::try_resolve_sidecast(ssr_module)
                     .await?
@@ -762,24 +832,6 @@ impl PageEndpoint {
                 .cell())
             } else {
                 let pathname = &**this.pathname.await?;
-
-                // `/_app` and `/_document` never get rendered directly so they don't need to be
-                // wrapped in the route module.
-                let ssr_module = if pathname == "/_app" || pathname == "/_document" {
-                    ssr_module
-                } else {
-                    create_page_ssr_entry_module(
-                        this.pathname,
-                        reference_type,
-                        project_root,
-                        Vc::upcast(module_context),
-                        self.source(),
-                        this.original_name,
-                        this.pages_structure,
-                        config.runtime,
-                        this.pages_project.project().next_config(),
-                    )
-                };
 
                 let asset_path = get_asset_path_from_pathname(pathname, ".js");
 
@@ -832,14 +884,10 @@ impl PageEndpoint {
         let this = self.await?;
         Ok(self.internal_ssr_chunk(
             SsrChunkType::Page,
-            Value::new(ReferenceType::Entry(EntryReferenceSubType::Page)),
             this.pages_project
                 .project()
                 .node_root()
                 .join("server".into()),
-            this.pages_project.project().project_path(),
-            this.pages_project.ssr_module_context(),
-            this.pages_project.edge_ssr_module_context(),
             this.pages_project.project().server_chunking_context(true),
             this.pages_project.project().edge_chunking_context(true),
             this.pages_project.ssr_runtime_entries(),
@@ -852,14 +900,10 @@ impl PageEndpoint {
         let this = self.await?;
         Ok(self.internal_ssr_chunk(
             SsrChunkType::Data,
-            Value::new(ReferenceType::Entry(EntryReferenceSubType::Page)),
             this.pages_project
                 .project()
                 .node_root()
                 .join("server/data".into()),
-            this.pages_project.project().project_path(),
-            this.pages_project.ssr_data_module_context(),
-            this.pages_project.edge_ssr_data_module_context(),
             this.pages_project.project().server_chunking_context(true),
             this.pages_project.project().edge_chunking_context(true),
             this.pages_project.ssr_data_runtime_entries(),
@@ -872,14 +916,10 @@ impl PageEndpoint {
         let this = self.await?;
         Ok(self.internal_ssr_chunk(
             SsrChunkType::Api,
-            Value::new(ReferenceType::Entry(EntryReferenceSubType::PagesApi)),
             this.pages_project
                 .project()
                 .node_root()
                 .join("server".into()),
-            this.pages_project.project().project_path(),
-            this.pages_project.api_module_context(),
-            this.pages_project.edge_api_module_context(),
             this.pages_project.project().server_chunking_context(false),
             this.pages_project.project().edge_chunking_context(false),
             this.pages_project.ssr_runtime_entries(),
@@ -1129,6 +1169,18 @@ impl PageEndpoint {
     }
 }
 
+#[turbo_tasks::value]
+pub struct InternalSsrChunkModule {
+    pub ssr_module: Vc<Box<dyn Module>>,
+    pub runtime: NextRuntime,
+}
+
+#[turbo_tasks::value]
+pub struct ClientChunksModules {
+    pub client_module: Vc<Box<dyn Module>>,
+    pub client_main_module: Vc<Box<dyn Module>>,
+}
+
 #[turbo_tasks::value_impl]
 impl Endpoint for PageEndpoint {
     #[turbo_tasks::function]
@@ -1211,6 +1263,23 @@ impl Endpoint for PageEndpoint {
             .pages_project
             .project()
             .client_changed(self.output().client_assets()))
+    }
+
+    #[turbo_tasks::function]
+    async fn root_modules(self: Vc<Self>) -> Result<Vc<Modules>> {
+        let mut modules = vec![];
+
+        let this = self.await?;
+
+        let ssr_chunk_module = self.internal_ssr_chunk_module().await?;
+        modules.push(ssr_chunk_module.ssr_module);
+        if let PageEndpointType::Html = this.ty {
+            let client_modules = self.client_chunks_modules().await?;
+            modules.push(client_modules.client_module);
+            modules.push(client_modules.client_main_module);
+        }
+
+        Ok(Vc::cell(modules))
     }
 }
 

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -34,7 +34,10 @@ use turbo_tasks_fs::{DiskFileSystem, FileSystem, FileSystemPath, VirtualFileSyst
 use turbopack::{evaluate_context::node_build_environment, ModuleAssetContext};
 use turbopack_core::{
     changed::content_changed,
-    chunk::ChunkingContext,
+    chunk::{
+        module_id_strategies::{DevModuleIdStrategy, ModuleIdStrategy},
+        ChunkingContext,
+    },
     compile_time_info::CompileTimeInfo,
     context::AssetContext,
     diagnostics::DiagnosticExt,
@@ -54,6 +57,7 @@ use crate::{
     app::{AppProject, OptionAppProject, ECMASCRIPT_CLIENT_TRANSITION_NAME},
     build,
     entrypoints::Entrypoints,
+    global_module_id_strategy::GlobalModuleIdStrategyBuilder,
     instrumentation::InstrumentationEndpoint,
     middleware::MiddlewareEndpoint,
     pages::PagesProject,
@@ -621,6 +625,7 @@ impl Project {
             self.next_config().computed_asset_prefix(),
             self.client_compile_time_info().environment(),
             self.next_mode(),
+            self.module_id_strategy(),
         ))
     }
 
@@ -637,6 +642,7 @@ impl Project {
                 self.client_relative_path(),
                 self.next_config().computed_asset_prefix(),
                 self.server_compile_time_info().environment(),
+                self.module_id_strategy(),
             )
         } else {
             get_server_chunking_context(
@@ -644,6 +650,7 @@ impl Project {
                 self.project_path(),
                 self.node_root(),
                 self.server_compile_time_info().environment(),
+                self.module_id_strategy(),
             )
         }
     }
@@ -661,6 +668,7 @@ impl Project {
                 self.client_relative_path(),
                 self.next_config().computed_asset_prefix(),
                 self.edge_compile_time_info().environment(),
+                self.module_id_strategy(),
             )
         } else {
             get_edge_chunking_context(
@@ -668,6 +676,7 @@ impl Project {
                 self.project_path(),
                 self.node_root(),
                 self.edge_compile_time_info().environment(),
+                self.module_id_strategy(),
             )
         }
     }
@@ -1160,6 +1169,17 @@ impl Project {
     pub fn client_changed(self: Vc<Self>, roots: Vc<OutputAssets>) -> Vc<Completion> {
         let path = self.client_root();
         any_output_changed(roots, path, false)
+    }
+
+    /// Get the module id strategy for the project.
+    /// In production mode, we use the global module id strategy with optimized ids.
+    /// In development mode, we use a standard module id strategy with no modifications.
+    #[turbo_tasks::function]
+    pub async fn module_id_strategy(self: Vc<Self>) -> Result<Vc<Box<dyn ModuleIdStrategy>>> {
+        match *self.next_mode().await? {
+            NextMode::Build => Ok(Vc::upcast(GlobalModuleIdStrategyBuilder::build(self))),
+            NextMode::Development => Ok(Vc::upcast(DevModuleIdStrategy::new())),
+        }
     }
 }
 

--- a/crates/next-api/src/route.rs
+++ b/crates/next-api/src/route.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{debug::ValueDebugFormat, trace::TraceRawVcs, Completion, RcStr, Vc};
+use turbopack_core::module::Modules;
 
 use crate::paths::ServerPath;
 
@@ -75,6 +76,7 @@ pub trait Endpoint {
     fn write_to_disk(self: Vc<Self>) -> Vc<WrittenEndpoint>;
     fn server_changed(self: Vc<Self>) -> Vc<Completion>;
     fn client_changed(self: Vc<Self>) -> Vc<Completion>;
+    fn root_modules(self: Vc<Self>) -> Vc<Modules>;
 }
 
 #[turbo_tasks::value(shared)]

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -14,7 +14,7 @@ use turbopack::{
 };
 use turbopack_browser::{react_refresh::assert_can_resolve_react_refresh, BrowserChunkingContext};
 use turbopack_core::{
-    chunk::ChunkingContext,
+    chunk::{module_id_strategies::ModuleIdStrategy, ChunkingContext},
     compile_time_info::{
         CompileTimeDefineValue, CompileTimeDefines, CompileTimeInfo, FreeVarReference,
         FreeVarReferences,
@@ -353,6 +353,7 @@ pub async fn get_client_chunking_context(
     asset_prefix: Vc<Option<RcStr>>,
     environment: Vc<Environment>,
     mode: Vc<NextMode>,
+    module_id_strategy: Vc<Box<dyn ModuleIdStrategy>>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
     let next_mode = mode.await?;
     let mut builder = BrowserChunkingContext::builder(
@@ -366,7 +367,8 @@ pub async fn get_client_chunking_context(
     )
     .chunk_base_path(asset_prefix)
     .minify_type(next_mode.minify_type())
-    .asset_base_path(asset_prefix);
+    .asset_base_path(asset_prefix)
+    .module_id_strategy(module_id_strategy);
 
     if next_mode.is_development() {
         builder = builder.hot_module_replacement();

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -6,7 +6,7 @@ use turbo_tasks_fs::FileSystemPath;
 use turbopack::resolve_options_context::ResolveOptionsContext;
 use turbopack_browser::BrowserChunkingContext;
 use turbopack_core::{
-    chunk::ChunkingContext,
+    chunk::{module_id_strategies::ModuleIdStrategy, ChunkingContext},
     compile_time_info::{
         CompileTimeDefineValue, CompileTimeDefines, CompileTimeInfo, FreeVarReference,
         FreeVarReferences,
@@ -178,6 +178,7 @@ pub async fn get_edge_chunking_context_with_client_assets(
     client_root: Vc<FileSystemPath>,
     asset_prefix: Vc<Option<RcStr>>,
     environment: Vc<Environment>,
+    module_id_strategy: Vc<Box<dyn ModuleIdStrategy>>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
     let output_root = node_root.join("server/edge".into());
     let next_mode = mode.await?;
@@ -193,6 +194,7 @@ pub async fn get_edge_chunking_context_with_client_assets(
         )
         .asset_base_path(asset_prefix)
         .minify_type(next_mode.minify_type())
+        .module_id_strategy(module_id_strategy)
         .build(),
     ))
 }
@@ -203,6 +205,7 @@ pub async fn get_edge_chunking_context(
     project_path: Vc<FileSystemPath>,
     node_root: Vc<FileSystemPath>,
     environment: Vc<Environment>,
+    module_id_strategy: Vc<Box<dyn ModuleIdStrategy>>,
 ) -> Result<Vc<Box<dyn ChunkingContext>>> {
     let output_root = node_root.join("server/edge".into());
     let next_mode = mode.await?;
@@ -222,6 +225,7 @@ pub async fn get_edge_chunking_context(
         // asset from the output directory.
         .asset_base_path(Vc::cell(Some("blob:server/edge/".into())))
         .minify_type(next_mode.minify_type())
+        .module_id_strategy(module_id_strategy)
         .build(),
     ))
 }

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -14,6 +14,7 @@ use turbopack::{
     transition::Transition,
 };
 use turbopack_core::{
+    chunk::module_id_strategies::ModuleIdStrategy,
     compile_time_info::{
         CompileTimeDefineValue, CompileTimeDefines, CompileTimeInfo, FreeVarReferences,
     },
@@ -922,6 +923,7 @@ pub async fn get_server_chunking_context_with_client_assets(
     client_root: Vc<FileSystemPath>,
     asset_prefix: Vc<Option<RcStr>>,
     environment: Vc<Environment>,
+    module_id_strategy: Vc<Box<dyn ModuleIdStrategy>>,
 ) -> Result<Vc<NodeJsChunkingContext>> {
     let next_mode = mode.await?;
     // TODO(alexkirsz) This should return a trait that can be implemented by the
@@ -938,6 +940,7 @@ pub async fn get_server_chunking_context_with_client_assets(
     )
     .asset_prefix(asset_prefix)
     .minify_type(next_mode.minify_type())
+    .module_id_strategy(module_id_strategy)
     .build())
 }
 
@@ -947,6 +950,7 @@ pub async fn get_server_chunking_context(
     project_path: Vc<FileSystemPath>,
     node_root: Vc<FileSystemPath>,
     environment: Vc<Environment>,
+    module_id_strategy: Vc<Box<dyn ModuleIdStrategy>>,
 ) -> Result<Vc<NodeJsChunkingContext>> {
     let next_mode = mode.await?;
     // TODO(alexkirsz) This should return a trait that can be implemented by the
@@ -962,5 +966,6 @@ pub async fn get_server_chunking_context(
         next_mode.runtime_type(),
     )
     .minify_type(next_mode.minify_type())
+    .module_id_strategy(module_id_strategy)
     .build())
 }

--- a/test/integration/externals-pages-bundle/node_modules/external-package/index.js
+++ b/test/integration/externals-pages-bundle/node_modules/external-package/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  foo: 'bar',
+  foo: 'external-package content',
 }

--- a/test/integration/externals-pages-bundle/node_modules/opted-out-external-package/index.js
+++ b/test/integration/externals-pages-bundle/node_modules/opted-out-external-package/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  bar: 'baz',
+  bar: 'opted-out-external-package content',
 }

--- a/test/integration/externals-pages-bundle/test/index.test.js
+++ b/test/integration/externals-pages-bundle/test/index.test.js
@@ -27,10 +27,8 @@ describe('bundle pages externals with config.bundlePagesRouterDependencies', () 
             allBundles += output
           }
 
-          // we don't know the name of the minified `__turbopack_external_require__`, so we just check the arguments.
-          expect(allBundles).not.toContain(
-            '"[externals]/ [external] (external-package, cjs)"'
-          )
+          // we don't know the name of the minified `__turbopack_external_require__`, so we just check the content.
+          expect(allBundles).toContain('"external-package content"')
         } else {
           const output = await fs.readFile(
             join(appDir, '.next/server/pages/index.js'),
@@ -53,9 +51,9 @@ describe('bundle pages externals with config.bundlePagesRouterDependencies', () 
             allBundles += output
           }
 
-          // we don't know the name of the minified `__turbopack_external_require__`, so we just check the arguments.
-          expect(allBundles).toContain(
-            '"[externals]/ [external] (opted-out-external-package, cjs)"'
+          // we don't know the name of the minified `__turbopack_external_require__`, so we just check the content.
+          expect(allBundles).not.toContain(
+            '"opted-out-external-package content"'
           )
         } else {
           const output = await fs.readFile(

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -6,6 +6,7 @@ use turbopack_core::{
     chunk::{
         availability_info::AvailabilityInfo,
         chunk_group::{make_chunk_group, MakeChunkGroupResult},
+        module_id_strategies::{DevModuleIdStrategy, ModuleIdStrategy},
         Chunk, ChunkGroupResult, ChunkItem, ChunkableModule, ChunkingContext,
         EntryChunkGroupResult, EvaluatableAssets, MinifyType, ModuleId,
     },
@@ -77,6 +78,11 @@ impl BrowserChunkingContextBuilder {
         self
     }
 
+    pub fn module_id_strategy(mut self, module_id_strategy: Vc<Box<dyn ModuleIdStrategy>>) -> Self {
+        self.chunking_context.module_id_strategy = module_id_strategy;
+        self
+    }
+
     pub fn build(self) -> Vc<BrowserChunkingContext> {
         BrowserChunkingContext::new(Value::new(self.chunking_context))
     }
@@ -122,6 +128,8 @@ pub struct BrowserChunkingContext {
     minify_type: MinifyType,
     /// Whether to use manifest chunks for lazy compilation
     manifest_chunks: bool,
+    /// The module id strategy to use
+    module_id_strategy: Vc<Box<dyn ModuleIdStrategy>>,
 }
 
 impl BrowserChunkingContext {
@@ -151,6 +159,7 @@ impl BrowserChunkingContext {
                 runtime_type,
                 minify_type: MinifyType::NoMinify,
                 manifest_chunks: false,
+                module_id_strategy: Vc::upcast(DevModuleIdStrategy::new()),
             },
         }
     }
@@ -477,6 +486,14 @@ impl ChunkingContext for BrowserChunkingContext {
         _availability_info: Value<AvailabilityInfo>,
     ) -> Result<Vc<EntryChunkGroupResult>> {
         bail!("Browser chunking context does not support entry chunk groups")
+    }
+
+    #[turbo_tasks::function]
+    async fn chunk_item_id_from_ident(
+        self: Vc<Self>,
+        ident: Vc<AssetIdent>,
+    ) -> Result<Vc<ModuleId>> {
+        Ok(self.await?.module_id_strategy.get_module_id(ident))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/changed.rs
+++ b/turbopack/crates/turbopack-core/src/changed.rs
@@ -17,7 +17,7 @@ async fn get_referenced_output_assets(
     Ok(parent.references().await?.clone_value().into_iter())
 }
 
-async fn get_referenced_modules(
+pub async fn get_referenced_modules(
     parent: Vc<Box<dyn Module>>,
 ) -> Result<impl Iterator<Item = Vc<Box<dyn Module>>> + Send> {
     Ok(primary_referenced_modules(parent)

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{trace::TraceRawVcs, RcStr, TaskInput, Upcast, Value, ValueToString, Vc};
+use turbo_tasks::{trace::TraceRawVcs, RcStr, TaskInput, Upcast, Value, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::DeterministicHash;
 
@@ -116,9 +116,7 @@ pub trait ChunkingContext {
     async fn chunk_item_id_from_ident(
         self: Vc<Self>,
         ident: Vc<AssetIdent>,
-    ) -> Result<Vc<ModuleId>> {
-        Ok(ModuleId::String(ident.to_string().await?.clone_value()).cell())
-    }
+    ) -> Result<Vc<ModuleId>>;
 
     fn chunk_item_id(self: Vc<Self>, chunk_item: Vc<Box<dyn ChunkItem>>) -> Vc<ModuleId> {
         self.chunk_item_id_from_ident(chunk_item.asset_ident())

--- a/turbopack/crates/turbopack-core/src/chunk/global_module_id_strategy.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/global_module_id_strategy.rs
@@ -1,0 +1,102 @@
+use std::collections::{HashMap, HashSet};
+
+use anyhow::Result;
+use turbo_tasks::{
+    graph::{AdjacencyMap, GraphTraversal},
+    ValueToString, Vc,
+};
+use turbo_tasks_hash::hash_xxh3_hash64;
+
+use crate::{
+    changed::get_referenced_modules,
+    chunk::ModuleId,
+    ident::AssetIdent,
+    module::{Module, Modules},
+};
+
+#[turbo_tasks::value]
+pub struct PreprocessedChildrenIdents {
+    // module_id -> full hash
+    // We save the full hash to avoid re-hashing in `merge_preprocessed_module_ids`
+    // if this endpoint did not change.
+    modules_idents: HashMap<AssetIdent, u64>,
+}
+
+// NOTE(LichuAcu) Called on endpoint.root_modules(). It would probably be better if this was called
+// directly on `Endpoint`, but such struct is not available in turbopack-core. The whole function
+// could be moved to `next-api`, but it would require adding turbo-tasks-hash to `next-api`,
+// making it heavier.
+#[turbo_tasks::function]
+pub async fn children_modules_idents(
+    root_modules: Vc<Modules>,
+) -> Result<Vc<PreprocessedChildrenIdents>> {
+    let children_modules_iter = AdjacencyMap::new()
+        .skip_duplicates()
+        .visit(root_modules.await?.iter().copied(), get_referenced_modules)
+        .await
+        .completed()?
+        .into_inner()
+        .into_reverse_topological();
+
+    // module_id -> full hash
+    let mut modules_idents = HashMap::new();
+
+    for module in children_modules_iter {
+        let module_ident = module.ident();
+        let hash = hash_xxh3_hash64(module_ident.to_string().await?);
+        modules_idents.insert(module_ident.await?.clone_value(), hash);
+    }
+
+    Ok(PreprocessedChildrenIdents { modules_idents }.cell())
+}
+
+// Note(LichuAcu): This could be split into two functions: one that merges the preprocessed module
+// ids and another that generates the final, optimized module ids. Thoughts?
+pub async fn merge_preprocessed_module_ids(
+    prepared_module_ids: Vec<Vc<PreprocessedChildrenIdents>>,
+) -> Result<HashMap<AssetIdent, Vc<ModuleId>>> {
+    let mut module_id_map: HashMap<AssetIdent, Vc<ModuleId>> = HashMap::new();
+    let mut used_ids: HashSet<u64> = HashSet::new();
+
+    for prepared_module_ids in prepared_module_ids {
+        for (module_ident, full_hash) in prepared_module_ids.await?.modules_idents.iter() {
+            process_module(
+                module_ident.clone(),
+                *full_hash,
+                &mut module_id_map,
+                &mut used_ids,
+            )
+            .await?;
+        }
+    }
+
+    Ok(module_id_map)
+}
+
+pub async fn process_module(
+    module_ident: AssetIdent,
+    full_hash: u64,
+    id_map: &mut HashMap<AssetIdent, Vc<ModuleId>>,
+    used_ids: &mut HashSet<u64>,
+) -> Result<()> {
+    if id_map.contains_key(&module_ident) {
+        return Ok(());
+    }
+
+    let mut masked_hash = full_hash & 0xF;
+    let mut mask = 0xF;
+    while used_ids.contains(&masked_hash) {
+        if mask == 0xFFFFFFFFFFFFFFFF {
+            return Err(anyhow::anyhow!("This is a... 64-bit hash collision?"));
+        }
+        mask = (mask << 4) | 0xF;
+        masked_hash = full_hash & mask;
+    }
+
+    let hashed_module_id = ModuleId::String(masked_hash.to_string().into());
+
+    id_map.insert(module_ident, hashed_module_id.cell());
+    used_ids.insert(masked_hash);
+
+    Ok(())
+}

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -6,6 +6,8 @@ pub(crate) mod chunking_context;
 pub(crate) mod containment_tree;
 pub(crate) mod data;
 pub(crate) mod evaluate;
+pub mod global_module_id_strategy;
+pub mod module_id_strategies;
 pub mod optimize;
 
 use std::{

--- a/turbopack/crates/turbopack-core/src/chunk/module_id_strategies.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/module_id_strategies.rs
@@ -1,0 +1,59 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use turbo_tasks::{ValueToString, Vc};
+use turbo_tasks_hash::hash_xxh3_hash64;
+
+use super::ModuleId;
+use crate::ident::AssetIdent;
+
+#[turbo_tasks::value_trait]
+pub trait ModuleIdStrategy {
+    fn get_module_id(self: Vc<Self>, ident: Vc<AssetIdent>) -> Vc<ModuleId>;
+}
+
+#[turbo_tasks::value]
+pub struct DevModuleIdStrategy;
+
+impl DevModuleIdStrategy {
+    pub fn new() -> Vc<Self> {
+        DevModuleIdStrategy {}.cell()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ModuleIdStrategy for DevModuleIdStrategy {
+    #[turbo_tasks::function]
+    async fn get_module_id(self: Vc<Self>, ident: Vc<AssetIdent>) -> Result<Vc<ModuleId>> {
+        Ok(ModuleId::String(ident.to_string().await?.clone_value()).cell())
+    }
+}
+
+#[turbo_tasks::value]
+pub struct GlobalModuleIdStrategy {
+    module_id_map: HashMap<AssetIdent, Vc<ModuleId>>,
+}
+
+impl GlobalModuleIdStrategy {
+    pub async fn new(module_id_map: HashMap<AssetIdent, Vc<ModuleId>>) -> Result<Vc<Self>> {
+        Ok(GlobalModuleIdStrategy { module_id_map }.cell())
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ModuleIdStrategy for GlobalModuleIdStrategy {
+    #[turbo_tasks::function]
+    async fn get_module_id(self: Vc<Self>, ident: Vc<AssetIdent>) -> Result<Vc<ModuleId>> {
+        if let Some(module_id) = self.await?.module_id_map.get(&ident.await?.clone_value()) {
+            // dbg!(format!("Hit {}", ident.to_string().await?));
+            return Ok(*module_id);
+        }
+        // dbg!(format!("Miss {}", ident.to_string().await?));
+        Ok(ModuleId::String(
+            hash_xxh3_hash64(ident.to_string().await?)
+                .to_string()
+                .into(),
+        )
+        .cell())
+    }
+}


### PR DESCRIPTION
### What?

Refactored module ID strategies implementation to walk modules graph individually for each endpoint.

Based on feedback from [next.js#68408](https://github.com/vercel/next.js/pull/68408) and [turbo#8912](https://github.com/vercel/turbo/pull/8912).

Comments marked with `NOTE(LichuAcu)` are intended to make reviewing easier and will be removed before merging.