### PR TITLE
sync-react: Remove redundant work 

### DIFF
--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -2,7 +2,9 @@
 
 const path = require('path')
 const fsp = require('fs/promises')
+const process = require('process')
 const execa = require('execa')
+const yargs = require('yargs')
 
 /** @type {any} */
 const fetch = require('node-fetch')
@@ -28,45 +30,14 @@ const appManifestsInstallingNextjsPeerDependencies = [
 // Update package.json but skip installing the dependencies automatically:
 //   pnpm run sync-react --no-install
 
-async function sync({ channel, useAsPeerDependency }) {
-  const errors = []
-
-  const noInstall = readBoolArg(process.argv, 'no-install')
+async function sync({
+  channel,
+  newVersionStr,
+  newSha,
+  newDateString,
+  noInstall,
+}) {
   const useExperimental = channel === 'experimental'
-  let newVersionStr = readStringArg(process.argv, 'version')
-  if (newVersionStr === null) {
-    const { stdout, stderr } = await execa(
-      'npm',
-      [
-        'view',
-        useExperimental ? 'react@experimental' : 'react@next',
-        'version',
-      ],
-      {
-        // Avoid "Usage Error: This project is configured to use pnpm".
-        cwd: '/tmp',
-      }
-    )
-    if (stderr) {
-      console.error(stderr)
-      throw new Error('Failed to read latest React canary version from npm.')
-    }
-    newVersionStr = stdout.trim()
-  }
-
-  const newVersionInfo = extractInfoFromReactVersion(newVersionStr)
-  if (!newVersionInfo) {
-    throw new Error(
-      `New react version does not match expected format: ${newVersionStr}
-
-Choose a React canary version from npm: https://www.npmjs.com/package/react?activeTab=versions
-
-Or, run this command with no arguments to use the most recently published version.
-`
-    )
-  }
-  newVersionInfo.releaseLabel = channel
-
   const cwd = process.cwd()
   const pkgJson = JSON.parse(
     await fsp.readFile(path.join(cwd, 'package.json'), 'utf-8')
@@ -85,11 +56,6 @@ Or, run this command with no arguments to use the most recently published versio
   }
 
   const {
-    sha: newSha,
-    releaseLabel: newReleaseLabel,
-    dateString: newDateString,
-  } = newVersionInfo
-  const {
     sha: baseSha,
     releaseLabel: baseReleaseLabel,
     dateString: baseDateString,
@@ -105,7 +71,7 @@ Or, run this command with no arguments to use the most recently published versio
     if (version.endsWith(`${baseReleaseLabel}-${baseSha}-${baseDateString}`)) {
       devDependencies[dep] = version.replace(
         `${baseReleaseLabel}-${baseSha}-${baseDateString}`,
-        `${newReleaseLabel}-${newSha}-${newDateString}`
+        `${channel}-${newSha}-${newDateString}`
       )
     }
   }
@@ -113,7 +79,7 @@ Or, run this command with no arguments to use the most recently published versio
     if (version.endsWith(`${baseReleaseLabel}-${baseSha}-${baseDateString}`)) {
       pnpmOverrides[dep] = version.replace(
         `${baseReleaseLabel}-${baseSha}-${baseDateString}`,
-        `${newReleaseLabel}-${newSha}-${newDateString}`
+        `${channel}-${newSha}-${newDateString}`
       )
     }
   }
@@ -123,155 +89,6 @@ Or, run this command with no arguments to use the most recently published versio
       // Prettier would add a newline anyway so do it manually to skip the additional `pnpm prettier-write`
       '\n'
   )
-  console.log('Successfully updated React dependencies in package.json.\n')
-
-  if (useAsPeerDependency) {
-    for (const fileName of filesReferencingReactPeerDependencyVersion) {
-      const filePath = path.join(cwd, fileName)
-      const previousSource = await fsp.readFile(filePath, 'utf-8')
-      const updatedSource = previousSource.replace(
-        `const nextjsReactPeerVersion = "${baseVersionStr}";`,
-        `const nextjsReactPeerVersion = "${newVersionStr}";`
-      )
-      if (updatedSource === previousSource) {
-        errors.push(
-          new Error(
-            `${fileName}: Failed to update ${baseVersionStr} to ${newVersionStr}. Is this file still referencing the React peer dependency version?`
-          )
-        )
-      } else {
-        await fsp.writeFile(filePath, updatedSource)
-      }
-    }
-
-    const nextjsPackageJsonPath = path.join(
-      cwd,
-      'packages',
-      'next',
-      'package.json'
-    )
-    const nextjsPackageJson = JSON.parse(
-      await fsp.readFile(nextjsPackageJsonPath, 'utf-8')
-    )
-    nextjsPackageJson.peerDependencies.react = `${newVersionStr}`
-    nextjsPackageJson.peerDependencies['react-dom'] = `${newVersionStr}`
-    await fsp.writeFile(
-      nextjsPackageJsonPath,
-      JSON.stringify(nextjsPackageJson, null, 2) +
-        // Prettier would add a newline anyway so do it manually to skip the additional `pnpm prettier-write`
-        '\n'
-    )
-
-    for (const fileName of appManifestsInstallingNextjsPeerDependencies) {
-      const packageJsonPath = path.join(cwd, fileName)
-      const packageJson = await fsp.readFile(packageJsonPath, 'utf-8')
-      const manifest = JSON.parse(packageJson)
-      manifest.dependencies['react'] = newVersionStr
-      manifest.dependencies['react-dom'] = newVersionStr
-      await fsp.writeFile(
-        packageJsonPath,
-        JSON.stringify(manifest, null, 2) +
-          // Prettier would add a newline anyway so do it manually to skip the additional `pnpm prettier-write`
-          '\n'
-      )
-    }
-  }
-
-  // Install the updated dependencies and build the vendored React files.
-  if (noInstall) {
-    console.log('Skipping install step because --no-install flag was passed.\n')
-  } else {
-    console.log('Installing dependencies...\n')
-
-    const installSubprocess = execa('pnpm', ['install'])
-    if (installSubprocess.stdout) {
-      installSubprocess.stdout.pipe(process.stdout)
-    }
-    try {
-      await installSubprocess
-    } catch (error) {
-      console.error(error)
-      throw new Error('Failed to install updated dependencies.')
-    }
-
-    console.log('Building vendored React files...\n')
-    const nccSubprocess = execa('pnpm', ['ncc-compiled'], {
-      cwd: path.join(cwd, 'packages', 'next'),
-    })
-    if (nccSubprocess.stdout) {
-      nccSubprocess.stdout.pipe(process.stdout)
-    }
-    try {
-      await nccSubprocess
-    } catch (error) {
-      console.error(error)
-      throw new Error('Failed to run ncc.')
-    }
-
-    // Print extra newline after ncc output
-    console.log()
-  }
-
-  if (useAsPeerDependency) {
-    console.log(
-      `**breaking change for canary users: Bumps peer dependency of React from \`${baseVersionStr}\` to \`${newVersionStr}\`**`
-    )
-  }
-
-  // Fetch the changelog from GitHub and print it to the console.
-  console.log(
-    `[diff facebook/react@${baseSha}...${newSha}](https://github.com/facebook/react/compare/${baseSha}...${newSha})`
-  )
-  try {
-    const changelog = await getChangelogFromGitHub(baseSha, newSha)
-    if (changelog === null) {
-      console.log(
-        `GitHub reported no changes between ${baseSha} and ${newSha}.`
-      )
-    } else {
-      console.log(
-        `<details>\n<summary>React upstream changes</summary>\n\n${changelog}\n\n</details>`
-      )
-    }
-  } catch (error) {
-    console.error(error)
-    console.log(
-      '\nFailed to fetch changelog from GitHub. Changes were applied, anyway.\n'
-    )
-  }
-
-  if (noInstall) {
-    console.log(
-      `
-To finish upgrading, complete the following steps:
-
-- Install the updated dependencies: pnpm install
-- Build the vendored React files: (inside packages/next dir) pnpm ncc-compiled
-
-Or run this command again without the --no-install flag to do both automatically.
-    `
-    )
-  }
-
-  await fsp.writeFile(path.join(cwd, '.github/.react-version'), newVersionStr)
-
-  if (errors.length) {
-    // eslint-disable-next-line no-undef -- Defined in Node.js
-    throw new AggregateError(errors)
-  }
-
-  console.log(
-    `Successfully updated React from \`${baseSha}-${baseDateString}\` to \`${newSha}-${newDateString}\``
-  )
-}
-
-function readBoolArg(argv, argName) {
-  return argv.indexOf('--' + argName) !== -1
-}
-
-function readStringArg(argv, argName) {
-  const argIndex = argv.indexOf('--' + argName)
-  return argIndex === -1 ? null : argv[argIndex + 1]
 }
 
 function extractInfoFromReactVersion(reactVersion) {
@@ -333,9 +150,210 @@ async function getChangelogFromGitHub(baseSha, newSha) {
   return changelog.length > 0 ? changelog.join('\n') : null
 }
 
-sync({ channel: 'experimental', useAsPeerDependency: false })
-  .then(() => sync({ channel: 'rc', useAsPeerDependency: true }))
-  .catch((error) => {
-    console.error(error)
-    process.exit(1)
+async function main() {
+  const cwd = process.cwd()
+  const errors = []
+  const { noInstall, version } = await yargs(process.argv.slice(2))
+    .options('version', { default: null, type: 'string' })
+    .options('no-install', { default: false, type: 'boolean' }).argv
+
+  let newVersionStr = version
+  if (newVersionStr === null) {
+    const { stdout, stderr } = await execa(
+      'npm',
+      ['view', 'react@canary', 'version'],
+      {
+        // Avoid "Usage Error: This project is configured to use pnpm".
+        cwd: '/tmp',
+      }
+    )
+    if (stderr) {
+      console.error(stderr)
+      throw new Error('Failed to read latest React canary version from npm.')
+    }
+    newVersionStr = stdout.trim()
+  }
+
+  const newVersionInfo = extractInfoFromReactVersion(newVersionStr)
+  if (!newVersionInfo) {
+    throw new Error(
+      `New react version does not match expected format: ${newVersionStr}
+
+Choose a React canary version from npm: https://www.npmjs.com/package/react?activeTab=versions
+
+Or, run this command with no arguments to use the most recently published version.
+`
+    )
+  }
+  const { sha: newSha, dateString: newDateString } = newVersionInfo
+  const rootManifest = JSON.parse(
+    await fsp.readFile(path.join(cwd, 'package.json'), 'utf-8')
+  )
+  const baseVersionStr = rootManifest.devDependencies['react-builtin'].replace(
+    /^npm:react@/,
+    ''
+  )
+
+  await sync({
+    newDateString,
+    newSha,
+    newVersionStr,
+    noInstall,
+    channel: 'experimental',
   })
+  await sync({
+    newDateString,
+    newSha,
+    newVersionStr,
+    noInstall,
+    channel: 'rc',
+  })
+
+  const baseVersionInfo = extractInfoFromReactVersion(baseVersionStr)
+  if (!baseVersionInfo) {
+    throw new Error(
+      'Base react version does not match expected format: ' + baseVersionStr
+    )
+  }
+
+  const { sha: baseSha, dateString: baseDateString } = baseVersionInfo
+  for (const fileName of filesReferencingReactPeerDependencyVersion) {
+    const filePath = path.join(cwd, fileName)
+    const previousSource = await fsp.readFile(filePath, 'utf-8')
+    const updatedSource = previousSource.replace(
+      `const nextjsReactPeerVersion = "${baseVersionStr}";`,
+      `const nextjsReactPeerVersion = "${newVersionStr}";`
+    )
+    if (updatedSource === previousSource) {
+      errors.push(
+        new Error(
+          `${fileName}: Failed to update ${baseVersionStr} to ${newVersionStr}. Is this file still referencing the React peer dependency version?`
+        )
+      )
+    } else {
+      await fsp.writeFile(filePath, updatedSource)
+    }
+  }
+
+  const nextjsPackageJsonPath = path.join(
+    process.cwd(),
+    'packages',
+    'next',
+    'package.json'
+  )
+  const nextjsPackageJson = JSON.parse(
+    await fsp.readFile(nextjsPackageJsonPath, 'utf-8')
+  )
+  nextjsPackageJson.peerDependencies.react = `${newVersionStr}`
+  nextjsPackageJson.peerDependencies['react-dom'] = `${newVersionStr}`
+  await fsp.writeFile(
+    nextjsPackageJsonPath,
+    JSON.stringify(nextjsPackageJson, null, 2) +
+      // Prettier would add a newline anyway so do it manually to skip the additional `pnpm prettier-write`
+      '\n'
+  )
+
+  for (const fileName of appManifestsInstallingNextjsPeerDependencies) {
+    const packageJsonPath = path.join(cwd, fileName)
+    const packageJson = await fsp.readFile(packageJsonPath, 'utf-8')
+    const manifest = JSON.parse(packageJson)
+    manifest.dependencies['react'] = newVersionStr
+    manifest.dependencies['react-dom'] = newVersionStr
+    await fsp.writeFile(
+      packageJsonPath,
+      JSON.stringify(manifest, null, 2) +
+        // Prettier would add a newline anyway so do it manually to skip the additional `pnpm prettier-write`
+        '\n'
+    )
+  }
+
+  // Install the updated dependencies and build the vendored React files.
+  if (noInstall) {
+    console.log('Skipping install step because --no-install flag was passed.\n')
+  } else {
+    console.log('Installing dependencies...\n')
+
+    const installSubprocess = execa('pnpm', ['install'])
+    if (installSubprocess.stdout) {
+      installSubprocess.stdout.pipe(process.stdout)
+    }
+    try {
+      await installSubprocess
+    } catch (error) {
+      console.error(error)
+      throw new Error('Failed to install updated dependencies.')
+    }
+
+    console.log('Building vendored React files...\n')
+    const nccSubprocess = execa('pnpm', ['ncc-compiled'], {
+      cwd: path.join(cwd, 'packages', 'next'),
+    })
+    if (nccSubprocess.stdout) {
+      nccSubprocess.stdout.pipe(process.stdout)
+    }
+    try {
+      await nccSubprocess
+    } catch (error) {
+      console.error(error)
+      throw new Error('Failed to run ncc.')
+    }
+
+    // Print extra newline after ncc output
+    console.log()
+  }
+
+  console.log(
+    `**breaking change for canary users: Bumps peer dependency of React from \`${baseVersionStr}\` to \`${newVersionStr}\`**`
+  )
+
+  // Fetch the changelog from GitHub and print it to the console.
+  console.log(
+    `[diff facebook/react@${baseSha}...${newSha}](https://github.com/facebook/react/compare/${baseSha}...${newSha})`
+  )
+  try {
+    const changelog = await getChangelogFromGitHub(baseSha, newSha)
+    if (changelog === null) {
+      console.log(
+        `GitHub reported no changes between ${baseSha} and ${newSha}.`
+      )
+    } else {
+      console.log(
+        `<details>\n<summary>React upstream changes</summary>\n\n${changelog}\n\n</details>`
+      )
+    }
+  } catch (error) {
+    console.error(error)
+    console.log(
+      '\nFailed to fetch changelog from GitHub. Changes were applied, anyway.\n'
+    )
+  }
+
+  if (noInstall) {
+    console.log(
+      `
+To finish upgrading, complete the following steps:
+
+- Install the updated dependencies: pnpm install
+- Build the vendored React files: (inside packages/next dir) pnpm ncc-compiled
+
+Or run this command again without the --no-install flag to do both automatically.
+    `
+    )
+  }
+
+  await fsp.writeFile(path.join(cwd, '.github/.react-version'), newVersionStr)
+
+  if (errors.length) {
+    // eslint-disable-next-line no-undef -- Defined in Node.js
+    throw new AggregateError(errors)
+  }
+
+  console.log(
+    `Successfully updated React from \`${baseSha}-${baseDateString}\` to \`${newSha}-${newDateString}\``
+  )
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
This mainly moves code out of the `sync` function into a parent main function.
The `main` takes care of the responsibilities that we really only need once while `sync` takes care of just syncing this specific React release channel:
- update peer dependencies
- install
- compile
- print changelog

The changelog could live in the `sync` function since it's technically specific to each release channel.
However, currently don't write React commits to indicate which release channel they affect.

## Test plan
- [x] https://github.com/vercel/next.js/pull/69196