### PR TITLE
backport: esm externals in turbopack

### DIFF
--- a/packages/next-swc/crates/next-api/src/app.rs
+++ b/packages/next-swc/crates/next-api/src/app.rs
@@ -846,13 +846,13 @@ impl AppEndpoint {
             {
                 entry_client_chunks.extend(chunks.await?.iter().copied());
             }
-            for chunks in client_references_chunks_ref
+            for (chunks, _) in client_references_chunks_ref
                 .client_component_client_chunks
                 .values()
             {
                 client_assets.extend(chunks.await?.iter().copied());
             }
-            for chunks in client_references_chunks_ref
+            for (chunks, _) in client_references_chunks_ref
                 .client_component_ssr_chunks
                 .values()
             {
@@ -929,7 +929,7 @@ impl AppEndpoint {
                 // initialization
                 let client_references_chunks = &*client_references_chunks.await?;
 
-                for &ssr_chunks in client_references_chunks
+                for (ssr_chunks, _) in client_references_chunks
                     .client_component_ssr_chunks
                     .values()
                 {

--- a/packages/next-swc/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/packages/next-swc/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -32,8 +32,10 @@ fn client_modules_ssr_modifier() -> Vc<String> {
 
 #[turbo_tasks::value]
 pub struct ClientReferencesChunks {
-    pub client_component_client_chunks: IndexMap<ClientReferenceType, Vc<OutputAssets>>,
-    pub client_component_ssr_chunks: IndexMap<ClientReferenceType, Vc<OutputAssets>>,
+    pub client_component_client_chunks:
+        IndexMap<ClientReferenceType, (Vc<OutputAssets>, AvailabilityInfo)>,
+    pub client_component_ssr_chunks:
+        IndexMap<ClientReferenceType, (Vc<OutputAssets>, AvailabilityInfo)>,
     pub layout_segment_client_chunks: IndexMap<Vc<NextServerComponentModule>, Vc<OutputAssets>>,
 }
 
@@ -66,23 +68,47 @@ pub async fn get_app_client_references_chunks(
                             ) => {
                                 let ecmascript_client_reference_ref =
                                     ecmascript_client_reference.await?;
-                                (
-                                    client_chunking_context.root_chunk_group_assets(Vc::upcast(
+
+                                let client_chunk_group = client_chunking_context
+                                    .root_chunk_group(Vc::upcast(
                                         ecmascript_client_reference_ref.client_module,
-                                    )),
-                                    ssr_chunking_context.map(|ssr_chunking_context| {
-                                        ssr_chunking_context.root_chunk_group_assets(Vc::upcast(
-                                            ecmascript_client_reference_ref.ssr_module,
+                                    ))
+                                    .await?;
+
+                                (
+                                    (
+                                        client_chunk_group.assets,
+                                        client_chunk_group.availability_info,
+                                    ),
+                                    if let Some(ssr_chunking_context) = ssr_chunking_context {
+                                        let ssr_chunk_group = ssr_chunking_context
+                                            .root_chunk_group(Vc::upcast(
+                                                ecmascript_client_reference_ref.ssr_module,
+                                            ))
+                                            .await?;
+
+                                        Some((
+                                            ssr_chunk_group.assets,
+                                            ssr_chunk_group.availability_info,
                                         ))
-                                    }),
+                                    } else {
+                                        None
+                                    },
                                 )
                             }
                             ClientReferenceType::CssClientReference(css_client_reference) => {
                                 let css_client_reference_ref = css_client_reference.await?;
-                                (
-                                    client_chunking_context.root_chunk_group_assets(Vc::upcast(
+                                let client_chunk_group = client_chunking_context
+                                    .root_chunk_group(Vc::upcast(
                                         css_client_reference_ref.client_module,
-                                    )),
+                                    ))
+                                    .await?;
+
+                                (
+                                    (
+                                        client_chunk_group.assets,
+                                        client_chunk_group.availability_info,
+                                    ),
                                     None,
                                 )
                             }
@@ -165,6 +191,7 @@ pub async fn get_app_client_references_chunks(
                     })
                     .try_flat_join()
                     .await?;
+
                 let ssr_chunk_group = if !ssr_modules.is_empty() {
                     let ssr_entry_module = IncludeModulesModule::new(
                         base_ident.with_modifier(client_modules_ssr_modifier()),
@@ -184,6 +211,7 @@ pub async fn get_app_client_references_chunks(
                 } else {
                     None
                 };
+
                 let client_modules = client_reference_types
                     .iter()
                     .map(|client_reference_ty| async move {
@@ -240,8 +268,10 @@ pub async fn get_app_client_references_chunks(
                         if let ClientReferenceType::EcmascriptClientReference(_) =
                             client_reference_ty
                         {
-                            client_component_client_chunks
-                                .insert(client_reference_ty, client_chunks);
+                            client_component_client_chunks.insert(
+                                client_reference_ty,
+                                (client_chunks, client_chunk_group.availability_info),
+                            );
                         }
                     }
                 }
@@ -261,7 +291,10 @@ pub async fn get_app_client_references_chunks(
                         if let ClientReferenceType::EcmascriptClientReference(_) =
                             client_reference_ty
                         {
-                            client_component_ssr_chunks.insert(client_reference_ty, ssr_chunks);
+                            client_component_ssr_chunks.insert(
+                                client_reference_ty,
+                                (ssr_chunks, ssr_chunk_group.availability_info),
+                            );
                         }
                     }
                 }

--- a/packages/next-swc/crates/next-core/src/next_edge/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_edge/context.rs
@@ -108,15 +108,8 @@ pub async fn get_edge_resolve_options_context(
             .map(ToString::to_string),
     );
 
-    match ty {
-        ServerContextType::AppRSC { .. } => custom_conditions.push("react-server".to_string()),
-        ServerContextType::AppRoute { .. }
-        | ServerContextType::Pages { .. }
-        | ServerContextType::PagesData { .. }
-        | ServerContextType::PagesApi { .. }
-        | ServerContextType::AppSSR { .. }
-        | ServerContextType::Middleware { .. }
-        | ServerContextType::Instrumentation { .. } => {}
+    if ty.supports_react_server() {
+        custom_conditions.push("react-server".to_string());
     };
 
     let resolve_options_context = ResolveOptionsContext {

--- a/packages/next-swc/crates/next-core/src/next_import_map.rs
+++ b/packages/next-swc/crates/next-core/src/next_import_map.rs
@@ -728,7 +728,7 @@ async fn rsc_aliases(
     }
 
     if runtime == NextRuntime::Edge {
-        if matches!(ty, ServerContextType::AppRSC { .. }) {
+        if ty.supports_react_server() {
             alias["react"] = format!("next/dist/compiled/react{react_channel}/react.react-server");
             alias["react-dom"] =
                 format!("next/dist/compiled/react-dom{react_channel}/react-dom.react-server");

--- a/packages/next-swc/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/packages/next-swc/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -5,7 +5,10 @@ use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_binding::turbopack::{
     core::{
         asset::AssetContent,
-        chunk::{ChunkItemExt, ChunkableModule, ModuleId as TurbopackModuleId},
+        chunk::{
+            availability_info::AvailabilityInfo, ChunkItem, ChunkItemExt, ChunkableModule,
+            ModuleId as TurbopackModuleId,
+        },
         output::OutputAsset,
         virtual_output::VirtualOutputAsset,
     },
@@ -66,61 +69,70 @@ impl ClientReferenceManifest {
                     .to_string()
                     .await?;
 
-                let client_module_id = ecmascript_client_reference
+                let client_chunk_item = ecmascript_client_reference
                     .client_module
-                    .as_chunk_item(Vc::upcast(client_chunking_context))
-                    .id()
-                    .await?;
+                    .as_chunk_item(Vc::upcast(client_chunking_context));
 
-                let client_chunks_paths = if let Some(client_chunks) = client_references_chunks
-                    .client_component_client_chunks
-                    .get(&app_client_reference_ty)
-                {
-                    let client_chunks = client_chunks.await?;
-                    let client_chunks_paths = client_chunks
-                        .iter()
-                        .map(|chunk| chunk.ident().path())
-                        .try_join()
-                        .await?;
+                let client_module_id = client_chunk_item.id().await?;
 
-                    client_chunks_paths
-                        .iter()
-                        .filter_map(|chunk_path| client_relative_path.get_path_to(chunk_path))
-                        .map(ToString::to_string)
-                        // It's possible that a chunk also emits CSS files, that will
-                        // be handled separatedly.
-                        .filter(|path| path.ends_with(".js"))
-                        .collect::<Vec<_>>()
-                } else {
-                    Vec::new()
-                };
+                let (client_chunks_paths, client_is_async) =
+                    if let Some((client_chunks, client_availability_info)) =
+                        client_references_chunks
+                            .client_component_client_chunks
+                            .get(&app_client_reference_ty)
+                    {
+                        let client_chunks = client_chunks.await?;
+                        let client_chunks_paths = client_chunks
+                            .iter()
+                            .map(|chunk| chunk.ident().path())
+                            .try_join()
+                            .await?;
+
+                        let chunk_paths = client_chunks_paths
+                            .iter()
+                            .filter_map(|chunk_path| client_relative_path.get_path_to(chunk_path))
+                            .map(ToString::to_string)
+                            // It's possible that a chunk also emits CSS files, that will
+                            // be handled separatedly.
+                            .filter(|path| path.ends_with(".js"))
+                            // .map(RcStr::from) // BACKPORT: no RcStr
+                            .collect::<Vec<_>>();
+
+                        let is_async =
+                            is_item_async(client_availability_info, client_chunk_item).await?;
+
+                        (chunk_paths, is_async)
+                    } else {
+                        (Vec::new(), false)
+                    };
+
                 entry_manifest.client_modules.module_exports.insert(
                     get_client_reference_module_key(&server_path, "*"),
                     ManifestNodeEntry {
                         name: "*".to_string(),
                         id: (&*client_module_id).into(),
                         chunks: client_chunks_paths,
-                        // TODO(WEB-434)
-                        r#async: false,
+                        r#async: client_is_async,
                     },
                 );
 
                 if let Some(ssr_chunking_context) = ssr_chunking_context {
-                    let ssr_module_id = ecmascript_client_reference
+                    let ssr_chunk_item = ecmascript_client_reference
                         .ssr_module
-                        .as_chunk_item(Vc::upcast(ssr_chunking_context))
-                        .id()
-                        .await?;
+                        .as_chunk_item(Vc::upcast(ssr_chunking_context));
 
-                    let ssr_chunks_paths = if runtime == NextRuntime::Edge {
+                    let ssr_module_id = ssr_chunk_item.id().await?;
+
+                    let (ssr_chunks_paths, ssr_is_async) = if runtime == NextRuntime::Edge {
                         // the chunks get added to the middleware-manifest.json instead
                         // of this file because the
                         // edge runtime doesn't support dynamically
                         // loading chunks.
-                        Vec::new()
-                    } else if let Some(ssr_chunks) = client_references_chunks
-                        .client_component_ssr_chunks
-                        .get(&app_client_reference_ty)
+                        (Vec::new(), false)
+                    } else if let Some((ssr_chunks, ssr_availability_info)) =
+                        client_references_chunks
+                            .client_component_ssr_chunks
+                            .get(&app_client_reference_ty)
                     {
                         let ssr_chunks = ssr_chunks.await?;
 
@@ -130,14 +142,20 @@ impl ClientReferenceManifest {
                             .try_join()
                             .await?;
 
-                        ssr_chunks_paths
+                        let chunk_paths = ssr_chunks_paths
                             .iter()
                             .filter_map(|chunk_path| node_root_ref.get_path_to(chunk_path))
                             .map(ToString::to_string)
-                            .collect::<Vec<_>>()
+                            // .map(RcStr::from) // BACKPORT: no RcStr
+                            .collect::<Vec<_>>();
+
+                        let is_async = is_item_async(ssr_availability_info, ssr_chunk_item).await?;
+
+                        (chunk_paths, is_async)
                     } else {
-                        Vec::new()
+                        (Vec::new(), false)
                     };
+
                     let mut ssr_manifest_node = ManifestNode::default();
                     ssr_manifest_node.module_exports.insert(
                         "*".to_string(),
@@ -145,8 +163,7 @@ impl ClientReferenceManifest {
                             name: "*".to_string(),
                             id: (&*ssr_module_id).into(),
                             chunks: ssr_chunks_paths,
-                            // TODO(WEB-434)
-                            r#async: false,
+                            r#async: ssr_is_async,
                         },
                     );
 
@@ -249,4 +266,19 @@ pub fn get_client_reference_module_key(server_path: &str, export_name: &str) -> 
     } else {
         format!("{}#{}", server_path, export_name)
     }
+}
+
+async fn is_item_async(
+    availability_info: &AvailabilityInfo,
+    chunk_item: Vc<Box<dyn ChunkItem>>,
+) -> Result<bool> {
+    let Some(available_chunk_items) = availability_info.available_chunk_items() else {
+        return Ok(false);
+    };
+
+    let Some(info) = &*available_chunk_items.get(chunk_item).await? else {
+        return Ok(false);
+    };
+
+    Ok(info.is_async)
 }

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -146,14 +146,15 @@ pub async fn get_server_resolve_options_context(
             .cloned(),
     );
 
+    let ty = ty.into_value();
+
     let server_component_externals_plugin = ExternalCjsModulesResolvePlugin::new(
         project_path,
         project_path.root(),
         ExternalPredicate::Only(Vc::cell(external_packages)).cell(),
-        // TODO(sokra) esmExternals support
-        false,
+        // app-ssr can't have esm externals as that would make the module async on the server only
+        *next_config.import_externals().await? && !matches!(ty, ServerContextType::AppSSR { .. }),
     );
-    let ty = ty.into_value();
 
     let mut custom_conditions = vec![mode.await?.condition().to_string()];
     custom_conditions.extend(

--- a/packages/next-swc/crates/next-core/src/next_server/context.rs
+++ b/packages/next-swc/crates/next-core/src/next_server/context.rs
@@ -99,6 +99,17 @@ pub enum ServerContextType {
     Instrumentation,
 }
 
+impl ServerContextType {
+    pub fn supports_react_server(&self) -> bool {
+        matches!(
+            self,
+            ServerContextType::AppRSC { .. }
+                | ServerContextType::AppRoute { .. }
+                | ServerContextType::PagesApi { .. }
+        )
+    }
+}
+
 #[turbo_tasks::function]
 pub async fn get_server_resolve_options_context(
     project_path: Vc<FileSystemPath>,
@@ -152,18 +163,10 @@ pub async fn get_server_resolve_options_context(
             .map(ToString::to_string),
     );
 
-    match ty {
-        ServerContextType::AppRSC { .. }
-        | ServerContextType::AppRoute { .. }
-        | ServerContextType::PagesApi { .. }
-        | ServerContextType::Middleware { .. } => {
-            custom_conditions.push("react-server".to_string())
-        }
-        ServerContextType::Pages { .. }
-        | ServerContextType::PagesData { .. }
-        | ServerContextType::AppSSR { .. }
-        | ServerContextType::Instrumentation { .. } => {}
+    if ty.supports_react_server() {
+        custom_conditions.push("react-server".to_string());
     };
+
     let external_cjs_modules_plugin = ExternalCjsModulesResolvePlugin::new(
         project_path,
         project_path.root(),
@@ -325,7 +328,7 @@ pub async fn get_server_module_options_context(
     let mut foreign_next_server_rules =
         get_next_server_transforms_rules(next_config, ty.into_value(), mode, true, next_runtime)
             .await?;
-    let internal_custom_rules =
+    let mut internal_custom_rules =
         get_next_server_internal_transforms_rules(ty.into_value(), *next_config.mdx_rs().await?)
             .await?;
 
@@ -622,10 +625,16 @@ pub async fn get_server_module_options_context(
             ecmascript_client_reference_transition_name,
         } => {
             next_server_rules.extend(source_transform_rules);
+
+            let mut common_next_server_rules = vec![
+                get_next_react_server_components_transform_rule(next_config, true, Some(app_dir))
+                    .await?,
+            ];
+
             if let Some(ecmascript_client_reference_transition_name) =
                 ecmascript_client_reference_transition_name
             {
-                next_server_rules.push(get_ecma_transform_rule(
+                common_next_server_rules.push(get_ecma_transform_rule(
                     Box::new(ClientDirectiveTransformer::new(
                         ecmascript_client_reference_transition_name,
                     )),
@@ -634,10 +643,8 @@ pub async fn get_server_module_options_context(
                 ));
             }
 
-            next_server_rules.push(
-                get_next_react_server_components_transform_rule(next_config, true, Some(app_dir))
-                    .await?,
-            );
+            next_server_rules.extend(common_next_server_rules.iter().cloned());
+            internal_custom_rules.extend(common_next_server_rules);
 
             let module_options_context = ModuleOptionsContext {
                 esm_url_rewrite_behavior: Some(UrlRewriteBehavior::Full),

--- a/test/e2e/app-dir/app-external/app-external.test.ts
+++ b/test/e2e/app-dir/app-external/app-external.test.ts
@@ -16,7 +16,7 @@ async function resolveStreamResponse(response: any, onData?: any) {
 }
 
 describe('app dir - external dependency', () => {
-  const { next, skipped, isTurbopack } = nextTestSetup({
+  const { next, skipped } = nextTestSetup({
     files: __dirname,
     dependencies: {
       swr: 'latest',
@@ -46,7 +46,7 @@ describe('app dir - external dependency', () => {
       expect(result).toContain('Server subpath: subpath.default')
       expect(result).toContain('Client: index.default')
       expect(result).toContain('Client subpath: subpath.default')
-      expect(result).toContain('opt-out-react-version: 18.3.1')
+      expect(result).not.toContain('opt-out-react-version: 18.3.0-canary')
     })
   })
 
@@ -286,10 +286,7 @@ describe('app dir - external dependency', () => {
       browser.elementByCss('#dual-pkg-outout button').click()
       await check(async () => {
         const text = await browser.elementByCss('#dual-pkg-outout p').text()
-        // TODO: enable esm externals for app router in turbopack for actions
-        expect(text).toBe(
-          isTurbopack ? 'dual-pkg-optout:cjs' : 'dual-pkg-optout:mjs'
-        )
+        expect(text).toBe('dual-pkg-optout:mjs')
         return 'success'
       }, /success/)
     })

--- a/test/e2e/app-dir/app-external/app-external.test.ts
+++ b/test/e2e/app-dir/app-external/app-external.test.ts
@@ -1,4 +1,4 @@
-import { createNextDescribe } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { check, hasRedbox, retry, shouldRunTurboDevTest } from 'next-test-utils'
 
 async function resolveStreamResponse(response: any, onData?: any) {
@@ -15,9 +15,8 @@ async function resolveStreamResponse(response: any, onData?: any) {
   return result
 }
 
-createNextDescribe(
-  'app dir - external dependency',
-  {
+describe('app dir - external dependency', () => {
+  const { next, skipped, isTurbopack } = nextTestSetup({
     files: __dirname,
     dependencies: {
       swr: 'latest',
@@ -34,291 +33,286 @@ createNextDescribe(
     startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
     buildCommand: 'pnpm build',
     skipDeployment: true,
-  },
-  ({ next, isTurbopack }) => {
-    it('should be able to opt-out 3rd party packages being bundled in server components', async () => {
-      await next.fetch('/react-server/optout').then(async (response) => {
-        const result = await resolveStreamResponse(response)
-        expect(result).toContain('Server: index.default')
-        expect(result).toContain('Server subpath: subpath.default')
-        expect(result).toContain('Client: index.default')
-        expect(result).toContain('Client subpath: subpath.default')
-        expect(result).toContain('opt-out-react-version: 18.3.1')
-      })
-    })
+  })
 
-    it('should handle external async module libraries correctly', async () => {
-      const clientHtml = await next.render('/external-imports/client')
-      const serverHtml = await next.render('/external-imports/server')
-      const sharedHtml = await next.render('/shared-esm-dep')
+  if (skipped) {
+    return
+  }
 
-      const browser = await next.browser('/external-imports/client')
-      const browserClientText = await browser.elementByCss('#content').text()
-
-      function containClientContent(content) {
-        expect(content).toContain('module type:esm-export')
-        expect(content).toContain('export named:named')
-        expect(content).toContain('export value:123')
-        expect(content).toContain('export array:4,5,6')
-        expect(content).toContain('export object:{x:1}')
-        expect(content).toContain('swr-state')
-      }
-
-      containClientContent(clientHtml)
-      containClientContent(browserClientText)
-
-      // support esm module imports on server side, and indirect imports from shared components
-      expect(serverHtml).toContain('pure-esm-module')
-      expect(sharedHtml).toContain(
-        'node_modules instance from client module pure-esm-module'
-      )
-    })
-
-    it('should transpile specific external packages with the `transpilePackages` option', async () => {
-      const clientHtml = await next.render('/external-imports/client')
-      expect(clientHtml).toContain('transpilePackages:5')
-    })
-
-    it('should resolve the subset react in server components based on the react-server condition', async () => {
-      await next.fetch('/react-server').then(async (response) => {
-        const result = await resolveStreamResponse(response)
-        expect(result).toContain('Server: <!-- -->subset')
-        expect(result).toContain('Client: <!-- -->full')
-      })
-    })
-
-    it('should resolve 3rd party package exports based on the react-server condition', async () => {
-      const $ = await next.render$('/react-server/3rd-party-package')
-
-      const result = $('body').text()
-
-      // Package should be resolved based on the react-server condition,
-      // as well as package's internal & external dependencies.
-      expect(result).toContain(
-        'Server: index.react-server:react.subset:dep.server'
-      )
-      expect(result).toContain('Client: index.default:react.full:dep.default')
-
-      // Subpath exports should be resolved based on the condition too.
-      expect(result).toContain('Server subpath: subpath.react-server')
+  it('should be able to opt-out 3rd party packages being bundled in server components', async () => {
+    await next.fetch('/react-server/optout').then(async (response) => {
+      const result = await resolveStreamResponse(response)
+      expect(result).toContain('Server: index.default')
+      expect(result).toContain('Server subpath: subpath.default')
+      expect(result).toContain('Client: index.default')
       expect(result).toContain('Client subpath: subpath.default')
-
-      // Prefer `module` field for isomorphic packages.
-      expect($('#main-field').text()).toContain('server-module-field:module')
+      expect(result).toContain('opt-out-react-version: 18.3.1')
     })
+  })
 
-    it('should correctly collect global css imports and mark them as side effects', async () => {
-      await next.fetch('/css/a').then(async (response) => {
-        const result = await resolveStreamResponse(response)
+  it('should handle external async module libraries correctly', async () => {
+    const clientHtml = await next.render('/external-imports/client')
+    const serverHtml = await next.render('/external-imports/server')
+    const sharedHtml = await next.render('/shared-esm-dep')
 
-        // It should include the global CSS import
-        expect(result).toMatch(/\.css/)
-      })
+    const browser = await next.browser('/external-imports/client')
+    const browserClientText = await browser.elementByCss('#content').text()
+
+    function containClientContent(content) {
+      expect(content).toContain('module type:esm-export')
+      expect(content).toContain('export named:named')
+      expect(content).toContain('export value:123')
+      expect(content).toContain('export array:4,5,6')
+      expect(content).toContain('export object:{x:1}')
+      expect(content).toContain('swr-state')
+    }
+
+    containClientContent(clientHtml)
+    containClientContent(browserClientText)
+
+    // support esm module imports on server side, and indirect imports from shared components
+    expect(serverHtml).toContain('pure-esm-module')
+    expect(sharedHtml).toContain(
+      'node_modules instance from client module pure-esm-module'
+    )
+  })
+
+  it('should transpile specific external packages with the `transpilePackages` option', async () => {
+    const clientHtml = await next.render('/external-imports/client')
+    expect(clientHtml).toContain('transpilePackages:5')
+  })
+
+  it('should resolve the subset react in server components based on the react-server condition', async () => {
+    await next.fetch('/react-server').then(async (response) => {
+      const result = await resolveStreamResponse(response)
+      expect(result).toContain('Server: <!-- -->subset')
+      expect(result).toContain('Client: <!-- -->full')
     })
+  })
 
-    it('should handle external css modules', async () => {
-      const browser = await next.browser('/css/modules')
+  it('should resolve 3rd party package exports based on the react-server condition', async () => {
+    const $ = await next.render$('/react-server/3rd-party-package')
 
-      expect(
-        await browser.eval(
-          `window.getComputedStyle(document.querySelector('h1')).color`
-        )
-      ).toBe('rgb(255, 0, 0)')
+    const result = $('body').text()
+
+    // Package should be resolved based on the react-server condition,
+    // as well as package's internal & external dependencies.
+    expect(result).toContain(
+      'Server: index.react-server:react.subset:dep.server'
+    )
+    expect(result).toContain('Client: index.default:react.full:dep.default')
+
+    // Subpath exports should be resolved based on the condition too.
+    expect(result).toContain('Server subpath: subpath.react-server')
+    expect(result).toContain('Client subpath: subpath.default')
+
+    // Prefer `module` field for isomorphic packages.
+    expect($('#main-field').text()).toContain('server-module-field:module')
+  })
+
+  it('should correctly collect global css imports and mark them as side effects', async () => {
+    await next.fetch('/css/a').then(async (response) => {
+      const result = await resolveStreamResponse(response)
+
+      // It should include the global CSS import
+      expect(result).toMatch(/\.css/)
     })
+  })
 
-    it('should use the same export type for packages in both ssr and client', async () => {
-      const browser = await next.browser('/client-dep')
-      expect(await browser.eval(`window.document.body.innerText`)).toBe('hello')
-    })
+  it('should handle external css modules', async () => {
+    const browser = await next.browser('/css/modules')
 
-    it('should handle external css modules in pages', async () => {
-      const browser = await next.browser('/test-pages')
+    expect(
+      await browser.eval(
+        `window.getComputedStyle(document.querySelector('h1')).color`
+      )
+    ).toBe('rgb(255, 0, 0)')
+  })
 
-      expect(
-        await browser.eval(
-          `window.getComputedStyle(document.querySelector('h1')).color`
-        )
-      ).toBe('rgb(255, 0, 0)')
-    })
+  it('should use the same export type for packages in both ssr and client', async () => {
+    const browser = await next.browser('/client-dep')
+    expect(await browser.eval(`window.document.body.innerText`)).toBe('hello')
+  })
 
-    it('should handle external next/font', async () => {
-      const browser = await next.browser('/font')
+  it('should handle external css modules in pages', async () => {
+    const browser = await next.browser('/test-pages')
 
-      expect(
-        await browser.eval(
-          `window.getComputedStyle(document.querySelector('p')).fontFamily`
-        )
-      ).toMatch(/^__myFont_.{6}, __myFont_Fallback_.{6}$/)
-    })
-    // TODO: This test depends on `new Worker` which is not supported in Turbopack yet.
-    ;(process.env.TURBOPACK ? it.skip : it)(
-      'should not apply swc optimizer transform for external packages in browser layer in web worker',
-      async () => {
-        const browser = await next.browser('/browser')
+    expect(
+      await browser.eval(
+        `window.getComputedStyle(document.querySelector('h1')).color`
+      )
+    ).toBe('rgb(255, 0, 0)')
+  })
+
+  it('should handle external next/font', async () => {
+    const browser = await next.browser('/font')
+
+    expect(
+      await browser.eval(
+        `window.getComputedStyle(document.querySelector('p')).fontFamily`
+      )
+    ).toMatch(/^__myFont_.{6}, __myFont_Fallback_.{6}$/)
+  })
+  // TODO: This test depends on `new Worker` which is not supported in Turbopack yet.
+  ;(process.env.TURBOPACK ? it.skip : it)(
+    'should not apply swc optimizer transform for external packages in browser layer in web worker',
+    async () => {
+      const browser = await next.browser('/browser')
+      // eslint-disable-next-line jest/no-standalone-expect
+      expect(await browser.elementByCss('#worker-state').text()).toBe('default')
+
+      await browser.elementByCss('button').click()
+
+      await retry(async () => {
         // eslint-disable-next-line jest/no-standalone-expect
         expect(await browser.elementByCss('#worker-state').text()).toBe(
-          'default'
-        )
-
-        await browser.elementByCss('button').click()
-
-        await retry(async () => {
-          // eslint-disable-next-line jest/no-standalone-expect
-          expect(await browser.elementByCss('#worker-state').text()).toBe(
-            'worker.js:browser-module/other'
-          )
-        })
-      }
-    )
-
-    describe('react in external esm packages', () => {
-      it('should use the same react in client app', async () => {
-        const html = await next.render('/esm/client')
-
-        const v1 = html.match(/App React Version: ([^<]+)</)[1]
-        const v2 = html.match(/External React Version: ([^<]+)</)[1]
-        expect(v1).toBe(v2)
-
-        // Should work with both esm and cjs imports
-        expect(html).toContain(
-          'CJS-ESM Compat package: cjs-esm-compat/index.mjs'
-        )
-        expect(html).toContain('CJS package: cjs-lib')
-        expect(html).toContain(
-          'Nested imports: nested-import:esm:cjs-esm-compat/index.mjs'
+          'worker.js:browser-module/other'
         )
       })
+    }
+  )
 
-      it('should use the same react in server app', async () => {
-        const html = await next.render('/esm/server')
+  describe('react in external esm packages', () => {
+    it('should use the same react in client app', async () => {
+      const html = await next.render('/esm/client')
 
-        const v1 = html.match(/App React Version: ([^<]+)</)[1]
-        const v2 = html.match(/External React Version: ([^<]+)</)[1]
-        expect(v1).toBe(v2)
+      const v1 = html.match(/App React Version: ([^<]+)</)[1]
+      const v2 = html.match(/External React Version: ([^<]+)</)[1]
+      expect(v1).toBe(v2)
 
-        // Should work with both esm and cjs imports
-        expect(html).toContain(
-          'CJS-ESM Compat package: cjs-esm-compat/index.mjs'
-        )
-        expect(html).toContain('CJS package: cjs-lib')
-      })
-
-      it('should use the same react in edge server app', async () => {
-        const html = await next.render('/esm/edge-server')
-
-        const v1 = html.match(/App React Version: ([^<]+)</)[1]
-        const v2 = html.match(/External React Version: ([^<]+)</)[1]
-        expect(v1).toBe(v2)
-
-        // Should work with both esm and cjs imports
-        expect(html).toContain(
-          'CJS-ESM Compat package: cjs-esm-compat/index.mjs'
-        )
-        expect(html).toContain('CJS package: cjs-lib')
-      })
-
-      it('should use the same react in pages', async () => {
-        const html = await next.render('/test-pages-esm')
-
-        const v1 = html.match(/App React Version: ([^<]+)</)[1]
-        const v2 = html.match(/External React Version: ([^<]+)</)[1]
-        expect(v1).toBe(v2)
-      })
-
-      it('should support namespace import with ESM packages', async () => {
-        const $ = await next.render$('/esm/react-namespace-import')
-        expect($('#namespace-import-esm').text()).toBe('namespace-import:esm')
-      })
-    })
-
-    describe('mixed syntax external modules', () => {
-      it('should handle mixed module with next/dynamic', async () => {
-        const browser = await next.browser('/mixed/dynamic')
-        expect(await browser.elementByCss('#component').text()).toContain(
-          'mixed-syntax-esm'
-        )
-      })
-
-      it('should handle mixed module in server and client components', async () => {
-        const $ = await next.render$('/mixed/import')
-        expect(await $('#server').text()).toContain('server:mixed-syntax-esm')
-        expect(await $('#client').text()).toContain('client:mixed-syntax-esm')
-        expect(await $('#relative-mixed').text()).toContain(
-          'relative-mixed-syntax-esm'
-        )
-      })
-    })
-
-    it('should emit cjs helpers for external cjs modules when compiled', async () => {
-      const $ = await next.render$('/cjs/client')
-      expect($('#private-prop').text()).toBe('prop')
-      expect($('#transpile-cjs-lib').text()).toBe('transpile-cjs-lib')
-
-      const browser = await next.browser('/cjs/client')
-      expect(await hasRedbox(browser)).toBe(false)
-    })
-
-    it('should export client module references in esm', async () => {
-      const html = await next.render('/esm-client-ref')
-      expect(html).toContain('hello')
-    })
-
-    it('should support exporting multiple star re-exports', async () => {
-      const html = await next.render('/wildcard')
-      expect(html).toContain('Foo')
-    })
-
-    it('should have proper tree-shaking for known modules in CJS', async () => {
-      const html = await next.render('/cjs/server')
-      expect(html).toContain('resolve response')
-
-      const outputFile = await next.readFile(
-        '.next/server/app/cjs/server/page.js'
+      // Should work with both esm and cjs imports
+      expect(html).toContain('CJS-ESM Compat package: cjs-esm-compat/index.mjs')
+      expect(html).toContain('CJS package: cjs-lib')
+      expect(html).toContain(
+        'Nested imports: nested-import:esm:cjs-esm-compat/index.mjs'
       )
-      expect(outputFile).not.toContain('image-response')
     })
 
-    it('should use the same async storages if imported directly', async () => {
-      const html = await next.render('/async-storage')
-      expect(html).toContain('success')
+    it('should use the same react in server app', async () => {
+      const html = await next.render('/esm/server')
+
+      const v1 = html.match(/App React Version: ([^<]+)</)[1]
+      const v2 = html.match(/External React Version: ([^<]+)</)[1]
+      expect(v1).toBe(v2)
+
+      // Should work with both esm and cjs imports
+      expect(html).toContain('CJS-ESM Compat package: cjs-esm-compat/index.mjs')
+      expect(html).toContain('CJS package: cjs-lib')
     })
 
-    describe('server actions', () => {
-      it('should prefer to resolve esm over cjs for bundling optout packages', async () => {
-        const browser = await next.browser('/optout/action')
-        expect(await browser.elementByCss('#dual-pkg-outout p').text()).toBe('')
+    it('should use the same react in edge server app', async () => {
+      const html = await next.render('/esm/edge-server')
 
-        browser.elementByCss('#dual-pkg-outout button').click()
-        await check(async () => {
-          const text = await browser.elementByCss('#dual-pkg-outout p').text()
-          // TODO: enable esm externals for app router in turbopack for actions
-          expect(text).toBe(
-            isTurbopack ? 'dual-pkg-optout:cjs' : 'dual-pkg-optout:mjs'
-          )
-          return 'success'
-        }, /success/)
-      })
+      const v1 = html.match(/App React Version: ([^<]+)</)[1]
+      const v2 = html.match(/External React Version: ([^<]+)</)[1]
+      expect(v1).toBe(v2)
 
-      it('should compile server actions from node_modules in client components', async () => {
-        // before action there's no action log
-        expect(next.cliOutput).not.toContain('action-log:server:action1')
-        const browser = await next.browser('/action/client')
-        await browser.elementByCss('#action').click()
-
-        await check(() => {
-          expect(next.cliOutput).toContain('action-log:server:action1')
-          return 'success'
-        }, /success/)
-      })
+      // Should work with both esm and cjs imports
+      expect(html).toContain('CJS-ESM Compat package: cjs-esm-compat/index.mjs')
+      expect(html).toContain('CJS package: cjs-lib')
     })
 
-    describe('app route', () => {
-      it('should resolve next/server api from external esm package', async () => {
-        const res = await next.fetch('/app-routes')
-        const text = await res.text()
-        expect(res.status).toBe(200)
-        expect(text).toBe('get route')
-      })
+    it('should use the same react in pages', async () => {
+      const html = await next.render('/test-pages-esm')
+
+      const v1 = html.match(/App React Version: ([^<]+)</)[1]
+      const v2 = html.match(/External React Version: ([^<]+)</)[1]
+      expect(v1).toBe(v2)
     })
-  }
-)
+
+    it('should support namespace import with ESM packages', async () => {
+      const $ = await next.render$('/esm/react-namespace-import')
+      expect($('#namespace-import-esm').text()).toBe('namespace-import:esm')
+    })
+  })
+
+  describe('mixed syntax external modules', () => {
+    it('should handle mixed module with next/dynamic', async () => {
+      const browser = await next.browser('/mixed/dynamic')
+      expect(await browser.elementByCss('#component').text()).toContain(
+        'mixed-syntax-esm'
+      )
+    })
+
+    it('should handle mixed module in server and client components', async () => {
+      const $ = await next.render$('/mixed/import')
+      expect(await $('#server').text()).toContain('server:mixed-syntax-esm')
+      expect(await $('#client').text()).toContain('client:mixed-syntax-esm')
+      expect(await $('#relative-mixed').text()).toContain(
+        'relative-mixed-syntax-esm'
+      )
+    })
+  })
+
+  it('should emit cjs helpers for external cjs modules when compiled', async () => {
+    const $ = await next.render$('/cjs/client')
+    expect($('#private-prop').text()).toBe('prop')
+    expect($('#transpile-cjs-lib').text()).toBe('transpile-cjs-lib')
+
+    const browser = await next.browser('/cjs/client')
+    expect(await hasRedbox(browser)).toBe(false)
+  })
+
+  it('should export client module references in esm', async () => {
+    const html = await next.render('/esm-client-ref')
+    expect(html).toContain('hello')
+  })
+
+  it('should support exporting multiple star re-exports', async () => {
+    const html = await next.render('/wildcard')
+    expect(html).toContain('Foo')
+  })
+
+  it('should have proper tree-shaking for known modules in CJS', async () => {
+    const html = await next.render('/cjs/server')
+    expect(html).toContain('resolve response')
+
+    const outputFile = await next.readFile(
+      '.next/server/app/cjs/server/page.js'
+    )
+    expect(outputFile).not.toContain('image-response')
+  })
+
+  it('should use the same async storages if imported directly', async () => {
+    const html = await next.render('/async-storage')
+    expect(html).toContain('success')
+  })
+
+  describe('server actions', () => {
+    it('should prefer to resolve esm over cjs for bundling optout packages', async () => {
+      const browser = await next.browser('/optout/action')
+      expect(await browser.elementByCss('#dual-pkg-outout p').text()).toBe('')
+
+      browser.elementByCss('#dual-pkg-outout button').click()
+      await check(async () => {
+        const text = await browser.elementByCss('#dual-pkg-outout p').text()
+        // TODO: enable esm externals for app router in turbopack for actions
+        expect(text).toBe(
+          isTurbopack ? 'dual-pkg-optout:cjs' : 'dual-pkg-optout:mjs'
+        )
+        return 'success'
+      }, /success/)
+    })
+
+    it('should compile server actions from node_modules in client components', async () => {
+      // before action there's no action log
+      expect(next.cliOutput).not.toContain('action-log:server:action1')
+      const browser = await next.browser('/action/client')
+      await browser.elementByCss('#action').click()
+
+      await check(() => {
+        expect(next.cliOutput).toContain('action-log:server:action1')
+        return 'success'
+      }, /success/)
+    })
+  })
+
+  describe('app route', () => {
+    it('should resolve next/server api from external esm package', async () => {
+      const res = await next.fetch('/app-routes')
+      const text = await res.text()
+      expect(res.status).toBe(200)
+      expect(text).toBe('get route')
+    })
+  })
+})

--- a/test/e2e/app-dir/app-routes-client-component/app-routes-client-component.test.ts
+++ b/test/e2e/app-dir/app-routes-client-component/app-routes-client-component.test.ts
@@ -8,6 +8,7 @@ describe('referencing a client component in an app route', () => {
   it('responds without error', async () => {
     expect(JSON.parse(await next.render('/runtime'))).toEqual({
       clientComponent: 'function',
+      myModuleClientComponent: 'function',
     })
   })
 })

--- a/test/e2e/app-dir/app-routes-client-component/app/runtime/route.ts
+++ b/test/e2e/app-dir/app-routes-client-component/app/runtime/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from 'next/server'
 import { ClientComponent } from '../../ClientComponent'
+import { MyModuleClientComponent } from 'my-module/MyModuleClientComponent'
 
 export function GET() {
   return NextResponse.json({
     clientComponent: typeof ClientComponent,
+    myModuleClientComponent: typeof MyModuleClientComponent,
   })
 }

--- a/test/e2e/app-dir/app-routes-client-component/node_modules/my-module/MyModuleClientComponent.tsx
+++ b/test/e2e/app-dir/app-routes-client-component/node_modules/my-module/MyModuleClientComponent.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export function MyModuleClientComponent() {
+  return <div>MyModuleClientComponent</div>
+}

--- a/test/e2e/esm-externals/esm-externals.test.ts
+++ b/test/e2e/esm-externals/esm-externals.test.ts
@@ -8,65 +8,63 @@ describe('esm-externals', () => {
   const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
   })
+
   // Pages
-  {
-    const urls = ['/static', '/ssr', '/ssg']
+  describe.each(['/static', '/ssr', '/ssg'])('pages url %s', (url) => {
+    // For invalid esm packages that have "import" pointing to a non-esm-flagged module
+    // webpack is using the CJS version instead, but Turbopack is opting out of
+    // externalizing and bundling the non-esm-flagged module.
+    const expectedHtml = isTurbopack
+      ? 'Hello World+World+World+World+World+World'
+      : url === '/static'
+      ? 'Hello World+World+Alternative+World+World+World'
+      : 'Hello World+World+Alternative+World+World+Alternative'
 
-    for (const url of urls) {
-      // For invalid esm packages that have "import" pointing to a non-esm-flagged module
-      // webpack is using the CJS version instead but Turbopack is opting out of
-      // externalizing and bundling the non-esm-flagged module.
-      const expectedHtml = isTurbopack
-        ? /Hello World\+World\+World\+World\+World\+World/
-        : url === '/static'
-        ? /Hello World\+World\+Alternative\+World\+World\+World/
-        : /Hello World\+World\+Alternative\+World\+World\+Alternative/
-      // On client side, webpack always bundlings so it uses the non-esm-flagged module too.
-      const expectedText =
-        isTurbopack || url === '/static'
-          ? /Hello World\+World\+World\+World\+World\+World/
-          : /Hello World\+World\+World\+World\+World\+Alternative/
+    // On the client side, webpack always bundles, so it uses the non-esm-flagged module too.
+    const expectedText =
+      isTurbopack || url === '/static'
+        ? 'Hello World+World+World+World+World+World'
+        : 'Hello World+World+World+World+World+Alternative'
 
-      it(`should return the correct SSR HTML for ${url}`, async () => {
-        const res = await next.fetch(url)
-        const html = await res.text()
-        expect(normalize(html)).toMatch(expectedHtml)
-      })
+    it('should return the correct SSR HTML', async () => {
+      const $ = await next.render$(url)
+      const body = $('body > div > div').html()
+      expect(normalize(body)).toEqual(expectedHtml)
+    })
 
-      it(`should render the correct page for ${url}`, async () => {
-        const browser = await next.browser(url)
-        expect(await browser.elementByCss('body').text()).toMatch(expectedText)
-      })
-    }
-  }
+    it('should render the correct page', async () => {
+      const browser = await next.browser(url)
+      expect(await browser.elementByCss('body > div').text()).toEqual(
+        expectedText
+      )
+    })
+  })
 
   // App dir
-  {
-    // TODO App Dir doesn't use esmExternals: true correctly for Turbopack
-    // so we only verify that the page doesn't crash, but ignore the actual content
-    // const expectedHtml = isTurbopack ? /Hello World\+World\+World/ : /Hello World\+World\+Alternative/
+  describe.each(['/server', '/client'])('app dir url %s', (url) => {
     const expectedHtml = isTurbopack
-      ? /Hello Wrong\+Wrong\+Alternative/
-      : /Hello World\+World\+Alternative/
-    const urls = ['/server', '/client']
+      ? url === '/client'
+        ? 'Hello Wrong+Wrong+Alternative'
+        : 'Hello World+World+World'
+      : 'Hello World+World+Alternative'
 
-    for (const url of urls) {
-      const expectedText =
-        url !== '/server'
-          ? /Hello World\+World\+World/
-          : isTurbopack
-          ? /Hello Wrong\+Wrong\+Alternative/
-          : /Hello World\+World\+Alternative/
-      it(`should return the correct SSR HTML for ${url}`, async () => {
-        const res = await next.fetch(url)
-        const html = await res.text()
-        expect(normalize(html)).toMatch(expectedHtml)
-      })
+    const expectedText = isTurbopack
+      ? 'Hello World+World+World'
+      : url === '/client'
+      ? 'Hello World+World+World'
+      : 'Hello World+World+Alternative'
 
-      it(`should render the correct page for ${url}`, async () => {
-        const browser = await next.browser(url)
-        expect(await browser.elementByCss('body').text()).toMatch(expectedText)
-      })
-    }
-  }
+    it('should return the correct SSR HTML', async () => {
+      const $ = await next.render$(url)
+      const body = $('body > div').html()
+      expect(normalize(body)).toEqual(expectedHtml)
+    })
+
+    it('should render the correct page', async () => {
+      const browser = await next.browser(url)
+      expect(await browser.elementByCss('body > div').text()).toEqual(
+        expectedText
+      )
+    })
+  })
 })


### PR DESCRIPTION
- [x] #64751
- [x] #64918

### ~~TODO~~

~~#64918 still needs to be cherry-picked. there's a bunch of conflicts and idk if it's easily doable... it seems like it depends on at least stuff from these two:~~
- ~~vercel/turbo#8221~~
- ~~#65421 (see also: 8cc3957b81a11a2f3f2e665e5d7680ed754ee455, which reverts it)~~