### PR TITLE
[Turbopack] transient when the self argument is transient

### DIFF
--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -9,7 +9,8 @@ pub use super::{
     manager::{find_cell_by_type, notify_scheduled_tasks, spawn_detached_for_testing},
 };
 use crate::{
-    debug::ValueDebugFormatString, task::TaskOutput, ResolvedValue, TaskInput, TaskPersistence, Vc,
+    debug::ValueDebugFormatString, task::TaskOutput, RawVc, ResolvedValue, TaskInput,
+    TaskPersistence, Vc,
 };
 
 #[inline(never)]
@@ -25,6 +26,17 @@ pub async fn value_debug_format_field(value: ValueDebugFormatString<'_>) -> Stri
 
 pub fn get_non_local_persistence_from_inputs(inputs: &impl TaskInput) -> TaskPersistence {
     if inputs.is_transient() {
+        TaskPersistence::Transient
+    } else {
+        TaskPersistence::Persistent
+    }
+}
+
+pub fn get_non_local_persistence_from_inputs_and_this(
+    this: RawVc,
+    inputs: &impl TaskInput,
+) -> TaskPersistence {
+    if this.is_transient() || inputs.is_transient() {
         TaskPersistence::Transient
     } else {
         TaskPersistence::Persistent

--- a/turbopack/crates/turbo-tasks/src/raw_vc.rs
+++ b/turbopack/crates/turbo-tasks/src/raw_vc.rs
@@ -79,6 +79,13 @@ impl RawVc {
         }
     }
 
+    pub fn is_transient(&self) -> bool {
+        match self {
+            RawVc::TaskOutput(task) | RawVc::TaskCell(task, _) => task.is_transient(),
+            RawVc::LocalCell(_, _) => true,
+        }
+    }
+
     pub(crate) fn into_read(self) -> ReadRawVcFuture {
         // returns a custom future to have something concrete and sized
         // this avoids boxing in IntoFuture


### PR DESCRIPTION
### What?

For calls with self argument, we also need to flag a task a transient when the self argument is transient.
