### PR TITLE
feat: Report correct errors for missing `use client` in global-errors.ts

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -618,7 +618,8 @@ impl ReactServerComponentValidator {
         if self.is_from_node_modules(&self.filepath) {
             return;
         }
-        static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"[\\/]error\.(ts|js)x?$").unwrap());
+        static RE: Lazy<Regex> =
+            Lazy::new(|| Regex::new(r"[\\/]((global-)?error)\.(ts|js)x?$").unwrap());
 
         let is_error_file = RE.is_match(&self.filepath);
 

--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, path::PathBuf, rc::Rc, sync::Arc};
 
+use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::Deserialize;
 use swc_core::{
@@ -617,9 +618,9 @@ impl ReactServerComponentValidator {
         if self.is_from_node_modules(&self.filepath) {
             return;
         }
-        let is_error_file = Regex::new(r"[\\/]error\.(ts|js)x?$")
-            .unwrap()
-            .is_match(&self.filepath);
+        static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"[\\/]error\.(ts|js)x?$").unwrap());
+
+        let is_error_file = RE.is_match(&self.filepath);
 
         if is_error_file {
             if let Some(app_dir) = &self.app_dir {


### PR DESCRIPTION
### What?

Adjust regex for file name which is used for linting.


### Why?

We should apply same validation as `error.ts` to `global-error.ts`

### How?

Closes PACK-2977
Fixes https://github.com/vercel/next.js/issues/64452
