### PR TITLE
sync-react: Print to console what should go into PR description

### DIFF
--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -212,7 +212,16 @@ Or, run this command with no arguments to use the most recently published versio
     console.log()
   }
 
+  if (useAsPeerDependency) {
+    console.log(
+      `**breaking change for canary users: Bumps peer dependency of React from \`${baseVersionStr}\` to \`${newVersionStr}\`**`
+    )
+  }
+
   // Fetch the changelog from GitHub and print it to the console.
+  console.log(
+    `[diff facebook/react@${baseSha}...${newSha}](https://github.com/facebook/react/compare/${baseSha}...${newSha})`
+  )
   try {
     const changelog = await getChangelogFromGitHub(baseSha, newSha)
     if (changelog === null) {
@@ -252,10 +261,7 @@ Or run this command again without the --no-install flag to do both automatically
   }
 
   console.log(
-    `Successfully updated React from ${baseSha} to ${newSha}.\n` +
-      `Don't forget to find & replace all references to the React version '${baseVersionStr}' with '${newVersionStr}':\n` +
-      `-${baseVersionStr}\n` +
-      `+${newVersionStr}\n`
+    `Successfully updated React from \`${baseSha}-${baseDateString}\` to \`${newSha}-${newDateString}\``
   )
 }
 


### PR DESCRIPTION
Updates what we print to console with stuff I usually manually add to the PR description:
- link to actual GitHub compare between commits
- title with date strings (these help to see at glance how far behind the sync is)
- breaking change notice when peer dependencies are changed
## Test plan
- [x] https://github.com/vercel/next.js/pull/69196