### PR TITLE
refactor(turbo-tasks): Add stubs for RawVc::TaskOutput

### DIFF
--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -20,7 +20,7 @@ use turbo_tasks::{
     registry,
     test_helpers::with_turbo_tasks_for_testing,
     util::{SharedError, StaticOrArc},
-    CellId, ExecutionId, InvalidationReason, MagicAny, RawVc, ReadConsistency, TaskId,
+    CellId, ExecutionId, InvalidationReason, LocalTaskId, MagicAny, RawVc, ReadConsistency, TaskId,
     TaskPersistence, TraitTypeId, TurboTasksApi, TurboTasksCallApi,
 };
 
@@ -240,6 +240,24 @@ impl TurboTasksApi for VcStorage {
         index: CellId,
     ) -> Result<TypedCellContent> {
         self.read_own_task_cell(current_task, index)
+    }
+
+    fn try_read_local_output(
+        &self,
+        parent_task_id: TaskId,
+        local_task_id: LocalTaskId,
+        consistency: ReadConsistency,
+    ) -> Result<Result<RawVc, EventListener>> {
+        self.try_read_local_output_untracked(parent_task_id, local_task_id, consistency)
+    }
+
+    fn try_read_local_output_untracked(
+        &self,
+        _parent_task_id: TaskId,
+        _local_task_id: LocalTaskId,
+        _consistency: ReadConsistency,
+    ) -> Result<Result<RawVc, EventListener>> {
+        unimplemented!()
     }
 
     fn emit_collectible(&self, _trait_type: turbo_tasks::TraitTypeId, _collectible: RawVc) {

--- a/turbopack/crates/turbo-tasks/src/id.rs
+++ b/turbopack/crates/turbo-tasks/src/id.rs
@@ -10,8 +10,16 @@ use serde::{de::Visitor, Deserialize, Serialize};
 use crate::{registry, TaskPersistence};
 
 macro_rules! define_id {
-    ($name:ident : $primitive:ty $(,derive($($derive:ty),*))?) => {
+    (
+        $name:ident : $primitive:ty
+        $(,derive($($derive:ty),*))?
+        $(,serde($serde:tt))?
+        $(,doc = $doc:literal)*
+        $(,)?
+    ) => {
+        $(#[doc = $doc])*
         #[derive(Hash, Clone, Copy, PartialEq, Eq, PartialOrd, Ord $($(,$derive)*)? )]
+        $(#[serde($serde)])?
         pub struct $name {
             id: NonZero<$primitive>,
         }
@@ -64,13 +72,24 @@ macro_rules! define_id {
     };
 }
 
-define_id!(TaskId: u32);
+define_id!(TaskId: u32, derive(Serialize, Deserialize), serde(transparent));
 define_id!(FunctionId: u32);
 define_id!(ValueTypeId: u32);
 define_id!(TraitTypeId: u32);
 define_id!(BackendJobId: u32);
 define_id!(ExecutionId: u64, derive(Debug));
-define_id!(LocalCellId: u32, derive(Debug));
+define_id!(
+    LocalCellId: u32,
+    derive(Debug),
+    doc = "Represents the nth call to `Vc::cell()` with `local_cells` inside of the parent ",
+    doc = "non-local task.",
+);
+define_id!(
+    LocalTaskId: u32,
+    derive(Debug, Serialize, Deserialize),
+    serde(transparent),
+    doc = "Represents the nth `local_cells` function call inside a task.",
+);
 
 impl Debug for TaskId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -160,38 +179,3 @@ make_serializable!(
     registry::get_trait_type_id_by_global_name,
     TraitTypeVisitor
 );
-
-impl Serialize for TaskId {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_u32(**self)
-    }
-}
-
-impl<'de> Deserialize<'de> for TaskId {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        struct V;
-
-        impl Visitor<'_> for V {
-            type Value = TaskId;
-
-            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                write!(f, "task id")
-            }
-
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(TaskId::from(v))
-            }
-        }
-
-        deserializer.deserialize_u32(V)
-    }
-}

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -81,7 +81,9 @@ use auto_hash_map::AutoSet;
 pub use collectibles::CollectiblesSource;
 pub use completion::{Completion, Completions};
 pub use display::ValueToString;
