### PR TITLE
Ensure `assertNoRedbox` has a stack when it fails

### DIFF
--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -875,7 +875,7 @@ export async function assertNoRedbox(browser: BrowserInterface) {
         `description: ${redboxDescription}\n` +
         `source: ${redboxSource}`
     )
-    Error.captureStackTrace(error, assertHasRedbox)
+    Error.captureStackTrace(error, assertNoRedbox)
     throw error
   }
 }


### PR DESCRIPTION
Accidentally passed the wrong function to cutoff the stack. Seems like `captureStackTrace` removes the whole stack if the function has no frame.