### PR TITLE
[Turbopack] use file.read() instead of file.track() in webpack loaders

### DIFF
--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -716,7 +716,7 @@ async fn dir_dependency_shallow(glob: Vc<ReadGlobResult>) -> Result<Vc<Completio
         // Reading all files to add itself as dependency
         match *item {
             DirectoryEntry::File(file) => {
-                file.track().await?;
+                file.read().await?;
             }
             DirectoryEntry::Directory(dir) => {
                 dir_dependency(dir.read_glob(Glob::new("**".into()), false)).await?;


### PR DESCRIPTION
### What?

`track()` invalidates based on watcher events and might have false invalidation when events occur but files do not actually change. This also happens when restoring from persistent caching where all files are considered as changed.

`read()` invalidates only when the file content actually changed.

Since webpack loaders are usually pretty expensive we want to use `read()` instead of `track()` here.