### PR TITLE
Explicitly assert on errors instead of the error number

### DIFF
--- a/test/integration/link-ref/test/index.test.js
+++ b/test/integration/link-ref/test/index.test.js
@@ -21,15 +21,15 @@ const noError = async (pathname) => {
   await browser.eval(`(function() {
     window.caughtErrors = []
     const origError = window.console.error
-    window.console.error = function () {
-      window.caughtErrors.push(1)
+    window.console.error = function (format) {
+      window.caughtErrors.push(format)
       origError(arguments)
     }
     window.next.router.replace('${pathname}')
   })()`)
   await waitFor(1000)
-  const numErrors = await browser.eval(`window.caughtErrors.length`)
-  expect(numErrors).toBe(0)
+  const errors = await browser.eval(`window.caughtErrors`)
+  expect(errors).toEqual([])
   await browser.close()
 }
 


### PR DESCRIPTION
Asserting on the number of errors is almost always inferior to asserting on the actual error message:
- If you expect N but got M, you want to know which ones are missing and which ones you got in addition
- if you expect N and get N, you don't actually know if something changed or not. Could be that the previous N errors disappeared and N new errors were added
- Only expecting 0 and getting 0 is fine. But tests are not useful if they always pass.
