### PR TITLE
fix i18n data pathname resolving

### DIFF
--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -395,6 +395,17 @@ export function getResolveRoutes(
               normalized = normalizers.postponed.normalize(normalized, true)
             }
 
+            if (config.i18n) {
+              const curLocaleResult = normalizeLocalePath(
+                normalized,
+                config.i18n.locales
+              )
+
+              if (curLocaleResult.detectedLocale) {
+                parsedUrl.query.__nextLocale = curLocaleResult.detectedLocale
+              }
+            }
+
             // If we updated the pathname, and it had a base path, re-add the
             // base path.
             if (updated) {

--- a/packages/next/src/shared/lib/i18n/normalize-locale-path.ts
+++ b/packages/next/src/shared/lib/i18n/normalize-locale-path.ts
@@ -17,17 +17,8 @@ export function normalizeLocalePath(
   locales?: string[]
 ): PathLocale {
   let detectedLocale: string | undefined
-  const isDataRoute = pathname.startsWith('/_next/data')
-
-  // Create a pathname for locale detection, removing /_next/data/[buildId] if present
-  // This is because locale detection relies on path splitting and so the first part
-  // should be the locale.
-  const pathNameNoDataPrefix = isDataRoute
-    ? pathname.replace(/^\/_next\/data\/[^/]+/, '')
-    : pathname
-
-  // Split the path for locale detection
-  const pathnameParts = pathNameNoDataPrefix.split('/')
+  // first item will be empty string from splitting at first char
+  const pathnameParts = pathname.split('/')
 
   ;(locales || []).some((locale) => {
     if (
@@ -36,16 +27,11 @@ export function normalizeLocalePath(
     ) {
       detectedLocale = locale
       pathnameParts.splice(1, 1)
+      pathname = pathnameParts.join('/') || '/'
       return true
     }
     return false
   })
-
-  // For non-data routes, we return the path with the locale stripped out.
-  // For data routes, we keep the path as is, since we only want to extract the locale.
-  if (detectedLocale && !isDataRoute) {
-    pathname = pathnameParts.join('/') || '/'
-  }
 
   return {
     pathname,

--- a/test/e2e/i18n-navigations-middleware/i18n-navigations-middleware.test.ts
+++ b/test/e2e/i18n-navigations-middleware/i18n-navigations-middleware.test.ts
@@ -1,0 +1,43 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('i18n-navigations-middleware', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should respect selected locale when navigating to a dynamic route', async () => {
+    const browser = await next.browser('/')
+    // change to "de" locale
+    await browser.elementByCss("[href='/de']").click()
+    const dynamicLink = await browser.waitForElementByCss(
+      "[href='/de/dynamic/1']"
+    )
+    expect(await browser.elementById('current-locale').text()).toBe(
+      'Current locale: de'
+    )
+
+    // navigate to dynamic route
+    await dynamicLink.click()
+
+    // the locale should still be "de"
+    expect(await browser.elementById('dynamic-locale').text()).toBe(
+      'Locale: de'
+    )
+  })
+
+  it('should respect selected locale when navigating to a static route', async () => {
+    const browser = await next.browser('/')
+    // change to "de" locale
+    await browser.elementByCss("[href='/de']").click()
+    const staticLink = await browser.waitForElementByCss("[href='/de/static']")
+    expect(await browser.elementById('current-locale').text()).toBe(
+      'Current locale: de'
+    )
+
+    // navigate to static route
+    await staticLink.click()
+
+    // the locale should still be "de"
+    expect(await browser.elementById('static-locale').text()).toBe('Locale: de')
+  })
+})

--- a/test/e2e/i18n-navigations-middleware/middleware.js
+++ b/test/e2e/i18n-navigations-middleware/middleware.js
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server'
+
+export const config = { matcher: ['/foo'] }
+export async function middleware(req) {
+  return NextResponse.next()
+}

--- a/test/e2e/i18n-navigations-middleware/next.config.js
+++ b/test/e2e/i18n-navigations-middleware/next.config.js
@@ -1,0 +1,9 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+module.exports = {
+  i18n: {
+    defaultLocale: 'default',
+    locales: ['default', 'en', 'de'],
+  },
+}

--- a/test/e2e/i18n-navigations-middleware/pages/dynamic/[id].js
+++ b/test/e2e/i18n-navigations-middleware/pages/dynamic/[id].js
@@ -1,0 +1,11 @@
+export const getServerSideProps = async ({ locale }) => {
+  return {
+    props: {
+      locale,
+    },
+  }
+}
+
+export default function Dynamic({ locale }) {
+  return <div id="dynamic-locale">Locale: {locale}</div>
+}

--- a/test/e2e/i18n-navigations-middleware/pages/index.js
+++ b/test/e2e/i18n-navigations-middleware/pages/index.js
@@ -1,0 +1,37 @@
+import Link from 'next/link'
+
+export const getServerSideProps = async ({ locale }) => {
+  return {
+    props: {
+      locale,
+    },
+  }
+}
+
+export default function Home({ locale }) {
+  return (
+    <main
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '20px',
+      }}
+    >
+      <p id="current-locale">Current locale: {locale}</p>
+      Locale switch:
+      <Link href="/" locale="default">
+        Default
+      </Link>
+      <Link href="/" locale="en">
+        English
+      </Link>
+      <Link href="/" locale="de">
+        German
+      </Link>
+      <br />
+      Test links:
+      <Link href="/dynamic/1">Dynamic 1</Link>
+      <Link href="/static">Static</Link>
+    </main>
+  )
+}

--- a/test/e2e/i18n-navigations-middleware/pages/static.js
+++ b/test/e2e/i18n-navigations-middleware/pages/static.js
@@ -1,0 +1,11 @@
+export const getServerSideProps = async ({ locale }) => {
+  return {
+    props: {
+      locale,
+    },
+  }
+}
+
+export default function Static({ locale }) {
+  return <div id="static-locale">Locale: {locale}</div>
+}


### PR DESCRIPTION
### What
When using middleware + i18n in pages router, and upon navigation to a dynamic route, the wrong locale would be served in `getServerSideProps`. 

### Why
The route resolver code handles detecting the initial locale by splitting the path and looking at the first non-empty index to determine which locale was set. However, it does this assuming it has a regular path name, and not a `/_next/data` URL. 

When middleware is present, the route resolver code hits the `middleware_next_data` branch, which doesn't have any logic to properly set the locale. This means that resolveRoutes will return the default locale rather than the locale from the path.

In the non-middleware case, this would normally flow through `handleNextDataRequest` in base-server which has handling to infer i18n via `i18nProvider`. This branch is functionally very similar to what we're doing in `resolveRoutes` but it does so in a different way: it reconstructs the URL without the `/_next/data` information and then attaches locale information. However because `middleware_next_data` rewrites the pathname to the actual route (ie `/_next/data/development/foo.json` -> `/foo`), `handleNextDataRequest` won't handle that request since it's no longer a data request.

It's strange to me that `handleNextDataRequest` and `middleware_next_data` are doing similar path normalization in completely different ways, but that was a deeper rabbit hole and simply removing the normalization logic in `resolveRoutes` causes other problems.

### How
Since data requests that flow through this middleware matcher logic aren't going to be handled by `handleNextDataRequest`, I've updated `middleware_next_data` to perform the logic of attaching the locale information to the query. Initially I was going to do this for anything that calls `normalizeLocalePath` but it seems like other branches of `resolveRoutes` do it in the matcher function directly.

Fixes #54217
Closes NDX-116