### PR TITLE
feat(turbopack): hash the font file name if it exceeds our max file size

### DIFF
--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -11,8 +11,9 @@ use turbo_tasks_env::{CommandLineProcessEnv, ProcessEnv};
 use turbo_tasks_fetch::{fetch, HttpResponseBody};
 use turbo_tasks_fs::{
     json::parse_json_with_source_context, DiskFileSystem, File, FileContent, FileSystem,
-    FileSystemPath,
+    FileSystemPath, MAX_FILE_NAME_LENGTH_UNIX,
 };
+use turbo_tasks_hash::hash_xxh3_hash64;
 use turbopack::evaluate_context::node_evaluate_asset_context;
 use turbopack_core::{
     asset::AssetContent,
@@ -363,6 +364,16 @@ impl ImportMappingReplacement for NextFontGoogleFontFileReplacer {
         }
         if preload {
             name.push_str(".p")
+        }
+
+        // turbo-fs has a hard limit of 255 characters on unix. for the sake of consistency, we'll
+        // also apply that limit to windows. some font files exceed this, so lets be safe and
+        // replace it with a hash of the font name if it exceeds the limit, with some buffer room
+        // in case downstream code needs to append more onto the file name.
+        //
+        // NOTE: we are hashing the _name_ not the _contents_.
+        if name.len() > MAX_FILE_NAME_LENGTH_UNIX - 50 {
+            name = format!("xxh3_{:x}", hash_xxh3_hash64(name.as_bytes()));
         }
 
         let font_virtual_path = next_js_file_path("internal/font/google".into())

--- a/turbopack/crates/turbo-tasks-hash/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-hash/src/lib.rs
@@ -13,5 +13,5 @@ pub use crate::{
     deterministic_hash::{DeterministicHash, DeterministicHasher},
     hex::encode_hex,
     md4::hash_md4,
-    xxh3_hash64::{hash_xxh3_hash64, Xxh3Hash64Hasher},
+    xxh3_hash64::{hash_xxh3_hash128, hash_xxh3_hash64, Xxh3Hash64Hasher},
 };

--- a/turbopack/crates/turbo-tasks-hash/src/xxh3_hash64.rs
+++ b/turbopack/crates/turbo-tasks-hash/src/xxh3_hash64.rs
@@ -1,6 +1,6 @@
 use std::hash::Hasher;
 
-use twox_hash::xxh3;
+use twox_hash::xxh3::{self, HasherExt};
 
 use crate::{DeterministicHash, DeterministicHasher};
 
@@ -9,6 +9,28 @@ pub fn hash_xxh3_hash64<T: DeterministicHash>(input: T) -> u64 {
     let mut hasher = Xxh3Hash64Hasher::new();
     input.deterministic_hash(&mut hasher);
     hasher.finish()
+}
+
+/// Hash some content with the Xxh3Hash128 non-cryptographic hash function. This longer hash is
+/// useful for avoiding collisions.
+pub fn hash_xxh3_hash128<T: DeterministicHash>(input: T) -> u128 {
+    // this isn't fully compatible with the 64-bit Hasher/DeterministicHasher APIs, so just use a
+    // private impl for this
+    struct Xxh3Hash128Hasher(xxh3::Hash128);
+
+    impl DeterministicHasher for Xxh3Hash128Hasher {
+        fn finish(&self) -> u64 {
+            unimplemented!("call self.0.finish_ext() instead!")
+        }
+
+        fn write_bytes(&mut self, bytes: &[u8]) {
+            self.0.write(bytes);
+        }
+    }
+
+    let mut hasher = Xxh3Hash128Hasher(xxh3::Hash128::with_seed(0));
+    input.deterministic_hash(&mut hasher);
+    hasher.0.finish_ext()
 }
 
 /// Xxh3Hash64 hasher.


### PR DESCRIPTION
### What?

When using google fonts, we import files and write them with their hash to the filesystem. Some of these fonts get very close to the file size limit which, after appending a hash onto them, causes turbo to fail with a write error.

### Why?

Different operating systems have different path length requirements. In short:

- macOS: limit per segment, longer limit for entire path length
- unix: limit per segment, longer limit for entire path length
- windows: hard limit of 260 chars unless using UNC

We need to respect these.

### How?

A small change in the font code that rewrites filesystem paths if they approach this limit, with some buffer room. ~Rather than truncating I opted for a 64 bit hash because many fonts have long common prefixes. We could bump this up to 128 or higher but in practice there will be very very few files that need this code path.~ _(bgw):_ This now uses a combination of truncation (for legibility/debuggability) and a 128 bit hash (for collision avoidance).

Another option is a general handler for this where reads and writes are intercepted in turbo tasks fs but I wanted to achieve a few things:

- explicitly handle sources of problematic file names at the source, rather than having a blanket impl
- avoid obscure hashed names appearing in our outputs generally since it makes debugging harder
- avoid lots of hashing on reads and writes

To me it is safer to have the source ensure they are meeting the needs of the system since we can control source specific implementations.

Closes PACK-3012
