### PR TITLE
 next-15-refactor-imports-from-@next-font-to-next-font.ts

### DIFF
--- a/packages/next-codemod/transforms/next-15-refactor-imports-from-@next-font-to-next-font.ts
+++ b/packages/next-codemod/transforms/next-15-refactor-imports-from-@next-font-to-next-font.ts
@@ -1,0 +1,15 @@
+export default function transform(file, api, options) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let dirtyFlag = false;
+
+  // Find the import declaration with the specific source
+  root.find(j.ImportDeclaration, { source: { value: '@next/font/google' } })
+    .forEach(path => {
+      // Update the source value
+      path.node.source.value = 'next/font/google';
+      dirtyFlag = true;
+    });
+
+  return dirtyFlag ? root.toSource() : undefined;
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:-->

<!----## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes --> 
## Refactor Imports from @next/font to next/font in Next15

#### This codemod refactors import statements in your code to replace @next/font with next/font, aligning with the latest Next.js module structure.

- Find Import Declarations: Identifies all ImportDeclaration nodes in the code.
- Check Import Path: Ensures that the import path starts with @next/font.
- Replace Import Path: Updates the import path to use next/font instead of @next/font.

To run this codemod run this command in project directory

`codemod Next/15/Refactor-Imports-from-@next/font-to-next/font`
#### Before 
js
`import { Inter } from "@next/font/google";`

#### After
js
`import { Inter } from "next/font/google";`
#### 🧪 Test Plan
Test the codemod by running it against the specified repository and Next.js  folder to ensure that import statements are correctly updated from `@next/font` to `next/font`. Verify that the refactored import paths work as expected and that there are no import errors in the application.

1. Apply the codemod to the repository available at (https://github.com/saleor/storefront)
2. Confirm that all occurrences of `@next/font` are replaced with `next/font`.
3. Test the application to ensure that it functions correctly with the updated import paths.
- All the other test cases are runned in the codemod studio and present in **/codemod/packages/codemods/next/15/next-font/_textfixtures_/**

