### PR TITLE
docs(usePathname): add note about using usePathname with rewrites

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/use-pathname.mdx
+++ b/docs/02-app/02-api-reference/04-functions/use-pathname.mdx
@@ -36,7 +36,7 @@ For example, a Client Component with `usePathname` will be rendered into HTML on
 > - Reading the current URL from a [Server Component](/docs/app/building-your-application/rendering/server-components) is not supported. This design is intentional to support layout state being preserved across page navigations.
 > - Compatibility mode:
 >   - `usePathname` can return `null` when a [fallback route](/docs/pages/api-reference/functions/get-static-paths#fallback-true) is being rendered or when a `pages` directory page has been [automatically statically optimized](/docs/pages/building-your-application/rendering/automatic-static-optimization) by Next.js and the router is not ready.
->   - When using `usePathname` with [rewrites](/docs/app/api-reference/next-config-js/rewrites), `useState` and `useEffect` must also be used in order to avoid hydration mismatch errors. See the [rewrites example](https://github.com/vercel/next.js/tree/canary/examples/rewrites) for more information.
+>   - When using `usePathname` with rewrites in [`next.config`](/docs/app/api-reference/next-config-js/rewrites) or [`Middleware`](/docs/app/building-your-application/routing/middleware), `useState` and `useEffect` must also be used in order to avoid hydration mismatch errors. See the [rewrites example](https://github.com/vercel/next.js/tree/canary/examples/rewrites) for more information.
 >   - Next.js will automatically update your types if it detects both an `app` and `pages` directory in your project.
 
 ## Parameters

--- a/docs/02-app/02-api-reference/04-functions/use-pathname.mdx
+++ b/docs/02-app/02-api-reference/04-functions/use-pathname.mdx
@@ -36,6 +36,7 @@ For example, a Client Component with `usePathname` will be rendered into HTML on
 > - Reading the current URL from a [Server Component](/docs/app/building-your-application/rendering/server-components) is not supported. This design is intentional to support layout state being preserved across page navigations.
 > - Compatibility mode:
 >   - `usePathname` can return `null` when a [fallback route](/docs/pages/api-reference/functions/get-static-paths#fallback-true) is being rendered or when a `pages` directory page has been [automatically statically optimized](/docs/pages/building-your-application/rendering/automatic-static-optimization) by Next.js and the router is not ready.
+>   - When using `usePathname` with [rewrites](/docs/app/api-reference/next-config-js/rewrites), `useState` and `useEffect` must also be used in order to avoid hydration mismatch errors. See the [rewrites example](https://github.com/vercel/next.js/tree/canary/examples/rewrites) for more information.
 >   - Next.js will automatically update your types if it detects both an `app` and `pages` directory in your project.
 
 ## Parameters


### PR DESCRIPTION
## Why?

A `useState` + `useState` need to be used with `usePathname` when the route is rewritten to. Adding this as a note to our documentation.

- x-ref: https://github.com/vercel/next.js/pull/69631#pullrequestreview-2278118356