### PR TITLE
chore(CI): Use Graphite's CI Optimization Feature

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,6 +28,10 @@ env:
   NEXT_TEST_JOB: 1
 
 jobs:
+  optimize-ci:
+    uses: ./.github/workflows/graphite_ci_optimizer.yml
+    secrets: inherit
+
   changes:
     name: Determine changes
     runs-on: ubuntu-latest
@@ -125,8 +129,8 @@ jobs:
 
   test-bench:
     name: test cargo benches
-    needs: ['changes', 'build-next']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    needs: ['optimize-ci', 'changes', 'build-next']
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
     uses: ./.github/workflows/test-turbopack-rust-bench-test.yml
     secrets: inherit
@@ -172,8 +176,8 @@ jobs:
 
   devlow-bench:
     name: Run devlow benchmarks
-    needs: ['changes', 'build-next', 'build-native']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    needs: ['optimize-ci', 'changes', 'build-next', 'build-native']
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
     strategy:
       fail-fast: false
@@ -191,8 +195,8 @@ jobs:
 
   test-turbopack-dev:
     name: test turbopack dev
-    needs: ['changes', 'build-next', 'build-native']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    needs: ['optimize-ci', 'changes', 'build-next', 'build-native']
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
     strategy:
       fail-fast: false
@@ -206,8 +210,8 @@ jobs:
 
   test-turbopack-integration:
     name: test turbopack development integration
-    needs: ['changes', 'build-next', 'build-native']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    needs: ['optimize-ci', 'changes', 'build-next', 'build-native']
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
     strategy:
       fail-fast: false
@@ -222,8 +226,8 @@ jobs:
 
   test-turbopack-production:
     name: test turbopack production
-    needs: ['changes', 'build-next', 'build-native']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    needs: ['optimize-ci', 'changes', 'build-next', 'build-native']
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
     strategy:
       fail-fast: false
@@ -238,8 +242,8 @@ jobs:
 
   test-turbopack-production-integration:
     name: test turbopack production integration
-    needs: ['changes', 'build-next', 'build-native']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    needs: ['optimize-ci', 'changes', 'build-next', 'build-native']
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
     strategy:
       fail-fast: false
@@ -254,8 +258,8 @@ jobs:
 
   test-next-swc-wasm:
     name: test next-swc wasm
-    needs: ['changes', 'build-next']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    needs: ['optimize-ci', 'changes', 'build-next']
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
     with:
@@ -266,7 +270,7 @@ jobs:
   #[NOTE] currently this only checks building wasi target
   test-next-swc-napi-wasi:
     name: test next-swc wasi
-    needs: ['changes', 'build-next']
+    needs: ['optimize-ci', 'changes', 'build-next']
     # TODO: Re-enable this when https://github.com/napi-rs/napi-rs/issues/2009 is addressed.
     # Specifically, the `platform` value is now `threads` in
     # https://github.com/napi-rs/napi-rs/blob/e4ad4767efaf093fdff3dc768856f6100a6e3f72/cli/src/api/build.ts#L530
@@ -299,8 +303,8 @@ jobs:
 
   test-new-tests-dev:
     name: Test new tests for flakes (dev)
-    needs: ['changes', 'build-native', 'build-next']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
     strategy:
       fail-fast: false
@@ -316,8 +320,8 @@ jobs:
 
   test-new-tests-start:
     name: Test new tests for flakes (prod)
-    needs: ['changes', 'build-native', 'build-next']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
     strategy:
       fail-fast: false
@@ -333,8 +337,9 @@ jobs:
 
   test-new-tests-deploy:
     name: Test new tests when deployed
-    needs: ['test-prod', 'test-new-tests-dev', 'test-new-tests-start']
-    if: ${{ needs.changes.outputs.docs-only == 'false' && !github.event.pull_request.head.repo.fork }}
+    needs:
+      ['optimize-ci', 'test-prod', 'test-new-tests-dev', 'test-new-tests-start']
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && !github.event.pull_request.head.repo.fork }}
 
     strategy:
       fail-fast: false
@@ -350,8 +355,8 @@ jobs:
 
   test-dev:
     name: test dev
-    needs: ['changes', 'build-native', 'build-next']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
     strategy:
       fail-fast: false
@@ -365,8 +370,8 @@ jobs:
 
   test-prod:
     name: test prod
