### PR TITLE
fix: sometimes buffer is toJSON'ed in response.

### DIFF
--- a/packages/next/src/server/render-result.ts
+++ b/packages/next/src/server/render-result.ts
@@ -53,6 +53,7 @@ export type RenderResultResponse =
   | ReadableStream<Uint8Array>
   | string
   | Buffer
+  | { type: 'Buffer'; data: number[] }
   | null
 
 export type RenderResultOptions<
@@ -187,8 +188,12 @@ export default class RenderResult<
       throw new Error('Invariant: static responses cannot be streamed')
     }
 
-    if (Buffer.isBuffer(this.response)) {
-      return streamFromBuffer(this.response)
+    if (Buffer.isBuffer(this.response) || 'type' in this.response) {
+      const buf = Buffer.isBuffer(this.response)
+        ? this.response
+        : Buffer.from(this.response['data'])
+
+      return streamFromBuffer(buf)
     }
 
     // If the response is an array of streams, then chain them together.
@@ -218,8 +223,11 @@ export default class RenderResult<
       responses = [streamFromString(this.response)]
     } else if (Array.isArray(this.response)) {
       responses = this.response
-    } else if (Buffer.isBuffer(this.response)) {
-      responses = [streamFromBuffer(this.response)]
+    } else if (Buffer.isBuffer(this.response) || 'type' in this.response) {
+      const buf = Buffer.isBuffer(this.response)
+        ? this.response
+        : Buffer.from(this.response['data'])
+      responses = [streamFromBuffer(buf)]
     } else {
       responses = [this.response]
     }


### PR DESCRIPTION
### What?
Sometimes when RSC pages are prefetched, the response is of type {type: "Buffer", data: number[]}, which is the return type of Buffer.toJSON().

### Why?
I don't know exactly why this happens, but it still occurs even after updating nextjs to the latest canary.

### How?
Just checking if the response is a weird JSON buffer and then converting it back to a real buffer fixes the issue.