### PR TITLE
ensure aliased prefetches return correct segment key

### DIFF
--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
@@ -118,7 +118,7 @@ describe('createInitialRouterState', () => {
             lastUsedTime: expect.any(Number),
             treeAtTimeOfPrefetch: initialTree,
             status: PrefetchCacheEntryStatus.fresh,
-            pathname: '/linking',
+            url: new URL('/linking', 'https://localhost'),
           },
         ],
       ]),

--- a/packages/next/src/client/components/router-reducer/prefetch-cache-utils.ts
+++ b/packages/next/src/client/components/router-reducer/prefetch-cache-utils.ts
@@ -90,8 +90,21 @@ function getExistingCacheEntry(
       ? cacheKeyWithParams
       : cacheKeyWithoutParams
 
-    if (prefetchCache.has(cacheKeyToUse)) {
-      return prefetchCache.get(cacheKeyToUse)
+    const existingEntry = prefetchCache.get(cacheKeyToUse)
+    if (existingEntry) {
+      // We know we're returning an aliased entry when the pathname matches but the search params don't,
+      const isAliased =
+        existingEntry.url.pathname === url.pathname &&
+        existingEntry.url.search !== url.search
+
+      if (isAliased) {
+        return {
+          ...existingEntry,
+          aliased: true,
+        }
+      }
+
+      return existingEntry
     }
 
     // If the request contains search params, and we're not doing a full prefetch, we can return the
@@ -120,7 +133,7 @@ function getExistingCacheEntry(
   if (process.env.NODE_ENV !== 'development' && kind !== PrefetchKind.FULL) {
     for (const cacheEntry of prefetchCache.values()) {
       if (
-        cacheEntry.pathname === url.pathname &&
+        cacheEntry.url.pathname === url.pathname &&
         // We shouldn't return the aliased entry if it was relocated to a new cache key.
         // Since it's rewritten, it could respond with a completely different loading state.
         !cacheEntry.key.includes(INTERCEPTION_CACHE_KEY_MARKER)
@@ -262,7 +275,7 @@ export function createPrefetchCacheEntryForInitialLoad({
     lastUsedTime: Date.now(),
     key: prefetchCacheKey,
     status: PrefetchCacheEntryStatus.fresh,
-    pathname: url.pathname,
+    url,
   } satisfies PrefetchCacheEntry
 
   prefetchCache.set(prefetchCacheKey, prefetchEntry)
@@ -338,7 +351,7 @@ function createLazyPrefetchEntry({
     lastUsedTime: null,
     key: prefetchCacheKey,
     status: PrefetchCacheEntryStatus.fresh,
-    pathname: url.pathname,
+    url,
   }
 
   prefetchCache.set(prefetchCacheKey, prefetchEntry)

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -20,7 +20,10 @@ import { handleMutable } from '../handle-mutable'
 import { applyFlightData } from '../apply-flight-data'
 import { prefetchQueue } from './prefetch-reducer'
 import { createEmptyCacheNode } from '../../app-router'
-import { DEFAULT_SEGMENT_KEY } from '../../../../shared/lib/segment'
+import {
+  addSearchParamsIfPageSegment,
+  DEFAULT_SEGMENT_KEY,
+} from '../../../../shared/lib/segment'
 import {
   listenForDynamicRequest,
   updateCacheNodeOnNavigation,
@@ -178,6 +181,15 @@ export function navigateReducer(
 
         // TODO-APP: remove ''
         const flightSegmentPathWithLeadingEmpty = ['', ...flightSegmentPath]
+
+        // Segments are keyed by searchParams (e.g. __PAGE__?{"foo":"bar"}), so if we returned an aliased entry,
+        // we need to ensure the correct searchParams are provided in the updated FlightRouterState tree.
+        if (prefetchValues.aliased) {
+          treePatch[0] = addSearchParamsIfPageSegment(
+            treePatch[0],
+            Object.fromEntries(url.searchParams)
+          )
+        }
 
         // Create new tree based on the flightSegmentPath and router state patch
         let newTree = applyRouterStatePatchToTree(

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -207,7 +207,7 @@ export type PrefetchCacheEntry = {
   lastUsedTime: number | null
   key: string
   status: PrefetchCacheEntryStatus
-  pathname: string
+  url: URL
 }
 
 export enum PrefetchCacheEntryStatus {

--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
@@ -1,23 +1,7 @@
 import type { LoaderTree } from '../lib/app-dir-module'
-import type { FlightRouterState, Segment } from './types'
+import type { FlightRouterState } from './types'
 import type { GetDynamicParamFromSegment } from './app-render'
-import { PAGE_SEGMENT_KEY } from '../../shared/lib/segment'
-
-export function addSearchParamsIfPageSegment(
-  segment: Segment,
-  searchParams: any
-) {
-  const isPageSegment = segment === PAGE_SEGMENT_KEY
-
-  if (isPageSegment) {
-    const stringifiedQuery = JSON.stringify(searchParams)
-    return stringifiedQuery !== '{}'
-      ? segment + '?' + stringifiedQuery
-      : segment
-  }
-
-  return segment
-}
+import { addSearchParamsIfPageSegment } from '../../shared/lib/segment'
 
 export function createFlightRouterStateFromLoaderTree(
   [segment, parallelRoutes, { layout }]: LoaderTree,

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -13,13 +13,13 @@ import {
 import type { LoaderTree } from '../lib/app-dir-module'
 import { getLinkAndScriptTags } from './get-css-inlined-link-tags'
 import { getPreloadableFonts } from './get-preloadable-fonts'
-import {
-  addSearchParamsIfPageSegment,
-  createFlightRouterStateFromLoaderTree,
-} from './create-flight-router-state-from-loader-tree'
+import { createFlightRouterStateFromLoaderTree } from './create-flight-router-state-from-loader-tree'
 import type { CreateSegmentPath, AppRenderContext } from './app-render'
 import { hasLoadingComponentInTree } from './has-loading-component-in-tree'
-import { DEFAULT_SEGMENT_KEY } from '../../shared/lib/segment'
+import {
+  DEFAULT_SEGMENT_KEY,
+  addSearchParamsIfPageSegment,
+} from '../../shared/lib/segment'
 import { createComponentTree } from './create-component-tree'
 
 /**

--- a/packages/next/src/shared/lib/segment.ts
+++ b/packages/next/src/shared/lib/segment.ts
@@ -1,6 +1,24 @@
+import type { Segment } from '../../server/app-render/types'
+
 export function isGroupSegment(segment: string) {
   // Use array[0] for performant purpose
   return segment[0] === '(' && segment.endsWith(')')
+}
+
+export function addSearchParamsIfPageSegment(
+  segment: Segment,
+  searchParams: Record<string, string | string[] | undefined>
+) {
+  const isPageSegment = segment.includes(PAGE_SEGMENT_KEY)
+
+  if (isPageSegment) {
+    const stringifiedQuery = JSON.stringify(searchParams)
+    return stringifiedQuery !== '{}'
+      ? PAGE_SEGMENT_KEY + '?' + stringifiedQuery
+      : PAGE_SEGMENT_KEY
+  }
+
+  return segment
 }
 
 export const PAGE_SEGMENT_KEY = '__PAGE__'

--- a/test/e2e/app-dir/searchparams-reuse-loading/app/other-page/page.tsx
+++ b/test/e2e/app-dir/searchparams-reuse-loading/app/other-page/page.tsx
@@ -1,0 +1,36 @@
+import Link from 'next/link'
+
+export default async function Home({ searchParams }) {
+  return (
+    <div>
+      <h1>
+        {searchParams.page ? (
+          <>You are on page {JSON.stringify(searchParams.page)}.</>
+        ) : (
+          <>You are on the root page.</>
+        )}
+      </h1>
+
+      <div>
+        <Link href="/other-page?page=2" replace>
+          page 2
+        </Link>
+      </div>
+      <div>
+        <Link href="/other-page?page=3" replace>
+          page 3
+        </Link>
+      </div>
+      <div>
+        <Link href="/other-page?page=4" replace>
+          page 4
+        </Link>
+      </div>
+      <div>
+        <Link href="/other-page" replace>
+          No Params
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/searchparams-reuse-loading/app/page.tsx
+++ b/test/e2e/app-dir/searchparams-reuse-loading/app/page.tsx
@@ -24,6 +24,11 @@ export default function Page({ searchParams }) {
             /search-params (prefetch: true)
           </Link>
         </li>
+        <li>
+          <Link href="/other-page" prefetch={false}>
+            /other-page
+          </Link>
+        </li>
       </ul>
     </>
   )

--- a/test/e2e/app-dir/searchparams-reuse-loading/searchparams-reuse-loading.test.ts
+++ b/test/e2e/app-dir/searchparams-reuse-loading/searchparams-reuse-loading.test.ts
@@ -39,7 +39,7 @@ describe('searchparams-reuse-loading', () => {
     expect(params).toBe('{"id":"1"}')
   })
 
-  it('should return reflect the correct searchParams when re-using the same page segment', async () => {
+  it('should reflect the correct searchParams when re-using the same page segment', async () => {
     const browser = await next.browser('/other-page')
     await browser.elementByCss("[href='/other-page?page=2']").click()
     await retry(async () => {
@@ -58,9 +58,9 @@ describe('searchparams-reuse-loading', () => {
     expect(await browser.elementByCss('h1').text()).toBe('You are on page "4".')
     await browser.elementByCss("[href='/other-page']").click()
     await retry(async () => {
-      const currentUrl = new URL(await browser.url());
-       expect(currentUrl.pathname).toBe('/other-page');
-        expect(currentUrl.search).toBe('');
+      const currentUrl = new URL(await browser.url())
+      expect(currentUrl.pathname).toBe('/other-page')
+      expect(currentUrl.search).toBe('')
     })
     expect(await browser.elementByCss('h1').text()).toBe(
       'You are on the root page.'

--- a/test/e2e/app-dir/searchparams-reuse-loading/searchparams-reuse-loading.test.ts
+++ b/test/e2e/app-dir/searchparams-reuse-loading/searchparams-reuse-loading.test.ts
@@ -58,7 +58,7 @@ describe('searchparams-reuse-loading', () => {
     expect(await browser.elementByCss('h1').text()).toBe('You are on page "4".')
     await browser.elementByCss("[href='/other-page']").click()
     await retry(async () => {
-      expect(await browser.url()).toContain('/other-page')
+      expect(await browser.url()).toEqual('/other-page')
     })
     expect(await browser.elementByCss('h1').text()).toBe(
       'You are on the root page.'

--- a/test/e2e/app-dir/searchparams-reuse-loading/searchparams-reuse-loading.test.ts
+++ b/test/e2e/app-dir/searchparams-reuse-loading/searchparams-reuse-loading.test.ts
@@ -58,7 +58,9 @@ describe('searchparams-reuse-loading', () => {
     expect(await browser.elementByCss('h1').text()).toBe('You are on page "4".')
     await browser.elementByCss("[href='/other-page']").click()
     await retry(async () => {
-      expect(await browser.url()).toEqual('/other-page')
+      const currentUrl = new URL(await browser.url());
+       expect(currentUrl.pathname).toBe('/other-page');
+        expect(currentUrl.search).toBe('');
     })
     expect(await browser.elementByCss('h1').text()).toBe(
       'You are on the root page.'

--- a/test/e2e/app-dir/searchparams-reuse-loading/searchparams-reuse-loading.test.ts
+++ b/test/e2e/app-dir/searchparams-reuse-loading/searchparams-reuse-loading.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
 import type { Route, Page } from 'playwright'
 
 describe('searchparams-reuse-loading', () => {
@@ -36,6 +37,32 @@ describe('searchparams-reuse-loading', () => {
     await browser.elementByCss("[href='/?id=1']").click()
     const params = await browser.waitForElementByCss('#root-params').text()
     expect(params).toBe('{"id":"1"}')
+  })
+
+  it('should return reflect the correct searchParams when re-using the same page segment', async () => {
+    const browser = await next.browser('/other-page')
+    await browser.elementByCss("[href='/other-page?page=2']").click()
+    await retry(async () => {
+      expect(await browser.url()).toContain('/other-page?page=2')
+    })
+    expect(await browser.elementByCss('h1').text()).toBe('You are on page "2".')
+    await browser.elementByCss("[href='/other-page?page=3']").click()
+    await retry(async () => {
+      expect(await browser.url()).toContain('/other-page?page=3')
+    })
+    expect(await browser.elementByCss('h1').text()).toBe('You are on page "3".')
+    await browser.elementByCss("[href='/other-page?page=4']").click()
+    await retry(async () => {
+      expect(await browser.url()).toContain('/other-page?page=4')
+    })
+    expect(await browser.elementByCss('h1').text()).toBe('You are on page "4".')
+    await browser.elementByCss("[href='/other-page']").click()
+    await retry(async () => {
+      expect(await browser.url()).toContain('/other-page')
+    })
+    expect(await browser.elementByCss('h1').text()).toBe(
+      'You are on the root page.'
+    )
   })
 
   // Dev doesn't perform prefetching, so this test is skipped, as it relies on intercepting


### PR DESCRIPTION
When returning an aliased prefetch, we need to make sure the final tree that is produced contains the final searchParams, as otherwise the router might not properly re-key the component to reflect the changed search value. This moves the existing util that handled appending `searchParams` to the `__PAGE__` segment into the shared segment helpers. On the client, when we detect that we returned an aliased prefetch, we update the segment key with the "final" data by calling this helper with the final searchParams.

This also fixes a missing `aliased` detection in the case where we do find an entry as it's possible the entry matches the path, but not the search. It wasn’t sufficient to only do this for full prefetches because while auto prefetches won’t return the CacheNode data, it will return a tree, so we need to make sure the tree contains the right params. 

Fixes #69847