### PR TITLE
refactor: create shared utils for mod resource

### DIFF
--- a/packages/next/src/build/webpack/loaders/utils.ts
+++ b/packages/next/src/build/webpack/loaders/utils.ts
@@ -5,14 +5,28 @@ import { RSC_MODULE_TYPES } from '../../../shared/lib/constants'
 const imageExtensions = ['jpg', 'jpeg', 'png', 'webp', 'avif', 'ico', 'svg']
 const imageRegex = new RegExp(`\\.(${imageExtensions.join('|')})$`)
 
+// Determine if the whole module is server action, 'use server' in the top level of module
+export function isActionServerLayerEntryModule(mod: {
+  resource: string
+  buildInfo?: any
+}) {
+  const rscInfo = mod.buildInfo.rsc
+  return !!(rscInfo?.actions && rscInfo?.type === RSC_MODULE_TYPES.server)
+}
+
+// Determine if the whole module is client action, 'use server' in nested closure in the client module
+function isActionClientLayerModule(mod: { resource: string; buildInfo?: any }) {
+  const rscInfo = mod.buildInfo.rsc
+  return !!(rscInfo?.actions && rscInfo?.type === RSC_MODULE_TYPES.client)
+}
+
 export function isClientComponentEntryModule(mod: {
   resource: string
   buildInfo?: any
 }) {
   const rscInfo = mod.buildInfo.rsc
   const hasClientDirective = rscInfo?.isClientRef
-  const isActionLayerEntry =
-    rscInfo?.actions && rscInfo?.type === RSC_MODULE_TYPES.client
+  const isActionLayerEntry = isActionClientLayerModule(mod)
   return (
     hasClientDirective || isActionLayerEntry || imageRegex.test(mod.resource)
   )
@@ -39,7 +53,7 @@ export function isCSSMod(mod: {
   )
 }
 
-export function getActions(mod: {
+export function getActionsFromBuildInfo(mod: {
   resource: string
   buildInfo?: any
 }): undefined | string[] {


### PR DESCRIPTION
### What

Refactor the `flight-client-entry-plugin` to share some utils and prepare for the later optimization

* Share the util of get unique resource path of a module
* Use the typed helper of getting the module identifier