### PR TITLE
Apply optimization for unused actions

### DIFF
--- a/test/production/app-dir/actions-tree-shaking/_testing/utils.ts
+++ b/test/production/app-dir/actions-tree-shaking/_testing/utils.ts
@@ -1,0 +1,78 @@
+import { type NextInstance } from 'e2e-utils'
+
+async function getActionsMappingByRuntime(
+  next: NextInstance,
+  runtime: 'node' | 'edge'
+) {
+  const manifest = JSON.parse(
+    await next.readFile('.next/server/server-reference-manifest.json')
+  )
+
+  return manifest[runtime]
+}
+
+export function markLayoutAsEdge(next: NextInstance) {
+  beforeAll(async () => {
+    await next.stop()
+    const layoutContent = await next.readFile('app/layout.js')
+    await next.patchFile(
+      'app/layout.js',
+      layoutContent + `\nexport const runtime = 'edge'`
+    )
+    await next.start()
+  })
+}
+
+/* 
+{ 
+  [route path]: { [layer]: Set<workerId> ]
+}
+*/
+type ActionsMappingOfRuntime = {
+  [actionId: string]: {
+    workers: {
+      [route: string]: string
+    }
+    layer: {
+      [route: string]: string
+    }
+  }
+}
+type ActionState = {
+  [route: string]: {
+    [layer: string]: number
+  }
+}
+
+function getActionsRoutesState(
+  actionsMappingOfRuntime: ActionsMappingOfRuntime
+): ActionState {
+  const state: ActionState = {}
+  Object.keys(actionsMappingOfRuntime).forEach((actionId) => {
+    const action = actionsMappingOfRuntime[actionId]
+    const routePaths = Object.keys(action.workers)
+
+    routePaths.forEach((routePath) => {
+      if (!state[routePath]) {
+        state[routePath] = {}
+      }
+      const layer = action.layer[routePath]
+
+      if (!state[routePath][layer]) {
+        state[routePath][layer] = 0
+      }
+
+      state[routePath][layer]++
+    })
+  })
+
+  return state
+}
+
+export async function getActionsRoutesStateByRuntime(next: NextInstance) {
+  const actionsMappingOfRuntime = await getActionsMappingByRuntime(
+    next,
+    process.env.TEST_EDGE ? 'edge' : 'node'
+  )
+  return getActionsRoutesState(actionsMappingOfRuntime)
+}

--- a/test/production/app-dir/actions-tree-shaking/basic/app/actions.js
+++ b/test/production/app-dir/actions-tree-shaking/basic/app/actions.js
@@ -1,0 +1,13 @@
+'use server'
+
+export async function serverComponentAction() {
+  return 'server-action'
+}
+
+export async function clientComponentAction() {
+  return 'client-action'
+}
+
+export async function unusedExportedAction() {
+  return 'unused-exported-action'
+}

--- a/test/production/app-dir/actions-tree-shaking/basic/app/client/page.js
+++ b/test/production/app-dir/actions-tree-shaking/basic/app/client/page.js
@@ -1,0 +1,21 @@
+'use client'
+
+import { useState } from 'react'
+import { clientComponentAction } from '../actions'
+
+export default function Page() {
+  const [text, setText] = useState('initial')
+  return (
+    <div>
+      <button
+        id="action-1"
+        onClick={async () => {
+          setText(await clientComponentAction())
+        }}
+      >
+        Action 1
+      </button>
+      <span>{text}</span>
+    </div>
+  )
+}

--- a/test/production/app-dir/actions-tree-shaking/basic/app/inline/page.js
+++ b/test/production/app-dir/actions-tree-shaking/basic/app/inline/page.js
@@ -1,0 +1,13 @@
+export default function Page() {
+  // Inline Server Action
+  async function inlineServerAction() {
+    'use server'
+    return 'inline-server-action'
+  }
+
+  return (
+    <form action={inlineServerAction}>
+      <button type="submit">Submit</button>
+    </form>
+  )
+}

--- a/test/production/app-dir/actions-tree-shaking/basic/app/layout.js
+++ b/test/production/app-dir/actions-tree-shaking/basic/app/layout.js
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/actions-tree-shaking/basic/app/server/page.js
+++ b/test/production/app-dir/actions-tree-shaking/basic/app/server/page.js
@@ -1,0 +1,10 @@
+import { serverComponentAction } from '../actions'
+
+export default function Page() {
+  return (
+    <form>
+      <input type="text" placeholder="input" />
+      <button formAction={serverComponentAction}>submit</button>
+    </form>
+  )
+}

