### PR TITLE
Fix next server component modules in graph traversal

### DIFF
--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -18,12 +18,12 @@ use crate::{
 };
 
 #[turbo_tasks::function]
-fn client_modules_modifier() -> Vc<RcStr> {
+pub fn client_modules_modifier() -> Vc<RcStr> {
     Vc::cell("client modules".into())
 }
 
 #[turbo_tasks::function]
-fn client_modules_ssr_modifier() -> Vc<RcStr> {
+pub fn client_modules_ssr_modifier() -> Vc<RcStr> {
     Vc::cell("client modules ssr".into())
 }
 

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -6,7 +6,7 @@ use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkItemExt, ChunkType, ChunkableModule, ChunkingContext},
     ident::AssetIdent,
-    module::Module,
+    module::{Module, Modules},
     reference::ModuleReferences,
 };
 use turbopack_ecmascript::{
@@ -14,11 +14,14 @@ use turbopack_ecmascript::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
         EcmascriptChunkType, EcmascriptExports,
     },
-    references::esm::EsmExports,
+    references::{esm::EsmExports, external_module::IncludeIdentModule},
     utils::StringifyJs,
 };
 
 use super::server_component_reference::NextServerComponentModuleReference;
+use crate::next_app::app_client_references_chunks::{
+    client_modules_modifier, client_modules_ssr_modifier,
+};
 
 #[turbo_tasks::function]
 fn modifier() -> Vc<RcStr> {
@@ -56,6 +59,18 @@ impl Module for NextServerComponentModule {
         Vc::cell(vec![Vc::upcast(NextServerComponentModuleReference::new(
             Vc::upcast(self.module),
         ))])
+    }
+
+    #[turbo_tasks::function]
+    fn additional_layers_modules(self: Vc<Self>) -> Vc<Modules> {
+        let base_ident = self.ident();
+        let ssr_entry_module = Vc::upcast(IncludeIdentModule::new(
+            base_ident.with_modifier(client_modules_ssr_modifier()),
+        ));
+        let client_entry_module = Vc::upcast(IncludeIdentModule::new(
+            base_ident.with_modifier(client_modules_modifier()),
+        ));
+        Vc::cell(vec![ssr_entry_module, client_entry_module])
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -244,3 +244,34 @@ impl EcmascriptChunkItem for CachedExternalModuleChunkItem {
         ))
     }
 }
+
+/// A module that only has an ident and no content. This is used
+/// to include a module's ident in the module graph before the module
+/// itself is resolved, as is the case with NextServerComponentModule's
+/// "client modules" and "client modules ssr".
+#[turbo_tasks::value]
+pub struct IncludeIdentModule {
+    ident: Vc<AssetIdent>,
+}
+
+#[turbo_tasks::value_impl]
+impl IncludeIdentModule {
+    #[turbo_tasks::function]
+    pub fn new(ident: Vc<AssetIdent>) -> Vc<Self> {
+        Self { ident }.cell()
+    }
+}
+
+impl Asset for IncludeIdentModule {
+    fn content(self: Vc<Self>) -> Vc<AssetContent> {
+        todo!("IncludeIdentModule doesn't implement content()")
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Module for IncludeIdentModule {
+    #[turbo_tasks::function]
+    fn ident(&self) -> Vc<AssetIdent> {
+        self.ident
+    }
+}


### PR DESCRIPTION
Next entry modules with the "client modules" or "client modules ssr" modifiers were not being reached by graph traversal. Now they are. 