### PR TITLE
Adapt external pages bundle test to minified module IDs

### DIFF
--- a/test/integration/externals-pages-bundle/node_modules/external-package/index.js
+++ b/test/integration/externals-pages-bundle/node_modules/external-package/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  foo: 'bar',
+  foo: 'external-package content',
 }

--- a/test/integration/externals-pages-bundle/node_modules/opted-out-external-package/index.js
+++ b/test/integration/externals-pages-bundle/node_modules/opted-out-external-package/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  bar: 'baz',
+  bar: 'opted-out-external-package content',
 }

--- a/test/integration/externals-pages-bundle/test/index.test.js
+++ b/test/integration/externals-pages-bundle/test/index.test.js
@@ -27,10 +27,8 @@ describe('bundle pages externals with config.bundlePagesRouterDependencies', () 
             allBundles += output
           }
 
-          // we don't know the name of the minified `__turbopack_external_require__`, so we just check the arguments.
-          expect(allBundles).not.toContain(
-            '"[externals]/ [external] (external-package, cjs)"'
-          )
+          // we don't know the name of the minified `__turbopack_external_require__`, so we just check the content.
+          expect(allBundles).toContain('"external-package content"')
         } else {
           const output = await fs.readFile(
             join(appDir, '.next/server/pages/index.js'),
@@ -53,9 +51,9 @@ describe('bundle pages externals with config.bundlePagesRouterDependencies', () 
             allBundles += output
           }
 
-          // we don't know the name of the minified `__turbopack_external_require__`, so we just check the arguments.
-          expect(allBundles).toContain(
-            '"[externals]/ [external] (opted-out-external-package, cjs)"'
+          // we don't know the name of the minified `__turbopack_external_require__`, so we just check the content.
+          expect(allBundles).not.toContain(
+            '"opted-out-external-package content"'
           )
         } else {
           const output = await fs.readFile(


### PR DESCRIPTION
### What?
Adapted `test/integration/external-pages-bundle` to work with minified module IDs. Instead of looking for the module name (which is minified so it cannot be looked for), it now looks for the module content.