-    needs: ['changes', 'build-native', 'build-next']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
     strategy:
       fail-fast: false
@@ -380,8 +385,8 @@ jobs:
 
   test-integration:
     name: test integration
-    needs: ['changes', 'build-native', 'build-next']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
     strategy:
       fail-fast: false
@@ -408,8 +413,8 @@ jobs:
 
   test-firefox-safari:
     name: test firefox and safari
-    needs: ['changes', 'build-native', 'build-next']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
     with:
@@ -421,8 +426,8 @@ jobs:
   # Manifest generated via: https://gist.github.com/wyattjoh/2ceaebd82a5bcff4819600fd60126431
   test-ppr-integration:
     name: test ppr integration
-    needs: ['changes', 'build-native', 'build-next']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
     with:
@@ -433,8 +438,8 @@ jobs:
 
   test-ppr-dev:
     name: test ppr dev
-    needs: ['changes', 'build-native', 'build-next']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
     strategy:
       fail-fast: false
@@ -448,8 +453,8 @@ jobs:
 
   test-ppr-prod:
     name: test ppr prod
-    needs: ['changes', 'build-native', 'build-next']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/graphite_ci_optimizer.yml
+++ b/.github/workflows/graphite_ci_optimizer.yml
@@ -1,0 +1,40 @@
+# Avoid running the full CI on mid-stack PRs: https://graphite.dev/docs/stacking-and-ci
+#
+# We still run some high-signal low-cost jobs (e.g. lint, unit tests) on these mid-stack PRs, just
+# not anything slow (e.g. integration tests).
+#
+# Because we don't use Graphite's CI batching, full CI will still run on every PR individually
+# before it merges. The goal is just to avoid wasting CI capacity when frequently rebasing large
+# stacks.
+#
+# This can by bypassed by labeling a PR with 'CI Bypass Graphite Optimization', and manually
+# re-running CI.
+
+name: Graphite CI Optimizer
+on:
+  workflow_call:
+    outputs:
+      skip:
+        description: "'true' if expensive CI checks should be skipped, 'false' otherwise."
+        value: ${{ jobs.optimize-ci.outputs.skip }}
+    secrets:
+      GRAPHITE_TOKEN:
+        description: 'The Graphite CI optimization secret'
+        required: true
+jobs:
+  optimize-ci:
+    name: Graphite CI Optimizer
+    runs-on: ubuntu-latest
+    outputs:
+      skip: |
+        ${{
+          github.event_name == 'pull_request' &&
+            !contains(github.event.pull_request.labels.*.name, 'CI Bypass Graphite Optimization') &&
+            steps.check-skip.outputs.skip == 'true'
+        }}
+    steps:
+      - name: Optimize CI
+        id: check-skip
+        uses: withgraphite/graphite-ci-action@main
+        with:
+          graphite_token: ${{ secrets.GRAPHITE_TOKEN }}

--- a/.github/workflows/graphite_ci_optimizer.yml
+++ b/.github/workflows/graphite_ci_optimizer.yml
@@ -21,20 +21,26 @@ on:
       GRAPHITE_TOKEN:
         description: 'The Graphite CI optimization secret'
         required: true
+env:
+  HAS_BYPASS_LABEL: |
+    ${{
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.labels.*.name, 'CI Bypass Graphite Optimization')
+    }}
 jobs:
   optimize-ci:
     name: Graphite CI Optimizer
     runs-on: ubuntu-latest
     outputs:
-      skip: |
-        ${{
-          github.event_name == 'pull_request' &&
-            !contains(github.event.pull_request.labels.*.name, 'CI Bypass Graphite Optimization') &&
-            steps.check-skip.outputs.skip == 'true'
-        }}
+      skip: ${{ env.HAS_BYPASS_LABEL == 'false' && steps.check-skip.outputs.skip == 'true' }}
     steps:
       - name: Optimize CI
         id: check-skip
         uses: withgraphite/graphite-ci-action@main
         with:
           graphite_token: ${{ secrets.GRAPHITE_TOKEN }}
+      - name: Debug Output
+        run: |
+          echo 'github.event_name: ${{ github.event_name }}'
+          echo 'env.HAS_BYPASS_LABEL: ${{ env.HAS_BYPASS_LABEL }}'
+          echo 'steps.check-skip.outputs.skip: ${{ steps.check-skip.outputs.skip }}'