--- a/test/production/app-dir/actions-tree-shaking/basic/basic-edge.test.ts
+++ b/test/production/app-dir/actions-tree-shaking/basic/basic-edge.test.ts
@@ -1,0 +1,3 @@
+process.env.TEST_EDGE = '1'
+
+require('./basic.test')

--- a/test/production/app-dir/actions-tree-shaking/basic/basic.test.ts
+++ b/test/production/app-dir/actions-tree-shaking/basic/basic.test.ts
@@ -1,0 +1,33 @@
+import { nextTestSetup } from 'e2e-utils'
+import {
+  getActionsRoutesStateByRuntime,
+  markLayoutAsEdge,
+} from '../_testing/utils'
+
+describe('actions-tree-shaking - basic', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (process.env.TEST_EDGE) {
+    markLayoutAsEdge(next)
+  }
+
+  it('should not have the unused action in the manifest', async () => {
+    const actionsRoutesState = await getActionsRoutesStateByRuntime(next)
+
+    expect(actionsRoutesState).toMatchObject({
+      // only one server layer action
+      'app/server/page': {
+        rsc: 1,
+      },
+      // only one browser layer action
+      'app/client/page': {
+        'action-browser': 1,
+      },
+      'app/inline/page': {
+        rsc: 1,
+      },
+    })
+  })
+})

--- a/test/production/app-dir/actions-tree-shaking/mixed-module-actions/app/layout.js
+++ b/test/production/app-dir/actions-tree-shaking/mixed-module-actions/app/layout.js
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/actions-tree-shaking/mixed-module-actions/app/mixed-module/cjs/actions.js
+++ b/test/production/app-dir/actions-tree-shaking/mixed-module-actions/app/mixed-module/cjs/actions.js
@@ -1,0 +1,13 @@
+'use server'
+
+export async function esmModuleTypeAction() {
+  return 'esm-module-type-action'
+}
+
+export async function cjsModuleTypeAction() {
+  return 'cjs-module-type-action'
+}
+
+export async function unusedModuleTypeAction1() {
+  return 'unused-module-type-action-1'
+}

--- a/test/production/app-dir/actions-tree-shaking/mixed-module-actions/app/mixed-module/cjs/page.js
+++ b/test/production/app-dir/actions-tree-shaking/mixed-module-actions/app/mixed-module/cjs/page.js
@@ -1,0 +1,13 @@
+const { cjsModuleTypeAction } = require('./actions')
+
+export default function Page() {
+  return (
+    <div>
+      <h3>One</h3>
+      <form>
+        <input type="text" placeholder="input" />
+        <button formAction={cjsModuleTypeAction}>submit</button>
+      </form>
+    </div>
+  )
+}

--- a/test/production/app-dir/actions-tree-shaking/mixed-module-actions/app/mixed-module/esm/actions.js
+++ b/test/production/app-dir/actions-tree-shaking/mixed-module-actions/app/mixed-module/esm/actions.js
@@ -1,0 +1,13 @@
+'use server'
+
+export async function esmModuleTypeAction() {
+  return 'esm-module-type-action'
+}
+
+export async function cjsModuleTypeAction() {
+  return 'cjs-module-type-action'
+}
+
+export async function unusedModuleTypeAction1() {
+  return 'unused-module-type-action-1'
+}

--- a/test/production/app-dir/actions-tree-shaking/mixed-module-actions/app/mixed-module/esm/page.js
+++ b/test/production/app-dir/actions-tree-shaking/mixed-module-actions/app/mixed-module/esm/page.js
@@ -1,0 +1,13 @@
+import { esmModuleTypeAction } from './actions'
+
+export default function Page() {
+  return (
+    <div>
+      <h3>One</h3>
+      <form>
+        <input type="text" placeholder="input" />
+        <button formAction={esmModuleTypeAction}>submit</button>
+      </form>
+    </div>
+  )
+}

