### PR TITLE
Docs: Add version tag and history for `instrumentationHook`

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/instrumentationHook.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/instrumentationHook.mdx
@@ -23,6 +23,6 @@ module.exports = {
 }
 ```
 
-| Version   | Changes                                                  |
-| --------- | -------------------------------------------------------- |
-| `v13.2.0` | `instrumentationHook` introduced as experimental feature |
+| Version   | Changes                                                     |
+| --------- | ----------------------------------------------------------- |
+| `v13.2.0` | `instrumentationHook` introduced as an experimental feature |

--- a/docs/02-app/02-api-reference/05-next-config-js/instrumentationHook.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/instrumentationHook.mdx
@@ -6,9 +6,12 @@ related:
   links:
     - app/api-reference/file-conventions/instrumentation
     - app/building-your-application/optimizing/instrumentation
+version: experimental
 ---
 
 {/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
+
+{/* TODO: Add note about it not being needed once version 15 is stable */}
 
 The experimental `instrumentationHook` option allows you to set up instrumentation via the [`instrumentation` file](/docs/app/api-reference/file-conventions/instrumentation) in your Next.js App.
 
@@ -19,3 +22,7 @@ module.exports = {
   },
 }
 ```
+
+| Version   | Changes                                                  |
+| --------- | -------------------------------------------------------- |
+| `v13.2.0` | `instrumentationHook` introduced as experimental feature |


### PR DESCRIPTION
Related to: https://linear.app/vercel/issue/DOC-3279/remove-instrumentationhook-tag-update-section-on-it-being-required

This feature will become stable in the Next.js RC release, we will then need to update the docs. 