### PR TITLE
docs: clarify ISR behavior

### DIFF
--- a/docs/02-app/01-building-your-application/02-data-fetching/04-incremental-static-regeneration.mdx
+++ b/docs/02-app/01-building-your-application/02-data-fetching/04-incremental-static-regeneration.mdx
@@ -426,10 +426,23 @@ This will make the Next.js server console log ISR cache hits and misses. You can
 
 ## Caveats
 
+<AppOnly>
+
 - ISR is only supported when using the Node.js runtime (default).
 - ISR is not supported when creating a [Static Export](/docs/app/building-your-application/deploying/static-exports).
-- If you have multiple `fetch` requests in a statically rendered route, and each has a different `revalidate` frequency, the lowest time will be used for all requests.
+- If you have multiple `fetch` requests in a statically rendered route, and each has a different `revalidate` frequency, the lowest time will be used for ISR. However, those revalidate frequencies will still be respected by the [Data Cache](/docs/app/building-your-application/caching#data-cache).
+- If any of the `fetch` requests used on a route have a `revalidate` time of `0`, or an explicit `no-store`, the route will be [dynamically rendered](/docs/app/building-your-application/rendering/server-components#dynamic-rendering).
 - Middleware won't be executed for on-demand ISR requests, meaning any path rewrites or logic in Middleware will not be applied. Ensure you are revalidating the exact path. For example, `/post/1` instead of a rewritten `/post-1`.
+
+</AppOnly>
+
+<PagesOnly>
+
+- ISR is only supported when using the Node.js runtime (default).
+- ISR is not supported when creating a [Static Export](/docs/app/building-your-application/deploying/static-exports).
+- Middleware won't be executed for on-demand ISR requests, meaning any path rewrites or logic in Middleware will not be applied. Ensure you are revalidating the exact path. For example, `/post/1` instead of a rewritten `/post-1`.
+
+</PagesOnly>
 
 ## Version history
 


### PR DESCRIPTION
- Clarifies that this fetch behavior is app-only, as pages doesn't tap into fetch for ISR heuristics
- Clarifies that the lowest revalidate time only influences the ISR cache time, not all of the fetches