### PR TITLE
Lazily init fetch dedupe cache

### DIFF
--- a/packages/next/src/server/lib/dedupe-fetch.ts
+++ b/packages/next/src/server/lib/dedupe-fetch.ts
@@ -3,8 +3,6 @@
  */
 import * as React from 'react'
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- url is the cache key
-const getCacheEntries = React.cache((url: string): Array<any> => [])
 const simpleCacheKey = '["GET",[],null,"follow",null,null,null,null]' // generateCacheKey(new Request('https://blank'));
 
 function generateCacheKey(request: Request): string {
@@ -27,6 +25,9 @@ function generateCacheKey(request: Request): string {
 }
 
 export function createDedupeFetch(originalFetch: typeof fetch) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- url is the cache key
+  const getCacheEntries = React.cache((url: string): Array<any> => [])
+
   return function dedupeFetch(
     resource: URL | RequestInfo,
     options?: RequestInit


### PR DESCRIPTION
This module may be included in Pages Router where we don't actually dedupe fetch.

Since `React.cache` is cleared between requests anyway, initialising it when we patch fetch does not mean we cache less.
Unless we re-patch during requests which would probably be a bug anyway.