### PR TITLE
Update the preview tarball binaries

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -106,16 +106,21 @@ jobs:
       fail-fast: false
       matrix:
         exclude:
-          # Exclude slow builds for automated previews
-          # These are rarely needed for the standard preview usage (e.g. Front sync)
+          # only build the binaries we usually test with
+          # darwin arm64, windows x64, linux GNU x64
           - settings:
               target: ${{ needs.deploy-target.outputs.value == 'automated-preview' && 'i686-pc-windows-msvc' }}
           - settings:
               target: ${{ needs.deploy-target.outputs.value == 'automated-preview' && 'aarch64-pc-windows-msvc' }}
           - settings:
+              target: ${{ needs.deploy-target.outputs.value == 'automated-preview' && 'aarch64-unknown-linux-gnu' }}
+          - settings:
               target: ${{ needs.deploy-target.outputs.value == 'automated-preview' && 'aarch64-unknown-linux-musl' }}
           - settings:
               target: ${{ needs.deploy-target.outputs.value == 'automated-preview' && 'x86_64-unknown-linux-musl' }}
+          - settings:
+              target: ${{ needs.deploy-target.outputs.value == 'automated-preview' && 'x86_64-apple-darwin' }}
+
         settings:
           - host:
               - 'self-hosted'


### PR DESCRIPTION
Our CI can get pretty backed up with build binaries for every push so this refines which binaries we are building by default some more to only build the ones we actually use for testing usually mac arm64, windows x64, and linux x64 GNU. 

x-ref: [slack thread](https://vercel.slack.com/archives/C04DUD7EB1B/p1725464388558009)
