### PR TITLE
bugfix: aliased prefetches should flow through PPR handling

### DIFF
--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -125,6 +125,12 @@ export function updateCacheNodeOnNavigation(
     const oldSegmentChild =
       oldRouterStateChild !== undefined ? oldRouterStateChild[0] : undefined
 
+    // A dynamic segment will be an array, and doesn't correspond with a page segment.
+    const isPageSegment = Array.isArray(newSegmentChild)
+      ? false
+      : // A page segment might contain search parameters, so we verify that it starts with the page segment key.
+        newSegmentChild.startsWith(PAGE_SEGMENT_KEY)
+
     const oldCacheNodeChild =
       oldSegmentMapChild !== undefined
         ? oldSegmentMapChild.get(newSegmentKeyChild)
@@ -136,7 +142,7 @@ export function updateCacheNodeOnNavigation(
       // We spawn a "task" just to keep track of the updated router state; unlike most, it's
       // already fulfilled and won't be affected by the dynamic response.
       taskChild = spawnReusedTask(oldRouterStateChild)
-    } else if (newSegmentChild === PAGE_SEGMENT_KEY) {
+    } else if (isPageSegment) {
       // This is a leaf segment — a page, not a shared layout. We always apply
       // its data.
       taskChild = spawnPendingTask(

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -215,7 +215,6 @@ export function navigateReducer(
             // an incremental step.
             seedData &&
             isRootRender &&
-            !prefetchValues.aliased &&
             postponed
           ) {
             const task = updateCacheNodeOnNavigation(

--- a/test/e2e/app-dir/searchparams-reuse-loading/app/page.tsx
+++ b/test/e2e/app-dir/searchparams-reuse-loading/app/page.tsx
@@ -1,8 +1,9 @@
 import Link from 'next/link'
 
-export default function Page() {
+export default function Page({ searchParams }) {
   return (
     <>
+      <div id="root-params">{JSON.stringify(searchParams)}</div>
       <Link href="/search">Go to search</Link>
       <hr />
 

--- a/test/e2e/app-dir/searchparams-reuse-loading/app/search-params/page.tsx
+++ b/test/e2e/app-dir/searchparams-reuse-loading/app/search-params/page.tsx
@@ -11,6 +11,7 @@ export default async function Page({
     <>
       <h1 id="params">{JSON.stringify(searchParams)}</h1>
       <Link href="/">Back</Link>
+      <Link href="/?id=1">/id=1</Link>
     </>
   )
 }

--- a/test/e2e/app-dir/searchparams-reuse-loading/searchparams-reuse-loading.test.ts
+++ b/test/e2e/app-dir/searchparams-reuse-loading/searchparams-reuse-loading.test.ts
@@ -31,6 +31,13 @@ describe('searchparams-reuse-loading', () => {
     expect(await newSearchValue.text()).toBe('Search Value: another')
   })
 
+  it('should properly render root page with searchParams when prefetch is aliased', async () => {
+    const browser = await next.browser('/search-params')
+    await browser.elementByCss("[href='/?id=1']").click()
+    const params = await browser.waitForElementByCss('#root-params').text()
+    expect(params).toBe('{"id":"1"}')
+  })
+
   // Dev doesn't perform prefetching, so this test is skipped, as it relies on intercepting
   // prefetch network requests.
   if (!isNextDev) {


### PR DESCRIPTION
I was previously incorrectly excluding aliased entries from flowing through the PPR path. However, since accessing `searchParams` will postpone, the aliased entry is safe to flow through the PPR branch. When PPR is enabled and the non-PPR branch attempts to handle this navigation, it won't know how to handle the postponed response. 

Separately, I noticed that the PPR branch was not spawning a pending task if the page segment contained search params, because it was checking for strict equality, when in reality it'd be something like `__PAGE__?{'foo':'bar'}`

Fixes #69437
Closes NDX-255