### PR TITLE
perf: Cache Rust `Regex`es

### DIFF
--- a/crates/next-core/src/next_edge/route_regex.rs
+++ b/crates/next-core/src/next_edge/route_regex.rs
@@ -226,9 +226,8 @@ fn get_named_parametrized_route(
             } else {
                 None
             };
-            let param_matches = Regex::new(r"\[((?:\[.*\])|.+)\]")
-                .unwrap()
-                .captures(segment);
+            static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\[((?:\[.*\])|.+)\]").unwrap());
+            let param_matches = RE.captures(segment);
             if let Some(matches) = param_matches {
                 return get_safe_key_from_segment(
                     get_safe_route_key,

--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, path::PathBuf, rc::Rc, sync::Arc};
 
+use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::Deserialize;
 use swc_core::{
@@ -566,7 +567,8 @@ impl ReactServerComponentValidator {
     }
 
     fn is_from_node_modules(&self, filepath: &str) -> bool {
-        Regex::new(r"node_modules[\\/]").unwrap().is_match(filepath)
+        static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"node_modules[\\/]").unwrap());
+        RE.is_match(filepath)
     }
 
     // Asserts the server lib apis
@@ -679,9 +681,9 @@ impl ReactServerComponentValidator {
         if self.is_from_node_modules(&self.filepath) {
             return;
         }
-        let is_layout_or_page = Regex::new(r"[\\/](page|layout)\.(ts|js)x?$")
-            .unwrap()
-            .is_match(&self.filepath);
+        static RE: Lazy<Regex> =
+            Lazy::new(|| Regex::new(r"[\\/](page|layout)\.(ts|js)x?$").unwrap());
+        let is_layout_or_page = RE.is_match(&self.filepath);
 
         if is_layout_or_page {
             let mut span = DUMMY_SP;


### PR DESCRIPTION
### What?

Use `Lazy<Regex>` instead of `Regex` if the pattern is known.

### Why?

It's way more efficient.

### How?

