### PR TITLE
backport: reading middleware cookies during render

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2813,6 +2813,10 @@ export default async function build(
                   // normalize header values as initialHeaders
                   // must be Record<string, string>
                   for (const key of headerKeys) {
+                    // set-cookie is already handled - the middleware cookie setting case
+                    // isn't needed for the prerender manifest since it can't read cookies
+                    if (key === 'x-middleware-set-cookie') continue
+
                     let value = exportHeaders[key]
 
                     if (Array.isArray(value)) {

--- a/packages/next/src/server/async-storage/request-async-storage-wrapper.ts
+++ b/packages/next/src/server/async-storage/request-async-storage-wrapper.ts
@@ -17,9 +17,9 @@ import {
   RequestCookiesAdapter,
   type ReadonlyRequestCookies,
 } from '../web/spec-extension/adapters/request-cookies'
-import type { ResponseCookies } from '../web/spec-extension/cookies'
-import { RequestCookies } from '../web/spec-extension/cookies'
+import { ResponseCookies, RequestCookies } from '../web/spec-extension/cookies'
 import { DraftModeProvider } from './draft-mode-provider'
+import { splitCookiesString } from '../web/utils'
 
 function getHeaders(headers: Headers | IncomingHttpHeaders): ReadonlyHeaders {
   const cleaned = HeadersAdapter.from(headers)
@@ -28,13 +28,6 @@ function getHeaders(headers: Headers | IncomingHttpHeaders): ReadonlyHeaders {
   }
 
   return HeadersAdapter.seal(cleaned)
-}
-
-function getCookies(
-  headers: Headers | IncomingHttpHeaders
-): ReadonlyRequestCookies {
-  const cookies = new RequestCookies(HeadersAdapter.from(headers))
-  return RequestCookiesAdapter.seal(cookies)
 }
 
 function getMutableCookies(
@@ -103,24 +96,32 @@ export const RequestAsyncStorageWrapper: AsyncStorageWrapper<
         if (!cache.cookies) {
           // if middleware is setting cookie(s), then include those in
           // the initial cached cookies so they can be read in render
-          let combinedCookies
+          const requestCookies = new RequestCookies(
+            HeadersAdapter.from(req.headers)
+          )
+
           if (
             'x-middleware-set-cookie' in req.headers &&
             typeof req.headers['x-middleware-set-cookie'] === 'string'
           ) {
-            combinedCookies = `${req.headers.cookie}; ${req.headers['x-middleware-set-cookie']}`
+            const setCookieValue = req.headers['x-middleware-set-cookie']
+            const responseHeaders = new Headers()
+
+            for (const cookie of splitCookiesString(setCookieValue)) {
+              responseHeaders.append('set-cookie', cookie)
+            }
+
+            const responseCookies = new ResponseCookies(responseHeaders)
+
+            // Transfer cookies from ResponseCookies to RequestCookies
+            for (const cookie of responseCookies.getAll()) {
+              requestCookies.set(cookie.name, cookie.value ?? '')
+            }
           }
 
           // Seal the cookies object that'll freeze out any methods that could
           // mutate the underlying data.
-          cache.cookies = getCookies(
-            combinedCookies
-              ? {
-                  ...req.headers,
-                  cookie: combinedCookies,
-                }
-              : req.headers
-          )
+          cache.cookies = RequestCookiesAdapter.seal(requestCookies)
         }
 
         return cache.cookies

--- a/packages/next/src/server/async-storage/request-async-storage-wrapper.ts
+++ b/packages/next/src/server/async-storage/request-async-storage-wrapper.ts
@@ -68,7 +68,7 @@ function mergeMiddlewareCookies(
 
     // Transfer cookies from ResponseCookies to RequestCookies
     for (const cookie of responseCookies.getAll()) {
-      existingCookies.set(cookie.name, cookie.value ?? '')
+      existingCookies.set(cookie)
     }
   }
 }

--- a/packages/next/src/server/async-storage/request-async-storage-wrapper.ts
+++ b/packages/next/src/server/async-storage/request-async-storage-wrapper.ts
@@ -44,6 +44,35 @@ export type RequestContext = {
   renderOpts?: RenderOpts
 }
 
+/**
+ * If middleware set cookies in this request (indicated by `x-middleware-set-cookie`),
+ * then merge those into the existing cookie object, so that when `cookies()` is accessed
+ * it's able to read the newly set cookies.
+ */
+function mergeMiddlewareCookies(
+  req: RequestContext['req'],
+  existingCookies: RequestCookies | ResponseCookies
+) {
+  if (
+    'x-middleware-set-cookie' in req.headers &&
+    typeof req.headers['x-middleware-set-cookie'] === 'string'
+  ) {
+    const setCookieValue = req.headers['x-middleware-set-cookie']
+    const responseHeaders = new Headers()
+
+    for (const cookie of splitCookiesString(setCookieValue)) {
+      responseHeaders.append('set-cookie', cookie)
+    }
+
+    const responseCookies = new ResponseCookies(responseHeaders)
+
+    // Transfer cookies from ResponseCookies to RequestCookies
+    for (const cookie of responseCookies.getAll()) {
+      existingCookies.set(cookie.name, cookie.value ?? '')
+    }
+  }
+}
+
 export const RequestAsyncStorageWrapper: AsyncStorageWrapper<
   RequestStore,
   RequestContext
@@ -100,24 +129,7 @@ export const RequestAsyncStorageWrapper: AsyncStorageWrapper<
             HeadersAdapter.from(req.headers)
           )
 
-          if (
-            'x-middleware-set-cookie' in req.headers &&
-            typeof req.headers['x-middleware-set-cookie'] === 'string'
-          ) {
-            const setCookieValue = req.headers['x-middleware-set-cookie']
-            const responseHeaders = new Headers()
-
-            for (const cookie of splitCookiesString(setCookieValue)) {
-              responseHeaders.append('set-cookie', cookie)
-            }
-
-            const responseCookies = new ResponseCookies(responseHeaders)
-
-            // Transfer cookies from ResponseCookies to RequestCookies
-            for (const cookie of responseCookies.getAll()) {
-              requestCookies.set(cookie.name, cookie.value ?? '')
-            }
-          }
+          mergeMiddlewareCookies(req, requestCookies)
 
           // Seal the cookies object that'll freeze out any methods that could
           // mutate the underlying data.
@@ -128,11 +140,15 @@ export const RequestAsyncStorageWrapper: AsyncStorageWrapper<
       },
       get mutableCookies() {
         if (!cache.mutableCookies) {
-          cache.mutableCookies = getMutableCookies(
+          const mutableCookies = getMutableCookies(
             req.headers,
             renderOpts?.onUpdateCookies ||
               (res ? defaultOnUpdateCookies : undefined)
           )
+
+          mergeMiddlewareCookies(req, mutableCookies)
+
+          cache.mutableCookies = mutableCookies
         }
         return cache.mutableCookies
       },

--- a/packages/next/src/server/web/spec-extension/cookies.ts
+++ b/packages/next/src/server/web/spec-extension/cookies.ts
@@ -1,4 +1,5 @@
 export {
   RequestCookies,
   ResponseCookies,
+  stringifyCookie,
 } from 'next/dist/compiled/@edge-runtime/cookies'

--- a/packages/next/src/server/web/spec-extension/response.ts
+++ b/packages/next/src/server/web/spec-extension/response.ts
@@ -1,3 +1,4 @@
+import { stringifyCookie } from '../../web/spec-extension/cookies'
 import type { I18NConfig } from '../../config-shared'
 import { NextURL } from '../next-url'
 import { toNodeOutgoingHttpHeaders, validateURL } from '../utils'
@@ -55,7 +56,13 @@ export class NextResponse<Body = unknown> extends Response {
               const newHeaders = new Headers(headers)
 
               if (result instanceof ResponseCookies) {
-                headers.set('x-middleware-set-cookie', result.toString())
+                headers.set(
+                  'x-middleware-set-cookie',
+                  result
+                    .getAll()
+                    .map((cookie) => stringifyCookie(cookie))
+                    .join(',')
+                )
               }
 
               handleMiddlewareField(init, newHeaders)

--- a/packages/next/src/server/web/spec-extension/response.ts
+++ b/packages/next/src/server/web/spec-extension/response.ts
@@ -1,6 +1,7 @@
 import type { I18NConfig } from '../../config-shared'
 import { NextURL } from '../next-url'
 import { toNodeOutgoingHttpHeaders, validateURL } from '../utils'
+import { ReflectAdapter } from './adapters/reflect'
 
 import { ResponseCookies } from './cookies'
 
@@ -41,11 +42,37 @@ export class NextResponse<Body = unknown> extends Response {
   constructor(body?: BodyInit | null, init: ResponseInit = {}) {
     super(body, init)
 
+    const headers = this.headers
+    const cookies = new ResponseCookies(headers)
+
+    const cookiesProxy = new Proxy(cookies, {
+      get(target, prop, receiver) {
+        switch (prop) {
+          case 'delete':
+          case 'set': {
+            return (...args: [string, string]) => {
+              const result = Reflect.apply(target[prop], target, args)
+              const newHeaders = new Headers(headers)
+
+              if (result instanceof ResponseCookies) {
+                headers.set('x-middleware-set-cookie', result.toString())
+              }
+
+              handleMiddlewareField(init, newHeaders)
+              return result
+            }
+          }
+          default:
+            return ReflectAdapter.get(target, prop, receiver)
+        }
+      },
+    })
+
     this[INTERNALS] = {
-      cookies: new ResponseCookies(this.headers),
+      cookies: cookiesProxy,
       url: init.url
         ? new NextURL(init.url, {
-            headers: toNodeOutgoingHttpHeaders(this.headers),
+            headers: toNodeOutgoingHttpHeaders(headers),
             nextConfig: init.nextConfig,
           })
         : undefined,

--- a/test/e2e/app-dir/app-middleware/app-middleware.test.ts
+++ b/test/e2e/app-dir/app-middleware/app-middleware.test.ts
@@ -171,6 +171,31 @@ createNextDescribe(
         )
       })
     })
+
+    it('should be possible to read cookies that are set during the middleware handling of a server action', async () => {
+      const browser = await next.browser('/rsc-cookies')
+      const initialRandom1 = await browser.elementById('rsc-cookie-1').text()
+      const initialRandom2 = await browser.elementById('rsc-cookie-2').text()
+      const totalCookies = await browser.elementById('total-cookies').text()
+
+      // cookies were set in middleware, assert they are present and match the Math.random() pattern
+      expect(initialRandom1).toMatch(/Cookie 1: \d+\.\d+/)
+      expect(initialRandom2).toMatch(/Cookie 2: \d+\.\d+/)
+      expect(totalCookies).toBe('Total Cookie Length: 2')
+
+      expect(await browser.eval('document.cookie')).toBeTruthy()
+
+      await browser.deleteCookies()
+
+      // assert that document.cookie is empty
+      expect(await browser.eval('document.cookie')).toBeFalsy()
+
+      await browser.elementById('submit-server-action').click()
+
+      await retry(() => {
+        expect(next.cliOutput).toMatch(/\[Cookie From Action\]: \d+\.\d+/)
+      })
+    })
   }
 )
 

