### PR TITLE
refactor(turbopack-ecmascript): Add `ImportOverrides` struct, and use that instead of the `ignore` boolean

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -1246,8 +1246,8 @@ impl VisitAstPath for Analyzer<'_> {
                             ignore: self
                                 .eval_context
                                 .imports
-                                .get_ignore(n.callee.span())
-                                .unwrap_or_default(),
+                                .get_overrides(n.callee.span())
+                                .ignore,
                         }),
                     );
                 }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -32,7 +32,7 @@ use turbopack_core::compile_time_info::{
 use url::Url;
 
 use self::imports::ImportAnnotations;
-pub(crate) use self::imports::ImportMap;
+pub(crate) use self::imports::{ImportMap, ImportOverrides};
 use crate::{references::require_context::RequireContextMap, utils::StringifyJs};
 
 pub mod builtin;

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -121,7 +121,7 @@ use crate::{
         imports::{ImportAnnotations, ImportedSymbol, Reexport},
         parse_require_context,
         top_level_await::has_top_level_await,
-        ConstantNumber, ConstantString, RequireContextValue,
+        ConstantNumber, ConstantString, ImportOverrides, RequireContextValue,
     },
     chunk::EcmascriptExports,
     code_gen::{CodeGen, CodeGenerateable, CodeGenerateableWithAsyncModuleInfo, CodeGenerateables},
@@ -370,7 +370,7 @@ impl<'a> AnalysisState<'a> {
     /// * `in_try` is true if the value is in a try block.
     /// * `ignore` is true if the value is ignored. This is perhaps the case when the webpackIgnore
     ///   or turbopackIgnore directives are present.
-    async fn link_value(&self, value: JsValue, ignore: bool) -> Result<JsValue> {
+    async fn link_value(&self, value: JsValue, overrides: &ImportOverrides) -> Result<JsValue> {
         let fun_args_values = self.fun_args_values.lock().clone();
         link(
             self.var_graph,
@@ -382,7 +382,7 @@ impl<'a> AnalysisState<'a> {
                     value,
                     self.compile_time_info,
                     self.var_graph,
-                    ignore,
+                    overrides,
                 )
             },
             fun_args_values,
@@ -926,7 +926,9 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                 span: _,
                 in_try: _,
             } => {
-                let condition = analysis_state.link_value(condition, false).await?;
+                let condition = analysis_state
+                    .link_value(condition, ImportOverrides::empty_ref())
+                    .await?;
 
                 macro_rules! inactive {
                     ($block:ident) => {
@@ -1075,10 +1077,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                 }
 
                 let func = analysis_state
-                    .link_value(
-                        func,
-                        eval_context.imports.get_ignore(span).unwrap_or_default(),
-                    )
+                    .link_value(func, eval_context.imports.get_overrides(span))
                     .await?;
 
                 handle_call(
@@ -1107,8 +1106,12 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                         continue;
                     }
                 }
-                let mut obj = analysis_state.link_value(obj, false).await?;
-                let prop = analysis_state.link_value(prop, false).await?;
+                let mut obj = analysis_state
+                    .link_value(obj, ImportOverrides::empty_ref())
+                    .await?;
+                let prop = analysis_state
+                    .link_value(prop, ImportOverrides::empty_ref())
+                    .await?;
 
                 if let JsValue::Array {
                     items: ref mut values,
@@ -1118,7 +1121,9 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                 {
                     if matches!(prop.as_str(), Some("map" | "forEach" | "filter")) {
                         if let [EffectArg::Closure(value, block)] = &mut args[..] {
-                            *value = analysis_state.link_value(take(value), false).await?;
+                            *value = analysis_state
+                                .link_value(take(value), ImportOverrides::empty_ref())
+                                .await?;
                             if let JsValue::Function(_, func_ident, _) = value {
                                 let mut closure_arg = JsValue::alternatives(take(values));
                                 if mutable {
@@ -1144,7 +1149,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                 let func = analysis_state
                     .link_value(
                         JsValue::member(Box::new(obj.clone()), Box::new(prop)),
-                        false,
+                        ImportOverrides::empty_ref(),
                     )
                     .await?;
 
@@ -1176,8 +1181,12 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                 span,
                 in_try: _,
             } => {
-                let obj = analysis_state.link_value(obj, false).await?;
-                let prop = analysis_state.link_value(prop, false).await?;
+                let obj = analysis_state
+                    .link_value(obj, ImportOverrides::empty_ref())
+                    .await?;
+                let prop = analysis_state
+                    .link_value(prop, ImportOverrides::empty_ref())
+                    .await?;
 
                 handle_member(&ast_path, obj, prop, span, &analysis_state, &mut analysis).await?;
             }
@@ -1204,7 +1213,9 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                 ast_path,
                 span,
             } => {
-                let arg = analysis_state.link_value(arg, false).await?;
+                let arg = analysis_state
+                    .link_value(arg, ImportOverrides::empty_ref())
+                    .await?;
                 handle_typeof(&ast_path, arg, span, &analysis_state, &mut analysis).await?;
             }
             Effect::ImportMeta {
@@ -1325,7 +1336,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                             JsValue::unknown_empty(true, "spread is not supported yet")
                         }
                     };
-                    state.link_value(value, false).await
+                    state.link_value(value, ImportOverrides::empty_ref()).await
                 }
             })
             .try_join()
@@ -1552,7 +1563,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         )),
                         args.clone(),
                     ),
-                    false,
+                    ImportOverrides::empty_ref(),
                 )
                 .await?;
 
