### PR TITLE
Run Azure Pipelines after merge

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,14 +10,11 @@ trigger:
       - docs
       - errors
       - examples
-  # Do not run Azure on `canary`, `main`, or release tags. This unnecessarily
-  # increases the backlog, and the change was already tested on the PR.
+  # Do not run Azure on release tags. This unnecessarily increases the backlog.
   branches:
     include:
       - '*'
     exclude:
-      - canary
-      - main
       - refs/tags/*
 
 pr:


### PR DESCRIPTION
One of the main use cases of CI is ensuring commits land cleanly. We already run CI provisioned in GitHub on `canary`. Now we do that also for Azure Pipelines (our Windows tests). This will help identifying when breakage was introduced since they're not actually required status checks on PRs.