### PR TITLE
Update Fetch Requests to Handle Caching in Next 15 

### DIFF
--- a/packages/next-codemod/transforms/fetchrequests.ts
+++ b/packages/next-codemod/transforms/fetchrequests.ts
@@ -1,0 +1,25 @@
+export default function transform(file, api, options) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let dirtyFlag = false;
+
+  // Find the default export function declaration
+  const defaultExport = root.find(j.ExportDefaultDeclaration);
+
+  // If a default export function is found, insert the new export statement before it
+  if (defaultExport.size() > 0) {
+    defaultExport.insertBefore(
+      j.exportNamedDeclaration(
+        j.variableDeclaration('const', [
+          j.variableDeclarator(
+            j.identifier('fetchCache'),
+            j.literal('default-cache')
+          )
+        ])
+      )
+    );
+    dirtyFlag = true;
+  }
+
+  return dirtyFlag ? root.toSource() : undefined;
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:-->

<!----## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes --> 

#### This codemod refactors fetch requests in your code to handle caching according to the new default behaviors in Next.js. By default, fetch requests are no longer cached. This codemod updates fetch requests to include the cache option for specific requests or adds fetchCache to layouts or pages for global caching control.

1.Find Fetch Requests: Identifies fetch requests in the code that require caching adjustments.
2. Property Check: Ensures fetch requests are updated with the appropriate cache option where necessary and adds the fetchCache option for global caching control.
3.Add Caching Configuration: Inserts export const fetchCache = 'default-cache'; in layouts or pages to apply default caching for all fetch requests unless overridden.
4. Clean Up: Removes the experimental object if it is empty after the migration.

To run this codemod, run the following command in the project directory:
`codemod Next/15/Update-Fetch-Requests-to-Handle-Caching`
#### Before 

   ```
// app/layout.js

   export default async function RootLayout() {
   const a = await fetch("https://example.com/data"); // Not Cached
   const b = await fetch("https://example.com/another-data", {
     cache: "force-cache",
    }); // Cached

   // ...
}
```

#### After
```

// app/layout.js

// Since this is the root layout, all fetch requests in the app
// that don't set their own cache option will be cached by default.
export const fetchCache = "default-cache";

export default async function RootLayout() {
  const a = await fetch("https://example.com/data"); // Cached
  const b = await fetch("https://example.com/another-data", {
    cache: "no-store",
  }); // Not Cached

  // ...
}
```

#### 🧪 Test Plan
Test the codemod by applying it to a specified repository to ensure fetch requests and layout files are correctly updated for caching behavior. Verify that fetch requests are correctly modified to include the cache option and that global caching settings are applied correctly with export const fetchCache = 'default-cache';.
-Apply the codemod to the repository available at (https://github.com/imbhargav5/nextbase-nextjs-supabase-starter) and (https://github.com/nisabmohd/ChatGPT).
- Confirm that all fetch requests are updated with appropriate caching options (cache or fetchCache).
- Test the application to ensure that it functions correctly with the updated fetch caching settings.
- All other test cases are run in the codemod studio and are present in /codemod/packages/codemods/next/15/fetch-request-caching/textfixtures/.

