### PR TITLE
Turbopack: Detect module type for webpack loaders and not hardcode JS

### DIFF
--- a/test/e2e/app-dir/webpack-loader-ts-transform/app/file.test-file.ts
+++ b/test/e2e/app-dir/webpack-loader-ts-transform/app/file.test-file.ts
@@ -1,0 +1,1 @@
+throw new Error('will be replaced by loader')

--- a/test/e2e/app-dir/webpack-loader-ts-transform/app/file.test-file.ts
+++ b/test/e2e/app-dir/webpack-loader-ts-transform/app/file.test-file.ts
@@ -1,1 +1,1 @@
-throw new Error('will be replaced by loader')
+export default 'wrong'

--- a/test/e2e/app-dir/webpack-loader-ts-transform/app/layout.tsx
+++ b/test/e2e/app-dir/webpack-loader-ts-transform/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/webpack-loader-ts-transform/app/page.tsx
+++ b/test/e2e/app-dir/webpack-loader-ts-transform/app/page.tsx
@@ -1,0 +1,9 @@
+import rsc from './file.test-file'
+
+export default function Page() {
+  return (
+    <div>
+      <p>{rsc}</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/webpack-loader-ts-transform/next.config.js
+++ b/test/e2e/app-dir/webpack-loader-ts-transform/next.config.js
@@ -1,0 +1,14 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    turbo: {
+      rules: {
+        '*.test-file.ts': [require.resolve('./test-file-loader.js')],
+      },
+    },
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/webpack-loader-ts-transform/test-file-loader.js
+++ b/test/e2e/app-dir/webpack-loader-ts-transform/test-file-loader.js
@@ -1,0 +1,3 @@
+module.exports = function () {
+  return `export default ("something" as string);`
+}

--- a/test/e2e/app-dir/webpack-loader-ts-transform/webpack-loader-ts-transform.test.ts
+++ b/test/e2e/app-dir/webpack-loader-ts-transform/webpack-loader-ts-transform.test.ts
@@ -1,0 +1,19 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('webpack-loader-ts-transform', () => {
+  const { next, isTurbopack, skipped } = nextTestSetup({
+    files: __dirname,
+    // This test is skipped because it's only expected to run in turbopack, which isn't enabled for builds
+    skipDeployment: true,
+  })
+
+  if (!isTurbopack || skipped) {
+    it('should only run the test in turbopack', () => {})
+    return
+  }
+
+  it('should render correctly on client side', async () => {
+    const $ = await next.render$('/')
+    expect($('p').text()).toBe('something')
+  })
+})

--- a/test/e2e/app-dir/webpack-loader-ts-transform/webpack-loader-ts-transform.test.ts
+++ b/test/e2e/app-dir/webpack-loader-ts-transform/webpack-loader-ts-transform.test.ts
@@ -12,7 +12,7 @@ describe('webpack-loader-ts-transform', () => {
     return
   }
 
-  it('should render correctly on client side', async () => {
+  it('should accept Typescript returned from Webpack loaders', async () => {
     const $ = await next.render$('/')
     expect($('p').text()).toBe('something')
   })

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -560,28 +560,20 @@ impl ModuleOptions {
                         },
                         ModuleRuleCondition::not(ModuleRuleCondition::ResourceIsVirtualSource),
                     ]),
-                    vec![
-                        // By default, loaders are expected to return ecmascript code.
-                        // This can be overriden by specifying e. g. `as: "*.css"` in the rule.
-                        ModuleRuleEffect::ModuleType(ModuleType::Ecmascript {
-                            transforms: app_transforms,
-                            options: ecmascript_options_vc,
-                        }),
-                        ModuleRuleEffect::SourceTransforms(Vc::cell(vec![Vc::upcast(
-                            WebpackLoaders::new(
-                                node_evaluate_asset_context(
-                                    execution_context,
-                                    Some(import_map),
-                                    None,
-                                    "webpack_loaders".into(),
-                                ),
+                    vec![ModuleRuleEffect::SourceTransforms(Vc::cell(vec![
+                        Vc::upcast(WebpackLoaders::new(
+                            node_evaluate_asset_context(
                                 execution_context,
-                                rule.loaders,
-                                rule.rename_as.clone(),
-                                resolve_options_context,
+                                Some(import_map),
+                                None,
+                                "webpack_loaders".into(),
                             ),
-                        )])),
-                    ],
+                            execution_context,
+                            rule.loaders,
+                            rule.rename_as.clone(),
+                            resolve_options_context,
+                        )),
+                    ]))],
                 ));
             }
         }


### PR DESCRIPTION
For e.g. TS-to-TS Webpack transforms, don't use `as: "*.tsx"` for now. That should ideally also work, but there is still an unrelated bug causing that to fail.

This definitely works for now (and just retains the module type detected by Turbopack):
```js
module.exports = {
  experimental: {
    turbo: {
      rules: {
        "*.ts": {
          loaders: ["./my-loader.js"],
        }
      }
    }
  }
};
```


This came up in https://x.com/aidenybai/status/1823615893903171645  @aidenybai

Closes PACK-3194