### PR TITLE
Change ID generation strategy

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -245,7 +245,7 @@ impl EcmascriptChunkItem for CachedExternalModuleChunkItem {
     }
 }
 
-/// A module that only has an ident and no content. This is used
+/// A module that only has an ident and no content nor references. It is used
 /// to include a module's ident in the module graph before the module
 /// itself is resolved, as is the case with NextServerComponentModule's
 /// "client modules" and "client modules ssr".


### PR DESCRIPTION
Previously, IDs were generated by hashing and taking the 4 least significant bits, and iteratively taking 4 more bits into account until an available ID was found. Now, the same is done but with digits, i.e. take the first digit of the hash, then first 2, then first 3, etc until an available ID is found.