--- a/test/e2e/app-dir/app-middleware/app-middleware.test.ts
+++ b/test/e2e/app-dir/app-middleware/app-middleware.test.ts
@@ -170,6 +170,32 @@ createNextDescribe(
           /Cookie 2: \d+\.\d+/
         )
       })
+      // Cleanup
+      await browser.deleteCookies()
+    })
+
+    it('should respect cookie options of merged middleware cookies', async () => {
+      const browser = await next.browser('/rsc-cookies/cookie-options')
+
+      const totalCookies = await browser.elementById('total-cookies').text()
+
+      // a secure cookie was set in middleware
+      expect(totalCookies).toBe('Total Cookie Length: 1')
+
+      // we don't expect to be able to read it
+      expect(await browser.eval('document.cookie')).toBeFalsy()
+
+      await browser.elementById('submit-server-action').click()
+
+      await retry(() => {
+        expect(next.cliOutput).toMatch(/\[Cookie From Action\]: \d+\.\d+/)
+      })
+
+      // ensure that we still can't read the secure cookie
+      expect(await browser.eval('document.cookie')).toBeFalsy()
+
+      // Cleanup
+      await browser.deleteCookies()
     })
 
     it('should be possible to read cookies that are set during the middleware handling of a server action', async () => {
@@ -195,6 +221,8 @@ createNextDescribe(
       await retry(() => {
         expect(next.cliOutput).toMatch(/\[Cookie From Action\]: \d+\.\d+/)
       })
+
+      await browser.deleteCookies()
     })
   }
 )

