### PR TITLE
feat(eslint-config-next): support typescript-eslint v8 (compatible wi…

### DIFF
--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -13,7 +13,7 @@
     "@next/eslint-plugin-next": "15.0.0-canary.137",
     "@rushstack/eslint-patch": "^1.3.3",
     "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
-    "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0" || ^8.0.0",
+    "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-import-resolver-typescript": "^3.5.2",
     "eslint-plugin-import": "^2.28.1",

--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "@next/eslint-plugin-next": "15.0.0-canary.137",
     "@rushstack/eslint-patch": "^1.3.3",
-    "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0",
-    "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0",
+    "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+    "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0" || ^8.0.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-import-resolver-typescript": "^3.5.2",
     "eslint-plugin-import": "^2.28.1",


### PR DESCRIPTION
Updates typescript-eslint plugins to support v8 as a dependancy. 
Currently, the config locks to v7 even if your parent config uses v8