### PR TITLE
[Turbopack] handle state serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3628,6 +3628,7 @@ checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
+ "serde",
 ]
 
 [[package]]

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -177,6 +177,10 @@ impl TurboTasksApi for VcStorage {
         unreachable!()
     }
 
+    fn invalidate_serialization(&self, _task: TaskId) {
+        // ingore
+    }
+
     fn notify_scheduled_tasks(&self) {
         // ignore
     }
@@ -306,6 +310,10 @@ impl TurboTasksApi for VcStorage {
     }
 
     fn mark_own_task_as_finished(&self, _task: TaskId) {
+        // no-op
+    }
+
+    fn mark_own_task_as_dirty_when_persisted(&self, _task: TaskId) {
         // no-op
     }
 

--- a/turbopack/crates/turbo-tasks/Cargo.toml
+++ b/turbopack/crates/turbo-tasks/Cargo.toml
@@ -28,7 +28,7 @@ futures = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 mopa = "0.2.0"
 once_cell = { workspace = true }
-parking_lot = { workspace = true }
+parking_lot = { workspace = true, features = ["serde"]}
 pin-project-lite = { workspace = true }
 regex = { workspace = true }
 rustc-hash = { workspace = true }

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -455,6 +455,13 @@ pub trait Backend: Sync + Send {
     fn invalidate_tasks(&self, tasks: &[TaskId], turbo_tasks: &dyn TurboTasksBackendApi<Self>);
     fn invalidate_tasks_set(&self, tasks: &TaskIdSet, turbo_tasks: &dyn TurboTasksBackendApi<Self>);
 
+    fn invalidate_serialization(
+        &self,
+        _task: TaskId,
+        _turbo_tasks: &dyn TurboTasksBackendApi<Self>,
+    ) {
+    }
+
     fn get_task_description(&self, task: TaskId) -> String;
 
     /// Task-local state that stored inside of [`TurboTasksBackendApi`]. Constructed with
@@ -616,6 +623,14 @@ pub trait Backend: Sync + Send {
     );
 
     fn mark_own_task_as_finished(
+        &self,
+        _task: TaskId,
+        _turbo_tasks: &dyn TurboTasksBackendApi<Self>,
+    ) {
+        // Do nothing by default
+    }
+
+    fn mark_own_task_as_dirty_when_persisted(
         &self,
         _task: TaskId,
         _turbo_tasks: &dyn TurboTasksBackendApi<Self>,

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -62,6 +62,7 @@ mod raw_vc;
 mod rcstr;
 mod read_ref;
 pub mod registry;
+mod serialization_invalidation;
 pub mod small_duration;
 mod state;
 pub mod task;
@@ -91,16 +92,17 @@ pub use invalidation::{
 pub use join_iter_ext::{JoinIterExt, TryFlatJoinIterExt, TryJoinIterExt};
 pub use magic_any::MagicAny;
 pub use manager::{
-    dynamic_call, dynamic_this_call, emit, mark_finished, mark_stateful, prevent_gc, run_once,
-    run_once_with_reason, spawn_blocking, spawn_thread, trait_call, turbo_tasks, CurrentCellRef,
-    ReadConsistency, TaskPersistence, TurboTasks, TurboTasksApi, TurboTasksBackendApi,
-    TurboTasksBackendApiExt, TurboTasksCallApi, Unused, UpdateInfo,
+    dynamic_call, dynamic_this_call, emit, mark_dirty_when_persisted, mark_finished, mark_stateful,
+    prevent_gc, run_once, run_once_with_reason, spawn_blocking, spawn_thread, trait_call,
+    turbo_tasks, CurrentCellRef, ReadConsistency, TaskPersistence, TurboTasks, TurboTasksApi,
+    TurboTasksBackendApi, TurboTasksBackendApiExt, TurboTasksCallApi, Unused, UpdateInfo,
 };
 pub use native_function::{FunctionMeta, NativeFunction};
 pub use raw_vc::{CellId, RawVc, ReadRawVcFuture, ResolveTypeError};
 pub use read_ref::ReadRef;
 use rustc_hash::FxHasher;
-pub use state::State;
+pub use serialization_invalidation::SerializationInvalidator;
+pub use state::{State, TransientState};
 pub use task::{task_input::TaskInput, SharedReference};
 pub use trait_ref::{IntoTraitRef, TraitRef};
 pub use turbo_tasks_macros::{function, value, value_impl, value_trait, TaskInput};

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -39,6 +39,7 @@ use crate::{
     magic_any::MagicAny,
     raw_vc::{CellId, RawVc},
     registry::{self, get_function},
+    serialization_invalidation::SerializationInvalidator,
     task::shared_reference::TypedSharedReference,
     trace::TraceRawVcs,
     trait_helpers::get_trait_method,
@@ -115,6 +116,8 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
     fn invalidate(&self, task: TaskId);
     fn invalidate_with_reason(&self, task: TaskId, reason: StaticOrArc<dyn InvalidationReason>);
 
+    fn invalidate_serialization(&self, task: TaskId);
+
     /// Eagerly notifies all tasks that were scheduled for notifications via
     /// `schedule_notify_tasks_set()`
     fn notify_scheduled_tasks(&self);
@@ -180,6 +183,7 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
     fn read_own_task_cell(&self, task: TaskId, index: CellId) -> Result<TypedCellContent>;
     fn update_own_task_cell(&self, task: TaskId, index: CellId, content: CellContent);
     fn mark_own_task_as_finished(&self, task: TaskId);
+    fn mark_own_task_as_dirty_when_persisted(&self, task: TaskId);
 
     fn connect_task(&self, task: TaskId);
 
@@ -1256,6 +1260,10 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         self.backend.invalidate_task(task, self);
     }
 
+    fn invalidate_serialization(&self, task: TaskId) {
+        self.backend.invalidate_serialization(task, self);
+    }
+
     fn notify_scheduled_tasks(&self) {
         let _ = CURRENT_GLOBAL_TASK_STATE.try_with(|cell| {
             let tasks = {
@@ -1393,6 +1401,11 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
 
     fn mark_own_task_as_finished(&self, task: TaskId) {
         self.backend.mark_own_task_as_finished(task, self);
+    }
+
+    fn mark_own_task_as_dirty_when_persisted(&self, task: TaskId) {
+        self.backend
+            .mark_own_task_as_dirty_when_persisted(task, self);
     }
 
     /// Creates a future that inherits the current task id and task state. The current global task
@@ -1677,6 +1690,15 @@ pub fn current_task_for_testing() -> TaskId {
     CURRENT_GLOBAL_TASK_STATE.with(|ts| ts.read().unwrap().task_id)
 }
 
+/// Marks the current task as dirty when restored from persistent cache.
+pub fn mark_dirty_when_persisted() {
+    with_turbo_tasks(|tt| {
+        tt.mark_own_task_as_dirty_when_persisted(current_task(
+            "turbo_tasks::mark_dirty_when_persisted()",
+        ))
+    });
+}
+
 /// Marks the current task as finished. This excludes it from waiting for
 /// strongly consistency.
 pub fn mark_finished() {
@@ -1687,10 +1709,15 @@ pub fn mark_finished() {
 
 /// Marks the current task as stateful. This prevents the tasks from being
 /// dropped without persisting the state.
-pub fn mark_stateful() {
+/// Returns a [`SerializationInvalidator`] that can be used to invalidate the
+/// serialization of the current task cells
+pub fn mark_stateful() -> SerializationInvalidator {
     CURRENT_GLOBAL_TASK_STATE.with(|cell| {
-        let CurrentGlobalTaskState { stateful, .. } = &mut *cell.write().unwrap();
+        let CurrentGlobalTaskState {
+            stateful, task_id, ..
+        } = &mut *cell.write().unwrap();
         *stateful = true;
+        SerializationInvalidator::new(*task_id)
     })
 }
 

--- a/turbopack/crates/turbo-tasks/src/serialization_invalidation.rs
+++ b/turbopack/crates/turbo-tasks/src/serialization_invalidation.rs
@@ -1,0 +1,95 @@
+use std::{
+    hash::Hash,
+    sync::{Arc, Weak},
+};
+
+use serde::{de::Visitor, Deserialize, Serialize};
+use tokio::runtime::Handle;
+
+use crate::{manager::with_turbo_tasks, trace::TraceRawVcs, TaskId, TurboTasksApi};
+
+pub struct SerializationInvalidator {
+    task: TaskId,
+    turbo_tasks: Weak<dyn TurboTasksApi>,
+    handle: Handle,
+}
+
+impl Hash for SerializationInvalidator {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.task.hash(state);
+    }
+}
+
+impl PartialEq for SerializationInvalidator {
+    fn eq(&self, other: &Self) -> bool {
+        self.task == other.task
+    }
+}
+
+impl Eq for SerializationInvalidator {}
+
+impl SerializationInvalidator {
+    pub fn invalidate(&self) {
+        let SerializationInvalidator {
+            task,
+            turbo_tasks,
+            handle,
+        } = self;
+        let _ = handle.enter();
+        if let Some(turbo_tasks) = turbo_tasks.upgrade() {
+            turbo_tasks.invalidate_serialization(*task);
+        }
+    }
+
+    pub(crate) fn new(task_id: TaskId) -> Self {
+        Self {
+            task: task_id,
+            turbo_tasks: with_turbo_tasks(Arc::downgrade),
+            handle: Handle::current(),
+        }
+    }
+}
+
+impl TraceRawVcs for SerializationInvalidator {
+    fn trace_raw_vcs(&self, _context: &mut crate::trace::TraceRawVcsContext) {
+        // nothing here
+    }
+}
+
+impl Serialize for SerializationInvalidator {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_newtype_struct("SerializationInvalidator", &self.task)
+    }
+}
+
+impl<'de> Deserialize<'de> for SerializationInvalidator {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct V;
+
+        impl<'de> Visitor<'de> for V {
+            type Value = SerializationInvalidator;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(f, "an SerializationInvalidator")
+            }
+
+            fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                Ok(SerializationInvalidator {
+                    task: TaskId::deserialize(deserializer)?,
+                    turbo_tasks: with_turbo_tasks(Arc::downgrade),
+                    handle: tokio::runtime::Handle::current(),
+                })
+            }
+        }
+        deserializer.deserialize_newtype_struct("SerializationInvalidator", V)
+    }
+}

--- a/turbopack/crates/turbo-tasks/src/state.rs
+++ b/turbopack/crates/turbo-tasks/src/state.rs
@@ -254,15 +254,6 @@ impl<T> PartialEq for TransientState<T> {
 }
 impl<T> Eq for TransientState<T> {}
 
-impl<T> Drop for TransientState<T> {
-    fn drop(&mut self) {
-        let mut inner = self.inner.lock();
-        for invalidator in take(&mut inner.invalidators) {
-            invalidator.invalidate();
-        }
-    }
-}
-
 impl<T> TransientState<T> {
     pub fn new() -> Self {
         mark_stateful();

--- a/turbopack/crates/turbo-tasks/src/state.rs
+++ b/turbopack/crates/turbo-tasks/src/state.rs
@@ -6,22 +6,100 @@ use std::{
 
 use auto_hash_map::AutoSet;
 use parking_lot::{Mutex, MutexGuard};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 
-use crate::{get_invalidator, mark_stateful, trace::TraceRawVcs, Invalidator};
+use crate::{
+    get_invalidator, mark_dirty_when_persisted, mark_stateful, trace::TraceRawVcs, Invalidator,
+    SerializationInvalidator,
+};
 
-pub struct State<T> {
-    inner: Mutex<StateInner<T>>,
-}
-
+#[derive(Serialize, Deserialize)]
 struct StateInner<T> {
     value: T,
     invalidators: AutoSet<Invalidator>,
 }
 
+impl<T> StateInner<T> {
+    pub fn new(value: T) -> Self {
+        Self {
+            value,
+            invalidators: AutoSet::new(),
+        }
+    }
+
+    pub fn add_invalidator(&mut self, invalidator: Invalidator) {
+        self.invalidators.insert(invalidator);
+    }
+
+    pub fn set_unconditionally(&mut self, value: T) {
+        self.value = value;
+        for invalidator in take(&mut self.invalidators) {
+            invalidator.invalidate();
+        }
+    }
+
+    pub fn update_conditionally(&mut self, update: impl FnOnce(&mut T) -> bool) -> bool {
+        if !update(&mut self.value) {
+            return false;
+        }
+        for invalidator in take(&mut self.invalidators) {
+            invalidator.invalidate();
+        }
+        true
+    }
+}
+
+impl<T: PartialEq> StateInner<T> {
+    pub fn set(&mut self, value: T) -> bool {
+        if self.value == value {
+            return false;
+        }
+        self.value = value;
+        for invalidator in take(&mut self.invalidators) {
+            invalidator.invalidate();
+        }
+        true
+    }
+}
+
 pub struct StateRef<'a, T> {
+    serialization_invalidator: Option<&'a SerializationInvalidator>,
     inner: MutexGuard<'a, StateInner<T>>,
     mutated: bool,
+}
+
+impl<'a, T> Deref for StateRef<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner.value
+    }
+}
+
+impl<'a, T> DerefMut for StateRef<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.mutated = true;
+        &mut self.inner.value
+    }
+}
+
+impl<'a, T> Drop for StateRef<'a, T> {
+    fn drop(&mut self) {
+        if self.mutated {
+            for invalidator in take(&mut self.inner.invalidators) {
+                invalidator.invalidate();
+            }
+            if let Some(serialization_invalidator) = self.serialization_invalidator {
+                serialization_invalidator.invalidate();
+            }
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct State<T> {
+    serialization_invalidator: SerializationInvalidator,
+    inner: Mutex<StateInner<T>>,
 }
 
 impl<T: Debug> Debug for State<T> {
@@ -52,30 +130,11 @@ impl<T> PartialEq for State<T> {
 }
 impl<T> Eq for State<T> {}
 
-impl<T> Serialize for State<T> {
-    fn serialize<S: serde::Serializer>(&self, _serializer: S) -> Result<S::Ok, S::Error> {
-        // For this to work at all we need to do more. Changing the state need to
-        // invalidate the serialization of the task that contains the state. So we
-        // probably need to store the state outside of the task to be able to serialize
-        // it independent from the creating task.
-        panic!("State serialization is not implemented yet");
-    }
-}
-
-impl<'de, T> Deserialize<'de> for State<T> {
-    fn deserialize<D: Deserializer<'de>>(_deserializer: D) -> Result<Self, D::Error> {
-        panic!("State serialization is not implemented yet");
-    }
-}
-
 impl<T> State<T> {
     pub fn new(value: T) -> Self {
-        mark_stateful();
         Self {
-            inner: Mutex::new(StateInner {
-                value,
-                invalidators: AutoSet::new(),
-            }),
+            serialization_invalidator: mark_stateful(),
+            inner: Mutex::new(StateInner::new(value)),
         }
     }
 
@@ -85,8 +144,9 @@ impl<T> State<T> {
     pub fn get(&self) -> StateRef<'_, T> {
         let invalidator = get_invalidator();
         let mut inner = self.inner.lock();
-        inner.invalidators.insert(invalidator);
+        inner.add_invalidator(invalidator);
         StateRef {
+            serialization_invalidator: Some(&self.serialization_invalidator),
             inner,
             mutated: false,
         }
@@ -96,6 +156,141 @@ impl<T> State<T> {
     pub fn get_untracked(&self) -> StateRef<'_, T> {
         let inner = self.inner.lock();
         StateRef {
+            serialization_invalidator: Some(&self.serialization_invalidator),
+            inner,
+            mutated: false,
+        }
+    }
+
+    /// Sets the current state without comparing it with the old value. This
+    /// should only be used if one is sure that the value has changed.
+    pub fn set_unconditionally(&self, value: T) {
+        {
+            let mut inner = self.inner.lock();
+            inner.set_unconditionally(value);
+        }
+        self.serialization_invalidator.invalidate();
+    }
+
+    /// Updates the current state with the `update` function. The `update`
+    /// function need to return `true` when the value was modified. Exposing
+    /// the current value from the `update` function is not allowed and will
+    /// result in incorrect cache invalidation.
+    pub fn update_conditionally(&self, update: impl FnOnce(&mut T) -> bool) {
+        {
+            let mut inner = self.inner.lock();
+            if !inner.update_conditionally(update) {
+                return;
+            }
+        }
+        self.serialization_invalidator.invalidate();
+    }
+}
+
+impl<T: PartialEq> State<T> {
+    /// Update the current state when the `value` is different from the current
+    /// value. `T` must implement [PartialEq] for this to work.
+    pub fn set(&self, value: T) {
+        {
+            let mut inner = self.inner.lock();
+            if !inner.set(value) {
+                return;
+            }
+        }
+        self.serialization_invalidator.invalidate();
+    }
+}
+
+pub struct TransientState<T> {
+    inner: Mutex<StateInner<Option<T>>>,
+}
+
+impl<T> Serialize for TransientState<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        Serialize::serialize(&(), serializer)
+    }
+}
+
+impl<'de, T> Deserialize<'de> for TransientState<T> {
+    fn deserialize<D>(deserializer: D) -> Result<TransientState<T>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let () = Deserialize::deserialize(deserializer)?;
+        Ok(TransientState {
+            inner: Mutex::new(StateInner::new(Default::default())),
+        })
+    }
+}
+
+impl<T: Debug> Debug for TransientState<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TransientState")
+            .field("value", &self.inner.lock().value)
+            .finish()
+    }
+}
+
+impl<T: TraceRawVcs> TraceRawVcs for TransientState<T> {
+    fn trace_raw_vcs(&self, trace_context: &mut crate::trace::TraceRawVcsContext) {
+        self.inner.lock().value.trace_raw_vcs(trace_context);
+    }
+}
+
+impl<T> Default for TransientState<T> {
+    fn default() -> Self {
+        // Need to be explicit to ensure marking as stateful.
+        Self::new()
+    }
+}
+
+impl<T> PartialEq for TransientState<T> {
+    fn eq(&self, _other: &Self) -> bool {
+        false
+    }
+}
+impl<T> Eq for TransientState<T> {}
+
+impl<T> Drop for TransientState<T> {
+    fn drop(&mut self) {
+        let mut inner = self.inner.lock();
+        for invalidator in take(&mut inner.invalidators) {
+            invalidator.invalidate();
+        }
+    }
+}
+
+impl<T> TransientState<T> {
+    pub fn new() -> Self {
+        mark_stateful();
+        Self {
+            inner: Mutex::new(StateInner::new(None)),
+        }
+    }
+
+    /// Gets the current value of the state. The current task will be registered
+    /// as dependency of the state and will be invalidated when the state
+    /// changes.
+    pub fn get(&self) -> StateRef<'_, Option<T>> {
+        mark_dirty_when_persisted();
+        let invalidator = get_invalidator();
+        let mut inner = self.inner.lock();
+        inner.add_invalidator(invalidator);
+        StateRef {
+            serialization_invalidator: None,
+            inner,
+            mutated: false,
+        }
+    }
+
+    /// Gets the current value of the state. Untracked.
+    pub fn get_untracked(&self) -> StateRef<'_, Option<T>> {
+        let inner = self.inner.lock();
+        StateRef {
+            serialization_invalidator: None,
             inner,
             mutated: false,
         }
@@ -105,63 +300,37 @@ impl<T> State<T> {
     /// should only be used if one is sure that the value has changed.
     pub fn set_unconditionally(&self, value: T) {
         let mut inner = self.inner.lock();
-        inner.value = value;
-        for invalidator in take(&mut inner.invalidators) {
-            invalidator.invalidate();
-        }
+        inner.set_unconditionally(Some(value));
+    }
+
+    /// Unset the current value without comparing it with the old value. This
+    /// should only be used if one is sure that the value has changed.
+    pub fn unset_unconditionally(&self) {
+        let mut inner = self.inner.lock();
+        inner.set_unconditionally(None);
     }
 
     /// Updates the current state with the `update` function. The `update`
     /// function need to return `true` when the value was modified. Exposing
     /// the current value from the `update` function is not allowed and will
     /// result in incorrect cache invalidation.
-    pub fn update_conditionally(&self, update: impl FnOnce(&mut T) -> bool) {
+    pub fn update_conditionally(&self, update: impl FnOnce(&mut Option<T>) -> bool) {
         let mut inner = self.inner.lock();
-        if !update(&mut inner.value) {
-            return;
-        }
-        for invalidator in take(&mut inner.invalidators) {
-            invalidator.invalidate();
-        }
+        inner.update_conditionally(update);
     }
 }
 
-impl<T: PartialEq> State<T> {
+impl<T: PartialEq> TransientState<T> {
     /// Update the current state when the `value` is different from the current
     /// value. `T` must implement [PartialEq] for this to work.
     pub fn set(&self, value: T) {
         let mut inner = self.inner.lock();
-        if inner.value == value {
-            return;
-        }
-        inner.value = value;
-        for invalidator in take(&mut inner.invalidators) {
-            invalidator.invalidate();
-        }
+        inner.set(Some(value));
     }
-}
 
-impl<'a, T> Deref for StateRef<'a, T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner.value
-    }
-}
-
-impl<'a, T> DerefMut for StateRef<'a, T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.mutated = true;
-        &mut self.inner.value
-    }
-}
-
-impl<'a, T> Drop for StateRef<'a, T> {
-    fn drop(&mut self) {
-        if self.mutated {
-            for invalidator in take(&mut self.inner.invalidators) {
-                invalidator.invalidate();
-            }
-        }
+    /// Unset the current value.
+    pub fn unset(&self) {
+        let mut inner = self.inner.lock();
+        inner.set(None);
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -247,8 +247,7 @@ pub struct EcmascriptModuleAsset {
     pub compile_time_info: Vc<CompileTimeInfo>,
     pub inner_assets: Option<Vc<InnerAssets>>,
     #[turbo_tasks(debug_ignore)]
-    #[serde(skip)]
-    last_successful_parse: turbo_tasks::State<Option<ReadRef<ParseResult>>>,
+    last_successful_parse: turbo_tasks::TransientState<ReadRef<ParseResult>>,
 }
 
 #[turbo_tasks::value_trait]
@@ -341,8 +340,7 @@ impl EcmascriptParsable for EcmascriptModuleAsset {
         let real_result_value = real_result.await?;
         let this = self.await?;
         let result_value = if matches!(*real_result_value, ParseResult::Ok { .. }) {
-            this.last_successful_parse
-                .set(Some(real_result_value.clone()));
+            this.last_successful_parse.set(real_result_value.clone());
             real_result_value
         } else {
             let state_ref = this.last_successful_parse.get();


### PR DESCRIPTION
### What?

State need some special handling for persistent caching. In particular we need to differ between two kind of states:

* Persistent State: It will be stored in the persistent cache and value will be kept between builds.
* Transient State: It's only valid for a session and will reset when restoring the persistent cache.

We didn't have the separating before, so this PR introduces a new type `TransientState<T>` next to `State<T>` which handles transient state. The value will always be an `Option<T>` and resets to `None` when restoring the persistent cache. This also means all task that depend on transient state will be invalidated on restoring.

Transient State can also be used when the value is not serializable. e. g. this is the case for the `last_successful_parse` state in ecmascript modules. We use that to avoid large structure changes to the module graph when introducing parse errors to modules. Using transient state for that means we only apply this optimization on a session, and it resets when restoring from persistent cache.
