### PR TITLE
fix: Move tree shaking config to `experimental.turbo`

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -399,6 +399,7 @@ pub struct ExperimentalTurboConfig {
     pub resolve_alias: Option<IndexMap<RcStr, JsonValue>>,
     pub resolve_extensions: Option<Vec<RcStr>>,
     pub use_swc_css: Option<bool>,
+    pub tree_shaking: Option<bool>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs)]
@@ -561,8 +562,6 @@ pub struct ExperimentalConfig {
     /// (doesn't apply to Turbopack).
     webpack_build_worker: Option<bool>,
     worker_threads: Option<bool>,
-
-    tree_shaking: Option<bool>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs)]

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1104,7 +1104,12 @@ impl NextConfig {
         self: Vc<Self>,
         is_development: bool,
     ) -> Result<Vc<OptionTreeShaking>> {
-        let tree_shaking = self.await?.experimental.tree_shaking;
+        let tree_shaking = self
+            .await?
+            .experimental
+            .turbo
+            .as_ref()
+            .and_then(|v| v.tree_shaking);
 
         Ok(OptionTreeShaking(match tree_shaking {
             Some(false) => Some(TreeShakingMode::ReexportsOnly),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -153,6 +153,11 @@ export interface ExperimentalTurboOptions {
    * A target memory limit for turbo, in bytes.
    */
   memoryLimit?: number
+
+  /**
+   * Enable tree shaking for the turbopack dev server and build.
+   */
+  treeShaking?: boolean
 }
 
 export interface WebpackConfigContext {


### PR DESCRIPTION
### What?

Move `experimental.treeShaking` to `experimental.turbo.treeShaking` in Rust code.

### Why?

To disable it, we need to keep config schema and Rust types in sync.

### How?
