### PR TITLE
docs: fix code out of the code block

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/useLightningcss.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/useLightningcss.mdx
@@ -14,6 +14,8 @@ const nextConfig: NextConfig = {
     useLightningcss: true,
   },
 }
+
+export default nextConfig
 ```
 
 ```js filename="next.config.js"
@@ -23,6 +25,6 @@ const nextConfig = {
     useLightningcss: true,
   },
 }
-```
 
 module.exports = nextConfig
+```


### PR DESCRIPTION
The PR moves `module.exports = nextConfig` into the code block. This was introduced in #69161 

/cc @samcx 