### PR TITLE
feat(turbo-tasks): Add a ResolveDeep trait

### DIFF
--- a/turbopack/crates/turbo-tasks-macros-tests/tests/resolve_deep.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/resolve_deep.rs
@@ -1,0 +1,25 @@
+use turbo_tasks::{ResolveDeep, Vc};
+use turbo_tasks_testing::{register, run, Registration};
+
+static REGISTRATION: Registration = register!();
+
+#[tokio::test]
+async fn ignored_indexes() {
+    #[derive(ResolveDeep)]
+    struct ContainsVc(Vc<i32>);
+
+    run(&REGISTRATION, || async {
+        let mut contains_vc = ContainsVc(returns_vc());
+        assert!(!contains_vc.0.is_resolved());
+        contains_vc.resolve_deep().await?;
+        assert!(contains_vc.0.is_resolved());
+        Ok(())
+    })
+    .await
+    .unwrap();
+}
+
+#[turbo_tasks::function]
+fn returns_vc() -> Vc<i32> {
+    Vc::cell(42)
+}

--- a/turbopack/crates/turbo-tasks-macros/src/derive/mod.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/mod.rs
@@ -1,4 +1,5 @@
 mod deterministic_hash_macro;
+mod resolve_deep_macro;
 mod resolved_value_macro;
 mod task_input_macro;
 mod trace_raw_vcs_macro;
@@ -6,6 +7,7 @@ mod value_debug_format_macro;
 mod value_debug_macro;
 
 pub use deterministic_hash_macro::derive_deterministic_hash;
+pub use resolve_deep_macro::derive_resolve_deep;
 pub use resolved_value_macro::derive_resolved_value;
 use syn::{spanned::Spanned, Attribute, Meta, MetaList, NestedMeta};
 pub use task_input_macro::derive_task_input;

--- a/turbopack/crates/turbo-tasks-macros/src/derive/resolve_deep_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/resolve_deep_macro.rs
@@ -1,0 +1,70 @@
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput, Field, FieldsNamed, FieldsUnnamed};
+use turbo_tasks_macros_shared::{generate_destructuring, match_expansion};
+
+use super::FieldAttributes;
+
+fn filter_field(field: &Field) -> bool {
+    // `trace_ignores` implies the field does not contain `Vc`s
+    // TODO: Rename this field into something a bit more generic, like `has_no_vcs`?
+    !FieldAttributes::from(field.attrs.as_slice()).trace_ignore
+}
+
+#[allow(dead_code)]
+pub fn derive_resolve_deep(input: TokenStream) -> TokenStream {
+    let mut derive_input = parse_macro_input!(input as DeriveInput);
+    let ident = &derive_input.ident;
+
+    for type_param in derive_input.generics.type_params_mut() {
+        type_param
+            .bounds
+            .push(syn::parse_quote!(turbo_tasks::ResolveDeep));
+    }
+    let (impl_generics, ty_generics, where_clause) = derive_input.generics.split_for_impl();
+
+    let resolve_items = match_expansion(
+        &derive_input,
+        &resolve_named,
+        &resolve_unnamed,
+        &resolve_unit,
+    );
+    quote! {
+        impl #impl_generics turbo_tasks::ResolveDeep for #ident #ty_generics #where_clause {
+            async fn resolve_deep(&mut self) -> turbo_tasks::macro_helpers::anyhow::Result<()> {
+                #resolve_items
+                Ok(())
+            }
+        }
+    }
+    .into()
+}
+
+fn resolve_named(_ident: TokenStream2, fields: &FieldsNamed) -> (TokenStream2, TokenStream2) {
+    let (captures, fields_idents) = generate_destructuring(fields.named.iter(), &filter_field);
+    (
+        captures,
+        quote! {
+            {#(
+                turbo_tasks::ResolveDeep::resolve_deep(#fields_idents).await?;
+            )*}
+        },
+    )
+}
+
+fn resolve_unnamed(_ident: TokenStream2, fields: &FieldsUnnamed) -> (TokenStream2, TokenStream2) {
+    let (captures, fields_idents) = generate_destructuring(fields.unnamed.iter(), &filter_field);
+    (
+        captures,
+        quote! {
+            {#(
+                turbo_tasks::ResolveDeep::resolve_deep(#fields_idents).await?;
+            )*}
+        },
+    )
+}
+
+fn resolve_unit(_ident: TokenStream2) -> TokenStream2 {
+    quote! { { } }
+}

