### PR TITLE
refactor(turbo-tasks): Use an enum for `strongly_consistent`/`ReadConsistency` instead of a bool

### DIFF
--- a/crates/next-build-test/src/lib.rs
+++ b/crates/next-build-test/src/lib.rs
@@ -10,7 +10,7 @@ use next_api::{
     project::{ProjectContainer, ProjectOptions},
     route::{Endpoint, Route},
 };
-use turbo_tasks::{RcStr, TransientInstance, TurboTasks, Vc};
+use turbo_tasks::{RcStr, ReadConsistency, TransientInstance, TurboTasks, Vc};
 use turbo_tasks_malloc::TurboMalloc;
 use turbo_tasks_memory::MemoryBackend;
 
@@ -261,7 +261,8 @@ async fn hmr(tt: &TurboTasks<MemoryBackend>, project: Vc<ProjectContainer>) -> R
                 Ok(Vc::<()>::cell(()))
             }
         });
-        tt.wait_task_completion(task, true).await?;
+        tt.wait_task_completion(task, ReadConsistency::Strong)
+            .await?;
         let e = start.elapsed();
         if e.as_millis() > 10 {
             tracing::info!("HMR: {:?} {:?}", ident, e);

--- a/turbopack/crates/node-file-trace/src/lib.rs
+++ b/turbopack/crates/node-file-trace/src/lib.rs
@@ -22,8 +22,8 @@ use serde::Deserialize;
 use serde::Serialize;
 use tokio::sync::mpsc::channel;
 use turbo_tasks::{
-    backend::Backend, util::FormatDuration, RcStr, TaskId, TransientInstance, TransientValue,
-    TurboTasks, UpdateInfo, Value, Vc,
+    backend::Backend, util::FormatDuration, RcStr, ReadConsistency, TaskId, TransientInstance,
+    TransientValue, TurboTasks, UpdateInfo, Value, Vc,
 };
 use turbo_tasks_fs::{
     glob::Glob, DirectoryEntry, DiskFileSystem, FileSystem, FileSystemPath, ReadGlobResult,
@@ -407,7 +407,10 @@ async fn run<B: Backend + 'static, F: Future<Output = ()>>(
     let start = Instant::now();
     let finish = |tt: Arc<TurboTasks<B>>, root_task: TaskId| async move {
         if watch {
-            if let Err(e) = tt.wait_task_completion(root_task, true).await {
+            if let Err(e) = tt
+                .wait_task_completion(root_task, ReadConsistency::Strong)
+                .await
+            {
                 println!("{}", e);
             }
             let UpdateInfo {
@@ -431,7 +434,9 @@ async fn run<B: Backend + 'static, F: Future<Output = ()>>(
                 println!("updated {} tasks in {}", tasks, FormatDuration(duration));
             }
         } else {
-            let result = tt.wait_task_completion(root_task, true).await;
+            let result = tt
+                .wait_task_completion(root_task, ReadConsistency::Strong)
+                .await;
             let dur = start.elapsed();
             let UpdateInfo {
                 duration, tasks, ..

--- a/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
+++ b/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
@@ -9,7 +9,7 @@ use std::{
 
 use anyhow::Result;
 use sha2::{Digest, Sha256};
-use turbo_tasks::{util::FormatDuration, RcStr, TurboTasks, UpdateInfo, Vc};
+use turbo_tasks::{util::FormatDuration, RcStr, ReadConsistency, TurboTasks, UpdateInfo, Vc};
 use turbo_tasks_fs::{
     register, DirectoryContent, DirectoryEntry, DiskFileSystem, FileContent, FileSystem,
     FileSystemPath,
@@ -41,7 +41,9 @@ async fn main() -> Result<()> {
             Ok::<Vc<()>, _>(Default::default())
         })
     });
-    tt.wait_task_completion(task, true).await.unwrap();
+    tt.wait_task_completion(task, ReadConsistency::Strong)
+        .await
+        .unwrap();
     println!("done in {}", FormatDuration(start.elapsed()));
 
     loop {

--- a/turbopack/crates/turbo-tasks-fs/examples/hash_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/examples/hash_glob.rs
@@ -9,7 +9,7 @@ use std::{
 
 use anyhow::Result;
 use sha2::{Digest, Sha256};
-use turbo_tasks::{util::FormatDuration, RcStr, TurboTasks, UpdateInfo, Vc};
+use turbo_tasks::{util::FormatDuration, RcStr, ReadConsistency, TurboTasks, UpdateInfo, Vc};
 use turbo_tasks_fs::{
     glob::Glob, register, DirectoryEntry, DiskFileSystem, FileContent, FileSystem, FileSystemPath,
     ReadGlobResult,
@@ -40,7 +40,9 @@ async fn main() -> Result<()> {
             Ok::<Vc<()>, _>(Default::default())
         })
     });
-    tt.wait_task_completion(task, true).await.unwrap();
+    tt.wait_task_completion(task, ReadConsistency::Strong)
+        .await
+        .unwrap();
     println!("done in {}", FormatDuration(start.elapsed()));
 
     loop {

--- a/turbopack/crates/turbo-tasks-memory/benches/scope_stress.rs
+++ b/turbopack/crates/turbo-tasks-memory/benches/scope_stress.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use criterion::{BenchmarkId, Criterion};
-use turbo_tasks::{Completion, TryJoinIterExt, TurboTasks, Vc};
+use turbo_tasks::{Completion, ReadConsistency, TryJoinIterExt, TurboTasks, Vc};
 use turbo_tasks_memory::MemoryBackend;
 
 use super::register;
@@ -49,7 +49,7 @@ pub fn scope_stress(c: &mut Criterion) {
                                         rectangle(a, b).strongly_consistent().await?;
                                         Ok::<Vc<()>, _>(Default::default())
                                     });
-                                    tt.wait_task_completion(task, false).await
+                                    tt.wait_task_completion(task, ReadConsistency::Weak).await
                                 }
                             })
                             .try_join()

--- a/turbopack/crates/turbo-tasks-memory/benches/scope_stress.rs
+++ b/turbopack/crates/turbo-tasks-memory/benches/scope_stress.rs
@@ -49,7 +49,8 @@ pub fn scope_stress(c: &mut Criterion) {
                                         rectangle(a, b).strongly_consistent().await?;
                                         Ok::<Vc<()>, _>(Default::default())
                                     });
-                                    tt.wait_task_completion(task, ReadConsistency::Weak).await
+                                    tt.wait_task_completion(task, ReadConsistency::Eventual)
+                                        .await
                                 }
                             })
                             .try_join()

