### PR TITLE
update pages-dir test for React 18 assertions

### DIFF
--- a/test/production/pages-dir/production/test/index.test.ts
+++ b/test/production/pages-dir/production/test/index.test.ts
@@ -29,6 +29,8 @@ if (process.env.TEST_WASM) {
   jest.setTimeout(120 * 1000)
 }
 
+const isReact18 = true
+
 describe('Production Usage', () => {
   const { next } = nextTestSetup({
     files: path.join(__dirname, '../fixture'),
@@ -181,7 +183,9 @@ describe('Production Usage', () => {
           /webpack-runtime\.js/,
           /node_modules\/react\/index\.js/,
           /node_modules\/react\/package\.json/,
-          /node_modules\/react\/cjs\/react\.production\.js/,
+          isReact18
+            ? /node_modules\/react\/cjs\/react\.production\.min\.js/
+            : /node_modules\/react\/cjs\/react\.production\.js/,
         ],
         notTests: [/\0/, /\?/, /!/],
       },
@@ -192,7 +196,9 @@ describe('Production Usage', () => {
           /chunks\/.*?\.js/,
           /node_modules\/react\/index\.js/,
           /node_modules\/react\/package\.json/,
-          /node_modules\/react\/cjs\/react\.production\.js/,
+          isReact18
+            ? /node_modules\/react\/cjs\/react\.production\.min\.js/
+            : /node_modules\/react\/cjs\/react\.production\.js/,
           /node_modules\/next/,
         ],
         notTests: [/\0/, /\?/, /!/],
@@ -204,7 +210,9 @@ describe('Production Usage', () => {
           /chunks\/.*?\.js/,
           /node_modules\/react\/index\.js/,
           /node_modules\/react\/package\.json/,
-          /node_modules\/react\/cjs\/react\.production\.js/,
+          isReact18
+            ? /node_modules\/react\/cjs\/react\.production\.min\.js/
+            : /node_modules\/react\/cjs\/react\.production\.js/,
           /node_modules\/next/,
           /node_modules\/nanoid\/index\.js/,
           /node_modules\/nanoid\/url-alphabet\/index\.js/,
@@ -219,7 +227,9 @@ describe('Production Usage', () => {
           /chunks\/.*?\.js/,
           /node_modules\/react\/index\.js/,
           /node_modules\/react\/package\.json/,
-          /node_modules\/react\/cjs\/react\.production\.js/,
+          isReact18
+            ? /node_modules\/react\/cjs\/react\.production\.min\.js/
+            : /node_modules\/react\/cjs\/react\.production\.js/,
           /node_modules\/next/,
         ],
         notTests: [


### PR DESCRIPTION
Matches the same guard we added in [`f06d21e` (#69484)](https://github.com/vercel/next.js/pull/69484/commits/f06d21e5de2785d24b815255b050040bebce8066)