### PR TITLE
Turbopack dev/build: Ignore empty tsconfig/jsconfig

### DIFF
--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -12686,10 +12686,10 @@
       "runtimeError": false
     },
     "test/integration/jsconfig-empty/test/index.test.js": {
-      "passed": [],
-      "failed": [
+      "passed": [
         "Empty JSConfig Support production mode should compile successfully"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false
@@ -15264,11 +15264,10 @@
         "tsconfig.json verifier allows you to set target mode",
         "tsconfig.json verifier allows you to set verbatimModuleSyntax true via extends without adding isolatedModules",
         "tsconfig.json verifier allows you to set verbatimModuleSyntax true without adding isolatedModules",
-        "tsconfig.json verifier creates compilerOptions when you extend another config"
-      ],
-      "failed": [
+        "tsconfig.json verifier creates compilerOptions when you extend another config",
         "tsconfig.json verifier Works with an empty tsconfig.json (docs)"
       ],
+      "failed": [],
       "pending": [
         "tsconfig.json verifier allows you to skip moduleResolution, esModuleInterop and resolveJsonModule when using \"module: preserve\""
       ],

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -53,6 +53,13 @@ pub async fn read_tsconfigs(
     let mut configs = Vec::new();
     let resolve_options = json_only(resolve_options);
     loop {
+        // tsc ignores empty config files.
+        if let FileContent::Content(file) = &*data.await? {
+            if file.content().is_empty() {
+                break;
+            }
+        }
+
         let parsed_data = data.parse_json_with_comments();
         match &*parsed_data.await? {
             FileJsonContent::Unparseable(e) => {


### PR DESCRIPTION
Fixes two tests for tsconfig/jsconfig being empty.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
