### PR TITLE
Simplify static indicator

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/container/StaticIndicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/StaticIndicator.tsx
@@ -7,17 +7,7 @@ export function StaticIndicator({ dispatcher }: { dispatcher?: Dispatcher }) {
   return (
     <Toast className="nextjs-static-indicator-toast-wrapper">
       <LightningBolt />
-      <span>
-        Statically rendered page.{' '}
-        <a
-          onClick={(e) => e.stopPropagation()}
-          href="https://nextjs.org/docs/app/api-reference/next-config-js/devIndicators"
-          target="_blank"
-          rel="noreferrer"
-        >
-          Learn more
-        </a>
-      </span>
+      <span>Static route </span>
       <button
         onClick={() => {
           dispatcher?.onStaticIndicator(false)

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -801,11 +801,14 @@ async function renderToHTMLOrFlightImpl(
     req.originalRequest.on('end', () => {
       const staticGenStore =
         ComponentMod.staticGenerationAsyncStorage.getStore()
+      const prerenderStore = prerenderAsyncStorage.getStore()
+      const isPPR = !!prerenderStore?.dynamicTracking?.dynamicAccesses?.length
 
       if (
         process.env.NODE_ENV === 'development' &&
         staticGenStore &&
-        renderOpts.setAppIsrStatus
+        renderOpts.setAppIsrStatus &&
+        !isPPR
       ) {
         // only node can be ISR so we only need to update the status here
         const { pathname } = new URL(req.url || '/', 'http://n')


### PR DESCRIPTION
This reduces the space the static indicator takes up a bit and simplifies wording. This also makes sure we don't show it for PPR routes as those aren't fully static. 

<details>

<summary>Preview</summary>


![CleanShot 2024-08-15 at 15 22 24@2x](https://github.com/user-attachments/assets/867a5517-d6bf-4804-843a-936f147cb051)

![CleanShot 2024-08-15 at 15 22 13@2x](https://github.com/user-attachments/assets/608a683a-4eb7-427e-8ee7-6e94d4988031)


</details>