### PR TITLE
Remove unsupported providerImportSource option

### DIFF
--- a/packages/next-mdx/readme.md
+++ b/packages/next-mdx/readme.md
@@ -128,8 +128,6 @@ const withMDX = require('@next/mdx')({
     // https://github.com/remarkjs/remark-gfm#install
     remarkPlugins: [],
     rehypePlugins: [],
-    // If you use `MDXProvider`, uncomment the following line.
-    // providerImportSource: "@mdx-js/react",
   },
 })
 


### PR DESCRIPTION
While working on applying custom components to nested MDX files using `MDXProvider`, I noticed an outdated comment in the Next.js MDX README. The comment references the `providerImportSource` option, which is no longer supported. This option removed, as explained by @leerob [here](https://github.com/vercel/next.js/issues/54212#issuecomment-1803973892).

This PR updates the Next.js MDX README by removing the outdated reference to the `providerImportSource` option. 

ccs:
@leerob
@wooorm
@remcohaszing
@manovotny
