### PR TITLE
test: both wrapped and unwrapped dynamic()

### DIFF
--- a/test/e2e/app-dir/dynamic/app/dynamic/named-export-unwrapped/client.js
+++ b/test/e2e/app-dir/dynamic/app/dynamic/named-export-unwrapped/client.js
@@ -1,0 +1,5 @@
+'use client'
+
+export function Button(props) {
+  return <button {...props} />
+}

--- a/test/e2e/app-dir/dynamic/app/dynamic/named-export-unwrapped/page.js
+++ b/test/e2e/app-dir/dynamic/app/dynamic/named-export-unwrapped/page.js
@@ -2,7 +2,7 @@ import dynamic from 'next/dynamic'
 
 const Button = dynamic(() =>
   import('./client').then((mod) => {
-    return { default: mod.Button }
+    return mod.Button
   })
 )
 

--- a/test/e2e/app-dir/dynamic/dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic/dynamic.test.ts
@@ -58,6 +58,11 @@ createNextDescribe(
       expect($('h1').text()).toBe('hello')
     })
 
+    it('14.x behavior: should support dynamic import that returns a client component not wrapped in a module', async () => {
+      const $ = await next.render$('/dynamic/named-export-unwrapped')
+      expect($('#client-button').text()).toBe('this is a client button')
+    })
+
     describe('no SSR', () => {
       it('should not render client component imported through ssr: false in client components in edge runtime', async () => {
         // noSSR should not show up in html


### PR DESCRIPTION
We should be testing both usage patterns, i.e. returning a component wrapped in a `{ default: ... }` and just a bare component.

Note that the behavior here will partially change in 15, so this test is just so that we can avoid regressing in 14.x.