### PR TITLE
Support turbo: true option for custom server

### DIFF
--- a/docs/02-app/01-building-your-application/07-configuring/10-custom-server.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/10-custom-server.mdx
@@ -97,6 +97,7 @@ The above `next` import is a function that receives an object with the following
 | `hostname`     | `String`           | (_Optional_) The hostname the server is running behind                              |
 | `port`         | `Number`           | (_Optional_) The port the server is running behind                                  |
 | `httpServer`   | `node:http#Server` | (_Optional_) The HTTP Server that Next.js is running behind                         |
+| `turbo`        | `Boolean`          | (_Optional_) Enable Turbopack                                                       |
 
 The returned `app` can then be used to let Next.js handle requests as required.
 

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -355,7 +355,7 @@ function createServer(
     turbo?: boolean
   }
 ): NextServer {
-  if (options.turbo) {
+  if (options && options.turbo) {
     process.env.TURBOPACK = '1'
   }
   // The package is used as a TypeScript plugin.

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -350,7 +350,14 @@ class NextCustomServer extends NextServer {
 }
 
 // This file is used for when users run `require('next')`
-function createServer(options: NextServerOptions): NextServer {
+function createServer(
+  options: NextServerOptions & {
+    turbo?: boolean
+  }
+): NextServer {
+  if (options.turbo) {
+    process.env.TURBOPACK = '1'
+  }
   // The package is used as a TypeScript plugin.
   if (
     options &&

--- a/test/e2e/multi-zone/app/server.js
+++ b/test/e2e/multi-zone/app/server.js
@@ -12,7 +12,6 @@ const http = require('http')
     const nextApp = next({
       dir: appDir,
       dev,
-      turbo: true,
     })
 
     await nextApp.prepare()

--- a/test/e2e/multi-zone/app/server.js
+++ b/test/e2e/multi-zone/app/server.js
@@ -12,6 +12,7 @@ const http = require('http')
     const nextApp = next({
       dir: appDir,
       dev,
+      turbo: true,
     })
 
     await nextApp.prepare()


### PR DESCRIPTION
Adds an option to the Custom Server API to enable Turbopack.

⚠️ You can't mix/match Turbopack/Webpack in the same process because it also requires a separate build of React. So if you do use `next()` twice you'll want to enable `turbo: true` on both, or separate them into multiple processes.


Fixes #65479
Closes PACK-3048

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
