### PR TITLE
Include versions in externals error message

### DIFF
--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -308,21 +308,25 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                 );
             };
             let (Some(name), Some(version)) = (
-                package_json_file.get("name"),
-                package_json_file.get("version"),
+                package_json_file.get("name").and_then(|v| v.as_str()),
+                package_json_file.get("version").and_then(|v| v.as_str()),
             ) else {
                 return unable_to_externalize(
                     request_str.into(),
-                    "The package.json of the package has not name or version.",
+                    "The package.json of the package has no name or version.",
                 );
             };
             let (Some(name2), Some(version2)) = (
-                package_json_from_original_location.get("name"),
-                package_json_from_original_location.get("version"),
+                package_json_from_original_location
+                    .get("name")
+                    .and_then(|v| v.as_str()),
+                package_json_from_original_location
+                    .get("version")
+                    .and_then(|v| v.as_str()),
             ) else {
                 return unable_to_externalize(
                     request_str.into(),
-                    "The package.json of the package resolved from project directory has not name \
+                    "The package.json of the package resolved from project directory has no name \
                      or version.",
                 );
             };
@@ -330,9 +334,12 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                 // this can't resolve with node.js from the original location, so bundle it
                 return unable_to_externalize(
                     request_str.into(),
-                    "The package resolves to a different version when requested from the project \
-                     directory compared to the package requested from the importing module.\nMake \
-                     sure to install the same version of the package in both locations.",
+                    &format!(
+                        "The package resolves to a different version when requested from the \
+                         project directory ({version}) compared to the package requested from the \
+                         importing module ({version2}).\nMake sure to install the same version of \
+                         the package in both locations."
+                    ),
                 );
             }
         }


### PR DESCRIPTION
Now the expected and actual version numbers are included in the error message:
```
Package @libsql/client (serverExternalPackages or default list) can't be external
The request @libsql/client matches serverExternalPackages (or the default list), but it can't be external:
The package resolves to a different version when requested from the project directory (0.9.0) compared to the package requested from the importing module (0.6.2).
Make sure to install the same version of the package in both locations.
```