### PR TITLE
Fix bad peer dependencies

### DIFF
--- a/examples/reproduction-template/package.json
+++ b/examples/reproduction-template/package.json
@@ -7,8 +7,8 @@
   },
   "dependencies": {
     "next": "canary",
-    "react": "0.0.0-experimental-f90a6bcc-20240827",
-    "react-dom": "0.0.0-experimental-f90a6bcc-20240827"
+    "react": "19.0.0-rc-f90a6bcc-20240827",
+    "react-dom": "19.0.0-rc-f90a6bcc-20240827"
   },
   "devDependencies": {
     "@types/node": "20.12.12",

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -13,7 +13,7 @@ import { GetTemplateFileArgs, InstallTemplateArgs } from "./types";
 
 // Do not rename or format. sync-react script relies on this line.
 // prettier-ignore
-const nextjsReactPeerVersion = "0.0.0-experimental-f90a6bcc-20240827";
+const nextjsReactPeerVersion = "19.0.0-rc-f90a6bcc-20240827";
 
 /**
  * Get the file path for a given file in a template, e.g. "next.config.js".

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -108,8 +108,8 @@
     "@opentelemetry/api": "^1.1.0",
     "@playwright/test": "^1.41.2",
     "babel-plugin-react-compiler": "*",
-    "react": "0.0.0-experimental-f90a6bcc-20240827",
-    "react-dom": "0.0.0-experimental-f90a6bcc-20240827",
+    "react": "19.0.0-rc-f90a6bcc-20240827",
+    "react-dom": "19.0.0-rc-f90a6bcc-20240827",
     "sass": "^1.3.0"
   },
   "peerDependenciesMeta": {

--- a/run-tests.js
+++ b/run-tests.js
@@ -20,7 +20,7 @@ const { getTestFilter } = require('./test/get-test-filter')
 
 // Do not rename or format. sync-react script relies on this line.
 // prettier-ignore
-const nextjsReactPeerVersion = "0.0.0-experimental-f90a6bcc-20240827";
+const nextjsReactPeerVersion = "19.0.0-rc-f90a6bcc-20240827";
 
 let argv = require('yargs/yargs')(process.argv.slice(2))
   .string('type')

--- a/test/.stats-app/package.json
+++ b/test/.stats-app/package.json
@@ -4,8 +4,8 @@
   "license": "MIT",
   "dependencies": {
     "next": "latest",
-    "react": "0.0.0-experimental-f90a6bcc-20240827",
-    "react-dom": "0.0.0-experimental-f90a6bcc-20240827"
+    "react": "19.0.0-rc-f90a6bcc-20240827",
+    "react-dom": "19.0.0-rc-f90a6bcc-20240827"
   },
   "engines": {
     "node": ">=18.18.0"

--- a/test/e2e/next-test/first-time-setup-js/package.json
+++ b/test/e2e/next-test/first-time-setup-js/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "next": "canary",
-    "react": "0.0.0-experimental-f90a6bcc-20240827",
-    "react-dom": "0.0.0-experimental-f90a6bcc-20240827"
+    "react": "19.0.0-rc-f90a6bcc-20240827",
+    "react-dom": "19.0.0-rc-f90a6bcc-20240827"
   }
 }

--- a/test/e2e/next-test/first-time-setup-ts/package.json
+++ b/test/e2e/next-test/first-time-setup-ts/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "next": "canary",
-    "react": "0.0.0-experimental-f90a6bcc-20240827",
-    "react-dom": "0.0.0-experimental-f90a6bcc-20240827"
+    "react": "19.0.0-rc-f90a6bcc-20240827",
+    "react-dom": "19.0.0-rc-f90a6bcc-20240827"
   },
   "devDependencies": {
     "@types/react": "^18",

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -51,7 +51,7 @@ type OmitFirstArgument<F> = F extends (
 
 // Do not rename or format. sync-react script relies on this line.
 // prettier-ignore
-const nextjsReactPeerVersion = "0.0.0-experimental-f90a6bcc-20240827";
+const nextjsReactPeerVersion = "19.0.0-rc-f90a6bcc-20240827";
 
 export class NextInstance {
   protected files: FileRef | { [filename: string]: string | FileRef }


### PR DESCRIPTION
Fixes [`fc29d06` (#69415)](https://github.com/vercel/next.js/pull/69415/commits/fc29d061ff0db0ba6c16c04f8a57c03aa940adda)

To trigger a sync, we polled for a new Experimental release (since that is always released after the Canary). However, we also triggered the sync for an experimental version which we don't want here (fixed in https://github.com/vercel/vercel-packages/pull/26).

~Generally, syncing with an arbitrary version is supported so we just need to remedy the fix here and then ensure in the notifier that we trigger the sync on a Canary.~
We don't support syncing with arbitrary versions anyway. Only bumping the sha is supported not the release channel or SemVer string.