### PR TITLE
Turbopack build: Fix script-loader test

### DIFF
--- a/test/integration/script-loader/test/index.test.js
+++ b/test/integration/script-loader/test/index.test.js
@@ -219,7 +219,9 @@ const runTests = (isDev) => {
     if (!isDev) {
       // Script is inserted before CSS
       expect(
-        $(`#inline-before ~ link[href^="/_next/static/css"]`).length
+        $(`#inline-before ~ link[href^="/_next/static/"]`).filter(
+          (i, element) => $(element).attr('href')?.endsWith('.css')
+        ).length
       ).toBeGreaterThan(0)
     }
   })

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -14807,11 +14807,10 @@
         "Next.js Script - Primary Strategies - Strict Mode priority beforeInteractive on navigate",
         "Next.js Script - Primary Strategies - Strict Mode priority beforeInteractive with inline script",
         "Next.js Script - Primary Strategies - Strict Mode priority beforeInteractive with inline script should execute",
-        "Next.js Script - Primary Strategies - Strict Mode priority lazyOnload"
-      ],
-      "failed": [
+        "Next.js Script - Primary Strategies - Strict Mode priority lazyOnload",
         "Next.js Script - Primary Strategies - Production Mode production mode priority beforeInteractive with inline script"
       ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false


### PR DESCRIPTION
With Turbopack the output path is a bit different that's why the test couldn't find the `.css` file. Changed the test to ensure it checks for `.css` files existing.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
