### PR TITLE
Create empty update_react.yml as a no-op

### DIFF
--- a/.github/workflows/update_react.yml
+++ b/.github/workflows/update_react.yml
@@ -1,0 +1,40 @@
+name: Update React
+
+on:
+  schedule:
+    # At 40 minutes past 16:00 on Mon, Tue, Wed, Thu, and Fri
+    # i.e. 30min past React nightlies: https://github.com/facebook/react/blob/941e1b4a0a81ca3d5f2ac6ef35682e2f8e96dae1/.github/workflows/runtime_prereleases_nightly.yml#L6
+    # TODO: automatically trigger on React release
+    - cron: 40 16 * * 1,2,3,4,5
+  # Allow manual runs
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version to update to. Uses latest Canary if omitted.'
+        required: false
+
+env:
+  NODE_LTS_VERSION: 20
+
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Commits made with the default `GITHUB_TOKEN` won't trigger workflows.
+          # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_LTS_VERSION }}
+          check-latest: true
+
+      - run: corepack enable
+
+      - name: Install dependencies
+        shell: bash
+        run: pnpm i


### PR DESCRIPTION
This will be used to create React syncs automatically. I need to merge this onto `main` before I can start testing it with `gh workflow run update_react.yml --repo vercel/next.js --ref "..."`. Until it's merged, I'll get a 404 even with the designated `ref` specified.