### PR TITLE
Partial Fallback Prerendering Route Shells

### DIFF
--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -370,6 +370,7 @@ export class ImageOptimizerCache {
             Date.now(),
           curRevalidate: maxAge,
           isStale: now > expireAt,
+          isFallback: false,
         }
       }
     } catch (_) {

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -395,6 +395,8 @@ export class IncrementalCache implements IncrementalCacheType {
       return null
     }
 
+    const { isFallback } = ctx
+
     cacheKey = this._getPathname(
       cacheKey,
       ctx.kind === IncrementalCacheKind.FETCH
@@ -429,7 +431,8 @@ export class IncrementalCache implements IncrementalCacheType {
           revalidate: revalidate,
         },
         revalidateAfter: Date.now() + revalidate * 1000,
-      }
+        isFallback,
+      } satisfies IncrementalCacheEntry
     }
 
     const curRevalidate = this.revalidateTimings.get(toRoute(cacheKey))
@@ -459,6 +462,7 @@ export class IncrementalCache implements IncrementalCacheType {
         curRevalidate,
         revalidateAfter,
         value: cacheData.value,
+        isFallback,
       }
     }
 
@@ -476,6 +480,7 @@ export class IncrementalCache implements IncrementalCacheType {
         value: null,
         curRevalidate,
         revalidateAfter,
+        isFallback,
       }
       this.set(cacheKey, entry.value, ctx)
     }

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -870,6 +870,7 @@ export default class NextNodeServer extends BaseServer<
                 etag,
                 extension: getExtension(contentType) as string,
               },
+              isFallback: false,
               revalidate: maxAge,
             }
           },

--- a/packages/next/src/server/response-cache/types.ts
+++ b/packages/next/src/server/response-cache/types.ts
@@ -135,6 +135,7 @@ export type IncrementalCacheEntry = {
   // -1 here dictates a blocking revalidate should be used
   isStale?: boolean | -1
   value: IncrementalCacheValue | null
+  isFallback: boolean | undefined
 }
 
 export type IncrementalCacheValue =
