### PR TITLE
Remove invalid app router etag normalizing

### DIFF
--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -697,37 +697,6 @@ describe('app-dir static/dynamic handling', () => {
   })
 
   if (isNextStart) {
-    it.failing(
-      'should have deterministic etag across revalidates',
-      async () => {
-        const initialRes = await next.fetch(
-          '/variable-revalidate-stable/revalidate-3'
-        )
-        expect(initialRes.status).toBe(200)
-
-        // check 2 revalidate passes to ensure it's consistent
-        for (let i = 0; i < 2; i++) {
-          let startIdx = next.cliOutput.length
-
-          await retry(
-            async () => {
-              const res = await next.fetch(
-                '/variable-revalidate-stable/revalidate-3'
-              )
-              expect(next.cliOutput.substring(startIdx)).toContain(
-                'rendering /variable-revalidate-stable'
-              )
-              expect(initialRes.headers.get('etag')).toBe(
-                res.headers.get('etag')
-              )
-            },
-            12_000,
-            3_000
-          )
-        }
-      }
-    )
-
     it('should output HTML/RSC files for static paths', async () => {
       const files = (
         await glob('**/*', {


### PR DESCRIPTION
This didn't end up achieving the normalizing we were hoping for as the react bump after this was landed causes indeterminism even with this fix. This needs to be resolved upstream in react itself so removing our attempted patch and failing assertion in the mean-time. 