### PR TITLE
sync-react: Automatically update all references to the React peer dependency version

### DIFF
--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -11,6 +11,10 @@ import pkg from "../package.json";
 
 import { GetTemplateFileArgs, InstallTemplateArgs } from "./types";
 
+// Do not rename or format. sync-react script relies on this line.
+// prettier-ignore
+const nextjsReactPeerVersion = "19.0.0-rc-1eaccd82-20240816";
+
 /**
  * Get the file path for a given file in a template, e.g. "next.config.js".
  */
@@ -184,8 +188,8 @@ export const installTemplate = async ({
      * Default dependencies.
      */
     dependencies: {
-      react: "19.0.0-rc-1eaccd82-20240816",
-      "react-dom": "19.0.0-rc-1eaccd82-20240816",
+      react: nextjsReactPeerVersion,
+      "react-dom": nextjsReactPeerVersion,
       next: version,
     },
     devDependencies: {},

--- a/run-tests.js
+++ b/run-tests.js
@@ -18,6 +18,10 @@ const exec = promisify(execOrig)
 const core = require('@actions/core')
 const { getTestFilter } = require('./test/get-test-filter')
 
+// Do not rename or format. sync-react script relies on this line.
+// prettier-ignore
+const nextjsReactPeerVersion = "19.0.0-rc-1eaccd82-20240816";
+
 let argv = require('yargs/yargs')(process.argv.slice(2))
   .string('type')
   .string('test-pattern')
@@ -409,7 +413,7 @@ ${ENDGROUP}`)
     // run `pnpm install` each time.
     console.log(`${GROUP}Creating shared Next.js install`)
     const reactVersion =
-      process.env.NEXT_TEST_REACT_VERSION || '19.0.0-rc-1eaccd82-20240816'
+      process.env.NEXT_TEST_REACT_VERSION || nextjsReactPeerVersion
     const { installDir, pkgPaths, tmpRepoDir } = await createNextInstall({
       parentSpan: mockTrace(),
       dependencies: {

--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -7,6 +7,12 @@ const execa = require('execa')
 /** @type {any} */
 const fetch = require('node-fetch')
 
+const filesReferencingReactPeerDependencyVersion = [
+  'run-tests.js',
+  'packages/create-next-app/templates/index.ts',
+  'test/lib/next-modes/base.ts',
+]
+
 // Use this script to update Next's vendored copy of React and related packages:
 //
 // Basic usage (defaults to most recent React canary version):
@@ -15,7 +21,9 @@ const fetch = require('node-fetch')
 // Update package.json but skip installing the dependencies automatically:
 //   pnpm run sync-react --no-install
 
-async function sync(channel = 'next') {
+async function sync({ channel, useAsPeerDependency }) {
+  const errors = []
+
   const noInstall = readBoolArg(process.argv, 'no-install')
   const useExperimental = channel === 'experimental'
   let newVersionStr = readStringArg(process.argv, 'version')
@@ -110,6 +118,26 @@ Or, run this command with no arguments to use the most recently published versio
   )
   console.log('Successfully updated React dependencies in package.json.\n')
 
+  if (useAsPeerDependency) {
+    for (const fileName of filesReferencingReactPeerDependencyVersion) {
+      const filePath = path.join(cwd, fileName)
+      const previousSource = await fsp.readFile(filePath, 'utf-8')
+      const updatedSource = previousSource.replace(
+        `const nextjsReactPeerVersion = "${baseVersionStr}";`,
+        `const nextjsReactPeerVersion = "${newVersionStr}";`
+      )
+      if (updatedSource === previousSource) {
+        errors.push(
+          new Error(
+            `${fileName}: Failed to update ${baseVersionStr} to ${newVersionStr}. Is this file still referencing the React peer dependency version?`
+          )
+        )
+      } else {
+        await fsp.writeFile(filePath, updatedSource)
+      }
+    }
+  }
+
   // Install the updated dependencies and build the vendored React files.
   if (noInstall) {
     console.log('Skipping install step because --no-install flag was passed.\n')
@@ -178,6 +206,11 @@ Or run this command again without the --no-install flag to do both automatically
   }
 
   await fsp.writeFile(path.join(cwd, '.github/.react-version'), newVersionStr)
+
+  if (errors.length) {
+    // eslint-disable-next-line no-undef -- Defined in Node.js
+    throw new AggregateError(errors)
+  }
 
   console.log(
     `Successfully updated React from ${baseSha} to ${newSha}.\n` +
@@ -255,8 +288,8 @@ async function getChangelogFromGitHub(baseSha, newSha) {
   return changelog.length > 0 ? changelog.join('\n') : null
 }
 
-sync('experimental')
-  .then(() => sync('rc'))
+sync({ channel: 'experimental', useAsPeerDependency: false })
+  .then(() => sync({ channel: 'rc', useAsPeerDependency: true }))
   .catch((error) => {
     console.error(error)
     process.exit(1)

--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -12,6 +12,13 @@ const filesReferencingReactPeerDependencyVersion = [
   'packages/create-next-app/templates/index.ts',
   'test/lib/next-modes/base.ts',
 ]
+const appManifestsInstallingNextjsPeerDependencies = [
+  'examples/reproduction-template/package.json',
+  'test/.stats-app/package.json',
+  // TODO: These should use the usual test helpers that automatically install the right React version
+  'test/e2e/next-test/first-time-setup-js/package.json',
+  'test/e2e/next-test/first-time-setup-ts/package.json',
+]
 
 // Use this script to update Next's vendored copy of React and related packages:
 //
@@ -154,6 +161,20 @@ Or, run this command with no arguments to use the most recently published versio
         // Prettier would add a newline anyway so do it manually to skip the additional `pnpm prettier-write`
         '\n'
     )
+
+    for (const fileName of appManifestsInstallingNextjsPeerDependencies) {
+      const packageJsonPath = path.join(cwd, fileName)
+      const packageJson = await fsp.readFile(packageJsonPath, 'utf-8')
+      const manifest = JSON.parse(packageJson)
+      manifest.dependencies['react'] = newVersionStr
+      manifest.dependencies['react-dom'] = newVersionStr
+      await fsp.writeFile(
+        packageJsonPath,
+        JSON.stringify(manifest, null, 2) +
+          // Prettier would add a newline anyway so do it manually to skip the additional `pnpm prettier-write`
+          '\n'
+      )
+    }
   }
 
   // Install the updated dependencies and build the vendored React files.

--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -136,6 +136,24 @@ Or, run this command with no arguments to use the most recently published versio
         await fsp.writeFile(filePath, updatedSource)
       }
     }
+
+    const nextjsPackageJsonPath = path.join(
+      cwd,
+      'packages',
+      'next',
+      'package.json'
+    )
+    const nextjsPackageJson = JSON.parse(
+      await fsp.readFile(nextjsPackageJsonPath, 'utf-8')
+    )
+    nextjsPackageJson.peerDependencies.react = `${newVersionStr}`
+    nextjsPackageJson.peerDependencies['react-dom'] = `${newVersionStr}`
+    await fsp.writeFile(
+      nextjsPackageJsonPath,
+      JSON.stringify(nextjsPackageJson, null, 2) +
+        // Prettier would add a newline anyway so do it manually to skip the additional `pnpm prettier-write`
+        '\n'
+    )
   }
 
   // Install the updated dependencies and build the vendored React files.

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -49,6 +49,9 @@ type OmitFirstArgument<F> = F extends (
   ? (...args: P) => R
   : never
 
+// prettier-ignore
+const nextjsReactPeerVersion = "19.0.0-rc-1eaccd82-20240816";
+
 export class NextInstance {
   protected files: FileRef | { [filename: string]: string | FileRef }
   protected nextConfig?: NextConfig
@@ -163,7 +166,7 @@ export class NextInstance {
         )
 
         const reactVersion =
-          process.env.NEXT_TEST_REACT_VERSION || '19.0.0-rc-1eaccd82-20240816'
+          process.env.NEXT_TEST_REACT_VERSION || nextjsReactPeerVersion
         const finalDependencies = {
           react: reactVersion,
           'react-dom': reactVersion,

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -49,6 +49,7 @@ type OmitFirstArgument<F> = F extends (
   ? (...args: P) => R
   : never
 
+// Do not rename or format. sync-react script relies on this line.
 // prettier-ignore
 const nextjsReactPeerVersion = "19.0.0-rc-1eaccd82-20240816";
 


### PR DESCRIPTION
Only the update to React as a peer dependency was left to do manually.

In package.json updating is trivial enough. For source code I just enforce a specific format (`const nextjsReactPeerVersion = "....";`) that is safe to update via find&replace
## Test plan
- [x] https://github.com/vercel/next.js/pull/69196