### PR TITLE
backport: esm externals

### DIFF
--- a/packages/next/src/build/handle-externals.ts
+++ b/packages/next/src/build/handle-externals.ts
@@ -1,5 +1,6 @@
-import { WEBPACK_LAYERS } from '../lib/constants'
 import type { WebpackLayerName } from '../lib/constants'
+import type { NextConfigComplete } from '../server/config-shared'
+import type { ResolveOptions } from 'webpack'
 import { defaultOverrides } from '../server/require-hook'
 import { BARREL_OPTIMIZATION_PREFIX } from '../shared/lib/constants'
 import path from '../shared/lib/isomorphic/path'
@@ -10,7 +11,6 @@ import {
   NODE_RESOLVE_OPTIONS,
 } from './webpack-config'
 import { isWebpackAppLayer, isWebpackServerOnlyLayer } from './utils'
-import type { NextConfigComplete } from '../server/config-shared'
 import { normalizePathSep } from '../shared/lib/page-path/normalize-path-sep'
 const reactPackagesRegex = /^(react|react-dom|react-server-dom-webpack)($|\/)/
 
@@ -24,15 +24,6 @@ const externalPattern = new RegExp(
 )
 
 const nodeModulesRegex = /node_modules[/\\].*\.[mc]?js$/
-
-function containsImportInPackages(
-  request: string,
-  packages: string[]
-): boolean {
-  return packages.some(
-    (pkg) => request === pkg || request.startsWith(pkg + '/')
-  )
-}
 
 export function isResourceInPackages(
   resource: string,
@@ -57,9 +48,9 @@ export async function resolveExternal(
   context: string,
   request: string,
   isEsmRequested: boolean,
-  optOutBundlingPackages: string[],
+  _optOutBundlingPackages: string[],
   getResolve: (
-    options: any
+    options: ResolveOptions
   ) => (
     resolveContext: string,
     resolveRequest: string
@@ -78,19 +69,12 @@ export async function resolveExternal(
   let isEsm: boolean = false
 
   const preferEsmOptions =
-    esmExternals &&
-    isEsmRequested &&
-    // For package that marked as externals that should be not bundled,
-    // we don't resolve them as ESM since it could be resolved as async module,
-    // such as `import(external package)` in the bundle, valued as a `Promise`.
-    !containsImportInPackages(request, optOutBundlingPackages)
-      ? [true, false]
-      : [false]
+    esmExternals && isEsmRequested ? [true, false] : [false]
 
   for (const preferEsm of preferEsmOptions) {
-    const resolve = getResolve(
-      preferEsm ? esmResolveOptions : nodeResolveOptions
-    )
+    const resolveOptions = preferEsm ? esmResolveOptions : nodeResolveOptions
+
+    const resolve = getResolve(resolveOptions)
 
     // Resolve the import with the webpack provided context, this
     // ensures we're resolving the correct version when multiple
@@ -273,23 +257,6 @@ export function makeExternalHandler({
       return resolveNextExternal(request)
     }
 
-    // Early return if the request needs to be bundled, such as in the client layer.
-    // Treat react packages and next internals as external for SSR layer,
-    // also map react to builtin ones with require-hook.
-    // Otherwise keep continue the process to resolve the externals.
-    if (layer === WEBPACK_LAYERS.serverSideRendering) {
-      const isRelative = request.startsWith('.')
-      const fullRequest = isRelative
-        ? normalizePathSep(path.join(context, request))
-        : request
-
-      // Check if it's opt out bundling package first
-      if (containsImportInPackages(fullRequest, optOutBundlingPackages)) {
-        return fullRequest
-      }
-      return resolveNextExternal(fullRequest)
-    }
-
     // TODO-APP: Let's avoid this resolve call as much as possible, and eventually get rid of it.
     const resolveResult = await resolveExternal(
       dir,
@@ -317,6 +284,13 @@ export function makeExternalHandler({
     // If the request cannot be resolved we need to have
     // webpack "bundle" it so it surfaces the not found error.
     if (!res) {
+      return
+    }
+
+    const isOptOutBundling = optOutBundlingPackageRegex.test(res)
+    // Apply bundling rules to all app layers.
+    // Since handleExternals only handle the server layers, we don't need to exclude client here
+    if (!isOptOutBundling && isAppLayer) {
       return
     }
 
@@ -370,13 +344,11 @@ export function makeExternalHandler({
 
     const resolvedBundlingOptOutRes = resolveBundlingOptOutPackages({
       resolvedRes: res,
-      optOutBundlingPackageRegex,
       config,
       resolvedExternalPackageDirs,
-      isEsm,
       isAppLayer,
-      layer,
       externalType,
+      isOptOutBundling,
       request,
     })
     if (resolvedBundlingOptOutRes) {
@@ -390,41 +362,34 @@ export function makeExternalHandler({
 
 function resolveBundlingOptOutPackages({
   resolvedRes,
-  optOutBundlingPackageRegex,
   config,
   resolvedExternalPackageDirs,
-  isEsm,
   isAppLayer,
-  layer,
   externalType,
+  isOptOutBundling,
   request,
 }: {
   resolvedRes: string
-  optOutBundlingPackageRegex: RegExp
   config: NextConfigComplete
   resolvedExternalPackageDirs: Map<string, string>
-  isEsm: boolean
   isAppLayer: boolean
-  layer: WebpackLayerName | null
   externalType: string
+  isOptOutBundling: boolean
   request: string
 }) {
-  const shouldBeBundled =
-    isResourceInPackages(
-      resolvedRes,
-      config.transpilePackages,
-      resolvedExternalPackageDirs
-    ) ||
-    (isEsm && isAppLayer) ||
-    (!isAppLayer && config.experimental.bundlePagesExternals)
-
   if (nodeModulesRegex.test(resolvedRes)) {
-    const isOptOutBundling = optOutBundlingPackageRegex.test(resolvedRes)
-    if (isWebpackServerOnlyLayer(layer)) {
-      if (isOptOutBundling) {
-        return `${externalType} ${request}` // Externalize if opted out
-      }
-    } else if (!shouldBeBundled || isOptOutBundling) {
+    const shouldBundlePages =
+      !isAppLayer &&
+      config.experimental.bundlePagesExternals &&
+      !isOptOutBundling
+    const shouldBeBundled =
+      shouldBundlePages ||
+      isResourceInPackages(
+        resolvedRes,
+        config.transpilePackages,
+        resolvedExternalPackageDirs
+      )
+    if (!shouldBeBundled) {
       return `${externalType} ${request}` // Externalize if not bundled or opted out
     }
   }

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -483,6 +483,13 @@ export default async function getBaseWebpackConfig(
     babel: useSWCLoader ? swcDefaultLoader : babelLoader!,
   }
 
+  const nextFlightLoader = {
+    loader: 'next-flight-loader',
+    options: {
+      isEdgeServer,
+    },
+  }
+
   const appServerLayerLoaders = hasAppDir
     ? [
         // When using Babel, we will have to add the SWC loader
@@ -495,6 +502,7 @@ export default async function getBaseWebpackConfig(
     : []
 
   const instrumentLayerLoaders = [
+    nextFlightLoader,
     // When using Babel, we will have to add the SWC loader
     // as an additional pass to handle RSC correctly.
     // This will cause some performance overhead but
@@ -504,6 +512,7 @@ export default async function getBaseWebpackConfig(
   ].filter(Boolean)
 
   const middlewareLayerLoaders = [
+    nextFlightLoader,
     // When using Babel, we will have to use SWC to do the optimization
     // for middleware to tree shake the unused default optimized imports like "next/server".
     // This will cause some performance overhead but
@@ -1349,9 +1358,7 @@ export default async function getBaseWebpackConfig(
                     isEdgeServer,
                   }),
                 },
-                use: {
-                  loader: 'next-flight-loader',
-                },
+                use: nextFlightLoader,
               },
             ]
           : []),

--- a/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
@@ -97,24 +97,21 @@ export default function transformSource(
         return
       }
 
-      // `proxy` is the module proxy that we treat the module as a client boundary.
-      // For ESM, we access the property of the module proxy directly for each export.
-      // This is bit hacky that treating using a CJS like module proxy for ESM's exports,
-      // but this will avoid creating nested proxies for each export. It will be improved in the future.
       let esmSource = `\
 import { createProxy } from "${MODULE_PROXY_PATH}"
-
-const proxy = createProxy(String.raw\`${resourceKey}\`)
 `
       let cnt = 0
       for (const ref of clientRefs) {
         if (ref === '') {
-          esmSource += `exports[''] = proxy['']\n`
+          esmSource += `\nexports[''] = createProxy(String.raw\`${resourceKey}#\`);`
         } else if (ref === 'default') {
-          esmSource += `export default createProxy(String.raw\`${resourceKey}#default\`);\n`
+          esmSource += `\
+export default createProxy(String.raw\`${resourceKey}#default\`);
+`
         } else {
-          esmSource += `const e${cnt} = proxy["${ref}"];\n`
-          esmSource += `export { e${cnt++} as ${ref} };\n`
+          esmSource += `
+const e${cnt} = createProxy(String.raw\`${resourceKey}#${ref}\`);
+export { e${cnt++} as ${ref} };`
         }
       }
 

--- a/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
@@ -99,14 +99,6 @@ export default function transformSource(
 
       let esmSource = `\
 import { createProxy } from "${MODULE_PROXY_PATH}"
-const proxy = createProxy(String.raw\`${resourceKey}\`)
-
-// Accessing the __esModule property and exporting $$typeof are required here.
-// The __esModule getter forces the proxy target to create the default export
-// and the $$typeof value is for rendering logic to determine if the module
-// is a client boundary.
-const { __esModule, $$typeof } = proxy;
-const __default__ = proxy.default;
 `
       let cnt = 0
       for (const ref of clientRefs) {
@@ -114,7 +106,6 @@ const __default__ = proxy.default;
           esmSource += `\nexports[''] = createProxy(String.raw\`${resourceKey}#\`);`
         } else if (ref === 'default') {
           esmSource += `\
-export { __esModule, $$typeof };
 export default createProxy(String.raw\`${resourceKey}#default\`);
 `
         } else {

--- a/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
@@ -97,21 +97,24 @@ export default function transformSource(
         return
       }
 
+      // `proxy` is the module proxy that we treat the module as a client boundary.
+      // For ESM, we access the property of the module proxy directly for each export.
+      // This is bit hacky that treating using a CJS like module proxy for ESM's exports,
+      // but this will avoid creating nested proxies for each export. It will be improved in the future.
       let esmSource = `\
 import { createProxy } from "${MODULE_PROXY_PATH}"
+
+const proxy = createProxy(String.raw\`${resourceKey}\`)
 `
       let cnt = 0
       for (const ref of clientRefs) {
         if (ref === '') {
-          esmSource += `\nexports[''] = createProxy(String.raw\`${resourceKey}#\`);`
+          esmSource += `exports[''] = proxy['']\n`
         } else if (ref === 'default') {
-          esmSource += `\
-export default createProxy(String.raw\`${resourceKey}#default\`);
-`
+          esmSource += `export default createProxy(String.raw\`${resourceKey}#default\`);\n`
         } else {
-          esmSource += `
-const e${cnt} = createProxy(String.raw\`${resourceKey}#${ref}\`);
-export { e${cnt++} as ${ref} };`
+          esmSource += `const e${cnt} = proxy["${ref}"];\n`
+          esmSource += `export { e${cnt++} as ${ref} };\n`
         }
       }
 

--- a/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
@@ -54,6 +54,9 @@ export default function transformSource(
     throw new Error('Expected source to have been transformed to a string.')
   }
 
+  const options = this.getOptions()
+  const { isEdgeServer } = options
+
   // Assign the RSC meta information to buildInfo.
   // Exclude next internal files which are not marked as client files
   const buildInfo = getModuleBuildInfo(this._module)
@@ -97,21 +100,31 @@ export default function transformSource(
         return
       }
 
+      // `proxy` is the module proxy that we treat the module as a client boundary.
+      // For ESM, we access the property of the module proxy directly for each export.
+      // This is bit hacky that treating using a CJS like module proxy for ESM's exports,
+      // but this will avoid creating nested proxies for each export. It will be improved in the future.
+
+      // Explanation for: await createProxy(...)
+      // We need to await the module proxy creation because it can be async module for SSR layer
+      // due to having async dependencies.
+      // We only apply `the await` for Node.js as only Edge doesn't have external dependencies.
       let esmSource = `\
 import { createProxy } from "${MODULE_PROXY_PATH}"
+
+const proxy = ${
+        isEdgeServer ? '' : 'await'
+      } createProxy(String.raw\`${resourceKey}\`)
 `
       let cnt = 0
       for (const ref of clientRefs) {
         if (ref === '') {
-          esmSource += `\nexports[''] = createProxy(String.raw\`${resourceKey}#\`);`
+          esmSource += `exports[''] = proxy['']\n`
         } else if (ref === 'default') {
-          esmSource += `\
-export default createProxy(String.raw\`${resourceKey}#default\`);
-`
+          esmSource += `export default proxy.default;\n`
         } else {
-          esmSource += `
-const e${cnt} = createProxy(String.raw\`${resourceKey}#${ref}\`);
-export { e${cnt++} as ${ref} };`
+          esmSource += `const e${cnt} = proxy["${ref}"];\n`
+          esmSource += `export { e${cnt++} as ${ref} };\n`
         }
       }
 

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -430,75 +430,6 @@ export class FlightClientEntryPlugin {
       )
     }
 
-    compilation.hooks.finishModules.tapPromise(PLUGIN_NAME, async () => {
-      const addedClientActionEntryList: Promise<any>[] = []
-      const actionMapsPerClientEntry: Record<string, Map<string, string[]>> = {}
-
-      // We need to create extra action entries that are created from the
-      // client layer.
-      // Start from each entry's created SSR dependency from our previous step.
-      for (const [name, ssrEntryDependencies] of Object.entries(
-        createdSSRDependenciesForEntry
-      )) {
-        // Collect from all entries, e.g. layout.js, page.js, loading.js, ...
-        // add aggregate them.
-        const actionEntryImports = this.collectClientActionsFromDependencies({
-          compilation,
-          dependencies: ssrEntryDependencies,
-        })
-
-        if (actionEntryImports.size > 0) {
-          if (!actionMapsPerClientEntry[name]) {
-            actionMapsPerClientEntry[name] = new Map()
-          }
-          actionMapsPerClientEntry[name] = new Map([
-            ...actionMapsPerClientEntry[name],
-            ...actionEntryImports,
-          ])
-        }
-      }
-
-      for (const [name, actionEntryImports] of Object.entries(
-        actionMapsPerClientEntry
-      )) {
-        // If an action method is already created in the server layer, we don't
-        // need to create it again in the action layer.
-        // This is to avoid duplicate action instances and make sure the module
-        // state is shared.
-        let remainingClientImportedActions = false
-        const remainingActionEntryImports = new Map<string, string[]>()
-        for (const [dep, actionNames] of actionEntryImports) {
-          const remainingActionNames = []
-          for (const actionName of actionNames) {
-            const id = name + '@' + dep + '@' + actionName
-            if (!createdActions.has(id)) {
-              remainingActionNames.push(actionName)
-            }
-          }
-          if (remainingActionNames.length > 0) {
-            remainingActionEntryImports.set(dep, remainingActionNames)
-            remainingClientImportedActions = true
-          }
-        }
-
-        if (remainingClientImportedActions) {
-          addedClientActionEntryList.push(
-            this.injectActionEntry({
-              compiler,
-              compilation,
-              actions: remainingActionEntryImports,
-              entryName: name,
-              bundlePath: name,
-              fromClient: true,
-            })
-          )
-        }
-      }
-
-      await Promise.all(addedClientActionEntryList)
-      return
-    })
-
     // Invalidate in development to trigger recompilation
     const invalidator = getInvalidator(compiler.outputPath)
     // Check if any of the entry injections need an invalidation
@@ -521,6 +452,72 @@ export class FlightClientEntryPlugin {
 
     // Wait for action entries to be added.
     await Promise.all(addActionEntryList)
+
+    const addedClientActionEntryList: Promise<any>[] = []
+    const actionMapsPerClientEntry: Record<string, Map<string, string[]>> = {}
+
+    // We need to create extra action entries that are created from the
+    // client layer.
+    // Start from each entry's created SSR dependency from our previous step.
+    for (const [name, ssrEntryDependencies] of Object.entries(
+      createdSSRDependenciesForEntry
+    )) {
+      // Collect from all entries, e.g. layout.js, page.js, loading.js, ...
+      // add aggregate them.
+      const actionEntryImports = this.collectClientActionsFromDependencies({
+        compilation,
+        dependencies: ssrEntryDependencies,
+      })
+
+      if (actionEntryImports.size > 0) {
+        if (!actionMapsPerClientEntry[name]) {
+          actionMapsPerClientEntry[name] = new Map()
+        }
+        actionMapsPerClientEntry[name] = new Map([
+          ...actionMapsPerClientEntry[name],
+          ...actionEntryImports,
+        ])
+      }
+    }
+
+    for (const [name, actionEntryImports] of Object.entries(
+      actionMapsPerClientEntry
+    )) {
+      // If an action method is already created in the server layer, we don't
+      // need to create it again in the action layer.
+      // This is to avoid duplicate action instances and make sure the module
+      // state is shared.
+      let remainingClientImportedActions = false
+      const remainingActionEntryImports = new Map<string, string[]>()
+      for (const [dep, actionNames] of actionEntryImports) {
+        const remainingActionNames = []
+        for (const actionName of actionNames) {
+          const id = name + '@' + dep + '@' + actionName
+          if (!createdActions.has(id)) {
+            remainingActionNames.push(actionName)
+          }
+        }
+        if (remainingActionNames.length > 0) {
+          remainingActionEntryImports.set(dep, remainingActionNames)
+          remainingClientImportedActions = true
+        }
+      }
+
+      if (remainingClientImportedActions) {
+        addedClientActionEntryList.push(
+          this.injectActionEntry({
+            compiler,
+            compilation,
+            actions: remainingActionEntryImports,
+            entryName: name,
+            bundlePath: name,
+            fromClient: true,
+          })
+        )
+      }
+    }
+
+    await Promise.all(addedClientActionEntryList)
   }
 
   collectClientActionsFromDependencies({

--- a/packages/next/src/lib/client-reference.ts
+++ b/packages/next/src/lib/client-reference.ts
@@ -1,3 +1,4 @@
-export function isClientReference(reference: any): boolean {
-  return reference?.$$typeof === Symbol.for('react.client.reference')
+export function isClientReference(mod: any): boolean {
+  const defaultExport = mod?.default || mod
+  return defaultExport?.$$typeof === Symbol.for('react.client.reference')
 }

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -260,7 +260,7 @@ async function createComponentTreeInternal({
   }
 
   const LayoutOrPage: React.ComponentType<any> | undefined = layoutOrPageMod
-    ? interopDefault(layoutOrPageMod)
+    ? await interopDefault(layoutOrPageMod)
     : undefined
 
   /**

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -260,7 +260,7 @@ async function createComponentTreeInternal({
   }
 
   const LayoutOrPage: React.ComponentType<any> | undefined = layoutOrPageMod
-    ? await interopDefault(layoutOrPageMod)
+    ? interopDefault(layoutOrPageMod)
     : undefined
 
   /**

--- a/packages/next/src/shared/lib/lazy-dynamic/loadable.tsx
+++ b/packages/next/src/shared/lib/lazy-dynamic/loadable.tsx
@@ -15,7 +15,7 @@ function convertModule<P>(
   // Cases:
   // mod: { default: Component }
   // mod: Component
-  // mod: { $$typeof, default: proxy(Component) }
+  // mod: { default: proxy(Component) }
   // mod: proxy(Component)
   const hasDefault = mod && 'default' in mod
   return {

--- a/packages/next/src/shared/lib/lazy-dynamic/loadable.tsx
+++ b/packages/next/src/shared/lib/lazy-dynamic/loadable.tsx
@@ -15,7 +15,7 @@ function convertModule<P>(
   // Cases:
   // mod: { default: Component }
   // mod: Component
-  // mod: { default: proxy(Component) }
+  // mod: { $$typeof, default: proxy(Component) }
   // mod: proxy(Component)
   const hasDefault = mod && 'default' in mod
   return {

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -54,9 +54,9 @@ describe('Error overlay for hydration errors', () => {
     if (isTurbopack) {
       expect(pseudoHtml).toMatchInlineSnapshot(`
         "...
-          <RedirectBoundary>
-            <RedirectErrorBoundary>
-              <InnerLayoutRouter>
+          <RedirectErrorBoundary>
+            <InnerLayoutRouter>
+              <ClientPageRoot>
                 <Mismatch>
                   <div>
                     <main>
@@ -251,16 +251,16 @@ describe('Error overlay for hydration errors', () => {
 
     if (isTurbopack) {
       expect(pseudoHtml).toMatchInlineSnapshot(`
-              "...
-                <NotFoundErrorBoundary>
-                  <RedirectBoundary>
-                    <RedirectErrorBoundary>
-                      <InnerLayoutRouter>
-                        <Mismatch>
-                          <div>
-                            <div>
-                              "only""
-            `)
+        "...
+          <RedirectBoundary>
+            <RedirectErrorBoundary>
+              <InnerLayoutRouter>
+                <ClientPageRoot>
+                  <Mismatch>
+                    <div>
+                      <div>
+                        "only""
+      `)
     } else {
       expect(pseudoHtml).toMatchInlineSnapshot(`
         "<Mismatch>
@@ -643,44 +643,45 @@ describe('Error overlay for hydration errors', () => {
     const fullPseudoHtml = await session.getRedboxComponentStack()
     if (isTurbopack) {
       expect(fullPseudoHtml).toMatchInlineSnapshot(`
-              "<Root>
-                <ServerRoot>
-                  <AppRouter>
-                    <ErrorBoundary>
-                      <ErrorBoundaryHandler>
-                        <Router>
-                          <HotReload>
-                            <ReactDevOverlay>
-                              <DevRootNotFoundBoundary>
-                                <NotFoundBoundary>
-                                  <NotFoundErrorBoundary>
-                                    <RedirectBoundary>
-                                      <RedirectErrorBoundary>
-                                        <RootLayout>
-                                          <html>
-                                            <body>
-                                              <OuterLayoutRouter>
-                                                <RenderFromTemplateContext>
-                                                  <ScrollAndFocusHandler>
-                                                    <InnerScrollAndFocusHandler>
-                                                      <ErrorBoundary>
-                                                        <LoadingBoundary>
-                                                          <NotFoundBoundary>
-                                                            <NotFoundErrorBoundary>
-                                                              <RedirectBoundary>
-                                                                <RedirectErrorBoundary>
-                                                                  <InnerLayoutRouter>
-                                                                    <Page>
+        "<Root>
+          <ServerRoot>
+            <AppRouter>
+              <ErrorBoundary>
+                <ErrorBoundaryHandler>
+                  <Router>
+                    <HotReload>
+                      <ReactDevOverlay>
+                        <DevRootNotFoundBoundary>
+                          <NotFoundBoundary>
+                            <NotFoundErrorBoundary>
+                              <RedirectBoundary>
+                                <RedirectErrorBoundary>
+                                  <RootLayout>
+                                    <html>
+                                      <body>
+                                        <OuterLayoutRouter>
+                                          <RenderFromTemplateContext>
+                                            <ScrollAndFocusHandler>
+                                              <InnerScrollAndFocusHandler>
+                                                <ErrorBoundary>
+                                                  <LoadingBoundary>
+                                                    <NotFoundBoundary>
+                                                      <NotFoundErrorBoundary>
+                                                        <RedirectBoundary>
+                                                          <RedirectErrorBoundary>
+                                                            <InnerLayoutRouter>
+                                                              <ClientPageRoot>
+                                                                <Page>
+                                                                  <div>
+                                                                    <div>
                                                                       <div>
                                                                         <div>
-                                                                          <div>
-                                                                            <div>
-                                                                              <Mismatch>
-                                                                                <p>
-                                                                                  <span>
-                                                                                    "server"
-                                                                                    "client""
-            `)
+                                                                          <Mismatch>
+                                                                            <p>
+                                                                              <span>
+                                                                                "server"
+                                                                                "client""
+      `)
     } else {
       expect(fullPseudoHtml).toMatchInlineSnapshot(`
         "<Page>

--- a/test/e2e/app-dir/app-external/app-external.test.ts
+++ b/test/e2e/app-dir/app-external/app-external.test.ts
@@ -35,7 +35,7 @@ createNextDescribe(
     buildCommand: 'pnpm build',
     skipDeployment: true,
   },
-  ({ next }) => {
+  ({ next, isTurbopack }) => {
     it('should be able to opt-out 3rd party packages being bundled in server components', async () => {
       await next.fetch('/react-server/optout').then(async (response) => {
         const result = await resolveStreamResponse(response)
@@ -284,14 +284,17 @@ createNextDescribe(
     })
 
     describe('server actions', () => {
-      it('should not prefer to resolve esm over cjs for bundling optout packages', async () => {
+      it('should prefer to resolve esm over cjs for bundling optout packages', async () => {
         const browser = await next.browser('/optout/action')
         expect(await browser.elementByCss('#dual-pkg-outout p').text()).toBe('')
 
         browser.elementByCss('#dual-pkg-outout button').click()
         await check(async () => {
           const text = await browser.elementByCss('#dual-pkg-outout p').text()
-          expect(text).toBe('dual-pkg-optout:cjs')
+          // TODO: enable esm externals for app router in turbopack for actions
+          expect(text).toBe(
+            isTurbopack ? 'dual-pkg-optout:cjs' : 'dual-pkg-optout:mjs'
+          )
           return 'success'
         }, /success/)
       })

--- a/test/e2e/app-dir/app-routes-client-component/app-routes-client-component.test.ts
+++ b/test/e2e/app-dir/app-routes-client-component/app-routes-client-component.test.ts
@@ -1,13 +1,15 @@
-import { nextTestSetup } from 'e2e-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
+import path from 'path'
 
 describe('referencing a client component in an app route', () => {
   const { next } = nextTestSetup({
-    files: __dirname,
+    files: new FileRef(path.join(__dirname)),
   })
 
   it('responds without error', async () => {
     expect(JSON.parse(await next.render('/runtime'))).toEqual({
-      clientComponent: 'function',
+      // Turbopack's proxy components are functions
+      clientComponent: process.env.TURBOPACK ? 'function' : 'object',
     })
   })
 })

--- a/test/e2e/app-dir/app-routes-client-component/app-routes-client-component.test.ts
+++ b/test/e2e/app-dir/app-routes-client-component/app-routes-client-component.test.ts
@@ -1,19 +1,13 @@
-import { FileRef, nextTestSetup } from 'e2e-utils'
-import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
 
 describe('referencing a client component in an app route', () => {
   const { next } = nextTestSetup({
-    files: new FileRef(path.join(__dirname)),
-    dependencies: {
-      react: 'latest',
-      'react-dom': 'latest',
-    },
+    files: __dirname,
   })
 
   it('responds without error', async () => {
     expect(JSON.parse(await next.render('/runtime'))).toEqual({
-      // Turbopack's proxy components are functions
-      clientComponent: process.env.TURBOPACK ? 'function' : 'object',
+      clientComponent: 'function',
     })
   })
 })

--- a/test/e2e/app-dir/app-routes-client-component/app-routes-client-component.test.ts
+++ b/test/e2e/app-dir/app-routes-client-component/app-routes-client-component.test.ts
@@ -1,15 +1,13 @@
-import { FileRef, nextTestSetup } from 'e2e-utils'
-import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
 
 describe('referencing a client component in an app route', () => {
   const { next } = nextTestSetup({
-    files: new FileRef(path.join(__dirname)),
+    files: __dirname,
   })
 
   it('responds without error', async () => {
     expect(JSON.parse(await next.render('/runtime'))).toEqual({
-      // Turbopack's proxy components are functions
-      clientComponent: process.env.TURBOPACK ? 'function' : 'object',
+      clientComponent: 'function',
     })
   })
 })

--- a/test/e2e/app-dir/dynamic/app/dynamic/named-export/page.js
+++ b/test/e2e/app-dir/dynamic/app/dynamic/named-export/page.js
@@ -2,7 +2,7 @@ import dynamic from 'next/dynamic'
 
 const Button = dynamic(() =>
   import('./client').then((mod) => {
-    return { default: mod.Button }
+    return mod.Button
   })
 )
 

--- a/test/e2e/app-dir/dynamic/app/dynamic/named-export/page.js
+++ b/test/e2e/app-dir/dynamic/app/dynamic/named-export/page.js
@@ -2,7 +2,7 @@ import dynamic from 'next/dynamic'
 
 const Button = dynamic(() =>
   import('./client').then((mod) => {
-    return mod.Button
+    return { default: mod.Button }
   })
 )
 

--- a/test/e2e/esm-externals/esm-externals.test.ts
+++ b/test/e2e/esm-externals/esm-externals.test.ts
@@ -13,13 +13,15 @@ describe('esm-externals', () => {
     const urls = ['/static', '/ssr', '/ssg']
 
     for (const url of urls) {
-      // TODO fix webpack behavior
+      // For invalid esm packages that have "import" pointing to a non-esm-flagged module
+      // webpack is using the CJS version instead but Turbopack is opting out of
+      // externalizing and bundling the non-esm-flagged module.
       const expectedHtml = isTurbopack
         ? /Hello World\+World\+World\+World\+World\+World/
         : url === '/static'
         ? /Hello World\+World\+Alternative\+World\+World\+World/
         : /Hello World\+World\+Alternative\+World\+World\+Alternative/
-      // TODO fix webpack behavior
+      // On client side, webpack always bundlings so it uses the non-esm-flagged module too.
       const expectedText =
         isTurbopack || url === '/static'
           ? /Hello World\+World\+World\+World\+World\+World/
@@ -40,18 +42,21 @@ describe('esm-externals', () => {
 
   // App dir
   {
-    // TODO App Dir doesn't use esmExternals: true correctly for webpack and Turbopack
+    // TODO App Dir doesn't use esmExternals: true correctly for Turbopack
     // so we only verify that the page doesn't crash, but ignore the actual content
-    // const expectedHtml = /Hello World\+World\+World/
-    const expectedHtml = /Hello Wrong\+Wrong\+Alternative/
-    // const expectedText = /Hello World\+World\+World/
+    // const expectedHtml = isTurbopack ? /Hello World\+World\+World/ : /Hello World\+World\+Alternative/
+    const expectedHtml = isTurbopack
+      ? /Hello Wrong\+Wrong\+Alternative/
+      : /Hello World\+World\+Alternative/
     const urls = ['/server', '/client']
 
     for (const url of urls) {
       const expectedText =
-        url === '/server'
+        url !== '/server'
+          ? /Hello World\+World\+World/
+          : isTurbopack
           ? /Hello Wrong\+Wrong\+Alternative/
-          : /Hello World\+World\+World/
+          : /Hello World\+World\+Alternative/
       it(`should return the correct SSR HTML for ${url}`, async () => {
         const res = await next.fetch(url)
         const html = await res.text()


### PR DESCRIPTION
- #65041
  - NOTE: needed to change `bundlePagesRouterDependencies` back to `experimental.bundlePagesExternals`
- #65519
- #66286
- #66727
- #66990
  - NOTE: It's different the second time. why did `nextFlightLoader` stuff change?