### PR TITLE
[Turbopack] fix require.resolve self hanging

### DIFF
--- a/turbopack/crates/turbo-tasks-memory/src/aggregation/notify_new_follower.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/aggregation/notify_new_follower.rs
@@ -189,6 +189,13 @@ impl<C: AggregationContext> PreparedInternalOperation<C> for PreparedNotifyNewFo
                                 let follower = ctx.node(&follower_id);
                                 let follower_aggregation_number = follower.aggregation_number();
                                 if follower_aggregation_number == upper_aggregation_number {
+                                    if upper_id == follower_id {
+                                        panic!(
+                                            "Cycle in call graph (A function calls itself \
+                                             recursively with the same arguments. This will never \
+                                             finish and would hang indefinitely.)"
+                                        );
+                                    }
                                     increase_aggregation_number_internal(
                                         ctx,
                                         balance_queue,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -74,7 +74,7 @@ use turbopack_core::{
     source_map::{GenerateSourceMap, OptionSourceMap, SourceMap},
 };
 use turbopack_resolve::{
-    ecmascript::{apply_cjs_specific_options, cjs_resolve},
+    ecmascript::{apply_cjs_specific_options, cjs_resolve_source},
     typescript::tsconfig,
 };
 use turbopack_swc_utils::emitter::IssueEmitter;
@@ -2409,14 +2409,14 @@ async fn require_resolve_visitor(
     Ok(if args.len() == 1 {
         let pat = js_value_to_pattern(&args[0]);
         let request = Request::parse(Value::new(pat.clone()));
-        let resolved = cjs_resolve(origin, request, None, IssueSeverity::Warning.cell())
+        let resolved = cjs_resolve_source(origin, request, None, IssueSeverity::Warning.cell())
             .resolve()
             .await?;
         let mut values = resolved
-            .primary_modules()
+            .primary_sources()
             .await?
             .iter()
-            .map(|&module| async move { require_resolve(module.ident().path()).await })
+            .map(|&source| async move { require_resolve(source.ident().path()).await })
             .try_join()
             .await?;
 

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/require-resolve/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/require-resolve/input/index.js
@@ -9,3 +9,15 @@ it('should support require.resolve with extensions', () => {
     '[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/require-resolve/input/resolved.js [test] (ecmascript)'
   )
 })
+
+it('should support require.resolve on the current module', () => {
+  expect(require.resolve('./index.js')).toBe(
+    '[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/require-resolve/input/index.js [test] (ecmascript)'
+  )
+  // Check if static evaluation is not hanging
+  if (require.resolve('./index.js') == "") {
+    throw new Error("no no");
+  }
+})
+
+export {};

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/require-resolve/options.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/require-resolve/options.json
@@ -1,0 +1,3 @@
+{
+  "treeShakingMode": "reexports-only"
+}


### PR DESCRIPTION
### What?

evaluation require.resolve tries to resolve and process a module during module analytics. Since analytics is part of processing a module this can create a call cycle when `require.resolve("./self")` is used. This happens in some npm packages and caused Turbopack to hange.

This PR fixes that problem by only resolving the module and not processing it when using `require.resolve`.

In addition to that it adds a panic when a call cycle occurs. The next time we mess it up and create a call cycle this will crash Turbopack instead of hanging, which makes it much easier to find the problem.

fixes PACK-3227