### PR TITLE
use setImmediate (if present) in edge react-dom/RSDW/RSDT

### DIFF
--- a/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.edge.development.js
+++ b/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.edge.development.js
@@ -9792,29 +9792,17 @@
       });
     };
 
-/** This is a patch added by Next.js */
-const setTimeoutOrImmediate = (() => {
+// This is a patch added by Next.js
+const setTimeoutOrImmediate = (
   // edge runtime sandbox defines a stub for setImmediate
   // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
   // so we can't just do this:
   //   typeof setImmediate === 'function'
-  // luckily it makes it non-enumerable, so we can use this instead
-  const _setImmediate = Object.keys(globalThis).includes("setImmediate")
+  // luckily the stub is non-enumerable, so we can check Object.keys instead
+  Object.keys(globalThis).includes("setImmediate")
     ? globalThis["set" + "Immediate"]
-    : undefined;
-
-  if (typeof _setImmediate === "function") {
-    return function setTimeoutOrImmediateImpl(cb, dur = 0, ...args) {
-      if (dur === 0 && args.length === 0) {
-        // likely a scheduleWork call
-        return _setImmediate(cb);
-      }
-      return setTimeout(cb, dur, ...args);
-    };
-  }
-
-  return setTimeout;
-})();
+    : setTimeout
+);
 
     exports.version = "19.0.0-experimental-49496d49-20240814";
   })();

--- a/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.edge.development.js
+++ b/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.edge.development.js
@@ -9791,7 +9791,6 @@
         startWork(request);
       });
     };
-    
 
 /** This is a patch added by Next.js */
 const setTimeoutOrImmediate = (() => {
@@ -9817,5 +9816,5 @@ const setTimeoutOrImmediate = (() => {
   return setTimeout;
 })();
 
-exports.version = "19.0.0-experimental-49496d49-20240814";
+    exports.version = "19.0.0-experimental-49496d49-20240814";
   })();

--- a/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.edge.development.js
+++ b/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.edge.development.js
@@ -9793,16 +9793,14 @@
     };
 
 // This is a patch added by Next.js
-const setTimeoutOrImmediate = (
+const setTimeoutOrImmediate =
+  typeof globalThis['set' + 'Immediate'] === 'function' &&
   // edge runtime sandbox defines a stub for setImmediate
   // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
-  // so we can't just do this:
-  //   typeof setImmediate === 'function'
-  // luckily the stub is non-enumerable, so we can check Object.keys instead
-  Object.keys(globalThis).includes("setImmediate")
-    ? globalThis["set" + "Immediate"]
-    : setTimeout
-);
+  // but it's made non-enumerable, so we can detect it
+  globalThis.propertyIsEnumerable('setImmediate')
+    ? globalThis['set' + 'Immediate']
+    : setTimeout;
 
     exports.version = "19.0.0-experimental-49496d49-20240814";
   })();

--- a/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.edge.development.js
+++ b/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.edge.development.js
@@ -9792,6 +9792,30 @@
       });
     };
     
-;const setTimeoutOrImmediate = typeof setImmediate === 'function' ? setImmediate : setTimeout;
+
+/** This is a patch added by Next.js */
+const setTimeoutOrImmediate = (() => {
+  // edge runtime sandbox defines a stub for setImmediate
+  // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
+  // so we can't just do this:
+  //   typeof setImmediate === 'function'
+  // luckily it makes it non-enumerable, so we can use this instead
+  const _setImmediate = Object.keys(globalThis).includes("setImmediate")
+    ? globalThis["set" + "Immediate"]
+    : undefined;
+
+  if (typeof _setImmediate === "function") {
+    return function setTimeoutOrImmediateImpl(cb, dur = 0, ...args) {
+      if (dur === 0 && args.length === 0) {
+        // likely a scheduleWork call
+        return _setImmediate(cb);
+      }
+      return setTimeout(cb, dur, ...args);
+    };
+  }
+
+  return setTimeout;
+})();
+
 exports.version = "19.0.0-experimental-49496d49-20240814";
   })();

