### PR TITLE
Set max retries for build failures to zero

### DIFF
--- a/packages/next/src/lib/worker.ts
+++ b/packages/next/src/lib/worker.ts
@@ -55,6 +55,7 @@ export class Worker {
             NODE_OPTIONS: formatNodeOptions(nodeOptions),
           } as any,
         },
+        maxRetries: 0,
       }) as JestWorker
       restartPromise = new Promise(
         (resolve) => (resolveRestartPromise = resolve)


### PR DESCRIPTION


We generally a failure in a build is a sign of an actual problem. JestWorker has a default retries of 3 which means for every failing error we atempt it 4 times before giving up. This update changes the max retires to 0 so that we abandon the build after the first failure.