### PR TITLE
docs: document the next/dynamic case with ssr: false option

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/07-lazy-loading.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/07-lazy-loading.mdx
@@ -58,7 +58,7 @@ export default function ClientComponentExample() {
 ### Skipping SSR
 
 When using `React.lazy()` and Suspense, Client Components will be pre-rendered (SSR) by default.
-Note: `ssr: false` option will only work for client components, move it into client components ensure the client code-splitting working properly.
+> **Note:** `ssr: false` option will only work for client components, move it into client components ensure the client code-splitting working properly.
 
 If you want to disable pre-rendering for a Client Component, you can use the `ssr` option set to `false`:
 
@@ -71,7 +71,7 @@ const ComponentC = dynamic(() => import('../components/C'), { ssr: false })
 If you dynamically import a Server Component, only the Client Components that are children of the Server Component will be lazy-loaded - not the Server Component itself.
 It will also help preload the static assets such as CSS when you're using it in Server Components.
 
-Note: `ssr: false` option is not supported in Server Components.
+> **Note:** `ssr: false` option is not supported in Server Components.
 
 ```jsx filename="app/page.js"
 import dynamic from 'next/dynamic'

--- a/docs/02-app/01-building-your-application/06-optimizing/07-lazy-loading.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/07-lazy-loading.mdx
@@ -58,6 +58,7 @@ export default function ClientComponentExample() {
 ### Skipping SSR
 
 When using `React.lazy()` and Suspense, Client Components will be pre-rendered (SSR) by default.
+
 > **Note:** `ssr: false` option will only work for client components, move it into client components ensure the client code-splitting working properly.
 
 If you want to disable pre-rendering for a Client Component, you can use the `ssr` option set to `false`:

--- a/docs/02-app/01-building-your-application/06-optimizing/07-lazy-loading.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/07-lazy-loading.mdx
@@ -58,6 +58,7 @@ export default function ClientComponentExample() {
 ### Skipping SSR
 
 When using `React.lazy()` and Suspense, Client Components will be pre-rendered (SSR) by default.
+Note: `ssr: false` option will only work for client components, move it into client components ensure the client code-splitting working properly.
 
 If you want to disable pre-rendering for a Client Component, you can use the `ssr` option set to `false`:
 
@@ -68,6 +69,9 @@ const ComponentC = dynamic(() => import('../components/C'), { ssr: false })
 ### Importing Server Components
 
 If you dynamically import a Server Component, only the Client Components that are children of the Server Component will be lazy-loaded - not the Server Component itself.
+It will also help preload the static assets such as CSS when you're using it in Server Components.
+
+Note: `ssr: false` option is not supported in Server Components.
 
 ```jsx filename="app/page.js"
 import dynamic from 'next/dynamic'
@@ -202,6 +206,8 @@ const DynamicComponent = dynamic(() =>
 To dynamically load a component on the client side, you can use the `ssr` option to disable server-rendering. This is useful if an external dependency or component relies on browser APIs like `window`.
 
 ```jsx
+'use client'
+
 import dynamic from 'next/dynamic'
 
 const DynamicHeader = dynamic(() => import('../components/header'), {


### PR DESCRIPTION
Explain the limitation of `ssr: false` option of `next/dynamic` when you use it in sever component. For instance `ssr: false` requires to work properly inside client components.

Related #69720