--- a/turbopack/crates/turbo-tasks-memory/benches/stress.rs
+++ b/turbopack/crates/turbo-tasks-memory/benches/stress.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use criterion::{BenchmarkId, Criterion};
-use turbo_tasks::{TryJoinIterExt, TurboTasks, Vc};
+use turbo_tasks::{ReadConsistency, TryJoinIterExt, TurboTasks, Vc};
 use turbo_tasks_memory::MemoryBackend;
 
 use super::register;
@@ -43,7 +43,9 @@ pub fn fibonacci(c: &mut Criterion) {
                         (0..size).map(|i| fib(i, i)).try_join().await?;
                         Ok::<Vc<()>, _>(Default::default())
                     });
-                    tt.wait_task_completion(task, false).await.unwrap();
+                    tt.wait_task_completion(task, ReadConsistency::Weak)
+                        .await
+                        .unwrap();
                     tt
                 }
             })

--- a/turbopack/crates/turbo-tasks-memory/benches/stress.rs
+++ b/turbopack/crates/turbo-tasks-memory/benches/stress.rs
@@ -43,7 +43,7 @@ pub fn fibonacci(c: &mut Criterion) {
                         (0..size).map(|i| fib(i, i)).try_join().await?;
                         Ok::<Vc<()>, _>(Default::default())
                     });
-                    tt.wait_task_completion(task, ReadConsistency::Weak)
+                    tt.wait_task_completion(task, ReadConsistency::Eventual)
                         .await
                         .unwrap();
                     tt

--- a/turbopack/crates/turbo-tasks-memory/src/aggregation/aggregation_data.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/aggregation/aggregation_data.rs
@@ -37,6 +37,7 @@ where
 
 /// Converted the given node to a fully aggregated node. To make the next call
 /// to `aggregation_data` instant.
