### PR TITLE
Ensure assertion failures include all versions in rsc-basic tests

### DIFF
--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -653,75 +653,77 @@ describe('app dir - rsc basics', () => {
               ${flag}: true
             }
           }
-          `
+          `,
+          async () => {
+            await next.start()
+            const resPages$ = await next.render$('/app-react')
+            const [
+              ssrReact,
+              ssrReactDOM,
+              ssrReactDOMServer,
+              ssrClientReact,
+              ssrClientReactDOM,
+              ssrClientReactDOMServer,
+            ] = [
+              resPages$('#react').text(),
+              resPages$('#react-dom').text(),
+              resPages$('#react-dom-server').text(),
+              resPages$('#client-react').text(),
+              resPages$('#client-react-dom').text(),
+              resPages$('#client-react-dom-server').text(),
+            ]
+            expect({
+              ssrReact,
+              ssrReactDOM,
+              ssrReactDOMServer,
+              ssrClientReact,
+              ssrClientReactDOM,
+              ssrClientReactDOMServer,
+            }).toEqual({
+              ssrReact: expect.stringMatching('-experimental-'),
+              ssrReactDOM: expect.stringMatching('-experimental-'),
+              ssrReactDOMServer: expect.stringMatching('-experimental-'),
+              ssrClientReact: expect.stringMatching('-experimental-'),
+              ssrClientReactDOM: expect.stringMatching('-experimental-'),
+              ssrClientReactDOMServer: expect.stringMatching('-experimental-'),
+            })
+
+            const browser = await next.browser('/app-react')
+            const [
+              browserReact,
+              browserReactDOM,
+              browserReactDOMServer,
+              browserClientReact,
+              browserClientReactDOM,
+              browserClientReactDOMServer,
+            ] = await browser.eval(`
+              [
+                document.querySelector('#react').innerText,
+                document.querySelector('#react-dom').innerText,
+                document.querySelector('#react-dom-server').innerText,
+                document.querySelector('#client-react').innerText,
+                document.querySelector('#client-react-dom').innerText,
+                document.querySelector('#client-react-dom-server').innerText,
+              ]
+            `)
+            expect({
+              browserReact,
+              browserReactDOM,
+              browserReactDOMServer,
+              browserClientReact,
+              browserClientReactDOM,
+              browserClientReactDOMServer,
+            }).toEqual({
+              browserReact: expect.stringMatching('-experimental-'),
+              browserReactDOM: expect.stringMatching('-experimental-'),
+              browserReactDOMServer: expect.stringMatching('-experimental-'),
+              browserClientReact: expect.stringMatching('-experimental-'),
+              browserClientReactDOM: expect.stringMatching('-experimental-'),
+              browserClientReactDOMServer:
+                expect.stringMatching('-experimental-'),
+            })
+          }
         )
