### PR TITLE
ensure test_e2e_deploy_release installs native swc binaries

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -71,9 +71,8 @@ env:
   TURBO_TEAM: 'vercel'
   TURBO_REMOTE_ONLY: 'true'
   NEXT_TELEMETRY_DISABLED: 1
-  # we build a dev binary for use in CI so skip downloading
-  # canary next-swc binaries in the monorepo
-  NEXT_SKIP_NATIVE_POSTINSTALL: 1
+  # only skip the install-native postinstall script if we're building a native binary
+  NEXT_SKIP_NATIVE_POSTINSTALL: ${{ inputs.skipNativeBuild != 'yes' && 'true' || '' }}
   DATADOG_API_KEY: ${{ secrets.DATA_DOG_API_KEY }}
   NEXT_JUNIT_TEST_REPORT: 'true'
   DD_ENV: 'ci'

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -21,6 +21,10 @@ on:
         required: false
         description: 'whether to skip building native modules'
         type: string
+      skipNativeInstall:
+        required: false
+        description: 'whether to skip native postinstall script'
+        type: string
       uploadAnalyzerArtifacts:
         required: false
         description: 'whether to upload analyzer artifacts'
@@ -71,8 +75,8 @@ env:
   TURBO_TEAM: 'vercel'
   TURBO_REMOTE_ONLY: 'true'
   NEXT_TELEMETRY_DISABLED: 1
-  # only skip the install-native postinstall script if we're building a native binary
-  NEXT_SKIP_NATIVE_POSTINSTALL: ${{ inputs.skipNativeBuild != 'yes' && 'true' || '' }}
+  # allow not skipping install-native postinstall script if we don't have a binary available already
+  NEXT_SKIP_NATIVE_POSTINSTALL: ${{ inputs.skipNativeInstall != 'yes' && 'true' || '' }}
   DATADOG_API_KEY: ${{ secrets.DATA_DOG_API_KEY }}
   NEXT_JUNIT_TEST_REPORT: 'true'
   DD_ENV: 'ci'

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -50,6 +50,7 @@ jobs:
     with:
       afterBuild: NEXT_TEST_MODE=deploy NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" node run-tests.js --timings -g ${{ matrix.group }} -c 2 --type e2e
       skipNativeBuild: 'yes'
+      skipNativeInstall: 'yes'
       stepName: 'test-deploy-${{ matrix.group }}'
       timeout_minutes: 180
       runs_on_labels: '["ubuntu-latest"]'


### PR DESCRIPTION
Deployment tests occasionally fail with errors when downloading swc (https://github.com/vercel/next.js/actions/runs/10587747214/job/29340241690)

Currently these jobs download SWC because `test_e2e_deploy_release` skips native but we depend on them for things like [`next/jest`](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/jest/jest.ts#L98-L99)

in `build_reusable` we always skip the native binary install. This adds a new flag to opt out of skipping postinstall so that native binaries are available

[x-ref](https://github.com/vercel/next.js/actions/runs/10587747214/job/29340241690)