### PR TITLE
Docs: Fix `serverComponentsHmrCache` spelling mistake and cross-link

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/logging.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/logging.mdx
@@ -19,8 +19,7 @@ module.exports = {
 }
 ```
 
-{/* TODO: Cross-reference severComponentsHmrCache page when #67839 has landed. */}
-Any `fetch` requests that are restored from the Server Components HMR cache are not logged by default. However, this can be enabled by setting `logging.fetches.hmrRefreshes` to `true`.
+Any `fetch` requests that are restored from the [Server Components HMR cache](/docs/app/api-reference/next-config-js/serverComponentsHmrCache) are not logged by default. However, this can be enabled by setting `logging.fetches.hmrRefreshes` to `true`.
 
 ```js filename="next.config.js"
 module.exports = {

--- a/docs/02-app/02-api-reference/05-next-config-js/serverComponentsHmrCache.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/serverComponentsHmrCache.mdx
@@ -1,5 +1,5 @@
 ---
-title: severComponentsHmrCache
+title: serverComponentsHmrCache
 description: Configure whether fetch responses in Server Components are cached across HMR refresh requests.
 version: RC
 ---


### PR DESCRIPTION
Noticed a spelling mistake in the `serverComponentsHmrCache` page title, also added a cross-link based on the to-do note in the `logging` page. 