### PR TITLE
Remove redundant code and call module_id_to_lit instead

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -9,7 +9,7 @@ use turbo_tasks::{RcStr, Value, ValueToString, Vc};
 use turbopack_core::{
     chunk::{
         ChunkItemExt, ChunkableModule, ChunkableModuleReference, ChunkingContext, ChunkingType,
-        ChunkingTypeOption, ModuleId,
+        ChunkingTypeOption,
     },
     issue::{IssueSeverity, IssueSource},
     module::Module,
@@ -30,6 +30,7 @@ use crate::{
     create_visitor, magic_identifier,
     references::util::{request_to_string, throw_module_not_found_expr},
     tree_shake::{asset::EcmascriptModulePartAsset, TURBOPACK_PART_IMPORT_SOURCE},
+    utils::module_id_to_lit,
 };
 
 #[turbo_tasks::value]
@@ -256,10 +257,7 @@ impl CodeGenerateable for EsmAssetReference {
                             let stmt = quote!(
                                 "var $name = __turbopack_import__($id);" as Stmt,
                                 name = Ident::new(ident.clone().into(), DUMMY_SP, Default::default()),
-                                id: Expr = Expr::Lit(match &*id {
-                                    ModuleId::String(s) => s.clone().as_str().into(),
-                                    ModuleId::Number(n) => (*n as f64).into(),
-                                })
+                                id: Expr = module_id_to_lit(&id),
                             );
                             insert_hoisted_stmt(program, stmt);
                         }));

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
-use swc_core::{ecma::ast::Expr, quote};
+use swc_core::quote;
 use turbo_tasks::{RcStr, ValueToString, Vc};
 use turbopack_core::{
     chunk::{
         ChunkItemExt, ChunkableModule, ChunkableModuleReference, ChunkingContext,
-        ChunkingTypeOption, ModuleId,
+        ChunkingTypeOption,
     },
     reference::ModuleReference,
     resolve::ModuleResolveResult,
@@ -15,6 +15,7 @@ use crate::{
     code_gen::{CodeGenerateable, CodeGeneration},
     create_visitor,
     references::AstPath,
+    utils::module_id_to_lit,
 };
 
 #[turbo_tasks::value]
@@ -72,10 +73,7 @@ impl CodeGenerateable for EsmModuleIdAssetReference {
                 .as_chunk_item(Vc::upcast(chunking_context))
                 .id()
                 .await?;
-            let id = Expr::Lit(match &*id {
-                ModuleId::String(s) => s.as_str().into(),
-                ModuleId::Number(n) => (*n as f64).into(),
-            });
+            let id = module_id_to_lit(&id);
             visitors.push(
                 create_visitor!(self.ast_path.await?, visit_mut_expr(expr: &mut Expr) {
                     *expr = id.clone()

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
@@ -1,14 +1,10 @@
 use anyhow::{bail, Context, Result};
-use swc_core::{
-    common::DUMMY_SP,
-    ecma::ast::{Expr, Ident},
-    quote,
-};
+use swc_core::{common::DUMMY_SP, ecma::ast::Ident, quote};
 use turbo_tasks::{RcStr, ValueToString, Vc};
 use turbopack_core::{
     chunk::{
         ChunkItemExt, ChunkableModule, ChunkableModuleReference, ChunkingContext, ChunkingType,
-        ChunkingTypeOption, ModuleId,
+        ChunkingTypeOption,
     },
     reference::ModuleReference,
     resolve::{ModulePart, ModuleResolveResult},
@@ -22,6 +18,7 @@ use crate::{
     code_gen::{CodeGenerateable, CodeGeneration},
     create_visitor,
     references::esm::base::{insert_hoisted_stmt, ReferencedAsset},
+    utils::module_id_to_lit,
 };
 
 /// A reference to the [EcmascriptModuleLocalsModule] variant of an original
@@ -133,10 +130,7 @@ impl CodeGenerateable for EcmascriptModulePartReference {
             let stmt = quote!(
                 "var $name = __turbopack_import__($id);" as Stmt,
                 name = Ident::new(ident.clone().into(), DUMMY_SP, Default::default()),
-                id: Expr = Expr::Lit(match &*id {
-                    ModuleId::String(s) => s.as_str().into(),
-                    ModuleId::Number(n) => (*n as f64).into(),
-                })
+                id: Expr = module_id_to_lit(&id),
             );
             insert_hoisted_stmt(program, stmt);
         }));


### PR DESCRIPTION
The logic implemented by `module_id_to_lit` was being re-implemented in multiple places in the code. This PR unifies all implementations into calls to `module_id_to_lit`.