@@ -1587,7 +1598,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         Box::new(JsValue::WellKnownFunction(WellKnownFunctionKind::PathJoin)),
                         args.clone(),
                     ),
-                    false,
+                    ImportOverrides::empty_ref(),
                 )
                 .await?;
             let pat = js_value_to_pattern(&linked_func_call);
@@ -1621,7 +1632,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 if pat.is_match_ignore_dynamic("node") && args.len() >= 2 {
                     let first_arg =
                         JsValue::member(Box::new(args[1].clone()), Box::new(0_f64.into()));
-                    let first_arg = state.link_value(first_arg, false).await?;
+                    let first_arg = state
+                        .link_value(first_arg, ImportOverrides::empty_ref())
+                        .await?;
                     let pat = js_value_to_pattern(&first_arg);
                     let dynamic = !pat.has_constant_parts();
                     if dynamic {
@@ -1742,7 +1755,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
 
             let args = linked_args(args).await?;
             if args.len() == 1 {
-                let first_arg = state.link_value(args[0].clone(), false).await?;
+                let first_arg = state
+                    .link_value(args[0].clone(), ImportOverrides::empty_ref())
+                    .await?;
                 if let Some(s) = first_arg.as_str() {
                     // TODO this resolving should happen within Vc<NodeGypBuildReference>
                     let current_context = origin
@@ -1772,7 +1787,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
 
             let args = linked_args(args).await?;
             if args.len() == 1 {
-                let first_arg = state.link_value(args[0].clone(), false).await?;
+                let first_arg = state
+                    .link_value(args[0].clone(), ImportOverrides::empty_ref())
+                    .await?;
                 if let Some(s) = first_arg.as_str() {
                     analysis
                         .add_reference(NodeBindingsReference::new(origin.origin_path(), s.into()));
@@ -1823,7 +1840,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                                                     pkg_or_dir.clone(),
                                                 ],
                                             ),
-                                            false,
+                                            ImportOverrides::empty_ref(),
                                         )
                                         .await?;
                                     js_value_to_pattern(&linked_func_call)
@@ -1880,7 +1897,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                                     "intl".into(),
                                 ],
                             ),
-                            false,
+                            ImportOverrides::empty_ref(),
                         )
                         .await?;
                     js_value_to_pattern(&linked_func_call)
@@ -2353,10 +2370,10 @@ async fn value_visitor(
     v: JsValue,
     compile_time_info: Vc<CompileTimeInfo>,
     var_graph: &VarGraph,
-    ignore: bool,
+    overrides: &ImportOverrides,
 ) -> Result<(JsValue, bool)> {
     let (mut v, modified) =
-        value_visitor_inner(origin, v, compile_time_info, var_graph, ignore).await?;
+        value_visitor_inner(origin, v, compile_time_info, var_graph, overrides).await?;
     v.normalize_shallow();
     Ok((v, modified))
 }
@@ -2366,8 +2383,9 @@ async fn value_visitor_inner(
     v: JsValue,
     compile_time_info: Vc<CompileTimeInfo>,
     var_graph: &VarGraph,
-    ignore: bool,
+    overrides: &ImportOverrides,
 ) -> Result<(JsValue, bool)> {
+    let ImportOverrides { ignore, .. } = *overrides;
     // This check is just an optimization
     if v.get_defineable_name_len().is_some() {
         let compile_time_info = compile_time_info.await?;


### PR DESCRIPTION
This addresses my comment here: https://github.com/vercel/next.js/pull/69113#pullrequestreview-2251925945

> I'd much prefer an enum to a bool for this for readability at callsites (e.g. https://app.graphite.dev/github/pr/vercel/next.js/68913).
>
> Alternatively, an `/* ignore */` comment (like you do in `turbopack/crates/turbopack-ecmascript/src/references/amd.rs`) is okay, but it should be consistently at every callsite. I still think an enum is better though, as it enforces consistency.

However, I didn't end up using a simple enum for a few reasons:

- I couldn't figure out what to name it. What would the `false` value be? `ImportIgnore::NotIgnored`?
- Webpack supports a lot of these "magic comments" that will need to be threaded through in a similar way if we want to support them.

The implementation passes around an `&ImportIgnore`. I don't want to `.clone()` values here as this is passed around frequently, and there's no need for it to be owned.

I could've made `ImportIgnore` implement `Copy`, but a ref seemed better when looking at the full list of magic comments that webpack supports, especially considering that some of them would require storing a non-Copy `String`.

For callsites that don't support the override comments, I'm passing in `ImportOverrides::empty_ref()`. I could also pass in `Default::default()`, but that's a bit more syntactically ambiguous. I could pass in `<&ImportOverrides>::default()`, but that feels awkward to write.

## Test Plan

```
cargo check
cargo nextest r -p turbopack-tests
```