@@ -157,6 +158,7 @@ export type ResponseCacheEntry = {
   value: ResponseCacheValue | null
   isStale?: boolean | -1
   isMiss?: boolean
+  isFallback: boolean | undefined
 }
 
 /**
@@ -176,6 +178,7 @@ export type IncrementalCacheItem = {
   value: IncrementalCacheValue | null
   isStale?: boolean | -1
   isMiss?: boolean
+  isFallback: boolean | undefined
 } | null
 
 export const enum IncrementalCacheKind {

--- a/packages/next/src/server/response-cache/utils.ts
+++ b/packages/next/src/server/response-cache/utils.ts
@@ -52,6 +52,7 @@ export async function toResponseCacheEntry(
     isMiss: response.isMiss,
     isStale: response.isStale,
     revalidate: response.revalidate,
+    isFallback: response.isFallback,
     value:
       response.value?.kind === CachedRouteKind.PAGES
         ? ({

--- a/test/e2e/app-dir/ppr-full/app/api/revalidate/route.js
+++ b/test/e2e/app-dir/ppr-full/app/api/revalidate/route.js
@@ -1,0 +1,24 @@
+import { revalidatePath } from 'next/cache'
+
+export async function GET(request) {
+  const url = new URL(request.url)
+  const pathnames = url.searchParams.getAll('pathname')
+  if (pathnames.length === 0) {
+    return new Response(null, { status: 400 })
+  }
+  for (const pathname of pathnames) {
+    let type
+    if (pathname.includes('[') && pathname.includes(']')) {
+      type = 'page'
+    }
+
+    revalidatePath(pathname, type)
+  }
+
+  return new Response(
+    JSON.stringify({
+      revalidated: pathnames,
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  )
+}

--- a/test/e2e/app-dir/ppr-full/app/fallback/dynamic/params/[slug]/layout.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/dynamic/params/[slug]/layout.jsx
@@ -1,0 +1,8 @@
+export default function Layout({ children }) {
+  return (
+    <>
+      <div data-layout={Math.random().toString(16).slice(2)} />
+      {children}
+    </>
+  )
+}

--- a/test/e2e/app-dir/ppr-full/app/fallback/dynamic/params/[slug]/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/dynamic/params/[slug]/page.jsx
@@ -1,0 +1,24 @@
+import { headers } from 'next/headers'
+import { Suspense } from 'react'
+import { setTimeout } from 'timers/promises'
+
+function Dynamic() {
+  const agent = headers().get('user-agent')
+
+  return <div data-agent={agent}>{agent}</div>
+}
+
+export default async function Page({ params }) {
+  await setTimeout(1000)
+
+  const { slug } = params
+
+  return (
+    <div>
+      <div data-slug={slug}>{slug}</div>
+      <Suspense>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/ppr-full/app/fallback/loading.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/loading.jsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div data-fallback>Dynamic Loading...</div>
+}

--- a/test/e2e/app-dir/ppr-full/app/fallback/nested/params/[...slug]/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/nested/params/[...slug]/page.jsx
@@ -1,16 +1,7 @@
-import { Suspense } from 'react'
 import { setTimeout } from 'timers/promises'
 
-async function Dynamic({ params = null }) {
+export default async function Page({ params }) {
   await setTimeout(1000)
 
   return <div data-slug={params.slug.join('/')}>{params.slug.join('/')}</div>
-}
-
-export default function Page({ params }) {
-  return (
-    <Suspense fallback={<div data-fallback>Dynamic Loading...</div>}>
-      <Dynamic params={params} />
-    </Suspense>
-  )
 }

--- a/test/e2e/app-dir/ppr-full/app/fallback/nested/use-params/[...slug]/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/nested/use-params/[...slug]/page.jsx
@@ -1,20 +1,12 @@
 'use client'
 
 import { useParams } from 'next/navigation'
-import { Suspense, use } from 'react'
+import { use } from 'react'
 
-function Dynamic() {
+export default function Page() {
   const params = useParams()
 
   use(new Promise((resolve) => setTimeout(resolve, 1000)))
 
   return <div data-slug={params.slug.join('/')}>{params.slug.join('/')}</div>
-}
-
-export default function Page() {
-  return (
-    <Suspense fallback={<div data-fallback>Dynamic Loading...</div>}>
-      <Dynamic />
-    </Suspense>
-  )
 }

--- a/test/e2e/app-dir/ppr-full/app/fallback/nested/use-pathname/[...slug]/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/nested/use-pathname/[...slug]/page.jsx
@@ -1,20 +1,12 @@
 'use client'
 
 import { usePathname } from 'next/navigation'
-import { Suspense, use } from 'react'
+import { use } from 'react'
 
-function Dynamic() {
+export default function Page() {
   const pathname = usePathname()
 
   use(new Promise((resolve) => setTimeout(resolve, 1000)))
 
   return <div data-slug={pathname}>{pathname}</div>
-}
-
-export default function Page() {
-  return (
-    <Suspense fallback={<div data-fallback>Dynamic Loading...</div>}>
-      <Dynamic />
-    </Suspense>
-  )
 }

--- a/test/e2e/app-dir/ppr-full/app/fallback/params/[slug]/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/params/[slug]/page.jsx
@@ -1,16 +1,7 @@
-import { Suspense } from 'react'
 import { setTimeout } from 'timers/promises'
 
-async function Dynamic({ params = null }) {
+export default async function Page({ params }) {
   await setTimeout(1000)
 
   return <div data-slug={params.slug}>{params.slug}</div>
-}
-
-export default function Page({ params }) {
-  return (
-    <Suspense fallback={<div data-fallback>Dynamic Loading...</div>}>
-      <Dynamic params={params} />
-    </Suspense>
-  )
 }

--- a/test/e2e/app-dir/ppr-full/app/fallback/use-params/[slug]/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/use-params/[slug]/page.jsx
@@ -1,20 +1,12 @@
 'use client'
 
 import { useParams } from 'next/navigation'
-import { Suspense, use } from 'react'
+import { use } from 'react'
 
-function Dynamic() {
+export default function Page() {
   const params = useParams()
 
   use(new Promise((resolve) => setTimeout(resolve, 1000)))
 
   return <div data-slug={params.slug}>{params.slug}</div>
-}
-
-export default function Page() {
-  return (
-    <Suspense fallback={<div data-fallback>Dynamic Loading...</div>}>
-      <Dynamic />
-    </Suspense>
-  )
 }

--- a/test/e2e/app-dir/ppr-full/app/fallback/use-pathname/[slug]/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/use-pathname/[slug]/page.jsx
@@ -1,20 +1,12 @@
 'use client'
 
 import { usePathname } from 'next/navigation'
-import { Suspense, use } from 'react'
+import { use } from 'react'
 
-function Dynamic() {
+export default function Page() {
   const pathname = usePathname()
 
   use(new Promise((resolve) => setTimeout(resolve, 1000)))
 
   return <div data-slug={pathname}>{pathname}</div>
-}
-
-export default function Page() {
-  return (
-    <Suspense fallback={<div data-fallback>Dynamic Loading...</div>}>
-      <Dynamic />
-    </Suspense>
-  )
 }

--- a/test/e2e/app-dir/ppr-full/app/layout.jsx
+++ b/test/e2e/app-dir/ppr-full/app/layout.jsx
@@ -1,6 +1,6 @@
 import { Layout } from '../components/layout'
 
-export default ({ children }) => {
+export default function RootLayout({ children }) {
   return (
     <html>
       <body>

--- a/test/e2e/app-dir/ppr-full/ppr-full.test.ts
+++ b/test/e2e/app-dir/ppr-full/ppr-full.test.ts
@@ -2,6 +2,7 @@ import { nextTestSetup, isNextStart } from 'e2e-utils'
 import { measurePPRTimings } from 'e2e-utils/ppr'
 import { links } from './components/links'
 import cheerio from 'cheerio'
+import { retry } from 'next-test-utils'
 
 type Page = {
   pathname: string
@@ -326,11 +327,13 @@ describe('ppr-full', () => {
               let $ = cheerio.load(chunks.static)
               let data = $('[data-slug]').text()
               expect(data).not.toContain(slug)
+              expect($('[data-slug]').closest('[hidden]').length).toBe(0)
 
               // The dynamic part should contain the dynamic parameter.
               $ = cheerio.load(chunks.dynamic)
               data = $('[data-slug]').text()
               expect(data).toContain(slug)
+              expect($('[data-slug]').closest('[hidden]').length).toBe(1)
 
               // The static part should contain the fallback shell.
               expect(chunks.static).toContain('data-fallback')
@@ -338,6 +341,132 @@ describe('ppr-full', () => {
           })
         }
       )
+
+      describe('Dynamic Shell', () => {
+        it('should render the fallback shell on first visit', async () => {
+          const random = Math.random().toString(16).slice(2)
+          const pathname = '/fallback/dynamic/params/on-first-visit-' + random
+          const $ = await next.render$(pathname)
+          expect($('[data-slug]').closest('[hidden]').length).toBe(1)
+          expect($('[data-agent]').closest('[hidden]').length).toBe(1)
+        })
+
+        it('should render the dynamic shell on the second visit', async () => {
+          const random = Math.random().toString(16).slice(2)
+          const pathname = '/fallback/dynamic/params/on-second-visit-' + random
+
+          let $ = await next.render$(pathname)
+          expect($('[data-slug]').closest('[hidden]').length).toBe(1)
+          expect($('[data-agent]').closest('[hidden]').length).toBe(1)
+
+          await retry(async () => {
+            $ = await next.render$(pathname)
+            expect($('[data-slug]').closest('[hidden]').length).toBe(0)
+            expect($('[data-agent]').closest('[hidden]').length).toBe(1)
+          })
+        })
+
+        it('should render the dynamic shell as static if the page is static', async () => {
+          const random = Math.random().toString(16).slice(2)
+          const pathname = '/fallback/params/on-second-visit-' + random
+
+          // Expect that the slug had to be resumed.
+          let $ = await next.render$(pathname)
+          expect($('[data-slug]').closest('[hidden]').length).toBe(1)
+
+          // The slug didn't have to be resumed, and it should all be static.
+          await retry(async () => {
+            $ = await next.render$(pathname)
+            expect($('[data-slug]').closest('[hidden]').length).toBe(0)
+
+            const {
+              timings: { streamFirstChunk, start, streamEnd },
+              chunks,
+            } = await measurePPRTimings(async () => {
+              const res = await next.fetch(pathname)
+              expect(res.status).toBe(200)
+              if (isNextDeploy) {
+                expect(res.headers.get('x-vercel-cache')).toBe('HIT')
+              } else {
+                expect(res.headers.get('x-nextjs-cache')).toBe('HIT')
+              }
+
+              return res.body
+            }, 1000)
+
+            expect(chunks.dynamic).toBe('')
+            expect(streamFirstChunk - start).toBeLessThan(500)
+            expect(streamEnd - start).toBeLessThan(500)
+          })
+        })
+
+        it('will only revalidate the page', async () => {
+          const random = Math.random().toString(16).slice(2)
+          const pathname = '/fallback/dynamic/params/revalidate-' + random
+
+          let $ = await next.render$(pathname)
+          const fallbackID = $('[data-layout]').data('layout') as string
+
+          let dynamicID: string
+          await retry(async () => {
+            $ = await next.render$(pathname)
+            dynamicID = $('[data-layout]').data('layout') as string
+
+            // These should be different,
+            expect(dynamicID).not.toBe(fallbackID)
+          })
+
+          // Now let's revalidate the page.
+          await next.fetch(
+            '/api/revalidate?pathname=' + encodeURIComponent(pathname)
+          )
+
+          // We expect to get the fallback shell again.
+          if (!isNextDeploy) {
+            $ = await next.render$(pathname)
+            expect($('[data-layout]').data('layout')).toBe(fallbackID)
+          }
+
+          // Let's wait for the page to be revalidated.
+          await retry(async () => {
+            $ = await next.render$(pathname)
+            const newDynamicID = $('[data-layout]').data('layout') as string
+            expect(newDynamicID).not.toBe(dynamicID)
+          })
+        })
+
+        it('will revalidate the page and fallback shell', async () => {
+          const random = Math.random().toString(16).slice(2)
+          const pathname = '/fallback/dynamic/params/revalidate-' + random
+
+          let $ = await next.render$(pathname)
+          const fallbackID = $('[data-layout]').data('layout') as string
+
+          let dynamicID: string
+          await retry(async () => {
+            $ = await next.render$(pathname)
+            dynamicID = $('[data-layout]').data('layout') as string
+
+            // These should be different,
+            expect(dynamicID).not.toBe(fallbackID)
+          })
+
+          // Now let's revalidate the page.
+          await next.fetch(
+            '/api/revalidate?pathname=/fallback/dynamic/params/[slug]'
+          )
+
+          // We expect to get a revalidated shell, not the same one as before.
+          $ = await next.render$(pathname)
+          expect($('[data-layout]').data('layout')).not.toBe(fallbackID)
+
+          // Let's wait for the page to be revalidated.
+          await retry(async () => {
+            $ = await next.render$(pathname)
+            expect($('[data-layout]').data('layout')).not.toBe(dynamicID)
+          })
+        })
+      })
     })
   }
 
@@ -421,27 +550,30 @@ describe('ppr-full', () => {
     describe('Prefetch RSC Response', () => {
       describe.each(pages)('for $pathname', ({ pathname, revalidate }) => {
         it('should have correct headers', async () => {
-          const res = await next.fetch(pathname, {
-            headers: { RSC: '1', 'Next-Router-Prefetch': '1' },
+          await retry(async () => {
+            const res = await next.fetch(pathname, {
+              headers: { RSC: '1', 'Next-Router-Prefetch': '1' },
+            })
+
+            expect(res.status).toEqual(200)
+            expect(res.headers.get('content-type')).toEqual('text/x-component')
+
+            if (isNextDeploy) {
+              expect(res.headers.get('cache-control')).toEqual(
+                'public, max-age=0, must-revalidate'
+              )
+            } else {
+              expect(res.headers.get('cache-control')).toEqual(
+                `s-maxage=${revalidate || '31536000'}, stale-while-revalidate`
+              )
+            }
+
+            if (!isNextDeploy) {
+              expect(res.headers.get('x-nextjs-cache')).toBe('HIT')
+            } else {
+              expect(res.headers.get('x-vercel-cache')).toBe('HIT')
+            }
           })
-          expect(res.status).toEqual(200)
-          expect(res.headers.get('content-type')).toEqual('text/x-component')
-
-          // cache header handling is different when in minimal mode
-          const cache = res.headers.get('cache-control')
-          if (isNextDeploy) {
-            expect(cache).toEqual('public, max-age=0, must-revalidate')
-          } else {
-            expect(cache).toEqual(
-              `s-maxage=${revalidate || '31536000'}, stale-while-revalidate`
-            )
-          }
-
-          if (!isNextDeploy) {
-            expect(res.headers.get('x-nextjs-cache')).toEqual('HIT')
-          } else {
-            expect(res.headers.get('x-nextjs-cache')).toEqual(null)
-          }
         })
 
         it('should not contain dynamic content', async () => {
@@ -472,7 +604,11 @@ describe('ppr-full', () => {
           expect(res.headers.get('cache-control')).toEqual(
             'private, no-cache, no-store, max-age=0, must-revalidate'
           )
-          expect(res.headers.get('x-nextjs-cache')).toEqual(null)
+          if (isNextDeploy) {
+            expect(res.headers.get('x-vercel-cache')).toBe('MISS')
+          } else {
+            expect(res.headers.get('x-nextjs-cache')).toEqual(null)
+          }
         })
 
         if (dynamic === true || dynamic === 'force-dynamic') {

--- a/test/e2e/app-dir/ppr-incremental/ppr-incremental.test.ts
+++ b/test/e2e/app-dir/ppr-incremental/ppr-incremental.test.ts
@@ -145,7 +145,7 @@ describe('ppr-incremental', () => {
           it.each(pathnames)('%s', async (pathname) => {
             const $ = await next.render$(pathname)
             expect($('#dynamic')).toHaveLength(1)
-            expect($('#dynamic').parent('[hidden]')).toHaveLength(0)
+            expect($('#dynamic').closest('[hidden]')).toHaveLength(0)
           })
         })
       }
@@ -197,7 +197,7 @@ describe('ppr-incremental', () => {
           it.each(pathnames)('%s', async (pathname) => {
             const $ = await next.render$(pathname)
             expect($('#dynamic')).toHaveLength(1)
-            expect($('#dynamic').parent('[hidden]')).toHaveLength(1)
+            expect($('#dynamic').closest('[hidden]')).toHaveLength(1)
           })
         })
       }


### PR DESCRIPTION
Building on Partial Fallback Prerendering (#68958), this expands the behaviour after a fallback shell is served. Once a fallback is served, the route shell is then generated. Future requests will then use this new route shell instead.