### PR TITLE
refactor(turbo-tasks): Remove some `format_description` logic from memory backend

### DIFF
--- a/turbopack/crates/turbo-tasks-memory/src/task.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/task.rs
@@ -598,39 +598,7 @@ impl Task {
         match ty {
             TaskTypeForDescription::Root => format!("[{}] root", id),
             TaskTypeForDescription::Once => format!("[{}] once", id),
-            TaskTypeForDescription::Persistent(ty) => match &***ty {
-                CachedTaskType::Native {
-                    fn_type: native_fn,
-                    this: _,
-                    arg: _,
-                } => {
-                    format!("[{}] {}", id, registry::get_function(*native_fn).name)
-                }
-                CachedTaskType::ResolveNative {
-                    fn_type: native_fn,
-                    this: _,
-                    arg: _,
-                } => {
-                    format!(
-                        "[{}] [resolve] {}",
-                        id,
-                        registry::get_function(*native_fn).name
-                    )
-                }
-                CachedTaskType::ResolveTrait {
-                    trait_type,
-                    method_name: fn_name,
-                    this: _,
-                    arg: _,
-                } => {
-                    format!(
-                        "[{}] [resolve trait] {} in trait {}",
-                        id,
-                        fn_name,
-                        registry::get_trait(*trait_type).name
-                    )
-                }
-            },
+            TaskTypeForDescription::Persistent(ty) => format!("[{id}] {ty}"),
         }
     }
 


### PR DESCRIPTION
#69663 made improvements to the display logic, we don't need as much logic here.