### PR TITLE
feat(turbopack): add support for polling file watcher

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -199,6 +199,7 @@ impl From<NapiWatchOptions> for WatchOptions {
             enable: val.enable,
             poll_interval: val
                 .poll_interval_ms
+                .filter(|interval| !interval.is_nan() && interval.is_finite() && *interval > 0.0)
                 .map(|interval| Duration::from_secs_f64(interval / 1000.0)),
         }
     }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -542,7 +542,7 @@ impl Project {
         if self.watch.enable {
             disk_fs
                 .await?
-                .start_watching_with_invalidation_reason(this.watch.poll_interval)?;
+                .start_watching_with_invalidation_reason(self.watch.poll_interval)?;
         }
         Ok(disk_fs)
     }

--- a/crates/next-build-test/src/lib.rs
+++ b/crates/next-build-test/src/lib.rs
@@ -31,10 +31,10 @@ pub async fn main_inner(
 
     if matches!(strat, Strategy::Development { .. }) {
         options.dev = true;
-        options.watch = true;
+        options.watch.enable = true;
     } else {
         options.dev = false;
-        options.watch = false;
+        options.watch.enable = false;
     }
 
     let project = tt

--- a/crates/next-build-test/src/main.rs
+++ b/crates/next-build-test/src/main.rs
@@ -153,7 +153,7 @@ fn main() {
                 },
                 project_path: canonical_path.to_string_lossy().into(),
                 root_path: "/".into(),
-                watch: false,
+                watch: Default::default(),
                 browserslist_query: "last 1 Chrome versions, last 1 Firefox versions, last 1 \
                                      Safari versions, last 1 Edge versions"
                     .into(),

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1370,7 +1370,9 @@ export default async function build(
               dir,
             nextConfig: config,
             jsConfig: await getTurbopackJsConfig(dir, config),
-            watch: false,
+            watch: {
+              enable: false,
+            },
             dev,
             env: process.env as Record<string, string>,
             defineEnv: createDefineEnv({

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -82,6 +82,15 @@ export interface NapiDraftModeOptions {
   previewModeEncryptionKey: string
   previewModeSigningKey: string
 }
+export interface NapiWatchOptions {
+  /** Whether to watch the filesystem for file changes. */
+  enable: boolean
+  /**
+   * Enable polling at a certain interval if the native file watching doesn't work (e.g.
+   * docker).
+   */
+  pollIntervalMs?: number
+}
 export interface NapiProjectOptions {
   /**
    * A root path from which all files must be nested under. Trying to access
@@ -95,8 +104,8 @@ export interface NapiProjectOptions {
    * deserializing next.config, so passing it as separate option.
    */
   distDir?: string
-  /** Whether to watch he filesystem for file changes. */
-  watch: boolean
+  /** Filesystem watcher options. */
+  watch: NapiWatchOptions
   /** The contents of next.config.js, serialized to JSON. */
   nextConfig: string
   /** The contents of ts/config read by load-jsconfig, serialized to JSON. */
@@ -133,8 +142,8 @@ export interface NapiPartialProjectOptions {
    * deserializing next.config, so passing it as separate option.
    */
   distDir?: string | undefined | null
-  /** Whether to watch he filesystem for file changes. */
-  watch?: boolean
+  /** Filesystem watcher options. */
+  watch?: NapiWatchOptions
   /** The contents of next.config.js, serialized to JSON. */
   nextConfig?: string
   /** The contents of ts/config read by load-jsconfig, serialized to JSON. */

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -346,7 +346,10 @@ export interface ProjectOptions {
   /**
    * Whether to watch the filesystem for file changes.
    */
-  watch: boolean
+  watch: {
+    enable: boolean
+    pollIntervalMs?: number
+  }
 
   /**
    * The mode in which Next.js is running.

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -137,7 +137,7 @@ const nodePathList = (process.env.NODE_PATH || '')
   .split(process.platform === 'win32' ? ';' : ':')
   .filter((p) => !!p)
 
-const watchOptions = Object.freeze({
+const baseWatchOptions: webpack.Configuration['watchOptions'] = Object.freeze({
   aggregateTimeout: 5,
   ignored:
     // Matches **/node_modules/**, **/.git/** and **/.next/**
@@ -1105,7 +1105,10 @@ export default async function getBaseWebpackConfig(
         ...entrypoints,
       }
     },
-    watchOptions,
+    watchOptions: Object.freeze({
+      ...baseWatchOptions,
+      poll: config.watchOptions?.pollIntervalMs,
+    }),
     output: {
       // we must set publicPath to an empty value to override the default of
       // auto which doesn't work in IE11

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -627,5 +627,10 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
     useFileSystemPublicRoutes: z.boolean().optional(),
     // The webpack config type is unknown, use z.any() here
     webpack: z.any().nullable().optional(),
+    watchOptions: z
+      .strictObject({
+        pollIntervalMs: z.number().positive().finite().optional(),
+      })
+      .optional(),
   })
 )

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -944,6 +944,10 @@ export interface NextConfig extends Record<string, any> {
    * were not detected on a per-page basis.
    */
   outputFileTracingIncludes?: Record<string, string[]>
+
+  watchOptions?: {
+    pollIntervalMs?: number
+  }
 }
 
 export const defaultConfig: NextConfig = {

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -152,7 +152,10 @@ export async function createHotReloaderTurbopack(
         dir,
       nextConfig: opts.nextConfig,
       jsConfig: await getTurbopackJsConfig(dir, nextConfig),
-      watch: dev,
+      watch: {
+        enable: dev,
+        pollIntervalMs: nextConfig.watchOptions?.pollIntervalMs,
+      },
       dev,
       env: process.env as Record<string, string>,
       defineEnv: createDefineEnv({

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -200,7 +200,9 @@ describe('next.rs api', () => {
       rootPath: process.env.NEXT_SKIP_ISOLATE
         ? path.resolve(__dirname, '../../..')
         : next.testDir,
-      watch: true,
+      watch: {
+        enable: true,
+      },
       dev: true,
       defineEnv: createDefineEnv({
         isTurbopack: true,

--- a/turbopack/crates/node-file-trace/src/lib.rs
+++ b/turbopack/crates/node-file-trace/src/lib.rs
@@ -190,7 +190,7 @@ impl Args {
 async fn create_fs(name: &str, root: &str, watch: bool) -> Result<Vc<Box<dyn FileSystem>>> {
     let fs = DiskFileSystem::new(name.into(), root.into(), vec![]);
     if watch {
-        fs.await?.start_watching()?;
+        fs.await?.start_watching(None)?;
     } else {
         fs.await?.invalidate_with_reason();
     }

--- a/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
+++ b/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
         Box::pin(async {
             let root = current_dir().unwrap().to_str().unwrap().into();
             let disk_fs = DiskFileSystem::new("project".into(), root, vec![]);
-            disk_fs.await?.start_watching()?;
+            disk_fs.await?.start_watching(None)?;
 
             // Smart Pointer cast
             let fs: Vc<Box<dyn FileSystem>> = Vc::upcast(disk_fs);

--- a/turbopack/crates/turbo-tasks-fs/examples/hash_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/examples/hash_glob.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
         Box::pin(async {
             let root = current_dir().unwrap().to_str().unwrap().into();
             let disk_fs = DiskFileSystem::new("project".into(), root, vec![]);
-            disk_fs.await?.start_watching()?;
+            disk_fs.await?.start_watching(None)?;
 
             // Smart Pointer cast
             let fs: Vc<Box<dyn FileSystem>> = Vc::upcast(disk_fs);

--- a/turbopack/crates/turbo-tasks-fs/src/embed/dir.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/dir.rs
@@ -12,7 +12,7 @@ pub async fn directory_from_relative_path(
     path: RcStr,
 ) -> Result<Vc<Box<dyn FileSystem>>> {
     let disk_fs = DiskFileSystem::new(name, path, vec![]);
-    disk_fs.await?.start_watching()?;
+    disk_fs.await?.start_watching(None)?;
 
     Ok(Vc::upcast(disk_fs))
 }

--- a/turbopack/crates/turbo-tasks-fs/src/embed/file.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/file.rs
@@ -23,7 +23,7 @@ pub async fn content_from_relative_path(
         root_path.to_string_lossy().into(),
         vec![],
     );
-    disk_fs.await?.start_watching()?;
+    disk_fs.await?.start_watching(None)?;
 
     let fs_path = disk_fs.root().join(path.into());
     Ok(fs_path.read())

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -36,6 +36,7 @@ use std::{
     mem::take,
     path::{Path, PathBuf, MAIN_SEPARATOR},
     sync::Arc,
+    time::Duration,
 };
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -59,7 +60,7 @@ use tokio::{
 use tracing::Instrument;
 use turbo_tasks::{
     mark_stateful, trace::TraceRawVcs, Completion, Invalidator, RcStr, ReadRef,
-    SerializationInvalidator, ValueToString, Vc,
+    SerializationInvalidator, ValueDefault, ValueToString, Vc,
 };
 use turbo_tasks_hash::{
     hash_xxh3_hash128, hash_xxh3_hash64, DeterministicHash, DeterministicHasher,
@@ -299,15 +300,22 @@ impl DiskFileSystem {
         self.serialization_invalidator.invalidate();
     }
 
-    pub fn start_watching(&self) -> Result<()> {
-        self.start_watching_internal(false)
+    pub fn start_watching(&self, poll_interval: Option<Duration>) -> Result<()> {
+        self.start_watching_internal(false, poll_interval)
     }
 
-    pub fn start_watching_with_invalidation_reason(&self) -> Result<()> {
-        self.start_watching_internal(true)
+    pub fn start_watching_with_invalidation_reason(
+        &self,
+        poll_interval: Option<Duration>,
+    ) -> Result<()> {
+        self.start_watching_internal(true, poll_interval)
     }
 
-    fn start_watching_internal(&self, report_invalidation_reason: bool) -> Result<()> {
+    fn start_watching_internal(
+        &self,
+        report_invalidation_reason: bool,
+        poll_interval: Option<Duration>,
+    ) -> Result<()> {
         let _span = tracing::info_span!("start filesystem watching", path = &*self.root).entered();
         let invalidator_map = self.invalidator_map.clone();
         let dir_invalidator_map = self.dir_invalidator_map.clone();
@@ -324,6 +332,7 @@ impl DiskFileSystem {
             invalidation_lock,
             invalidator_map,
             dir_invalidator_map,
+            poll_interval,
         )?;
         self.serialization_invalidator.invalidate();
 
@@ -388,6 +397,20 @@ fn format_absolute_fs_path(path: &Path, name: &str, root_path: &Path) -> Option<
 
 pub fn path_to_key(path: impl AsRef<Path>) -> String {
     path.as_ref().to_string_lossy().to_string()
+}
+
+#[turbo_tasks::value(shared)]
+#[derive(Default)]
+pub struct DiskFileSystemConfig {
+    pub poll_interval: Option<Duration>,
+}
+
+#[turbo_tasks::value_impl]
+impl ValueDefault for DiskFileSystemConfig {
+    #[turbo_tasks::function]
+    fn value_default() -> Vc<Self> {
+        Self::default().cell()
+    }
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -60,7 +60,7 @@ use tokio::{
 use tracing::Instrument;
 use turbo_tasks::{
     mark_stateful, trace::TraceRawVcs, Completion, Invalidator, RcStr, ReadRef,
-    SerializationInvalidator, ValueDefault, ValueToString, Vc,
+    SerializationInvalidator, ValueToString, Vc,
 };
 use turbo_tasks_hash::{
     hash_xxh3_hash128, hash_xxh3_hash64, DeterministicHash, DeterministicHasher,
@@ -397,20 +397,6 @@ fn format_absolute_fs_path(path: &Path, name: &str, root_path: &Path) -> Option<
 
 pub fn path_to_key(path: impl AsRef<Path>) -> String {
     path.as_ref().to_string_lossy().to_string()
-}
-
-#[turbo_tasks::value(shared)]
-#[derive(Default)]
-pub struct DiskFileSystemConfig {
-    pub poll_interval: Option<Duration>,
-}
-
-#[turbo_tasks::value_impl]
-impl ValueDefault for DiskFileSystemConfig {
-    #[turbo_tasks::function]
-    fn value_default() -> Vc<Self> {
-        Self::default().cell()
-    }
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbo-tasks/src/primitives.rs
+++ b/turbopack/crates/turbo-tasks/src/primitives.rs
@@ -1,4 +1,4 @@
-use std::{future::IntoFuture, ops::Deref};
+use std::{future::IntoFuture, ops::Deref, time::Duration};
 
 use anyhow::Result;
 use futures::TryFutureExt;
@@ -71,6 +71,7 @@ __turbo_tasks_internal_primitive!(i128);
 __turbo_tasks_internal_primitive!(usize);
 __turbo_tasks_internal_primitive!(isize);
 __turbo_tasks_internal_primitive!(serde_json::Value);
+__turbo_tasks_internal_primitive!(Duration);
 __turbo_tasks_internal_primitive!(Vec<u8>);
 
 __turbo_tasks_internal_primitive!(Vec<bool>);

--- a/turbopack/crates/turbo-tasks/src/task/task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_input.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, fmt::Debug, future::Future, hash::Hash};
+use std::{any::Any, fmt::Debug, future::Future, hash::Hash, time::Duration};
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -40,7 +40,8 @@ impl_task_input! {
     usize,
     RcStr,
     TaskId,
-    ValueTypeId
+    ValueTypeId,
+    Duration
 }
 
 impl<T> TaskInput for Vec<T>

--- a/turbopack/crates/turbopack-cli/src/util.rs
+++ b/turbopack/crates/turbopack-cli/src/util.rs
@@ -62,13 +62,13 @@ pub fn normalize_entries(entries: &Option<Vec<String>>) -> Vec<RcStr> {
 #[turbo_tasks::function]
 pub async fn project_fs(project_dir: RcStr) -> Result<Vc<Box<dyn FileSystem>>> {
     let disk_fs = DiskFileSystem::new("project".into(), project_dir, vec![]);
-    disk_fs.await?.start_watching()?;
+    disk_fs.await?.start_watching(None)?;
     Ok(Vc::upcast(disk_fs))
 }
 
 #[turbo_tasks::function]
 pub async fn output_fs(project_dir: RcStr) -> Result<Vc<Box<dyn FileSystem>>> {
     let disk_fs = DiskFileSystem::new("output".into(), project_dir, vec![]);
-    disk_fs.await?.start_watching()?;
+    disk_fs.await?.start_watching(None)?;
     Ok(Vc::upcast(disk_fs))
 }

--- a/turbopack/crates/turbopack/examples/turbopack.rs
+++ b/turbopack/crates/turbopack/examples/turbopack.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
         Box::pin(async {
             let root: RcStr = current_dir().unwrap().to_str().unwrap().into();
             let disk_fs = DiskFileSystem::new(PROJECT_FILESYSTEM_NAME.into(), root, vec![]);
-            disk_fs.await?.start_watching()?;
+            disk_fs.await?.start_watching(None)?;
 
             // Smart Pointer cast
             let fs: Vc<Box<dyn FileSystem>> = Vc::upcast(disk_fs);


### PR DESCRIPTION
### What?
The normal file watcher doesn't work inside a docker container, the workaround is to enable a polling file watcher, which was supported in webpack but not turbopack so far.

This PR adds support for a polling file watcher to turbopack and a `next.config.js` option to configure the polling file watcher for both webpack and turbopack.


Unfortunately, the rust file watcher seems to be a lot slower than the poll interval.

Closes PACK-3206
Fixes #68255
