### PR TITLE
Ensure fetch cache TTL is updated properly

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/fetch-cache.ts
@@ -337,26 +337,6 @@ export default class FetchCache implements CacheHandler {
   public async set(...args: Parameters<CacheHandler['set']>) {
     const [key, data, ctx] = args
 
-    const newValue =
-      data?.kind === CachedRouteKind.FETCH ? data.data : undefined
-    const existingCache = memoryCache?.get(key)
-    const existingValue = existingCache?.value
-    if (
-      existingValue?.kind === CachedRouteKind.FETCH &&
-      Object.keys(existingValue.data).every(
-        (field) =>
-          JSON.stringify(
-            (existingValue.data as Record<string, string | Object>)[field]
-          ) ===
-          JSON.stringify((newValue as Record<string, string | Object>)[field])
-      )
-    ) {
-      if (DEBUG) {
-        console.log(`skipping cache set for ${key} as not modified`)
-      }
-      return
-    }
-
     const { fetchCache, fetchIdx, fetchUrl, tags } = ctx
     if (!fetchCache) return
 

--- a/test/ppr-tests-manifest.json
+++ b/test/ppr-tests-manifest.json
@@ -5,8 +5,9 @@
       "passed": [],
       "failed": [
         "fetch-cache should have correct fetchUrl field for fetches and unstable_cache",
+        "fetch-cache should not retry for failed fetch-cache GET",
         "fetch-cache should retry 3 times when revalidate times out",
-        "fetch-cache should not retry for failed fetch-cache GET"
+        "fetch-cache should update cache TTL even if cache data does not change"
       ],
       "pending": [],
       "flakey": [],

--- a/test/production/app-dir/fetch-cache/app/not-changed/page.tsx
+++ b/test/production/app-dir/fetch-cache/app/not-changed/page.tsx
@@ -1,0 +1,33 @@
+import { unstable_cache } from 'next/cache'
+
+export const dynamic = 'force-dynamic'
+export const fetchCache = 'default-cache'
+
+// this is ensuring we still update TTL even
+// if the cache value didn't change during revalidate
+const stableCacheItem = unstable_cache(
+  async () => {
+    return 'consistent value'
+  },
+  [],
+  {
+    revalidate: 3,
+    tags: ['thankyounext'],
+  }
+)
+
+export default async function Page() {
+  const data = await fetch('https://example.vercel.sh', {
+    next: { tags: ['thankyounext'], revalidate: 3 },
+  }).then((res) => res.text())
+
+  const cachedValue = stableCacheItem()
+
+  return (
+    <>
+      <p>hello world</p>
+      <p id="data">{data}</p>
+      <p id="cache">{cachedValue}</p>
+    </>
+  )
+}

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -15637,7 +15637,8 @@
       "failed": [
         "fetch-cache should have correct fetchUrl field for fetches and unstable_cache",
         "fetch-cache should not retry for failed fetch-cache GET",
-        "fetch-cache should retry 3 times when revalidate times out"
+        "fetch-cache should retry 3 times when revalidate times out",
+        "fetch-cache should update cache TTL even if cache data does not change"
       ],
       "pending": [],
       "flakey": [],


### PR DESCRIPTION
To reduce the number of set requests we were sending upstream we added an optimization to skip sending the set request if the cached data didn't change after a revalidation. The problem with this optimization is the upstream service relies on this set request to know to update the cache entries TTL and consider it up to date. This causes unexpected revalidations while the cache value hasn't changed and the TTL is kept stale.  

x-ref: NEXT-3693