### PR TITLE
fix: Allow guarded usage of node.js APIs from edge runtime

### DIFF
--- a/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
+++ b/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
@@ -183,6 +183,9 @@ Learn more: https://nextjs.org/docs/api-reference/edge-runtime",
         if !self.is_in_middleware_layer() || prop.sym == "env" {
             return;
         }
+        if self.in_process_guards.contains(&prop.sym) {
+            return;
+        }
 
         self.emit_unsupported_api_error(span, &format!("process.{}", prop.sym));
     }

--- a/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
+++ b/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
@@ -302,6 +302,7 @@ impl Visit for WarnForEdgeRuntime {
     fn visit_unary_expr(&mut self, node: &UnaryExpr) {
         if node.op == op!("typeof") {
             self.add_guard_for_test(&node.arg);
+            return;
         }
 
         node.visit_children_with(self);

--- a/crates/next-custom-transforms/tests/fixture/edge-assert/guarded-nodejs/input.js
+++ b/crates/next-custom-transforms/tests/fixture/edge-assert/guarded-nodejs/input.js
@@ -1,0 +1,3 @@
+if (typeof clearImmediate) {
+  console.log(clearImmediate())
+}

--- a/crates/next-custom-transforms/tests/fixture/edge-assert/guarded-nodejs/input.js
+++ b/crates/next-custom-transforms/tests/fixture/edge-assert/guarded-nodejs/input.js
@@ -1,3 +1,9 @@
-if (typeof clearImmediate) {
+if (typeof clearImmediate === 'function') {
   console.log(clearImmediate())
 }
+
+// We allow this.
+const scheduleTimeoutA =
+  typeof setImmediate === 'function' ? setImmediate : setTimeout
+const scheduleTimeoutB =
+  typeof setImmediate !== 'function' ? setTimeout : setImmediate

--- a/crates/next-custom-transforms/tests/fixture/edge-assert/guarded-nodejs/output.js
+++ b/crates/next-custom-transforms/tests/fixture/edge-assert/guarded-nodejs/output.js
@@ -1,0 +1,3 @@
+if (typeof clearImmediate) {
+    console.log(clearImmediate());
+}

--- a/crates/next-custom-transforms/tests/fixture/edge-assert/guarded-nodejs/output.js
+++ b/crates/next-custom-transforms/tests/fixture/edge-assert/guarded-nodejs/output.js
@@ -1,3 +1,6 @@
-if (typeof clearImmediate) {
+if (typeof clearImmediate === 'function') {
     console.log(clearImmediate());
 }
+// We allow this.
+const scheduleTimeoutA = typeof setImmediate === 'function' ? setImmediate : setTimeout;
+const scheduleTimeoutB = typeof setImmediate !== 'function' ? setTimeout : setImmediate;

--- a/crates/next-custom-transforms/tests/fixture/edge-assert/guarded-process/input.js
+++ b/crates/next-custom-transforms/tests/fixture/edge-assert/guarded-process/input.js
@@ -1,0 +1,3 @@
+if (typeof process.loadEnvFile === 'function') {
+  console.log(process.loadEnvFile())
+}

--- a/crates/next-custom-transforms/tests/fixture/edge-assert/guarded-process/output.js
+++ b/crates/next-custom-transforms/tests/fixture/edge-assert/guarded-process/output.js
@@ -1,0 +1,3 @@
+if (typeof process.loadEnvFile === 'function') {
+    console.log(process.loadEnvFile());
+}


### PR DESCRIPTION
### What?

Improve the node.js linter

### Why?

It should not warn for _safe_ usage.

x-ref: https://vercel.slack.com/archives/C04DUD7EB1B/p1724522593235339

### How?
