### PR TITLE
re-order CacheNodeSeedData to put containing segment first

### DIFF
--- a/packages/next/src/client/components/router-reducer/apply-flight-data.ts
+++ b/packages/next/src/client/components/router-reducer/apply-flight-data.ts
@@ -19,7 +19,7 @@ export function applyFlightData(
   }
 
   if (flightDataPath.length === 3) {
-    const rsc = cacheNodeSeedData[2]
+    const rsc = cacheNodeSeedData[1]
     const loading = cacheNodeSeedData[3]
     cache.loading = loading
     cache.rsc = rsc

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
@@ -36,7 +36,7 @@ describe('createInitialRouterState', () => {
     const state = createInitialRouterState({
       buildId,
       initialFlightData: [
-        [initialTree, ['', {}, children, null], <title>Test</title>],
+        [initialTree, ['', children, {}, null], <title>Test</title>],
       ],
       initialCanonicalUrl,
       initialParallelRoutes,
@@ -48,7 +48,7 @@ describe('createInitialRouterState', () => {
     const state2 = createInitialRouterState({
       buildId,
       initialFlightData: [
-        [initialTree, ['', {}, children, null], <title>Test</title>],
+        [initialTree, ['', children, {}, null], <title>Test</title>],
       ],
       initialCanonicalUrl,
       initialParallelRoutes,

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -31,7 +31,7 @@ export function createInitialRouterState({
   // For the root render, there'll only be a top-level FlightDataPath array.
   const [initialTree, initialSeedData, initialHead] = initialFlightData[0]
   const isServer = !location
-  const rsc = initialSeedData[2]
+  const rsc = initialSeedData[1]
 
   const cache: CacheNode = {
     lazyData: null,

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
@@ -46,7 +46,7 @@ function fillCacheHelper(
         !childCacheNode.lazyData ||
         childCacheNode === existingChildCacheNode)
     ) {
-      const rsc = cacheNodeSeedData[2]
+      const rsc = cacheNodeSeedData[1]
       const loading = cacheNodeSeedData[3]
       childCacheNode = {
         lazyData: null,

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
@@ -39,8 +39,8 @@ export function fillLazyItemsTillLeafWithHead(
     // in the response format, so that we don't have to send the keys twice.
     // Then the client can convert them into separate representations.
     const parallelSeedData =
-      cacheNodeSeedData !== null && cacheNodeSeedData[1][key] !== undefined
-        ? cacheNodeSeedData[1][key]
+      cacheNodeSeedData !== null && cacheNodeSeedData[2][key] !== undefined
+        ? cacheNodeSeedData[2][key]
         : null
     if (existingCache) {
       const existingParallelRoutesCacheNode =
@@ -55,7 +55,7 @@ export function fillLazyItemsTillLeafWithHead(
         let newCacheNode: CacheNode
         if (parallelSeedData !== null) {
           // New data was sent from the server.
-          const seedNode = parallelSeedData[2]
+          const seedNode = parallelSeedData[1]
           const loading = parallelSeedData[3]
           newCacheNode = {
             lazyData: null,
@@ -120,7 +120,7 @@ export function fillLazyItemsTillLeafWithHead(
     let newCacheNode: CacheNode
     if (parallelSeedData !== null) {
       // New data was sent from the server.
-      const seedNode = parallelSeedData[2]
+      const seedNode = parallelSeedData[1]
       const loading = parallelSeedData[3]
       newCacheNode = {
         lazyData: null,

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -73,7 +73,7 @@ export function updateCacheNodeOnNavigation(
   // Diff the old and new trees to reuse the shared layouts.
   const oldRouterStateChildren = oldRouterState[1]
   const newRouterStateChildren = newRouterState[1]
-  const prefetchDataChildren = prefetchData[1]
+  const prefetchDataChildren = prefetchData[2]
 
   const oldParallelRoutes = oldCacheNode.parallelRoutes
 
@@ -466,7 +466,7 @@ function finishTaskUsingDynamicDataPayload(
   // The server returned more data than we need to finish the task. Skip over
   // the extra segments until we reach the leaf task node.
   const serverChildren = serverRouterState[1]
-  const dynamicDataChildren = dynamicData[1]
+  const dynamicDataChildren = dynamicData[2]
 
   for (const parallelRouteKey in serverRouterState) {
     const serverRouterStateChild: FlightRouterState =
@@ -504,7 +504,7 @@ function createPendingCacheNode(
   prefetchHead: React.ReactNode
 ): ReadyCacheNode {
   const routerStateChildren = routerState[1]
-  const prefetchDataChildren = prefetchData !== null ? prefetchData[1] : null
+  const prefetchDataChildren = prefetchData !== null ? prefetchData[2] : null
 
   const parallelRoutes = new Map()
   for (let parallelRouteKey in routerStateChildren) {
@@ -533,7 +533,7 @@ function createPendingCacheNode(
   // on corresponding logic in fill-lazy-items-till-leaf-with-head.ts
   const isLeafSegment = parallelRoutes.size === 0
 
-  const maybePrefetchRsc = prefetchData !== null ? prefetchData[2] : null
+  const maybePrefetchRsc = prefetchData !== null ? prefetchData[1] : null
   const maybePrefetchLoading = prefetchData !== null ? prefetchData[3] : null
   return {
     lazyData: null,
@@ -569,7 +569,7 @@ function finishPendingCacheNode(
   // data promise to `null` to trigger a lazy fetch during render.
   const taskStateChildren = taskState[1]
   const serverStateChildren = serverState[1]
-  const dataChildren = dynamicData[1]
+  const dataChildren = dynamicData[2]
 
   // The router state that we traverse the tree with (taskState) is the same one
   // that we used to construct the pending Cache Node tree. That way we're sure
@@ -629,7 +629,7 @@ function finishPendingCacheNode(
   // Use the dynamic data from the server to fulfill the deferred RSC promise
   // on the Cache Node.
   const rsc = cacheNode.rsc
-  const dynamicSegmentData = dynamicData[2]
+  const dynamicSegmentData = dynamicData[1]
   if (rsc === null) {
     // This is a lazy cache node. We can overwrite it. This is only safe
     // because we know that the LayoutRouter suspends if `rsc` is `null`.

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -292,7 +292,7 @@ export function navigateReducer(
               if (flightDataPath.length === 3) {
                 // Fill in the cache with the new loading / rsc data
                 const cacheNodeSeedData = flightDataPath[1]
-                const rsc = cacheNodeSeedData[2]
+                const rsc = cacheNodeSeedData[1]
                 const loading = cacheNodeSeedData[3]
                 cache.loading = loading
                 cache.rsc = rsc

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -107,7 +107,7 @@ export function refreshReducer(
 
         // Handles case where prefetch only returns the router tree patch without rendered components.
         if (cacheNodeSeedData !== null) {
-          const rsc = cacheNodeSeedData[2]
+          const rsc = cacheNodeSeedData[1]
           const loading = cacheNodeSeedData[3]
           cache.rsc = rsc
           cache.prefetchRsc = null

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -256,7 +256,7 @@ export function serverActionReducer(
 
         // The one before last item is the router state tree patch
         const [cacheNodeSeedData, head] = flightDataPath.slice(-2)
-        const rsc = cacheNodeSeedData !== null ? cacheNodeSeedData[2] : null
+        const rsc = cacheNodeSeedData !== null ? cacheNodeSeedData[1] : null
 
         // Handles case where prefetch only returns the router tree patch without rendered components.
         if (rsc !== null) {

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -612,11 +612,11 @@ async function getErrorRSCPayload(
   // so we create a not found page with AppRouter
   const initialSeedData: CacheNodeSeedData = [
     initialTree[0],
-    {},
     <html id="__next_error__">
       <head></head>
       <body></body>
     </html>,
+    {},
     null,
   ]
 

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -496,7 +496,6 @@ async function createComponentTreeInternal({
   if (!Component) {
     return [
       actualSegment,
-      parallelRouteCacheNodeSeedData,
       // TODO: I don't think the extra fragment is necessary. React treats top
       // level fragments as transparent, i.e. the runtime behavior should be
       // identical even without it. But maybe there's some findDOMNode-related
@@ -506,6 +505,7 @@ async function createComponentTreeInternal({
         {layerAssets}
         {parallelRouteProps.children}
       </React.Fragment>,
+      parallelRouteCacheNodeSeedData,
       loadingData,
     ]
   }
@@ -528,7 +528,6 @@ async function createComponentTreeInternal({
   ) {
     return [
       actualSegment,
-      parallelRouteCacheNodeSeedData,
       <React.Fragment key={cacheNodeKey}>
         <Postpone
           reason='dynamic = "force-dynamic" was used'
@@ -536,6 +535,7 @@ async function createComponentTreeInternal({
         />
         {layerAssets}
       </React.Fragment>,
+      parallelRouteCacheNodeSeedData,
       loadingData,
     ]
   }
@@ -619,7 +619,6 @@ async function createComponentTreeInternal({
 
   return [
     actualSegment,
-    parallelRouteCacheNodeSeedData,
     <React.Fragment key={cacheNodeKey}>
       {segmentElement}
       {/* This null is currently critical. The wrapped Component can render null and if there was not fragment
@@ -632,6 +631,7 @@ async function createComponentTreeInternal({
             TODO-APP update router to use a Symbol for partial tree detection */}
       {null}
     </React.Fragment>,
+    parallelRouteCacheNodeSeedData,
     loadingData,
   ]
 }

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -90,10 +90,10 @@ export type FlightSegmentPath =
  */
 export type CacheNodeSeedData = [
   segment: Segment,
+  node: React.ReactNode | null,
   parallelRoutes: {
     [parallelRouterKey: string]: CacheNodeSeedData | null
   },
-  node: React.ReactNode | null,
   loading: LoadingModuleData,
 ]
 


### PR DESCRIPTION
The `CacheNodeSeedData` structure puts parallel routes (eg page segment data, and other parallel routes) before the containing segment data (eg the layout). When React serializes the RSC payload it'll handle the deeper tree first (parallel route) before the higher level things. In a PPR world this can lead to de-opts since we'll bail out of rendering when we detect dynamic access.

This PR doesn't change any functionality, it just swaps the ordering of these two items so that the deeper tree is serialized after the layout / containing segment.

Closes NDX-177
