### PR TITLE
sync-react: Fix `--version` and `--no-install` being ignored

### DIFF
--- a/.github/workflows/update_react.yml
+++ b/.github/workflows/update_react.yml
@@ -1,0 +1,40 @@
+name: Update React
+
+on:
+  schedule:
+    # At 40 minutes past 16:00 on Mon, Tue, Wed, Thu, and Fri
+    # i.e. 30min past React nightlies: https://github.com/facebook/react/blob/941e1b4a0a81ca3d5f2ac6ef35682e2f8e96dae1/.github/workflows/runtime_prereleases_nightly.yml#L6
+    # TODO: automatically trigger on React release
+    - cron: 40 16 * * 1,2,3,4,5
+  # Allow manual runs
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version to update to. Uses latest Canary if omitted.'
+        required: false
+
+env:
+  NODE_LTS_VERSION: 20
+
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Commits made with the default `GITHUB_TOKEN` won't trigger workflows.
+          # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_LTS_VERSION }}
+          check-latest: true
+
+      - run: corepack enable
+
+      - name: Install dependencies
+        shell: bash
+        run: pnpm i

--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -153,9 +153,11 @@ async function getChangelogFromGitHub(baseSha, newSha) {
 async function main() {
   const cwd = process.cwd()
   const errors = []
-  const { noInstall, version } = await yargs(process.argv.slice(2))
-    .options('version', { default: null, type: 'string' })
-    .options('no-install', { default: false, type: 'boolean' }).argv
+  const argv = await yargs(process.argv.slice(2))
+    .version(false)
+    .options('install', { default: true, type: 'boolean' })
+    .options('version', { default: null, type: 'string' }).argv
+  const { install, version } = argv
 
   let newVersionStr = version
   if (newVersionStr === null) {
@@ -198,14 +200,14 @@ Or, run this command with no arguments to use the most recently published versio
     newDateString,
     newSha,
     newVersionStr,
-    noInstall,
+    noInstall: !install,
     channel: 'experimental',
   })
   await sync({
     newDateString,
     newSha,
     newVersionStr,
-    noInstall,
+    noInstall: !install,
     channel: 'rc',
   })
 
@@ -268,7 +270,7 @@ Or, run this command with no arguments to use the most recently published versio
   }
 
   // Install the updated dependencies and build the vendored React files.
-  if (noInstall) {
+  if (!install) {
     console.log('Skipping install step because --no-install flag was passed.\n')
   } else {
     console.log('Installing dependencies...\n')
@@ -328,7 +330,7 @@ Or, run this command with no arguments to use the most recently published versio
     )
   }
 
-  if (noInstall) {
+  if (!install) {
     console.log(
       `
 To finish upgrading, complete the following steps:


### PR DESCRIPTION
From a CLI user perspective, nothing changes

These parameters broke in https://github.com/vercel/next.js/pull/69199 when we switched to Yargs. Yargs already has a built-in notion of `--version` so we have to disable that with `.version(false)`. Yargs also already understands the `--no-` prefix so we just have to define the argument has `install` and flip the default. 
