### PR TITLE
Adjust span names to say "(partial render tree)" instead of "RSC" for RSC requests

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -909,7 +909,10 @@ export default abstract class Server<
 
             const route = rootSpanAttributes.get('next.route')
             if (route) {
-              const name = `${method} ${route}`
+              const name = isRSCRequest
+                ? `${method} ${route} (partial render tree)`
+                : `${method} ${route}`
+
               span.setAttributes({
                 'next.route': route,
                 'http.route': route,
@@ -917,7 +920,11 @@ export default abstract class Server<
               })
               span.updateName(name)
             } else {
-              span.updateName(`${method} ${req.url}`)
+              span.updateName(
+                isRSCRequest
+                  ? `${method} ${req.url} (partial render tree)`
+                  : `${method} ${req.url}`
+              )
             }
           })
       )

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -909,10 +909,7 @@ export default abstract class Server<
 
             const route = rootSpanAttributes.get('next.route')
             if (route) {
-              const name = isRSCRequest
-                ? `RSC ${method} ${route}`
-                : `${method} ${route}`
-
+              const name = `${method} ${route}`
               span.setAttributes({
                 'next.route': route,
                 'http.route': route,
@@ -920,11 +917,7 @@ export default abstract class Server<
               })
               span.updateName(name)
             } else {
-              span.updateName(
-                isRSCRequest
-                  ? `RSC ${method} ${req.url}`
-                  : `${method} ${req.url}`
-              )
+              span.updateName(`${method} ${req.url}`)
             }
           })
       )

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -367,7 +367,7 @@ describe('opentelemetry', () => {
               runtime: 'nodejs',
               traceId: env.span.traceId,
               parentId: env.span.rootParentId,
-              name: 'GET /app/[param]/rsc-fetch',
+              name: 'GET /app/[param]/rsc-fetch (partial render tree)',
               attributes: {
                 'http.method': 'GET',
                 'http.route': '/app/[param]/rsc-fetch',
@@ -375,7 +375,8 @@ describe('opentelemetry', () => {
                 'http.target': '/app/param/rsc-fetch',
                 'next.route': '/app/[param]/rsc-fetch',
                 'next.rsc': true,
-                'next.span_name': 'GET /app/[param]/rsc-fetch',
+                'next.span_name':
+                  'GET /app/[param]/rsc-fetch (partial render tree)',
                 'next.span_type': 'BaseServer.handleRequest',
               },
               kind: 1,

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -367,7 +367,7 @@ describe('opentelemetry', () => {
               runtime: 'nodejs',
               traceId: env.span.traceId,
               parentId: env.span.rootParentId,
-              name: 'RSC GET /app/[param]/rsc-fetch',
+              name: 'GET /app/[param]/rsc-fetch',
               attributes: {
                 'http.method': 'GET',
                 'http.route': '/app/[param]/rsc-fetch',
@@ -375,7 +375,7 @@ describe('opentelemetry', () => {
                 'http.target': '/app/param/rsc-fetch',
                 'next.route': '/app/[param]/rsc-fetch',
                 'next.rsc': true,
-                'next.span_name': 'RSC GET /app/[param]/rsc-fetch',
+                'next.span_name': 'GET /app/[param]/rsc-fetch',
                 'next.span_type': 'BaseServer.handleRequest',
               },
               kind: 1,


### PR DESCRIPTION
### What?

This PR removes the `RSC` prefix from OpenTelemetry span names for "RSC Requests". From my understanding RSC Requests in the code base are requests that are made as part of a navigation in app router, requesting an RSC payload.

### Why?

This should probably be changed because a) it does not follow the Semantic OpenTelemetry conventions (https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name) b) it causes grouping issues with other RSC requests that are non navigational, like prefetch requests, and initial pageloads/hard-navigations.

The original PR that added this prefix does not contain a description so I may lack some background info as to why the prefix was introduced in the first place: https://github.com/vercel/next.js/pull/62464

In my opinion, it is not clear to downstream users what the "RSC" prefix actually means, so it is fine to remove. I am happy to learn something different though!

### How?

Right now this PR simply updates the name. In theory, no data is lost because the fact whether the request was an "RSC request" by the definition above is still stored as a `next.rsc` span attribute.

Relates to https://github.com/vercel/next.js/discussions/64723
Fixes https://github.com/getsentry/sentry-javascript/issues/13597