--- a/.github/workflows/graphite_ci_optimizer.yml
+++ b/.github/workflows/graphite_ci_optimizer.yml
@@ -22,7 +22,7 @@ on:
         description: 'The Graphite CI optimization secret'
         required: true
 env:
-  HAS_BYPASS_LABEL: |
+  HAS_BYPASS_LABEL: |-
     ${{
       github.event_name == 'pull_request' &&
       contains(github.event.pull_request.labels.*.name, 'CI Bypass Graphite Optimization')


### PR DESCRIPTION
## What?

https://graphite.dev/blog/ci-optimizer
https://graphite.dev/docs/stacking-and-ci

> Stacking leads to developers creating smaller easier-to-review pull requests, which can lead to more CI runs unless you optimize your CI for stacking. [...]
>
> Additional CI runs occur when stacking PRs in part due to to the additional PRs created, and due to behind-the-scenes rebasing to keep stacked branches up to date.
>
> To solve this, Graphite offers first-class integrations with [...] GitHub Actions to let you customize which PRs in stacks you want to run CI on.

I've configured CI optimization to run on the top & bottom commits of each stack:

![Screenshot 2024-08-22 at 3.33.35 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/67c9e2a6-92f4-4726-bb08-3b9df246ed9b.png)

## Failure Handling

If this fails for some reason, the full CI suite should run.

> Graphite's [...] GitHub Actions integrations are configured to "fail open" so that outages and errors still result in your CI running.

## Opting Out

Add the new `CI Bypass Graphite Optimization` label to your PR, and then push an update to the branch.

**Ugly:** You must push an update to the branch. Triggering on label change would cause unintended side-effects, and just triggering the workflow to re-run in the GitHub UI doesn't cause the workflow to pick up the changed label, as the label is part of the pull request event.

## What about `build_and_deploy`?

Because this currently triggers off of a `push` event rather than a `pull_request` (allowing preview deployments without making a PR), there's currently no way to change the behavior on `build_and_deploy`.

This is implemented as a reusable workflow, so it should be possible to hook this into other workflows in the future (e.g. if we wanted to avoid running `pull_request_stats` as well), as long as they trigger on `pull_request` events.

## Testing

### Breakage on Top of Stack

Push a PR to the top of the stack that breaks an e2e test. See that CI fails on that PR as expected, and that all of the appropriate CI jobs run.

![Screenshot 2024-08-26 at 16-08-14 please-ignore(CI) Break e2e test (tests #69204) · vercel_next js@fb33205](https://github.com/user-attachments/assets/f62698df-1dcc-45bf-ac1c-7cf2ca17af83)

### Breakage in Middle of Stack

Push another PR on top of the stack, so that the e2e breakage is in the middle of the stack. Force github to re-run the workflow using the github UI. See that the CI optimizer skips the PR because it's in the middle:

<img width="1024" alt="Screenshot 2024-08-26 at 4 17 52 PM" src="https://github.com/user-attachments/assets/3fd2c473-64e0-4c7c-8169-438fbb60e758">

And see that most jobs are skipped, leaving us with a very small set of test jobs:

<img width="875" alt="Screenshot 2024-08-26 at 4 21 53 PM" src="https://github.com/user-attachments/assets/91623d84-b4b7-4d00-8177-37ffbf773046">


### Observed Failure at Top of Stack

Even though the failure is caused by the middle of the stack, a documentation-only change at the top of the stack still catches the failure caused by the middle of the stack, as the "documentation only" check compares against canary, not just the parent PR in the stack.

<img width="1713" alt="Screenshot 2024-08-26 at 4 24 27 PM" src="https://github.com/user-attachments/assets/dd2ba177-8579-42c7-a602-56d03732f44d">


### Bypassing CI Optimization

Add the new label to the PR in the middle of the stack, and force it to re-run by making a change to the commit message and re-submitting with `gh submit`.

<img width="468" alt="Screenshot 2024-08-26 at 4 26 49 PM" src="https://github.com/user-attachments/assets/c04b0379-b4f4-4d83-b41b-a1aa3a297f8d">

See that the debug output shows the label being detected:

<img width="416" alt="Screenshot 2024-08-26 at 4 35 11 PM" src="https://github.com/user-attachments/assets/a2828f49-7a76-4266-ba7c-de370045bcb5">

And see that the full CI suite runs!