### PR TITLE
Turbopack build: Implement `regions` and `assets` field in manifest for middleware

### DIFF
--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -3,7 +3,7 @@ use next_core::{
     all_assets_from_entries,
     middleware::get_middleware_module,
     next_edge::entry::wrap_edge_entry,
-    next_manifests::{EdgeFunctionDefinition, MiddlewareMatcher, MiddlewaresManifestV2, Regions},
+    next_manifests::{EdgeFunctionDefinition, MiddlewareMatcher, MiddlewaresManifestV2},
     next_server::{get_server_runtime_entries, ServerContextType},
     util::{parse_config_from_source, MiddlewareMatcherKind},
 };
@@ -123,7 +123,7 @@ impl MiddlewareEndpoint {
 
         let userland_module = self.userland_module();
 
-        let config = parse_config_from_source(userland_module).await?;
+        let config = parse_config_from_source(userland_module);
 
         let edge_files = self.edge_files();
         let mut output_assets = edge_files.await?.clone_value();
@@ -138,21 +138,7 @@ impl MiddlewareEndpoint {
         let wasm_paths_from_root =
             get_wasm_paths_from_root(&node_root_value, &all_output_assets).await?;
 
-        let regions = if let Some(regions) = config.regions.as_ref() {
-            if regions.len() == 1 {
-                if let Some(region) = regions.first() {
-                    Some(Regions::Single(region.clone()))
-                } else {
-                    None
-                }
-            } else {
-                Some(Regions::Multiple(regions.clone()))
-            }
-        } else {
-            None
-        };
-
-        let matchers = if let Some(matchers) = config.matcher.as_ref() {
+        let matchers = if let Some(matchers) = config.await?.matcher.as_ref() {
             matchers
                 .iter()
                 .map(|matcher| match matcher {
@@ -176,7 +162,7 @@ impl MiddlewareEndpoint {
             wasm: wasm_paths_to_bindings(wasm_paths_from_root),
             name: "middleware".into(),
             page: "/".into(),
-            regions,
+            regions: None,
             matchers,
             env: this.project.edge_env().await?.clone_value(),
             ..Default::default()

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -140,9 +140,11 @@ impl MiddlewareEndpoint {
 
         let regions = if let Some(regions) = config.regions.as_ref() {
             if regions.len() == 1 {
-                regions
-                    .first()
-                    .map(|region| Regions::Single(region.clone()))
+                if let Some(region) = regions.first() {
+                    Some(Regions::Single(region.clone()))
+                } else {
+                    None
+                }
             } else {
                 Some(Regions::Multiple(regions.clone()))
             }

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -140,11 +140,9 @@ impl MiddlewareEndpoint {
 
         let regions = if let Some(regions) = config.regions.as_ref() {
             if regions.len() == 1 {
-                if let Some(region) = regions.first() {
-                    Some(Regions::Single(region.clone()))
-                } else {
-                    None
-                }
+                regions
+                    .first()
+                    .map(|region| Regions::Single(region.clone()))
             } else {
                 Some(Regions::Multiple(regions.clone()))
             }

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -123,7 +123,7 @@ impl MiddlewareEndpoint {
 
         let userland_module = self.userland_module();
 
-        let config = parse_config_from_source(userland_module).await?;
+        let config = parse_config_from_source(userland_module);
 
         let edge_files = self.edge_files();
         let mut output_assets = edge_files.await?.clone_value();
@@ -140,6 +140,9 @@ impl MiddlewareEndpoint {
 
         let all_assets =
             get_paths_from_root(&node_root_value, &all_output_assets, |_asset| true).await?;
+
+        // Awaited later for parallelism
+        let config = config.await?;
 
         let regions = if let Some(regions) = config.regions.as_ref() {
             if regions.len() == 1 {

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -24,8 +24,8 @@ use turbopack_ecmascript::chunk::EcmascriptChunkPlaceable;
 
 use crate::{
     paths::{
-        all_paths_in_root, all_server_paths, get_js_paths_from_root, get_wasm_paths_from_root,
-        wasm_paths_to_bindings,
+        all_paths_in_root, all_server_paths, get_js_paths_from_root, get_paths_from_root,
+        get_wasm_paths_from_root, paths_to_bindings, wasm_paths_to_bindings,
     },
     project::Project,
     route::{Endpoint, WrittenEndpoint},
@@ -138,6 +138,9 @@ impl MiddlewareEndpoint {
         let wasm_paths_from_root =
             get_wasm_paths_from_root(&node_root_value, &all_output_assets).await?;
 
+        let all_assets =
+            get_paths_from_root(&node_root_value, &all_output_assets, |_asset| true).await?;
+
         let regions = if let Some(regions) = config.regions.as_ref() {
             if regions.len() == 1 {
                 regions
@@ -172,12 +175,12 @@ impl MiddlewareEndpoint {
         let edge_function_definition = EdgeFunctionDefinition {
             files: file_paths_from_root,
             wasm: wasm_paths_to_bindings(wasm_paths_from_root),
+            assets: paths_to_bindings(all_assets),
             name: "middleware".into(),
             page: "/".into(),
             regions,
             matchers,
             env: this.project.edge_env().await?.clone_value(),
-            ..Default::default()
         };
         let middleware_manifest_v2 = MiddlewaresManifestV2 {
             middleware: [("/".into(), edge_function_definition)]

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -64,8 +64,8 @@ use crate::{
     font::create_font_manifest,
     loadable_manifest::create_react_loadable_manifest,
     paths::{
-        all_paths_in_root, all_server_paths, get_js_paths_from_root, get_wasm_paths_from_root,
-        wasm_paths_to_bindings,
+        all_paths_in_root, all_server_paths, get_js_paths_from_root, get_paths_from_root,
+        get_wasm_paths_from_root, paths_to_bindings, wasm_paths_to_bindings,
     },
     project::Project,
     route::{Endpoint, Route, Routes, WrittenEndpoint},
@@ -1110,6 +1110,10 @@ impl PageEndpoint {
                 wasm_paths_from_root
                     .extend(get_wasm_paths_from_root(&node_root_value, &all_output_assets).await?);
 
+                let all_assets =
+                    get_paths_from_root(&node_root_value, &all_output_assets, |_asset| true)
+                        .await?;
+
                 let named_regex = get_named_middleware_regex(&pathname).into();
                 let matchers = MiddlewareMatcher {
                     regexp: Some(named_regex),
@@ -1120,12 +1124,12 @@ impl PageEndpoint {
                 let edge_function_definition = EdgeFunctionDefinition {
                     files: file_paths_from_root,
                     wasm: wasm_paths_to_bindings(wasm_paths_from_root),
+                    assets: paths_to_bindings(all_assets),
                     name: pathname.clone_value(),
                     page: original_name.clone_value(),
                     regions: None,
                     matchers: vec![matchers],
                     env: this.pages_project.project().edge_env().await?.clone_value(),
-                    ..Default::default()
                 };
                 let middleware_manifest_v2 = MiddlewaresManifestV2 {
                     sorted_middleware: vec![pathname.clone_value()],

--- a/crates/next-api/src/paths.rs
+++ b/crates/next-api/src/paths.rs
@@ -159,3 +159,13 @@ pub(crate) fn wasm_paths_to_bindings(paths: Vec<RcStr>) -> Vec<AssetBinding> {
         })
         .collect()
 }
+
+pub(crate) fn paths_to_bindings(paths: Vec<RcStr>) -> Vec<AssetBinding> {
+    paths
+        .into_iter()
+        .map(|path| AssetBinding {
+            name: path.clone().into(),
+            file_path: path,
+        })
+        .collect()
+}

--- a/crates/next-api/src/paths.rs
+++ b/crates/next-api/src/paths.rs
@@ -164,7 +164,7 @@ pub(crate) fn paths_to_bindings(paths: Vec<RcStr>) -> Vec<AssetBinding> {
     paths
         .into_iter()
         .map(|path| AssetBinding {
-            name: path.clone().into(),
+            name: path.clone(),
             file_path: path,
         })
         .collect()

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -56,7 +56,6 @@ impl Default for MiddlewaresManifest {
     TraceRawVcs,
     Serialize,
     Deserialize,
-    Default,
 )]
 #[serde(rename_all = "camelCase")]
 pub struct MiddlewareMatcher {
@@ -72,6 +71,18 @@ pub struct MiddlewareMatcher {
     pub original_source: RcStr,
 }
 
+impl Default for MiddlewareMatcher {
+    fn default() -> Self {
+        Self {
+            regexp: None,
+            locale: true,
+            has: None,
+            missing: None,
+            original_source: Default::default(),
+        }
+    }
+}
+
 fn bool_is_true(b: &bool) -> bool {
     *b
 }
@@ -82,9 +93,7 @@ pub struct EdgeFunctionDefinition {
     pub name: RcStr,
     pub page: RcStr,
     pub matchers: Vec<MiddlewareMatcher>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub wasm: Vec<AssetBinding>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub assets: Vec<AssetBinding>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub regions: Option<Regions>,

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -56,6 +56,7 @@ impl Default for MiddlewaresManifest {
     TraceRawVcs,
     Serialize,
     Deserialize,
+    Default,
 )]
 #[serde(rename_all = "camelCase")]
 pub struct MiddlewareMatcher {
@@ -71,18 +72,6 @@ pub struct MiddlewareMatcher {
     pub original_source: RcStr,
 }
 
-impl Default for MiddlewareMatcher {
-    fn default() -> Self {
-        Self {
-            regexp: None,
-            locale: true,
-            has: None,
-            missing: None,
-            original_source: Default::default(),
-        }
-    }
-}
-
 fn bool_is_true(b: &bool) -> bool {
     *b
 }
@@ -93,7 +82,9 @@ pub struct EdgeFunctionDefinition {
     pub name: RcStr,
     pub page: RcStr,
     pub matchers: Vec<MiddlewareMatcher>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub wasm: Vec<AssetBinding>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub assets: Vec<AssetBinding>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub regions: Option<Regions>,

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -94,6 +94,7 @@ pub struct EdgeFunctionDefinition {
     pub page: RcStr,
     pub matchers: Vec<MiddlewareMatcher>,
     pub wasm: Vec<AssetBinding>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub assets: Vec<AssetBinding>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub regions: Option<Regions>,

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -94,7 +94,6 @@ pub struct EdgeFunctionDefinition {
     pub page: RcStr,
     pub matchers: Vec<MiddlewareMatcher>,
     pub wasm: Vec<AssetBinding>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub assets: Vec<AssetBinding>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub regions: Option<Regions>,

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -539,7 +539,7 @@ fn parse_config_from_js_value(module: Vc<Box<dyn Module>>, value: &JsValue) -> N
                                                 module.ident(),
                                                 "Values of the `config.regions` array need to \
                                                  static strings",
-                                                &item,
+                                                item,
                                             );
                                         }
                                     }
@@ -550,7 +550,7 @@ fn parse_config_from_js_value(module: Vc<Box<dyn Module>>, value: &JsValue) -> N
                                         module.ident(),
                                         "`config.regions` needs to be a static string or array of \
                                          static strings",
-                                        &value,
+                                        value,
                                     );
                                     Vec::new()
                                 }

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -539,7 +539,7 @@ fn parse_config_from_js_value(module: Vc<Box<dyn Module>>, value: &JsValue) -> N
                                                 module.ident(),
                                                 "Values of the `config.regions` array need to \
                                                  static strings",
-                                                item,
+                                                &item,
                                             );
                                         }
                                     }
@@ -550,7 +550,7 @@ fn parse_config_from_js_value(module: Vc<Box<dyn Module>>, value: &JsValue) -> N
                                         module.ident(),
                                         "`config.regions` needs to be a static string or array of \
                                          static strings",
-                                        value,
+                                        &value,
                                     );
                                     Vec::new()
                                 }

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -20,7 +20,7 @@ use turbopack_core::{
     virtual_source::VirtualSource,
 };
 use turbopack_ecmascript::{
-    analyzer::{JsValue, ObjectPart},
+    analyzer::{ConstantValue, JsValue, ObjectPart},
     parse::ParseResult,
     utils::StringifyJs,
     EcmascriptParsable,
@@ -178,6 +178,8 @@ pub struct NextSourceConfig {
 
     /// Middleware router matchers
     pub matcher: Option<Vec<MiddlewareMatcherKind>>,
+
+    pub regions: Option<Vec<RcStr>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -518,6 +520,43 @@ fn parse_config_from_js_value(module: Vc<Box<dyn Module>>, value: &JsValue) -> N
                         if key == "matcher" {
                             config.matcher =
                                 parse_route_matcher_from_js_value(module.ident(), value);
+                        }
+                        if key == "regions" {
+                            let regions = match value {
+                                // Single value is turned into a single-element Vec.
+                                JsValue::Constant(ConstantValue::Str(str)) => {
+                                    vec![str.to_string().into()]
+                                }
+                                // Array of strings is turned into a Vec. If one of the values in
+                                // not a String it will error.
+                                JsValue::Array { items, .. } => {
+                                    let mut regions: Vec<RcStr> = Vec::new();
+                                    for item in items {
+                                        if let JsValue::Constant(ConstantValue::Str(str)) = item {
+                                            regions.push(str.to_string().into());
+                                        } else {
+                                            emit_invalid_config_warning(
+                                                module.ident(),
+                                                "Values of the `config.regions` array need to \
+                                                 static strings",
+                                                &item,
+                                            );
+                                        }
+                                    }
+                                    regions
+                                }
+                                _ => {
+                                    emit_invalid_config_warning(
+                                        module.ident(),
+                                        "`config.regions` needs to be a static string or array of \
+                                         static strings",
+                                        &value,
+                                    );
+                                    Vec::new()
+                                }
+                            };
+
+                            config.regions = Some(regions)
                         }
                     } else {
                         emit_invalid_config_warning(

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -522,10 +522,10 @@ fn parse_config_from_js_value(module: Vc<Box<dyn Module>>, value: &JsValue) -> N
                                 parse_route_matcher_from_js_value(module.ident(), value);
                         }
                         if key == "regions" {
-                            let regions = match value {
+                            config.regions = match value {
                                 // Single value is turned into a single-element Vec.
                                 JsValue::Constant(ConstantValue::Str(str)) => {
-                                    vec![str.to_string().into()]
+                                    Some(vec![str.to_string().into()])
                                 }
                                 // Array of strings is turned into a Vec. If one of the values in
                                 // not a String it will error.
@@ -543,7 +543,7 @@ fn parse_config_from_js_value(module: Vc<Box<dyn Module>>, value: &JsValue) -> N
                                             );
                                         }
                                     }
-                                    regions
+                                    Some(regions)
                                 }
                                 _ => {
                                     emit_invalid_config_warning(
@@ -552,11 +552,9 @@ fn parse_config_from_js_value(module: Vc<Box<dyn Module>>, value: &JsValue) -> N
                                          static strings",
                                         value,
                                     );
-                                    Vec::new()
+                                    None
                                 }
                             };
-
-                            config.regions = Some(regions)
                         }
                     } else {
                         emit_invalid_config_warning(

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -174,10 +174,13 @@ describe('Middleware Runtime', () => {
         }
         delete middlewareWithoutEnvs.env
         expect(middlewareWithoutEnvs).toEqual({
-          files: expect.arrayContaining([
-            'server/edge-runtime-webpack.js',
-            'server/middleware.js',
-          ]),
+          // Turbopack creates more files as it can do chunking.
+          files: process.env.TURBOPACK
+            ? expect.toBeArray()
+            : expect.arrayContaining([
+                'server/edge-runtime-webpack.js',
+                'server/middleware.js',
+              ]),
           name: 'middleware',
           page: '/',
           matchers: [{ regexp: '^/.*$', originalSource: '/:path*' }],
@@ -211,9 +214,12 @@ describe('Middleware Runtime', () => {
         )
         for (const key of Object.keys(manifest.middleware)) {
           const middleware = manifest.middleware[key]
-          expect(middleware.files).toContainEqual(
-            expect.stringContaining('server/edge-runtime-webpack')
-          )
+          if (!process.env.TURBOPACK) {
+            expect(middleware.files).toContainEqual(
+              expect.stringContaining('server/edge-runtime-webpack')
+            )
+          }
+
           expect(middleware.files).not.toContainEqual(
             expect.stringContaining('static/chunks/')
           )

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -174,13 +174,10 @@ describe('Middleware Runtime', () => {
         }
         delete middlewareWithoutEnvs.env
         expect(middlewareWithoutEnvs).toEqual({
-          // Turbopack creates more files as it can do chunking.
-          files: process.env.TURBOPACK
-            ? expect.toBeArray()
-            : expect.arrayContaining([
-                'server/edge-runtime-webpack.js',
-                'server/middleware.js',
-              ]),
+          files: expect.arrayContaining([
+            'server/edge-runtime-webpack.js',
+            'server/middleware.js',
+          ]),
           name: 'middleware',
           page: '/',
           matchers: [{ regexp: '^/.*$', originalSource: '/:path*' }],
@@ -214,12 +211,9 @@ describe('Middleware Runtime', () => {
         )
         for (const key of Object.keys(manifest.middleware)) {
           const middleware = manifest.middleware[key]
-          if (!process.env.TURBOPACK) {
-            expect(middleware.files).toContainEqual(
-              expect.stringContaining('server/edge-runtime-webpack')
-            )
-          }
-
+          expect(middleware.files).toContainEqual(
+            expect.stringContaining('server/edge-runtime-webpack')
+          )
           expect(middleware.files).not.toContainEqual(
             expect.stringContaining('static/chunks/')
           )

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -185,7 +185,7 @@ describe('Middleware Runtime', () => {
           page: '/',
           matchers: [{ regexp: '^/.*$', originalSource: '/:path*' }],
           wasm: [],
-          assets: [],
+          assets: process.env.TURBOPACK ? expect.toBeArray() : [],
           regions: 'auto',
         })
         expect(envs).toContainAllKeys([

--- a/test/e2e/og-api/app/app/og-node/route.js
+++ b/test/e2e/og-api/app/app/og-node/route.js
@@ -1,4 +1,4 @@
-import { ImageResponse } from '@vercel/og'
+import { ImageResponse } from 'next/og'
 
 export async function GET() {
   return new ImageResponse(<div>hi</div>, {

--- a/test/e2e/og-api/app/app/og/route.js
+++ b/test/e2e/og-api/app/app/og/route.js
@@ -1,4 +1,4 @@
-import { ImageResponse } from '@vercel/og'
+import { ImageResponse } from 'next/og'
 
 export async function GET() {
   return new ImageResponse(<div>hi</div>, {

--- a/test/e2e/og-api/app/pages/api/og-wrong-runtime.js
+++ b/test/e2e/og-api/app/pages/api/og-wrong-runtime.js
@@ -1,5 +1,5 @@
 // /pages/api/og.jsx
-import { ImageResponse } from '@vercel/og'
+import { ImageResponse } from 'next/og'
 
 export default function () {
   return new ImageResponse(

--- a/test/e2e/og-api/app/pages/api/og.js
+++ b/test/e2e/og-api/app/pages/api/og.js
@@ -1,5 +1,5 @@
 // /pages/api/og.jsx
-import { ImageResponse } from '@vercel/og'
+import { ImageResponse } from 'next/og'
 
 export const config = {
   runtime: 'edge',

--- a/test/e2e/og-api/index.test.ts
+++ b/test/e2e/og-api/index.test.ts
@@ -10,9 +10,6 @@ describe('og-api', () => {
   beforeAll(async () => {
     next = await createNext({
       files: new FileRef(join(__dirname, 'app')),
-      dependencies: {
-        '@vercel/og': 'latest',
-      },
     })
   })
   afterAll(() => next.destroy())

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -5363,15 +5363,15 @@
         "Middleware Runtime without i18n should validate & parse request url from any route",
         "Middleware Runtime without i18n should warn when using NextResponse.redirect with a relative URL",
         "Middleware Runtime without i18n should warn when using Response.redirect with a relative URL",
-        "Middleware Runtime without i18n should work with notFound: true correctly"
+        "Middleware Runtime without i18n should work with notFound: true correctly",
+        "Middleware Runtime with i18n should have valid middleware field in manifest",
+        "Middleware Runtime without i18n should have valid middleware field in manifest",
+        "Middleware Runtime with i18n should have correct files in manifest",
+        "Middleware Runtime without i18n should have correct files in manifest"
       ],
       "failed": [
-        "Middleware Runtime with i18n should have correct files in manifest",
         "Middleware Runtime with i18n should have the custom config in the manifest",
-        "Middleware Runtime with i18n should have valid middleware field in manifest",
-        "Middleware Runtime without i18n should have correct files in manifest",
-        "Middleware Runtime without i18n should have the custom config in the manifest",
-        "Middleware Runtime without i18n should have valid middleware field in manifest"
+        "Middleware Runtime without i18n should have the custom config in the manifest"
       ],
       "pending": [],
       "flakey": [],

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -5363,15 +5363,15 @@
         "Middleware Runtime without i18n should validate & parse request url from any route",
         "Middleware Runtime without i18n should warn when using NextResponse.redirect with a relative URL",
         "Middleware Runtime without i18n should warn when using Response.redirect with a relative URL",
-        "Middleware Runtime without i18n should work with notFound: true correctly",
-        "Middleware Runtime with i18n should have valid middleware field in manifest",
-        "Middleware Runtime without i18n should have valid middleware field in manifest",
-        "Middleware Runtime with i18n should have correct files in manifest",
-        "Middleware Runtime without i18n should have correct files in manifest"
+        "Middleware Runtime without i18n should work with notFound: true correctly"
       ],
       "failed": [
+        "Middleware Runtime with i18n should have correct files in manifest",
         "Middleware Runtime with i18n should have the custom config in the manifest",
-        "Middleware Runtime without i18n should have the custom config in the manifest"
+        "Middleware Runtime with i18n should have valid middleware field in manifest",
+        "Middleware Runtime without i18n should have correct files in manifest",
+        "Middleware Runtime without i18n should have the custom config in the manifest",
+        "Middleware Runtime without i18n should have valid middleware field in manifest"
       ],
       "pending": [],
       "flakey": [],


### PR DESCRIPTION
Fixes the tests related to `config.regions` with Turbopack. There's another case for Pages Router using edge runtime exporting the same config. I'm going to implement that in a follow-up PR.

After implementing `regions` and making sure `wasm` and `assets` stay in the manifest when empty (to pass another middleware test) I found that `assets` was not implemented yet, causing the changes in this PR to fail other tests related to `next/og` because that ships with a default font file that it tries to load.

Since it was failing the PR and thus blocking the changes related to `regions` I've implemented `assets` as well.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