--- a/test/production/app-dir/actions-tree-shaking/mixed-module-actions/mixed-module-actions-edge.test.ts
+++ b/test/production/app-dir/actions-tree-shaking/mixed-module-actions/mixed-module-actions-edge.test.ts
@@ -1,0 +1,3 @@
+process.env.TEST_EDGE = '1'
+
+require('./mixed-module-actions.test')

--- a/test/production/app-dir/actions-tree-shaking/mixed-module-actions/mixed-module-actions.test.ts
+++ b/test/production/app-dir/actions-tree-shaking/mixed-module-actions/mixed-module-actions.test.ts
@@ -1,0 +1,29 @@
+import { nextTestSetup } from 'e2e-utils'
+import {
+  getActionsRoutesStateByRuntime,
+  markLayoutAsEdge,
+} from '../_testing/utils'
+
+describe('actions-tree-shaking - mixed-module-actions', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (process.env.TEST_EDGE) {
+    markLayoutAsEdge(next)
+  }
+
+  it('should not do tree shake for cjs module when import server actions', async () => {
+    const actionsRoutesState = await getActionsRoutesStateByRuntime(next)
+
+    expect(actionsRoutesState).toMatchObject({
+      'app/mixed-module/esm/page': {
+        rsc: 1,
+      },
+      // CJS import is not able to tree shake, so it will include all actions
+      'app/mixed-module/cjs/page': {
+        rsc: 3,
+      },
+    })
+  })
+})

--- a/test/production/app-dir/actions-tree-shaking/reexport/app/layout.js
+++ b/test/production/app-dir/actions-tree-shaking/reexport/app/layout.js
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/actions-tree-shaking/reexport/app/named-reexport/client/actions.js
+++ b/test/production/app-dir/actions-tree-shaking/reexport/app/named-reexport/client/actions.js
@@ -1,0 +1,13 @@
+'use server'
+
+export async function sharedClientLayerAction() {
+  return 'shared-client-layer-action'
+}
+
+export async function unusedClientLayerAction1() {
+  return 'unused-client-layer-action-1'
+}
+
+export async function unusedClientLayerAction2() {
+  return 'unused-client-layer-action-2'
+}

--- a/test/production/app-dir/actions-tree-shaking/reexport/app/named-reexport/client/page.js
+++ b/test/production/app-dir/actions-tree-shaking/reexport/app/named-reexport/client/page.js
@@ -1,0 +1,21 @@
+'use client'
+
+import { useState } from 'react'
+import { sharedClientLayerAction } from './reexport-action'
+
+export default function Page() {
+  const [text, setText] = useState('initial')
+  return (
+    <div>
+      <button
+        id="action-1"
+        onClick={async () => {
+          setText(await sharedClientLayerAction())
+        }}
+      >
+        Action 1
+      </button>
+      <span>{text}</span>
+    </div>
+  )
+}

--- a/test/production/app-dir/actions-tree-shaking/reexport/app/named-reexport/client/reexport-action.js
+++ b/test/production/app-dir/actions-tree-shaking/reexport/app/named-reexport/client/reexport-action.js
@@ -1,0 +1,5 @@
+export {
+  sharedClientLayerAction,
+  unusedClientLayerAction1,
+  unusedClientLayerAction2,
+} from './actions'

--- a/test/production/app-dir/actions-tree-shaking/reexport/app/named-reexport/server/actions.js
+++ b/test/production/app-dir/actions-tree-shaking/reexport/app/named-reexport/server/actions.js
@@ -1,0 +1,13 @@
+'use server'
+
+export async function sharedServerLayerAction() {
+  return 'shared-server-layer-action'
+}
+
+export async function unusedServerLayerAction1() {
+  return 'unused-server-layer-action-1'
+}
+
+export async function unusedServerLayerAction2() {
+  return 'unused-server-layer-action-2'
+}

--- a/test/production/app-dir/actions-tree-shaking/reexport/app/named-reexport/server/page.js
+++ b/test/production/app-dir/actions-tree-shaking/reexport/app/named-reexport/server/page.js
@@ -1,0 +1,12 @@
+import { sharedServerLayerAction } from './reexport-action'
+
+export default function Page() {
+  return (
+    <div>
+      <form>
+        <input type="text" placeholder="input" />
+        <button formAction={sharedServerLayerAction}>submit</button>
+      </form>
+    </div>
+  )
+}

