### PR TITLE
feat(turbopack): Add lint for node.js imports from edge

### DIFF
--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -134,12 +134,12 @@ pub async fn get_next_server_transforms_rules(
 
         if let NextRuntime::Edge = next_runtime {
             rules.push(get_middleware_dynamic_assert_rule(mdx_rs));
-            if matches!(context_ty, ServerContextType::Middleware { .. }) {
-                rules.push(next_edge_node_api_assert(
-                    mdx_rs,
-                    matches!(*mode.await?, NextMode::Build),
-                ));
-            }
+
+            rules.push(next_edge_node_api_assert(
+                mdx_rs,
+                matches!(context_ty, ServerContextType::Middleware { .. })
+                    && matches!(*mode.await?, NextMode::Build),
+            ));
         }
     }
 

--- a/crates/next-core/src/next_shared/transforms/next_edge_node_api_assert.rs
+++ b/crates/next-core/src/next_shared/transforms/next_edge_node_api_assert.rs
@@ -11,11 +11,13 @@ use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, Transfor
 
 use super::module_rule_match_js_no_url;
 
-pub fn next_edge_node_api_assert(enable_mdx_rs: bool, should_error: bool) -> ModuleRule {
-    let transformer =
-        EcmascriptInputTransform::Plugin(Vc::cell(
-            Box::new(NextEdgeNodeApiAssert { should_error }) as _,
-        ));
+pub fn next_edge_node_api_assert(
+    enable_mdx_rs: bool,
+    should_error_for_node_apis: bool,
+) -> ModuleRule {
+    let transformer = EcmascriptInputTransform::Plugin(Vc::cell(Box::new(NextEdgeNodeApiAssert {
+        should_error_for_node_apis,
+    }) as _));
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
@@ -27,7 +29,7 @@ pub fn next_edge_node_api_assert(enable_mdx_rs: bool, should_error: bool) -> Mod
 
 #[derive(Debug)]
 struct NextEdgeNodeApiAssert {
-    should_error: bool,
+    should_error_for_node_apis: bool,
 }
 
 #[async_trait]
@@ -40,7 +42,7 @@ impl CustomTransformer for NextEdgeNodeApiAssert {
                 is_unresolved_ref_safe: false,
                 unresolved_ctxt: SyntaxContext::empty().apply_mark(ctx.unresolved_mark),
             },
-            self.should_error,
+            self.should_error_for_node_apis,
         );
         program.visit_with(&mut visitor);
         Ok(())

--- a/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
+++ b/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
@@ -130,7 +130,11 @@ Learn More: https://nextjs.org/docs/messages/node-module-in-edge-runtime",
             );
 
             HANDLER.with(|h| {
-                h.struct_span_err(span, &msg).emit();
+                if self.should_error {
+                    h.struct_span_err(span, &msg).emit();
+                } else {
+                    h.struct_span_warn(span, &msg).emit();
+                }
             });
         }
 

