### PR TITLE
Resolve route interception problem with (..)(..)

### DIFF
--- a/packages/next/src/shared/lib/router/utils/prepare-destination.ts
+++ b/packages/next/src/shared/lib/router/utils/prepare-destination.ts
@@ -248,7 +248,12 @@ export function prepareDestination(args: {
         segment.startsWith(m)
       )
       if (marker) {
-        args.params['0'] = marker
+        if (marker === "(..)(..)") {
+          args.params["0"] = "(..)"
+          args.params["1"] = "(..)"
+        } else {
+          args.params["0"] = marker
+        }
         break
       }
     }


### PR DESCRIPTION
fixes #57016

### What?

When the marker is `"(..)(..)"`, setting:
```
args.params["0"] = "(..)"
args.params["1"] = "(..)"
```
helps prevent the bug that occurs with:
```
var value = data ? data[token.name] : undefined;
```
For example, if the tokens passed to tokensToFunction are:
```
[
  '/foo/bar',
  { name: 0, prefix: '/', suffix: '', pattern: '..', modifier: '' },
  { name: 1, prefix: '', suffix: '', pattern: '..', modifier: '' },
  'fizz'
]
```
then the data in function(data) will be:
```
{ '0': '(..)', '1': '(..)' }
```
allowing you to access data[1] without errors with:
```
var value = data ? data[token.name] : undefined;
```
This method also minimizes the impact on existing code.

### Why?

### How?

