### PR TITLE
docs: inform middleware usage along with metadata files

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/14-middleware.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/14-middleware.mdx
@@ -110,9 +110,9 @@ export const config = {
      * - api (API routes)
      * - _next/static (static files)
      * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
+     * - favicon.ico, sitemap.xml, robots.txt (metadata files)
      */
-    '/((?!api|_next/static|_next/image|favicon.ico).*)',
+    '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
   ],
 }
 ```
@@ -127,10 +127,11 @@ export const config = {
      * - api (API routes)
      * - _next/static (static files)
      * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
+     * - favicon.ico, sitemap.xml, robots.txt (metadata files)
      */
     {
-      source: '/((?!api|_next/static|_next/image|favicon.ico).*)',
+      source:
+        '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
       missing: [
         { type: 'header', key: 'next-router-prefetch' },
         { type: 'header', key: 'purpose', value: 'prefetch' },
@@ -138,7 +139,8 @@ export const config = {
     },
 
     {
-      source: '/((?!api|_next/static|_next/image|favicon.ico).*)',
+      source:
+        '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
       has: [
         { type: 'header', key: 'next-router-prefetch' },
         { type: 'header', key: 'purpose', value: 'prefetch' },
@@ -146,7 +148,8 @@ export const config = {
     },
 
     {
-      source: '/((?!api|_next/static|_next/image|favicon.ico).*)',
+      source:
+        '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
       has: [{ type: 'header', key: 'x-present' }],
       missing: [{ type: 'header', key: 'x-missing', value: 'prefetch' }],
     },

--- a/docs/02-app/02-api-reference/02-file-conventions/01-metadata/index.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/01-metadata/index.mdx
@@ -10,4 +10,7 @@ Each file convention can be defined using a static file (e.g. `opengraph-image.j
 
 Once a file is defined, Next.js will automatically serve the file (with hashes in production for caching) and update the relevant head elements with the correct metadata, such as the asset's URL, file type, and image size.
 
-> **Good to know**: Special Route Handlers like [`sitemap.ts`](/docs/app/api-reference/file-conventions/metadata/sitemap), [`opengraph-image.tsx`](/docs/app/api-reference/file-conventions/metadata/opengraph-image), and [`icon.tsx`](/docs/app/api-reference/file-conventions/metadata/app-icons), and other [metadata files](/docs/app/api-reference/file-conventions/metadata) are cached by default.
+> **Good to know**:
+>
+> - Special Route Handlers like [`sitemap.ts`](/docs/app/api-reference/file-conventions/metadata/sitemap), [`opengraph-image.tsx`](/docs/app/api-reference/file-conventions/metadata/opengraph-image), and [`icon.tsx`](/docs/app/api-reference/file-conventions/metadata/app-icons), and other [metadata files](/docs/app/api-reference/file-conventions/metadata) are cached by default.
+> - If using along with [`middleware.ts`](/docs/app/api-reference/file-conventions/middleware), [configure the matcher](/docs/app/building-your-application/routing/middleware#matcher) to exclude the metadata files.


### PR DESCRIPTION
### What?

When the user sets `robots.ts`, `sitemap.ts`, or other metadata files with `middleware.ts`, it may end in unexpected behavior if the middleware matcher is not set to ignore the corresponding paths.

### Why? 

The docs are missing the information for the users to "**configure middleware matcher if you have one along with generating metadata files to prevent route interference**".

### How?

Updated the docs to add the matcher configuration as:

```ts
export const config = {
  matcher: [
    /*
     * Match all request paths except for the ones starting with:
     * - api (API routes)
     * - _next/static (static files)
     * - _next/image (image optimization files)
     * - favicon.ico, sitemap.xml, robots.txt (metadata files) <--- combined here
     */
    '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
  ],
}
```

Added a "Good to Know" at the [entry of metadata API](https://nextjs.org/docs/app/api-reference/file-conventions/metadata) to configure the middleware matcher if used.

Closes NDX-219