### PR TITLE
consolidate handling for well known objects across refs and analysis

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/resolved-effects.snapshot
@@ -15,22 +15,24 @@
 0 -> 9 call = require*0*("fs/promises")
 - *0* require: The require method from CommonJS
 
-0 -> 11 member call = module<fs/promises, {}>["readFile"]("./hello.txt", "utf-8")
+0 -> 11 member call = fs*0*["readFile"]("./hello.txt", "utf-8")
+- *0* fs: The Node.js fs module: https://nodejs.org/api/fs.html
 
 0 -> 14 member call = ???*0*["status"](200)
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 
 0 -> 15 member call = ???*0*["json"](
-    {
-        "users": [{"id": 1}, {"id": 2}, {"id": 3}],
-        "hello": module<fs/promises, {}>["readFile"]("./hello.txt", "utf-8")
-    }
+    {"users": [{"id": 1}, {"id": 2}, {"id": 3}], "hello": ???*2*}
 )
 - *0* ???*1*["status"](200)
   ⚠️  unknown callee object
 - *1* arguments[1]
   ⚠️  function calls are not analysed yet
+- *2* fs.readFile*3*("./hello.txt", "utf-8")
+  ⚠️  unsupported function
+  ⚠️  This value might have side effects
+- *3* fs.readFile: A file reading method from the Node.js fs module: https://nodejs.org/api/fs.html
 
 0 -> 16 free var = FreeVar(require)
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/resolved-explained.snapshot
@@ -36,13 +36,18 @@ exports = {}
 
 handler = (...) => undefined
 
-hello = module<fs/promises, {}>["readFile"]("./hello.txt", "utf-8")
+hello = ???*0*
+- *0* fs.readFile*1*("./hello.txt", "utf-8")
+  ⚠️  unsupported function
+  ⚠️  This value might have side effects
+- *1* fs.readFile: A file reading method from the Node.js fs module: https://nodejs.org/api/fs.html
 
 moduleId = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-promises_namespaceObject = module<fs/promises, {}>
+promises_namespaceObject = fs*0*
+- *0* fs: The Node.js fs module: https://nodejs.org/api/fs.html
 
 res = ???*0*
 - *0* arguments[1]


### PR DESCRIPTION
### What?

We have a set of known functions with special handling to fix problematic or nonstandard packages. This PR ensures the logic for mapping string package names to these well known functions is in one place and one place only.

### Why?

We had two slowly diverging implementations.

### How?

Utility function. I opted not to implement TryInto as we do not have a surjective mapping into the codomain.