### PR TITLE
chore(turbopack-ecmascript): Remove more `_boxed` async recursion helpers, and remove the async-recursion macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,17 +438,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-recursion"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.58",
-]
-
-[[package]]
 name = "async-signal"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4135,7 +4124,6 @@ version = "0.1.0"
 dependencies = [
  "allsorts",
  "anyhow",
- "async-recursion",
  "async-trait",
  "auto-hash-map",
  "base64 0.21.4",
@@ -8802,7 +8790,6 @@ name = "turbopack"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-recursion",
  "criterion",
  "difference",
  "futures",
@@ -8940,7 +8927,6 @@ name = "turbopack-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-recursion",
  "async-trait",
  "auto-hash-map",
  "browserslist-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,6 @@ async-compression = { version = "0.3.13", default-features = false, features = [
   "gzip",
   "tokio",
 ] }
-async-recursion = "1.0.2"
 async-trait = "0.1.64"
 atty = "0.2.14"
 bytes = "1.1.0"

--- a/crates/next-core/Cargo.toml
+++ b/crates/next-core/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-async-recursion = { workspace = true }
 async-trait = { workspace = true }
 base64 = "0.21.0"
 lazy-regex = "3.0.1"

--- a/crates/next-core/src/app_segment_config.rs
+++ b/crates/next-core/src/app_segment_config.rs
@@ -1,7 +1,6 @@
 use std::ops::Deref;
 
 use anyhow::{bail, Result};
-use async_recursion::async_recursion;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use swc_core::{
@@ -478,7 +477,6 @@ pub async fn parse_segment_config_from_loader_tree(
         .cell())
 }
 
