### PR TITLE
Escape backslash in delimiters

### DIFF
--- a/packages/next/src/shared/lib/router/utils/escape-path-delimiters.ts
+++ b/packages/next/src/shared/lib/router/utils/escape-path-delimiters.ts
@@ -4,7 +4,7 @@ export default function escapePathDelimiters(
   escapeEncoded?: boolean
 ): string {
   return segment.replace(
-    new RegExp(`([/#?]${escapeEncoded ? '|%(2f|23|3f)' : ''})`, 'gi'),
+    new RegExp(`([/#?]${escapeEncoded ? '|%(2f|23|3f|5c)' : ''})`, 'gi'),
     (char: string) => encodeURIComponent(char)
   )
 }


### PR DESCRIPTION
This adds `%5c` to `escapePathDelimiters` as it can be a Win32 path separator.