--- a/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
+++ b/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
@@ -123,7 +123,7 @@ impl WarnForEdgeRuntime {
             let loc = self.cm.lookup_line(span.lo).ok()?;
 
             let msg = format!(
-                "A Node.js module is loaded ('${module_specifier}' at line {}) which is not \
+                "A Node.js module is loaded ('{module_specifier}' at line {}) which is not \
                  supported in the Edge Runtime.
 Learn More: https://nextjs.org/docs/messages/node-module-in-edge-runtime",
                 loc.line + 1

--- a/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
+++ b/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
@@ -44,11 +44,82 @@ const EDGE_UNSUPPORTED_NODE_APIS: &[&str] = &[
     "WritableStreamDefaultController",
 ];
 
-const NODEJS_MODULE_NAMES: &[&str] = &[];
+/// Get this value from `require('module').builtinModules`
+const NODEJS_MODULE_NAMES: &[&str] = &[
+    "_http_agent",
+    "_http_client",
+    "_http_common",
+    "_http_incoming",
+    "_http_outgoing",
+    "_http_server",
+    "_stream_duplex",
+    "_stream_passthrough",
+    "_stream_readable",
+    "_stream_transform",
+    "_stream_wrap",
+    "_stream_writable",
+    "_tls_common",
+    "_tls_wrap",
+    "assert",
+    "assert/strict",
+    "async_hooks",
+    "buffer",
+    "child_process",
+    "cluster",
+    "console",
+    "constants",
+    "crypto",
+    "dgram",
+    "diagnostics_channel",
+    "dns",
+    "dns/promises",
+    "domain",
+    "events",
+    "fs",
+    "fs/promises",
+    "http",
+    "http2",
+    "https",
+    "inspector",
+    "module",
+    "net",
+    "os",
+    "path",
+    "path/posix",
+    "path/win32",
+    "perf_hooks",
+    "process",
+    "punycode",
+    "querystring",
+    "readline",
+    "readline/promises",
+    "repl",
+    "stream",
+    "stream/consumers",
+    "stream/promises",
+    "stream/web",
+    "string_decoder",
+    "sys",
+    "timers",
+    "timers/promises",
+    "tls",
+    "trace_events",
+    "tty",
+    "url",
+    "util",
+    "util/types",
+    "v8",
+    "vm",
+    "wasi",
+    "worker_threads",
+    "zlib",
+];
 
 impl WarnForEdgeRuntime {
     fn warn_if_nodejs_module(&self, span: Span, module_specifier: &str) -> Option<()> {
-        if NODEJS_MODULE_NAMES.contains(&module_specifier) {
+        // Node.js modules can be loaded with `node:` prefix or directly
+        if module_specifier.starts_with("node:") || NODEJS_MODULE_NAMES.contains(&module_specifier)
+        {
             let loc = self.cm.lookup_line(span.lo).ok()?;
 
             let msg = format!(
@@ -105,15 +176,14 @@ Learn more: https://nextjs.org/docs/api-reference/edge-runtime",
 }
 
 impl Visit for WarnForEdgeRuntime {
-    fn visit_member_expr(&mut self, n: &MemberExpr) {
-        if n.obj.is_global_ref_to(&self.ctx, "process") {
-            if let MemberProp::Ident(prop) = &n.prop {
-                self.warn_for_unsupported_process_api(n.span, prop);
-                return;
+    fn visit_call_expr(&mut self, n: &CallExpr) {
+        n.visit_children_with(self);
+
+        if let Callee::Import(_) = &n.callee {
+            if let Some(Expr::Lit(Lit::Str(s))) = n.args.first().map(|e| &*e.expr) {
+                self.warn_if_nodejs_module(n.span, &s.value);
             }
         }
-
-        n.visit_children_with(self);
     }
 
     fn visit_expr(&mut self, n: &Expr) {
@@ -137,21 +207,22 @@ impl Visit for WarnForEdgeRuntime {
         self.warn_if_nodejs_module(n.span, &n.src.value);
     }
 
+    fn visit_member_expr(&mut self, n: &MemberExpr) {
+        if n.obj.is_global_ref_to(&self.ctx, "process") {
+            if let MemberProp::Ident(prop) = &n.prop {
+                self.warn_for_unsupported_process_api(n.span, prop);
+                return;
+            }
+        }
+
+        n.visit_children_with(self);
+    }
+
     fn visit_named_export(&mut self, n: &NamedExport) {
         n.visit_children_with(self);
 
         if let Some(module_specifier) = &n.src {
             self.warn_if_nodejs_module(n.span, &module_specifier.value);
-        }
-    }
-
-    fn visit_call_expr(&mut self, n: &CallExpr) {
-        n.visit_children_with(self);
-
-        if let Callee::Import(_) = &n.callee {
-            if let Some(Expr::Lit(Lit::Str(s))) = n.args.first().map(|e| &*e.expr) {
-                self.warn_if_nodejs_module(n.span, &s.value);
-            }
         }
     }
 }

--- a/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
+++ b/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
@@ -130,11 +130,7 @@ Learn More: https://nextjs.org/docs/messages/node-module-in-edge-runtime",
             );
 
             HANDLER.with(|h| {
-                if self.should_error {
-                    h.struct_span_err(span, &msg).emit();
-                } else {
-                    h.struct_span_warn(span, &msg).emit();
-                }
+                h.struct_span_warn(span, &msg).emit();
             });
         }
 

--- a/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
+++ b/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
@@ -11,18 +11,22 @@ use swc_core::{
     },
 };
 
-pub fn warn_for_edge_runtime(cm: Arc<SourceMap>, ctx: ExprCtx, should_error: bool) -> impl Visit {
+pub fn warn_for_edge_runtime(
+    cm: Arc<SourceMap>,
+    ctx: ExprCtx,
+    should_error_for_node_apis: bool,
+) -> impl Visit {
     WarnForEdgeRuntime {
         cm,
         ctx,
-        should_error,
+        should_error_for_node_apis,
     }
 }
 
 struct WarnForEdgeRuntime {
     cm: Arc<SourceMap>,
     ctx: ExprCtx,
-    should_error: bool,
+    should_error_for_node_apis: bool,
 }
 
 const EDGE_UNSUPPORTED_NODE_APIS: &[&str] = &[
@@ -148,7 +152,7 @@ Learn more: https://nextjs.org/docs/api-reference/edge-runtime",
         );
 
         HANDLER.with(|h| {
-            if self.should_error {
+            if self.should_error_for_node_apis {
                 h.struct_span_err(span, &msg).emit();
             } else {
                 h.struct_span_warn(span, &msg).emit();

--- a/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
+++ b/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
@@ -130,11 +130,7 @@ Learn More: https://nextjs.org/docs/messages/node-module-in-edge-runtime",
             );
 
             HANDLER.with(|h| {
-                if self.should_error {
-                    h.struct_span_err(span, &msg).emit();
-                } else {
-                    h.struct_span_warn(span, &msg).emit();
-                }
+                h.struct_span_err(span, &msg).emit();
             });
         }
 

--- a/crates/next-custom-transforms/tests/fixture/edge-assert/nodejs-import-prefix/input.js
+++ b/crates/next-custom-transforms/tests/fixture/edge-assert/nodejs-import-prefix/input.js
@@ -1,0 +1,1 @@
+import 'node:fs'

--- a/crates/next-custom-transforms/tests/fixture/edge-assert/nodejs-import-prefix/output.js
+++ b/crates/next-custom-transforms/tests/fixture/edge-assert/nodejs-import-prefix/output.js
@@ -1,0 +1,1 @@
+import 'node:fs';

--- a/crates/next-custom-transforms/tests/fixture/edge-assert/nodejs-import-prefix/output.stderr
+++ b/crates/next-custom-transforms/tests/fixture/edge-assert/nodejs-import-prefix/output.stderr
@@ -1,0 +1,6 @@
+  x A Node.js module is loaded ('node:fs' at line 1) which is not supported in the Edge Runtime.
+  | Learn More: https://nextjs.org/docs/messages/node-module-in-edge-runtime
+   ,-[input.js:1:1]
+ 1 | import 'node:fs'
+   : ^^^^^^^^^^^^^^^^
+   `----

--- a/crates/next-custom-transforms/tests/fixture/edge-assert/nodejs-import-prefix/output.stderr
+++ b/crates/next-custom-transforms/tests/fixture/edge-assert/nodejs-import-prefix/output.stderr
@@ -1,6 +1,0 @@
-  x A Node.js module is loaded ('node:fs' at line 1) which is not supported in the Edge Runtime.
-  | Learn More: https://nextjs.org/docs/messages/node-module-in-edge-runtime
-   ,-[input.js:1:1]
- 1 | import 'node:fs'
-   : ^^^^^^^^^^^^^^^^
-   `----

--- a/crates/next-custom-transforms/tests/fixture/edge-assert/nodejs-import/input.js
+++ b/crates/next-custom-transforms/tests/fixture/edge-assert/nodejs-import/input.js
@@ -1,0 +1,1 @@
+import 'fs'

--- a/crates/next-custom-transforms/tests/fixture/edge-assert/nodejs-import/output.js
+++ b/crates/next-custom-transforms/tests/fixture/edge-assert/nodejs-import/output.js
@@ -1,0 +1,1 @@
+import 'fs';

--- a/crates/next-custom-transforms/tests/fixture/edge-assert/nodejs-import/output.stderr
+++ b/crates/next-custom-transforms/tests/fixture/edge-assert/nodejs-import/output.stderr
@@ -1,0 +1,6 @@
+  x A Node.js module is loaded ('fs' at line 1) which is not supported in the Edge Runtime.
+  | Learn More: https://nextjs.org/docs/messages/node-module-in-edge-runtime
+   ,-[input.js:1:1]
+ 1 | import 'fs'
+   : ^^^^^^^^^^^
+   `----

--- a/crates/next-custom-transforms/tests/fixture/edge-assert/nodejs-import/output.stderr
+++ b/crates/next-custom-transforms/tests/fixture/edge-assert/nodejs-import/output.stderr
@@ -1,6 +1,0 @@
-  x A Node.js module is loaded ('fs' at line 1) which is not supported in the Edge Runtime.
-  | Learn More: https://nextjs.org/docs/messages/node-module-in-edge-runtime
-   ,-[input.js:1:1]
- 1 | import 'fs'
-   : ^^^^^^^^^^^
-   `----

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -8961,14 +8961,13 @@
         "Edge runtime code with imports Middleware statically importing 3rd party module production mode does not build and reports",
         "Edge runtime code with imports Middleware statically importing 3rd party module throws not-found module error in dev at runtime and highlights the faulty line",
         "Edge runtime code with imports Middleware using Buffer polyfill does not throw in dev at runtime",
-        "Edge runtime code with imports Middleware using Buffer polyfill production mode does not throw in production at runtime"
-      ],
-      "failed": [
+        "Edge runtime code with imports Middleware using Buffer polyfill production mode does not throw in production at runtime",
         "Edge runtime code with imports Edge API dynamically importing node.js module in a lib production mode throws unsupported module error in production at runtime and prints error on logs",
         "Edge runtime code with imports Edge API dynamically importing node.js module production mode throws unsupported module error in production at runtime and prints error on logs",
         "Edge runtime code with imports Middleware dynamically importing node.js module in a lib production mode throws unsupported module error in production at runtime and prints error on logs",
         "Edge runtime code with imports Middleware dynamically importing node.js module production mode throws unsupported module error in production at runtime and prints error on logs"
       ],
+      "failed": [],
       "pending": [
         "Edge runtime code with imports Edge API dynamically importing node.js module development mode throws unsupported module error in dev at runtime and highlights the faulty line",
         "Edge runtime code with imports Edge API dynamically importing node.js module in a lib development mode throws unsupported module error in dev at runtime and highlights the faulty line",
@@ -8991,13 +8990,13 @@
         "Edge runtime code with imports Middleware importing unused 3rd party module production mode does not build and reports module not found error",
         "Edge runtime code with imports Middleware importing unused 3rd party module throws not-found module error in dev at runtime and highlights the faulty line",
         "Edge runtime code with imports Middleware importing unused node.js module does not throw in dev at runtime",
-        "Edge runtime code with imports Middleware statically importing node.js module throws unsupported module error in dev at runtime and highlights the faulty line"
+        "Edge runtime code with imports Middleware statically importing node.js module throws unsupported module error in dev at runtime and highlights the faulty line",
+        "Edge runtime code with imports Edge API statically importing node.js module production mode throws unsupported module error in production at runtime and prints error on logs",
+        "Edge runtime code with imports Middleware statically importing node.js module production mode throws unsupported module error in production at runtime and prints error on logs"
       ],
       "failed": [
         "Edge runtime code with imports Edge API importing unused node.js module production mode does not throw in production at runtime",
-        "Edge runtime code with imports Edge API statically importing node.js module production mode throws unsupported module error in production at runtime and prints error on logs",
-        "Edge runtime code with imports Middleware importing unused node.js module production mode does not throw in production at runtime",
-        "Edge runtime code with imports Middleware statically importing node.js module production mode throws unsupported module error in production at runtime and prints error on logs"
+        "Edge runtime code with imports Middleware importing unused node.js module production mode does not throw in production at runtime"
       ],
       "pending": [],
       "flakey": [],

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/scss/output/turbopack_crates_turbopack-tests_tests_snapshot_css_scss_input_index_37ce57.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/scss/output/turbopack_crates_turbopack-tests_tests_snapshot_css_scss_input_index_37ce57.js
@@ -1,0 +1,9 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push(["output/turbopack_crates_turbopack-tests_tests_snapshot_css_scss_input_index_37ce57.js", {
+
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/scss/input/index.js [test] (ecmascript)": (function({ r: __turbopack_require__, f: __turbopack_module_context__, i: __turbopack_import__, s: __turbopack_esm__, v: __turbopack_export_value__, n: __turbopack_export_namespace__, c: __turbopack_cache__, M: __turbopack_modules__, l: __turbopack_load__, j: __turbopack_dynamic__, P: __turbopack_resolve_absolute_path__, U: __turbopack_relative_url__, R: __turbopack_resolve_module_id_path__, g: global, __dirname, m: module, e: exports, t: require }) { !function() {
+
+const e = new Error("Could not parse module '[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/scss/input/index.js'");
+e.code = 'MODULE_UNPARSEABLE';
+throw e;
+}.call(this) }),
+}]);

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/scss/output/turbopack_crates_turbopack-tests_tests_snapshot_css_scss_input_index_37ce57.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/scss/output/turbopack_crates_turbopack-tests_tests_snapshot_css_scss_input_index_37ce57.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/scss/output/turbopack_crates_turbopack-tests_tests_snapshot_css_scss_input_index_67dcb7.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/scss/output/turbopack_crates_turbopack-tests_tests_snapshot_css_scss_input_index_67dcb7.js
@@ -1,0 +1,6 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
+    "output/turbopack_crates_turbopack-tests_tests_snapshot_css_scss_input_index_67dcb7.js",
+    {},
+    {"otherChunks":["output/turbopack_crates_turbopack-tests_tests_snapshot_css_scss_input_index_37ce57.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/css/scss/input/index.js [test] (ecmascript)"]}
+]);
+// Dummy runtime

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/scss/output/turbopack_crates_turbopack-tests_tests_snapshot_css_scss_input_index_67dcb7.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/scss/output/turbopack_crates_turbopack-tests_tests_snapshot_css_scss_input_index_67dcb7.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}


### PR DESCRIPTION
### What?

Implement a lint for imports from node.js internal modules.

### Why?

It will not work on runtime because edge runtime does not have such modules.

x-ref: https://vercel.slack.com/archives/C04KC8A53T7/p1724310187996899?thread_ts=1723669243.397119&cid=C04KC8A53T7

### How?


Closes PACK-3216