### PR TITLE
Fix action loader modules in graph traversal (fixed from revert)

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1172,6 +1172,7 @@ impl Project {
         any_output_changed(roots, path, false)
     }
 
+    /// The Next.js client runtime modules.
     #[turbo_tasks::function]
     pub async fn client_main_modules(self: Vc<Self>) -> Result<Vc<Modules>> {
         let pages_project = self.pages_project();

--- a/test/integration/module-id-strategies/app/info/page.js
+++ b/test/integration/module-id-strategies/app/info/page.js
@@ -1,0 +1,3 @@
+export default function Info() {
+  return <div>App Router Page</div>
+}

--- a/test/integration/module-id-strategies/test/index.test.js
+++ b/test/integration/module-id-strategies/test/index.test.js
@@ -64,6 +64,12 @@ describe('minified module ids', () => {
     it('should have no long module id for the next client runtime module', async () => {
       expect(staticBundles).not.toContain('next/dist/client/next-turbopack')
     })
+
+    it('should have no long module id for action loader modules', async () => {
+      expect(ssrBundles).not.toContain(
+        'next-internal/server/app/info/page/actions.js'
+      )
+    })
   })
   ;(!process.env.TURBOPACK || process.env.TURBOPACK_BUILD
     ? describe.skip
@@ -76,6 +82,7 @@ describe('minified module ids', () => {
       app = await launchApp(appDir, appPort)
 
       await renderViaHTTP(appPort, '/')
+      await renderViaHTTP(appPort, '/info')
 
       const ssrPath = join(appDir, '.next/server/chunks/ssr/')
       const ssrBundleBasenames = (await fs.readdir(ssrPath)).filter((p) =>
@@ -116,6 +123,12 @@ describe('minified module ids', () => {
 
     it('should have long module id for the next client runtime module', async () => {
       expect(staticBundles).toContain('next/dist/client/next-dev-turbopack')
+    })
+
+    it('should have long module id for action loader modules', async () => {
+      expect(ssrBundles).toContain(
+        'next-internal/server/app/info/page/actions.js'
+      )
     })
   })
 })

--- a/turbopack/crates/turbopack-ecmascript/src/global_module_id_strategy.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/global_module_id_strategy.rs
@@ -22,6 +22,15 @@ pub struct PreprocessedChildrenIdents {
     modules_idents: HashMap<RcStr, u64>,
 }
 
+impl PreprocessedChildrenIdents {
+    pub fn from_single_ident(ident: RcStr) -> Vc<Self> {
+        Self {
+            modules_idents: HashMap::from([(ident.clone(), hash_xxh3_hash64(ident.to_string()))]),
+        }
+        .cell()
+    }
+}
+
 #[derive(Clone, Hash)]
 #[turbo_tasks::value(shared)]
 pub enum ReferencedModule {


### PR DESCRIPTION
The [previous PR](https://github.com/vercel/next.js/pull/69154) fixing this issue got reverted because it was causing a timeout in a test. This PR fixes the same issue in a more straightforward approach that should not produce any significant time increase.

Closes PACK-3942