### PR TITLE
Disable experimental.optimizeServer by default to fix failed server action

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1066,7 +1066,7 @@ export const defaultConfig: NextConfig = {
       ),
     webpackBuildWorker: undefined,
     webpackMemoryOptimizations: false,
-    optimizeServerReact: true,
+    optimizeServerReact: false,
     useEarlyImport: false,
     staleTimes: {
       dynamic: 0,

--- a/test/production/app-dir/actions-tree-shaking/_testing/utils.ts
+++ b/test/production/app-dir/actions-tree-shaking/_testing/utils.ts
@@ -1,3 +1,4 @@
+// @ts-ignore avoid ts errors during manual testing
 import { type NextInstance } from 'e2e-utils'
 
 async function getActionsMappingByRuntime(

--- a/test/production/app-dir/actions-tree-shaking/shared-module-actions/tsconfig.json
+++ b/test/production/app-dir/actions-tree-shaking/shared-module-actions/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/test/production/app-dir/actions-tree-shaking/use-effect-actions/app/layout.js
+++ b/test/production/app-dir/actions-tree-shaking/use-effect-actions/app/layout.js
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/actions-tree-shaking/use-effect-actions/app/mixed/actions.ts
+++ b/test/production/app-dir/actions-tree-shaking/use-effect-actions/app/mixed/actions.ts
@@ -1,0 +1,11 @@
+'use server'
+
+export async function action1() {
+  return { hello: 'world' }
+}
+export async function action2() {
+  return { hello: 'action2' }
+}
+export async function action3() {
+  return { hello: 'action3' }
+}

--- a/test/production/app-dir/actions-tree-shaking/use-effect-actions/app/mixed/my-component.tsx
+++ b/test/production/app-dir/actions-tree-shaking/use-effect-actions/app/mixed/my-component.tsx
@@ -1,0 +1,9 @@
+import { action3 } from './actions'
+
+export default function MyComponent() {
+  // to prevent tree-shaking
+  if (globalThis.DO_NOT_TREE_SHAKE) {
+    console.log('MyComponent imported action3', action3)
+  }
+  return <span>i'm MyComponent</span>
+}

--- a/test/production/app-dir/actions-tree-shaking/use-effect-actions/app/mixed/page.tsx
+++ b/test/production/app-dir/actions-tree-shaking/use-effect-actions/app/mixed/page.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import React, { useEffect } from 'react'
+import { action1, action2 } from './actions'
+import MyComponent from './my-component'
+
+export default function Page() {
+  // to prevent tree-shaking
+  if (globalThis.DO_NOT_TREE_SHAKE) {
+    console.log('Page imported action2', action2)
+  }
+
+  // calling action1 fails!!
+  useEffect(() => {
+    if (globalThis.DO_NOT_TREE_SHAKE) {
+      action1().then((obj) => {
+        console.log('action1 returned:', obj)
+      })
+    }
+  }, [])
+
+  return <MyComponent />
+}

--- a/test/production/app-dir/actions-tree-shaking/use-effect-actions/tsconfig.json
+++ b/test/production/app-dir/actions-tree-shaking/use-effect-actions/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/test/production/app-dir/actions-tree-shaking/use-effect-actions/use-effect-actions-edge.test.ts
+++ b/test/production/app-dir/actions-tree-shaking/use-effect-actions/use-effect-actions-edge.test.ts
@@ -1,0 +1,3 @@
+process.env.TEST_EDGE = '1'
+
+require('./use-effect-actions.test')

--- a/test/production/app-dir/actions-tree-shaking/use-effect-actions/use-effect-actions.test.ts
+++ b/test/production/app-dir/actions-tree-shaking/use-effect-actions/use-effect-actions.test.ts
@@ -1,0 +1,25 @@
+import { nextTestSetup } from 'e2e-utils'
+import {
+  getActionsRoutesStateByRuntime,
+  markLayoutAsEdge,
+} from '../_testing/utils'
+
+describe('actions-tree-shaking - use-effect-actions', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (process.env.TEST_EDGE) {
+    markLayoutAsEdge(next)
+  }
+
+  it('should not tree shake the used action under useEffect', async () => {
+    const actionsRoutesState = await getActionsRoutesStateByRuntime(next)
+
+    expect(actionsRoutesState).toMatchObject({
+      'app/mixed/page': {
+        'action-browser': 3,
+      },
+    })
+  })
+})

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -15675,6 +15675,24 @@
       "flakey": [],
       "runtimeError": false
     },
+    "test/production/app-dir/actions-tree-shaking/use-effect-actions/use-effect-actions-edge.test.ts": {
+      "passed": [],
+      "failed": [
+        "actions-tree-shaking - use-effect-actions should not tree shake the used action under useEffect"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
+    "test/production/app-dir/actions-tree-shaking/use-effect-actions/use-effect-actions.test.ts": {
+      "passed": [],
+      "failed": [
+        "actions-tree-shaking - use-effect-actions should not tree shake the used action under useEffect"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
     "test/production/app-dir/app-edge-middleware/app-edge-middleware.test.ts": {
       "passed": [
         "app edge middleware without node.js modules should not have any errors about using Node.js modules if not present in middleware"


### PR DESCRIPTION
### What

This PR fixes the server actions used under react hooks like `useEffect` are accidentally removed from server action manifest which resulted into a failed server action call.

### Why

The server actions collection need to collect the used actions even in the 1st round of traversing. During fixing this I found it's broken due to the the react hooks are dropped in SSR bundle. That option is enabled since 14.2.0 by default and it will optimize the server side uesless hook call, however the action call under it will also be dropped along with the whole hook. Since we're collecting the used actions from server compiler in webpack, it's not possible to collect those actions if they're already dropped. So we disabled that flag in this PR by default unelss users enable by default.

Follow up improvement in the future: We either figure out a way that can refine the detection which react hook is better not optimized, or explore the client side used server action detection and reflect it to server actions manifest so that we don't have to rely on disabling `experimental.optimizeServer`.

Fixes #69756