### PR TITLE
[docs] Recommend disabling static analysis to combat build OOM if CI already handles that

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/13-memory-usage.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/13-memory-usage.mdx
@@ -91,6 +91,39 @@ const nextConfig = {
 export default nextConfig
 ```
 
+## Disable static analysis
+
+Typechecking and linting may require a lot of memory, especially in large projects.
+However, most projects have a dedicated CI runner that already handles these tasks.
+When the build produces out-of-memory issues during the "Linting and checking validity of types" step, you can disable these task during builds:
+
+```js filename="next.config.mjs"
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  eslint: {
+    // Warning: This allows production builds to successfully complete even if
+    // your project has ESLint errors.
+    ignoreDuringBuilds: true,
+  },
+  typescript: {
+    // !! WARN !!
+    // Dangerously allow production builds to successfully complete even if
+    // your project has type errors.
+    // !! WARN !!
+    ignoreBuildErrors: true,
+  },
+}
+
+export default nextConfig
+```
+
+- [Ignoring TypeScript Errors](/docs/pages/building-your-application/configuring/typescript#ignoring-typescript-errors)
+- [ESLint in Next.js config](/docs/pages/api-reference/next-config-js/eslint)
+
+Keep in mind that this may produce faulty deploys due to type errors or linting issues.
+We strongly recommend only promoting builds to production after static analysis has completed.
+If you deploy to Vercel, you can check out the [guide for staging deployments](https://vercel.com/docs/deployments/managing-deployments#staging-and-promoting-a-production-deployment) to learn how to promote builds to production after custom tasks have succeeded.
+
 ## Disable source maps
 
 Generating source maps consumes extra memory during the build process.


### PR DESCRIPTION
[Preview](https://github.com/vercel/next.js/blob/sebbie/08-22-_docs_recommend_disabling_static_analysis_to_combat_build_oom_iff_ci_already_handles_that/docs/02-app/01-building-your-application/06-optimizing/13-memory-usage.mdx#disable-static-analysis)

Larger apps may encounter OOM in builds during static analysis (eslint+ts). Most larger apps already have a dedicated CI which is better suited for these tasks. 

This may result in deploy of broken builds but so is deploying without waiting for tests.

The added section specifically talks about OOM and recommends manual promotion after static analysis. How to do CI/CD properly is its own industry though so we shouldn't be too opinionated in smaller sections and just describe what tools are available.

Closes https://linear.app/vercel/issue/NEXT-3690