### PR TITLE
Revert "Fix action loader modules in graph traversal"

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -49,7 +49,7 @@ use turbopack_core::{
     asset::AssetContent,
     chunk::{
         availability_info::AvailabilityInfo, ChunkingContext, ChunkingContextExt,
-        EntryChunkGroupResult, EvaluatableAsset, EvaluatableAssets,
+        EntryChunkGroupResult, EvaluatableAssets,
     },
     file_source::FileSource,
     ident::AssetIdent,
@@ -75,7 +75,7 @@ use crate::{
     },
     project::Project,
     route::{AppPageRoute, Endpoint, Route, Routes, WrittenEndpoint},
-    server_actions::{build_server_actions_loader, create_server_actions_manifest, get_actions},
+    server_actions::create_server_actions_manifest,
 };
 
 #[turbo_tasks::value]
@@ -765,42 +765,6 @@ impl AppEndpoint {
     }
 
     #[turbo_tasks::function]
-    async fn server_actions_loader(self: Vc<Self>) -> Result<Vc<Box<dyn EvaluatableAsset>>> {
-        let this = self.await?;
-
-        let app_entry = self.app_endpoint_entry().await?;
-        let rsc_entry = app_entry.rsc_entry;
-
-        let runtime = app_entry.config.await?.runtime.unwrap_or_default();
-
-        let rsc_entry_asset = Vc::upcast(rsc_entry);
-        let client_references = client_reference_graph(Vc::cell(vec![rsc_entry_asset]));
-        let client_reference_types = client_references.types();
-        let app_server_reference_modules = get_app_server_reference_modules(client_reference_types);
-
-        let asset_context = match runtime {
-            NextRuntime::Edge => Vc::upcast(this.app_project.edge_rsc_module_context()),
-            NextRuntime::NodeJs => Vc::upcast(this.app_project.rsc_module_context()),
-        };
-
-        let actions = get_actions(rsc_entry, app_server_reference_modules, asset_context);
-
-        let server_actions_loader = build_server_actions_loader(
-            this.app_project.project().project_path(),
-            app_entry.original_name.clone(),
-            actions,
-            asset_context,
-        );
-
-        let evaluatable_server_actions_loader =
-            Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(server_actions_loader)
-                .await?
-                .context("loader module must be evaluatable")?;
-
-        Ok(evaluatable_server_actions_loader)
-    }
-
-    #[turbo_tasks::function]
     fn output_assets(self: Vc<Self>) -> Vc<OutputAssets> {
         self.output().output_assets()
     }
@@ -1084,12 +1048,11 @@ impl AppEndpoint {
                     .context("Entry module must be evaluatable")?;
                 evaluatable_assets.push(evaluatable);
 
-                let loader = self.server_actions_loader();
                 if let Some(app_server_reference_modules) = app_server_reference_modules {
-                    let manifest = create_server_actions_manifest(
+                    let (loader, manifest) = create_server_actions_manifest(
                         Vc::upcast(app_entry.rsc_entry),
-                        loader,
                         app_server_reference_modules,
+                        this.app_project.project().project_path(),
                         node_root,
                         &app_entry.original_name,
                         NextRuntime::Edge,
@@ -1229,12 +1192,11 @@ impl AppEndpoint {
                     .project()
                     .server_chunking_context(process_client);
 
-                let loader = self.server_actions_loader();
                 if let Some(app_server_reference_modules) = app_server_reference_modules {
-                    let manifest = create_server_actions_manifest(
+                    let (loader, manifest) = create_server_actions_manifest(
                         Vc::upcast(app_entry.rsc_entry),
-                        loader,
                         app_server_reference_modules,
+                        this.app_project.project().project_path(),
                         node_root,
                         &app_entry.original_name,
                         NextRuntime::NodeJs,
@@ -1409,17 +1371,8 @@ impl Endpoint for AppEndpoint {
 
     #[turbo_tasks::function]
     async fn root_modules(self: Vc<Self>) -> Result<Vc<Modules>> {
-        let this = self.await?;
-
         let rsc_entry = self.app_endpoint_entry().await?.rsc_entry;
-        let mut modules = vec![rsc_entry];
-
-        if matches!(this.ty, AppEndpointType::Page { .. }) {
-            let server_actions_loader_module = Vc::upcast(self.server_actions_loader());
-            modules.push(server_actions_loader_module);
-        }
-
-        Ok(Vc::cell(modules))
+        Ok(Vc::cell(vec![rsc_entry]))
     }
 }
 


### PR DESCRIPTION
Reverts vercel/next.js#69154

turbopack build tests were broken by #69154 

x-ref: https://github.com/vercel/next.js/actions/runs/10574555048/job/29297790193
x-ref: https://github.com/vercel/next.js/actions/runs/10574095661/job/29295798896
x-ref: https://github.com/vercel/next.js/actions/runs/10572488465/job/29290960591