### PR TITLE
docs: add section for copying devtool debugging url

### DIFF
--- a/docs/02-app/01-building-your-application/07-configuring/16-debugging.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/16-debugging.mdx
@@ -100,6 +100,13 @@ Once the server starts, open a new tab in Chrome and visit `chrome://inspect`, w
 
 Debugging server-side code here works much like debugging client-side code with Chrome DevTools, except that when you search for files here with `Ctrl+P` or `⌘+P`, your source files will have paths starting with `webpack://{application-name}/./` (where `{application-name}` will be replaced with the name of your application according to your `package.json` file).
 
+### Inspect Server Errors with Chrome DevTools
+
+When you bumped to an error, inspecting the source code will be super helpful to trace the root cause of errors.
+In the incoming Next.js v15, Next.js will display a Node.js logo like green button on dev overlay during the inspect mode. By clicking that button you can copy the Chrome DevTool url into clipboard, and you can open a new browser tab with that url to inspect the Next.js server process with Chrome DevTool.
+
+There's a limitation of directly opening the DevTool in user-land pages.
+
 ### Debugging on Windows
 
 Windows users may run into an issue when using `NODE_OPTIONS='--inspect'` as that syntax is not supported on Windows platforms. To get around this, install the [`cross-env`](https://www.npmjs.com/package/cross-env) package as a development dependency (`-D` with `npm` and `yarn`) and replace the `dev` script with the following.

--- a/docs/02-app/01-building-your-application/07-configuring/16-debugging.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/16-debugging.mdx
@@ -103,7 +103,7 @@ Debugging server-side code here works much like debugging client-side code with 
 ### Inspect Server Errors with Chrome DevTools
 
 When you bumped to an error, inspecting the source code will be super helpful to trace the root cause of errors.
-In the incoming Next.js v15, Next.js will display a Node.js logo like green button on dev overlay during the inspect mode. By clicking that button you can copy the Chrome DevTool url into clipboard, and you can open a new browser tab with that url to inspect the Next.js server process with Chrome DevTool.
+In the incoming Next.js v15, Next.js will display a Node.js logo like green button on dev overlay with Node.js inspector. By clicking that button you can copy the Chrome DevTool url into clipboard, and you can open a new browser tab with that url to inspect the Next.js server process with Chrome DevTool.
 
 There's a limitation of directly opening the DevTool in user-land pages, you'll have to click that button to copy the url and paste it in a new window or tab to inspect.
 

--- a/docs/02-app/01-building-your-application/07-configuring/16-debugging.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/16-debugging.mdx
@@ -102,8 +102,10 @@ Debugging server-side code here works much like debugging client-side code with 
 
 ### Inspect Server Errors with Chrome DevTools
 
-When you bumped to an error, inspecting the source code will be super helpful to trace the root cause of errors.
-In the incoming Next.js v15, Next.js will display a Node.js logo like green button on dev overlay with Node.js inspector. By clicking that button you can copy the Chrome DevTool url into clipboard, and you can open a new browser tab with that url to inspect the Next.js server process with Chrome DevTool.
+When you encounter an error, inspecting the source code can help trace the root cause of errors.
+
+Next.js will display a Node.js logo like green button on dev overlay with Node.js inspector. By clicking that button you can copy the Chrome DevTool url into clipboard, and you can open a new browser tab with that url to inspect the Next.js server process with Chrome DevTool.
+This feature is released on latest Next.js canary release.
 
 <Image
   alt="Copy Chrome DevTool url example"

--- a/docs/02-app/01-building-your-application/07-configuring/16-debugging.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/16-debugging.mdx
@@ -105,7 +105,15 @@ Debugging server-side code here works much like debugging client-side code with 
 When you bumped to an error, inspecting the source code will be super helpful to trace the root cause of errors.
 In the incoming Next.js v15, Next.js will display a Node.js logo like green button on dev overlay during the inspect mode. By clicking that button you can copy the Chrome DevTool url into clipboard, and you can open a new browser tab with that url to inspect the Next.js server process with Chrome DevTool.
 
-There's a limitation of directly opening the DevTool in user-land pages.
+There's a limitation of directly opening the DevTool in user-land pages, you'll have to click that button to copy the url and paste it in a new window or tab to inspect.
+
+<Image
+  alt="Copy Chrome DevTool url example"
+  srcLight="/docs/dark/copy-devtool-url-example.png"
+  srcDark="/docs/dark/copy-devtool-url-example.png"
+  width="1600"
+  height="594"
+/>
 
 ### Debugging on Windows
 

--- a/docs/02-app/01-building-your-application/07-configuring/16-debugging.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/16-debugging.mdx
@@ -105,8 +105,6 @@ Debugging server-side code here works much like debugging client-side code with 
 When you bumped to an error, inspecting the source code will be super helpful to trace the root cause of errors.
 In the incoming Next.js v15, Next.js will display a Node.js logo like green button on dev overlay with Node.js inspector. By clicking that button you can copy the Chrome DevTool url into clipboard, and you can open a new browser tab with that url to inspect the Next.js server process with Chrome DevTool.
 
-There's a limitation of directly opening the DevTool in user-land pages, you'll have to click that button to copy the url and paste it in a new window or tab to inspect.
-
 <Image
   alt="Copy Chrome DevTool url example"
   srcLight="/docs/dark/copy-devtool-url-example.png"


### PR DESCRIPTION
### What

Add a new section of copy chrome devtool url in debugging docs

x-ref: https://github.com/vercel/next.js/pull/69357