### PR TITLE
cleanup FlightDataPath array access/slicing

### DIFF
--- a/packages/next/src/client/components/router-reducer/apply-flight-data.ts
+++ b/packages/next/src/client/components/router-reducer/apply-flight-data.ts
@@ -3,6 +3,10 @@ import type { FlightDataPath } from '../../../server/app-render/types'
 import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-head'
 import { fillCacheWithNewSubTreeData } from './fill-cache-with-new-subtree-data'
 import type { PrefetchCacheEntry } from './router-reducer-types'
+import {
+  getFlightDataPartsFromPath,
+  isRootFlightDataPath,
+} from '../../flight-data-helpers'
 
 export function applyFlightData(
   existingCache: CacheNode,
@@ -11,16 +15,20 @@ export function applyFlightData(
   prefetchEntry?: PrefetchCacheEntry
 ): boolean {
   // The one before last item is the router state tree patch
-  const [treePatch, cacheNodeSeedData, head] = flightDataPath.slice(-3)
+  const {
+    tree: treePatch,
+    seedData,
+    head,
+  } = getFlightDataPartsFromPath(flightDataPath)
 
   // Handles case where prefetch only returns the router tree patch without rendered components.
-  if (cacheNodeSeedData === null) {
+  if (seedData === null) {
     return false
   }
 
-  if (flightDataPath.length === 3) {
-    const rsc = cacheNodeSeedData[1]
-    const loading = cacheNodeSeedData[3]
+  if (isRootFlightDataPath(flightDataPath)) {
+    const rsc = seedData[1]
+    const loading = seedData[3]
     cache.loading = loading
     cache.rsc = rsc
     // This is a PPR-only field. When PPR is enabled, we shouldn't hit
@@ -33,7 +41,7 @@ export function applyFlightData(
       cache,
       existingCache,
       treePatch,
-      cacheNodeSeedData,
+      seedData,
       head,
       prefetchEntry
     )

--- a/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.ts
+++ b/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.ts
@@ -3,6 +3,7 @@ import type {
   FlightSegmentPath,
 } from '../../../server/app-render/types'
 import { DEFAULT_SEGMENT_KEY } from '../../../shared/lib/segment'
+import { getNextFlightSegmentPath } from '../../flight-data-helpers'
 import { matchSegment } from '../match-segments'
 import { addRefreshMarkerToActiveParallelSegments } from './refetch-inactive-parallel-segments'
 
@@ -106,7 +107,7 @@ export function applyRouterStatePatchToTree(
     parallelRoutePatch = applyPatch(parallelRoutes[parallelRouteKey], treePatch)
   } else {
     parallelRoutePatch = applyRouterStatePatchToTree(
-      flightSegmentPath.slice(2),
+      getNextFlightSegmentPath(flightSegmentPath),
       parallelRoutes[parallelRouteKey],
       treePatch,
       path

--- a/packages/next/src/client/components/router-reducer/clear-cache-node-data-for-segment-path.ts
+++ b/packages/next/src/client/components/router-reducer/clear-cache-node-data-for-segment-path.ts
@@ -1,5 +1,6 @@
 import type { FlightSegmentPath } from '../../../server/app-render/types'
 import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
+import { getNextFlightSegmentPath } from '../../flight-data-helpers'
 import { createRouterCacheKey } from './create-router-cache-key'
 
 /**
@@ -80,6 +81,6 @@ export function clearCacheNodeDataForSegmentPath(
   return clearCacheNodeDataForSegmentPath(
     childCacheNode,
     existingChildCacheNode,
-    flightSegmentPath.slice(2)
+    getNextFlightSegmentPath(flightSegmentPath)
   )
 }

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.ts
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.ts
@@ -1,6 +1,7 @@
 import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
 import type { FlightSegmentPath } from '../../../server/app-render/types'
 import { createRouterCacheKey } from './create-router-cache-key'
+import { getNextFlightSegmentPath } from '../../flight-data-helpers'
 
 /**
  * Fill cache up to the end of the flightSegmentPath, invalidating anything below it.
@@ -60,6 +61,6 @@ export function invalidateCacheBelowFlightSegmentPath(
   invalidateCacheBelowFlightSegmentPath(
     childCacheNode,
     existingChildCacheNode,
-    flightSegmentPath.slice(2)
+    getNextFlightSegmentPath(flightSegmentPath)
   )
 }

--- a/packages/next/src/client/components/router-reducer/reducers/hmr-refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/hmr-refresh-reducer.ts
@@ -15,6 +15,10 @@ import type { CacheNode } from '../../../../shared/lib/app-router-context.shared
 import { createEmptyCacheNode } from '../../app-router'
 import { handleSegmentMismatch } from '../handle-segment-mismatch'
 import { hasInterceptionRouteInCurrentTree } from './has-interception-route-in-current-tree'
+import {
+  getFlightDataPartsFromPath,
+  isRootFlightDataPath,
+} from '../../../flight-data-helpers'
 
 // A version of refresh reducer that keeps the cache around instead of wiping all of it.
 function hmrRefreshReducerImpl(
@@ -60,15 +64,14 @@ function hmrRefreshReducerImpl(
       let currentCache = state.cache
 
       for (const flightDataPath of flightData) {
-        // FlightDataPath with more than two items means unexpected Flight data was returned
-        if (flightDataPath.length !== 3) {
+        if (!isRootFlightDataPath(flightDataPath)) {
           // TODO-APP: handle this case better
           console.log('REFRESH FAILED')
           return state
         }
 
-        // Given the path can only have two items the items are only the router state and rsc for the root.
-        const [treePatch] = flightDataPath
+        const { tree: treePatch } = getFlightDataPartsFromPath(flightDataPath)
+
         const newTree = applyRouterStatePatchToTree(
           // TODO-APP: remove ''
           [''],

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
@@ -13,6 +13,7 @@ import { handleMutable } from '../handle-mutable'
 import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
 import { createEmptyCacheNode } from '../../app-router'
 import { handleSegmentMismatch } from '../handle-segment-mismatch'
+import { getFlightDataPartsFromPath } from '../../../flight-data-helpers'
 
 export function serverPatchReducer(
   state: ReadonlyReducerState,
@@ -40,10 +41,9 @@ export function serverPatchReducer(
   let currentCache = state.cache
 
   for (const flightDataPath of flightData) {
-    // Slices off the last segment (which is at -4) as it doesn't exist in the tree yet
-    const flightSegmentPath = flightDataPath.slice(0, -4)
+    const { segmentPath: flightSegmentPath, tree: treePatch } =
+      getFlightDataPartsFromPath(flightDataPath)
 
-    const [treePatch] = flightDataPath.slice(-3, -2)
     const newTree = applyRouterStatePatchToTree(
       // TODO-APP: remove ''
       ['', ...flightSegmentPath],

--- a/packages/next/src/client/components/router-reducer/should-hard-navigate.ts
+++ b/packages/next/src/client/components/router-reducer/should-hard-navigate.ts
@@ -3,6 +3,7 @@ import type {
   FlightDataPath,
   Segment,
 } from '../../../server/app-render/types'
+import { getNextFlightSegmentPath } from '../../flight-data-helpers'
 import { matchSegment } from '../match-segments'
 
 // TODO-APP: flightSegmentPath will be empty in case of static response, needs to be handled.
@@ -34,7 +35,7 @@ export function shouldHardNavigate(
   }
 
   return shouldHardNavigate(
-    flightSegmentPath.slice(2),
+    getNextFlightSegmentPath(flightSegmentPath),
     parallelRoutes[parallelRouteKey]
   )
 }

--- a/packages/next/src/client/flight-data-helpers.ts
+++ b/packages/next/src/client/flight-data-helpers.ts
@@ -1,0 +1,59 @@
+import type {
+  CacheNodeSeedData,
+  FlightDataPath,
+  FlightRouterState,
+  FlightSegmentPath,
+  Segment,
+} from '../server/app-render/types'
+
+export function getFlightDataPartsFromPath(flightDataPath: FlightDataPath): {
+  /**
+   * The full `FlightSegmentPath` inclusive of the final `Segment`
+   */
+  segmentPath: FlightSegmentPath
+  /**
+   * The `FlightSegmentPath` exclusive of the final `Segment`
+   */
+  pathToSegment: FlightSegmentPath
+  segment: Segment
+  tree: FlightRouterState
+  seedData: CacheNodeSeedData | null
+  head: React.ReactNode | null
+} {
+  // tree, seedData, and head are *always* the last three items in the `FlightDataPath`.
+  const [tree, seedData, head] = flightDataPath.slice(-3)
+  // The `FlightSegmentPath` is everything except the last three items. For a root render, it won't be present.
+  const segmentPath = flightDataPath.slice(0, -3)
+
+  return {
+    // TODO: Unify these two segment path helpers. We are inconsistently pushing an empty segment ("")
+    // to the start of the segment path in some places which makes it hard to use solely the segment path.
+    // Look for "// TODO-APP: remove ''" in the codebase.
+    pathToSegment: segmentPath.slice(0, -1),
+    segmentPath,
+    // if the `FlightDataPath` corresponds with the root, there'll be no segment path,
+    // in which case we default to ''.
+    segment: segmentPath[segmentPath.length - 1] ?? '',
+    tree,
+    seedData,
+    head,
+  }
+}
+
+export function isRootFlightDataPath(flightDataPath: FlightDataPath): boolean {
+  return flightDataPath.length === 3
+}
+
+export function isLastFlightDataPathEntry(
+  flightDataPath: FlightDataPath
+): boolean {
+  return flightDataPath.length === 5
+}
+
+export function getNextFlightSegmentPath(
+  flightSegmentPath: FlightSegmentPath
+): FlightSegmentPath {
+  // Since `FlightSegmentPath` is a repeated tuple of `Segment` and `ParallelRouteKey`, we slice off two items
+  // to get the next segment path.
+  return flightSegmentPath.slice(2)
+}

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -97,6 +97,13 @@ export type CacheNodeSeedData = [
   loading: LoadingModuleData,
 ]
 
+export type FlightDataSegment = [
+  /* segment of the rendered slice: */ Segment,
+  /* treePatch */ FlightRouterState,
+  /* cacheNodeSeedData */ CacheNodeSeedData | null, // Can be null during prefetch if there's no loading component
+  /* head */ React.ReactNode | null,
+]
+
 export type FlightDataPath =
   // Uses `any` as repeating pattern can't be typed.
   | any[]
@@ -104,10 +111,7 @@ export type FlightDataPath =
   | [
       // Holds full path to the segment.
       ...FlightSegmentPath[],
-      /* segment of the rendered slice: */ Segment,
-      /* treePatch */ FlightRouterState,
-      /* cacheNodeSeedData */ CacheNodeSeedData, // Can be null during prefetch if there's no loading component
-      /* head */ React.ReactNode | null,
+      ...FlightDataSegment,
     ]
 
 /**

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -1,5 +1,6 @@
 import type {
   FlightDataPath,
+  FlightDataSegment,
   FlightRouterState,
   FlightSegmentPath,
   PreloadCallbacks,
@@ -135,7 +136,14 @@ export async function walkTreeWithFlightRouterState({
 
     if (shouldSkipComponentTree) {
       // Send only the router state
-      return [[overriddenSegment, routerState, null, null]]
+      return [
+        [
+          overriddenSegment,
+          routerState,
+          null,
+          null,
+        ] satisfies FlightDataSegment,
+      ]
     } else {
       // Create component tree using the slice of the loaderTree
       const seedData = await createComponentTree(
@@ -156,7 +164,14 @@ export async function walkTreeWithFlightRouterState({
         }
       )
 
-      return [[overriddenSegment, routerState, seedData, rscPayloadHead]]
+      return [
+        [
+          overriddenSegment,
+          routerState,
+          seedData,
+          rscPayloadHead,
+        ] satisfies FlightDataSegment,
+      ]
     }
   }
 

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -4,6 +4,7 @@ import type { NextConfigComplete } from '../config-shared'
 import type {
   DynamicParamTypesShort,
   FlightRouterState,
+  FlightSegmentPath,
 } from '../app-render/types'
 import type { CompilerNameValues } from '../../shared/lib/constants'
 import type { RouteDefinition } from '../route-definitions/route-definition'
@@ -43,6 +44,7 @@ import { scheduleOnNextTick } from '../../lib/scheduler'
 import { Batcher } from '../../lib/batcher'
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 import { PAGE_TYPES } from '../../lib/page-types'
+import { getNextFlightSegmentPath } from '../../client/flight-data-helpers'
 
 const debug = createDebug('next:on-demand-entry-handler')
 
@@ -54,7 +56,7 @@ const keys = Object.keys as <T>(o: T) => Extract<keyof T, string>[]
 const COMPILER_KEYS = keys(COMPILER_INDEXES)
 
 function treePathToEntrypoint(
-  segmentPath: string[],
+  segmentPath: FlightSegmentPath,
   parentPath?: string
 ): string {
   const [parallelRouteKey, segment] = segmentPath
@@ -72,7 +74,7 @@ function treePathToEntrypoint(
     return path
   }
 
-  const childSegmentPath = segmentPath.slice(2)
+  const childSegmentPath = getNextFlightSegmentPath(segmentPath)
   return treePathToEntrypoint(childSegmentPath, path)
 }
 


### PR DESCRIPTION
Working with `FlightDataPath` and `FlightSegmentPath` is tricky because they're typed as `any[]`. Array access and slicing is sprinkled throughout the router code which makes it difficult to add/remove/re-order properties. It also results in more untyped code, because anything that touches `FlightDataPath` becomes `any`.

To improve the DX around working with this data structure, I'm starting by moving all of the array slicing/property access into a single location. And `getFlightDataPartsFromPath` provides types for the different properties it returns 	so things like `seedData` aren't `any`. 

There's currently two similarly named but different paths that get returned by this function to support forked handling (ppr vs non-PPR): `pathToSegment` and `segmentPath`. Open to alternative names here, but my goal in an upcoming PR is to just have a single segment path and unify the handling. To get there, I first need to investigate all the `// TODO-APP remove ''` comments because we're inconsistent with how the segment path is constructed & consumed.