### PR TITLE
refactor(turbo-tasks): Add TaskPersistence enum for task creation functions

### DIFF
--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use proc_macro2::{Ident, Span, TokenStream};
-use quote::{quote, quote_spanned};
+use quote::{quote, quote_spanned, ToTokens};
 use syn::{
     parenthesized,
     parse::{Parse, ParseStream},
@@ -24,6 +24,8 @@ pub struct TurboFn {
     inputs: Vec<Input>,
     /// Should we check that the return type contains a `ResolvedValue`?
     resolved: Option<Span>,
+    /// Should this function use `TaskPersistence::LocalCells`?
+    local_cells: bool,
 }
 
 #[derive(Debug)]
@@ -257,6 +259,7 @@ impl TurboFn {
             this,
             inputs,
             resolved: args.resolved,
+            local_cells: args.local_cells.is_some(),
         })
     }
 
@@ -301,15 +304,24 @@ impl TurboFn {
         }
     }
 
-    fn inputs(&self) -> Vec<&Ident> {
-        self.inputs
-            .iter()
-            .map(|Input { ident, .. }| ident)
-            .collect()
+    fn input_idents(&self) -> impl Iterator<Item = &Ident> {
+        self.inputs.iter().map(|Input { ident, .. }| ident)
     }
 
     pub fn input_types(&self) -> Vec<&Type> {
         self.inputs.iter().map(|Input { ty, .. }| ty).collect()
+    }
+
+    pub fn persistence(&self) -> impl ToTokens {
+        if self.local_cells {
+            quote! {
+                turbo_tasks::TaskPersistence::LocalCells
+            }
+        } else {
+            quote! {
+                turbo_tasks::macro_helpers::get_non_local_persistence_from_inputs(&*inputs)
+            }
+        }
     }
 
     fn converted_this(&self) -> Option<Expr> {
@@ -344,31 +356,33 @@ impl TurboFn {
     /// The block of the exposed function for a dynamic dispatch call to the
     /// given trait.
     pub fn dynamic_block(&self, trait_type_id_ident: &Ident) -> Block {
-        let ident = &self.ident;
-        let output = &self.output;
-        let assertions = self.get_assertions();
-        if let Some(converted_this) = self.converted_this() {
-            let inputs = self.inputs();
-            parse_quote! {
-                {
-                    #assertions
-                    let turbo_tasks_transient = #( turbo_tasks::TaskInput::is_transient(&#inputs) ||)* false;
-                    <#output as turbo_tasks::task::TaskOutput>::try_from_raw_vc(
-                        turbo_tasks::trait_call(
-                            *#trait_type_id_ident,
-                            std::borrow::Cow::Borrowed(stringify!(#ident)),
-                            #converted_this,
-                            Box::new((#(#inputs,)*)) as Box<dyn turbo_tasks::MagicAny>,
-                            turbo_tasks_transient,
-                        )
-                    )
-                }
-            }
-        } else {
-            parse_quote! {
+        let Some(converted_this) = self.converted_this() else {
+            return parse_quote! {
                 {
                     unimplemented!("trait methods without self are not yet supported")
                 }
+            };
+        };
+
+        let ident = &self.ident;
+        let output = &self.output;
+        let assertions = self.get_assertions();
+        let inputs = self.input_idents();
+        let persistence = self.persistence();
+        parse_quote! {
+            {
+                #assertions
+                let inputs = std::boxed::Box::new((#(#inputs,)*));
+                let persistence = #persistence;
+                <#output as turbo_tasks::task::TaskOutput>::try_from_raw_vc(
+                    turbo_tasks::trait_call(
+                        *#trait_type_id_ident,
+                        std::borrow::Cow::Borrowed(stringify!(#ident)),
+                        #converted_this,
+                        inputs as std::boxed::Box<dyn turbo_tasks::MagicAny>,
+                        persistence,
+                    )
+                )
             }
         }
     }
@@ -377,19 +391,21 @@ impl TurboFn {
     /// given native function.
     pub fn static_block(&self, native_function_id_ident: &Ident) -> Block {
         let output = &self.output;
-        let inputs = self.inputs();
+        let inputs = self.input_idents();
+        let persistence = self.persistence();
         let assertions = self.get_assertions();
         if let Some(converted_this) = self.converted_this() {
             parse_quote! {
                 {
                     #assertions
-                    let turbo_tasks_transient = #( turbo_tasks::TaskInput::is_transient(&#inputs) ||)* false;
+                    let inputs = std::boxed::Box::new((#(#inputs,)*));
+                    let persistence = #persistence;
                     <#output as turbo_tasks::task::TaskOutput>::try_from_raw_vc(
                         turbo_tasks::dynamic_this_call(
                             *#native_function_id_ident,
                             #converted_this,
-                            Box::new((#(#inputs,)*)) as Box<dyn turbo_tasks::MagicAny>,
-                            turbo_tasks_transient
+                            inputs as std::boxed::Box<dyn turbo_tasks::MagicAny>,
+                            persistence,
                         )
                     )
                 }
@@ -398,12 +414,13 @@ impl TurboFn {
             parse_quote! {
                 {
                     #assertions
-                    let turbo_tasks_transient = #( turbo_tasks::TaskInput::is_transient(&#inputs) ||)* false;
+                    let inputs = std::boxed::Box::new((#(#inputs,)*));
+                    let persistence = #persistence;
                     <#output as turbo_tasks::task::TaskOutput>::try_from_raw_vc(
                         turbo_tasks::dynamic_call(
                             *#native_function_id_ident,
-                            Box::new((#(#inputs,)*)) as Box<dyn turbo_tasks::MagicAny>,
-                            turbo_tasks_transient,
+                            inputs as std::boxed::Box<dyn turbo_tasks::MagicAny>,
+                            persistence,
                         )
                     )
                 }

--- a/turbopack/crates/turbo-tasks-memory/src/task.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/task.rs
@@ -810,7 +810,7 @@ impl Task {
                         native_fn_id,
                         *this,
                         &**arg,
-                        self.id.is_transient(),
+                        self.id.persistence(),
                         turbo_tasks,
                     ));
                     drop(entered);
@@ -833,7 +833,7 @@ impl Task {
                         name,
                         *this,
                         &**arg,
-                        self.id.is_transient(),
+                        self.id.persistence(),
                         turbo_tasks,
                     ));
                     drop(entered);

--- a/turbopack/crates/turbo-tasks-memory/tests/local_cell.rs
+++ b/turbopack/crates/turbo-tasks-memory/tests/local_cell.rs
@@ -1,0 +1,1 @@
+../../turbo-tasks-testing/tests/local_cell.rs

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -20,8 +20,8 @@ use turbo_tasks::{
     registry,
     test_helpers::with_turbo_tasks_for_testing,
     util::{SharedError, StaticOrArc},
-    CellId, ExecutionId, InvalidationReason, MagicAny, RawVc, TaskId, TraitTypeId, TurboTasksApi,
-    TurboTasksCallApi,
+    CellId, ExecutionId, InvalidationReason, MagicAny, RawVc, TaskId, TaskPersistence, TraitTypeId,
+    TurboTasksApi, TurboTasksCallApi,
 };
 
 pub use crate::run::{run, run_without_cache_check, Registration};
@@ -92,7 +92,7 @@ impl TurboTasksCallApi for VcStorage {
         &self,
         func: turbo_tasks::FunctionId,
         arg: Box<dyn MagicAny>,
-        _is_transient: bool,
+        _persistence: TaskPersistence,
     ) -> RawVc {
         self.dynamic_call(func, None, arg)
     }
@@ -102,7 +102,7 @@ impl TurboTasksCallApi for VcStorage {
         func: turbo_tasks::FunctionId,
         this_arg: RawVc,
         arg: Box<dyn MagicAny>,
-        _is_transient: bool,
+        _persistence: TaskPersistence,
     ) -> RawVc {
         self.dynamic_call(func, Some(this_arg), arg)
     }
@@ -111,7 +111,7 @@ impl TurboTasksCallApi for VcStorage {
         &self,
         _func: turbo_tasks::FunctionId,
         _arg: Box<dyn MagicAny>,
-        _is_transient: bool,
+        _persistence: TaskPersistence,
     ) -> RawVc {
         unreachable!()
     }
@@ -121,7 +121,7 @@ impl TurboTasksCallApi for VcStorage {
         _func: turbo_tasks::FunctionId,
         _this: RawVc,
         _arg: Box<dyn MagicAny>,
-        _is_transient: bool,
+        _persistence: TaskPersistence,
     ) -> RawVc {
         unreachable!()
     }
@@ -132,7 +132,7 @@ impl TurboTasksCallApi for VcStorage {
         _trait_fn_name: Cow<'static, str>,
         _this: RawVc,
         _arg: Box<dyn MagicAny>,
-        _is_transient: bool,
+        _persistence: TaskPersistence,
     ) -> RawVc {
         unreachable!()
     }

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -23,8 +23,8 @@ use crate::{
     task::shared_reference::TypedSharedReference,
     trait_helpers::{get_trait_method, has_trait, traits},
     triomphe_utils::unchecked_sidecast_triomphe_arc,
-    FunctionId, RawVc, ReadRef, SharedReference, TaskId, TaskIdSet, TraitRef, TraitTypeId,
-    ValueTypeId, VcRead, VcValueTrait, VcValueType,
+    FunctionId, RawVc, ReadRef, SharedReference, TaskId, TaskIdSet, TaskPersistence, TraitRef,
+    TraitTypeId, ValueTypeId, VcRead, VcValueTrait, VcValueType,
 };
 
 type TransientTaskRoot =
@@ -608,7 +608,7 @@ impl CachedTaskType {
         fn_id: FunctionId,
         mut this: Option<RawVc>,
         arg: &dyn MagicAny,
-        is_transient: bool,
+        persistence: TaskPersistence,
         turbo_tasks: Arc<dyn TurboTasksBackendApi<B>>,
     ) -> Result<RawVc> {
         if let Some(this) = this.as_mut() {
@@ -616,9 +616,9 @@ impl CachedTaskType {
         }
         let arg = registry::get_function(fn_id).arg_meta.resolve(arg).await?;
         Ok(if let Some(this) = this {
-            turbo_tasks.this_call(fn_id, this, arg, is_transient)
+            turbo_tasks.this_call(fn_id, this, arg, persistence)
         } else {
-            turbo_tasks.native_call(fn_id, arg, is_transient)
+            turbo_tasks.native_call(fn_id, arg, persistence)
         })
     }
 
@@ -636,7 +636,7 @@ impl CachedTaskType {
         name: Cow<'static, str>,
         this: RawVc,
         arg: &dyn MagicAny,
-        is_transient: bool,
+        persistence: TaskPersistence,
         turbo_tasks: Arc<dyn TurboTasksBackendApi<B>>,
     ) -> Result<RawVc> {
         let this = this.resolve().await?;
@@ -647,7 +647,7 @@ impl CachedTaskType {
             .arg_meta
             .resolve(arg)
             .await?;
-        Ok(turbo_tasks.dynamic_this_call(native_fn, this, arg, is_transient))
+        Ok(turbo_tasks.dynamic_this_call(native_fn, this, arg, persistence))
     }
 
     /// Shared helper used by [`Self::resolve_trait_method`] and

--- a/turbopack/crates/turbo-tasks/src/id.rs
+++ b/turbopack/crates/turbo-tasks/src/id.rs
@@ -7,7 +7,7 @@ use std::{
 
 use serde::{de::Visitor, Deserialize, Serialize};
 
-use crate::registry;
+use crate::{registry, TaskPersistence};
 
 macro_rules! define_id {
     ($name:ident : $primitive:ty $(,derive($($derive:ty),*))?) => {
@@ -83,6 +83,14 @@ pub const TRANSIENT_TASK_BIT: u32 = 0x8000_0000;
 impl TaskId {
     pub fn is_transient(&self) -> bool {
         **self & TRANSIENT_TASK_BIT != 0
+    }
+    pub fn persistence(&self) -> TaskPersistence {
+        // tasks with `TaskPersistence::LocalCells` have no `TaskId`, so we can ignore that case
+        if self.is_transient() {
+            TaskPersistence::Transient
+        } else {
+            TaskPersistence::Persistent
+        }
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -90,8 +90,8 @@ pub use magic_any::MagicAny;
 pub use manager::{
     dynamic_call, dynamic_this_call, emit, get_invalidator, mark_finished, mark_stateful,
     prevent_gc, run_once, run_once_with_reason, spawn_blocking, spawn_thread, trait_call,
-    turbo_tasks, CurrentCellRef, Invalidator, TurboTasks, TurboTasksApi, TurboTasksBackendApi,
-    TurboTasksCallApi, Unused, UpdateInfo,
+    turbo_tasks, CurrentCellRef, Invalidator, TaskPersistence, TurboTasks, TurboTasksApi,
+    TurboTasksBackendApi, TurboTasksCallApi, Unused, UpdateInfo,
 };
 pub use native_function::{FunctionMeta, NativeFunction};
 pub use raw_vc::{CellId, RawVc, ReadRawVcFuture, ResolveTypeError};

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -8,7 +8,7 @@ pub use super::{
     magic_any::MagicAny,
     manager::{find_cell_by_type, notify_scheduled_tasks, spawn_detached_for_testing},
 };
-use crate::debug::ValueDebugFormatString;
+use crate::{debug::ValueDebugFormatString, TaskInput, TaskPersistence};
 
 #[inline(never)]
 pub async fn value_debug_format_field(value: ValueDebugFormatString<'_>) -> String {
@@ -18,6 +18,14 @@ pub async fn value_debug_format_field(value: ValueDebugFormatString<'_>) -> Stri
             Err(err) => format!("{0:?}", err),
         },
         Err(err) => format!("{0:?}", err),
+    }
+}
+
+pub fn get_non_local_persistence_from_inputs(inputs: &impl TaskInput) -> TaskPersistence {
+    if inputs.is_transient() {
+        TaskPersistence::Transient
+    } else {
+        TaskPersistence::Persistent
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -257,8 +257,8 @@ pub enum TaskPersistence {
     /// Tasks that will be persisted in memory for the life of this session, but won't persist
     /// between sessions.
     ///
-    /// This is used for tasks with an argument of type
-    /// [`TransientValue`][crate::value::TransientValue] or
+    /// This is used for [root tasks][TurboTasks::spawn_root_task] and tasks with an argument of
+    /// type [`TransientValue`][crate::value::TransientValue] or
     /// [`TransientInstance`][crate::value::TransientInstance].
     Transient,
 

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -47,7 +47,12 @@ use crate::{
 pub trait TurboTasksCallApi: Sync + Send {
     /// Calls a native function with arguments. Resolves arguments when needed
     /// with a wrapper task.
-    fn dynamic_call(&self, func: FunctionId, arg: Box<dyn MagicAny>, is_transient: bool) -> RawVc;
+    fn dynamic_call(
+        &self,
+        func: FunctionId,
+        arg: Box<dyn MagicAny>,
+        persistence: TaskPersistence,
+    ) -> RawVc;
     /// Calls a native function with arguments. Resolves arguments when needed
     /// with a wrapper task.
     fn dynamic_this_call(
@@ -55,11 +60,16 @@ pub trait TurboTasksCallApi: Sync + Send {
         func: FunctionId,
         this: RawVc,
         arg: Box<dyn MagicAny>,
-        is_transient: bool,
+        persistence: TaskPersistence,
     ) -> RawVc;
     /// Call a native function with arguments.
     /// All inputs must be resolved.
-    fn native_call(&self, func: FunctionId, arg: Box<dyn MagicAny>, is_transient: bool) -> RawVc;
+    fn native_call(
+        &self,
+        func: FunctionId,
+        arg: Box<dyn MagicAny>,
+        persistence: TaskPersistence,
+    ) -> RawVc;
     /// Call a native function with arguments.
     /// All inputs must be resolved.
     fn this_call(
@@ -67,7 +77,7 @@ pub trait TurboTasksCallApi: Sync + Send {
         func: FunctionId,
         this: RawVc,
         arg: Box<dyn MagicAny>,
-        is_transient: bool,
+        persistence: TaskPersistence,
     ) -> RawVc;
     /// Calls a trait method with arguments. First input is the `self` object.
     /// Uses a wrapper task to resolve
@@ -77,7 +87,7 @@ pub trait TurboTasksCallApi: Sync + Send {
         trait_fn_name: Cow<'static, str>,
         this: RawVc,
         arg: Box<dyn MagicAny>,
-        is_transient: bool,
+        persistence: TaskPersistence,
     ) -> RawVc;
 
     fn run_once(
@@ -237,6 +247,34 @@ pub struct UpdateInfo {
     pub reasons: InvalidationReasonSet,
     #[allow(dead_code)]
     placeholder_for_future_fields: (),
+}
+
+#[derive(Clone, Copy)]
+pub enum TaskPersistence {
+    /// Tasks that may be persisted across sessions using serialization.
+    Persistent,
+
+    /// Tasks that will be persisted in memory for the life of this session, but won't persist
+    /// between sessions.
+    ///
+    /// This is used for tasks with an argument of type
+    /// [`TransientValue`][crate::value::TransientValue] or
+    /// [`TransientInstance`][crate::value::TransientInstance].
+    Transient,
+
+    /// Tasks that are persisted only for the lifetime of the nearest non-`LocalCells` parent
+    /// caller.
+    ///
+    /// This task does not have a unique task id, and is not shared with the backend. Instead it
+    /// uses the parent task's id.
+    ///
+    /// Cells are allocated onto a temporary arena by default. Resolved cells inside a local task
+    /// are allocated into the parent task's cells.
+    ///
+    /// This is useful for functions that have a low cache hit rate. Those functions could be
+    /// converted to non-task functions, but that would break their function signature. This
+    /// provides a mechanism for skipping caching without changing the function signature.
+    LocalCells,
 }
 
 pub struct TurboTasks<B: Backend + 'static> {
@@ -416,25 +454,31 @@ impl<B: Backend + 'static> TurboTasks<B> {
         &self,
         func: FunctionId,
         arg: Box<dyn MagicAny>,
-        is_transient: bool,
+        persistence: TaskPersistence,
     ) -> RawVc {
         let task_type = CachedTaskType::Native {
             fn_type: func,
             this: None,
             arg,
         };
-        if is_transient {
-            RawVc::TaskOutput(self.backend.get_or_create_transient_task(
-                task_type,
-                current_task("turbo_function calls"),
-                self,
-            ))
-        } else {
-            RawVc::TaskOutput(self.backend.get_or_create_persistent_task(
-                task_type,
-                current_task("turbo_function calls"),
-                self,
-            ))
+        match persistence {
+            TaskPersistence::LocalCells => {
+                todo!("bgw: local tasks");
+            }
+            TaskPersistence::Transient => {
+                RawVc::TaskOutput(self.backend.get_or_create_transient_task(
+                    task_type,
+                    current_task("turbo_function calls"),
+                    self,
+                ))
+            }
+            TaskPersistence::Persistent => {
+                RawVc::TaskOutput(self.backend.get_or_create_persistent_task(
+                    task_type,
+                    current_task("turbo_function calls"),
+                    self,
+                ))
+            }
         }
     }
 
@@ -443,25 +487,31 @@ impl<B: Backend + 'static> TurboTasks<B> {
         func: FunctionId,
         this: RawVc,
         arg: Box<dyn MagicAny>,
-        is_transient: bool,
+        persistence: TaskPersistence,
     ) -> RawVc {
         let task_type = CachedTaskType::Native {
             fn_type: func,
             this: Some(this),
             arg,
         };
-        if is_transient {
-            RawVc::TaskOutput(self.backend.get_or_create_transient_task(
-                task_type,
-                current_task("turbo_function calls"),
-                self,
-            ))
-        } else {
-            RawVc::TaskOutput(self.backend.get_or_create_persistent_task(
-                task_type,
-                current_task("turbo_function calls"),
-                self,
-            ))
+        match persistence {
+            TaskPersistence::LocalCells => {
+                todo!("bgw: local tasks");
+            }
+            TaskPersistence::Transient => {
+                RawVc::TaskOutput(self.backend.get_or_create_transient_task(
+                    task_type,
+                    current_task("turbo_function calls"),
+                    self,
+                ))
+            }
+            TaskPersistence::Persistent => {
+                RawVc::TaskOutput(self.backend.get_or_create_persistent_task(
+                    task_type,
+                    current_task("turbo_function calls"),
+                    self,
+                ))
+            }
         }
     }
 
@@ -469,31 +519,38 @@ impl<B: Backend + 'static> TurboTasks<B> {
         &self,
         func: FunctionId,
         arg: Box<dyn MagicAny>,
-        is_transient: bool,
+        persistence: TaskPersistence,
     ) -> RawVc {
         // TODO(bgw): Don't create a full turbo task if this is a function using local_cells
         if registry::get_function(func).arg_meta.is_resolved(&*arg) {
-            self.native_call(func, arg, is_transient)
-        } else if is_transient {
-            RawVc::TaskOutput(self.backend.get_or_create_transient_task(
-                CachedTaskType::ResolveNative {
-                    fn_type: func,
-                    this: None,
-                    arg,
-                },
-                current_task("turbo_function calls"),
-                self,
-            ))
-        } else {
-            RawVc::TaskOutput(self.backend.get_or_create_persistent_task(
-                CachedTaskType::ResolveNative {
-                    fn_type: func,
-                    this: None,
-                    arg,
-                },
-                current_task("turbo_function calls"),
-                self,
-            ))
+            return self.native_call(func, arg, persistence);
+        }
+        match persistence {
+            TaskPersistence::LocalCells => {
+                todo!("bgw: local tasks");
+            }
+            TaskPersistence::Transient => {
+                RawVc::TaskOutput(self.backend.get_or_create_transient_task(
+                    CachedTaskType::ResolveNative {
+                        fn_type: func,
+                        this: None,
+                        arg,
+                    },
+                    current_task("turbo_function calls"),
+                    self,
+                ))
+            }
+            TaskPersistence::Persistent => {
+                RawVc::TaskOutput(self.backend.get_or_create_persistent_task(
+                    CachedTaskType::ResolveNative {
+                        fn_type: func,
+                        this: None,
+                        arg,
+                    },
+                    current_task("turbo_function calls"),
+                    self,
+                ))
+            }
         }
     }
 
@@ -502,23 +559,28 @@ impl<B: Backend + 'static> TurboTasks<B> {
         func: FunctionId,
         this: RawVc,
         arg: Box<dyn MagicAny>,
-        is_transient: bool,
+        persistence: TaskPersistence,
     ) -> RawVc {
         if this.is_resolved() && registry::get_function(func).arg_meta.is_resolved(&*arg) {
-            self.this_call(func, this, arg, is_transient)
-        } else {
-            let task_type = CachedTaskType::ResolveNative {
-                fn_type: func,
-                this: Some(this),
-                arg,
-            };
-            if is_transient {
+            return self.this_call(func, this, arg, persistence);
+        }
+        let task_type = CachedTaskType::ResolveNative {
+            fn_type: func,
+            this: Some(this),
+            arg,
+        };
+        match persistence {
+            TaskPersistence::LocalCells => {
+                todo!("bgw: local tasks");
+            }
+            TaskPersistence::Transient => {
                 RawVc::TaskOutput(self.backend.get_or_create_transient_task(
                     task_type,
                     current_task("turbo_function calls"),
                     self,
                 ))
-            } else {
+            }
+            TaskPersistence::Persistent => {
                 RawVc::TaskOutput(self.backend.get_or_create_persistent_task(
                     task_type,
                     current_task("turbo_function calls"),
@@ -534,7 +596,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
         mut trait_fn_name: Cow<'static, str>,
         this: RawVc,
         arg: Box<dyn MagicAny>,
-        is_transient: bool,
+        persistence: TaskPersistence,
     ) -> RawVc {
         // avoid creating a wrapper task if self is already resolved
         // for resolved cells we already know the value type so we can lookup the
@@ -542,7 +604,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
         if let RawVc::TaskCell(_, CellId { type_id, .. }) = this {
             match get_trait_method(trait_type, type_id, trait_fn_name) {
                 Ok(native_fn) => {
-                    return self.dynamic_this_call(native_fn, this, arg, is_transient);
+                    return self.dynamic_this_call(native_fn, this, arg, persistence);
                 }
                 Err(name) => {
                     trait_fn_name = name;
@@ -557,18 +619,24 @@ impl<B: Backend + 'static> TurboTasks<B> {
             this,
             arg,
         };
-        if is_transient {
-            RawVc::TaskOutput(self.backend.get_or_create_transient_task(
-                task_type,
-                current_task("turbo_function calls"),
-                self,
-            ))
-        } else {
-            RawVc::TaskOutput(self.backend.get_or_create_persistent_task(
-                task_type,
-                current_task("turbo_function calls"),
-                self,
-            ))
+        match persistence {
+            TaskPersistence::LocalCells => {
+                todo!("bgw: local tasks");
+            }
+            TaskPersistence::Transient => {
+                RawVc::TaskOutput(self.backend.get_or_create_transient_task(
+                    task_type,
+                    current_task("turbo_function calls"),
+                    self,
+                ))
+            }
+            TaskPersistence::Persistent => {
+                RawVc::TaskOutput(self.backend.get_or_create_persistent_task(
+                    task_type,
+                    current_task("turbo_function calls"),
+                    self,
+                ))
+            }
         }
     }
 
@@ -951,29 +1019,39 @@ impl<B: Backend + 'static> TurboTasks<B> {
 }
 
 impl<B: Backend + 'static> TurboTasksCallApi for TurboTasks<B> {
-    fn dynamic_call(&self, func: FunctionId, arg: Box<dyn MagicAny>, is_transient: bool) -> RawVc {
-        self.dynamic_call(func, arg, is_transient)
+    fn dynamic_call(
+        &self,
+        func: FunctionId,
+        arg: Box<dyn MagicAny>,
+        persistence: TaskPersistence,
+    ) -> RawVc {
+        self.dynamic_call(func, arg, persistence)
     }
     fn dynamic_this_call(
         &self,
         func: FunctionId,
         this: RawVc,
         arg: Box<dyn MagicAny>,
-        is_transient: bool,
+        persistence: TaskPersistence,
     ) -> RawVc {
-        self.dynamic_this_call(func, this, arg, is_transient)
+        self.dynamic_this_call(func, this, arg, persistence)
     }
-    fn native_call(&self, func: FunctionId, arg: Box<dyn MagicAny>, is_transient: bool) -> RawVc {
-        self.native_call(func, arg, is_transient)
+    fn native_call(
+        &self,
+        func: FunctionId,
+        arg: Box<dyn MagicAny>,
+        persistence: TaskPersistence,
+    ) -> RawVc {
+        self.native_call(func, arg, persistence)
     }
     fn this_call(
         &self,
         func: FunctionId,
         this: RawVc,
         arg: Box<dyn MagicAny>,
-        is_transient: bool,
+        persistence: TaskPersistence,
     ) -> RawVc {
-        self.this_call(func, this, arg, is_transient)
+        self.this_call(func, this, arg, persistence)
     }
     fn trait_call(
         &self,
@@ -981,9 +1059,9 @@ impl<B: Backend + 'static> TurboTasksCallApi for TurboTasks<B> {
         trait_fn_name: Cow<'static, str>,
         this: RawVc,
         arg: Box<dyn MagicAny>,
-        is_transient: bool,
+        persistence: TaskPersistence,
     ) -> RawVc {
-        self.trait_call(trait_type, trait_fn_name, this, arg, is_transient)
+        self.trait_call(trait_type, trait_fn_name, this, arg, persistence)
     }
 
     #[track_caller]
@@ -1475,8 +1553,12 @@ pub async fn run_once_with_reason<T: Send + 'static>(
 }
 
 /// Calls [`TurboTasks::dynamic_call`] for the current turbo tasks instance.
-pub fn dynamic_call(func: FunctionId, arg: Box<dyn MagicAny>, is_transient: bool) -> RawVc {
-    with_turbo_tasks(|tt| tt.dynamic_call(func, arg, is_transient))
+pub fn dynamic_call(
+    func: FunctionId,
+    arg: Box<dyn MagicAny>,
+    persistence: TaskPersistence,
+) -> RawVc {
+    with_turbo_tasks(|tt| tt.dynamic_call(func, arg, persistence))
 }
 
 /// Calls [`TurboTasks::dynamic_this_call`] for the current turbo tasks
@@ -1485,9 +1567,9 @@ pub fn dynamic_this_call(
     func: FunctionId,
     this: RawVc,
     arg: Box<dyn MagicAny>,
-    is_transient: bool,
+    persistence: TaskPersistence,
 ) -> RawVc {
-    with_turbo_tasks(|tt| tt.dynamic_this_call(func, this, arg, is_transient))
+    with_turbo_tasks(|tt| tt.dynamic_this_call(func, this, arg, persistence))
 }
 
 /// Calls [`TurboTasks::trait_call`] for the current turbo tasks instance.
@@ -1496,9 +1578,9 @@ pub fn trait_call(
     trait_fn_name: Cow<'static, str>,
     this: RawVc,
     arg: Box<dyn MagicAny>,
-    is_transient: bool,
+    persistence: TaskPersistence,
 ) -> RawVc {
-    with_turbo_tasks(|tt| tt.trait_call(trait_type, trait_fn_name, this, arg, is_transient))
+    with_turbo_tasks(|tt| tt.trait_call(trait_type, trait_fn_name, this, arg, persistence))
 }
 
 pub fn turbo_tasks() -> Arc<dyn TurboTasksApi> {


### PR DESCRIPTION
Builds on top of the `is_transient` boolean arguments from #68436, but uses an enum to provide a third variant of `TaskPersistence::LocalCells`.

The branches for this are `todo!()` right now, but the idea is that we'll intercept these in the manager and schedule them inside the manager instead of creating a unique task with its own `TaskId` on the backend.

## Testing

Some of the `local_cell` tests are broken with this change, as functions annotated with `#[turbo_tasks::function(local_cells)]` now hit the `todo!()` blocks added in this PR. Those tests are disabled for now, and I'll fix this in a later PR. *(This is okay, nothing is using local cells yet, aside from those tests)*