--- a/test/e2e/app-dir/app-middleware/app-middleware.test.ts
+++ b/test/e2e/app-dir/app-middleware/app-middleware.test.ts
@@ -140,10 +140,12 @@ createNextDescribe(
 
       const initialRandom1 = await browser.elementById('rsc-cookie-1').text()
       const initialRandom2 = await browser.elementById('rsc-cookie-2').text()
+      const totalCookies = await browser.elementById('total-cookies').text()
 
       // cookies were set in middleware, assert they are present and match the Math.random() pattern
       expect(initialRandom1).toMatch(/Cookie 1: \d+\.\d+/)
       expect(initialRandom2).toMatch(/Cookie 2: \d+\.\d+/)
+      expect(totalCookies).toBe('Total Cookie Length: 2')
 
       await browser.refresh()
 

--- a/test/e2e/app-dir/app-middleware/app/rsc-cookies-delete/page.js
+++ b/test/e2e/app-dir/app-middleware/app/rsc-cookies-delete/page.js
@@ -8,6 +8,7 @@ export default function Page() {
     <div>
       <p id="rsc-cookie-1">Cookie 1: {rscCookie1}</p>
       <p id="rsc-cookie-2">Cookie 2: {rscCookie2}</p>
+      <p id="total-cookies">Total Cookie Length: {cookies().size}</p>
     </div>
   )
 }

