### PR TITLE
Match peer dependencies in rsc-binary tests

### DIFF
--- a/test/e2e/app-dir/binary/rsc-binary.test.ts
+++ b/test/e2e/app-dir/binary/rsc-binary.test.ts
@@ -6,8 +6,6 @@ describe('RSC binary serialization', () => {
     files: __dirname,
     skipDeployment: true,
     dependencies: {
-      react: '19.0.0-beta-04b058868c-20240508',
-      'react-dom': '19.0.0-beta-04b058868c-20240508',
       'server-only': 'latest',
     },
   })


### PR DESCRIPTION
Just a leftover. It now uses the same version the other tests use.