### PR TITLE
fix(turbopack-ecmascript-plugins): Accept a partial object for StyledComponentsTransformConfig

### DIFF
--- a/test/development/basic/styled-components/next.config.js
+++ b/test/development/basic/styled-components/next.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   compiler: {
-    styledComponents: true,
+    styledComponents: {
+      displayName: true,
+    },
   },
 }

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/styled_components.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/styled_components.rs
@@ -14,7 +14,7 @@ pub struct OptionStyledComponentsTransformConfig(Option<Vc<StyledComponentsTrans
 
 #[turbo_tasks::value(shared)]
 #[derive(Clone, Debug)]
-#[serde(rename_all = "camelCase")]
+#[serde(default, rename_all = "camelCase")]
 pub struct StyledComponentsTransformConfig {
     pub display_name: bool,
     pub ssr: bool,


### PR DESCRIPTION
`StyledComponentsTransformConfig` should've used `#[serde(default)]` to allow the user to provide a partial object with only some of the fields.

https://serde.rs/container-attrs.html#default

> When deserializing, any missing fields should be filled in from the struct's implementation of `Default`. Only allowed on structs.

Without that, when serde tries to deserialize, it is expecting that the object has all of it's fields filled in, and breaks because you've only got two of them. The test suite only ever tested `styledComponents: true` (not using an object), so it missed this.

## Test Plan

```
pnpm swc-build-native
TURBOPACK=1 TURBOPACK_DEV=1 pnpm test test/development/basic/styled-components
```