### PR TITLE
Add note about image optimisation in edge

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/01-images.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/01-images.mdx
@@ -28,7 +28,7 @@ The Next.js Image component extends the HTML `<img>` element with features for a
 - **Asset Flexibility:** On-demand image resizing, even for images stored on remote servers
 
 > **🎥 Watch:** Learn more about how to use `next/image` → [YouTube (9 minutes)](https://youtu.be/IU_qq_c_lKA).
-
+> **📝 Note:** Image Optimisation does not work if the server does not support Node.js API's at all i.e. it only supports edge.
 ## Usage
 
 ```js


### PR DESCRIPTION

### What?

It specifies in [https://nextjs.org/docs/app/building-your-application/optimizing/images](<https://nextjs.org/docs/app/building-your-application/optimizing/images>) that image optimisation is not supported on edge

### Why?
It'll help people plan before using next/image, if they are using a different hosting platform like cloudflare pages
