### PR TITLE
fixes #68956: SSG with empty generated params for dynamic routes

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2138,8 +2138,9 @@ export default async function build(
                           if (appConfig.revalidate !== 0) {
                             const isDynamic = isDynamicRoute(page)
                             const hasGenerateStaticParams =
-                              workerResult.prerenderedRoutes &&
-                              workerResult.prerenderedRoutes.length > 0
+                              workerResult.prerenderedRoutes;
+                            const generateStaticParamsIsEmpty =
+                              workerResult.prerenderedRoutes && workerResult.prerenderedRoutes.length === 0;
 
                             if (
                               config.output === 'export' &&
@@ -2148,6 +2149,10 @@ export default async function build(
                             ) {
                               throw new Error(
                                 `Page "${page}" is missing "generateStaticParams()" so it cannot be used with "output: export" config.`
+                              )
+                            } else if (generateStaticParamsIsEmpty) {
+                              console.warn(
+                                `"generateStaticParams()" in page "${page}" is empty so it will be skipped when used with "output: export" config.`
                               )
                             }
 


### PR DESCRIPTION
### What?
Skipping pages with empty static params while using output export instead of throwing an error on build.

### Why?
Allowing conditional building of sites with dynamic routes that are generated (for example) through a CMS on build time. 

### How?
Introducing another flag called `generateStaticParamsIsEmpty`.
Based on this flag we can allow build to skip this route generation. 
Added a console.warn message to avoid unwanted route skips. 

### Possible Improvements
Could be beneficial to add this behavior under an experimental flag. 

Fixes #68956
