### PR TITLE
Add module id strategy option to next config

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -400,6 +400,7 @@ pub struct ExperimentalTurboConfig {
     pub resolve_extensions: Option<Vec<RcStr>>,
     pub use_swc_css: Option<bool>,
     pub tree_shaking: Option<bool>,
+    pub module_id_strategy: Option<ModuleIdStrategy>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs)]
@@ -431,6 +432,17 @@ pub enum LoaderItem {
     LoaderName(RcStr),
     LoaderOptions(WebpackLoaderItem),
 }
+
+#[turbo_tasks::value]
+#[derive(Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum ModuleIdStrategy {
+    Named,
+    Deterministic,
+}
+
+#[turbo_tasks::value(transparent)]
+pub struct OptionModuleIdStrategy(pub Option<ModuleIdStrategy>);
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs)]
 #[serde(untagged)]
@@ -1131,6 +1143,20 @@ impl NextConfig {
         _is_development: bool,
     ) -> Result<Vc<OptionTreeShaking>> {
         Ok(Vc::cell(Some(TreeShakingMode::ReexportsOnly)))
+    }
+
+    #[turbo_tasks::function]
+    pub async fn module_id_strategy_config(self: Vc<Self>) -> Result<Vc<OptionModuleIdStrategy>> {
+        let this = self.await?;
+        let Some(module_id_strategy) = this
+            .experimental
+            .turbo
+            .as_ref()
+            .and_then(|t| t.module_id_strategy.as_ref())
+        else {
+            return Ok(Vc::cell(None));
+        };
+        Ok(Vc::cell(Some(module_id_strategy.clone())))
     }
 }
 

--- a/docs/02-app/02-api-reference/05-next-config-js/turbo.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/turbo.mdx
@@ -102,3 +102,25 @@ module.exports = {
 This overwrites the original resolve extensions with the provided list. Make sure to include the default extensions.
 
 For more information and guidance for how to migrate your app to Turbopack from webpack, see [Turbopack's documentation on webpack compatibility](https://turbo.build/pack/docs/migrating-from-webpack).
+
+## Module ID strategy
+
+Turbopack currently supports two strategies for assigning module IDs: `'named'` and `'deterministic'`.
+
+`'named'` assigns readable module IDs based on the module's path and functionality.
+
+`'deterministic'` assigns small hashed numeric module IDs, which are mostly consistent between builds and therefore help with long-term caching.
+
+If not set, Turbopack will use `'named'` for development builds and `'deterministic'` for production builds.
+
+To configure the module IDs strategy, use the `moduleIdStrategy` field in `next.config.js`:
+
+```js filename="next.config.js"
+module.exports = {
+  experimental: {
+    turbo: {
+      moduleIdStrategy: 'deterministic',
+    },
+  },
+}
+```

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -390,6 +390,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
             useSwcCss: z.boolean().optional(),
             treeShaking: z.boolean().optional(),
             memoryLimit: z.number().optional(),
+            moduleIdStrategy: z.enum(['named', 'deterministic']).optional(),
           })
           .optional(),
         optimizePackageImports: z.array(z.string()).optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -158,6 +158,13 @@ export interface ExperimentalTurboOptions {
    * Enable tree shaking for the turbopack dev server and build.
    */
   treeShaking?: boolean
+
+  /**
+   * The module ID strategy to use for Turbopack.
+   * If not set, the default is `'named'` for development and `'deterministic'`
+   * for production.
+   */
+  moduleIdStrategy?: 'named' | 'deterministic'
 }
 
 export interface WebpackConfigContext {


### PR DESCRIPTION
Adds a `experimental.turbo.moduleIdStrategy` field to `next.config.js` to configure what module ID generation strategy to use.

`'named'` assigns readable module IDs based on the module's path and functionality.

`'deterministic'` assigns small hashed numeric module IDs.

If not set, Turbopack will use `'named'` for development builds and `'deterministic'` for production builds.