### PR TITLE
Add required legacyBehavior for passHref to work

### DIFF
--- a/errors/link-passhref.mdx
+++ b/errors/link-passhref.mdx
@@ -10,7 +10,7 @@ title: 'Link `passHref`'
 
 ## Possible Ways to Fix It
 
-If you're using a custom component that wraps an `<a>` tag, make sure to add `passHref`:
+If you're using a custom component that wraps an `<a>` tag, make sure to add `passHref` and `legacyBehavior`:
 
 ```jsx filename="nav-link.js"
 import Link from 'next/link'
@@ -22,7 +22,7 @@ const StyledLink = styled.a`
 
 function NavLink({ href, name }) {
   return (
-    <Link href={href} passHref>
+    <Link href={href} passHref legacyBehavior>
       <StyledLink>{name}</StyledLink>
     </Link>
   )


### PR DESCRIPTION
the `passHref` is supposed to allow for using a child link (styled component or similar) but prop does not work without passing the `legacyBehaviour`. The docs do not mention this anywhere so I've added it here