### PR TITLE
Turbopack build: Fix next-image-new/base-path test

### DIFF
--- a/test/integration/next-image-new/base-path/test/static.test.js
+++ b/test/integration/next-image-new/base-path/test/static.test.js
@@ -184,7 +184,11 @@ describe('Build Error Tests', () => {
           "Module not found: Can't resolve '../public/foo/test-rect-broken.jpg"
         )
         // should contain the importing module
-        expect(stderr).toContain('./pages/static-img.js')
+        if (process.env.TURBOPACK) {
+          expect(stderr).toContain('/pages/static-img.js')
+        } else {
+          expect(stderr).toContain('./pages/static-img.js')
+        }
         // should contain a import trace
         expect(stderr).not.toContain('Import trace for requested module')
       })

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -13478,11 +13478,10 @@
         "Static Image Component Tests for basePath production mode should have <head> containing <meta name=\"viewport\"> followed by <link rel=\"preload\"> for priority image",
         "Static Image Component Tests for basePath production mode should use height prop to adjust both width and height",
         "Static Image Component Tests for basePath production mode should use width and height prop to override import",
-        "Static Image Component Tests for basePath production mode should use width prop to adjust both width and height"
-      ],
-      "failed": [
+        "Static Image Component Tests for basePath production mode should use width prop to adjust both width and height",
         "Build Error Tests production mode should throw build error when import statement is used with missing file"
       ],
+      "failed": [],
       "pending": [
         "Static Image Component Tests for basePath development mode Should allow an image with a static src to omit height and width",
         "Static Image Component Tests for basePath development mode Should automatically provide an image height and width",


### PR DESCRIPTION
Since this is in `test/integration` the path with Turbopack will start at the repository root, it's still correct.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
