### PR TITLE
refactor: include tsconfig for all ts and tsx files for test dir

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,10 +21,5 @@
       "test-log": ["./test/lib/test-log"]
     }
   },
-  "include": [
-    "test/**/*.test.ts",
-    "test/**/*.test.tsx",
-    "test/lib/**/*.ts",
-    "turbo/**/*.ts"
-  ]
+  "include": ["test/**/*.ts", "test/**/*.tsx", "turbo/**/*.ts"]
 }


### PR DESCRIPTION
### Why?

When adding test files in TypeScript, we get this error:

<img width="683" alt="Screenshot 2024-08-29 at 1 43 47 PM" src="https://github.com/user-attachments/assets/cd324b9a-dbb8-4788-a7a8-587676f4de50">

It is because the `test/**/*.tsx` pattern is not included in the `include` of the tsconfig.

https://github.com/vercel/next.js/blob/9720d0adc0b0687267e35804b6f6380fa351ab0c/tsconfig.json#L24-L29
