### PR TITLE
Improve create not found tree and remove asNotFound

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -898,7 +898,6 @@ export async function handleAction({
           result: await generateFlight(req, ctx, {
             skipFlight: false,
             actionResult: promise,
-            asNotFound: true,
           }),
         }
       }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1196,7 +1196,6 @@ async function renderToStream(
   tree: LoaderTree,
   formState: any
 ): Promise<ReadableStream<Uint8Array>> {
-  const is404 = res.statusCode === 404
   const renderOpts = ctx.renderOpts
   const ComponentMod = renderOpts.ComponentMod
   // TODO: fix this typescript
@@ -1280,7 +1279,7 @@ async function renderToStream(
 
   try {
     // This is a dynamic render. We don't do dynamic tracking because we're not prerendering
-    const RSCPayload = await getRSCPayload(tree, ctx, is404)
+    const RSCPayload = await getRSCPayload(tree, ctx, res.statusCode === 404)
     const reactServerStream = ComponentMod.renderToReadableStream(
       RSCPayload,
       clientReferenceManifest.clientModules,
@@ -1484,6 +1483,7 @@ async function renderToStream(
       setHeader('Location', redirectUrl)
     }
 
+    const is404 = res.statusCode === 404
     if (!is404 && !hasRedirectError && !shouldBailoutToCSR) {
       res.statusCode = 500
     }
@@ -1602,7 +1602,6 @@ async function prerenderToStream(
   staticGenerationStore: StaticGenerationStore,
   tree: LoaderTree
 ): Promise<PrenderToStringResult> {
-  const is404 = res.statusCode === 404
   // When prerendering formState is always null. We still include it
   // because some shared APIs expect a formState value and this is slightly
   // more explicit than making it an optional function argument
@@ -1705,7 +1704,7 @@ async function prerenderToStream(
       const reactServerPrerenderStore = {
         dynamicTracking,
       }
-      const RSCPayload = await getRSCPayload(tree, ctx, is404)
+      const RSCPayload = await getRSCPayload(tree, ctx, res.statusCode === 404)
       const reactServerStream: ReadableStream<Uint8Array> =
         prerenderAsyncStorage.run(
           reactServerPrerenderStore,
@@ -1869,7 +1868,7 @@ async function prerenderToStream(
     } else {
       // This is a regular static generation. We don't do dynamic tracking because we rely on
       // the old-school dynamic error handling to bail out of static generation
-      const RSCPayload = await getRSCPayload(tree, ctx, is404)
+      const RSCPayload = await getRSCPayload(tree, ctx, res.statusCode === 404)
       const reactServerStream = ComponentMod.renderToReadableStream(
         RSCPayload,
         clientReferenceManifest.clientModules,
@@ -1993,6 +1992,7 @@ async function prerenderToStream(
       setHeader('Location', redirectUrl)
     }
 
+    const is404 = res.statusCode === 404
     if (!is404 && !hasRedirectError && !shouldBailoutToCSR) {
       res.statusCode = 500
     }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -133,6 +133,7 @@ import { createInitialRouterState } from '../../client/components/router-reducer
 import { createMutableActionQueue } from '../../shared/lib/router/action-queue'
 import { prerenderAsyncStorage } from './prerender-async-storage.external'
 import { getRevalidateReason } from '../instrumentation/utils'
+import { PAGE_SEGMENT_KEY } from '../../shared/lib/segment'
 
 export type GetDynamicParamFromSegment = (
   // [slug] / [[slug]] / [...slug]
@@ -228,7 +229,20 @@ function parseRequestHeaders(
 
 function createNotFoundLoaderTree(loaderTree: LoaderTree): LoaderTree {
   // Align the segment with parallel-route-default in next-app-loader
-  return ['', {}, loaderTree[2]]
+  const components = loaderTree[2]
+  return [
+    '',
+    {
+      children: [
+        PAGE_SEGMENT_KEY,
+        {},
+        {
+          page: components['not-found'],
+        },
+      ],
+    },
+    components,
+  ]
 }
 
 export type CreateSegmentPath = (child: FlightSegmentPath) => FlightSegmentPath
@@ -522,7 +536,7 @@ async function getRSCPayload(
     injectedJS,
     injectedFontPreloadTags,
     rootLayoutIncluded: false,
-    asNotFound: asNotFound,
+    asNotFound,
     getMetadataReady,
     missingSlots,
     preloadCallbacks,
@@ -1594,7 +1608,6 @@ async function prerenderToStream(
   ctx: AppRenderContext,
   metadata: AppPageRenderResultMetadata,
   staticGenerationStore: StaticGenerationStore,
-
   asNotFound: boolean,
   tree: LoaderTree
 ): Promise<PrenderToStringResult> {

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -547,24 +547,24 @@ async function createComponentTreeInternal({
 
   // If it's a not found route, and we don't have any matched parallel
   // routes, we try to render the not found component if it exists.
-  if (
-    NotFound &&
-    asNotFound &&
-    // In development, it could hit the parallel-route-default not found, so we only need to check the segment.
-    // Or if there's no parallel routes means it reaches the end.
-    !parallelRouteMap.length
-  ) {
-    props.children = (
-      <>
-        <meta name="robots" content="noindex" />
-        {process.env.NODE_ENV === 'development' && (
-          <meta name="next-error" content="not-found" />
-        )}
-        {notFoundStyles}
-        <NotFound />
-      </>
-    )
-  }
+  // if (
+  //   NotFound &&
+  //   asNotFound &&
+  //   // In development, it could hit the parallel-route-default not found, so we only need to check the segment.
+  //   // Or if there's no parallel routes means it reaches the end.
+  //   !parallelRouteMap.length
+  // ) {
+  //   props.children = (
+  //     <>
+  //       <meta name="robots" content="noindex" />
+  //       {process.env.NODE_ENV === 'development' && (
+  //         <meta name="next-error" content="not-found" />
+  //       )}
+  //       {notFoundStyles}
+  //       <NotFound />
+  //     </>
+  //   )
+  // }
 
   // Assign params to props
   if (

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -33,7 +33,6 @@ export function createComponentTree(props: {
   injectedCSS: Set<string>
   injectedJS: Set<string>
   injectedFontPreloadTags: Set<string>
-  asNotFound?: boolean
   getMetadataReady: () => Promise<void>
   ctx: AppRenderContext
   missingSlots?: Set<string>
@@ -65,7 +64,6 @@ async function createComponentTreeInternal({
   injectedCSS,
   injectedJS,
   injectedFontPreloadTags,
-  asNotFound,
   getMetadataReady,
   ctx,
   missingSlots,
@@ -79,7 +77,6 @@ async function createComponentTreeInternal({
   injectedCSS: Set<string>
   injectedJS: Set<string>
   injectedFontPreloadTags: Set<string>
-  asNotFound?: boolean
   getMetadataReady: () => Promise<void>
   ctx: AppRenderContext
   missingSlots?: Set<string>
@@ -437,7 +434,6 @@ async function createComponentTreeInternal({
             injectedCSS: injectedCSSWithCurrentLayout,
             injectedJS: injectedJSWithCurrentLayout,
             injectedFontPreloadTags: injectedFontPreloadTagsWithCurrentLayout,
-            asNotFound,
             // getMetadataReady is used to conditionally throw. In the case of parallel routes we will have more than one page
             // but we only want to throw on the first one.
             getMetadataReady: isChildrenRouteKey
@@ -544,27 +540,6 @@ async function createComponentTreeInternal({
 
   // We avoid cloning this object because it gets consumed here exclusively.
   const props: { [prop: string]: any } = parallelRouteProps
-
-  // If it's a not found route, and we don't have any matched parallel
-  // routes, we try to render the not found component if it exists.
-  // if (
-  //   NotFound &&
-  //   asNotFound &&
-  //   // In development, it could hit the parallel-route-default not found, so we only need to check the segment.
-  //   // Or if there's no parallel routes means it reaches the end.
-  //   !parallelRouteMap.length
-  // ) {
-  //   props.children = (
-  //     <>
-  //       <meta name="robots" content="noindex" />
-  //       {process.env.NODE_ENV === 'development' && (
-  //         <meta name="next-error" content="not-found" />
-  //       )}
-  //       {notFoundStyles}
-  //       <NotFound />
-  //     </>
-  //   )
-  // }
 
   // Assign params to props
   if (

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -37,7 +37,6 @@ export async function walkTreeWithFlightRouterState({
   injectedJS,
   injectedFontPreloadTags,
   rootLayoutIncluded,
-  asNotFound,
   getMetadataReady,
   ctx,
   preloadCallbacks,
@@ -53,7 +52,6 @@ export async function walkTreeWithFlightRouterState({
   injectedJS: Set<string>
   injectedFontPreloadTags: Set<string>
   rootLayoutIncluded: boolean
-  asNotFound?: boolean
   getMetadataReady: () => Promise<void>
   ctx: AppRenderContext
   preloadCallbacks: PreloadCallbacks
@@ -153,7 +151,6 @@ export async function walkTreeWithFlightRouterState({
           injectedFontPreloadTags,
           // This is intentionally not "rootLayoutIncludedAtThisLevelOrAbove" as createComponentTree starts at the current level and does a check for "rootLayoutAtThisLevel" too.
           rootLayoutIncluded,
-          asNotFound,
           getMetadataReady,
           preloadCallbacks,
         }
@@ -214,7 +211,6 @@ export async function walkTreeWithFlightRouterState({
           injectedJS: injectedJSWithCurrentLayout,
           injectedFontPreloadTags: injectedFontPreloadTagsWithCurrentLayout,
           rootLayoutIncluded: rootLayoutIncludedAtThisLevelOrAbove,
-          asNotFound,
           getMetadataReady,
           preloadCallbacks,
         })


### PR DESCRIPTION
### What

* Improve the loader tree for 404 page, rendering the page based on the loader tree
* Drop the `asNotFound` as it was bit confused in the rendering logic

### Why

Previously we use a `asNotFound` property to mark that we're going to render 404 page, which is formed by the root `layout` and root `not-found`. But the 404 page rendering is actually based on 2 factors: `asNotFound` option and the fake loader tree. The loader tree was actually a fake one, and rendering process was following the `asNotFound` option to decide when to render `not-found` component as the page content. 

This is bit hard to follow, so in this PR we improved the loader tree structure of the loader tree structure of 404 page, fill the nested children tree nodes with the `not-found` as page content, let render process follow the loader tree and render the page headlessly.