### PR TITLE
Ensure vendored `react-dom/server.browser` is used

### DIFF
--- a/packages/next/src/build/create-compiler-aliases.ts
+++ b/packages/next/src/build/create-compiler-aliases.ts
@@ -266,6 +266,7 @@ export function createRSCAliases(
     'react/compiler-runtime$': `next/dist/compiled/react${bundledReactChannel}/compiler-runtime`,
     'react-dom/client$': `next/dist/compiled/react-dom${bundledReactChannel}/client`,
     'react-dom/server$': `next/dist/compiled/react-dom${bundledReactChannel}/server`,
+    'react-dom/server.browser$': `next/dist/compiled/react-dom${bundledReactChannel}/server.browser`,
     'react-dom/static$': `next/dist/compiled/react-dom${bundledReactChannel}/static`,
     'react-dom/static.edge$': `next/dist/compiled/react-dom${bundledReactChannel}/static.edge`,
     'react-dom/static.browser$': `next/dist/compiled/react-dom${bundledReactChannel}/static.browser`,

--- a/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
+++ b/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
@@ -39,8 +39,8 @@ describe('react-dom/server in React Server environment', () => {
       '/exports/app-code/react-dom-server-browser-explicit'
     )
 
+    await assertNoRedbox(browser)
     if (isTurbopack) {
-      await assertNoRedbox(browser)
       if (isReactExperimental) {
         expect(await browser.elementByCss('main').text())
           .toMatchInlineSnapshot(`
@@ -83,7 +83,47 @@ describe('react-dom/server in React Server environment', () => {
         `)
       }
     } else {
-      await assertHasRedbox(browser)
+      if (isReactExperimental) {
+        expect(await browser.elementByCss('main').text())
+          .toMatchInlineSnapshot(`
+          "{
+            "default": [
+              "renderToReadableStream",
+              "renderToStaticMarkup",
+              "renderToString",
+              "resume",
+              "version"
+            ],
+            "named": [
+              "default",
+              "renderToReadableStream",
+              "renderToStaticMarkup",
+              "renderToString",
+              "resume",
+              "version"
+            ]
+          }"
+        `)
+      } else {
+        expect(await browser.elementByCss('main').text())
+          .toMatchInlineSnapshot(`
+          "{
+            "default": [
+              "renderToReadableStream",
+              "renderToStaticMarkup",
+              "renderToString",
+              "version"
+            ],
+            "named": [
+              "default",
+              "renderToReadableStream",
+              "renderToStaticMarkup",
+              "renderToString",
+              "version"
+            ]
+          }"
+        `)
+      }
     }
     const redbox = {
       description: await getRedboxDescription(browser),
@@ -99,7 +139,7 @@ describe('react-dom/server in React Server environment', () => {
     } else {
       expect(redbox).toMatchInlineSnapshot(`
         {
-          "description": "Error: react-dom/server is not supported in React Server Components.",
+          "description": null,
           "source": null,
         }
       `)


### PR DESCRIPTION
Fixes
> ⨯ Error: Incompatible React versions: The "react" and "react-dom" packages must have the exact same version. Instead got:
>  - react:      19.0.0-experimental-1eaccd82-20240816
>  - react-dom:  19.0.0-rc-1eaccd82-20240816

-- https://github.com/vercel/next.js/actions/runs/10481716237/job/29032218695#step:29:530

Silly oversight in https://github.com/vercel/next.js/pull/68988 that we still need that alias.
I need to find out how the existing aliasing from `/server` to `/server.browser` works in browser builds.
Also confusing that CI originally didn't catch that mistake.

