### PR TITLE
fix(turbopack): Store minimumCacheTTL as a u64

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -315,7 +315,7 @@ pub struct ImageConfig {
     pub domains: Vec<String>,
     pub disable_static_images: bool,
     #[serde(rename(deserialize = "minimumCacheTTL"))]
-    pub minimum_cache_ttl: u32,
+    pub minimum_cache_ttl: u64,
     pub formats: Vec<ImageFormat>,
     #[serde(rename(deserialize = "dangerouslyAllowSVG"))]
     pub dangerously_allow_svg: bool,


### PR DESCRIPTION
Fixes (part of) #69330

We were using a `u32` here instead of a `u64` for no good reason.

The workaround if you're encountering this is to just use `u32::MAX` instead, which should be large enough for all practical purposes: `4294967295`.

## Test Plan

Build turbopack in the next.js repo:

```
pnpm pack-next
```

Follow the repro in #69330:

```
git clone https://github.com/Enkratia/css-reload-show-2.git
# edit the package.json following the instructions from `pnpm pack-next` above
rm package-lock.json
pnpm i
pnpm dev --turbo
```

## Integration Testing?

There are some tests in `test/integration/image-optimizer/test/index.test.ts`, but I didn't see the obviously best way to test this, as most of those tests are looking for errors by scanning stderr, and this is about not generating any error.

Either way, I think this is very unlikely to regress.