### PR TITLE
add implementation for webpackIgnore and turbopackIgnore

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -572,6 +572,7 @@ impl AppProject {
             ))),
             None,
             IssueSeverity::Error.cell(),
+            false,
         )
         .resolve()
         .await?

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -292,6 +292,7 @@ async fn build_dynamic_imports_map_for_module(
             Value::new(EcmaScriptModulesReferenceSubType::DynamicImport),
             IssueSeverity::Error.cell(),
             None,
+            false,
         )
         .first_module()
         .await?;

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -575,6 +575,7 @@ impl PagesProject {
             Value::new(EcmaScriptModulesReferenceSubType::Undefined),
             IssueSeverity::Error.cell(),
             None,
+            false,
         )
         .first_module()
         .await?

--- a/crates/next-core/src/next_client/runtime_entry.rs
+++ b/crates/next-core/src/next_client/runtime_entry.rs
@@ -38,6 +38,7 @@ impl RuntimeEntry {
             request,
             None,
             IssueSeverity::Error.cell(),
+            false,
         )
         .resolve()
         .await?

--- a/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
@@ -38,6 +38,7 @@ impl RuntimeEntry {
             request,
             None,
             IssueSeverity::Error.cell(),
+            false,
         )
         .resolve()
         .await?

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -1242,7 +1242,13 @@ impl VisitAstPath for Analyzer<'_> {
                 if let Some(require_var_id) = extract_var_from_umd_factory(callee, &n.args) {
                     self.add_value(
                         require_var_id,
-                        JsValue::WellKnownFunction(WellKnownFunctionKind::Require),
+                        JsValue::WellKnownFunction(WellKnownFunctionKind::Require {
+                            ignore: self
+                                .eval_context
+                                .imports
+                                .get_ignore(n.callee.span())
+                                .unwrap_or_default(),
+                        }),
                     );
                 }
             }

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -364,7 +364,7 @@ impl EcmascriptParsable for EcmascriptModuleAsset {
 impl EcmascriptAnalyzable for EcmascriptModuleAsset {
     #[turbo_tasks::function]
     fn analyze(self: Vc<Self>) -> Vc<AnalyzeEcmascriptModuleResult> {
-        analyse_ecmascript_module(self, None, None)
+        analyse_ecmascript_module(self, None)
     }
 
     /// Generates module contents without an analysis pass. This is useful for
@@ -417,6 +417,7 @@ impl EcmascriptModuleAsset {
     pub fn new(
         source: Vc<Box<dyn Source>>,
         asset_context: Vc<Box<dyn AssetContext>>,
+
         ty: Value<EcmascriptModuleAssetType>,
         transforms: Vc<EcmascriptInputTransforms>,
         options: Vc<EcmascriptOptions>,
@@ -428,6 +429,7 @@ impl EcmascriptModuleAsset {
             ty: ty.into_value(),
             transforms,
             options,
+
             compile_time_info,
             inner_assets: None,
             last_successful_parse: Default::default(),
@@ -440,6 +442,7 @@ impl EcmascriptModuleAsset {
         asset_context: Vc<Box<dyn AssetContext>>,
         ty: Value<EcmascriptModuleAssetType>,
         transforms: Vc<EcmascriptInputTransforms>,
+
         options: Vc<EcmascriptOptions>,
         compile_time_info: Vc<CompileTimeInfo>,
         inner_assets: Vc<InnerAssets>,
@@ -459,6 +462,11 @@ impl EcmascriptModuleAsset {
     #[turbo_tasks::function]
     pub async fn source(self: Vc<Self>) -> Result<Vc<Box<dyn Source>>> {
         Ok(self.await?.source)
+    }
+
+    #[turbo_tasks::function]
+    pub fn analyze(self: Vc<Self>) -> Vc<AnalyzeEcmascriptModuleResult> {
+        analyse_ecmascript_module(self, None)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -206,7 +206,7 @@ async fn parse_internal(
             FileContent::Content(file) => match file.content().to_str() {
                 Ok(string) => {
                     let transforms = &*transforms.await?;
-                    match parse_content(
+                    match parse_file_content(
                         string.into_owned(),
                         fs_path_vc,
                         fs_path,
@@ -246,7 +246,7 @@ async fn parse_internal(
     })
 }
 
-async fn parse_content(
+async fn parse_file_content(
     string: String,
     fs_path_vc: Vc<FileSystemPath>,
     fs_path: &FileSystemPath,
@@ -433,7 +433,7 @@ async fn parse_content(
                 &parsed_program,
                 unresolved_mark,
                 top_level_mark,
-                None,
+                Some(&comments),
                 Some(source),
             );
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -65,6 +65,7 @@ impl ModuleReference for AmdDefineAssetReference {
             self.request,
             Some(self.issue_source),
             try_to_severity(self.in_try),
+            /* ignore */ false,
         )
     }
 }
@@ -160,6 +161,7 @@ impl CodeGenerateable for AmdDefineWithDependenciesCodeGen {
                                 *request,
                                 Some(self.issue_source),
                                 try_to_severity(self.in_try),
+                                false,
                             ),
                             Value::new(ChunkItem),
                         )

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -56,6 +56,7 @@ impl ModuleReference for CjsAssetReference {
             self.request,
             Some(self.issue_source),
             try_to_severity(self.in_try),
+            false,
         )
     }
 }
@@ -81,6 +82,7 @@ pub struct CjsRequireAssetReference {
     pub path: Vc<AstPath>,
     pub issue_source: Vc<IssueSource>,
     pub in_try: bool,
+    pub ignore_import: bool,
 }
 
 #[turbo_tasks::value_impl]
@@ -92,6 +94,7 @@ impl CjsRequireAssetReference {
         path: Vc<AstPath>,
         issue_source: Vc<IssueSource>,
         in_try: bool,
+        ignore_import: bool,
     ) -> Vc<Self> {
         Self::cell(CjsRequireAssetReference {
             origin,
@@ -99,6 +102,7 @@ impl CjsRequireAssetReference {
             path,
             issue_source,
             in_try,
+            ignore_import,
         })
     }
 }
@@ -112,6 +116,7 @@ impl ModuleReference for CjsRequireAssetReference {
             self.request,
             Some(self.issue_source),
             try_to_severity(self.in_try),
+            self.ignore_import,
         )
     }
 }
@@ -145,6 +150,7 @@ impl CodeGenerateable for CjsRequireAssetReference {
                 self.request,
                 Some(self.issue_source),
                 try_to_severity(self.in_try),
+                self.ignore_import,
             ),
             Value::new(ChunkItem),
         )
@@ -188,6 +194,7 @@ pub struct CjsRequireResolveAssetReference {
     pub path: Vc<AstPath>,
     pub issue_source: Vc<IssueSource>,
     pub in_try: bool,
+    pub ignore: bool,
 }
 
 #[turbo_tasks::value_impl]
@@ -199,6 +206,7 @@ impl CjsRequireResolveAssetReference {
         path: Vc<AstPath>,
         issue_source: Vc<IssueSource>,
         in_try: bool,
+        ignore: bool,
     ) -> Vc<Self> {
         Self::cell(CjsRequireResolveAssetReference {
             origin,
@@ -206,6 +214,7 @@ impl CjsRequireResolveAssetReference {
             path,
             issue_source,
             in_try,
+            ignore,
         })
     }
 }
@@ -219,6 +228,7 @@ impl ModuleReference for CjsRequireResolveAssetReference {
             self.request,
             Some(self.issue_source),
             try_to_severity(self.in_try),
+            self.ignore,
         )
     }
 }
@@ -252,6 +262,7 @@ impl CodeGenerateable for CjsRequireResolveAssetReference {
                 self.request,
                 Some(self.issue_source),
                 try_to_severity(self.in_try),
+                self.ignore,
             ),
             Value::new(ChunkItem),
         )

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -31,6 +31,7 @@ pub struct EsmAsyncAssetReference {
     pub issue_source: Vc<IssueSource>,
     pub in_try: bool,
     pub import_externals: bool,
+    pub ignore: bool,
 }
 
 #[turbo_tasks::value_impl]
@@ -43,6 +44,7 @@ impl EsmAsyncAssetReference {
         issue_source: Vc<IssueSource>,
         in_try: bool,
         import_externals: bool,
+        ignore: bool,
     ) -> Vc<Self> {
         Self::cell(EsmAsyncAssetReference {
             origin,
@@ -51,6 +53,7 @@ impl EsmAsyncAssetReference {
             issue_source,
             in_try,
             import_externals,
+            ignore,
         })
     }
 }
@@ -65,6 +68,7 @@ impl ModuleReference for EsmAsyncAssetReference {
             Value::new(EcmaScriptModulesReferenceSubType::DynamicImport),
             try_to_severity(self.in_try),
             Some(self.issue_source),
+            self.ignore,
         )
     }
 }
