### PR TITLE
extract `href` argument in `next/navigation` to separate type

### DIFF
--- a/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
@@ -108,6 +108,8 @@ export interface PrefetchOptions {
   kind: PrefetchKind
 }
 
+export interface NavigationUrl extends string {}
+
 export interface AppRouterInstance {
   /**
    * Navigate to the previous history entry.
@@ -130,16 +132,16 @@ export interface AppRouterInstance {
    * Navigate to the provided href.
    * Pushes a new history entry.
    */
-  push(href: string, options?: NavigateOptions): void
+  push(href: NavigationUrl, options?: NavigateOptions): void
   /**
    * Navigate to the provided href.
    * Replaces the current history entry.
    */
-  replace(href: string, options?: NavigateOptions): void
+  replace(href: NavigationUrl, options?: NavigateOptions): void
   /**
    * Prefetch the provided href.
    */
-  prefetch(href: string, options?: PrefetchOptions): void
+  prefetch(href: NavigationUrl, options?: PrefetchOptions): void
 }
 
 export const AppRouterContext = React.createContext<AppRouterInstance | null>(


### PR DESCRIPTION
### What?
this PR adds a type `NavigationUrl` for methods in router

### Why?
by extracting it to a different type, i can override this type in `d.ts` files without worrying about it breaking when method signature changes in the future
