### PR TITLE
backport branch: disable unnecessary CI tasks

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -183,38 +183,6 @@ jobs:
       stepName: 'test-turbopack-integration-${{ matrix.group }}'
     secrets: inherit
 
-  test-turbopack-production:
-    name: test turbopack production
-    needs: ['changes', 'build-next', 'build-native']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        group: [1/5, 2/5, 3/5, 4/5, 5/5]
-    uses: ./.github/workflows/build_reusable.yml
-    with:
-      nodeVersion: 18.17.0
-      afterBuild: RUST_BACKTRACE=0 NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-build-tests-manifest.json" TURBOPACK=1 TURBOPACK_BUILD=1 NEXT_TEST_MODE=start node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type production
-      stepName: 'test-turbopack-production-${{ matrix.group }}'
-    secrets: inherit
-
-  test-turbopack-production-integration:
-    name: test turbopack production integration
-    needs: ['changes', 'build-next', 'build-native']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        group: [1/5, 2/5, 3/5, 4/5, 5/5]
-    uses: ./.github/workflows/build_reusable.yml
-    with:
-      nodeVersion: 18.17.0
-      afterBuild: RUST_BACKTRACE=0 NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-build-tests-manifest.json" TURBOPACK=1 TURBOPACK_BUILD=1 node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type integration
-      stepName: 'test-turbopack-production-integration-${{ matrix.group }}'
-    secrets: inherit
-
   test-next-swc-wasm:
     name: test next-swc wasm
     needs: ['changes', 'build-next']
@@ -353,91 +321,6 @@ jobs:
       stepName: 'test-firefox-safari'
     secrets: inherit
 
-  # TODO: remove these jobs once PPR is the default
-  # Manifest generated via: https://gist.github.com/wyattjoh/2ceaebd82a5bcff4819600fd60126431
-  test-ppr-integration:
-    name: test ppr integration
-    needs: ['changes', 'build-native', 'build-next']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
-
-    uses: ./.github/workflows/build_reusable.yml
-    with:
-      nodeVersion: 18.17.0
-      afterBuild: __NEXT_EXPERIMENTAL_PPR=true NEXT_EXTERNAL_TESTS_FILTERS="test/ppr-tests-manifest.json" node run-tests.js --timings -c ${TEST_CONCURRENCY} --type integration
-      stepName: 'test-ppr-integration'
-    secrets: inherit
-
-  test-ppr-dev:
-    name: test ppr dev
-    needs: ['changes', 'build-native', 'build-next']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        group: [1/4, 2/4, 3/4, 4/4]
-    uses: ./.github/workflows/build_reusable.yml
-    with:
-      afterBuild: __NEXT_EXPERIMENTAL_PPR=true NEXT_EXTERNAL_TESTS_FILTERS="test/ppr-tests-manifest.json" NEXT_TEST_MODE=dev node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type development
-      stepName: 'test-ppr-dev-${{ matrix.group }}'
-    secrets: inherit
-
-  test-ppr-prod:
-    name: test ppr prod
-    needs: ['changes', 'build-native', 'build-next']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        group: [1/4, 2/4, 3/4, 4/4]
-    uses: ./.github/workflows/build_reusable.yml
-    with:
-      afterBuild: __NEXT_EXPERIMENTAL_PPR=true NEXT_EXTERNAL_TESTS_FILTERS="test/ppr-tests-manifest.json" NEXT_TEST_MODE=start node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type production
-      stepName: 'test-ppr-prod-${{ matrix.group }}'
-    secrets: inherit
-
-  report-test-results-to-datadog:
-    needs:
-      [
-        'changes',
-        'test-unit',
-        'test-dev',
-        'test-prod',
-        'test-integration',
-        'test-ppr-dev',
-        'test-ppr-prod',
-        'test-ppr-integration',
-        'test-turbopack-dev',
-        'test-turbopack-integration',
-        'test-turbopack-production',
-        'test-turbopack-production-integration',
-      ]
-    if: ${{ always() && needs.changes.outputs.docs-only == 'false' && !github.event.pull_request.head.repo.fork }}
-
-    runs-on: ubuntu-latest
-    name: report test results to datadog
-    steps:
-      - name: Download test report artifacts
-        id: download-test-reports
-        uses: actions/download-artifact@v4
-        with:
-          pattern: test-reports-*
-          path: test
-          merge-multiple: true
-
-      - name: Upload test report to datadog
-        run: |
-          if [ -d ./test/test-junit-report ]; then
-            # Add a `test.type` tag to distinguish between turbopack and next.js runs
-            DD_ENV=ci npx @datadog/datadog-ci@2.23.1 junit upload --tags test.type:nextjs --service nextjs ./test/test-junit-report
-          fi
-
-          if [ -d ./test/turbopack-test-junit-report ]; then
-            # Add a `test.type` tag to distinguish between turbopack and next.js runs
-            DD_ENV=ci npx @datadog/datadog-ci@2.23.1 junit upload --tags test.type:turbopack --service nextjs ./test/turbopack-test-junit-report
-          fi
-
   tests-pass:
     needs:
       [
@@ -451,9 +334,6 @@ jobs:
         'test-prod',
         'test-integration',
         'test-firefox-safari',
-        'test-ppr-dev',
-        'test-ppr-prod',
-        'test-ppr-integration',
         'test-cargo-unit',
         'rust-check',
         'test-next-swc-wasm',

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -85,19 +85,6 @@ jobs:
       stepName: 'lint'
     secrets: inherit
 
-  validate-docs-links:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
-      - run: corepack enable
-      - name: 'Run link checker'
-        run: node ./.github/actions/validate-docs-links/dist/index.js
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   check-types-precompiled:
     name: types and precompiled
     needs: ['changes', 'build-native', 'build-next']
@@ -327,7 +314,6 @@ jobs:
         'build-native',
         'build-next',
         'lint',
-        'validate-docs-links',
         'check-types-precompiled',
         'test-unit',
         'test-dev',


### PR DESCRIPTION
Frees up some runners and unexpected test failures for features that are not expected to be productionized in v14.

Disables:

- Turbopack Build tests
- PPR dev/prod tests (will throw an error anyway if you attempt to use PPR outside of canary)
- Datadog test reporting (to avoid conflicting with our primary reports about test stability)
- Docs link verification (backport docs are never going to be changed / productionized) 