### PR TITLE
feat(turbopack): add `experimental.turbo.root` config option

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1333,7 +1333,10 @@ export default async function build(
         const project = await bindings.turbo.createProject(
           {
             projectPath: dir,
-            rootPath: config.outputFileTracingRoot || dir,
+            rootPath:
+              config.experimental?.turbo?.root ||
+              config.outputFileTracingRoot ||
+              dir,
             nextConfig: config,
             jsConfig: await getTurbopackJsConfig(dir, config),
             watch: false,

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -165,6 +165,12 @@ export interface ExperimentalTurboOptions {
    * for production.
    */
   moduleIdStrategy?: 'named' | 'deterministic'
+
+  /**
+   * This is the repo root usually and only files above this
+   * directory can be resolved by turbopack.
+   */
+  root?: string
 }
 
 export interface WebpackConfigContext {

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -136,7 +136,10 @@ export async function createHotReloaderTurbopack(
   const project = await bindings.turbo.createProject(
     {
       projectPath: dir,
-      rootPath: opts.nextConfig.outputFileTracingRoot || dir,
+      rootPath:
+        opts.nextConfig.experimental.turbo?.root ||
+        opts.nextConfig.outputFileTracingRoot ||
+        dir,
       nextConfig: opts.nextConfig,
       jsConfig: await getTurbopackJsConfig(dir, nextConfig),
       watch: true,

--- a/packages/next/src/shared/lib/dset.d.ts
+++ b/packages/next/src/shared/lib/dset.d.ts
@@ -1,0 +1,5 @@
+export function dset<T extends object, V>(
+  obj: T,
+  keys: string | ArrayLike<string | number>,
+  value: V
+): void

--- a/packages/next/src/shared/lib/dset.js
+++ b/packages/next/src/shared/lib/dset.js
@@ -1,0 +1,36 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) Luke Edwards <luke.edwards05@gmail.com> (lukeed.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+// This file is based on https://github.com/lukeed/dset/blob/v3.1.3/src/index.js
+// It's been edited for the needs of this script
+// See the LICENSE at the top of the file
+
+export function dset(obj, keys, val) {
+  keys.split && (keys = keys.split('.'))
+  var i = 0,
+    l = keys.length,
+    t = obj,
+    x,
+    k
+  while (i < l) {
+    k = keys[i++]
+    if (k === '__proto__' || k === 'constructor' || k === 'prototype') break
+    t = t[k] =
+      i === l
+        ? val
+        : typeof (x = t[k]) === typeof keys
+          ? x
+          : keys[i] * 0 !== 0 || !!~('' + keys[i]).indexOf('.')
+            ? {}
+            : []
+  }
+}


### PR DESCRIPTION
### TL;DR

Added support for a new `experimental.turbo.root` configuration option in Next.js.

### What changed?

- Introduced a new `root` property in the `ExperimentalTurboOptions` interface.
- Updated the build process and hot reloader to use the new `experimental.turbo.root` configuration.
- Added fallback logic to use `outputFileTracingRoot` or the project directory if `experimental.turbo.root` is not set.
- Implemented warning messages for non-absolute paths in `experimental.turbo.root` and `outputFileTracingRoot`.
- Added a utility function `dset` for safely setting nested object properties.

### How to test?

1. Set up a Next.js project with Turbopack enabled.
2. Add the `experimental.turbo.root` option to your `next.config.js`:
   ```javascript
   module.exports = {
     experimental: {
       turbo: {
         root: '/path/to/your/root'
       }
     }
   }
   ```
3. Run the development server and build process to ensure they use the new root path.
4. Verify that file resolution works correctly with the new root path.

### Why make this change?

This change allows developers to explicitly set the root directory for Turbopack, providing more control over file resolution and project structure. It enhances flexibility for monorepo setups and projects with complex directory structures, ensuring that Turbopack can correctly resolve files above the project directory when necessary.


Closes PACK-2646
Fixes #62409