### PR TITLE
Revert "ci: only trigger slack webhook from canary"

### DIFF
--- a/.github/workflows/retry_deploy_test.yml
+++ b/.github/workflows/retry_deploy_test.yml
@@ -41,7 +41,6 @@ jobs:
       ${{ 
         github.event.workflow_run.conclusion == 'failure' &&
         github.event.workflow_run.run_attempt >= 2 &&
-        github.event.workflow_run.head_branch == 'canary' &&
         !github.event.workflow_run.head_repository.fork
       }}
     runs-on: ubuntu-latest

--- a/.github/workflows/retry_test.yml
+++ b/.github/workflows/retry_test.yml
@@ -42,7 +42,6 @@ jobs:
       ${{ 
         github.event.workflow_run.conclusion == 'failure' &&
         github.event.workflow_run.run_attempt >= 3 &&
-        github.event.workflow_run.head_branch == 'canary' &&
         !github.event.workflow_run.head_repository.fork
       }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reverts vercel/next.js#69632

It appears to not be working quite right. 

skip: https://github.com/vercel/next.js/actions/runs/10692363199
failed retry: https://github.com/vercel/next.js/actions/runs/10692293873/job/29641598903