### PR TITLE
docs: examples page

### DIFF
--- a/docs/02-app/01-building-your-application/12-examples/index.mdx
+++ b/docs/02-app/01-building-your-application/12-examples/index.mdx
@@ -1,0 +1,65 @@
+---
+title: Next.js Examples
+nav_title: Examples
+description: Examples of popular Next.js UI patterns and use cases.
+---
+
+{/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
+
+### Data Fetching
+
+- [Using the `fetch` API](/docs/app/building-your-application/data-fetching/fetching#fetch-api)
+- [Using an ORM or database client](/docs/app/building-your-application/data-fetching/fetching#orms-and-database-clients)
+- Streaming data to a Client Component
+
+### Revalidating Data
+
+- [Using ISR to revalidate data after a certain time](/docs/app/building-your-application/data-fetching/caching-and-revalidating#time-based-revalidation)
+- [Using ISR to revalidate data on-demand](/docs/app/building-your-application/data-fetching/caching-and-revalidating#on-demand-revalidation)
+
+### Forms
+
+- [Showing a pending state while submitting a form](/docs/app/building-your-application/data-fetching/server-actions-and-mutations#pending-states)
+- [Server-side form validation](/docs/app/building-your-application/data-fetching/server-actions-and-mutations#server-side-validation-and-error-handling)
+- [Handling expected errors](/docs/app/building-your-application/routing/error-handling#handling-expected-errors-from-server-actions)
+- [Handling unexpected exceptions](/docs/app/building-your-application/routing/error-handling#uncaught-exceptions)
+- [Showing optimistic UI updates](/docs/app/building-your-application/data-fetching/server-actions-and-mutations#optimistic-updates)
+- [Programmatic form submission](/docs/app/building-your-application/data-fetching/server-actions-and-mutations#programmatic-form-submission)
+
+### Server Actions
+
+- [Passing additional values](/docs/app/building-your-application/data-fetching/server-actions-and-mutations#passing-additional-arguments)
+- [Revalidating data](/docs/app/building-your-application/data-fetching/server-actions-and-mutations#revalidating-data)
+- [Redirecting](/docs/app/building-your-application/data-fetching/server-actions-and-mutations#redirecting)
+- [Setting cookies](/docs/app/api-reference/functions/cookies#cookiessetname-value-options)
+- [Deleting cookies](/docs/app/api-reference/functions/cookies#deleting-cookies)
+
+### Metadata
+
+- [Creating an RSS feed](/docs/app/building-your-application/routing/route-handlers#non-ui-responses)
+- [Creating an Open Graph image](/docs/app/api-reference/file-conventions/metadata/opengraph-image)
+- [Creating a sitemap](/docs/app/api-reference/file-conventions/metadata/sitemap)
+- [Creating a robots.txt file](/docs/app/api-reference/file-conventions/metadata/robots)
+- [Creating a custom 404 page](/docs/app/api-reference/file-conventions/not-found)
+- [Creating a custom 500 page](/docs/app/api-reference/file-conventions/error)
+
+### Auth
+
+- [Creating a sign-up form](/docs/app/building-your-application/authentication#sign-up-and-login-functionality)
+- [Stateless, cookie-based session management](/docs/app/building-your-application/authentication#stateless-sessions)
+- [Stateful, database-backed session management](/docs/app/building-your-application/authentication#database-sessions)
+- [Managing authorization](/docs/app/building-your-application/authentication#authorization)
+
+### Testing
+
+- [Vitest](/docs/app/building-your-application/testing/vitest)
+- [Jest](/docs/app/building-your-application/testing/jest)
+- [Playwright](/docs/app/building-your-application/testing/playwright)
+- [Cypress](/docs/app/building-your-application/testing/cypress)
+
+### Deployment
+
+- [Creating a Dockerfile](/docs/app/building-your-application/deploying#docker-image)
+- [Creating a static export (SPA)](/docs/app/building-your-application/deploying/static-exports)
+- [Configuring caching when self-hosting](/docs/app/building-your-application/deploying#configuring-caching)
+- [Configuring Image Optimization when self-hosting](/docs/app/building-your-application/deploying#image-optimization)

--- a/docs/02-app/01-building-your-application/12-examples/index.mdx
+++ b/docs/02-app/01-building-your-application/12-examples/index.mdx
@@ -20,7 +20,7 @@ description: Examples of popular Next.js UI patterns and use cases.
 ### Forms
 
 - [Showing a pending state while submitting a form](/docs/app/building-your-application/data-fetching/server-actions-and-mutations#pending-states)
-- [Server-side form validation](/docs/app/building-your-application/data-fetching/server-actions-and-mutations#server-side-validation-and-error-handling)
+- [Server-side form validation](/docs/app/building-your-application/data-fetching/server-actions-and-mutations#server-side-form-validation)
 - [Handling expected errors](/docs/app/building-your-application/routing/error-handling#handling-expected-errors-from-server-actions)
 - [Handling unexpected exceptions](/docs/app/building-your-application/routing/error-handling#uncaught-exceptions)
 - [Showing optimistic UI updates](/docs/app/building-your-application/data-fetching/server-actions-and-mutations#optimistic-updates)

--- a/docs/03-pages/01-building-your-application/11-examples/index.mdx
+++ b/docs/03-pages/01-building-your-application/11-examples/index.mdx
@@ -1,8 +1,0 @@
----
-title: Next.js Examples
-nav_title: Examples
-description: Examples of popular Next.js UI patterns and use cases.
-source: app/building-your-application/examples
----
-
-{/* DO NOT EDIT. The content of this doc is generated from the source above. To edit the content of this page, navigate to the source page in your editor. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}

--- a/docs/03-pages/01-building-your-application/11-examples/index.mdx
+++ b/docs/03-pages/01-building-your-application/11-examples/index.mdx
@@ -1,0 +1,8 @@
+---
+title: Next.js Examples
+nav_title: Examples
+description: Examples of popular Next.js UI patterns and use cases.
+source: app/building-your-application/examples
+---
+
+{/* DO NOT EDIT. The content of this doc is generated from the source above. To edit the content of this page, navigate to the source page in your editor. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}


### PR DESCRIPTION
This is definitely _not_ where we want it to be yet, _but_ it's worth co-locating many of the examples linked in multiple places in the docs.