### PR TITLE
Fix no ending quotation mark in 09-authentication blog

### DIFF
--- a/docs/02-app/01-building-your-application/09-authentication/index.mdx
+++ b/docs/02-app/01-building-your-application/09-authentication/index.mdx
@@ -1109,7 +1109,7 @@ While Middleware can be useful for initial checks, it should not be your only li
 
 > **Tips**:
 >
-> - In Middleware, you can also read cookies using `req.cookies.get('session).value`.
+> - In Middleware, you can also read cookies using `req.cookies.get('session').value`.
 > - Middleware uses the [Edge Runtime](/docs/app/building-your-application/rendering/edge-and-nodejs-runtimes), check if your Auth library and session management library are compatible.
 > - You can use the `matcher` property in the Middleware to specify which routes Middleware should run on. Although, for auth, it's recommended Middleware runs on all routes.
 


### PR DESCRIPTION
In the 09-authentication blog there is a minor mistake.
[optimistic-checks-with-middleware-optional](https://nextjs.org/docs/app/building-your-application/authentication#optimistic-checks-with-middleware-optional) in the tips section

- In Middleware, you ... req.cookies.get('session).value.

should be

- In Middleware, you ... req.cookies.get('session').value.

