### PR TITLE
refactor(turbo-tasks): Make CURRENT_TASK_STATE shareable across multiple tokio tasks / threads, wait for detached work to finish before exiting a turbo task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8180,16 +8180,17 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
+ "hashbrown 0.14.5",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -8562,6 +8563,7 @@ dependencies = [
  "serde_regex",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
  "triomphe 0.1.12",
  "turbo-tasks-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,7 +205,7 @@ tempfile = "3.3.0"
 thiserror = "1.0.48"
 tiny-gradient = "0.1.0"
 tokio = "1.25.0"
-tokio-util = { version = "0.7.7", features = ["io"] }
+tokio-util = { version = "0.7.11", features = ["io", "rt"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 triomphe = { git = "https://github.com/sokra/triomphe", branch = "sokra/unstable" }

--- a/turbopack/crates/turbo-tasks-memory/tests/detached.rs
+++ b/turbopack/crates/turbo-tasks-memory/tests/detached.rs
@@ -1,0 +1,1 @@
+../../turbo-tasks-testing/tests/detached.rs

--- a/turbopack/crates/turbo-tasks-testing/tests/detached.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/detached.rs
@@ -1,0 +1,54 @@
+#![feature(arbitrary_self_types)]
+
+use tokio::{
+    sync::{watch, Notify},
+    time::{timeout, Duration},
+};
+use turbo_tasks::{turbo_tasks, Completion, TransientInstance, Vc};
+use turbo_tasks_testing::{register, run, Registration};
+
+static REGISTRATION: Registration = register!();
+
+#[tokio::test]
+async fn test_spawns_detached() -> anyhow::Result<()> {
+    run(&REGISTRATION, || async {
+        let notify = TransientInstance::new(Notify::new());
+        let (tx, mut rx) = watch::channel(None);
+
+        // create the task
+        let out_vc = spawns_detached(notify.clone(), TransientInstance::new(tx));
+
+        // see that the task does not exit yet
+        timeout(Duration::from_millis(100), out_vc.strongly_consistent())
+            .await
+            .expect_err("should wait on the detached task");
+
+        // let the detached future exit
+        notify.notify_waiters();
+
+        // it should send us back a cell
+        let detached_vc: Vc<u32> = rx.wait_for(|opt| opt.is_some()).await.unwrap().unwrap();
+        assert_eq!(*detached_vc.await.unwrap(), 42);
+
+        // the parent task should now be able to exit
+        out_vc.strongly_consistent().await.unwrap();
+
+        Ok(())
+    })
+    .await
+}
+
+#[turbo_tasks::function]
+fn spawns_detached(
+    notify: TransientInstance<Notify>,
+    sender: TransientInstance<watch::Sender<Option<Vc<u32>>>>,
+) -> Vc<Completion> {
+    tokio::spawn(turbo_tasks().detached_for_testing(Box::pin(async move {
+        notify.notified().await;
+        // creating cells after the normal lifetime of the task should be okay, as the parent task
+        // is waiting on us before exiting!
+        sender.send(Some(Vc::cell(42))).unwrap();
+        Ok(())
+    })));
+    Completion::new()
+}

--- a/turbopack/crates/turbo-tasks/Cargo.toml
+++ b/turbopack/crates/turbo-tasks/Cargo.toml
@@ -37,6 +37,7 @@ serde_json = { workspace = true }
 serde_regex = "1.1.0"
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+tokio-util = { workspace = true }
 tracing = { workspace = true }
 triomphe = { workspace = true, features = ["unsize", "unstable"] }
 turbo-tasks-hash = { workspace = true }


### PR DESCRIPTION
The current plan is that tasks using `local_cells` will still be spawned on separate threads using `tokio::spawn`. This means two things:

- `CURRENT_TASK_STATE` must use an `Arc<Mutex<...>>` so that multiple tasks across multiple threads can modify the same cell counters, local cells, etc.
- We can't `.take()` the data structures in `CURRENT_TASK_STATE` and perform cleanup of the parent task until all the child tasks using `local_cells` are complete.

Waiting for cleanup of child tasks is performed using [`tokio_util::task::TaskTracker`](https://docs.rs/tokio-util/latest/tokio_util/task/task_tracker/struct.TaskTracker.html), which seems like a reasonably clean and lightweight way of doing this (it uses some refcounts and a `tokio::sync::Notify` instance).

Because `TurboTasks::detached_for_testing` suffered similar problems to what `local_cells` will face in regards to task cleanup, I'm using that API as a way of testing some of these changes.

## Testing

Added test coverage for `TurboTasks::detached_for_testing` that asserts that the parent task waits for the detached task to complete before exiting. Confirmed that the test fails if I comment out

```
ltt.wait().await
```

in the `TurboTasks::schedule` method.

Ran the test with:

```
cargo nextest r -p turbo-tasks-memory -- test_spawns_detached
```

## Benchmarking

*The switch from a `RefCell` to a `RwLock` will inevitably make this code run slower, though hopefully `RwLock` should still be fast enough in the case where there's no lock contention. There would only be lock contention if you're actually using detached futures or `local_cells`.*

On a [low noise machine](https://github.com/bgw/benchmark-scripts):

```
cargo bench -p turbopack-bench -p turbopack-cli -- "hmr_to_eval/Turbopack CSR"
```

Manually modified the test to use more time and samples:

```diff
diff --git a/turbopack/crates/turbopack-bench/src/lib.rs b/turbopack/crates/turbopack-bench/src/lib.rs
index 4e3df12db0..e2f16fb0d6 100644
--- a/turbopack/crates/turbopack-bench/src/lib.rs
+++ b/turbopack/crates/turbopack-bench/src/lib.rs
@@ -127,8 +127,8 @@ enum CodeLocation {

 pub fn bench_hmr_to_eval(c: &mut Criterion, bundlers: &[Box<dyn Bundler>]) {
     let mut g = c.benchmark_group("bench_hmr_to_eval");
-    g.sample_size(10);
-    g.measurement_time(Duration::from_secs(60));
+    g.sample_size(50);
+    g.measurement_time(Duration::from_secs(300));

     bench_hmr_internal(g, CodeLocation::Evaluation, bundlers);
 }
```

**Before:**

```
bench_hmr_to_eval/Turbopack CSR/1000 modules
                        time:   [14.714 ms 14.776 ms 14.854 ms]
Found 2 outliers among 50 measurements (4.00%)
  1 (2.00%) high mild
  1 (2.00%) high severe
```

**After:**

```
bench_hmr_to_eval/Turbopack CSR/1000 modules
                        time:   [14.773 ms 14.846 ms 14.937 ms]
                        change: [-0.9937% +0.4037% +1.8024%] (p = 0.58 > 0.05)
                        No change in performance detected.
Found 1 outliers among 50 measurements (2.00%)
  1 (2.00%) high severe
```

## Memory Benchmarking

```
cd ~/next.js
cargo build -p next-build-test --release
cargo run -p next-build-test --release -- generate ~/shadcn-ui/apps/www/ > ~/shadcn-ui/apps/www/project_options.json

cd ~/shadcn-ui/apps/www
heaptrack ~/next.js/target/release/next-build-test run sequential 1 1 '/sink'
heaptrack --analyze /home/bgw.linux/shadcn-ui/apps/www/heaptrack.next-build-test.1138984.zst | tail -50
```

Before *(Run 1)*:

```
total runtime: 791.00s.
calls to allocation functions: 245495035 (310358/s)
temporary memory allocations: 19923850 (25188/s)
peak heap memory consumption: 7.61G
peak RSS (including heaptrack overhead): 9.97G
total memory leaked: 12.53M
suppressed leaks: 7.24K
```

Before *(Run 2)*:

```
total runtime: 635.10s.
calls to allocation functions: 245867464 (387133/s)
temporary memory allocations: 19575558 (30822/s)
peak heap memory consumption: 7.62G
peak RSS (including heaptrack overhead): 9.96G
total memory leaked: 13.16M
suppressed leaks: 7.24K
```

After *(Run 1)*:

```
total runtime: 792.50s.
calls to allocation functions: 253642374 (320053/s)
temporary memory allocations: 19250501 (24290/s)
peak heap memory consumption: 7.62G
peak RSS (including heaptrack overhead): 9.96G
total memory leaked: 12.98M
suppressed leaks: 7.24K
```

After *(Run 2)*:

```
total runtime: 691.16s.
calls to allocation functions: 252890162 (365891/s)
temporary memory allocations: 19143529 (27697/s)
peak heap memory consumption: 7.61G
peak RSS (including heaptrack overhead): 9.98G
total memory leaked: 13.42M
suppressed leaks: 7.24K
```