### PR TITLE
docs: add missing colons `:` to Good to Knows

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/09-colocation.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/09-colocation.mdx
@@ -84,7 +84,7 @@ Since files in the `app` directory can be [safely colocated by default](#safe-co
 - Sorting and grouping files in code editors.
 - Avoiding potential naming conflicts with future Next.js file conventions.
 
-> **Good to know**
+> **Good to know**:
 >
 > - While not a framework convention, you might also consider marking files outside private folders as "private" using the same underscore pattern.
 > - You can create URL segments that start with an underscore by prefixing the folder name with `%5F` (the URL-encoded form of an underscore): `%5FfolderName`.

--- a/docs/02-app/01-building-your-application/06-optimizing/09-instrumentation.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/09-instrumentation.mdx
@@ -38,7 +38,7 @@ export function register() {
 
 See the [Next.js with OpenTelemetry example](https://github.com/vercel/next.js/tree/canary/examples/with-opentelemetry) for a complete implementation.
 
-> **Good to know**
+> **Good to know**:
 >
 > - This feature is **experimental**. To use it, you must explicitly opt in by defining [`experimental.instrumentationHook = true;`](/docs/app/api-reference/next-config-js/instrumentationHook) in your `next.config.js`.
 > - The `instrumentation` file should be in the root of your project and not inside the `app` or `pages` directory. If you're using the `src` folder, then place the file inside `src` alongside `pages` and `app`.

--- a/docs/02-app/01-building-your-application/06-optimizing/10-open-telemetry.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/10-open-telemetry.mdx
@@ -65,7 +65,7 @@ See the [`@vercel/otel` documentation](https://www.npmjs.com/package/@vercel/ote
 
 <AppOnly>
 
-> **Good to know**
+> **Good to know**:
 >
 > - The `instrumentation` file should be in the root of your project and not inside the `app` or `pages` directory. If you're using the `src` folder, then place the file inside `src` alongside `pages` and `app`.
 > - If you use the [`pageExtensions` config option](/docs/app/api-reference/next-config-js/pageExtensions) to add a suffix, you will also need to update the `instrumentation` filename to match.
@@ -75,7 +75,7 @@ See the [`@vercel/otel` documentation](https://www.npmjs.com/package/@vercel/ote
 
 <PagesOnly>
 
-> **Good to know**
+> **Good to know**:
 >
 > - The `instrumentation` file should be in the root of your project and not inside the `app` or `pages` directory. If you're using the `src` folder, then place the file inside `src` alongside `pages` and `app`.
 > - If you use the [`pageExtensions` config option](/docs/pages/api-reference/next-config-js/pageExtensions) to add a suffix, you will also need to update the `instrumentation` filename to match.

--- a/docs/02-app/01-building-your-application/07-configuring/06-src-directory.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/06-src-directory.mdx
@@ -22,7 +22,7 @@ To use the `src` directory, move the `app` Router folder or `pages` Router folde
   height="687"
 />
 
-> **Good to know**
+> **Good to know**:
 >
 > - The `/public` directory should remain in the root of your project.
 > - Config files like `package.json`, `next.config.js` and `tsconfig.json` should remain in the root of your project.

--- a/docs/02-app/02-api-reference/02-file-conventions/01-metadata/app-icons.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/01-metadata/app-icons.mdx
@@ -59,7 +59,7 @@ Add an `apple-icon.(jpg|jpeg|png)` image file.
 />
 ```
 
-> **Good to know**
+> **Good to know**:
 >
 > - You can set multiple icons by adding a number suffix to the file name. For example, `icon1.png`, `icon2.png`, etc. Numbered files will sort lexically.
 > - Favicons can only be set in the root `/app` segment. If you need more granularity, you can use [`icon`](#icon).
@@ -164,7 +164,7 @@ export default function Icon() {
 <link rel="icon" href="/icon?<generated>" type="image/png" sizes="32x32" />
 ```
 
-> **Good to know**
+> **Good to know**:
 >
 > - By default, generated icons are [**statically optimized**](/docs/app/building-your-application/rendering/server-components#static-rendering-default) (generated at build time and cached) unless they use [dynamic functions](/docs/app/building-your-application/rendering/server-components#server-rendering-strategies#dynamic-functions) or uncached data.
 > - You can generate multiple icons in the same file using [`generateImageMetadata`](/docs/app/api-reference/functions/generate-image-metadata).

--- a/docs/02-app/02-api-reference/02-file-conventions/01-metadata/opengraph-image.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/01-metadata/opengraph-image.mdx
@@ -82,7 +82,7 @@ Generate a route segment's shared image by creating an `opengraph-image` or `twi
 | `opengraph-image` | `.js`, `.ts`, `.tsx` |
 | `twitter-image`   | `.js`, `.ts`, `.tsx` |
 
-> **Good to know**
+> **Good to know**:
 >
 > - By default, generated images are [**statically optimized**](/docs/app/building-your-application/rendering/server-components#static-rendering-default) (generated at build time and cached) unless they use [dynamic functions](/docs/app/building-your-application/rendering/server-components#server-rendering-strategies#dynamic-functions) or uncached data.
 > - You can generate multiple Images in the same file using [`generateImageMetadata`](/docs/app/api-reference/functions/generate-image-metadata).

--- a/docs/02-app/02-api-reference/02-file-conventions/loading.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/loading.mdx
@@ -23,7 +23,7 @@ export default function Loading() {
 
 Loading UI components do not accept any parameters.
 
-> **Good to know**
+> **Good to know**:
 >
 > - While designing loading UI, you may find it helpful to use the [React Developer Tools](https://react.dev/learn/react-developer-tools) to manually toggle Suspense boundaries.
 

--- a/docs/02-app/02-api-reference/04-functions/generate-static-params.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-static-params.mdx
@@ -23,7 +23,7 @@ export default function Page({ params }) {
 }
 ```
 
-> **Good to know**
+> **Good to know**:
 >
 > - You can use the [`dynamicParams`](/docs/app/api-reference/file-conventions/route-segment-config#dynamicparams) segment config option to control what happens when a dynamic segment is visited that was not generated with `generateStaticParams`.
 > - You must return [an empty array from `generateStaticParams`](#all-paths-at-build-time) or utilize [`export const dynamic = 'force-static'`](/docs/app/api-reference/file-conventions/route-segment-config#dynamic) in order to revalidate (ISR) [paths at runtime](#all-paths-at-runtime).

--- a/docs/03-pages/01-building-your-application/01-routing/05-custom-app.mdx
+++ b/docs/03-pages/01-building-your-application/01-routing/05-custom-app.mdx
@@ -31,7 +31,7 @@ The `Component` prop is the active `page`, so whenever you navigate between rout
 
 `pageProps` is an object with the initial props that were preloaded for your page by one of our [data fetching methods](/docs/pages/building-your-application/data-fetching), otherwise it's an empty object.
 
-> **Good to know**
+> **Good to know**:
 >
 > - If your app is running and you added a custom `App`, you'll need to restart the development server. Only required if `pages/_app.js` didn't exist before.
 > - `App` does not support Next.js [Data Fetching methods](/docs/pages/building-your-application/data-fetching) like [`getStaticProps`](/docs/pages/building-your-application/data-fetching/get-static-props) or [`getServerSideProps`](/docs/pages/building-your-application/data-fetching/get-server-side-props).

--- a/docs/03-pages/01-building-your-application/01-routing/06-custom-document.mdx
+++ b/docs/03-pages/01-building-your-application/01-routing/06-custom-document.mdx
@@ -39,7 +39,7 @@ export default function Document() {
 }
 ```
 
-> **Good to know**
+> **Good to know**:
 >
 > - `_document` is only rendered on the server, so event handlers like `onClick` cannot be used in this file.
 > - `<Html>`, `<Head />`, `<Main />` and `<NextScript />` are required for the page to be properly rendered.
@@ -141,7 +141,7 @@ class MyDocument extends Document {
 export default MyDocument
 ```
 
-> **Good to know**
+> **Good to know**:
 >
 > - `getInitialProps` in `_document` is not called during client-side transitions.
 > - The `ctx` object for `_document` is equivalent to the one received in [`getInitialProps`](/docs/pages/api-reference/functions/get-initial-props#context-object), with the addition of `renderPage`.


### PR DESCRIPTION
### Why?

Most Good to Know have colons `:`, but some are missing.

This PR added the missing colons `:` to the "Good to Know" sections.