### PR TITLE
fix(CI): Don't require the GRAPHITE_TOKEN secret, as it's not available in forks

### DIFF
--- a/.github/workflows/graphite_ci_optimizer.yml
+++ b/.github/workflows/graphite_ci_optimizer.yml
@@ -20,8 +20,12 @@ on:
     secrets:
       GRAPHITE_TOKEN:
         description: 'The Graphite CI optimization secret'
-        required: true
+        # secrets are not available in forks, check-skip will just fail-open with a warning
+        required: false
 env:
+  # FYI, if you add this label, you must *push* to the repository again to trigger a new event. Just
+  # re-running in the GitHub actions UI won't work, as it will re-use the old event with the old
+  # labels.
   HAS_BYPASS_LABEL: |-
     ${{
       github.event_name == 'pull_request' &&
@@ -42,5 +46,6 @@ jobs:
       - name: Debug Output
         run: |
           echo 'github.event_name: ${{ github.event_name }}'
+          echo "secrets.GRAPHITE_TOKEN != '': ${{ secrets.GRAPHITE_TOKEN != '' }}"
           echo 'env.HAS_BYPASS_LABEL: ${{ env.HAS_BYPASS_LABEL }}'
           echo 'steps.check-skip.outputs.skip: ${{ steps.check-skip.outputs.skip }}'


### PR DESCRIPTION
> With the exception of `GITHUB_TOKEN`, secrets are not passed to the runner when a workflow is triggered from a forked repository.

-- https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow

## Test plan

Make a PR from a fork: #69518

Check the actions log and make sure it behaves as expected (fails open, runs all tests):

<img width="1121" alt="Screenshot 2024-08-30 at 3 46 27 PM" src="https://github.com/user-attachments/assets/e9ba7629-61da-431f-9822-8833dbb497b3">
<img width="309" alt="Screenshot 2024-08-30 at 3 46 35 PM" src="https://github.com/user-attachments/assets/4d7d4cb0-ce2e-4cdd-bbdb-90de1347a77b">
