### PR TITLE
[Turbopack] store project options in state

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -336,7 +336,7 @@ pub async fn project_new(
         .run_once(async move {
             let project = ProjectContainer::new("next.js".into(), options.dev);
             let project = project.resolve().await?;
-            project.await?.initialize(options);
+            project.initialize(options).await?;
             Ok(project)
         })
         .await
@@ -375,7 +375,7 @@ async fn benchmark_file_io(directory: Vc<FileSystemPath>) -> Result<Vc<Completio
         .await?;
 
     let directory = fs.to_sys_path(directory).await?;
-    let temp_path = directory.join(&format!(
+    let temp_path = directory.join(format!(
         "tmp_file_io_benchmark_{:x}",
         rand::random::<u128>()
     ));
@@ -424,7 +424,7 @@ pub async fn project_update(
     let container = project.container;
     turbo_tasks
         .run_once(async move {
-            container.await?.update(options)?;
+            container.update(options).await?;
             Ok(())
         })
         .await

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -366,9 +366,6 @@ pub async fn project_new(
 /// - https://github.com/oven-sh/bun/blob/06a9aa80c38b08b3148bfeabe560/src/install/install.zig#L3038
 #[tracing::instrument]
 async fn benchmark_file_io(directory: Vc<FileSystemPath>) -> Result<Vc<Completion>> {
-    let temp_path =
-        directory.join(format!("tmp_file_io_benchmark_{:x}", rand::random::<u128>()).into());
-
     // try to get the real file path on disk so that we can use it with tokio
     let fs = Vc::try_resolve_downcast_type::<DiskFileSystem>(directory.fs())
         .await?
@@ -376,7 +373,12 @@ async fn benchmark_file_io(directory: Vc<FileSystemPath>) -> Result<Vc<Completio
             "expected node_root to be a DiskFileSystem, cannot benchmark"
         ))?
         .await?;
-    let temp_path = fs.to_sys_path(temp_path).await?;
+
+    let directory = fs.to_sys_path(directory).await?;
+    let temp_path = directory.join(&format!(
+        "tmp_file_io_benchmark_{:x}",
+        rand::random::<u128>()
+    ));
 
     let mut random_buffer = [0u8; 512];
     rand::thread_rng().fill(&mut random_buffer[..]);
@@ -405,7 +407,7 @@ async fn benchmark_file_io(directory: Vc<FileSystemPath>) -> Result<Vc<Completio
         println!(
             "Slow filesystem detected. If {} is a network drive, consider moving it to a local \
              folder. If you have an antivirus enabled, consider excluding your project directory.",
-            fs.to_sys_path(directory).await?.to_string_lossy(),
+            directory.to_string_lossy(),
         );
     }
 

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -331,11 +331,12 @@ pub async fn project_new(
             .unwrap();
         });
     }
-    let options = options.into();
+    let options: ProjectOptions = options.into();
     let container = turbo_tasks
         .run_once(async move {
-            let project = ProjectContainer::new(options);
+            let project = ProjectContainer::new("next.js".into(), options.dev);
             let project = project.resolve().await?;
+            project.await?.initialize(options);
             Ok(project)
         })
         .await
@@ -421,7 +422,7 @@ pub async fn project_update(
     let container = project.container;
     turbo_tasks
         .run_once(async move {
-            container.update(options).await?;
+            container.await?.update(options)?;
             Ok(())
         })
         .await

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -194,6 +194,7 @@ impl ProjectContainer {
 }
 
 impl ProjectContainer {
+    #[tracing::instrument(level = "info", name = "initialize project", skip_all)]
     pub async fn initialize(self: Vc<Self>, options: ProjectOptions) -> Result<()> {
         self.await?.options_state.set(Some(options));
         let project = self.project();
@@ -210,6 +211,7 @@ impl ProjectContainer {
         Ok(())
     }
 
+    #[tracing::instrument(level = "info", name = "update project", skip_all)]
     pub async fn update(self: Vc<Self>, options: PartialProjectOptions) -> Result<()> {
         let PartialProjectOptions {
             root_path,

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -201,12 +201,12 @@ impl ProjectContainer {
             .project_fs()
             .strongly_consistent()
             .await?
-            .start_watching()?;
+            .start_watching_with_invalidation_reason()?;
         project
             .output_fs()
             .strongly_consistent()
             .await?
-            .invalidate();
+            .invalidate_with_reason();
         Ok(())
     }
 
@@ -279,10 +279,10 @@ impl ProjectContainer {
 
         if !ReadRef::ptr_eq(&prev_project_fs, &project_fs) {
             // TODO stop watching: prev_project_fs.stop_watching()?;
-            project_fs.start_watching()?;
+            project_fs.start_watching_with_invalidation_reason()?;
         }
         if !ReadRef::ptr_eq(&prev_output_fs, &output_fs) {
-            prev_output_fs.invalidate();
+            prev_output_fs.invalidate_with_reason();
         }
 
         Ok(())

--- a/crates/next-build-test/src/lib.rs
+++ b/crates/next-build-test/src/lib.rs
@@ -38,7 +38,12 @@ pub async fn main_inner(
     }
 
     let project = tt
-        .run_once(async { Ok(ProjectContainer::new(options)) })
+        .run_once(async {
+            let project = ProjectContainer::new("next-build-test".into(), options.dev);
+            let project = project.resolve().await?;
+            project.await?.initialize(options);
+            Ok(project)
+        })
         .await?;
 
     tracing::info!("collecting endpoints");

--- a/crates/next-build-test/src/lib.rs
+++ b/crates/next-build-test/src/lib.rs
@@ -41,7 +41,7 @@ pub async fn main_inner(
         .run_once(async {
             let project = ProjectContainer::new("next-build-test".into(), options.dev);
             let project = project.resolve().await?;
-            project.await?.initialize(options);
+            project.initialize(options).await?;
             Ok(project)
         })
         .await?;

--- a/turbopack/crates/node-file-trace/src/lib.rs
+++ b/turbopack/crates/node-file-trace/src/lib.rs
@@ -192,7 +192,7 @@ async fn create_fs(name: &str, root: &str, watch: bool) -> Result<Vc<Box<dyn Fil
     if watch {
         fs.await?.start_watching()?;
     } else {
-        fs.await?.invalidate();
+        fs.await?.invalidate_with_reason();
     }
     Ok(Vc::upcast(fs))
 }

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -165,6 +165,7 @@ impl DiskFileSystem {
     }
 
     pub fn invalidate(&self) {
+        let _span = tracing::info_span!("invalidate filesystem", path = &*self.root).entered();
         for (_, invalidators) in take(&mut *self.invalidator_map.lock().unwrap()).into_iter() {
             invalidators.into_iter().for_each(|i| i.invalidate());
         }
@@ -174,6 +175,7 @@ impl DiskFileSystem {
     }
 
     pub fn invalidate_with_reason<T: InvalidationReason + Clone>(&self, reason: T) {
+        let _span = tracing::info_span!("invalidate filesystem", path = &*self.root).entered();
         for (_, invalidators) in take(&mut *self.invalidator_map.lock().unwrap()).into_iter() {
             invalidators
                 .into_iter()
@@ -195,6 +197,7 @@ impl DiskFileSystem {
     }
 
     fn start_watching_internal(&self, report_invalidation_reason: bool) -> Result<()> {
+        let _span = tracing::info_span!("start filesystem watching", path = &*self.root).entered();
         let invalidator_map = self.invalidator_map.clone();
         let dir_invalidator_map = self.dir_invalidator_map.clone();
         let root_path = self.root_path().to_path_buf();

--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -153,15 +153,18 @@ impl DiskWatcher {
 
         // We need to invalidate all reads that happened before watching
         // Best is to start_watching before starting to read
-        for invalidator in take(&mut *invalidator_map.lock().unwrap())
-            .into_iter()
-            .chain(take(&mut *dir_invalidator_map.lock().unwrap()).into_iter())
-            .flat_map(|(_, invalidators)| invalidators.into_iter())
         {
-            if report_invalidation_reason.is_some() {
-                invalidator.invalidate_with_reason(WatchStart { name: name.clone() })
-            } else {
-                invalidator.invalidate();
+            let _span = tracing::info_span!("invalidate filesystem").entered();
+            for invalidator in take(&mut *invalidator_map.lock().unwrap())
+                .into_iter()
+                .chain(take(&mut *dir_invalidator_map.lock().unwrap()).into_iter())
+                .flat_map(|(_, invalidators)| invalidators.into_iter())
+            {
+                if report_invalidation_reason.is_some() {
+                    invalidator.invalidate_with_reason(WatchStart { name: name.clone() })
+                } else {
+                    invalidator.invalidate();
+                }
             }
         }
 


### PR DESCRIPTION
### What?

We can't pass the whole config (including next config) as argument to `ProjectContainer::new` as this would result in a new project every time the config is different. (It's always different due to some random values).

So to leverage persistent caching we need to remove the argument from `ProjectContainer::new` (so it's always the same project) and push the config into a `State`. This way we "modify" the project and can benefit from caching for the unchanged values.
