### PR TITLE
docs: add missing types for next-config-ts

### DIFF
--- a/docs/02-app/01-building-your-application/07-configuring/01-typescript.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/01-typescript.mdx
@@ -313,6 +313,8 @@ const nextConfig: NextConfig = {
     ignoreBuildErrors: true,
   },
 }
+
+export default nextConfig
 ```
 
 ## Custom Type Declarations

--- a/docs/02-app/01-building-your-application/07-configuring/01-typescript.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/01-typescript.mdx
@@ -302,7 +302,9 @@ If disabled, be sure you are running type checks as part of your build or deploy
 Open `next.config.ts` and enable the `ignoreBuildErrors` option in the `typescript` config:
 
 ```ts filename="next.config.ts"
-export default {
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
   typescript: {
     // !! WARN !!
     // Dangerously allow production builds to successfully complete even if

--- a/docs/02-app/02-api-reference/05-next-config-js/reactCompiler.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/reactCompiler.mdx
@@ -26,9 +26,20 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
+```js filename="next.config.js" switcher
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    reactCompiler: true,
+  },
+}
+
+module.exports = nextConfig
+```
+
 Optionally, you can configure the compiler to run in "opt-in" mode as follows:
 
-```ts filename="next.config.ts"
+```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
@@ -40,6 +51,19 @@ const nextConfig: NextConfig = {
 }
 
 export default nextConfig
+```
+
+```js filename="next.config.js" switcher
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    reactCompiler: {
+      compilationMode: 'annotation',
+    },
+  },
+}
+
+module.exports = nextConfig
 ```
 
 > **Note:** The React Compiler is currently only possible to use in Next.js through a Babel plugin. This will opt-out of Next.js's default [Rust-based compiler](/docs/architecture/nextjs-compiler), which could result in slower build times. We are working on support for the React Compiler as our default compiler.

--- a/docs/02-app/02-api-reference/05-next-config-js/reactCompiler.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/reactCompiler.mdx
@@ -14,7 +14,7 @@ npm install babel-plugin-react-compiler
 
 Then, add `experimental.reactCompiler` option in `next.config.js`:
 
-```ts filename="next.config.ts"
+```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {

--- a/docs/02-app/02-api-reference/05-next-config-js/reactCompiler.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/reactCompiler.mdx
@@ -14,21 +14,24 @@ npm install babel-plugin-react-compiler
 
 Then, add `experimental.reactCompiler` option in `next.config.js`:
 
-```js filename="next.config.js"
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+```ts filename="next.config.ts"
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
   experimental: {
     reactCompiler: true,
   },
 }
 
-module.exports = nextConfig
+export default nextConfig
 ```
 
 Optionally, you can configure the compiler to run in "opt-in" mode as follows:
 
-```tsx filename="next.config.ts"
-const nextConfig = {
+```ts filename="next.config.ts"
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
   experimental: {
     reactCompiler: {
       compilationMode: 'annotation',
@@ -36,7 +39,7 @@ const nextConfig = {
   },
 }
 
-module.exports = nextConfig
+export default nextConfig
 ```
 
 > **Note:** The React Compiler is currently only possible to use in Next.js through a Babel plugin. This will opt-out of Next.js's default [Rust-based compiler](/docs/architecture/nextjs-compiler), which could result in slower build times. We are working on support for the React Compiler as our default compiler.


### PR DESCRIPTION
This PR added importing `type NextConfig` in examples of next-config-ts.
Closes NDX-227