### PR TITLE
bugfix: ensure rsc isn't reused for page segments when reusing loading data

### DIFF
--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
@@ -4,6 +4,7 @@ import { invalidateCacheByRouterState } from './invalidate-cache-by-router-state
 import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-head'
 import { createRouterCacheKey } from './create-router-cache-key'
 import type { PrefetchCacheEntry } from './router-reducer-types'
+import { PAGE_SEGMENT_KEY } from '../../../shared/lib/segment'
 
 /**
  * Common logic for filling cache with new sub tree data.
@@ -46,11 +47,15 @@ function fillCacheHelper(
         !childCacheNode.lazyData ||
         childCacheNode === existingChildCacheNode)
     ) {
+      const incomingSegment = cacheNodeSeedData[0]
       const rsc = cacheNodeSeedData[1]
       const loading = cacheNodeSeedData[3]
+
       childCacheNode = {
         lazyData: null,
-        rsc,
+        // When `fillLazyItems` is false, we only want to fill the RSC data for the layout,
+        // not the page segment.
+        rsc: fillLazyItems || incomingSegment !== PAGE_SEGMENT_KEY ? rsc : null,
         prefetchRsc: null,
         head: null,
         prefetchHead: null,

--- a/test/e2e/app-dir/searchparams-reuse-loading/app/search/page.tsx
+++ b/test/e2e/app-dir/searchparams-reuse-loading/app/search/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { Search } from './search'
 
 export default async function Page({ searchParams }: { searchParams: any }) {
@@ -7,6 +8,9 @@ export default async function Page({ searchParams }: { searchParams: any }) {
     <main id="page-content">
       <Search />
       <p id="search-value">Search Value: {searchParams.q ?? 'None'}</p>
+      <Link href="/search" prefetch>
+        Home
+      </Link>
     </main>
   )
 }


### PR DESCRIPTION
Follow up to #68340: When a prefetch is aliased (meaning we returned a prefetch entry that corresponded with the same pathname, but different / missing search params), we signal to the router that it should only copy the loading state from this prefetch entry, and null everything else out so it can be fetched from the server. In the original implementation I was always copying over `rsc`, but `rsc` can correspond with the page segment data, meaning we'd potentially be copying over the final page data as well. We should only copy over the `rsc` portion of the `CacheNode` if we know it's not the page segment.

To catch this regression I added a link with a full prefetch on the existing test cases for this, which causes the test to fail without this patch applied because it'll copy over the full prefetch RSC data and not actually fetch new data from the server. 