### PR TITLE
fix CNA example handling on Windows

### DIFF
--- a/packages/create-next-app/helpers/examples.ts
+++ b/packages/create-next-app/helpers/examples.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { Readable } from 'node:stream'
-import { sep } from 'node:path'
+import { sep, posix } from 'node:path'
 import { pipeline } from 'node:stream/promises'
 import { x } from 'tar'
 
@@ -109,16 +109,21 @@ export async function downloadAndExtractRepo(
       cwd: root,
       strip: filePath ? filePath.split('/').length + 1 : 1,
       filter: (p: string) => {
+        // Convert Windows path separators to POSIX style
+        const posixPath = p.split(sep).join(posix.sep)
+
         // Determine the unpacked root path dynamically instead of hardcoding to the fetched repo's name / branch.
         // This avoids the condition when the repository has been renamed, and the old repository name is used to fetch the example.
         // The tar download will work as it is redirected automatically, but the root directory of the extracted
         // example will be the new, renamed name instead of the name used to fetch the example, breaking the filter.
         if (rootPath === null) {
-          const pathSegments = p.split(sep)
+          const pathSegments = posixPath.split(posix.sep)
           rootPath = pathSegments.length ? pathSegments[0] : null
         }
 
-        return p.startsWith(`${rootPath}${filePath ? `/${filePath}/` : '/'}`)
+        return posixPath.startsWith(
+          `${rootPath}${filePath ? `/${filePath}/` : '/'}`
+        )
       },
     })
   )


### PR DESCRIPTION
Azure tests have been failing on CNA examples and I believe it's because the filter function introduced in #68802 wasn't accounting for Windows paths when computing the `rootPath`. This normalizes to a POSIX path to ensure handling is consistent. 

[Successful run](https://dev.azure.com/nextjs/next.js/_build/results?buildId=94852&view=logs&j=14d0eb3f-bc66-5450-3353-28256327ad6c&t=7e988112-57f9-5e14-1c8c-05f6c2b0ea47)