### PR TITLE
refactor(turbo-tasks): Move OutputContent from memory backend into turbo-tasks, represent Empty as None

### DIFF
--- a/turbopack/crates/turbo-tasks-memory/src/output.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/output.rs
@@ -1,39 +1,16 @@
-use std::{
-    borrow::Cow,
-    fmt::{Debug, Display},
-    mem::take,
-};
+use std::{borrow::Cow, fmt::Debug, mem::take};
 
 use anyhow::{anyhow, Error, Result};
-use turbo_tasks::{util::SharedError, RawVc, TaskId, TaskIdSet, TurboTasksBackendApi};
+use turbo_tasks::{
+    util::SharedError, OutputContent, RawVc, TaskId, TaskIdSet, TurboTasksBackendApi,
+};
 
 use crate::MemoryBackend;
 
 #[derive(Default, Debug)]
 pub struct Output {
-    pub(crate) content: OutputContent,
+    pub(crate) content: Option<OutputContent>,
     pub(crate) dependent_tasks: TaskIdSet,
-}
-
-#[derive(Clone, Debug, Default)]
-pub enum OutputContent {
-    #[default]
-    Empty,
-    Link(RawVc),
-    Error(SharedError),
-    Panic(Option<Box<Cow<'static, str>>>),
-}
-
-impl Display for OutputContent {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            OutputContent::Empty => write!(f, "empty"),
-            OutputContent::Link(raw_vc) => write!(f, "link {:?}", raw_vc),
-            OutputContent::Error(err) => write!(f, "error {}", err),
-            OutputContent::Panic(Some(message)) => write!(f, "panic {}", message),
-            OutputContent::Panic(None) => write!(f, "panic"),
-        }
-    }
 }
 
 impl Output {
@@ -44,25 +21,22 @@ impl Output {
 
     /// INVALIDATION: Be careful with this, it will not track dependencies, so
     /// using it could break cache invalidation.
-    pub fn read_untracked(&mut self) -> Result<RawVc> {
+    pub fn read_untracked(&self) -> Result<RawVc> {
         match &self.content {
-            OutputContent::Empty => Err(anyhow!("Output is empty")),
-            OutputContent::Error(err) => Err(anyhow::Error::new(err.clone())),
-            OutputContent::Link(raw_vc) => Ok(*raw_vc),
-            OutputContent::Panic(Some(message)) => Err(anyhow!("A task panicked: {message}")),
-            OutputContent::Panic(None) => Err(anyhow!("A task panicked")),
+            None => Err(anyhow!("Output is empty")),
+            Some(content) => content.read_untracked(),
         }
     }
 
     pub fn link(&mut self, target: RawVc, turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>) {
         debug_assert!(*self != target);
-        if let OutputContent::Link(old_target) = &self.content {
+        if let Some(OutputContent::Link(old_target)) = &self.content {
             if *old_target == target {
                 // unchanged
                 return;
             }
         }
-        self.content = OutputContent::Link(target);
+        self.content = Some(OutputContent::Link(target));
         // notify
         if !self.dependent_tasks.is_empty() {
             turbo_tasks.schedule_notify_tasks_set(&take(&mut self.dependent_tasks));
@@ -70,7 +44,7 @@ impl Output {
     }
 
     pub fn error(&mut self, error: Error, turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>) {
-        self.content = OutputContent::Error(SharedError::new(error));
+        self.content = Some(OutputContent::Error(SharedError::new(error)));
         // notify
         if !self.dependent_tasks.is_empty() {
             turbo_tasks.schedule_notify_tasks_set(&take(&mut self.dependent_tasks));
@@ -82,7 +56,7 @@ impl Output {
         message: Option<Cow<'static, str>>,
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) {
-        self.content = OutputContent::Panic(message.map(Box::new));
+        self.content = Some(OutputContent::Panic(message.map(Box::new)));
         // notify
         if !self.dependent_tasks.is_empty() {
             turbo_tasks.schedule_notify_tasks_set(&take(&mut self.dependent_tasks));
@@ -100,8 +74,8 @@ impl Output {
 impl PartialEq<RawVc> for Output {
     fn eq(&self, rhs: &RawVc) -> bool {
         match &self.content {
-            OutputContent::Link(old_target) => old_target == rhs,
-            OutputContent::Empty | OutputContent::Error(_) | OutputContent::Panic(_) => false,
+            Some(OutputContent::Link(old_target)) => old_target == rhs,
+            Some(OutputContent::Error(_) | OutputContent::Panic(_)) | None => false,
         }
     }
 }

--- a/turbopack/crates/turbo-tasks-memory/src/output.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/output.rs
@@ -24,7 +24,7 @@ impl Output {
     pub fn read_untracked(&self) -> Result<RawVc> {
         match &self.content {
             None => Err(anyhow!("Output is empty")),
-            Some(content) => content.read_untracked(),
+            Some(content) => content.as_read_result(),
         }
     }
 

--- a/turbopack/crates/turbo-tasks-memory/src/task.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/task.rs
@@ -32,7 +32,7 @@ use crate::{
     cell::{Cell, ReadContentError},
     edges_set::{TaskEdge, TaskEdgesList, TaskEdgesSet},
     gc::{GcQueue, GcTaskState},
-    output::{Output, OutputContent},
+    output::Output,
     task::aggregation::{TaskAggregationContext, TaskChange},
     MemoryBackend,
 };
@@ -876,7 +876,7 @@ impl Task {
                 Ok(Ok(result)) => {
                     if state.output != result {
                         if cfg!(feature = "print_task_invalidation")
-                            && !matches!(state.output.content, OutputContent::Empty)
+                            && state.output.content.is_some()
                         {
                             println!(
                                 "Task {{ id: {}, name: {} }} invalidates:",

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -56,6 +56,7 @@ mod manager;
 mod native_function;
 mod no_move_vec;
 mod once_map;
+mod output;
 pub mod persisted_graph;
 pub mod primitives;
 mod raw_vc;
@@ -98,6 +99,7 @@ pub use manager::{
     TurboTasksBackendApi, TurboTasksBackendApiExt, TurboTasksCallApi, Unused, UpdateInfo,
 };
 pub use native_function::{FunctionMeta, NativeFunction};
+pub use output::OutputContent;
 pub use raw_vc::{CellId, RawVc, ReadRawVcFuture, ResolveTypeError};
 pub use read_ref::ReadRef;
 use rustc_hash::FxHasher;

--- a/turbopack/crates/turbo-tasks/src/output.rs
+++ b/turbopack/crates/turbo-tasks/src/output.rs
@@ -1,0 +1,40 @@
+use std::{
+    borrow::Cow,
+    fmt::{self, Display},
+};
+
+use anyhow::anyhow;
+
+use crate::{util::SharedError, RawVc};
+
+/// A helper type representing the output of a resolved task.
+#[derive(Clone, Debug)]
+pub enum OutputContent {
+    Link(RawVc),
+    Error(SharedError),
+    Panic(Option<Box<Cow<'static, str>>>),
+}
+
+impl OutputContent {
+    /// INVALIDATION: Be careful with this, it will not track dependencies, so
+    /// using it could break cache invalidation.
+    pub fn read_untracked(&self) -> anyhow::Result<RawVc> {
+        match &self {
+            Self::Error(err) => Err(anyhow::Error::new(err.clone())),
+            Self::Link(raw_vc) => Ok(*raw_vc),
+            Self::Panic(Some(message)) => Err(anyhow!("A task panicked: {message}")),
+            Self::Panic(None) => Err(anyhow!("A task panicked")),
+        }
+    }
+}
+
+impl Display for OutputContent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Link(raw_vc) => write!(f, "link {:?}", raw_vc),
+            Self::Error(err) => write!(f, "error {}", err),
+            Self::Panic(Some(message)) => write!(f, "panic {}", message),
+            Self::Panic(None) => write!(f, "panic"),
+        }
+    }
+}

--- a/turbopack/crates/turbo-tasks/src/output.rs
+++ b/turbopack/crates/turbo-tasks/src/output.rs
@@ -16,9 +16,7 @@ pub enum OutputContent {
 }
 
 impl OutputContent {
-    /// INVALIDATION: Be careful with this, it will not track dependencies, so
-    /// using it could break cache invalidation.
-    pub fn read_untracked(&self) -> anyhow::Result<RawVc> {
+    pub fn as_read_result(&self) -> anyhow::Result<RawVc> {
         match &self {
             Self::Error(err) => Err(anyhow::Error::new(err.clone())),
             Self::Link(raw_vc) => Ok(*raw_vc),


### PR DESCRIPTION
This is preparation for local tasks/cells in #69126.

- Moves this into the `turbo-tasks` crate so that it can be used with local cells/outputs in #69126.
- Remove the `Empty` state from the enum because the implementation in #69126 does not currently need that. This can still be represented using `None`.