### PR TITLE
 Update Route Handlers to Handle Caching in Next15

### DIFF
--- a/packages/next-codemod/transforms/routehandlers.ts
+++ b/packages/next-codemod/transforms/routehandlers.ts
@@ -1,0 +1,227 @@
+import { describe, it } from 'vitest';
+import jscodeshift, { type API } from 'jscodeshift';
+import transform from '../src/index.js';
+import assert from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const buildApi = (parser: string | undefined): API => ({
+  j: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  jscodeshift: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  stats: () => {
+    console.error(
+      'The stats function was called, which is not supported on purpose',
+    );
+  },
+  report: () => {
+    console.error(
+      'The report function was called, which is not supported on purpose',
+    );
+  },
+});
+
+describe('async-export-force-static', () => {
+  it('test #1', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #2', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture2.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture2.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #3', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture3.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture3.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #4', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture4.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture4.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #5', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture5.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture5.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #6', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture6.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture6.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #7', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture7.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture7.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #8', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture8.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture8.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #9', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture9.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture9.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #10', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture10.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture10.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #11', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture11.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture11.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #12', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture12.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture12.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+});


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:-->

<!----## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes --> 

#### This codemod refactors Route Handler files to manage caching behavior for GET functions. In the updated setup, GET methods are no longer cached by default. This codemod updates your Route Handler files to specify caching by adding the dynamic configuration option to routes requiring caching.

1. Find Route Handlers: Identifies all GET functions in the Route Handler files.
2. Property Check: Ensures the presence of GET functions and adds the dynamic configuration option where necessary.
3. Add Caching Configuration: Inserts export const dynamic = 'force-static'; to enable caching for GET methods.
4. Clean Up: Removes the experimental object if it is empty after the migration.

To run this codemod, run the following command in the project directory:
`codemod Next/15/Update-Route-Handlers`
#### Before 
`
export async function GET() {}`

#### After

```
export const dynamic = "force-static";
export async function GET() {}
```

#### 🧪 Test Plan
Test the codemod by applying it to a specified repository to ensure that Route Handler files are updated correctly with the caching configuration. Verify that GET functions are correctly modified to include export const dynamic = 'force-static'; where needed and that there are no caching errors in the application.

- Apply the codemod to the repository available at 
(https://github.com/imbhargav5/nextbase-nextjs-supabase-starter) and (https://github.com/nisabmohd/ChatGPT)
- Could you confirm that all GET functions are updated to include the dynamic configuration for caching?
- Test the application to ensure it functions correctly with the updated caching settings.

    All other test cases are run in the codemod studio and are present in `/codemod/packages/codemods/next/15/route-handler-caching/textfixtures/.`