@@ -104,6 +108,7 @@ impl CodeGenerateable for EsmAsyncAssetReference {
                 Value::new(EcmaScriptModulesReferenceSubType::DynamicImport),
                 try_to_severity(self.in_try),
                 Some(self.issue_source),
+                self.ignore,
             ),
             if matches!(
                 *chunking_context.environment().chunk_loading().await?,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2103,7 +2103,7 @@ async fn handle_free_var_reference(
                     None => None,
                 },
                 state.import_externals,
-                true,
+                false,
             )
             .resolve()
             .await?;

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -176,7 +176,7 @@ impl RequireContextMap {
         for (context_relative, path) in list {
             if let Some(origin_relative) = origin_path.get_relative_path_to(&*path.await?) {
                 let request = Request::parse(Value::new(origin_relative.clone().into()));
-                let result = cjs_resolve(origin, request, issue_source, issue_severity);
+                let result = cjs_resolve(origin, request, issue_source, issue_severity, false);
 
                 map.insert(
                     context_relative.clone(),

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
@@ -13,7 +13,7 @@ use crate::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
         EcmascriptChunkType,
     },
-    EcmascriptAnalyzable, EcmascriptModuleContent,
+    EcmascriptModuleContent,
 };
 
 /// The chunk item for [EcmascriptModuleLocalsModule].

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -19,7 +19,7 @@ use crate::{
         async_module::OptionAsyncModule,
         esm::{EsmExport, EsmExports},
     },
-    EcmascriptAnalyzable, EcmascriptModuleAsset,
+    EcmascriptModuleAsset,
 };
 
 /// A module derived from an original ecmascript module that only contains the

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -1,7 +1,4 @@
-use std::collections::HashSet;
-
 use anyhow::{Context, Result};
-use swc_core::common::Span;
 use turbo_tasks::Vc;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -62,11 +59,7 @@ impl EcmascriptAnalyzable for EcmascriptModulePartAsset {
     async fn analyze(self: Vc<Self>) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
         let this = self.await?;
         let part = this.part;
-        Ok(analyse_ecmascript_module(
-            this.full_module,
-            Some(part),
-            None,
-        ))
+        Ok(analyse_ecmascript_module(this.full_module, Some(part)))
     }
 
     #[turbo_tasks::function]
@@ -138,7 +131,7 @@ impl Module for EcmascriptModulePartAsset {
     async fn references(&self) -> Result<Vc<ModuleReferences>> {
         let split_data = split_module(self.full_module).await?;
 
-        let analyze = analyze(self.full_module, self.part, None).await?;
+        let analyze = analyze(self.full_module, self.part).await?;
 
         let (deps, entrypoints) = match &*split_data {
             SplitResult::Ok {
@@ -271,7 +264,7 @@ impl EcmascriptModulePartAsset {
     pub(super) async fn analyze(self: Vc<Self>) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
         let this = self.await?;
 
-        Ok(analyze(this.full_module, this.part, None))
+        Ok(analyze(this.full_module, this.part))
     }
 }
 
@@ -279,9 +272,8 @@ impl EcmascriptModulePartAsset {
 fn analyze(
     module: Vc<EcmascriptModuleAsset>,
     part: Vc<ModulePart>,
-    ignored_spans: Option<Vc<HashSet<Span>>>,
 ) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
-    Ok(analyse_ecmascript_module(module, Some(part), ignored_spans))
+    Ok(analyse_ecmascript_module(module, Some(part)))
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -182,7 +182,13 @@ impl CompilerReference {
 impl ModuleReference for CompilerReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        cjs_resolve(self.origin, self.request, None, IssueSeverity::Error.cell())
+        cjs_resolve(
+            self.origin,
+            self.request,
+            None,
+            IssueSeverity::Error.cell(),
+            false,
+        )
     }
 }
 
@@ -251,7 +257,13 @@ impl TsNodeRequireReference {
 impl ModuleReference for TsNodeRequireReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        cjs_resolve(self.origin, self.request, None, IssueSeverity::Error.cell())
+        cjs_resolve(
+            self.origin,
+            self.request,
+            None,
+            IssueSeverity::Error.cell(),
+            false,
+        )
     }
 }
 

--- a/turbopack/crates/turbopack-resolve/src/ecmascript.rs
+++ b/turbopack/crates/turbopack-resolve/src/ecmascript.rs
@@ -80,12 +80,22 @@ pub async fn esm_resolve(
     ty: Value<EcmaScriptModulesReferenceSubType>,
     issue_severity: Vc<IssueSeverity>,
     issue_source: Option<Vc<IssueSource>>,
+    ignore: bool,
 ) -> Result<Vc<ModuleResolveResult>> {
     let ty = Value::new(ReferenceType::EcmaScriptModules(ty.into_value()));
     let options = apply_esm_specific_options(origin.resolve_options(ty.clone()), ty.clone())
         .resolve()
         .await?;
-    specific_resolve(origin, request, options, ty, issue_severity, issue_source).await
+    specific_resolve(
+        origin,
+        request,
+        options,
+        ty,
+        issue_severity,
+        issue_source,
+        ignore,
+    )
+    .await
 }
 
 #[turbo_tasks::function]
@@ -94,13 +104,23 @@ pub async fn cjs_resolve(
     request: Vc<Request>,
     issue_source: Option<Vc<IssueSource>>,
     issue_severity: Vc<IssueSeverity>,
+    ignore: bool,
 ) -> Result<Vc<ModuleResolveResult>> {
     // TODO pass CommonJsReferenceSubType
     let ty = Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined));
     let options = apply_cjs_specific_options(origin.resolve_options(ty.clone()))
         .resolve()
         .await?;
-    specific_resolve(origin, request, options, ty, issue_severity, issue_source).await
+    specific_resolve(
+        origin,
+        request,
+        options,
+        ty,
+        issue_severity,
+        issue_source,
+        ignore,
+    )
+    .await
 }
 
 #[turbo_tasks::function]
@@ -141,7 +161,12 @@ async fn specific_resolve(
     reference_type: Value<ReferenceType>,
     issue_severity: Vc<IssueSeverity>,
     issue_source: Option<Vc<IssueSource>>,
+    ignore: bool,
 ) -> Result<Vc<ModuleResolveResult>> {
+    if ignore {
+        return Ok(ModuleResolveResult::ignored().cell());
+    }
+
     let result = origin.resolve_asset(request, options, reference_type.clone());
 
     handle_resolve_error(

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/ignore/import/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/ignore/import/input/index.js
@@ -1,0 +1,27 @@
+it('should ignore webpackIgnore comments', async () => {
+  const _webpackImportIgnore = await import(
+    /* webpackIgnore: true */ './ignore.js'
+  )
+  // just the fact that this doesn't fail in bundling is enough
+})
+
+it('should ignore turbopackIgnore comments', async () => {
+  const _turbopackImportIgnore = await import(
+    /* turbopackIgnore: true */ './ignore.js'
+  )
+  // just the fact that this doesn't fail in bundling is enough
+})
+
+it('should not ignore webpackIgnore comments', async () => {
+  const webpackImportNotIgnore = await import(
+    /* webpackIgnore: false */ './util.js'
+  )
+  expect(webpackImportNotIgnore).toBeDefined()
+})
+
+it('should not ignore turbopackIgnore comments', async () => {
+  const turbopackImportNotIgnore = await import(
+    /* turbopackIgnore: false */ './util.js'
+  )
+  expect(turbopackImportNotIgnore).toBeDefined()
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/ignore/import/input/util.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/ignore/import/input/util.js
@@ -1,0 +1,1 @@
+export default "util";

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/ignore/require/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/ignore/require/input/index.js
@@ -1,0 +1,19 @@
+it('should ignore webpackIgnore comments', async () => {
+  const _webpackImportIgnore = require(/* webpackIgnore: true */ './ignore.js')
+  // just the fact that this doesn't fail in bundling is enough
+})
+
+it('should ignore turbopackIgnore comments', async () => {
+  const _turbopackImportIgnore = require(/* turbopackIgnore: true */ './ignore.js')
+  // just the fact that this doesn't fail in bundling is enough
+})
+
+it('should not ignore webpackIgnore comments', async () => {
+  const webpackImportNotIgnore = require(/* webpackIgnore: false */ './util.js')
+  expect(webpackImportNotIgnore).toBeDefined()
+})
+
+it('should not ignore turbopackIgnore comments', async () => {
+  const turbopackImportNotIgnore = require(/* turbopackIgnore: false */ './util.js')
+  expect(turbopackImportNotIgnore).toBeDefined()
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/ignore/require/input/util.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/ignore/require/input/util.js
@@ -1,0 +1,1 @@
+export default "util";


### PR DESCRIPTION
### What?

Certain bundles may be designed specifically to be included at runtime. To support this usecase, webpack implemented a comment directive `webpackIgnore` that opted out that particular import from bundle time optimisations. We need to support this, as some libraries take advantage of this (mapbox).

### Why?

Parity with webpack and library support.

### How?

Following #68451, we consult the newly collected ignore metadata at link time to specifically return `ModuleResolveResult::ignored()`. This is handled similarly to the try block special case. In the future we may consider breaking this out to curb the proliferation of boolean flags through the analysis code.

Closes PACK-3046

