### PR TITLE
Fix flying-shuttle full mode breaking instrumentation

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1155,9 +1155,10 @@ export default async function getBaseWebpackConfig(
               return `static/chunks/[name]-[contenthash].js`
             },
 
-            path: isNodeServer
-              ? path.join(outputPath, `chunks-${buildId}`)
-              : outputPath,
+            path:
+              !dev && isNodeServer
+                ? path.join(outputPath, `chunks-${buildId}`)
+                : outputPath,
 
             chunkFilename: isNodeOrEdgeCompilation
               ? `[name].js`

--- a/packages/next/src/server/web/globals.ts
+++ b/packages/next/src/server/web/globals.ts
@@ -18,6 +18,8 @@ export async function getEdgeInstrumentationModule(): Promise<
 
 let instrumentationModulePromise: Promise<any> | null = null
 async function registerInstrumentation() {
+  // Ensure registerInstrumentation is not called in production build
+  if (process.env.NEXT_PHASE === 'phase-production-build') return
   if (!instrumentationModulePromise) {
     instrumentationModulePromise = getEdgeInstrumentationModule()
   }

--- a/test/e2e/instrumentation-hook/flying-shuttle/app/edge/page.js
+++ b/test/e2e/instrumentation-hook/flying-shuttle/app/edge/page.js
@@ -1,0 +1,5 @@
+export default function Page() {
+  return 'edge'
+}
+
+export const runtime = 'edge'

--- a/test/e2e/instrumentation-hook/flying-shuttle/app/layout.js
+++ b/test/e2e/instrumentation-hook/flying-shuttle/app/layout.js
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/instrumentation-hook/flying-shuttle/app/page.js
+++ b/test/e2e/instrumentation-hook/flying-shuttle/app/page.js
@@ -1,0 +1,5 @@
+export default function Page() {
+  return 'node'
+}
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/instrumentation-hook/flying-shuttle/flying-shuttle.test.ts
+++ b/test/e2e/instrumentation-hook/flying-shuttle/flying-shuttle.test.ts
@@ -1,0 +1,31 @@
+import fs from 'fs-extra'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('instrumentation-hook - flying-shuttle', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  beforeAll(async () => {
+    await fs.remove('.next')
+  })
+
+  it('should only register without errors', async () => {
+    await next.fetch('/')
+    await next.fetch('/edge')
+
+    await retry(() => {
+      expect(next.cliOutput).toIncludeRepeated('register:edge', 1)
+      expect(next.cliOutput).not.toContain(
+        'An error occurred while loading instrumentation hook'
+      )
+      expect(next.cliOutput).toIncludeRepeated('register:nodejs', 1)
+    })
+  })
+})

--- a/test/e2e/instrumentation-hook/flying-shuttle/instrumentation.js
+++ b/test/e2e/instrumentation-hook/flying-shuttle/instrumentation.js
@@ -1,0 +1,3 @@
+export function register() {
+  console.log('register:' + process.env.NEXT_RUNTIME)
+}

--- a/test/e2e/instrumentation-hook/flying-shuttle/instrumentation.js
+++ b/test/e2e/instrumentation-hook/flying-shuttle/instrumentation.js
@@ -1,3 +1,3 @@
 export function register() {
-  console.log('register:' + process.env.NEXT_RUNTIME)
+  console.trace('register:' + process.env.NEXT_RUNTIME)
 }

--- a/test/e2e/instrumentation-hook/flying-shuttle/next.config.js
+++ b/test/e2e/instrumentation-hook/flying-shuttle/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+module.exports = {
+  experimental: {
+    flyingShuttle: {
+      mode: 'full',
+    },
+    instrumentationHook: true,
+  },
+}


### PR DESCRIPTION
### What

* Align the webpack config `output.path` in flying shuttle mode with default mode, only change chunking folder in production mode.
* Only call `register()` in non build mode for edge runtime

### Why

Noticing `{ flying-shuttle: { mode: 'full' } }` would break instrumentation in dev mode, cause Next.js will assume the `instrumentation.js` is always output to `.next/server/instrumentation.js`. Changing the `server/` to `server/chunks-{buildId}` would break this convention

```
Error: An error occurred while loading instrumentation hook: Cannot find module '/workspace
/app/.next/server/instrumentation'
  code: 'MODULE_NOT_FOUND'
```

The bug was introduced in #67785

Also the in edge runtime the instrumentation register was still involked during phase build, this was not spposed to happen. Adding a env check there to avoid it's happening again.