### PR TITLE
[Turbopack] [HMR] Allow `Option`s to be returned by `VersionedContentMap`

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -734,7 +734,7 @@ pub fn project_hmr_events(
                     let project = project.project().resolve().await?;
                     let state = project.hmr_version_state(identifier.clone(), session);
 
-                    let Some(state) = &*state.await? else {
+                    let Some(state) = &*state.strongly_consistent().await? else {
                         // If there's no matching version state and no error was returned, refresh
                         // the page.
                         return Ok((None, Arc::new(vec![]), Arc::new(vec![])));

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -734,13 +734,7 @@ pub fn project_hmr_events(
                     let project = project.project().resolve().await?;
                     let state = project.hmr_version_state(identifier.clone(), session);
 
-                    let Some(state) = &*state.strongly_consistent().await? else {
-                        // If there's no matching version state and no error was returned, refresh
-                        // the page.
-                        return Ok((None, Arc::new(vec![]), Arc::new(vec![])));
-                    };
-
-                    let update = hmr_update(project, identifier, *state)
+                    let update = hmr_update(project, identifier.clone(), state)
                         .strongly_consistent()
                         .await
                         .inspect_err(|e| log_panic_and_inform(e))?;

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -26,6 +26,7 @@ pub struct OutputAssetsOperation(Vc<OutputAssets>);
 struct MapEntry {
     assets_operation: Vc<OutputAssets>,
     side_effects: Vc<Completion>,
+    /// Precomputed map for quick access to output asset by filepath
     path_to_asset: HashMap<Vc<FileSystemPath>, Vc<Box<dyn OutputAsset>>>,
 }
 
@@ -33,6 +34,7 @@ struct MapEntry {
 struct OptionMapEntry(Option<MapEntry>);
 
 type PathToOutputOperation = HashMap<Vc<FileSystemPath>, IndexSet<Vc<OutputAssets>>>;
+// A precomputed map for quick access to output asset by filepath
 type OutputOperationToComputeEntry = HashMap<Vc<OutputAssets>, Vc<OptionMapEntry>>;
 
 #[turbo_tasks::value]
@@ -67,6 +69,7 @@ impl VersionedContentMap {
     #[turbo_tasks::function]
     pub async fn insert_output_assets(
         self: Vc<Self>,
+        // Output assets to emit
         assets_operation: Vc<OutputAssetsOperation>,
         node_root: Vc<FileSystemPath>,
         client_relative_path: Vc<FileSystemPath>,
@@ -88,6 +91,8 @@ impl VersionedContentMap {
         Ok(entry.side_effects)
     }
 
+    /// Creates a ComputEntry (a pre-computed map for optimized lookup) for an output assets
+    /// operation. When assets change, map_path_to_op is updated.
     #[turbo_tasks::function]
     async fn compute_entry(
         self: Vc<Self>,

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -11,9 +11,9 @@ use turbo_tasks::{
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::Asset,
-    output::{OutputAsset, OutputAssets},
+    output::{OptionOutputAsset, OutputAsset, OutputAssets},
     source_map::{GenerateSourceMap, OptionSourceMap},
-    version::VersionedContent,
+    version::OptionVersionedContent,
 };
 
 /// An unresolved output assets operation. We need to pass an operation here as
@@ -148,8 +148,13 @@ impl VersionedContentMap {
     }
 
     #[turbo_tasks::function]
-    pub fn get(self: Vc<Self>, path: Vc<FileSystemPath>) -> Vc<Box<dyn VersionedContent>> {
-        self.get_asset(path).versioned_content()
+    pub async fn get(
+        self: Vc<Self>,
+        path: Vc<FileSystemPath>,
+    ) -> Result<Vc<OptionVersionedContent>> {
+        Ok(Vc::cell(
+            (*self.get_asset(path).await?).map(|a| a.versioned_content()),
+        ))
     }
 
     #[turbo_tasks::function]
@@ -158,8 +163,12 @@ impl VersionedContentMap {
         path: Vc<FileSystemPath>,
         section: Option<RcStr>,
     ) -> Result<Vc<OptionSourceMap>> {
+        let Some(asset) = &*self.get_asset(path).await? else {
+            return Ok(Vc::cell(None));
+        };
+
         if let Some(generate_source_map) =
-            Vc::try_resolve_sidecast::<Box<dyn GenerateSourceMap>>(self.get_asset(path)).await?
+            Vc::try_resolve_sidecast::<Box<dyn GenerateSourceMap>>(*asset).await?
         {
             Ok(if let Some(section) = section {
                 generate_source_map.by_section(section)
@@ -176,7 +185,7 @@ impl VersionedContentMap {
     pub async fn get_asset(
         self: Vc<Self>,
         path: Vc<FileSystemPath>,
-    ) -> Result<Vc<Box<dyn OutputAsset>>> {
+    ) -> Result<Vc<OptionOutputAsset>> {
         let result = self.raw_get(path).await?;
         if let Some(MapEntry {
             assets_operation: _,
@@ -187,17 +196,17 @@ impl VersionedContentMap {
             side_effects.await?;
 
             if let Some(asset) = path_to_asset.get(&path) {
-                return Ok(*asset);
+                return Ok(Vc::cell(Some(*asset)));
             } else {
                 let path = path.to_string().await?;
                 bail!(
                     "could not find asset for path {} (asset has been removed)",
-                    path
+                    path,
                 );
             }
         }
-        let path = path.to_string().await?;
-        bail!("could not find asset for path {}", path);
+
+        Ok(Vc::cell(None))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-build-test/src/lib.rs
+++ b/crates/next-build-test/src/lib.rs
@@ -257,12 +257,10 @@ async fn hmr(tt: &TurboTasks<MemoryBackend>, project: Vc<ProjectContainer>) -> R
             let session = session.clone();
             async move {
                 let project = project.project();
-                project
-                    .hmr_update(
-                        ident.clone(),
-                        project.hmr_version_state(ident.clone(), session),
-                    )
-                    .await?;
+                let state = *project.hmr_version_state(ident.clone(), session).await?;
+                if let Some(state) = state {
+                    project.hmr_update(ident.clone(), state).await?;
+                }
                 Ok(Vc::<()>::cell(()))
             }
         });

--- a/crates/next-build-test/src/lib.rs
+++ b/crates/next-build-test/src/lib.rs
@@ -257,10 +257,8 @@ async fn hmr(tt: &TurboTasks<MemoryBackend>, project: Vc<ProjectContainer>) -> R
             let session = session.clone();
             async move {
                 let project = project.project();
-                let state = *project.hmr_version_state(ident.clone(), session).await?;
-                if let Some(state) = state {
-                    project.hmr_update(ident.clone(), state).await?;
-                }
+                let state = project.hmr_version_state(ident.clone(), session);
+                project.hmr_update(ident.clone(), state).await?;
                 Ok(Vc::<()>::cell(()))
             }
         });

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/update.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/update.rs
@@ -122,7 +122,7 @@ pub(super) async fn update_chunk_list(
                         },
                     );
                 }
-                Update::None => {}
+                Update::Missing | Update::None => {}
             }
         } else {
             chunks.insert(chunk_path.as_ref(), ChunkUpdate::Deleted);
@@ -156,7 +156,7 @@ pub(super) async fn update_chunk_list(
                 Update::Partial(partial) => {
                     merged.push(partial.instruction.clone());
                 }
-                Update::None => {}
+                Update::Missing | Update::None => {}
             }
         }
     }

--- a/turbopack/crates/turbopack-core/src/output.rs
+++ b/turbopack/crates/turbopack-core/src/output.rs
@@ -4,6 +4,9 @@ use turbo_tasks::Vc;
 
 use crate::{asset::Asset, ident::AssetIdent};
 
+#[turbo_tasks::value(transparent)]
+pub struct OptionOutputAsset(Option<Vc<Box<dyn OutputAsset>>>);
+
 /// An asset that should be outputted, e. g. written to disk or served from a
 /// server.
 #[turbo_tasks::value_trait]

--- a/turbopack/crates/turbopack-core/src/version.rs
+++ b/turbopack/crates/turbopack-core/src/version.rs
@@ -10,6 +10,9 @@ use turbo_tasks_hash::{encode_hex, hash_xxh3_hash64};
 
 use crate::asset::AssetContent;
 
+#[turbo_tasks::value(transparent)]
+pub struct OptionVersionedContent(Option<Vc<Box<dyn VersionedContent>>>);
+
 /// The content of an [Asset] alongside its version.
 #[turbo_tasks::value_trait]
 pub trait VersionedContent {
@@ -115,6 +118,9 @@ impl VersionedContentExt for AssetContent {
     }
 }
 
+#[turbo_tasks::value(transparent)]
+pub struct OptionVersion(Option<Vc<Box<dyn Version>>>);
+
 /// Describes the current version of an object, and how to update them from an
 /// earlier version.
 #[turbo_tasks::value_trait]
@@ -176,6 +182,9 @@ pub enum Update {
     /// specific set of instructions.
     Partial(PartialUpdate),
 
+    // The asset is now missing, so it can't be updated. A full reload is required.
+    Missing,
+
     /// No update required.
     None,
 }
@@ -234,6 +243,9 @@ impl Version for FileHashVersion {
         Ok(Vc::cell(self.hash.clone()))
     }
 }
+
+#[turbo_tasks::value(transparent)]
+pub struct OptionVersionState(Option<Vc<VersionState>>);
 
 #[turbo_tasks::value]
 pub struct VersionState {

--- a/turbopack/crates/turbopack-core/src/version.rs
+++ b/turbopack/crates/turbopack-core/src/version.rs
@@ -118,9 +118,6 @@ impl VersionedContentExt for AssetContent {
     }
 }
 
-#[turbo_tasks::value(transparent)]
-pub struct OptionVersion(Option<Vc<Box<dyn Version>>>);
-
 /// Describes the current version of an object, and how to update them from an
 /// earlier version.
 #[turbo_tasks::value_trait]
@@ -243,9 +240,6 @@ impl Version for FileHashVersion {
         Ok(Vc::cell(self.hash.clone()))
     }
 }
-
-#[turbo_tasks::value(transparent)]
-pub struct OptionVersionState(Option<Vc<VersionState>>);
 
 #[turbo_tasks::value]
 pub struct VersionState {

--- a/turbopack/crates/turbopack-dev-server/src/update/server.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/server.rs
@@ -143,7 +143,7 @@ impl<P: SourceProvider + Clone + Send + Sync> UpdateServer<P> {
                             ))
                             .await?;
                     }
-                    Update::Total(_total) => {
+                    Update::Missing | Update::Total(_) => {
                         client
                             .send(ClientUpdateInstruction::restart(&resource, &issues))
                             .await?;

--- a/turbopack/crates/turbopack-dev-server/src/update/stream.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/stream.rs
@@ -234,7 +234,7 @@ impl UpdateStream {
                                     Some(item)
                                 }
                                 // Do not propagate empty updates.
-                                Update::None => {
+                                Update::None | Update::Missing => {
                                     if has_issues || issues_changed {
                                         Some(item)
                                     } else {


### PR DESCRIPTION
Building on #68698, which causes `Error`s propagated from the `VersionedContentMap` to surface as errors instead of reloading the page, allow intentionally missing values to be returned.

There are scenarios in which this is desirable and not an error, such as when the content of entries change and the page must be reloaded.

In these cases, a `Update:Missing` is returned, which causes the page to be reloaded.

Test Plan: CI

PACK-3188
