### PR TITLE
Turbopack: fix issue source location for special exports

### DIFF
--- a/crates/next-core/src/app_segment_config.rs
+++ b/crates/next-core/src/app_segment_config.rs
@@ -312,7 +312,7 @@ pub async fn parse_segment_config_from_source(
 }
 
 fn issue_source(source: Vc<Box<dyn Source>>, span: Span) -> Vc<IssueSource> {
-    IssueSource::from_byte_offset(source, span.lo.to_usize(), span.hi.to_usize())
+    IssueSource::from_swc_offsets(source, span.lo.to_usize(), span.hi.to_usize())
 }
 
 fn parse_config_value(


### PR DESCRIPTION
Before:
```
 ✓ Compiled / in 2.4s
 ⚠ ./bench/basic-app/app/page.js:7:25
Unable to parse config export in source file1
  5 | }
  6 |
> 7 | export const dynamic = 'force-dynamicc'
    |                         ^^^^^^^^^^^^^^^
> 8 |
    | ^
```

After:
```
 ⚠ ./bench/basic-app/app/page.js:7:24
Unable to parse config export in source file1
  5 | }
  6 |
> 7 | export const dynamic = 'force-dynamicc'
    |                        ^^^^^^^^^^^^^^^^
  8 |
```