+#[cfg(test)]
 pub fn prepare_aggregation_data<C: AggregationContext>(ctx: &C, node_id: &C::NodeRef) {
     let mut balance_queue = BalanceQueue::new();
     increase_aggregation_number_internal(

--- a/turbopack/crates/turbo-tasks-memory/src/aggregation/mod.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/aggregation/mod.rs
@@ -23,7 +23,7 @@ mod root_query;
 mod tests;
 mod uppers;
 
-pub use aggregation_data::{aggregation_data, prepare_aggregation_data, AggregationDataGuard};
+pub use aggregation_data::{aggregation_data, AggregationDataGuard};
 use balance_edge::balance_edge;
 use increase::increase_aggregation_number_internal;
 pub use new_edge::handle_new_edge;

--- a/turbopack/crates/turbo-tasks-memory/src/task.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/task.rs
@@ -29,8 +29,7 @@ use turbo_tasks::{
 
 use crate::{
     aggregation::{
-        aggregation_data, handle_new_edge, prepare_aggregation_data, query_root_info,
-        AggregationDataGuard, PreparedOperation,
+        aggregation_data, handle_new_edge, query_root_info, AggregationDataGuard, PreparedOperation,
     },
     cell::{Cell, ReadContentError},
     edges_set::{TaskEdge, TaskEdgesList, TaskEdgesSet},
@@ -1629,7 +1628,6 @@ impl Task {
     ) -> Result<Result<T, EventListener>> {
         let mut aggregation_context = TaskAggregationContext::new(turbo_tasks, backend);
         let mut state = if consistency == ReadConsistency::Strong {
-            prepare_aggregation_data(&aggregation_context, &self.id);
             let mut aggregation = aggregation_data(&aggregation_context, &self.id);
             if aggregation.unfinished > 0 {
                 if aggregation.root_type.is_none() {

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -20,8 +20,8 @@ use turbo_tasks::{
     registry,
     test_helpers::with_turbo_tasks_for_testing,
     util::{SharedError, StaticOrArc},
-    CellId, ExecutionId, InvalidationReason, MagicAny, RawVc, TaskId, TaskPersistence, TraitTypeId,
-    TurboTasksApi, TurboTasksCallApi,
+    CellId, ExecutionId, InvalidationReason, MagicAny, RawVc, ReadConsistency, TaskId,
+    TaskPersistence, TraitTypeId, TurboTasksApi, TurboTasksCallApi,
 };
 
 pub use crate::run::{run, run_without_cache_check, Registration};
@@ -184,7 +184,7 @@ impl TurboTasksApi for VcStorage {
     fn try_read_task_output(
         &self,
         id: TaskId,
-        _strongly_consistent: bool,
+        _consistency: ReadConsistency,
     ) -> Result<Result<RawVc, EventListener>> {
         let tasks = self.tasks.lock().unwrap();
         let i = *id - 1;
@@ -201,9 +201,9 @@ impl TurboTasksApi for VcStorage {
     fn try_read_task_output_untracked(
         &self,
         task: TaskId,
-        strongly_consistent: bool,
+        consistency: ReadConsistency,
     ) -> Result<Result<RawVc, EventListener>> {
-        self.try_read_task_output(task, strongly_consistent)
+        self.try_read_task_output(task, consistency)
     }
 
     fn try_read_task_cell(

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -17,7 +17,7 @@ pub use crate::id::{BackendJobId, ExecutionId};
 use crate::{
     event::EventListener,
     magic_any::MagicAny,
-    manager::TurboTasksBackendApi,
+    manager::{ReadConsistency, TurboTasksBackendApi},
     raw_vc::CellId,
     registry,
     task::shared_reference::TypedSharedReference,
@@ -484,7 +484,7 @@ pub trait Backend: Sync + Send {
         &self,
         task: TaskId,
         reader: TaskId,
-        strongly_consistent: bool,
+        consistency: ReadConsistency,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> Result<Result<RawVc, EventListener>>;
 
@@ -493,7 +493,7 @@ pub trait Backend: Sync + Send {
     fn try_read_task_output_untracked(
         &self,
         task: TaskId,
-        strongly_consistent: bool,
+        consistency: ReadConsistency,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> Result<Result<RawVc, EventListener>>;
 

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -90,8 +90,8 @@ pub use magic_any::MagicAny;
 pub use manager::{
     dynamic_call, dynamic_this_call, emit, get_invalidator, mark_finished, mark_stateful,
     prevent_gc, run_once, run_once_with_reason, spawn_blocking, spawn_thread, trait_call,
-    turbo_tasks, CurrentCellRef, Invalidator, TaskPersistence, TurboTasks, TurboTasksApi,
-    TurboTasksBackendApi, TurboTasksCallApi, Unused, UpdateInfo,
+    turbo_tasks, CurrentCellRef, Invalidator, ReadConsistency, TaskPersistence, TurboTasks,
+    TurboTasksApi, TurboTasksBackendApi, TurboTasksCallApi, Unused, UpdateInfo,
 };
 pub use native_function::{FunctionMeta, NativeFunction};
 pub use raw_vc::{CellId, RawVc, ReadRawVcFuture, ResolveTypeError};

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -281,7 +281,7 @@ pub enum TaskPersistence {
 pub enum ReadConsistency {
     /// The default behavior for most APIs. Reads are faster, but may return stale values, which
     /// may later trigger re-computation.
-    Weak,
+    Eventual,
     /// Ensures all dependencies are fully resolved before returning the cell or output data, at
     /// the cost of slower reads.
     ///
@@ -455,7 +455,8 @@ impl<B: Backend + 'static> TurboTasks<B> {
         });
         // INVALIDATION: A Once task will never invalidate, therefore we don't need to
         // track a dependency
-        let raw_result = read_task_output_untracked(self, task_id, ReadConsistency::Weak).await?;
+        let raw_result =
+            read_task_output_untracked(self, task_id, ReadConsistency::Eventual).await?;
         ReadVcFuture::<Completion>::from(raw_result.into_read_untracked_with_turbo_tasks(self))
             .await?;
 
@@ -1544,7 +1545,7 @@ pub async fn run_once<T: Send + 'static>(
 
     // INVALIDATION: A Once task will never invalidate, therefore we don't need to
     // track a dependency
-    let raw_result = read_task_output_untracked(&*tt, task_id, ReadConsistency::Weak).await?;
+    let raw_result = read_task_output_untracked(&*tt, task_id, ReadConsistency::Eventual).await?;
     ReadVcFuture::<Completion>::from(raw_result.into_read_untracked_with_turbo_tasks(&*tt)).await?;
 
     Ok(rx.await?)
@@ -1569,7 +1570,7 @@ pub async fn run_once_with_reason<T: Send + 'static>(
 
     // INVALIDATION: A Once task will never invalidate, therefore we don't need to
     // track a dependency
-    let raw_result = read_task_output_untracked(&*tt, task_id, ReadConsistency::Weak).await?;
+    let raw_result = read_task_output_untracked(&*tt, task_id, ReadConsistency::Eventual).await?;
     ReadVcFuture::<Completion>::from(raw_result.into_read_untracked_with_turbo_tasks(&*tt)).await?;
 
     Ok(rx.await?)

--- a/turbopack/crates/turbo-tasks/src/raw_vc.rs
+++ b/turbopack/crates/turbo-tasks/src/raw_vc.rs
@@ -144,7 +144,7 @@ impl RawVc {
         loop {
             match current {
                 RawVc::TaskOutput(task) => {
-                    current = read_task_output(&*tt, task, ReadConsistency::Weak)
+                    current = read_task_output(&*tt, task, ReadConsistency::Eventual)
                         .await
                         .map_err(|source| ResolveTypeError::TaskError { source })?;
                 }
@@ -181,7 +181,7 @@ impl RawVc {
 
     /// See [`crate::Vc::resolve`].
     pub(crate) async fn resolve(self) -> Result<RawVc> {
-        self.resolve_inner(ReadConsistency::Weak).await
+        self.resolve_inner(ReadConsistency::Eventual).await
     }
 
     /// See [`crate::Vc::resolve_strongly_consistent`].
@@ -262,7 +262,7 @@ impl ReadRawVcFuture {
         let tt = turbo_tasks();
         ReadRawVcFuture {
             turbo_tasks: tt,
-            consistency: ReadConsistency::Weak,
+            consistency: ReadConsistency::Eventual,
             current: vc,
             untracked: false,
             listener: None,
@@ -273,7 +273,7 @@ impl ReadRawVcFuture {
         let tt = turbo_tasks.pin();
         ReadRawVcFuture {
             turbo_tasks: tt,
-            consistency: ReadConsistency::Weak,
+            consistency: ReadConsistency::Eventual,
             current: vc,
             untracked: true,
             listener: None,
@@ -284,7 +284,7 @@ impl ReadRawVcFuture {
         let tt = turbo_tasks();
         ReadRawVcFuture {
             turbo_tasks: tt,
-            consistency: ReadConsistency::Weak,
+            consistency: ReadConsistency::Eventual,
             current: vc,
             untracked: true,
             listener: None,
@@ -344,7 +344,7 @@ impl Future for ReadRawVcFuture {
                             // We no longer need to read strongly consistent, as any Vc returned
                             // from the first task will be inside of the scope of the first task. So
                             // it's already strongly consistent.
-                            this.consistency = ReadConsistency::Weak;
+                            this.consistency = ReadConsistency::Eventual;
                             this.current = vc;
                             continue 'outer;
                         }

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -6,7 +6,9 @@ use std::{
 };
 
 use anyhow::{bail, Context, Result};
-use turbo_tasks::{RcStr, TransientInstance, TryJoinIterExt, TurboTasks, Value, Vc};
+use turbo_tasks::{
+    RcStr, ReadConsistency, TransientInstance, TryJoinIterExt, TurboTasks, Value, Vc,
+};
 use turbo_tasks_fs::FileSystem;
 use turbo_tasks_memory::MemoryBackend;
 use turbopack_cli_utils::issue::{ConsoleUi, LogOptions};
@@ -148,7 +150,9 @@ impl TurbopackBuildBuilder {
             Ok(Default::default())
         });
 
-        self.turbo_tasks.wait_task_completion(task, true).await?;
+        self.turbo_tasks
+            .wait_task_completion(task, ReadConsistency::Strong)
+            .await?;
 
         Ok(())
     }

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -12,7 +12,9 @@ use anyhow::{bail, Context, Result};
 use dunce::canonicalize;
 use serde::Deserialize;
 use serde_json::json;
-use turbo_tasks::{RcStr, ReadRef, TryJoinIterExt, TurboTasks, Value, ValueToString, Vc};
+use turbo_tasks::{
+    RcStr, ReadConsistency, ReadRef, TryJoinIterExt, TurboTasks, Value, ValueToString, Vc,
+};
 use turbo_tasks_env::DotenvProcessEnv;
 use turbo_tasks_fs::{
     json::parse_json_with_source_context, util::sys_to_unix, DiskFileSystem, FileSystem,
@@ -170,7 +172,8 @@ async fn run(resource: PathBuf) -> Result<()> {
             .context("Unable to handle issues")?;
         Ok(Vc::<()>::default())
     });
-    tt.wait_task_completion(task, true).await?;
+    tt.wait_task_completion(task, ReadConsistency::Strong)
+        .await?;
 
     Ok(())
 }

--- a/turbopack/crates/turbopack/benches/node_file_trace.rs
+++ b/turbopack/crates/turbopack/benches/node_file_trace.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, fs, path::PathBuf};
 
 use criterion::{Bencher, BenchmarkId, Criterion};
 use regex::Regex;
-use turbo_tasks::{RcStr, TurboTasks, Value, Vc};
+use turbo_tasks::{RcStr, ReadConsistency, TurboTasks, Value, Vc};
 use turbo_tasks_fs::{DiskFileSystem, FileSystem, NullFileSystem};
 use turbo_tasks_memory::MemoryBackend;
 use turbopack::{
@@ -113,7 +113,9 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
 
                 Ok::<Vc<()>, _>(Default::default())
             });
-            tt.wait_task_completion(task, true).await.unwrap();
+            tt.wait_task_completion(task, ReadConsistency::Strong)
+                .await
+                .unwrap();
         }
     })
 }

--- a/turbopack/crates/turbopack/examples/turbopack.rs
+++ b/turbopack/crates/turbopack/examples/turbopack.rs
@@ -8,7 +8,9 @@ use std::{
 
 use anyhow::Result;
 use tokio::{spawn, time::sleep};
-use turbo_tasks::{util::FormatDuration, RcStr, TurboTasks, UpdateInfo, Value, Vc};
+use turbo_tasks::{
+    util::FormatDuration, RcStr, ReadConsistency, TurboTasks, UpdateInfo, Value, Vc,
+};
 use turbo_tasks_fs::{DiskFileSystem, FileSystem};
 use turbo_tasks_memory::MemoryBackend;
 use turbopack::{emit_with_completion, rebase::RebasedAsset, register};
@@ -72,7 +74,9 @@ async fn main() -> Result<()> {
     spawn({
         let tt = tt.clone();
         async move {
-            tt.wait_task_completion(task, true).await.unwrap();
+            tt.wait_task_completion(task, ReadConsistency::Strong)
+                .await
+                .unwrap();
             println!("done in {}", FormatDuration(start.elapsed()));
 
             loop {


### PR DESCRIPTION
This should be completely equivalent. Double checked the diff and made sure that the conversions from `true`/`false` to `ReadConsistency::Strong`/`ReadConsistency::Eventual` are correct.

## Why?

Without keyword arguments in the language, boolean arguments can be hard to read. Inlay hints and type-signature-on-hover with rust-analyzer help, but it's more obvious what these do if they use a clearly labeled enum.

E.g. discussion: https://www.reddit.com/r/rust/comments/bm6s3t/rust_patterns_enums_instead_of_booleans/

Unlike my other change from a bool to an enum in #68866, I don't expect that we'd ever introduce more levels of read consistency than eventual and strong, so this PR is only about readability.