-pub use id::{ExecutionId, FunctionId, TaskId, TraitTypeId, ValueTypeId, TRANSIENT_TASK_BIT};
+pub use id::{
+    ExecutionId, FunctionId, LocalTaskId, TaskId, TraitTypeId, ValueTypeId, TRANSIENT_TASK_BIT,
+};
 pub use invalidation::{
     get_invalidator, DynamicEqHash, InvalidationReason, InvalidationReasonKind,
     InvalidationReasonSet, Invalidator,

--- a/turbopack/crates/turbo-tasks/src/raw_vc.rs
+++ b/turbopack/crates/turbo-tasks/src/raw_vc.rs
@@ -15,10 +15,10 @@ use thiserror::Error;
 use crate::{
     backend::{CellContent, TypedCellContent},
     event::EventListener,
-    id::{ExecutionId, LocalCellId},
+    id::{ExecutionId, LocalCellId, LocalTaskId},
     manager::{
-        assert_execution_id, current_task, read_local_cell, read_task_cell, read_task_output,
-        TurboTasksApi,
+        assert_execution_id, current_task, read_local_cell, read_local_output, read_task_cell,
+        read_task_output, TurboTasksApi,
     },
     registry::{self, get_value_type},
     turbo_tasks, CollectiblesSource, ReadConsistency, TaskId, TraitTypeId, ValueType, ValueTypeId,
@@ -58,6 +58,7 @@ impl Display for CellId {
 pub enum RawVc {
     TaskOutput(TaskId),
     TaskCell(TaskId, CellId),
+    LocalOutput(TaskId, LocalTaskId),
     #[serde(skip)]
     LocalCell(ExecutionId, LocalCellId),
 }
@@ -67,6 +68,7 @@ impl RawVc {
         match self {
             RawVc::TaskOutput(_) => false,
             RawVc::TaskCell(_, _) => true,
+            RawVc::LocalOutput(_, _) => false,
             RawVc::LocalCell(_, _) => false,
         }
     }
@@ -75,6 +77,7 @@ impl RawVc {
         match self {
             RawVc::TaskOutput(_) => false,
             RawVc::TaskCell(_, _) => false,
+            RawVc::LocalOutput(_, _) => true,
             RawVc::LocalCell(_, _) => true,
         }
     }
@@ -162,6 +165,12 @@ impl RawVc {
                         return Err(ResolveTypeError::NoContent);
                     }
                 }
+                RawVc::LocalOutput(task_id, local_cell_id) => {
+                    current =
+                        read_local_output(&*tt, task_id, local_cell_id, ReadConsistency::Eventual)
+                            .await
+                            .map_err(|source| ResolveTypeError::TaskError { source })?;
+                }
                 RawVc::LocalCell(execution_id, local_cell_id) => {
                     let shared_reference = read_local_cell(execution_id, local_cell_id);
                     return Ok(
@@ -193,16 +202,23 @@ impl RawVc {
         let tt = turbo_tasks();
         let mut current = self;
         let mut notified = false;
+        let mut lazily_notify = || {
+            if !notified {
+                tt.notify_scheduled_tasks();
+                notified = true;
+            }
+        };
         loop {
             match current {
                 RawVc::TaskOutput(task) => {
-                    if !notified {
-                        tt.notify_scheduled_tasks();
-                        notified = true;
-                    }
+                    lazily_notify();
                     current = read_task_output(&*tt, task, consistency).await?;
                 }
                 RawVc::TaskCell(_, _) => return Ok(current),
+                RawVc::LocalOutput(task_id, local_cell_id) => {
+                    lazily_notify();
+                    current = read_local_output(&*tt, task_id, local_cell_id, consistency).await?;
+                }
                 RawVc::LocalCell(execution_id, local_cell_id) => {
                     let shared_reference = read_local_cell(execution_id, local_cell_id);
                     let value_type = get_value_type(shared_reference.0);
@@ -219,7 +235,7 @@ impl RawVc {
 
     pub fn get_task_id(&self) -> TaskId {
         match self {
-            RawVc::TaskOutput(t) | RawVc::TaskCell(t, _) => *t,
+            RawVc::TaskOutput(t) | RawVc::TaskCell(t, _) | RawVc::LocalOutput(t, _) => *t,
             RawVc::LocalCell(execution_id, _) => {
                 assert_execution_id(*execution_id);
                 current_task("RawVc::get_task_id")
@@ -362,6 +378,30 @@ impl Future for ReadRawVcFuture {
                         Ok(Ok(content)) => {
                             // SAFETY: Constructor ensures that T and U are binary identical
                             return Poll::Ready(Ok(content));
+                        }
+                        Ok(Err(listener)) => listener,
+                        Err(err) => return Poll::Ready(Err(err)),
+                    }
+                }
+                RawVc::LocalOutput(task_id, local_output_id) => {
+                    let read_result = if this.untracked {
+                        this.turbo_tasks.try_read_local_output_untracked(
+                            task_id,
+                            local_output_id,
+                            this.consistency,
+                        )
+                    } else {
+                        this.turbo_tasks.try_read_local_output(
+                            task_id,
+                            local_output_id,
+                            this.consistency,
+                        )
+                    };
+                    match read_result {
+                        Ok(Ok(vc)) => {
+                            this.consistency = ReadConsistency::Eventual;
+                            this.current = vc;
+                            continue 'outer;
                         }
                         Ok(Err(listener)) => listener,
                         Err(err) => return Poll::Ready(Err(err)),


### PR DESCRIPTION
## Why?

https://www.notion.so/vercel/RawVc-LocalOutput-aede5f463f594ca58396eb3fdaffd865

When returning from a function using `local_cells`, we need to return a `RawVc`, but we don't know that the output type is yet, so we need a `RawVc` variant that does not require a type.

This is fundamentally the same problem that `RawVc::TaskOutput` solves. `RawVc::LocalOutput` is the same thing, but for functions using `local_cells`.

## Implementation

There's an (partially broken) implementation in #69126. This PR exists to help break #69126 into more reviewable chunks.