### PR TITLE
docs: Use `useFormState` over `useActionState`

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/05-error-handling.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/05-error-handling.mdx
@@ -8,10 +8,8 @@ related:
 
 Errors can be divided into two categories: **expected errors** and **uncaught exceptions**:
 
-- **Model expected errors as return values**: Avoid using `try`/`catch` for expected errors in Server Actions. Use [`useActionState`](https://react.dev/reference/react/useActionState) to manage these errors and return them to the client.
+- **Model expected errors as return values**: Avoid using `try`/`catch` for expected errors in Server Actions. Use `useFormState` to manage these errors and return them to the client.
 - **Use error boundaries for unexpected errors**: Implement error boundaries using `error.tsx` and `global-error.tsx` files to handle unexpected errors and provide a fallback UI.
-
-> **Good to know**: These examples use React's `useActionState` hook, which is available in React 19 RC. If you are using an earlier version of React, use `useFormState` instead. See the [React docs](https://react.dev/reference/react/useActionState) for more information.
 
 ## Handling Expected Errors
 
@@ -19,7 +17,7 @@ Expected errors are those that can occur during the normal operation of the appl
 
 ### Handling Expected Errors from Server Actions
 
-Use the [`useActionState`](https://react.dev/reference/react/useActionState) hook to manage the state of Server Actions, including handling errors. This approach avoids `try`/`catch` blocks for expected errors, which should be modeled as return values rather than thrown exceptions.
+Use the `useFormState` hook to manage the state of Server Actions, including handling errors. This approach avoids `try`/`catch` blocks for expected errors, which should be modeled as return values rather than thrown exceptions.
 
 ```tsx filename="app/actions.ts" switcher
 'use server'
@@ -55,12 +53,12 @@ export async function createUser(prevState, formData) {
 }
 ```
 
-Then, you can pass your action to the `useActionState` hook and use the returned `state` to display an error message.
+Then, you can pass your action to the `useFormState` hook and use the returned `state` to display an error message.
 
 ```tsx filename="app/ui/signup.tsx" highlight={11,18-20} switcher
 'use client'
 
-import { useActionState } from 'react'
+import { useFormState } from 'react'
 import { createUser } from '@/app/actions'
 
 const initialState = {
@@ -68,7 +66,7 @@ const initialState = {
 }
 
 export function Signup() {
-  const [state, formAction] = useActionState(createUser, initialState)
+  const [state, formAction] = useFormState(createUser, initialState)
 
   return (
     <form action={formAction}>
@@ -85,7 +83,7 @@ export function Signup() {
 ```jsx filename="app/ui/signup.js" highlight={11,18-20} switcher
 'use client'
 
-import { useActionState } from 'react'
+import { useFormState } from 'react'
 import { createUser } from '@/app/actions'
 
 const initialState = {
@@ -93,7 +91,7 @@ const initialState = {
 }
 
 export function Signup() {
-  const [state, formAction] = useActionState(createUser, initialState)
+  const [state, formAction] = useFormState(createUser, initialState)
 
   return (
     <form action={formAction}>
@@ -106,6 +104,8 @@ export function Signup() {
   )
 }
 ```
+
+> **Good to know**: These examples use React's `useFormState` hook, which is bundled with the Next.js App Router. If you are using React 19, use `useActionState` instead. See the [React docs](https://react.dev/reference/react/useActionState) for more information.
 
 You could also use the returned state to display a toast message from the client component.
 

--- a/docs/02-app/01-building-your-application/02-data-fetching/03-server-actions-and-mutations.mdx
+++ b/docs/02-app/01-building-your-application/02-data-fetching/03-server-actions-and-mutations.mdx
@@ -32,7 +32,7 @@ export default function Page() {
 }
 ```
 
-```jsx filename="app/page.jsx" switcher
+```jsx filename="app/page.js" switcher
 export default function Page() {
   // Server Action
   async function create() {
@@ -100,7 +100,7 @@ export default function ClientComponent({
 }
 ```
 
-```jsx filename="app/client-component.jsx" switcher
+```jsx filename="app/client-component.js" switcher
 'use client'
 
 export default function ClientComponent({ updateItemAction }) {
@@ -154,7 +154,7 @@ export default function Page() {
 }
 ```
 
-```jsx filename="app/invoices/page.jsx" switcher
+```jsx filename="app/invoices/page.js" switcher
 export default function Page() {
   async function createInvoice(formData) {
     'use server'
@@ -262,7 +262,7 @@ export function Entry() {
 }
 ```
 
-```jsx filename="app/entry.jsx" switcher
+```jsx filename="app/entry.js" switcher
 'use client'
 
 export function Entry() {
@@ -346,12 +346,10 @@ export default async function createsUser(formData) {
 }
 ```
 
-Once the fields have been validated on the server, you can return a serializable object in your action and use the React [`useActionState`](https://react.dev/reference/react/useActionState) hook to show a message to the user.
+Once the fields have been validated on the server, you can return a serializable object in your action and use the React `useFormState` hook to show a message to the user.
 
-- By passing the action to `useActionState`, the action's function signature changes to receive a new `prevState` or `initialState` parameter as its first argument.
-- `useActionState` is a React hook and therefore must be used in a Client Component.
-
-> **Good to know**: These examples use React's `useActionState` hook, which is available in React 19 RC. If you are using an earlier version of React, use `useFormState` instead. See the [React docs](https://react.dev/reference/react/useActionState) for more information.
+- By passing the action to `useFormState`, the action's function signature changes to receive a new `prevState` or `initialState` parameter as its first argument.
+- `useFormState` is a React hook and therefore must be used in a Client Component.
 
 ```tsx filename="app/actions.ts" switcher
 'use server'
@@ -387,12 +385,12 @@ export async function createUser(prevState, formData) {
 }
 ```
 
-Then, you can pass your action to the `useActionState` hook and use the returned `state` to display an error message.
+Then, you can pass your action to the `useFormState` hook and use the returned `state` to display an error message.
 
 ```tsx filename="app/ui/signup.tsx" highlight={11,18-20} switcher
 'use client'
 
-import { useActionState } from 'react'
+import { useFormState } from 'react'
 import { createUser } from '@/app/actions'
 
 const initialState = {
@@ -400,7 +398,7 @@ const initialState = {
 }
 
 export function Signup() {
-  const [state, formAction] = useActionState(createUser, initialState)
+  const [state, formAction] = useFormState(createUser, initialState)
 
   return (
     <form action={formAction}>
@@ -417,7 +415,7 @@ export function Signup() {
 ```jsx filename="app/ui/signup.js" highlight={11,18-20} switcher
 'use client'
 
-import { useActionState } from 'react'
+import { useFormState } from 'react'
 import { createUser } from '@/app/actions'
 
 const initialState = {
@@ -425,7 +423,7 @@ const initialState = {
 }
 
 export function Signup() {
-  const [state, formAction] = useActionState(createUser, initialState)
+  const [state, formAction] = useFormState(createUser, initialState)
 
   return (
     <form action={formAction}>
@@ -441,71 +439,50 @@ export function Signup() {
 
 > **Good to know:**
 >
-> - Before mutating data, you should always ensure a user is also authorized to perform the action. See [Authentication and Authorization](#authentication-and-authorization).
+> - These examples use React's `useFormState` hook, which is bundled with the Next.js App Router. If you are using React 19, use `useActionState` instead. See the [React docs](https://react.dev/reference/react/useActionState) for more information.
 
 ### Pending states
 
-The [`useActionState`](https://react.dev/reference/react/useActionState) hook exposes a `pending` state that can be used to show a loading indicator while the action is being executed.
+> - Before mutating data, you should always ensure a user is also authorized to perform the action. See [Authentication and Authorization](#authentication-and-authorization).
 
-```tsx filename="app/submit-button.tsx" highlight={11,21-23} switcher
+The [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus) hook exposes a `pending` boolean that can be used to show a loading indicator while the action is being executed.
+
+```tsx filename="app/submit-button.tsx" highlight={6} switcher
 'use client'
 
-import { useActionState } from 'react'
-import { createUser } from '@/app/actions'
+import { useFormStatus } from 'react'
 
-const initialState = {
-  message: '',
-}
-
-export function Signup() {
-  const [state, formAction, pending] = useActionState(createUser, initialState)
+export function SubmitButton() {
+  const { pending } = useFormStatus()
 
   return (
-    <form action={formAction}>
-      <label htmlFor="email">Email</label>
-      <input type="text" id="email" name="email" required />
-      {/* ... */}
-      <p aria-live="polite" className="sr-only">
-        {state?.message}
-      </p>
-      <button aria-disabled={pending} type="submit">
-        {pending ? 'Submitting...' : 'Sign up'}
-      </button>
-    </form>
+    <button disabled={pending} type="submit">
+      Sign Up
+    </button>
   )
 }
 ```
 
-```jsx filename="app/submit-button.jsx" highlight={11,21-23} switcher
+```jsx filename="app/submit-button.js" highlight={6} switcher
 'use client'
 
-import { useActionState } from 'react'
-import { createUser } from '@/app/actions'
+import { useFormStatus } from 'react'
 
-const initialState = {
-  message: '',
-}
-
-export function Signup() {
-  const [state, formAction, pending] = useActionState(createUser, initialState)
+export function SubmitButton() {
+  const { pending } = useFormStatus()
 
   return (
-    <form action={formAction}>
-      <label htmlFor="email">Email</label>
-      <input type="text" id="email" name="email" required />
-      {/* ... */}
-      <p aria-live="polite" className="sr-only">
-        {state?.message}
-      </p>
-      <button aria-disabled={pending} type="submit">
-        {pending ? 'Submitting...' : 'Sign up'}
-      </button>
-    </form>
+    <button disabled={pending} type="submit">
+      Sign Up
+    </button>
   )
 }
 ```
 
-> **Good to know:** Alternatively, you can also use the [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus) hook to show a pending state for a specific form.
+> **Good to know:**
+>
+> - In React 19, `useFormStatus` includes additional keys on the returned object, like data, method, and action. If you are not using React 19, only the `pending` key is available.
+> - In React 19, `useActionState` also includes a `pending` key on the returned state.
 
 ### Optimistic updates
 
@@ -547,7 +524,7 @@ export function Thread({ messages }: { messages: Message[] }) {
 }
 ```
 
-```jsx filename="app/page.jsx" switcher
+```jsx filename="app/page.js" switcher
 'use client'
 
 import { useOptimistic } from 'react'
@@ -739,7 +716,7 @@ export async function createTodo(prevState, formData) {
 
 > **Good to know:**
 >
-> - Aside from throwing the error, you can also return an object to be handled by `useActionState`. See [Server-side validation and error handling](#server-side-form-validation).
+> - Aside from throwing the error, you can also return an object to be handled by `useFormState`. See [Server-side validation and error handling](#server-side-form-validation).
 
 ### Revalidating data
 
@@ -997,7 +974,7 @@ Learn more about [Security and Server Actions](https://nextjs.org/blog/security-
 
 ## Additional resources
 
-For more information on Server Actions, check out the following React docs:
+For more information, check out the following React docs:
 
 - [Server Actions](https://react.dev/reference/rsc/server-actions)
 - [`"use server"`](https://react.dev/reference/react/use-server)

--- a/docs/02-app/01-building-your-application/09-authentication/index.mdx
+++ b/docs/02-app/01-building-your-application/09-authentication/index.mdx
@@ -29,9 +29,7 @@ The examples on this page walk through basic username and password auth for educ
 
 ### Sign-up and login functionality
 
-> **Good to know**: These examples use React's `useActionState` hook, which is available in React 19 RC. If you are using an earlier version of React, use `useFormState` instead. See the [React docs](https://react.dev/reference/react/useActionState) for more information.
-
-You can use the [`<form>`](https://react.dev/reference/react-dom/components/form) element with React's [Server Actions](/docs/app/building-your-application/data-fetching/server-actions-and-mutations) and [`useActionState`](https://react.dev/reference/react/useActionState) to capture user credentials, validate form fields, and call your Authentication Provider's API or database.
+You can use the [`<form>`](https://react.dev/reference/react-dom/components/form) element with React's [Server Actions](/docs/app/building-your-application/data-fetching/server-actions-and-mutations) and `useFormState` to capture user credentials, validate form fields, and call your Authentication Provider's API or database.
 
 Since Server Actions always execute on the server, they provide a secure environment for handling authentication logic.
 
@@ -202,16 +200,16 @@ export async function signup(state, formData) {
 }
 ```
 
-Back in your `<SignupForm />`, you can use React's `useActionState()` hook to display validation errors and a pending state while the form is submitting:
+Back in your `<SignupForm />`, you can use React's `useFormState` hook to display validation errors while the form is submitting:
 
 ```tsx filename="app/ui/signup-form.tsx" switcher highlight={7,15,21,27-39}
 'use client'
 
-import { useActionState } from 'react'
+import { useFormState, useFormStatus } from 'react'
 import { signup } from '@/app/actions/auth'
 
 export function SignupForm() {
-  const [state, action, pending] = useActionState(signup, undefined)
+  const [state, action] = useFormState(signup, undefined)
 
   return (
     <form action={action}>
@@ -241,10 +239,18 @@ export function SignupForm() {
           </ul>
         </div>
       )}
-      <button aria-disabled={pending} type="submit">
-        {pending ? 'Submitting...' : 'Sign up'}
-      </button>
+      <SubmitButton />
     </form>
+  )
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus()
+
+  return (
+    <button disabled={pending} type="submit">
+      Sign Up
+    </button>
   )
 }
 ```
@@ -252,11 +258,11 @@ export function SignupForm() {
 ```jsx filename="app/ui/signup-form.js" switcher highlight={7,15,21,27-39}
 'use client'
 
-import { useActionState } from 'react'
+import { useFormState, useFormStatus } from 'react'
 import { signup } from '@/app/actions/auth'
 
 export function SignupForm() {
-  const [state, action, pending] = useActionState(signup, undefined)
+  const [state, action] = useFormState(signup, undefined)
 
   return (
     <form action={action}>
@@ -286,15 +292,28 @@ export function SignupForm() {
           </ul>
         </div>
       )}
-      <button aria-disabled={pending} type="submit">
-        {pending ? 'Submitting...' : 'Sign up'}
-      </button>
+      <SubmitButton />
     </form>
+  )
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus()
+
+  return (
+    <button disabled={pending} type="submit">
+      Sign Up
+    </button>
   )
 }
 ```
 
-> **Good to know:** Alternatively, you can use the [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus) hook to display the pending state.
+> **Good to know:**
+>
+> - These examples use React's `useFormState` hook, which is bundled with the Next.js App Router. If you are using React 19, use `useActionState` instead. See the [React docs](https://react.dev/reference/react/useActionState) for more information.
+> - In React 19, `useFormStatus` includes additional keys on the returned object, like data, method, and action. If you are not using React 19, only the `pending` key is available.
+> - In React 19, `useActionState` also includes a `pending` key on the returned state.
+> - Before mutating data, you should always ensure a user is also authorized to perform the action. See [Authentication and Authorization](#authentication-and-authorization).
 
 #### 3. Create a user or check user credentials
 

--- a/docs/02-app/01-building-your-application/09-authentication/index.mdx
+++ b/docs/02-app/01-building-your-application/09-authentication/index.mdx
@@ -313,7 +313,7 @@ function SubmitButton() {
 > - These examples use React's `useFormState` hook, which is bundled with the Next.js App Router. If you are using React 19, use `useActionState` instead. See the [React docs](https://react.dev/reference/react/useActionState) for more information.
 > - In React 19, `useFormStatus` includes additional keys on the returned object, like data, method, and action. If you are not using React 19, only the `pending` key is available.
 > - In React 19, `useActionState` also includes a `pending` key on the returned state.
-> - Before mutating data, you should always ensure a user is also authorized to perform the action. See [Authentication and Authorization](#authentication-and-authorization).
+> - Before mutating data, you should always ensure a user is also authorized to perform the action. See [Authentication and Authorization](#authorization).
 
 #### 3. Create a user or check user credentials
 

--- a/docs/02-app/01-building-your-application/11-upgrading/02-version-15.mdx
+++ b/docs/02-app/01-building-your-application/11-upgrading/02-version-15.mdx
@@ -34,6 +34,12 @@ bun add next@rc react@rc react-dom@rc eslint-config-next@rc
 
 - The minimum `react` and `react-dom` is now 19.
 
+## React 19
+
+- `useFormState` has been replaced by `useActionState`. The `useFormState` hook is still available in React 19, but it is deprecated and will be removed in a future release. `useActionState` is recommended and includes additional properties like reading the `pending` state directly. [Learn more](https://react.dev/reference/react/useActionState).
+- `useFormStatus` now includes additional keys like `data`, `method`, and `action`. If you are not using React 19, only the `pending` key is available. [Learn more](https://react.dev/reference/react-dom/hooks/useFormStatus).
+- Read more in the [React 19 upgrade guide](https://react.dev/blog/2024/04/25/react-19-upgrade-guide).
+
 ## `fetch` requests
 
 [`fetch` requests](/docs/app/api-reference/functions/fetch) are no longer cached by default.

--- a/examples/next-forms/app/add-form.tsx
+++ b/examples/next-forms/app/add-form.tsx
@@ -19,6 +19,7 @@ function SubmitButton() {
 }
 
 export function AddForm() {
+  // useActionState is available with React 19 (Next.js App Router)
   const [state, formAction] = useActionState(createTodo, initialState);
 
   return (

--- a/examples/next-forms/app/delete-form.tsx
+++ b/examples/next-forms/app/delete-form.tsx
@@ -19,6 +19,7 @@ function DeleteButton() {
 }
 
 export function DeleteForm({ id, todo }: { id: number; todo: string }) {
+  // useActionState is available with React 19 (Next.js App Router)
   const [state, formAction] = useActionState(deleteTodo, initialState);
 
   return (

--- a/examples/next-forms/package.json
+++ b/examples/next-forms/package.json
@@ -9,10 +9,10 @@
     "@types/node": "20.10.6",
     "@types/react": "18.2.46",
     "@types/react-dom": "18.2.18",
-    "next": "latest",
+    "next": "canary",
     "postgres": "^3.4.3",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "react": "rc",
+    "react-dom": "rc",
     "typescript": "5.3.3",
     "zod": "^3.22.4"
   }

--- a/examples/with-fauna/components/EntryForm.tsx
+++ b/examples/with-fauna/components/EntryForm.tsx
@@ -22,6 +22,7 @@ const initialState = {
 };
 
 export default function EntryForm() {
+  // useActionState is available with React 19 (Next.js App Router)
   const [state, formAction] = useActionState(createEntryAction, initialState);
   const { pending } = useFormStatus();
 

--- a/examples/with-fauna/package.json
+++ b/examples/with-fauna/package.json
@@ -10,9 +10,9 @@
     "classnames": "2.3.1",
     "date-fns": "2.28.0",
     "fauna": "^1.2.0",
-    "next": "latest",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "next": "canary",
+    "react": "rc",
+    "react-dom": "rc",
     "server-only": "^0.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
We recently merged and combined the RC docs into the main docs, so there is a single codebase. This added new icons and callouts for parts of Next.js that are experimental or in a canary release.

However, this gets a little tricky with React 19. There have been changes to `useFormState` and `useFormStatus` which differ from the latest v14.x release and 15 + React 19 RC.

As 14 is still the stable release, we need to default to showing `useFormState` and add proper callouts for those on canary/RC. I also added more details to the upgrade guide for v15.