--- a/test/production/app-dir/actions-tree-shaking/reexport/app/named-reexport/server/reexport-action.js
+++ b/test/production/app-dir/actions-tree-shaking/reexport/app/named-reexport/server/reexport-action.js
@@ -1,0 +1,5 @@
+export {
+  sharedServerLayerAction,
+  unusedServerLayerAction1,
+  unusedServerLayerAction2,
+} from './actions'

--- a/test/production/app-dir/actions-tree-shaking/reexport/app/namespace-reexport/client/actions.js
+++ b/test/production/app-dir/actions-tree-shaking/reexport/app/namespace-reexport/client/actions.js
@@ -1,0 +1,13 @@
+'use server'
+
+export async function sharedClientLayerAction() {
+  return 'shared-client-layer-action'
+}
+
+export async function unusedClientLayerAction1() {
+  return 'unused-client-layer-action-1'
+}
+
+export async function unusedClientLayerAction2() {
+  return 'unused-client-layer-action-2'
+}

--- a/test/production/app-dir/actions-tree-shaking/reexport/app/namespace-reexport/client/page.js
+++ b/test/production/app-dir/actions-tree-shaking/reexport/app/namespace-reexport/client/page.js
@@ -1,0 +1,21 @@
+'use client'
+
+import { useState } from 'react'
+import * as actionMod from './actions'
+
+export default function Page() {
+  const [text, setText] = useState('initial')
+  return (
+    <div>
+      <button
+        id="action-1"
+        onClick={async () => {
+          setText(await actionMod.sharedClientLayerAction())
+        }}
+      >
+        Action 1
+      </button>
+      <span>{text}</span>
+    </div>
+  )
+}

--- a/test/production/app-dir/actions-tree-shaking/reexport/app/namespace-reexport/server/actions.js
+++ b/test/production/app-dir/actions-tree-shaking/reexport/app/namespace-reexport/server/actions.js
@@ -1,0 +1,13 @@
+'use server'
+
+export async function sharedServerLayerAction() {
+  return 'shared-server-layer-action'
+}
+
+export async function unusedServerLayerAction1() {
+  return 'unused-server-layer-action-1'
+}
+
+export async function unusedServerLayerAction2() {
+  return 'unused-server-layer-action-2'
+}

--- a/test/production/app-dir/actions-tree-shaking/reexport/app/namespace-reexport/server/page.js
+++ b/test/production/app-dir/actions-tree-shaking/reexport/app/namespace-reexport/server/page.js
@@ -1,0 +1,12 @@
+import * as actionMod from './actions'
+
+export default function Page() {
+  return (
+    <div>
+      <form>
+        <input type="text" placeholder="input" />
+        <button formAction={actionMod.sharedServerLayerAction}>submit</button>
+      </form>
+    </div>
+  )
+}

--- a/test/production/app-dir/actions-tree-shaking/reexport/reexport-edge.test.ts
+++ b/test/production/app-dir/actions-tree-shaking/reexport/reexport-edge.test.ts
@@ -1,0 +1,3 @@
+process.env.TEST_EDGE = '1'
+
+require('./reexport.test')

--- a/test/production/app-dir/actions-tree-shaking/reexport/reexport.test.ts
+++ b/test/production/app-dir/actions-tree-shaking/reexport/reexport.test.ts
@@ -1,0 +1,35 @@
+import { nextTestSetup } from 'e2e-utils'
+import {
+  getActionsRoutesStateByRuntime,
+  markLayoutAsEdge,
+} from '../_testing/utils'
+
+describe('actions-tree-shaking - reexport', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (process.env.TEST_EDGE) {
+    markLayoutAsEdge(next)
+  }
+
+  it('should not have the unused action in the manifest', async () => {
+    const actionsRoutesState = await getActionsRoutesStateByRuntime(next)
+
+    expect(actionsRoutesState).toMatchObject({
+      'app/namespace-reexport/server/page': {
+        rsc: 1,
+      },
+      'app/namespace-reexport/client/page': {
+        'action-browser': 1,
+      },
+      // We're not able to tree-shake these re-exports here
+      'app/named-reexport/server/page': {
+        rsc: 3,
+      },
+      'app/named-reexport/client/page': {
+        'action-browser': 3,
+      },
+    })
+  })
+})

