### PR TITLE
perf(turbo-tasks-macros): Move `assert_returns_resolved_value` into helper module

### DIFF
--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_resolved_inherent_impl.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_resolved_inherent_impl.stderr
@@ -15,7 +15,10 @@ error[E0277]: the trait bound `IntegersVec: ResolvedValue` is not satisfied
              (E, D, C, B, A, Z, Y, X, W, V, U, T)
            and $N others
 note: required by a bound in `assert_returns_resolved_value`
-  --> tests/function/fail_resolved_inherent_impl.rs:14:29
+  --> $WORKSPACE/turbopack/crates/turbo-tasks/src/macro_helpers.rs
    |
-14 |     #[turbo_tasks::function(resolved)]
-   |                             ^^^^^^^^ required by this bound in `assert_returns_resolved_value`
+   | pub fn assert_returns_resolved_value<ReturnType, Rv>()
+   |        ----------------------------- required by a bound in this function
+...
+   |     Rv: ResolvedValue + Send,
+   |         ^^^^^^^^^^^^^ required by this bound in `assert_returns_resolved_value`

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_resolved_static.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_resolved_static.stderr
@@ -15,7 +15,10 @@ error[E0277]: the trait bound `IntegersVec: ResolvedValue` is not satisfied
             (E, D, C, B, A, Z, Y, X, W, V, U, T)
           and $N others
 note: required by a bound in `assert_returns_resolved_value`
- --> tests/function/fail_resolved_static.rs:9:25
+ --> $WORKSPACE/turbopack/crates/turbo-tasks/src/macro_helpers.rs
   |
-9 | #[turbo_tasks::function(resolved)]
-  |                         ^^^^^^^^ required by this bound in `assert_returns_resolved_value`
+  | pub fn assert_returns_resolved_value<ReturnType, Rv>()
+  |        ----------------------------- required by a bound in this function
+...
+  |     Rv: ResolvedValue + Send,
+  |         ^^^^^^^^^^^^^ required by this bound in `assert_returns_resolved_value`

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_resolved_trait_impl.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_resolved_trait_impl.stderr
@@ -15,7 +15,10 @@ error[E0277]: the trait bound `IntegersVec: ResolvedValue` is not satisfied
              (E, D, C, B, A, Z, Y, X, W, V, U, T)
            and $N others
 note: required by a bound in `assert_returns_resolved_value`
-  --> tests/function/fail_resolved_trait_impl.rs:19:29
+  --> $WORKSPACE/turbopack/crates/turbo-tasks/src/macro_helpers.rs
    |
-19 |     #[turbo_tasks::function(resolved)]
-   |                             ^^^^^^^^ required by this bound in `assert_returns_resolved_value`
+   | pub fn assert_returns_resolved_value<ReturnType, Rv>()
+   |        ----------------------------- required by a bound in this function
+...
+   |     Rv: ResolvedValue + Send,
+   |         ^^^^^^^^^^^^^ required by this bound in `assert_returns_resolved_value`

--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -338,14 +338,7 @@ impl TurboFn {
             quote_spanned! {
                 span =>
                 {
-                    fn assert_returns_resolved_value<
-                        ReturnType,
-                        Rv,
-                    >() where
-                        ReturnType: turbo_tasks::task::TaskOutput<Return = Vc<Rv>>,
-                        Rv: turbo_tasks::ResolvedValue + Send,
-                    {}
-                    assert_returns_resolved_value::<#return_type, _>()
+                    turbo_tasks::macro_helpers::assert_returns_resolved_value::<#return_type, _>()
                 }
             }
         } else {

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -8,7 +8,9 @@ pub use super::{
     magic_any::MagicAny,
     manager::{find_cell_by_type, notify_scheduled_tasks, spawn_detached_for_testing},
 };
-use crate::{debug::ValueDebugFormatString, TaskInput, TaskPersistence};
+use crate::{
+    debug::ValueDebugFormatString, task::TaskOutput, ResolvedValue, TaskInput, TaskPersistence, Vc,
+};
 
 #[inline(never)]
 pub async fn value_debug_format_field(value: ValueDebugFormatString<'_>) -> String {
@@ -27,6 +29,13 @@ pub fn get_non_local_persistence_from_inputs(inputs: &impl TaskInput) -> TaskPer
     } else {
         TaskPersistence::Persistent
     }
+}
+
+pub fn assert_returns_resolved_value<ReturnType, Rv>()
+where
+    ReturnType: TaskOutput<Return = Vc<Rv>>,
+    Rv: ResolvedValue + Send,
+{
 }
 
 #[macro_export]


### PR DESCRIPTION
This avoids re-creating the function for every assertion we make on function return values, potentially slightly speeding up the macro compilation.

This shouldn't make much/any difference right now because nothing (outside of a few tests) uses resolved functions yet.

## Testing

```
TRYBUILD=overwrite cargo nextest r -p turbo-tasks-macros-tests
```