### PR TITLE
chore: auto-install @types/react-dom when react is installed

### DIFF
--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -69,11 +69,18 @@ export async function verifyTypeScriptSetup({
         ])
       ).resolved.has('react')
     ) {
-      requiredPackages.push({
-        file: '@types/react/index.d.ts',
-        pkg: '@types/react',
-        exportsRestrict: true,
-      })
+      requiredPackages.push(
+        {
+          file: '@types/react/index.d.ts',
+          pkg: '@types/react',
+          exportsRestrict: true,
+        },
+        {
+          file: '@types/react-dom/index.d.ts',
+          pkg: '@types/react-dom',
+          exportsRestrict: true,
+        }
+      )
     }
 
     // Ensure TypeScript and necessary `@types/*` are installed:


### PR DESCRIPTION
When the project is using TypeScript, we auto-installed `@types/react` but not `@types/react-dom`, so we install it as well if `react` exists in the project.