### PR TITLE
backport: swc fixes

### DIFF
--- a/packages/next/src/build/webpack/plugins/terser-webpack-plugin/src/index.ts
+++ b/packages/next/src/build/webpack/plugins/terser-webpack-plugin/src/index.ts
@@ -157,6 +157,9 @@ export class TerserPlugin {
                     : {}),
                   compress: true,
                   mangle: true,
+                  output: {
+                    comments: false,
+                  },
                 }
               )
 

--- a/test/production/terser-class-static-blocks/pages/index.tsx
+++ b/test/production/terser-class-static-blocks/pages/index.tsx
@@ -1,3 +1,10 @@
+/**
+ * My JSDoc comment that should be minified away
+ *
+ * @author Example One <example1@example.com>
+ * @author Example Two <example2@example.com>
+ * @copyright 2024 Vercel Inc
+ */
 class TestClass {
   static text = 'hello world'
 }

--- a/test/production/terser-class-static-blocks/terser-class-static-blocks.test.ts
+++ b/test/production/terser-class-static-blocks/terser-class-static-blocks.test.ts
@@ -1,17 +1,14 @@
-import { createNextDescribe } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 
-createNextDescribe(
-  'terser-class-static-blocks',
-  {
+describe('terser-class-static-blocks', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
     nextConfig: {
       swcMinify: false,
     },
-  },
-  ({ next }) => {
-    it('should work using cheerio', async () => {
-      const $ = await next.render$('/')
-      expect($('p').text()).toBe('hello world')
-    })
-  }
-)
+  })
+  it('should work using cheerio', async () => {
+    const $ = await next.render$('/')
+    expect($('p').text()).toBe('hello world')
+  })
+})

--- a/test/production/terser-class-static-blocks/terser-class-static-blocks.test.ts
+++ b/test/production/terser-class-static-blocks/terser-class-static-blocks.test.ts
@@ -1,7 +1,9 @@
+import glob from 'glob'
 import { nextTestSetup } from 'e2e-utils'
+import path from 'path'
 
 describe('terser-class-static-blocks', () => {
-  const { next } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
     nextConfig: {
       swcMinify: false,
@@ -11,4 +13,27 @@ describe('terser-class-static-blocks', () => {
     const $ = await next.render$('/')
     expect($('p').text()).toBe('hello world')
   })
+
+  if (!isNextDeploy) {
+    it('should have stripped away all comments', async () => {
+      const chunksDir = path.join(next.testDir, '.next/static')
+      const chunks = glob.sync('**/*.js', {
+        cwd: chunksDir,
+      })
+
+      expect(chunks.length).toBeGreaterThan(0)
+
+      await Promise.all(
+        chunks.map(async (chunk) => {
+          expect(
+            await next.readFile(path.join('.next/static', chunk))
+          ).not.toContain('/*')
+
+          expect(
+            await next.readFile(path.join('.next/static', chunk))
+          ).not.toContain('My JSDoc comment that')
+        })
+      )
+    })
+  }
 })


### PR DESCRIPTION
- [x] #68372

this was meant to include #66817, but `module: 'unknown'` requires newer SWC, which might break wasm plugins that users are currently using on 14.x (plugins [are not compatible across versions](https://swc.rs/docs/plugin/selecting-swc-core))