### PR TITLE
Turbopack build: Fix middleware matchers implementation

### DIFF
--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -223,7 +223,6 @@ impl MiddlewareEndpoint {
                 ..Default::default()
             }]
         };
-        println!("matchers: {:?}", matchers);
 
         let edge_function_definition = EdgeFunctionDefinition {
             files: file_paths_from_root,

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -205,7 +205,7 @@ impl MiddlewareEndpoint {
                     source = format!("/:nextData(_next/data/[^/]{{1,}})?{}{}", source, last_part);
 
                     if let Some(base_path) = base_path {
-                        source = format!("{}{}", base_path.to_string(), source);
+                        source = format!("{}{}", base_path, source);
                     }
 
                     // TODO: The implementation of getMiddlewareMatchers outputs a regex here using

--- a/test/e2e/middleware-trailing-slash/test/index.test.ts
+++ b/test/e2e/middleware-trailing-slash/test/index.test.ts
@@ -114,15 +114,17 @@ describe('Middleware Runtime trailing slash', () => {
         }
         delete middlewareWithoutEnvs.env
         expect(middlewareWithoutEnvs).toEqual({
-          files: expect.arrayContaining([
-            'server/edge-runtime-webpack.js',
-            'server/middleware.js',
-          ]),
+          files: process.env.TURBOPACK
+            ? expect.toBeArray()
+            : expect.arrayContaining([
+                'server/edge-runtime-webpack.js',
+                'server/middleware.js',
+              ]),
           name: 'middleware',
           page: '/',
           matchers: [{ regexp: '^/.*$', originalSource: '/:path*' }],
           wasm: [],
-          assets: [],
+          assets: process.env.TURBOPACK ? expect.toBeArray() : [],
         })
       })
 
@@ -132,9 +134,11 @@ describe('Middleware Runtime trailing slash', () => {
         )
         for (const key of Object.keys(manifest.middleware)) {
           const middleware = manifest.middleware[key]
-          expect(middleware.files).toContainEqual(
-            expect.stringContaining('server/edge-runtime-webpack')
-          )
+          if (!process.env.TURBOPACK) {
+            expect(middleware.files).toContainEqual(
+              expect.stringContaining('server/edge-runtime-webpack')
+            )
+          }
           expect(middleware.files).not.toContainEqual(
             expect.stringContaining('static/chunks/')
           )

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -5400,9 +5400,7 @@
         "using a single matcher with i18n does not add the header for an unmatched path",
         "using root matcher adds the header for a matched data path (with header)",
         "using root matcher adds the header for a matched data path (without header)",
-        "using root matcher adds the header to the /"
-      ],
-      "failed": [
+        "using root matcher adds the header to the /",
         "using a single matcher with i18n adds the header for a matched path",
         "using a single matcher with i18n adds the header for a mathed root path with /index",
         "using a single matcher with i18n adds the headers for a matched data path",
@@ -5417,6 +5415,7 @@
         "using a single matcher with i18n and trailingSlash adds the headers for a matched data path",
         "using root matcher adds the header to the /index"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -5224,10 +5224,10 @@
     "test/e2e/middleware-custom-matchers-i18n/test/index.test.ts": {
       "passed": [
         "Middleware custom matchers i18n should not match",
-        "Middleware custom matchers with root should not match",
-        "Middleware custom matchers i18n should match"
+        "Middleware custom matchers with root should not match"
       ],
       "failed": [
+        "Middleware custom matchers i18n should match",
         "Middleware custom matchers i18n should match has query on client routing"
       ],
       "pending": [],

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -5586,12 +5586,11 @@
         "Middleware Runtime trailing slash with .html extension should work when requesting the page directly",
         "Middleware Runtime trailing slash without .html extension should work using browser",
         "Middleware Runtime trailing slash without .html extension should work when navigating",
-        "Middleware Runtime trailing slash without .html extension should work when requesting the page directly"
-      ],
-      "failed": [
+        "Middleware Runtime trailing slash without .html extension should work when requesting the page directly",
         "Middleware Runtime trailing slash should have correct files in manifest",
         "Middleware Runtime trailing slash should have valid middleware field in manifest"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -5211,11 +5211,12 @@
       "runtimeError": false
     },
     "test/e2e/middleware-custom-matchers-basepath/test/index.test.ts": {
-      "passed": ["Middleware custom matchers basePath should not match"],
-      "failed": [
+      "passed": [
+        "Middleware custom matchers basePath should not match",
         "Middleware custom matchers basePath should match",
         "Middleware custom matchers basePath should match has query on client routing"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false
@@ -5223,10 +5224,10 @@
     "test/e2e/middleware-custom-matchers-i18n/test/index.test.ts": {
       "passed": [
         "Middleware custom matchers i18n should not match",
-        "Middleware custom matchers with root should not match"
+        "Middleware custom matchers with root should not match",
+        "Middleware custom matchers i18n should match"
       ],
       "failed": [
-        "Middleware custom matchers i18n should match",
         "Middleware custom matchers i18n should match has query on client routing"
       ],
       "pending": [],


### PR DESCRIPTION
Found that middleware matchers were not fully implemented. Copied the implementation we have for webpack as much as possible. Had to add a workaround for path-to-regexp being used so now we post-processes the manifest that the compiler outputs to turn the path-to-regexp string to a regex.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