--- a/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.edge.development.js
+++ b/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.edge.development.js
@@ -4724,7 +4724,7 @@
       request.pingedTasks.push(task);
       1 === request.pingedTasks.length &&
         ((request.flushScheduled = null !== request.destination),
-        setTimeout(function () {
+        setTimeoutOrImmediate(function () {
           return performWork(request);
         }, 0));
     }
@@ -7940,22 +7940,22 @@
     function startWork(request) {
       request.flushScheduled = null !== request.destination;
       supportsRequestStorage
-        ? setTimeout(function () {
+        ? setTimeoutOrImmediate(function () {
             return requestStorage.run(request, performWork, request);
           }, 0)
-        : setTimeout(function () {
+        : setTimeoutOrImmediate(function () {
             return performWork(request);
           }, 0);
       null === request.trackedPostpones &&
         (supportsRequestStorage
-          ? setTimeout(function () {
+          ? setTimeoutOrImmediate(function () {
               return requestStorage.run(
                 request,
                 enqueueEarlyPreloadsAfterInitialWork,
                 request
               );
             }, 0)
-          : setTimeout(function () {
+          : setTimeoutOrImmediate(function () {
               return enqueueEarlyPreloadsAfterInitialWork(request);
             }, 0));
     }
@@ -7967,7 +7967,7 @@
         0 === request.pingedTasks.length &&
         null !== request.destination &&
         ((request.flushScheduled = !0),
-        setTimeout(function () {
+        setTimeoutOrImmediate(function () {
           var destination = request.destination;
           destination
             ? flushCompletedQueues(request, destination)
@@ -9791,5 +9791,7 @@
         startWork(request);
       });
     };
-    exports.version = "19.0.0-experimental-49496d49-20240814";
+    
+;const setTimeoutOrImmediate = typeof setImmediate === 'function' ? setImmediate : setTimeout;
+exports.version = "19.0.0-experimental-49496d49-20240814";
   })();

--- a/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.edge.production.js
+++ b/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.edge.production.js
@@ -4240,7 +4240,7 @@ function pingTask(request, task) {
   request.pingedTasks.push(task);
   1 === request.pingedTasks.length &&
     ((request.flushScheduled = null !== request.destination),
-    setTimeout(function () {
+    setTimeoutOrImmediate(function () {
       return performWork(request);
     }, 0));
 }
@@ -6448,22 +6448,22 @@ function flushCompletedQueues(request, destination) {
 function startWork(request) {
   request.flushScheduled = null !== request.destination;
   supportsRequestStorage
-    ? setTimeout(function () {
+    ? setTimeoutOrImmediate(function () {
         return requestStorage.run(request, performWork, request);
       }, 0)
-    : setTimeout(function () {
+    : setTimeoutOrImmediate(function () {
         return performWork(request);
       }, 0);
   null === request.trackedPostpones &&
     (supportsRequestStorage
-      ? setTimeout(function () {
+      ? setTimeoutOrImmediate(function () {
           return requestStorage.run(
             request,
             enqueueEarlyPreloadsAfterInitialWork,
             request
           );
         }, 0)
-      : setTimeout(function () {
+      : setTimeoutOrImmediate(function () {
           return enqueueEarlyPreloadsAfterInitialWork(request);
         }, 0));
 }
@@ -6475,7 +6475,7 @@ function enqueueFlush(request) {
     0 === request.pingedTasks.length &&
     null !== request.destination &&
     ((request.flushScheduled = !0),
-    setTimeout(function () {
+    setTimeoutOrImmediate(function () {
       var destination = request.destination;
       destination
         ? flushCompletedQueues(request, destination)
@@ -6780,4 +6780,6 @@ exports.resume = function (children, postponedState, options) {
     startWork(request);
   });
 };
+
+;const setTimeoutOrImmediate = typeof setImmediate === 'function' ? setImmediate : setTimeout;
 exports.version = "19.0.0-experimental-49496d49-20240814";

--- a/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.edge.production.js
+++ b/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.edge.production.js
@@ -6782,15 +6782,13 @@ exports.resume = function (children, postponedState, options) {
 };
 
 // This is a patch added by Next.js
-const setTimeoutOrImmediate = (
+const setTimeoutOrImmediate =
+  typeof globalThis['set' + 'Immediate'] === 'function' &&
   // edge runtime sandbox defines a stub for setImmediate
   // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
-  // so we can't just do this:
-  //   typeof setImmediate === 'function'
-  // luckily the stub is non-enumerable, so we can check Object.keys instead
-  Object.keys(globalThis).includes("setImmediate")
-    ? globalThis["set" + "Immediate"]
-    : setTimeout
-);
+  // but it's made non-enumerable, so we can detect it
+  globalThis.propertyIsEnumerable('setImmediate')
+    ? globalThis['set' + 'Immediate']
+    : setTimeout;
 
 exports.version = "19.0.0-experimental-49496d49-20240814";

--- a/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.edge.production.js
+++ b/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.edge.production.js
@@ -6781,5 +6781,29 @@ exports.resume = function (children, postponedState, options) {
   });
 };
 
-;const setTimeoutOrImmediate = typeof setImmediate === 'function' ? setImmediate : setTimeout;
+
+/** This is a patch added by Next.js */
+const setTimeoutOrImmediate = (() => {
+  // edge runtime sandbox defines a stub for setImmediate
+  // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
+  // so we can't just do this:
+  //   typeof setImmediate === 'function'
+  // luckily it makes it non-enumerable, so we can use this instead
+  const _setImmediate = Object.keys(globalThis).includes("setImmediate")
+    ? globalThis["set" + "Immediate"]
+    : undefined;
+
+  if (typeof _setImmediate === "function") {
+    return function setTimeoutOrImmediateImpl(cb, dur = 0, ...args) {
+      if (dur === 0 && args.length === 0) {
+        // likely a scheduleWork call
+        return _setImmediate(cb);
+      }
+      return setTimeout(cb, dur, ...args);
+    };
+  }
+
+  return setTimeout;
+})();
+
 exports.version = "19.0.0-experimental-49496d49-20240814";

--- a/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.edge.production.js
+++ b/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.edge.production.js
@@ -6781,7 +6781,6 @@ exports.resume = function (children, postponedState, options) {
   });
 };
 
-
 /** This is a patch added by Next.js */
 const setTimeoutOrImmediate = (() => {
   // edge runtime sandbox defines a stub for setImmediate

--- a/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.edge.production.js
+++ b/packages/next/src/compiled/react-dom-experimental/cjs/react-dom-server.edge.production.js
@@ -6781,28 +6781,16 @@ exports.resume = function (children, postponedState, options) {
   });
 };
 
-/** This is a patch added by Next.js */
-const setTimeoutOrImmediate = (() => {
+// This is a patch added by Next.js
+const setTimeoutOrImmediate = (
   // edge runtime sandbox defines a stub for setImmediate
   // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
   // so we can't just do this:
   //   typeof setImmediate === 'function'
-  // luckily it makes it non-enumerable, so we can use this instead
-  const _setImmediate = Object.keys(globalThis).includes("setImmediate")
+  // luckily the stub is non-enumerable, so we can check Object.keys instead
+  Object.keys(globalThis).includes("setImmediate")
     ? globalThis["set" + "Immediate"]
-    : undefined;
-
-  if (typeof _setImmediate === "function") {
-    return function setTimeoutOrImmediateImpl(cb, dur = 0, ...args) {
-      if (dur === 0 && args.length === 0) {
-        // likely a scheduleWork call
-        return _setImmediate(cb);
-      }
-      return setTimeout(cb, dur, ...args);
-    };
-  }
-
-  return setTimeout;
-})();
+    : setTimeout
+);
 
 exports.version = "19.0.0-experimental-49496d49-20240814";

--- a/packages/next/src/compiled/react-dom/cjs/react-dom-server.edge.development.js
+++ b/packages/next/src/compiled/react-dom/cjs/react-dom-server.edge.development.js
@@ -8806,6 +8806,30 @@
       });
     };
     
-;const setTimeoutOrImmediate = typeof setImmediate === 'function' ? setImmediate : setTimeout;
+
+/** This is a patch added by Next.js */
+const setTimeoutOrImmediate = (() => {
+  // edge runtime sandbox defines a stub for setImmediate
+  // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
+  // so we can't just do this:
+  //   typeof setImmediate === 'function'
+  // luckily it makes it non-enumerable, so we can use this instead
+  const _setImmediate = Object.keys(globalThis).includes("setImmediate")
+    ? globalThis["set" + "Immediate"]
+    : undefined;
+
+  if (typeof _setImmediate === "function") {
+    return function setTimeoutOrImmediateImpl(cb, dur = 0, ...args) {
+      if (dur === 0 && args.length === 0) {
+        // likely a scheduleWork call
+        return _setImmediate(cb);
+      }
+      return setTimeout(cb, dur, ...args);
+    };
+  }
+
+  return setTimeout;
+})();
+
 exports.version = "19.0.0-rc-49496d49-20240814";
   })();

--- a/packages/next/src/compiled/react-dom/cjs/react-dom-server.edge.development.js
+++ b/packages/next/src/compiled/react-dom/cjs/react-dom-server.edge.development.js
@@ -8805,7 +8805,6 @@
         startWork(request$jscomp$0);
       });
     };
-    
 
 /** This is a patch added by Next.js */
 const setTimeoutOrImmediate = (() => {
@@ -8831,5 +8830,5 @@ const setTimeoutOrImmediate = (() => {
   return setTimeout;
 })();
 
-exports.version = "19.0.0-rc-49496d49-20240814";
+    exports.version = "19.0.0-rc-49496d49-20240814";
   })();

--- a/packages/next/src/compiled/react-dom/cjs/react-dom-server.edge.development.js
+++ b/packages/next/src/compiled/react-dom/cjs/react-dom-server.edge.development.js
@@ -8806,29 +8806,17 @@
       });
     };
 
-/** This is a patch added by Next.js */
-const setTimeoutOrImmediate = (() => {
+// This is a patch added by Next.js
+const setTimeoutOrImmediate = (
   // edge runtime sandbox defines a stub for setImmediate
   // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
   // so we can't just do this:
   //   typeof setImmediate === 'function'
-  // luckily it makes it non-enumerable, so we can use this instead
-  const _setImmediate = Object.keys(globalThis).includes("setImmediate")
+  // luckily the stub is non-enumerable, so we can check Object.keys instead
+  Object.keys(globalThis).includes("setImmediate")
     ? globalThis["set" + "Immediate"]
-    : undefined;
-
-  if (typeof _setImmediate === "function") {
-    return function setTimeoutOrImmediateImpl(cb, dur = 0, ...args) {
-      if (dur === 0 && args.length === 0) {
-        // likely a scheduleWork call
-        return _setImmediate(cb);
-      }
-      return setTimeout(cb, dur, ...args);
-    };
-  }
-
-  return setTimeout;
-})();
+    : setTimeout
+);
 
     exports.version = "19.0.0-rc-49496d49-20240814";
   })();

--- a/packages/next/src/compiled/react-dom/cjs/react-dom-server.edge.development.js
+++ b/packages/next/src/compiled/react-dom/cjs/react-dom-server.edge.development.js
@@ -8807,16 +8807,14 @@
     };
 
 // This is a patch added by Next.js
-const setTimeoutOrImmediate = (
+const setTimeoutOrImmediate =
+  typeof globalThis['set' + 'Immediate'] === 'function' &&
   // edge runtime sandbox defines a stub for setImmediate
   // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
-  // so we can't just do this:
-  //   typeof setImmediate === 'function'
-  // luckily the stub is non-enumerable, so we can check Object.keys instead
-  Object.keys(globalThis).includes("setImmediate")
-    ? globalThis["set" + "Immediate"]
-    : setTimeout
-);
+  // but it's made non-enumerable, so we can detect it
+  globalThis.propertyIsEnumerable('setImmediate')
+    ? globalThis['set' + 'Immediate']
+    : setTimeout;
 
     exports.version = "19.0.0-rc-49496d49-20240814";
   })();

--- a/packages/next/src/compiled/react-dom/cjs/react-dom-server.edge.development.js
+++ b/packages/next/src/compiled/react-dom/cjs/react-dom-server.edge.development.js
@@ -4419,7 +4419,7 @@
       request.pingedTasks.push(task);
       1 === request.pingedTasks.length &&
         ((request.flushScheduled = null !== request.destination),
-        setTimeout(function () {
+        setTimeoutOrImmediate(function () {
           return performWork(request);
         }, 0));
     }
@@ -7153,22 +7153,22 @@
     function startWork(request) {
       request.flushScheduled = null !== request.destination;
       supportsRequestStorage
-        ? setTimeout(function () {
+        ? setTimeoutOrImmediate(function () {
             return requestStorage.run(request, performWork, request);
           }, 0)
-        : setTimeout(function () {
+        : setTimeoutOrImmediate(function () {
             return performWork(request);
           }, 0);
       null === request.trackedPostpones &&
         (supportsRequestStorage
-          ? setTimeout(function () {
+          ? setTimeoutOrImmediate(function () {
               return requestStorage.run(
                 request,
                 enqueueEarlyPreloadsAfterInitialWork,
                 request
               );
             }, 0)
-          : setTimeout(function () {
+          : setTimeoutOrImmediate(function () {
               return enqueueEarlyPreloadsAfterInitialWork(request);
             }, 0));
     }
@@ -7180,7 +7180,7 @@
         0 === request.pingedTasks.length &&
         null !== request.destination &&
         ((request.flushScheduled = !0),
-        setTimeout(function () {
+        setTimeoutOrImmediate(function () {
           var destination = request.destination;
           destination
             ? flushCompletedQueues(request, destination)
@@ -8805,5 +8805,7 @@
         startWork(request$jscomp$0);
       });
     };
-    exports.version = "19.0.0-rc-49496d49-20240814";
+    
+;const setTimeoutOrImmediate = typeof setImmediate === 'function' ? setImmediate : setTimeout;
+exports.version = "19.0.0-rc-49496d49-20240814";
   })();

--- a/packages/next/src/compiled/react-dom/cjs/react-dom-server.edge.production.js
+++ b/packages/next/src/compiled/react-dom/cjs/react-dom-server.edge.production.js
@@ -6043,5 +6043,29 @@ exports.renderToReadableStream = function (children, options) {
   });
 };
 
-;const setTimeoutOrImmediate = typeof setImmediate === 'function' ? setImmediate : setTimeout;
+
+/** This is a patch added by Next.js */
+const setTimeoutOrImmediate = (() => {
+  // edge runtime sandbox defines a stub for setImmediate
+  // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
+  // so we can't just do this:
+  //   typeof setImmediate === 'function'
+  // luckily it makes it non-enumerable, so we can use this instead
+  const _setImmediate = Object.keys(globalThis).includes("setImmediate")
+    ? globalThis["set" + "Immediate"]
+    : undefined;
+
+  if (typeof _setImmediate === "function") {
+    return function setTimeoutOrImmediateImpl(cb, dur = 0, ...args) {
+      if (dur === 0 && args.length === 0) {
+        // likely a scheduleWork call
+        return _setImmediate(cb);
+      }
+      return setTimeout(cb, dur, ...args);
+    };
+  }
+
+  return setTimeout;
+})();
+
 exports.version = "19.0.0-rc-49496d49-20240814";

--- a/packages/next/src/compiled/react-dom/cjs/react-dom-server.edge.production.js
+++ b/packages/next/src/compiled/react-dom/cjs/react-dom-server.edge.production.js
@@ -6043,7 +6043,6 @@ exports.renderToReadableStream = function (children, options) {
   });
 };
 
-
 /** This is a patch added by Next.js */
 const setTimeoutOrImmediate = (() => {
   // edge runtime sandbox defines a stub for setImmediate

--- a/packages/next/src/compiled/react-dom/cjs/react-dom-server.edge.production.js
+++ b/packages/next/src/compiled/react-dom/cjs/react-dom-server.edge.production.js
@@ -6044,15 +6044,13 @@ exports.renderToReadableStream = function (children, options) {
 };
 
 // This is a patch added by Next.js
-const setTimeoutOrImmediate = (
+const setTimeoutOrImmediate =
+  typeof globalThis['set' + 'Immediate'] === 'function' &&
   // edge runtime sandbox defines a stub for setImmediate
   // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
-  // so we can't just do this:
-  //   typeof setImmediate === 'function'
-  // luckily the stub is non-enumerable, so we can check Object.keys instead
-  Object.keys(globalThis).includes("setImmediate")
-    ? globalThis["set" + "Immediate"]
-    : setTimeout
-);
+  // but it's made non-enumerable, so we can detect it
+  globalThis.propertyIsEnumerable('setImmediate')
+    ? globalThis['set' + 'Immediate']
+    : setTimeout;
 
 exports.version = "19.0.0-rc-49496d49-20240814";

--- a/packages/next/src/compiled/react-dom/cjs/react-dom-server.edge.production.js
+++ b/packages/next/src/compiled/react-dom/cjs/react-dom-server.edge.production.js
@@ -6043,28 +6043,16 @@ exports.renderToReadableStream = function (children, options) {
   });
 };
 
-/** This is a patch added by Next.js */
-const setTimeoutOrImmediate = (() => {
+// This is a patch added by Next.js
+const setTimeoutOrImmediate = (
   // edge runtime sandbox defines a stub for setImmediate
   // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
   // so we can't just do this:
   //   typeof setImmediate === 'function'
-  // luckily it makes it non-enumerable, so we can use this instead
-  const _setImmediate = Object.keys(globalThis).includes("setImmediate")
+  // luckily the stub is non-enumerable, so we can check Object.keys instead
+  Object.keys(globalThis).includes("setImmediate")
     ? globalThis["set" + "Immediate"]
-    : undefined;
-
-  if (typeof _setImmediate === "function") {
-    return function setTimeoutOrImmediateImpl(cb, dur = 0, ...args) {
-      if (dur === 0 && args.length === 0) {
-        // likely a scheduleWork call
-        return _setImmediate(cb);
-      }
-      return setTimeout(cb, dur, ...args);
-    };
-  }
-
-  return setTimeout;
-})();
+    : setTimeout
+);
 
 exports.version = "19.0.0-rc-49496d49-20240814";

--- a/packages/next/src/compiled/react-dom/cjs/react-dom-server.edge.production.js
+++ b/packages/next/src/compiled/react-dom/cjs/react-dom-server.edge.production.js
@@ -3944,7 +3944,7 @@ function pingTask(request, task) {
   request.pingedTasks.push(task);
   1 === request.pingedTasks.length &&
     ((request.flushScheduled = null !== request.destination),
-    setTimeout(function () {
+    setTimeoutOrImmediate(function () {
       return performWork(request);
     }, 0));
 }
@@ -5887,22 +5887,22 @@ function flushCompletedQueues(request, destination) {
 function startWork(request) {
   request.flushScheduled = null !== request.destination;
   supportsRequestStorage
-    ? setTimeout(function () {
+    ? setTimeoutOrImmediate(function () {
         return requestStorage.run(request, performWork, request);
       }, 0)
-    : setTimeout(function () {
+    : setTimeoutOrImmediate(function () {
         return performWork(request);
       }, 0);
   null === request.trackedPostpones &&
     (supportsRequestStorage
-      ? setTimeout(function () {
+      ? setTimeoutOrImmediate(function () {
           return requestStorage.run(
             request,
             enqueueEarlyPreloadsAfterInitialWork,
             request
           );
         }, 0)
-      : setTimeout(function () {
+      : setTimeoutOrImmediate(function () {
           return enqueueEarlyPreloadsAfterInitialWork(request);
         }, 0));
 }
@@ -5914,7 +5914,7 @@ function enqueueFlush(request) {
     0 === request.pingedTasks.length &&
     null !== request.destination &&
     ((request.flushScheduled = !0),
-    setTimeout(function () {
+    setTimeoutOrImmediate(function () {
       var destination = request.destination;
       destination
         ? flushCompletedQueues(request, destination)
@@ -6042,4 +6042,6 @@ exports.renderToReadableStream = function (children, options) {
     startWork(request);
   });
 };
+
+;const setTimeoutOrImmediate = typeof setImmediate === 'function' ? setImmediate : setTimeout;
 exports.version = "19.0.0-rc-49496d49-20240814";

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.edge.development.js
@@ -3964,16 +3964,14 @@
     };
 
 // This is a patch added by Next.js
-const setTimeoutOrImmediate = (
+const setTimeoutOrImmediate =
+  typeof globalThis['set' + 'Immediate'] === 'function' &&
   // edge runtime sandbox defines a stub for setImmediate
   // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
-  // so we can't just do this:
-  //   typeof setImmediate === 'function'
-  // luckily the stub is non-enumerable, so we can check Object.keys instead
-  Object.keys(globalThis).includes("setImmediate")
-    ? globalThis["set" + "Immediate"]
-    : setTimeout
-);
+  // but it's made non-enumerable, so we can detect it
+  globalThis.propertyIsEnumerable('setImmediate')
+    ? globalThis['set' + 'Immediate']
+    : setTimeout;
 
     exports.renderToReadableStream = function (model, turbopackMap, options) {
       var request = new RequestInstance(

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.edge.development.js
@@ -24,7 +24,7 @@
       return obj;
     }
     function handleErrorInNextTick(error) {
-      setTimeout(function () {
+      setTimeoutOrImmediate(function () {
         throw error;
       });
     }
@@ -2577,10 +2577,10 @@
     function startWork(request) {
       request.flushScheduled = null !== request.destination;
       supportsRequestStorage
-        ? setTimeout(function () {
+        ? setTimeoutOrImmediate(function () {
             return requestStorage.run(request, performWork, request);
           }, 0)
-        : setTimeout(function () {
+        : setTimeoutOrImmediate(function () {
             return performWork(request);
           }, 0);
     }
@@ -2589,7 +2589,7 @@
         0 === request.pingedTasks.length &&
         null !== request.destination &&
         ((request.flushScheduled = !0),
-        setTimeout(function () {
+        setTimeoutOrImmediate(function () {
           request.flushScheduled = !1;
           var destination = request.destination;
           destination && flushCompletedChunks(request, destination);
@@ -3962,6 +3962,19 @@
         bind: { value: bind, configurable: !0 }
       });
     };
+
+// This is a patch added by Next.js
+const setTimeoutOrImmediate = (
+  // edge runtime sandbox defines a stub for setImmediate
+  // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
+  // so we can't just do this:
+  //   typeof setImmediate === 'function'
+  // luckily the stub is non-enumerable, so we can check Object.keys instead
+  Object.keys(globalThis).includes("setImmediate")
+    ? globalThis["set" + "Immediate"]
+    : setTimeout
+);
+
     exports.renderToReadableStream = function (model, turbopackMap, options) {
       var request = new RequestInstance(
         model,

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.edge.production.js
@@ -12,7 +12,7 @@
 var ReactDOM = require("react-dom"),
   React = require("react");
 function handleErrorInNextTick(error) {
-  setTimeout(function () {
+  setTimeoutOrImmediate(function () {
     throw error;
   });
 }
@@ -1913,10 +1913,10 @@ function flushCompletedChunks(request, destination) {
 function startWork(request) {
   request.flushScheduled = null !== request.destination;
   supportsRequestStorage
-    ? setTimeout(function () {
+    ? setTimeoutOrImmediate(function () {
         return requestStorage.run(request, performWork, request);
       }, 0)
-    : setTimeout(function () {
+    : setTimeoutOrImmediate(function () {
         return performWork(request);
       }, 0);
 }
@@ -1925,7 +1925,7 @@ function enqueueFlush(request) {
     0 === request.pingedTasks.length &&
     null !== request.destination &&
     ((request.flushScheduled = !0),
-    setTimeout(function () {
+    setTimeoutOrImmediate(function () {
       request.flushScheduled = !1;
       var destination = request.destination;
       destination && flushCompletedChunks(request, destination);
@@ -2784,6 +2784,19 @@ exports.registerServerReference = function (reference, id, exportName) {
     bind: { value: bind, configurable: !0 }
   });
 };
+
+// This is a patch added by Next.js
+const setTimeoutOrImmediate = (
+  // edge runtime sandbox defines a stub for setImmediate
+  // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
+  // so we can't just do this:
+  //   typeof setImmediate === 'function'
+  // luckily the stub is non-enumerable, so we can check Object.keys instead
+  Object.keys(globalThis).includes("setImmediate")
+    ? globalThis["set" + "Immediate"]
+    : setTimeout
+);
+
 exports.renderToReadableStream = function (model, turbopackMap, options) {
   var request = new RequestInstance(
     model,

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.edge.production.js
@@ -2786,16 +2786,14 @@ exports.registerServerReference = function (reference, id, exportName) {
 };
 
 // This is a patch added by Next.js
-const setTimeoutOrImmediate = (
+const setTimeoutOrImmediate =
+  typeof globalThis['set' + 'Immediate'] === 'function' &&
   // edge runtime sandbox defines a stub for setImmediate
   // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
-  // so we can't just do this:
-  //   typeof setImmediate === 'function'
-  // luckily the stub is non-enumerable, so we can check Object.keys instead
-  Object.keys(globalThis).includes("setImmediate")
-    ? globalThis["set" + "Immediate"]
-    : setTimeout
-);
+  // but it's made non-enumerable, so we can detect it
+  globalThis.propertyIsEnumerable('setImmediate')
+    ? globalThis['set' + 'Immediate']
+    : setTimeout;
 
 exports.renderToReadableStream = function (model, turbopackMap, options) {
   var request = new RequestInstance(

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.edge.development.js
@@ -24,7 +24,7 @@
       return obj;
     }
     function handleErrorInNextTick(error) {
-      setTimeout(function () {
+      setTimeoutOrImmediate(function () {
         throw error;
       });
     }
@@ -2157,10 +2157,10 @@
     function startWork(request) {
       request.flushScheduled = null !== request.destination;
       supportsRequestStorage
-        ? setTimeout(function () {
+        ? setTimeoutOrImmediate(function () {
             return requestStorage.run(request, performWork, request);
           }, 0)
-        : setTimeout(function () {
+        : setTimeoutOrImmediate(function () {
             return performWork(request);
           }, 0);
     }
@@ -2169,7 +2169,7 @@
         0 === request.pingedTasks.length &&
         null !== request.destination &&
         ((request.flushScheduled = !0),
-        setTimeout(function () {
+        setTimeoutOrImmediate(function () {
           request.flushScheduled = !1;
           var destination = request.destination;
           destination && flushCompletedChunks(request, destination);
@@ -3492,6 +3492,19 @@
         bind: { value: bind, configurable: !0 }
       });
     };
+
+// This is a patch added by Next.js
+const setTimeoutOrImmediate = (
+  // edge runtime sandbox defines a stub for setImmediate
+  // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
+  // so we can't just do this:
+  //   typeof setImmediate === 'function'
+  // luckily the stub is non-enumerable, so we can check Object.keys instead
+  Object.keys(globalThis).includes("setImmediate")
+    ? globalThis["set" + "Immediate"]
+    : setTimeout
+);
+
     exports.renderToReadableStream = function (model, turbopackMap, options) {
       var request = new RequestInstance(
         model,

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.edge.development.js
@@ -3494,16 +3494,14 @@
     };
 
 // This is a patch added by Next.js
-const setTimeoutOrImmediate = (
+const setTimeoutOrImmediate =
+  typeof globalThis['set' + 'Immediate'] === 'function' &&
   // edge runtime sandbox defines a stub for setImmediate
   // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
-  // so we can't just do this:
-  //   typeof setImmediate === 'function'
-  // luckily the stub is non-enumerable, so we can check Object.keys instead
-  Object.keys(globalThis).includes("setImmediate")
-    ? globalThis["set" + "Immediate"]
-    : setTimeout
-);
+  // but it's made non-enumerable, so we can detect it
+  globalThis.propertyIsEnumerable('setImmediate')
+    ? globalThis['set' + 'Immediate']
+    : setTimeout;
 
     exports.renderToReadableStream = function (model, turbopackMap, options) {
       var request = new RequestInstance(

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.edge.production.js
@@ -2660,16 +2660,14 @@ exports.registerServerReference = function (reference, id, exportName) {
 };
 
 // This is a patch added by Next.js
-const setTimeoutOrImmediate = (
+const setTimeoutOrImmediate =
+  typeof globalThis['set' + 'Immediate'] === 'function' &&
   // edge runtime sandbox defines a stub for setImmediate
   // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
-  // so we can't just do this:
-  //   typeof setImmediate === 'function'
-  // luckily the stub is non-enumerable, so we can check Object.keys instead
-  Object.keys(globalThis).includes("setImmediate")
-    ? globalThis["set" + "Immediate"]
-    : setTimeout
-);
+  // but it's made non-enumerable, so we can detect it
+  globalThis.propertyIsEnumerable('setImmediate')
+    ? globalThis['set' + 'Immediate']
+    : setTimeout;
 
 exports.renderToReadableStream = function (model, turbopackMap, options) {
   var request = new RequestInstance(

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.edge.production.js
@@ -12,7 +12,7 @@
 var ReactDOM = require("react-dom"),
   React = require("react");
 function handleErrorInNextTick(error) {
-  setTimeout(function () {
+  setTimeoutOrImmediate(function () {
     throw error;
   });
 }
@@ -1800,10 +1800,10 @@ function flushCompletedChunks(request, destination) {
 function startWork(request) {
   request.flushScheduled = null !== request.destination;
   supportsRequestStorage
-    ? setTimeout(function () {
+    ? setTimeoutOrImmediate(function () {
         return requestStorage.run(request, performWork, request);
       }, 0)
-    : setTimeout(function () {
+    : setTimeoutOrImmediate(function () {
         return performWork(request);
       }, 0);
 }
@@ -1812,7 +1812,7 @@ function enqueueFlush(request) {
     0 === request.pingedTasks.length &&
     null !== request.destination &&
     ((request.flushScheduled = !0),
-    setTimeout(function () {
+    setTimeoutOrImmediate(function () {
       request.flushScheduled = !1;
       var destination = request.destination;
       destination && flushCompletedChunks(request, destination);
@@ -2658,6 +2658,19 @@ exports.registerServerReference = function (reference, id, exportName) {
     bind: { value: bind, configurable: !0 }
   });
 };
+
+// This is a patch added by Next.js
+const setTimeoutOrImmediate = (
+  // edge runtime sandbox defines a stub for setImmediate
+  // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
+  // so we can't just do this:
+  //   typeof setImmediate === 'function'
+  // luckily the stub is non-enumerable, so we can check Object.keys instead
+  Object.keys(globalThis).includes("setImmediate")
+    ? globalThis["set" + "Immediate"]
+    : setTimeout
+);
+
 exports.renderToReadableStream = function (model, turbopackMap, options) {
   var request = new RequestInstance(
     model,

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.development.js
@@ -3969,16 +3969,14 @@
     };
 
 // This is a patch added by Next.js
-const setTimeoutOrImmediate = (
+const setTimeoutOrImmediate =
+  typeof globalThis['set' + 'Immediate'] === 'function' &&
   // edge runtime sandbox defines a stub for setImmediate
   // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
-  // so we can't just do this:
-  //   typeof setImmediate === 'function'
-  // luckily the stub is non-enumerable, so we can check Object.keys instead
-  Object.keys(globalThis).includes("setImmediate")
-    ? globalThis["set" + "Immediate"]
-    : setTimeout
-);
+  // but it's made non-enumerable, so we can detect it
+  globalThis.propertyIsEnumerable('setImmediate')
+    ? globalThis['set' + 'Immediate']
+    : setTimeout;
 
     exports.renderToReadableStream = function (model, webpackMap, options) {
       var request = new RequestInstance(

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.development.js
@@ -24,7 +24,7 @@
       return obj;
     }
     function handleErrorInNextTick(error) {
-      setTimeout(function () {
+      setTimeoutOrImmediate(function () {
         throw error;
       });
     }
@@ -2581,10 +2581,10 @@
     function startWork(request) {
       request.flushScheduled = null !== request.destination;
       supportsRequestStorage
-        ? setTimeout(function () {
+        ? setTimeoutOrImmediate(function () {
             return requestStorage.run(request, performWork, request);
           }, 0)
-        : setTimeout(function () {
+        : setTimeoutOrImmediate(function () {
             return performWork(request);
           }, 0);
     }
@@ -2593,7 +2593,7 @@
         0 === request.pingedTasks.length &&
         null !== request.destination &&
         ((request.flushScheduled = !0),
-        setTimeout(function () {
+        setTimeoutOrImmediate(function () {
           request.flushScheduled = !1;
           var destination = request.destination;
           destination && flushCompletedChunks(request, destination);
@@ -3967,6 +3967,19 @@
         bind: { value: bind, configurable: !0 }
       });
     };
+
+// This is a patch added by Next.js
+const setTimeoutOrImmediate = (
+  // edge runtime sandbox defines a stub for setImmediate
+  // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
+  // so we can't just do this:
+  //   typeof setImmediate === 'function'
+  // luckily the stub is non-enumerable, so we can check Object.keys instead
+  Object.keys(globalThis).includes("setImmediate")
+    ? globalThis["set" + "Immediate"]
+    : setTimeout
+);
+
     exports.renderToReadableStream = function (model, webpackMap, options) {
       var request = new RequestInstance(
         model,

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.production.js
@@ -2787,16 +2787,14 @@ exports.registerServerReference = function (reference, id, exportName) {
 };
 
 // This is a patch added by Next.js
-const setTimeoutOrImmediate = (
+const setTimeoutOrImmediate =
+  typeof globalThis['set' + 'Immediate'] === 'function' &&
   // edge runtime sandbox defines a stub for setImmediate
   // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
-  // so we can't just do this:
-  //   typeof setImmediate === 'function'
-  // luckily the stub is non-enumerable, so we can check Object.keys instead
-  Object.keys(globalThis).includes("setImmediate")
-    ? globalThis["set" + "Immediate"]
-    : setTimeout
-);
+  // but it's made non-enumerable, so we can detect it
+  globalThis.propertyIsEnumerable('setImmediate')
+    ? globalThis['set' + 'Immediate']
+    : setTimeout;
 
 exports.renderToReadableStream = function (model, webpackMap, options) {
   var request = new RequestInstance(

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.production.js
@@ -12,7 +12,7 @@
 var ReactDOM = require("react-dom"),
   React = require("react");
 function handleErrorInNextTick(error) {
-  setTimeout(function () {
+  setTimeoutOrImmediate(function () {
     throw error;
   });
 }
@@ -1913,10 +1913,10 @@ function flushCompletedChunks(request, destination) {
 function startWork(request) {
   request.flushScheduled = null !== request.destination;
   supportsRequestStorage
-    ? setTimeout(function () {
+    ? setTimeoutOrImmediate(function () {
         return requestStorage.run(request, performWork, request);
       }, 0)
-    : setTimeout(function () {
+    : setTimeoutOrImmediate(function () {
         return performWork(request);
       }, 0);
 }
@@ -1925,7 +1925,7 @@ function enqueueFlush(request) {
     0 === request.pingedTasks.length &&
     null !== request.destination &&
     ((request.flushScheduled = !0),
-    setTimeout(function () {
+    setTimeoutOrImmediate(function () {
       request.flushScheduled = !1;
       var destination = request.destination;
       destination && flushCompletedChunks(request, destination);
@@ -2785,6 +2785,19 @@ exports.registerServerReference = function (reference, id, exportName) {
     bind: { value: bind, configurable: !0 }
   });
 };
+
+// This is a patch added by Next.js
+const setTimeoutOrImmediate = (
+  // edge runtime sandbox defines a stub for setImmediate
+  // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
+  // so we can't just do this:
+  //   typeof setImmediate === 'function'
+  // luckily the stub is non-enumerable, so we can check Object.keys instead
+  Object.keys(globalThis).includes("setImmediate")
+    ? globalThis["set" + "Immediate"]
+    : setTimeout
+);
+
 exports.renderToReadableStream = function (model, webpackMap, options) {
   var request = new RequestInstance(
     model,

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js
@@ -24,7 +24,7 @@
       return obj;
     }
     function handleErrorInNextTick(error) {
-      setTimeout(function () {
+      setTimeoutOrImmediate(function () {
         throw error;
       });
     }
@@ -2161,10 +2161,10 @@
     function startWork(request) {
       request.flushScheduled = null !== request.destination;
       supportsRequestStorage
-        ? setTimeout(function () {
+        ? setTimeoutOrImmediate(function () {
             return requestStorage.run(request, performWork, request);
           }, 0)
-        : setTimeout(function () {
+        : setTimeoutOrImmediate(function () {
             return performWork(request);
           }, 0);
     }
@@ -2173,7 +2173,7 @@
         0 === request.pingedTasks.length &&
         null !== request.destination &&
         ((request.flushScheduled = !0),
-        setTimeout(function () {
+        setTimeoutOrImmediate(function () {
           request.flushScheduled = !1;
           var destination = request.destination;
           destination && flushCompletedChunks(request, destination);
@@ -3497,6 +3497,19 @@
         bind: { value: bind, configurable: !0 }
       });
     };
+
+// This is a patch added by Next.js
+const setTimeoutOrImmediate = (
+  // edge runtime sandbox defines a stub for setImmediate
+  // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
+  // so we can't just do this:
+  //   typeof setImmediate === 'function'
+  // luckily the stub is non-enumerable, so we can check Object.keys instead
+  Object.keys(globalThis).includes("setImmediate")
+    ? globalThis["set" + "Immediate"]
+    : setTimeout
+);
+
     exports.renderToReadableStream = function (model, webpackMap, options) {
       var request = new RequestInstance(
         model,

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js
@@ -3499,16 +3499,14 @@
     };
 
 // This is a patch added by Next.js
-const setTimeoutOrImmediate = (
+const setTimeoutOrImmediate =
+  typeof globalThis['set' + 'Immediate'] === 'function' &&
   // edge runtime sandbox defines a stub for setImmediate
   // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
-  // so we can't just do this:
-  //   typeof setImmediate === 'function'
-  // luckily the stub is non-enumerable, so we can check Object.keys instead
-  Object.keys(globalThis).includes("setImmediate")
-    ? globalThis["set" + "Immediate"]
-    : setTimeout
-);
+  // but it's made non-enumerable, so we can detect it
+  globalThis.propertyIsEnumerable('setImmediate')
+    ? globalThis['set' + 'Immediate']
+    : setTimeout;
 
     exports.renderToReadableStream = function (model, webpackMap, options) {
       var request = new RequestInstance(

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.production.js
@@ -2661,16 +2661,14 @@ exports.registerServerReference = function (reference, id, exportName) {
 };
 
 // This is a patch added by Next.js
-const setTimeoutOrImmediate = (
+const setTimeoutOrImmediate =
+  typeof globalThis['set' + 'Immediate'] === 'function' &&
   // edge runtime sandbox defines a stub for setImmediate
   // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
-  // so we can't just do this:
-  //   typeof setImmediate === 'function'
-  // luckily the stub is non-enumerable, so we can check Object.keys instead
-  Object.keys(globalThis).includes("setImmediate")
-    ? globalThis["set" + "Immediate"]
-    : setTimeout
-);
+  // but it's made non-enumerable, so we can detect it
+  globalThis.propertyIsEnumerable('setImmediate')
+    ? globalThis['set' + 'Immediate']
+    : setTimeout;
 
 exports.renderToReadableStream = function (model, webpackMap, options) {
   var request = new RequestInstance(

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.production.js
@@ -12,7 +12,7 @@
 var ReactDOM = require("react-dom"),
   React = require("react");
 function handleErrorInNextTick(error) {
-  setTimeout(function () {
+  setTimeoutOrImmediate(function () {
     throw error;
   });
 }
@@ -1800,10 +1800,10 @@ function flushCompletedChunks(request, destination) {
 function startWork(request) {
   request.flushScheduled = null !== request.destination;
   supportsRequestStorage
-    ? setTimeout(function () {
+    ? setTimeoutOrImmediate(function () {
         return requestStorage.run(request, performWork, request);
       }, 0)
-    : setTimeout(function () {
+    : setTimeoutOrImmediate(function () {
         return performWork(request);
       }, 0);
 }
@@ -1812,7 +1812,7 @@ function enqueueFlush(request) {
     0 === request.pingedTasks.length &&
     null !== request.destination &&
     ((request.flushScheduled = !0),
-    setTimeout(function () {
+    setTimeoutOrImmediate(function () {
       request.flushScheduled = !1;
       var destination = request.destination;
       destination && flushCompletedChunks(request, destination);
@@ -2659,6 +2659,19 @@ exports.registerServerReference = function (reference, id, exportName) {
     bind: { value: bind, configurable: !0 }
   });
 };
+
+// This is a patch added by Next.js
+const setTimeoutOrImmediate = (
+  // edge runtime sandbox defines a stub for setImmediate
+  // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
+  // so we can't just do this:
+  //   typeof setImmediate === 'function'
+  // luckily the stub is non-enumerable, so we can check Object.keys instead
+  Object.keys(globalThis).includes("setImmediate")
+    ? globalThis["set" + "Immediate"]
+    : setTimeout
+);
+
 exports.renderToReadableStream = function (model, webpackMap, options) {
   var request = new RequestInstance(
     model,

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -1704,16 +1704,14 @@ export async function copy_vendor_react(task_) {
         '\n\n' +
         outdent`
           // This is a patch added by Next.js
-          const setTimeoutOrImmediate = (
+          const setTimeoutOrImmediate =
+            typeof globalThis['set' + 'Immediate'] === 'function' &&
             // edge runtime sandbox defines a stub for setImmediate
             // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
-            // so we can't just do this:
-            //   typeof setImmediate === 'function'
-            // luckily the stub is non-enumerable, so we can check Object.keys instead
-            Object.keys(globalThis).includes("setImmediate")
-              ? globalThis["set" + "Immediate"]
-              : setTimeout
-          );
+            // but it's made non-enumerable, so we can detect it
+            globalThis.propertyIsEnumerable('setImmediate')
+              ? globalThis['set' + 'Immediate']
+              : setTimeout;
         ` +
         '\n'
 

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -1675,8 +1675,9 @@ export async function copy_vendor_react(task_) {
             `setTimeoutOrImmediate`
           )
 
-          const anchor = 'exports.version ='
-          const insertionPoint = newSource.indexOf(anchor)
+          const anchorPattern = /\n\s*exports\.version =/
+
+          const insertionPoint = newSource.search(anchorPattern)
           if (insertionPoint === -1) {
             throw new Error(
               `Cannot find insertion point for setTimeoutOrImmediate in ${filepath}`
@@ -1710,7 +1711,7 @@ const setTimeoutOrImmediate = (() => {
   return setTimeout;
 })();
           ` +
-            '\n\n'
+            '\n'
 
           newSource =
             newSource.slice(0, insertionPoint) +

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -1,5 +1,4 @@
-import { outdent } from 'outdent'
-
+const { outdent } = require('outdent')
 const { relative, basename, resolve, join, dirname } = require('path')
 // eslint-disable-next-line import/no-extraneous-dependencies
 const glob = require('glob')

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -1687,29 +1687,29 @@ export async function copy_vendor_react(task_) {
           const toInsert =
             '\n\n' +
             outdent`
-/** This is a patch added by Next.js */
-const setTimeoutOrImmediate = (() => {
-  // edge runtime sandbox defines a stub for setImmediate
-  // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
-  // so we can't just do this:
-  //   typeof setImmediate === 'function'
-  // luckily it makes it non-enumerable, so we can use this instead
-  const _setImmediate = Object.keys(globalThis).includes("setImmediate")
-    ? globalThis["set" + "Immediate"]
-    : undefined;
+            /** This is a patch added by Next.js */
+            const setTimeoutOrImmediate = (() => {
+              // edge runtime sandbox defines a stub for setImmediate
+              // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
+              // so we can't just do this:
+              //   typeof setImmediate === 'function'
+              // luckily it makes it non-enumerable, so we can use this instead
+              const _setImmediate = Object.keys(globalThis).includes("setImmediate")
+                ? globalThis["set" + "Immediate"]
+                : undefined;
 
-  if (typeof _setImmediate === "function") {
-    return function setTimeoutOrImmediateImpl(cb, dur = 0, ...args) {
-      if (dur === 0 && args.length === 0) {
-        // likely a scheduleWork call
-        return _setImmediate(cb);
-      }
-      return setTimeout(cb, dur, ...args);
-    };
-  }
+              if (typeof _setImmediate === "function") {
+                return function setTimeoutOrImmediateImpl(cb, dur = 0, ...args) {
+                  if (dur === 0 && args.length === 0) {
+                    // likely a scheduleWork call
+                    return _setImmediate(cb);
+                  }
+                  return setTimeout(cb, dur, ...args);
+                };
+              }
 
-  return setTimeout;
-})();
+              return setTimeout;
+            })();
           ` +
             '\n'
 

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -1651,62 +1651,11 @@ export async function copy_vendor_react(task_) {
             filepath
           )
         ) {
-          // FIXME: we need this hack until we can use the Node build of 'react-dom/server'
-          //
-          // We're currently using the Edge build of 'react-dom/server' everywhere.
-          // But if we're in Node, we want to change the implementation of `scheduleWork` from the Edge one:
-          //   https://github.com/facebook/react/blob/19bd26beb689e554fceb0b929dc5199be8cba594/packages/react-server/src/ReactServerStreamConfigEdge.js#L31-L33
-          // to the Node one:
-          //   https://github.com/facebook/react/blob/19bd26beb689e554fceb0b929dc5199be8cba594/packages/react-server/src/ReactServerStreamConfigNode.js#L25-L27
-          // for performance and correctness reasons (e.g. in DynamicIO).
-          //
-          // Since `scheduleWork` is inlined, we have to convert `setTimeout` calls like this
-          //   setTimeout(() => ..., 0)
-          // into this:
-          //   setImmediate(() => ...)
-          //
-          // ReactDOM only ever calls `setTimeout` with `0` (and no further arguments),
-          // so we can just naively replace `setTimeout` with `setImmediate`.
-          // Technically the `0` will then be passed to the callback as an argument,
-          // but the callbacks will always ignore it anyway.
-
-          // NOTE: we have to replace these before inserting the definition of `setTimeoutOrImmediate`,
-          // otherwise we'd break it!
-          newSource = newSource.replaceAll(
-            `setTimeout`,
-            `setTimeoutOrImmediate`
-          )
-
-          const anchorPattern = /\n\s*exports\.version =/
-
-          const insertionPoint = newSource.search(anchorPattern)
-          if (insertionPoint === -1) {
-            throw new Error(
-              `Cannot find insertion point for setTimeoutOrImmediate in ${filepath}`
-            )
-          }
-
-          const toInsert =
-            '\n\n' +
-            outdent`
-            // This is a patch added by Next.js
-            const setTimeoutOrImmediate = (
-              // edge runtime sandbox defines a stub for setImmediate
-              // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
-              // so we can't just do this:
-              //   typeof setImmediate === 'function'
-              // luckily the stub is non-enumerable, so we can check Object.keys instead
-              Object.keys(globalThis).includes("setImmediate")
-                ? globalThis["set" + "Immediate"]
-                : setTimeout
-            );
-          ` +
-            '\n'
-
-          newSource =
-            newSource.slice(0, insertionPoint) +
-            toInsert +
-            newSource.slice(insertionPoint)
+          newSource = replaceSetTimeout({
+            code: newSource,
+            file: filepath,
+            insertBefore: /\n\s*exports\.version =/,
+          })
         }
 
         file.data = newSource
@@ -1715,6 +1664,63 @@ export async function copy_vendor_react(task_) {
         // as it mighe be aliased to the server rendering stub.
       })
       .target(`src/compiled/react-dom${packageSuffix}/cjs`)
+
+    function replaceSetTimeout({
+      code,
+      file,
+      insertBefore: insertBeforePattern,
+    }) {
+      // FIXME: we need this hack until we can use the Node build of 'react-dom/server'
+      //
+      // We're currently using the Edge builds of 'react-dom/server' and 'react-server-dom-{webpack,turbopack}' everywhere.
+      // But if we're in Node, we want to change the implementation of `scheduleWork` from the Edge one:
+      //   https://github.com/facebook/react/blob/19bd26beb689e554fceb0b929dc5199be8cba594/packages/react-server/src/ReactServerStreamConfigEdge.js#L31-L33
+      // to the Node one:
+      //   https://github.com/facebook/react/blob/19bd26beb689e554fceb0b929dc5199be8cba594/packages/react-server/src/ReactServerStreamConfigNode.js#L25-L27
+      // for performance and correctness reasons (e.g. in DynamicIO).
+      //
+      // Since `scheduleWork` is inlined, we have to convert `setTimeout` calls like this
+      //   setTimeout(() => ..., 0)
+      // into this:
+      //   setImmediate(() => ...)
+      //
+      // ReactDOM only ever calls `setTimeout` with `0` (and no further arguments),
+      // so we can just naively replace `setTimeout` with `setImmediate`.
+      // Technically the `0` will then be passed to the callback as an argument,
+      // but the callbacks will always ignore it anyway.
+
+      // NOTE: we have to replace these before inserting the definition of `setTimeoutOrImmediate`,
+      // otherwise we'd break it!
+      code = code.replaceAll(`setTimeout`, `setTimeoutOrImmediate`)
+
+      const insertionPoint = code.search(insertBeforePattern)
+      if (insertionPoint === -1) {
+        throw new Error(
+          `Cannot find insertion point for setTimeoutOrImmediate in ${file}`
+        )
+      }
+
+      const toInsert =
+        '\n\n' +
+        outdent`
+          // This is a patch added by Next.js
+          const setTimeoutOrImmediate = (
+            // edge runtime sandbox defines a stub for setImmediate
+            // (see 'addStub' in packages/next/src/server/web/sandbox/context.ts)
+            // so we can't just do this:
+            //   typeof setImmediate === 'function'
+            // luckily the stub is non-enumerable, so we can check Object.keys instead
+            Object.keys(globalThis).includes("setImmediate")
+              ? globalThis["set" + "Immediate"]
+              : setTimeout
+          );
+        ` +
+        '\n'
+
+      return (
+        code.slice(0, insertionPoint) + toInsert + code.slice(insertionPoint)
+      )
+    }
 
     // Remove unused files
     const reactDomCompiledDir = join(
@@ -1768,10 +1774,18 @@ export async function copy_vendor_react(task_) {
             !file.base.startsWith('react-server-dom-webpack-server.browser'))
         ) {
           const source = file.data.toString()
-          file.data = source.replace(
+          let newSource = source.replace(
             /__webpack_require__/g,
             'globalThis.__next_require__'
           )
+          if (file.base.startsWith('react-server-dom-webpack-server.edge')) {
+            newSource = replaceSetTimeout({
+              code: newSource,
+              file: file.base,
+              insertBefore: /\n\s*exports\.renderToReadableStream =/,
+            })
+          }
+          file.data = newSource
         } else if (file.base === 'package.json') {
           file.data = overridePackageName(file.data)
         }
@@ -1815,9 +1829,19 @@ export async function copy_vendor_react(task_) {
             !file.base.startsWith('react-server-dom-turbopack-server.browser'))
         ) {
           const source = file.data.toString()
-          file.data = source
+          let newSource = source
             .replace(/__turbopack_load__/g, 'globalThis.__next_chunk_load__')
             .replace(/__turbopack_require__/g, 'globalThis.__next_require__')
+
+          if (file.base.startsWith('react-server-dom-turbopack-server.edge')) {
+            newSource = replaceSetTimeout({
+              code: newSource,
+              file: file.base,
+              insertBefore: /\n\s*exports\.renderToReadableStream =/,
+            })
+          }
+
+          file.data = newSource
         } else if (file.base === 'package.json') {
           file.data = overridePackageName(file.data)
         }

--- a/test/e2e/app-dir/react-max-headers-length/react-max-headers-length.test.ts
+++ b/test/e2e/app-dir/react-max-headers-length/react-max-headers-length.test.ts
@@ -28,6 +28,7 @@ describe('react-max-headers-length', () => {
 
       it('should respect reactMaxHeadersLength', async () => {
         const res = await next.fetch('/')
+        expect(res.status).toBe(200)
 
         // React currently only sets the `Link` header, so we should check to
         // see that the length of the header has respected the configured
@@ -35,6 +36,7 @@ describe('react-max-headers-length', () => {
         const header = res.headers.get('Link')
         if (reactMaxHeadersLength === undefined) {
           // This is the default case.
+          expect(header).not.toBeNull()
           expect(header).toBeString()
 
           expect(header.length).toBeGreaterThanOrEqual(
@@ -47,6 +49,7 @@ describe('react-max-headers-length', () => {
         } else if (typeof reactMaxHeadersLength === 'number') {
           // This is the case where the header is emitted and the length is
           // respected.
+          expect(header).not.toBeNull()
           expect(header).toBeString()
 
           expect(header.length).toBeGreaterThanOrEqual(


### PR DESCRIPTION
This is a hack that we need until we refactor everything to use the Node builds of `'react-dom/server'` and `'react-server-dom-{webpack,turbopack}'` when running in Node.

Currently, we're using the Edge builds of `'react-dom/server'` and `'react-server-dom-{webpack,turbopack}'` everywhere. Ideally, we'd use the Node builds in Node (for both performance and correctness reasons, e.g. in DynamicIO), but that refactor will take a lot of work.

So for now, we'll just patch react a bit and make the Edge build act more like the Node build (when it's being used in Node). In particular, we want to change the implementation of `scheduleWork` from [the Edge one](https://github.com/facebook/react/blob/19bd26beb689e554fceb0b929dc5199be8cba594/packages/react-server/src/ReactServerStreamConfigEdge.js#L31-L33) to [the Node one](https://github.com/facebook/react/blob/19bd26beb689e554fceb0b929dc5199be8cba594/packages/react-server/src/ReactServerStreamConfigNode.js#L25-L27).

But `scheduleWork` is inlined, so we basically have to convert `setTimeout` calls like this
```
setTimeout(() => ..., 0)
```
into this:
```
setImmediate(() => ...)
```
Luckily `setTimeout` isn't really used for anything else in those packages, so we can get away with just doing a dumb string replacement.