--- a/test/e2e/app-dir/app-middleware/app/rsc-cookies-delete/page.js
+++ b/test/e2e/app-dir/app-middleware/app/rsc-cookies-delete/page.js
@@ -1,0 +1,13 @@
+import { cookies } from 'next/headers'
+
+export default function Page() {
+  const rscCookie1 = cookies().get('rsc-cookie-value-1')?.value
+  const rscCookie2 = cookies().get('rsc-cookie-value-2')?.value
+
+  return (
+    <div>
+      <p id="rsc-cookie-1">Cookie 1: {rscCookie1}</p>
+      <p id="rsc-cookie-2">Cookie 2: {rscCookie2}</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-middleware/app/rsc-cookies/cookie-options/page.js
+++ b/test/e2e/app-dir/app-middleware/app/rsc-cookies/cookie-options/page.js
@@ -1,0 +1,25 @@
+import { cookies } from 'next/headers'
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <p id="total-cookies">Total Cookie Length: {cookies().size}</p>
+      <Link href="/rsc-cookies-delete">To Delete Cookies Route</Link>
+
+      <form
+        action={async () => {
+          'use server'
+          console.log(
+            '[Cookie From Action]:',
+            cookies().get('rsc-secure-cookie').value
+          )
+        }}
+      >
+        <button type="submit" id="submit-server-action">
+          server action
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-middleware/app/rsc-cookies/page.js
+++ b/test/e2e/app-dir/app-middleware/app/rsc-cookies/page.js
@@ -9,6 +9,7 @@ export default function Page() {
     <div>
       <p id="rsc-cookie-1">Cookie 1: {rscCookie1}</p>
       <p id="rsc-cookie-2">Cookie 2: {rscCookie2}</p>
+      <p id="total-cookies">Total Cookie Length: {cookies().size}</p>
       <Link href="/rsc-cookies-delete">To Delete Cookies Route</Link>
     </div>
   )

--- a/test/e2e/app-dir/app-middleware/app/rsc-cookies/page.js
+++ b/test/e2e/app-dir/app-middleware/app/rsc-cookies/page.js
@@ -1,0 +1,15 @@
+import { cookies } from 'next/headers'
+import Link from 'next/link'
+
+export default function Page() {
+  const rscCookie1 = cookies().get('rsc-cookie-value-1')?.value
+  const rscCookie2 = cookies().get('rsc-cookie-value-2')?.value
+
+  return (
+    <div>
+      <p id="rsc-cookie-1">Cookie 1: {rscCookie1}</p>
+      <p id="rsc-cookie-2">Cookie 2: {rscCookie2}</p>
+      <Link href="/rsc-cookies-delete">To Delete Cookies Route</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-middleware/app/rsc-cookies/page.js
+++ b/test/e2e/app-dir/app-middleware/app/rsc-cookies/page.js
@@ -11,6 +11,20 @@ export default function Page() {
       <p id="rsc-cookie-2">Cookie 2: {rscCookie2}</p>
       <p id="total-cookies">Total Cookie Length: {cookies().size}</p>
       <Link href="/rsc-cookies-delete">To Delete Cookies Route</Link>
+
+      <form
+        action={async () => {
+          'use server'
+          console.log(
+            '[Cookie From Action]:',
+            cookies().get('rsc-cookie-value-1')?.value
+          )
+        }}
+      >
+        <button type="submit" id="submit-server-action">
+          server action
+        </button>
+      </form>
     </div>
   )
 }

--- a/test/e2e/app-dir/app-middleware/middleware.js
+++ b/test/e2e/app-dir/app-middleware/middleware.js
@@ -52,6 +52,16 @@ export async function middleware(request) {
     return res
   }
 
+  if (request.nextUrl.pathname === '/rsc-cookies/cookie-options') {
+    const res = NextResponse.next()
+    res.cookies.set('rsc-secure-cookie', `${Math.random()}`, {
+      secure: true,
+      httpOnly: true,
+    })
+
+    return res
+  }
+
   if (request.nextUrl.pathname === '/rsc-cookies-delete') {
     const res = NextResponse.next()
     res.cookies.delete('rsc-cookie-value-1')

--- a/test/e2e/app-dir/app-middleware/middleware.js
+++ b/test/e2e/app-dir/app-middleware/middleware.js
@@ -44,6 +44,21 @@ export async function middleware(request) {
     return NextResponse.rewrite(request.nextUrl)
   }
 
+  if (request.nextUrl.pathname === '/rsc-cookies') {
+    const res = NextResponse.next()
+    res.cookies.set('rsc-cookie-value-1', `${Math.random()}`)
+    res.cookies.set('rsc-cookie-value-2', `${Math.random()}`)
+
+    return res
+  }
+
+  if (request.nextUrl.pathname === '/rsc-cookies-delete') {
+    const res = NextResponse.next()
+    res.cookies.delete('rsc-cookie-value-1')
+
+    return res
+  }
+
   return NextResponse.next({
     request: {
       headers: headersFromRequest,


### PR DESCRIPTION
Backport changes related to reading middleware-set cookies in render/actions.

- [x] #65008: initialize ALS with cookies in middleware
- [x] #65820: fix middleware cookie initialization
- [x] #67924: ensure cookies set in middleware can be read in a server action
- [x] #67956: fix: merged middleware cookies should preserve options

this required some minor surgery because RequestAsyncStorageWrapper became withRequestStore, but nothing that seems too bad