--- a/test/production/app-dir/actions-tree-shaking/shared-module-actions/app/client/actions.js
+++ b/test/production/app-dir/actions-tree-shaking/shared-module-actions/app/client/actions.js
@@ -1,0 +1,13 @@
+'use server'
+
+export async function sharedClientLayerAction() {
+  return 'shared-client-layer-action'
+}
+
+export async function unusedClientLayerAction1() {
+  return 'unused-client-layer-action-1'
+}
+
+export async function unusedClientLayerAction2() {
+  return 'unused-client-layer-action-2'
+}

--- a/test/production/app-dir/actions-tree-shaking/shared-module-actions/app/client/one/page.js
+++ b/test/production/app-dir/actions-tree-shaking/shared-module-actions/app/client/one/page.js
@@ -1,0 +1,22 @@
+'use client'
+
+import { useState } from 'react'
+import { sharedClientLayerAction } from '../actions'
+
+export default function Page() {
+  const [text, setText] = useState('initial')
+  return (
+    <div>
+      <h1>One</h1>
+      <button
+        id="action-1"
+        onClick={async () => {
+          setText(await sharedClientLayerAction())
+        }}
+      >
+        Action 1
+      </button>
+      <span>{text}</span>
+    </div>
+  )
+}

--- a/test/production/app-dir/actions-tree-shaking/shared-module-actions/app/client/two/page.js
+++ b/test/production/app-dir/actions-tree-shaking/shared-module-actions/app/client/two/page.js
@@ -1,0 +1,22 @@
+'use client'
+
+import { useState } from 'react'
+import { sharedClientLayerAction } from '../actions'
+
+export default function Page() {
+  const [text, setText] = useState('initial')
+  return (
+    <div>
+      <h1>Two</h1>
+      <button
+        id="action-1"
+        onClick={async () => {
+          setText(await sharedClientLayerAction())
+        }}
+      >
+        Action 1
+      </button>
+      <span>{text}</span>
+    </div>
+  )
+}

--- a/test/production/app-dir/actions-tree-shaking/shared-module-actions/app/layout.js
+++ b/test/production/app-dir/actions-tree-shaking/shared-module-actions/app/layout.js
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/actions-tree-shaking/shared-module-actions/app/server/actions.js
+++ b/test/production/app-dir/actions-tree-shaking/shared-module-actions/app/server/actions.js
@@ -1,0 +1,13 @@
+'use server'
+
+export async function sharedServerLayerAction() {
+  return 'shared-server-layer-action'
+}
+
+export async function unusedServerLayerAction1() {
+  return 'unused-server-layer-action-1'
+}
+
+export async function unusedServerLayerAction2() {
+  return 'unused-server-layer-action-2'
+}

--- a/test/production/app-dir/actions-tree-shaking/shared-module-actions/app/server/one/page.js
+++ b/test/production/app-dir/actions-tree-shaking/shared-module-actions/app/server/one/page.js
@@ -1,0 +1,13 @@
+import { sharedServerLayerAction } from '../actions'
+
+export default function Page() {
+  return (
+    <div>
+      <h3>One</h3>
+      <form>
+        <input type="text" placeholder="input" />
+        <button formAction={sharedServerLayerAction}>submit</button>
+      </form>
+    </div>
+  )
+}

--- a/test/production/app-dir/actions-tree-shaking/shared-module-actions/app/server/two/page.js
+++ b/test/production/app-dir/actions-tree-shaking/shared-module-actions/app/server/two/page.js
@@ -1,0 +1,13 @@
+import { sharedServerLayerAction } from '../actions'
+
+export default function Page() {
+  return (
+    <div>
+      <h3>One</h3>
+      <form>
+        <input type="text" placeholder="input" />
+        <button formAction={sharedServerLayerAction}>submit</button>
+      </form>
+    </div>
+  )
+}

--- a/test/production/app-dir/actions-tree-shaking/shared-module-actions/shared-module-actions-edge.test.ts
+++ b/test/production/app-dir/actions-tree-shaking/shared-module-actions/shared-module-actions-edge.test.ts
@@ -1,0 +1,3 @@
+process.env.TEST_EDGE = '1'
+
+require('./shared-module-actions.test')

