### PR TITLE
Turbopack: fix parallel intercepting routes with catch-all

### DIFF
--- a/test/e2e/app-dir/interception-catch-all/app/explicit/@children/[...segments]/page.tsx
+++ b/test/e2e/app-dir/interception-catch-all/app/explicit/@children/[...segments]/page.tsx
@@ -1,0 +1,7 @@
+export default function CatchAll({
+  params,
+}: {
+  params: { segments: string[] }
+}) {
+  return <div>children catch-all</div>
+}

--- a/test/e2e/app-dir/interception-catch-all/app/explicit/@children/cart/page.tsx
+++ b/test/e2e/app-dir/interception-catch-all/app/explicit/@children/cart/page.tsx
@@ -1,0 +1,3 @@
+export default async function CartPage() {
+  return <div>full cart</div>
+}

--- a/test/e2e/app-dir/interception-catch-all/app/explicit/@children/page.tsx
+++ b/test/e2e/app-dir/interception-catch-all/app/explicit/@children/page.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <Link href="/explicit/cart">Open cart</Link>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/interception-catch-all/app/explicit/@modal/(.)cart/page.tsx
+++ b/test/e2e/app-dir/interception-catch-all/app/explicit/@modal/(.)cart/page.tsx
@@ -1,0 +1,3 @@
+export default async function CartModalPage() {
+  return <div>cart modal</div>
+}

--- a/test/e2e/app-dir/interception-catch-all/app/explicit/@modal/[...segments]/page.tsx
+++ b/test/e2e/app-dir/interception-catch-all/app/explicit/@modal/[...segments]/page.tsx
@@ -1,0 +1,7 @@
+// This component is required for the cart modal to hide when the user navigates to a new page
+// https://nextjs.org/docs/app/building-your-application/routing/parallel-routes#closing-the-modal
+// Since client-side navigations to a route that no longer match the slot will remain visible,
+// we need to match the slot to a route that returns null to close the modal.
+export default function CatchAll() {
+  return 'modal catch-all'
+}

--- a/test/e2e/app-dir/interception-catch-all/app/explicit/@modal/default.tsx
+++ b/test/e2e/app-dir/interception-catch-all/app/explicit/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function ModalCartDefault() {
+  return 'default parent'
+}

--- a/test/e2e/app-dir/interception-catch-all/app/explicit/layout.tsx
+++ b/test/e2e/app-dir/interception-catch-all/app/explicit/layout.tsx
@@ -1,0 +1,22 @@
+export default function RootLayout({
+  children,
+  modal,
+}: Readonly<{
+  children: React.ReactNode
+  modal: React.ReactNode
+}>) {
+  return (
+    <html lang="en">
+      <body>
+        <section>
+          <h2>Children</h2>
+          <div id="children">{children}</div>
+        </section>
+        <section>
+          <h2>Modal</h2>
+          <div id="modal">{modal}</div>
+        </section>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/interception-catch-all/app/implicit/@modal/(.)cart/page.tsx
+++ b/test/e2e/app-dir/interception-catch-all/app/implicit/@modal/(.)cart/page.tsx
@@ -1,0 +1,3 @@
+export default async function CartModalPage() {
+  return <div>cart modal</div>
+}

--- a/test/e2e/app-dir/interception-catch-all/app/implicit/@modal/[...segments]/page.tsx
+++ b/test/e2e/app-dir/interception-catch-all/app/implicit/@modal/[...segments]/page.tsx
@@ -1,0 +1,7 @@
+// This component is required for the cart modal to hide when the user navigates to a new page
+// https://nextjs.org/docs/app/building-your-application/routing/parallel-routes#closing-the-modal
+// Since client-side navigations to a route that no longer match the slot will remain visible,
+// we need to match the slot to a route that returns null to close the modal.
+export default function CatchAll() {
+  return 'modal catchall'
+}

--- a/test/e2e/app-dir/interception-catch-all/app/implicit/@modal/default.tsx
+++ b/test/e2e/app-dir/interception-catch-all/app/implicit/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function ModalCartDefault() {
+  return 'default parent'
+}

--- a/test/e2e/app-dir/interception-catch-all/app/implicit/[...segments]/page.tsx
+++ b/test/e2e/app-dir/interception-catch-all/app/implicit/[...segments]/page.tsx
@@ -1,0 +1,8 @@
+export default function CatchAll({
+  params,
+}: {
+  params: { segments: string[] }
+}) {
+  // return null;
+  return <div>This is a catch-all route: {JSON.stringify(params.segments)}</div>
+}

--- a/test/e2e/app-dir/interception-catch-all/app/implicit/cart/page.tsx
+++ b/test/e2e/app-dir/interception-catch-all/app/implicit/cart/page.tsx
@@ -1,0 +1,3 @@
+export default async function CartModalPage() {
+  return <div>This is cart full page</div>
+}

--- a/test/e2e/app-dir/interception-catch-all/app/implicit/layout.tsx
+++ b/test/e2e/app-dir/interception-catch-all/app/implicit/layout.tsx
@@ -1,0 +1,22 @@
+export default function RootLayout({
+  children,
+  modal,
+}: Readonly<{
+  children: React.ReactNode
+  modal: React.ReactNode
+}>) {
+  return (
+    <html lang="en">
+      <body>
+        <section>
+          <h2>Children</h2>
+          <div id="children">{children}</div>
+        </section>
+        <section>
+          <h2>Modal</h2>
+          <div id="modal">{modal}</div>
+        </section>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/interception-catch-all/app/implicit/page.tsx
+++ b/test/e2e/app-dir/interception-catch-all/app/implicit/page.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <Link href="/implicit/cart">Open cart</Link>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/interception-catch-all/interception-catch-all.test.ts
+++ b/test/e2e/app-dir/interception-catch-all/interception-catch-all.test.ts
@@ -1,0 +1,28 @@
+import { nextTestSetup } from 'e2e-utils'
+import { check } from 'next-test-utils'
+
+describe('interception-catch-all', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should work when interception route is used together with catch-all in implicit children', async () => {
+    const browser = await next.browser('/implicit')
+    expect(await browser.elementById('children').text()).toBe('Home\nOpen cart')
+    expect(await browser.elementById('modal').text()).toBe('default parent')
+
+    await browser.elementByCss('[href="/implicit/cart"]').click()
+    await check(() => browser.elementById('children').text(), 'Home\nOpen cart')
+    await check(() => browser.elementById('modal').text(), 'cart modal')
+  })
+
+  it('should work when interception route is used together with catch-all in explicit children', async () => {
+    const browser = await next.browser('/explicit')
+    expect(await browser.elementById('children').text()).toBe('Home\nOpen cart')
+    expect(await browser.elementById('modal').text()).toBe('default parent')
+
+    await browser.elementByCss('[href="/explicit/cart"]').click()
+    await check(() => browser.elementById('children').text(), 'Home\nOpen cart')
+    await check(() => browser.elementById('modal').text(), 'cart modal')
+  })
+})

--- a/test/e2e/app-dir/interception-catch-all/next.config.js
+++ b/test/e2e/app-dir/interception-catch-all/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
Previously, the children route (somewhat sensibly) switched to a catch-all route if a parallel route intercepted a navigation.
This didn't happen with Webpack, so align the behavior.

I'm not entirely sure yet if the check I added covers all situations

Closes PACK-3219