### PR TITLE
[devlow-bench] fail with non-zero exit and restore file.js

### DIFF
--- a/turbopack/packages/devlow-bench/src/cli.ts
+++ b/turbopack/packages/devlow-bench/src/cli.ts
@@ -111,4 +111,5 @@ import { pathToFileURL } from "url";
   await runScenarios(scenarios, compose(...ifaces));
 })().catch((e) => {
   console.error(e.stack);
+  process.exit(1);
 });

--- a/turbopack/packages/devlow-bench/src/file.ts
+++ b/turbopack/packages/devlow-bench/src/file.ts
@@ -1,0 +1,60 @@
+import { watch } from 'fs'
+import { access, constants } from 'fs/promises'
+import { dirname } from 'path'
+
+export async function waitForFile(
+  path: string,
+  timeout: number
+): Promise<void> {
+  let currentAction = ''
+  let timeoutRef
+  const timeoutPromise = new Promise<void>((resolve, reject) => {
+    timeoutRef = setTimeout(() => {
+      reject(
+        new Error(`Timed out waiting for file ${path} (${currentAction}))`)
+      )
+    }, timeout || 60000)
+  })
+  const elements: string[] = []
+  let current = path
+  while (true) {
+    elements.push(current)
+    const parent = dirname(current)
+    if (parent === current) {
+      break
+    }
+    current = parent
+  }
+  elements.reverse()
+  try {
+    for (const path of elements) {
+      const checkAccess = () =>
+        access(path, constants.F_OK)
+          .then(() => true)
+          .catch(() => false)
+      if (!(await checkAccess())) {
+        let resolveCheckAgain = () => {}
+        const watcher = watch(dirname(path), () => {
+          resolveCheckAgain()
+        })
+        currentAction = `waiting for ${path}`
+        let checkAgainPromise = new Promise<void>((resolve) => {
+          resolveCheckAgain = resolve
+        })
+        try {
+          do {
+            await Promise.race([timeoutPromise, checkAgainPromise])
+            // eslint-disable-next-line no-loop-func
+            checkAgainPromise = new Promise<void>((resolve) => {
+              resolveCheckAgain = resolve
+            })
+          } while (!(await checkAccess()))
+        } finally {
+          watcher.close()
+        }
+      }
+    }
+  } finally {
+    clearTimeout(timeoutRef)
+  }
+}

--- a/turbopack/packages/devlow-bench/src/interfaces/console.ts
+++ b/turbopack/packages/devlow-bench/src/interfaces/console.ts
@@ -1,7 +1,9 @@
+import picocolors from "picocolors";
 import { Interface } from "../index.js";
-import { bgCyan, bold, magenta, red, underline } from "picocolors";
 import { formatUnit } from "../units.js";
 import { formatVariant } from "../utils.js";
+
+const { bgCyan, bold, magenta, red, underline } = picocolors;
 
 export default function createInterface(): Interface {
   const iface: Interface = {


### PR DESCRIPTION
devlow-bench regressed, and it went unnoticed since the cli simply logged a stack and exited the process normally [0], so CI continued passing. This corrects that by exiting the process with a non-zero code.

This also fixes the cause of the regression, where `file.js` was not brought over during the repo merge.

Test Plan: devlow-bench job in CI.

[0] https://github.com/vercel/next.js/blob/cc484b996ad235c4a5acc284c099c2d5cab8c72d/turbopack/packages/devlow-bench/src/cli.ts#L112-L114
