### PR TITLE
Add ERROR to clarify that the build failed due to a problem

### DIFF
--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -310,7 +310,7 @@ async function exportAppImpl(
         Object.keys(serverActionsManifest.edge).length > 0
       ) {
         throw new ExportError(
-          `Server Actions are not supported with static export.`
+          `ERROR: Server Actions are not supported with static export.`
         )
       }
     }

--- a/test/e2e/app-dir/actions/app-action-export.test.ts
+++ b/test/e2e/app-dir/actions/app-action-export.test.ts
@@ -34,7 +34,7 @@ describe('app-dir action handling - next export', () => {
 
   it('should error when use export output for server actions', async () => {
     expect(next.cliOutput).toContain(
-      `Server Actions are not supported with static export.`
+      `ERROR: Server Actions are not supported with static export.`
     )
   })
 })


### PR DESCRIPTION
### What?
During build if it fails, Just writing down a msg is not clear enough that there is a problem.

### Why?
Work with an engineer and it took us a few good runs to understand that the msg is an error! and the build have failed! Build process tends to have a lot of msgs and lots of text so it's not always as easy to see a problem.

### How?
Just make it clear that there is a problem and there is an error during the build.