### PR TITLE
refactor: auto-install `@types/react` only if `react` is installed

### DIFF
--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -69,11 +69,18 @@ export async function verifyTypeScriptSetup({
         ])
       ).resolved.has('react')
     ) {
-      requiredPackages.push({
-        file: '@types/react/index.d.ts',
-        pkg: '@types/react',
-        exportsRestrict: true,
-      })
+      requiredPackages.push(
+        {
+          file: '@types/react/index.d.ts',
+          pkg: '@types/react',
+          exportsRestrict: true,
+        },
+        {
+          file: '@types/react-dom/index.d.ts',
+          pkg: '@types/react-dom',
+          exportsRestrict: true,
+        }
+      )
     }
 
     // Ensure TypeScript and necessary `@types/*` are installed:

--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -22,11 +22,6 @@ const requiredPackages = [
     exportsRestrict: true,
   },
   {
-    file: '@types/react/index.d.ts',
-    pkg: '@types/react',
-    exportsRestrict: true,
-  },
-  {
     file: '@types/node/index.d.ts',
     pkg: '@types/node',
     exportsRestrict: true,
@@ -61,6 +56,24 @@ export async function verifyTypeScriptSetup({
     const intent = await getTypeScriptIntent(dir, intentDirs, tsconfigPath)
     if (!intent) {
       return { version: null }
+    }
+
+    if (
+      (
+        await hasNecessaryDependencies(dir, [
+          {
+            file: 'react/index.js',
+            pkg: 'react',
+            exportsRestrict: false,
+          },
+        ])
+      ).resolved.has('react')
+    ) {
+      requiredPackages.push({
+        file: '@types/react/index.d.ts',
+        pkg: '@types/react',
+        exportsRestrict: true,
+      })
     }
 
     // Ensure TypeScript and necessary `@types/*` are installed:

--- a/test/e2e/app-dir/no-react/app/layout.tsx
+++ b/test/e2e/app-dir/no-react/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/no-react/app/page.tsx
+++ b/test/e2e/app-dir/no-react/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/no-react/next.config.js
+++ b/test/e2e/app-dir/no-react/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/no-react/no-react.test.ts
+++ b/test/e2e/app-dir/no-react/no-react.test.ts
@@ -1,0 +1,13 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('no-react', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    installCommand: 'pnpm remove react react-dom',
+  })
+
+  it('should work using cheerio without react, react-dom', async () => {
+    const $ = await next.render$('/')
+    expect($('p').text()).toBe('hello world')
+  })
+})

--- a/test/e2e/app-dir/no-react/no-react.test.ts
+++ b/test/e2e/app-dir/no-react/no-react.test.ts
@@ -1,19 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
-describe('no-react', () => {
+describe('app-dir no-react', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    installCommand: 'pnpm remove react react-dom',
+    skippedDependencies: ['react', 'react-dom'],
   })
 
-  it('should not have react or react-dom in the package.json', async () => {
-    const packageJson = await next.readJSON('package.json')
-    expect(packageJson.dependencies).toHaveProperty('next')
-    expect(packageJson.dependencies).not.toHaveProperty('react')
-    expect(packageJson.dependencies).not.toHaveProperty('react-dom')
-  })
-
-  it('should work using cheerio without react, react-dom', async () => {
+  it('should render without react, react-dom in App Router', async () => {
     const $ = await next.render$('/')
     expect($('p').text()).toBe('hello world')
   })

--- a/test/e2e/app-dir/no-react/no-react.test.ts
+++ b/test/e2e/app-dir/no-react/no-react.test.ts
@@ -6,6 +6,13 @@ describe('no-react', () => {
     installCommand: 'pnpm remove react react-dom',
   })
 
+  it('should not have react or react-dom in the package.json', async () => {
+    const packageJson = await next.readJSON('package.json')
+    expect(packageJson.dependencies).toHaveProperty('next')
+    expect(packageJson.dependencies).not.toHaveProperty('react')
+    expect(packageJson.dependencies).not.toHaveProperty('react-dom')
+  })
+
   it('should work using cheerio without react, react-dom', async () => {
     const $ = await next.render$('/')
     expect($('p').text()).toBe('hello world')

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -26,6 +26,7 @@ export type PackageJson = {
 export interface NextInstanceOpts {
   files: FileRef | string | { [filename: string]: string | FileRef }
   dependencies?: { [name: string]: string }
+  skippedDependencies?: string[]
   resolutions?: { [name: string]: string }
   packageJson?: PackageJson
   nextConfig?: NextConfig
@@ -56,6 +57,7 @@ export class NextInstance {
   protected buildCommand?: string
   protected startCommand?: string
   protected dependencies?: PackageJson['dependencies'] = {}
+  protected skippedDependencies?: string[] = []
   protected resolutions?: PackageJson['resolutions']
   protected events: { [eventName: string]: Set<any> } = {}
   public testDir: string
@@ -173,6 +175,10 @@ export class NextInstance {
           '@types/node': 'latest',
           ...this.dependencies,
           ...this.packageJson?.dependencies,
+        }
+
+        for (const skippedDependency of this.skippedDependencies) {
+          delete finalDependencies[skippedDependency]
         }
 
         if (skipInstall || skipIsolatedNext) {


### PR DESCRIPTION
### Why?

If `react` is not installed in the project, it does not require `@types/react` either.
This could happen when the user tries to run a headless Next.js app that does not require `react`.

Also, we are working on adding a create-next-app template for the case above.

x-ref: https://github.com/vercel/next.js/issues/68118

Closes NDX-220