--- a/turbopack/crates/turbo-tasks-macros/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/lib.rs
@@ -22,6 +22,11 @@ pub fn derive_trace_raw_vcs_attr(input: TokenStream) -> TokenStream {
     derive::derive_trace_raw_vcs(input)
 }
 
+#[proc_macro_derive(ResolveDeep, attributes(turbo_tasks))]
+pub fn derive_resolve_deep_attr(input: TokenStream) -> TokenStream {
+    derive::derive_resolve_deep(input)
+}
+
 #[proc_macro_derive(ResolvedValue, attributes(turbo_tasks))]
 pub fn derive_resolved_value_attr(input: TokenStream) -> TokenStream {
     derive::derive_resolved_value(input)

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -107,9 +107,9 @@ pub use turbo_tasks_macros::{function, value, value_impl, value_trait, TaskInput
 pub use value::{TransientInstance, TransientValue, Value};
 pub use value_type::{TraitMethod, TraitType, ValueType};
 pub use vc::{
-    Dynamic, ResolvedValue, ResolvedVc, TypedForInput, Upcast, ValueDefault, Vc, VcCast,
-    VcCellNewMode, VcCellSharedMode, VcDefaultRead, VcRead, VcTransparentRead, VcValueTrait,
-    VcValueTraitCast, VcValueType, VcValueTypeCast,
+    Dynamic, ResolveDeep, ResolvedValue, ResolvedVc, TypedForInput, Upcast, ValueDefault, Vc,
+    VcCast, VcCellNewMode, VcCellSharedMode, VcDefaultRead, VcRead, VcTransparentRead,
+    VcValueTrait, VcValueTraitCast, VcValueType, VcValueTypeCast,
 };
 
 pub use crate::rcstr::RcStr;

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -1,4 +1,5 @@
 //! Runtime helpers for [turbo-tasks-macro].
+pub use anyhow;
 pub use async_trait::async_trait;
 pub use once_cell::sync::{Lazy, OnceCell};
 pub use serde;


### PR DESCRIPTION
## Problem

For certain safety guarantees with local tasks, we need to enforce that for _all_ `#[turbo_task::function]`s, every `TaskInput` and `TaskOutput` is deeply resolved (including `Vc`s stored inside structs/collections/etc).

This is needed to ensure that unresolved `Vc`s, which may be task-local, cannot escape their task without first being resolved.

_If we cannot feasibly do this, we can fall back to using some [global storage](https://www.notion.so/vercel/RawVc-LocalOutput-aede5f463f594ca58396eb3fdaffd865?pvs=4#02af94e3b9b64a3690f3e467abc0a47e) to store local task information, but that comes with additional complexity and caveats._

## Context: ResolvedValue

We have `ResolvedValue`, which guarantees at compile time that a type does not contain unresolved `Vc`s. Unfortunately, in it's current state there are [556 `#[turbo_task::value]`s (out of 1677 total) that cannot implement this without changes to one or more of their fields](https://github.com/vercel/next.js/compare/canary...bgw/default-resolved-value).

That's too many things to fix all-at-once by hand.

## ResolveDeep

If we can't guarantee that a type doesn't contain unresolved `Vc`s at compile time, we can add a runtime check that attempts to in-place resolve all the `Vc`s inside of a `#[turbo_task::value]` when it's passed as `TaskInput` or returned as a `TaskOutput`. We'll only need to do this for types that do not implement `ResolvedValue` (`ResolveDeep` is a no-op in that case).

For large collections, this will have undesirable performance characteristics, but the goal is to get to something that works first (and proves the memory usage win!), and then to optimize the CPU usage of large collections down second.

Not everything can implement `ResolveDeep`: anything that uses a `Vc` inside of an `Arc` (for example), including deeply nested `Vc`s can't implement `ResolveDeep`. However, the goal is that that set of types should be small enough that those values can quickly be fixed by hand (ideally by implementing `ResolvedValue` instead).