### PR TITLE
chore(examples): clean up About component in example/rewrites

### DIFF
--- a/examples/rewrites/app/about/page.tsx
+++ b/examples/rewrites/app/about/page.tsx
@@ -1,22 +1,18 @@
 "use client";
-import { useState, useEffect } from "react";
+
 import { usePathname } from "next/navigation";
 import Link from "next/link";
+
 import styles from "../../styles.module.css";
 import Code from "../_components/Code";
 
 export default function About() {
   const pathname = usePathname();
-  const [path, setPath] = useState<string | null>(null);
-
-  useEffect(() => {
-    setPath(pathname);
-  }, [pathname]);
 
   return (
     <div className={styles.container}>
       <div className={styles.card}>
-        <h1>Path: {path}</h1>
+        <h1>Path: {pathname}</h1>
         <hr className={styles.hr} />
         <p>
           {" "}


### PR DESCRIPTION
## Why?

No need to have a `useState` and `useEffect` in the About component in the rewrites example.

- x-ref: https://github.com/vercel/next.js/pull/69495#discussion_r1740506544