### PR TITLE
Exhaustive modules graph traversal

### DIFF
--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -57,10 +57,9 @@ impl Module for EcmascriptClientReferenceModule {
     }
 
     #[turbo_tasks::function]
-    async fn children_modules(self: Vc<Self>) -> Result<Vc<Modules>> {
-        let this = self.await?;
-        let client_module = Vc::upcast(this.client_module);
-        let ssr_module = Vc::upcast(this.ssr_module);
+    async fn additional_layers_modules(&self) -> Result<Vc<Modules>> {
+        let client_module = Vc::upcast(self.client_module);
+        let ssr_module = Vc::upcast(self.ssr_module);
         Ok(Vc::cell(vec![client_module, ssr_module]))
     }
 }

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -4,7 +4,7 @@ use turbo_tasks::{RcStr, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     ident::AssetIdent,
-    module::Module,
+    module::{Module, Modules},
 };
 use turbopack_ecmascript::chunk::EcmascriptChunkPlaceable;
 
@@ -54,6 +54,14 @@ impl Module for EcmascriptClientReferenceModule {
     fn ident(&self) -> Vc<AssetIdent> {
         self.server_ident
             .with_modifier(ecmascript_client_reference_modifier())
+    }
+
+    #[turbo_tasks::function]
+    async fn children_modules(self: Vc<Self>) -> Result<Vc<Modules>> {
+        let this = self.await?;
+        let client_module = Vc::upcast(this.client_module);
+        let ssr_module = Vc::upcast(this.ssr_module);
+        Ok(Vc::cell(vec![client_module, ssr_module]))
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/chunk/global_module_id_strategy.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/global_module_id_strategy.rs
@@ -11,6 +11,7 @@ use crate::{
     chunk::ModuleId,
     ident::AssetIdent,
     module::{Module, Modules},
+    reference::primary_referenced_modules,
 };
 
 #[turbo_tasks::value]
@@ -24,7 +25,9 @@ pub struct PreprocessedChildrenIdents {
 pub async fn get_children_modules(
     parent: Vc<Box<dyn Module>>,
 ) -> Result<impl Iterator<Item = Vc<Box<dyn Module>>> + Send> {
-    Ok(parent.children_modules().await?.clone_value().into_iter())
+    let mut primary_modules = primary_referenced_modules(parent).await?.clone_value();
+    primary_modules.extend(parent.additional_layers_modules().await?.clone_value());
+    Ok(primary_modules.into_iter())
 }
 
 // NOTE(LichuAcu) Called on endpoint.root_modules(). It would probably be better if this was called

--- a/turbopack/crates/turbopack-core/src/module.rs
+++ b/turbopack/crates/turbopack-core/src/module.rs
@@ -1,7 +1,11 @@
 use indexmap::IndexSet;
 use turbo_tasks::Vc;
 
-use crate::{asset::Asset, ident::AssetIdent, reference::ModuleReferences};
+use crate::{
+    asset::Asset,
+    ident::AssetIdent,
+    reference::{primary_referenced_modules, ModuleReferences},
+};
 
 /// A module. This usually represents parsed source code, which has references
 /// to other modules.
@@ -15,6 +19,10 @@ pub trait Module: Asset {
     // TODO refactor to avoid returning [OutputAsset]s here
     fn references(self: Vc<Self>) -> Vc<ModuleReferences> {
         ModuleReferences::empty()
+    }
+
+    fn children_modules(self: Vc<Self>) -> Vc<Modules> {
+        primary_referenced_modules(self)
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/module.rs
+++ b/turbopack/crates/turbopack-core/src/module.rs
@@ -1,11 +1,7 @@
 use indexmap::IndexSet;
 use turbo_tasks::Vc;
 
-use crate::{
-    asset::Asset,
-    ident::AssetIdent,
-    reference::{primary_referenced_modules, ModuleReferences},
-};
+use crate::{asset::Asset, ident::AssetIdent, reference::ModuleReferences};
 
 /// A module. This usually represents parsed source code, which has references
 /// to other modules.
@@ -21,8 +17,8 @@ pub trait Module: Asset {
         ModuleReferences::empty()
     }
 
-    fn children_modules(self: Vc<Self>) -> Vc<Modules> {
-        primary_referenced_modules(self)
+    fn additional_layers_modules(self: Vc<Self>) -> Vc<Modules> {
+        Vc::cell(vec![])
     }
 }
 


### PR DESCRIPTION
### What?
Improves the traversal of the module graph by doing a more exhaustive search of the children modules, thus increasing the "hit rate" for optimized module IDs (which should be 100%).

### Why?
Some structs that implement the `Module` trait return an empty list in the `references` method, but still "own" some child modules. This is the case of `EcmascriptClientReferenceModule`, for example, which returns empty in `references` but owns a `client_module` and an `ssr_module`. These modules are ignored when traversing the module graph with the `get_referenced_modules` function we used before, so neither they nor their children are ever assigned an optimized ID.

### How?
To solve this, a `children_modules` method is added to the `Module` trait, which should exhaustively return all direct children of the module. The function defaults to `primary_referenced_modules`, which simply calls `references`, but structs like `EcmascriptClientReferenceModule` can reimplement it and return "hidden" children modules like the aforementioned `client_module` and `ssr_module`.