-#[async_recursion]
 pub async fn parse_segment_config_from_loader_tree_internal(
     loader_tree: &LoaderTree,
 ) -> Result<NextSegmentConfig> {
@@ -488,7 +486,7 @@ pub async fn parse_segment_config_from_loader_tree_internal(
         .parallel_routes
         .values()
         .map(|loader_tree| async move {
-            parse_segment_config_from_loader_tree_internal(loader_tree).await
+            Box::pin(parse_segment_config_from_loader_tree_internal(loader_tree)).await
         })
         .try_join()
         .await?;

--- a/crates/next-core/src/loader_tree.rs
+++ b/crates/next-core/src/loader_tree.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use anyhow::Result;
-use async_recursion::async_recursion;
 use indexmap::IndexMap;
 use indoc::formatdoc;
 use turbo_tasks::{RcStr, Value, ValueToString, Vc};
@@ -355,7 +354,6 @@ impl LoaderTreeBuilder {
         Ok(())
     }
 
-    #[async_recursion]
     async fn walk_tree(&mut self, loader_tree: &LoaderTree, root: bool) -> Result<()> {
         use std::fmt::Write;
 
@@ -404,7 +402,7 @@ impl LoaderTreeBuilder {
         // add parallel_routes
         for (key, parallel_route) in parallel_routes.iter() {
             write!(self.loader_tree_code, "{key}: ", key = StringifyJs(key))?;
-            self.walk_tree(parallel_route, false).await?;
+            Box::pin(self.walk_tree(parallel_route, false)).await?;
             writeln!(self.loader_tree_code, ",")?;
         }
         writeln!(self.loader_tree_code, "}}, {{")?;

--- a/turbopack/crates/turbopack-core/Cargo.toml
+++ b/turbopack/crates/turbopack-core/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-async-recursion = { workspace = true }
 async-trait = { workspace = true }
 auto-hash-map = { workspace = true }
 browserslist-rs = { workspace = true }

--- a/turbopack/crates/turbopack-core/src/chunk/chunking.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking.rs
@@ -1,11 +1,9 @@
 use std::{
     borrow::Cow,
     mem::{replace, take},
-    pin::Pin,
 };
 
 use anyhow::Result;
-use futures::Future;
 use indexmap::IndexMap;
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -255,16 +253,6 @@ async fn package_name_split(
     Ok(())
 }
 
-/// A boxed version of [folder_split] for recursion.
-fn folder_split_boxed<'a, 'b>(
-    chunk_items: Vec<ChunkItemWithInfo>,
-    location: usize,
-    name: Cow<'a, str>,
-    split_context: &'a mut SplitContext<'b>,
-) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
-    Box::pin(folder_split(chunk_items, location, name, split_context))
-}
-
 /// Split chunk items by folder structure.
 #[tracing::instrument(level = Level::TRACE, skip_all, fields(name = display(&name), location))]
 async fn folder_split(
@@ -306,7 +294,13 @@ async fn folder_split(
         let mut key = format!("{}-{}", name, folder_name);
         if !handle_split_group(&mut list, &mut key, split_context, Some(&mut remaining)).await? {
             if let Some(new_location) = new_location {
-                folder_split_boxed(list, new_location, Cow::Borrowed(&name), split_context).await?;
+                Box::pin(folder_split(
+                    list,
+                    new_location,
+                    Cow::Borrowed(&name),
+                    split_context,
+                ))
+                .await?;
             } else {
                 make_chunk(list, &mut key, split_context).await?;
             }

--- a/turbopack/crates/turbopack-core/src/condition.rs
+++ b/turbopack/crates/turbopack-core/src/condition.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use async_recursion::async_recursion;
 use futures::{stream, StreamExt};
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{trace::TraceRawVcs, Vc};
@@ -31,7 +30,6 @@ impl ContextCondition {
         ContextCondition::Not(Box::new(condition))
     }
 
-    #[async_recursion]
     /// Returns true if the condition matches the context.
     pub async fn matches(&self, path: &FileSystemPath) -> Result<bool> {
         match self {
@@ -40,7 +38,7 @@ impl ContextCondition {
                 #[allow(clippy::manual_try_fold)]
                 stream::iter(conditions)
                     .fold(Ok(true), |acc, c| async move {
-                        Ok(acc? && c.matches(path).await?)
+                        Ok(acc? && Box::pin(c.matches(path)).await?)
                     })
                     .await
             }
@@ -49,11 +47,11 @@ impl ContextCondition {
                 #[allow(clippy::manual_try_fold)]
                 stream::iter(conditions)
                     .fold(Ok(false), |acc, c| async move {
-                        Ok(acc? || c.matches(path).await?)
+                        Ok(acc? || Box::pin(c.matches(path)).await?)
                     })
                     .await
             }
-            ContextCondition::Not(condition) => condition.matches(path).await.map(|b| !b),
+            ContextCondition::Not(condition) => Box::pin(condition.matches(path)).await.map(|b| !b),
             ContextCondition::InPath(other_path) => {
                 Ok(path.is_inside_or_equal_ref(&*other_path.await?))
             }

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -338,7 +338,7 @@ async fn import_mapping_to_result(
         }
         ReplacedImportMapping::Alternatives(list) => ImportMapResult::Alternatives(
             list.iter()
-                .map(|mapping| import_mapping_to_result_boxed(*mapping, lookup_path, request))
+                .map(|mapping| Box::pin(import_mapping_to_result(*mapping, lookup_path, request)))
                 .try_join()
                 .await?,
         ),
@@ -382,18 +382,6 @@ impl ValueToString for ImportMapResult {
             ImportMapResult::NoEntry => Ok(Vc::cell("No import map entry".into())),
         }
     }
-}
-
-// This cannot be inlined within `import_mapping_to_result`, otherwise we run
-// into the following error:
-//     cycle detected when computing type of
-//     `resolve::options::import_mapping_to_result::{opaque#0}`
-fn import_mapping_to_result_boxed(
-    mapping: Vc<ReplacedImportMapping>,
-    lookup_path: Vc<FileSystemPath>,
-    request: Vc<Request>,
-) -> Pin<Box<dyn Future<Output = Result<ImportMapResult>> + Send>> {
-    Box::pin(async move { import_mapping_to_result(mapping, lookup_path, request).await })
 }
 
 impl ImportMap {

--- a/turbopack/crates/turbopack/Cargo.toml
+++ b/turbopack/crates/turbopack/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-async-recursion = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 lazy_static = { workspace = true }
 regex = { workspace = true }


### PR DESCRIPTION
An extension of #69762:

> There are also a few more of these helpers if you search for `_boxed(`.

These things used to be needed before Rust 1.77.0: https://blog.rust-lang.org/2024/03/21/Rust-1.77.0.html#support-for-recursion-in-async-fn

These days, we can just do the boxing inline!

I also noticed we could remove the `async-recursion` macro, as it's not providing much value on Rust >=1.77.0.