--- a/test/production/app-dir/actions-tree-shaking/shared-module-actions/shared-module-actions.test.ts
+++ b/test/production/app-dir/actions-tree-shaking/shared-module-actions/shared-module-actions.test.ts
@@ -1,0 +1,34 @@
+import { nextTestSetup } from 'e2e-utils'
+import {
+  getActionsRoutesStateByRuntime,
+  markLayoutAsEdge,
+} from '../_testing/utils'
+
+describe('actions-tree-shaking - shared-module-actions', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (process.env.TEST_EDGE) {
+    markLayoutAsEdge(next)
+  }
+
+  it('should not have the unused action in the manifest', async () => {
+    const actionsRoutesState = await getActionsRoutesStateByRuntime(next)
+
+    expect(actionsRoutesState).toMatchObject({
+      'app/server/one/page': {
+        rsc: 1,
+      },
+      'app/server/two/page': {
+        rsc: 1,
+      },
+      'app/client/one/page': {
+        'action-browser': 1,
+      },
+      'app/client/two/page': {
+        'action-browser': 1,
+      },
+    })
+  })
+})

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -16566,6 +16566,78 @@
       "pending": [],
       "flakey": [],
       "runtimeError": false
+    },
+    "test/production/app-dir/actions-tree-shaking/basic/basic.test.ts": {
+      "passed": [],
+      "failed": [
+        "actions-tree-shaking - basic should not have the unused action in the manifest"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/production/app-dir/actions-tree-shaking/mixed-module-actions/mixed-module-actions.test.ts": {
+      "passed": [],
+      "failed": [
+        "actions-tree-shaking - mixed-module-actions should not do tree shake for cjs module when import server actions"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/production/app-dir/actions-tree-shaking/reexport/reexport.test.ts": {
+      "passed": [],
+      "failed": [
+        "actions-tree-shaking - reexport should not have the unused action in the manifest"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/production/app-dir/actions-tree-shaking/shared-module-actions/shared-module-actions.test.ts": {
+      "passed": [],
+      "failed": [
+        "actions-tree-shaking - shared-module-actions should not have the unused action in the manifest"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/production/app-dir/actions-tree-shaking/basic/basic-edge.test.ts": {
+      "passed": [],
+      "failed": [
+        "actions-tree-shaking - basic should not have the unused action in the manifest"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/production/app-dir/actions-tree-shaking/mixed-module-actions/mixed-module-actions-edge.test.ts": {
+      "passed": [],
+      "failed": [
+        "actions-tree-shaking - mixed-module-actions should not do tree shake for cjs module when import server actions"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/production/app-dir/actions-tree-shaking/reexport/reexport-edge.test.ts": {
+      "passed": [],
+      "failed": [
+        "actions-tree-shaking - reexport should not have the unused action in the manifest"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/production/app-dir/actions-tree-shaking/shared-module-actions/shared-module-actions-edge.test.ts": {
+      "passed": [],
+      "failed": [
+        "actions-tree-shaking - shared-module-actions should not have the unused action in the manifest"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
     }
   },
   "rules": {


### PR DESCRIPTION
### What

This PR introduces a strategy of optimizing the created endpoints for unused server actions. 

### Why

One simple example is when one server action is imported from a server action module, and being used inside the page, the rest of unused server actions should not be created as endpoints.

As we were creating all the server actions as endpoints right now, this can lead to developers accidentally exposing endpoints that they didn't mean to and don't ever consume on the client.

Server actions modules are transformed by complex SWC into a side-effect JS modules, **normal tree-shaking strategy of JS module doesn't really apply to it**. We need to create a different approach to remove those unused logic.

### How

To achieve the goal of "tree-shaking of unused server actions", we decide to filter out the unused ones since we already got a server action module path and action names mapping before we generate the actions manifest.

We're going to collect the used action names first and pick the unused ones out from the list, then they'll be erased from the manifest. We introduced a map that collected the used actions per entry, then travse the module graph to collect the imported identifiers from server action modules. This way enabled us on collecting the actual used action ids from the bundled modules, both in RSC and SSR bundle layers.

Of course for the inlined server actions, we cannot tree-shake them as they're not really modules. So those anonymous server actions will also be collected and preserved.

At last while generating the server action manifest, we find the collected action paths and names based on the entry name and runtime, and use them to filter out the unused ones from the whole action list. Finally the generated manifest won't contain any of them.

#### Limitation

The indirect unused imports are not be abled to droppped, cause we're collect based on the modules in the module graph 


Fixes #63804
Closes NDX-147

