### PR TITLE
Remove references to removed react-dom/server APIs in Webpack shims

### DIFF
--- a/packages/next/src/build/webpack/alias/react-dom-server-browser-experimental.js
+++ b/packages/next/src/build/webpack/alias/react-dom-server-browser-experimental.js
@@ -10,8 +10,6 @@ if (process.env.NODE_ENV === 'production') {
 exports.version = l.version
 exports.renderToString = l.renderToString
 exports.renderToStaticMarkup = l.renderToStaticMarkup
-exports.renderToNodeStream = l.renderToNodeStream
-exports.renderToStaticNodeStream = l.renderToStaticNodeStream
 exports.renderToReadableStream = s.renderToReadableStream
 if (s.resume) {
   exports.resume = s.resume

--- a/packages/next/src/build/webpack/alias/react-dom-server-browser.js
+++ b/packages/next/src/build/webpack/alias/react-dom-server-browser.js
@@ -10,8 +10,6 @@ if (process.env.NODE_ENV === 'production') {
 exports.version = l.version
 exports.renderToString = l.renderToString
 exports.renderToStaticMarkup = l.renderToStaticMarkup
-exports.renderToNodeStream = l.renderToNodeStream
-exports.renderToStaticNodeStream = l.renderToStaticNodeStream
 exports.renderToReadableStream = s.renderToReadableStream
 if (s.resume) {
   exports.resume = s.resume

--- a/packages/next/src/build/webpack/alias/react-dom-server-edge-experimental.js
+++ b/packages/next/src/build/webpack/alias/react-dom-server-edge-experimental.js
@@ -14,8 +14,6 @@ if (process.env.NODE_ENV === 'production') {
 
 exports.version = b.version
 exports.renderToReadableStream = b.renderToReadableStream
-exports.renderToNodeStream = b.renderToNodeStream
-exports.renderToStaticNodeStream = b.renderToStaticNodeStream
 exports.renderToString = error
 exports.renderToStaticMarkup = error
 if (b.resume) {

--- a/packages/next/src/build/webpack/alias/react-dom-server-edge.js
+++ b/packages/next/src/build/webpack/alias/react-dom-server-edge.js
@@ -14,8 +14,6 @@ if (process.env.NODE_ENV === 'production') {
 
 exports.version = b.version
 exports.renderToReadableStream = b.renderToReadableStream
-exports.renderToNodeStream = b.renderToNodeStream
-exports.renderToStaticNodeStream = b.renderToStaticNodeStream
 exports.renderToString = error
 exports.renderToStaticMarkup = error
 if (b.resume) {

--- a/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
+++ b/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
@@ -88,20 +88,16 @@ describe('react-dom/server in React Server environment', () => {
           .toMatchInlineSnapshot(`
           "{
             "default": [
-              "renderToNodeStream",
               "renderToReadableStream",
               "renderToStaticMarkup",
-              "renderToStaticNodeStream",
               "renderToString",
               "resume",
               "version"
             ],
             "named": [
               "default",
-              "renderToNodeStream",
               "renderToReadableStream",
               "renderToStaticMarkup",
-              "renderToStaticNodeStream",
               "renderToString",
               "resume",
               "version"
@@ -113,19 +109,15 @@ describe('react-dom/server in React Server environment', () => {
           .toMatchInlineSnapshot(`
           "{
             "default": [
-              "renderToNodeStream",
               "renderToReadableStream",
               "renderToStaticMarkup",
-              "renderToStaticNodeStream",
               "renderToString",
               "version"
             ],
             "named": [
               "default",
-              "renderToNodeStream",
               "renderToReadableStream",
               "renderToStaticMarkup",
-              "renderToStaticNodeStream",
               "renderToString",
               "version"
             ]
@@ -208,20 +200,16 @@ describe('react-dom/server in React Server environment', () => {
           .toMatchInlineSnapshot(`
           "{
             "default": [
-              "renderToNodeStream",
               "renderToReadableStream",
               "renderToStaticMarkup",
-              "renderToStaticNodeStream",
               "renderToString",
               "resume",
               "version"
             ],
             "named": [
               "default",
-              "renderToNodeStream",
               "renderToReadableStream",
               "renderToStaticMarkup",
-              "renderToStaticNodeStream",
               "renderToString",
               "resume",
               "version"
@@ -231,26 +219,22 @@ describe('react-dom/server in React Server environment', () => {
       } else {
         expect(await browser.elementByCss('main').text())
           .toMatchInlineSnapshot(`
-                  "{
-                    "default": [
-                      "renderToNodeStream",
-                      "renderToReadableStream",
-                      "renderToStaticMarkup",
-                      "renderToStaticNodeStream",
-                      "renderToString",
-                      "version"
-                    ],
-                    "named": [
-                      "default",
-                      "renderToNodeStream",
-                      "renderToReadableStream",
-                      "renderToStaticMarkup",
-                      "renderToStaticNodeStream",
-                      "renderToString",
-                      "version"
-                    ]
-                  }"
-              `)
+          "{
+            "default": [
+              "renderToReadableStream",
+              "renderToStaticMarkup",
+              "renderToString",
+              "version"
+            ],
+            "named": [
+              "default",
+              "renderToReadableStream",
+              "renderToStaticMarkup",
+              "renderToString",
+              "version"
+            ]
+          }"
+        `)
       }
     }
     const redbox = {
@@ -499,20 +483,16 @@ describe('react-dom/server in React Server environment', () => {
           "{
             "default": {
               "default": [
-                "renderToNodeStream",
                 "renderToReadableStream",
                 "renderToStaticMarkup",
-                "renderToStaticNodeStream",
                 "renderToString",
                 "resume",
                 "version"
               ],
               "named": [
                 "default",
-                "renderToNodeStream",
                 "renderToReadableStream",
                 "renderToStaticMarkup",
-                "renderToStaticNodeStream",
                 "renderToString",
                 "resume",
                 "version"
@@ -523,28 +503,24 @@ describe('react-dom/server in React Server environment', () => {
       } else {
         expect(await browser.elementByCss('main').text())
           .toMatchInlineSnapshot(`
-                  "{
-                    "default": {
-                      "default": [
-                        "renderToNodeStream",
-                        "renderToReadableStream",
-                        "renderToStaticMarkup",
-                        "renderToStaticNodeStream",
-                        "renderToString",
-                        "version"
-                      ],
-                      "named": [
-                        "default",
-                        "renderToNodeStream",
-                        "renderToReadableStream",
-                        "renderToStaticMarkup",
-                        "renderToStaticNodeStream",
-                        "renderToString",
-                        "version"
-                      ]
-                    }
-                  }"
-              `)
+          "{
+            "default": {
+              "default": [
+                "renderToReadableStream",
+                "renderToStaticMarkup",
+                "renderToString",
+                "version"
+              ],
+              "named": [
+                "default",
+                "renderToReadableStream",
+                "renderToStaticMarkup",
+                "renderToString",
+                "version"
+              ]
+            }
+          }"
+        `)
       }
     }
     const redbox = {
@@ -627,20 +603,16 @@ describe('react-dom/server in React Server environment', () => {
           "{
             "default": {
               "default": [
-                "renderToNodeStream",
                 "renderToReadableStream",
                 "renderToStaticMarkup",
-                "renderToStaticNodeStream",
                 "renderToString",
                 "resume",
                 "version"
               ],
               "named": [
                 "default",
-                "renderToNodeStream",
                 "renderToReadableStream",
                 "renderToStaticMarkup",
-                "renderToStaticNodeStream",
                 "renderToString",
                 "resume",
                 "version"
@@ -651,28 +623,24 @@ describe('react-dom/server in React Server environment', () => {
       } else {
         expect(await browser.elementByCss('main').text())
           .toMatchInlineSnapshot(`
-                  "{
-                    "default": {
-                      "default": [
-                        "renderToNodeStream",
-                        "renderToReadableStream",
-                        "renderToStaticMarkup",
-                        "renderToStaticNodeStream",
-                        "renderToString",
-                        "version"
-                      ],
-                      "named": [
-                        "default",
-                        "renderToNodeStream",
-                        "renderToReadableStream",
-                        "renderToStaticMarkup",
-                        "renderToStaticNodeStream",
-                        "renderToString",
-                        "version"
-                      ]
-                    }
-                  }"
-              `)
+          "{
+            "default": {
+              "default": [
+                "renderToReadableStream",
+                "renderToStaticMarkup",
+                "renderToString",
+                "version"
+              ],
+              "named": [
+                "default",
+                "renderToReadableStream",
+                "renderToStaticMarkup",
+                "renderToString",
+                "version"
+              ]
+            }
+          }"
+        `)
       }
     }
     const redbox = {


### PR DESCRIPTION
The slimmer react-dom/server bundle without the legacy APIs was still referencing react-dom/server APIs that were removed in React 19. 