-
-        await next.start()
-        const resPages$ = await next.render$('/app-react')
-        const [
-          ssrReact,
-          ssrReactDOM,
-          ssrReactDOMServer,
-          ssrClientReact,
-          ssrClientReactDOM,
-          ssrClientReactDOMServer,
-        ] = [
-          resPages$('#react').text(),
-          resPages$('#react-dom').text(),
-          resPages$('#react-dom-server').text(),
-          resPages$('#client-react').text(),
-          resPages$('#client-react-dom').text(),
-          resPages$('#client-react-dom-server').text(),
-        ]
-        expect({
-          ssrReact,
-          ssrReactDOM,
-          ssrReactDOMServer,
-          ssrClientReact,
-          ssrClientReactDOM,
-          ssrClientReactDOMServer,
-        }).toEqual({
-          ssrReact: expect.stringMatching('-experimental-'),
-          ssrReactDOM: expect.stringMatching('-experimental-'),
-          ssrReactDOMServer: expect.stringMatching('-experimental-'),
-          ssrClientReact: expect.stringMatching('-experimental-'),
-          ssrClientReactDOM: expect.stringMatching('-experimental-'),
-          ssrClientReactDOMServer: expect.stringMatching('-experimental-'),
-        })
-
-        const browser = await next.browser('/app-react')
-        const [
-          browserReact,
-          browserReactDOM,
-          browserReactDOMServer,
-          browserClientReact,
-          browserClientReactDOM,
-          browserClientReactDOMServer,
-        ] = await browser.eval(`
-          [
-            document.querySelector('#react').innerText,
-            document.querySelector('#react-dom').innerText,
-            document.querySelector('#react-dom-server').innerText,
-            document.querySelector('#client-react').innerText,
-            document.querySelector('#client-react-dom').innerText,
-            document.querySelector('#client-react-dom-server').innerText,
-          ]
-        `)
-        expect({
-          browserReact,
-          browserReactDOM,
-          browserReactDOMServer,
-          browserClientReact,
-          browserClientReactDOM,
-          browserClientReactDOMServer,
-        }).toEqual({
-          browserReact: expect.stringMatching('-experimental-'),
-          browserReactDOM: expect.stringMatching('-experimental-'),
-          browserReactDOMServer: expect.stringMatching('-experimental-'),
-          browserClientReact: expect.stringMatching('-experimental-'),
-          browserClientReactDOM: expect.stringMatching('-experimental-'),
-          browserClientReactDOMServer: expect.stringMatching('-experimental-'),
-        })
       }
     )
   })

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -658,21 +658,46 @@ describe('app dir - rsc basics', () => {
 
         await next.start()
         const resPages$ = await next.render$('/app-react')
-        const ssrPagesReactVersions = [
-          await resPages$('#react').text(),
-          await resPages$('#react-dom').text(),
-          await resPages$('#react-dom-server').text(),
-          await resPages$('#client-react').text(),
-          await resPages$('#client-react-dom').text(),
-          await resPages$('#client-react-dom-server').text(),
+        const [
+          ssrReact,
+          ssrReactDOM,
+          ssrReactDOMServer,
+          ssrClientReact,
+          ssrClientReactDOM,
+          ssrClientReactDOMServer,
+        ] = [
+          resPages$('#react').text(),
+          resPages$('#react-dom').text(),
+          resPages$('#react-dom-server').text(),
+          resPages$('#client-react').text(),
+          resPages$('#client-react-dom').text(),
+          resPages$('#client-react-dom-server').text(),
         ]
-
-        ssrPagesReactVersions.forEach((version) => {
-          expect(version).toMatch('-experimental-')
+        expect({
+          ssrReact,
+          ssrReactDOM,
+          ssrReactDOMServer,
+          ssrClientReact,
+          ssrClientReactDOM,
+          ssrClientReactDOMServer,
+        }).toEqual({
+          ssrReact: expect.stringMatching('-experimental-'),
+          ssrReactDOM: expect.stringMatching('-experimental-'),
+          ssrReactDOMServer: expect.stringMatching('-experimental-'),
+          ssrClientReact: expect.stringMatching('-experimental-'),
+          ssrClientReactDOM: expect.stringMatching('-experimental-'),
+          ssrClientReactDOMServer: expect.stringMatching('-experimental-'),
         })
 
         const browser = await next.browser('/app-react')
-        const browserAppReactVersions = await browser.eval(`
+        const [
+          browserReact,
+          browserReactDOM,
+          browserReactDOMServer,
+          browserClientReact,
+          browserClientReactDOM,
+          browserClientReactDOMServer,
+        ] = await browser.eval(`
           [
             document.querySelector('#react').innerText,
             document.querySelector('#react-dom').innerText,
@@ -682,9 +707,21 @@ describe('app dir - rsc basics', () => {
             document.querySelector('#client-react-dom-server').innerText,
           ]
         `)
-        browserAppReactVersions.forEach((version) =>
-          expect(version).toMatch('-experimental-')
-        )
+        expect({
+          browserReact,
+          browserReactDOM,
+          browserReactDOMServer,
+          browserClientReact,
+          browserClientReactDOM,
+          browserClientReactDOMServer,
+        }).toEqual({
+          browserReact: expect.stringMatching('-experimental-'),
+          browserReactDOM: expect.stringMatching('-experimental-'),
+          browserReactDOMServer: expect.stringMatching('-experimental-'),
+          browserClientReact: expect.stringMatching('-experimental-'),
+          browserClientReactDOM: expect.stringMatching('-experimental-'),
+          browserClientReactDOMServer: expect.stringMatching('-experimental-'),
+        })
       }
     )
   })

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -542,21 +542,48 @@ describe('app dir - rsc basics', () => {
 
   it('should use canary react for app', async () => {
     const resPages$ = await next.render$('/app-react')
-    const ssrPagesReactVersions = [
-      await resPages$('#react').text(),
-      await resPages$('#react-dom').text(),
-      await resPages$('#react-dom-server').text(),
-      await resPages$('#client-react').text(),
-      await resPages$('#client-react-dom').text(),
-      await resPages$('#client-react-dom-server').text(),
+    const [
+      ssrReact,
+      ssrReactDOM,
+      ssrReactDOMServer,
+      ssrClientReact,
+      ssrClientReactDOM,
+      ssrClientReactDOMServer,
+    ] = [
+      resPages$('#react').text(),
+      resPages$('#react-dom').text(),
+      resPages$('#react-dom-server').text(),
+      resPages$('#client-react').text(),
+      resPages$('#client-react-dom').text(),
+      resPages$('#client-react-dom-server').text(),
     ]
-
-    ssrPagesReactVersions.forEach((version) => {
-      expect(version).toMatch(bundledReactVersionPattern)
+    expect({
+      ssrReact,
+      ssrReactDOM,
+      ssrReactDOMServer,
+      ssrClientReact,
+      ssrClientReactDOM,
+      ssrClientReactDOMServer,
+    }).toEqual({
+      ssrReact: expect.stringMatching(bundledReactVersionPattern),
+      ssrReactDOM: expect.stringMatching(bundledReactVersionPattern),
+      ssrReactDOMServer: expect.stringMatching(bundledReactVersionPattern),
+      ssrClientReact: expect.stringMatching(bundledReactVersionPattern),
+      ssrClientReactDOM: expect.stringMatching(bundledReactVersionPattern),
+      ssrClientReactDOMServer: expect.stringMatching(
+        bundledReactVersionPattern
+      ),
     })
 
     const browser = await next.browser('/app-react')
-    const browserAppReactVersions = await browser.eval(`
+    const [
+      browserReact,
+      browserReactDOM,
+      browserReactDOMServer,
+      browserClientReact,
+      browserClientReactDOM,
+      browserClientReactDOMServer,
+    ] = await browser.eval(`
       [
         document.querySelector('#react').innerText,
         document.querySelector('#react-dom').innerText,
@@ -566,9 +593,23 @@ describe('app dir - rsc basics', () => {
         document.querySelector('#client-react-dom-server').innerText,
       ]
     `)
-    browserAppReactVersions.forEach((version) =>
-      expect(version).toMatch(bundledReactVersionPattern)
-    )
+    expect({
+      browserReact,
+      browserReactDOM,
+      browserReactDOMServer,
+      browserClientReact,
+      browserClientReactDOM,
+      browserClientReactDOMServer,
+    }).toEqual({
+      browserReact: expect.stringMatching(bundledReactVersionPattern),
+      browserReactDOM: expect.stringMatching(bundledReactVersionPattern),
+      browserReactDOMServer: expect.stringMatching(bundledReactVersionPattern),
+      browserClientReact: expect.stringMatching(bundledReactVersionPattern),
+      browserClientReactDOM: expect.stringMatching(bundledReactVersionPattern),
+      browserClientReactDOMServer: expect.stringMatching(
+        bundledReactVersionPattern
+      ),
+    })
   })
 
   it('should be able to call legacy react-dom/server APIs in client components', async () => {


### PR DESCRIPTION
We're starting to see test failures but without a useful message:
>  Expected substring: "-experimental-"
>  Received string:    ""
-- https://github.com/vercel/next.js/actions/runs/10481716237/job/29032218695#step:29:612

Since it's caused by a version mismatch this may not help but it's best practice to assert on the whole thing anyway.