### PR TITLE
Report Turbopack error to error overlay

### DIFF
--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -81,7 +81,7 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 
 fn init() {
     set_hook(Box::new(|panic_info| {
-        util::log_panic_and_inform(format!(
+        util::log_internal_error_and_inform(format!(
             "Panic: {}\nBacktrace: {:?}",
             panic_info,
             Backtrace::new()

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -81,7 +81,7 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 
 fn init() {
     set_hook(Box::new(|panic_info| {
-        util::log_internal_error_and_inform(format!(
+        util::log_internal_error_and_inform(&format!(
             "Panic: {}\nBacktrace: {:?}",
             panic_info,
             Backtrace::new()

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -48,7 +48,7 @@ use super::{
         TurbopackResult, VcArc,
     },
 };
-use crate::{register, util::log_panic_and_inform};
+use crate::register;
 
 /// Used by [`benchmark_file_io`]. This is a noisy benchmark, so set the
 /// threshold high.
@@ -736,8 +736,7 @@ pub fn project_hmr_events(
 
                     let update = hmr_update(project, identifier.clone(), state)
                         .strongly_consistent()
-                        .await
-                        .inspect_err(|e| log_panic_and_inform(e))?;
+                        .await?;
                     let HmrUpdateWithIssues {
                         update,
                         issues,

--- a/crates/napi/src/next_api/utils.rs
+++ b/crates/napi/src/next_api/utils.rs
@@ -17,7 +17,7 @@ use turbopack_core::{
     source_pos::SourcePos,
 };
 
-use crate::util::log_panic_and_inform;
+use crate::util::log_internal_error_and_inform;
 
 /// A helper type to hold both a Vc operation and the TurboTasks root process.
 /// Without this, we'd need to pass both individually all over the place
@@ -315,7 +315,7 @@ pub fn subscribe<T: 'static + Send + Sync, F: Future<Output = Result<T>> + Send,
 
             let status = func.call(
                 result.map_err(|e| {
-                    log_panic_and_inform(&e);
+                    log_internal_error_and_inform(&e);
                     napi::Error::from_reason(PrettyPrintError(&e).to_string())
                 }),
                 ThreadsafeFunctionCallMode::NonBlocking,

--- a/crates/napi/src/next_api/utils.rs
+++ b/crates/napi/src/next_api/utils.rs
@@ -17,6 +17,8 @@ use turbopack_core::{
     source_pos::SourcePos,
 };
 
+use crate::util::log_panic_and_inform;
+
 /// A helper type to hold both a Vc operation and the TurboTasks root process.
 /// Without this, we'd need to pass both individually all over the place
 #[derive(Clone)]
@@ -312,7 +314,10 @@ pub fn subscribe<T: 'static + Send + Sync, F: Future<Output = Result<T>> + Send,
             let result = handler().await;
 
             let status = func.call(
-                result.map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string())),
+                result.map_err(|e| {
+                    log_panic_and_inform(&e);
+                    napi::Error::from_reason(PrettyPrintError(&e).to_string())
+                }),
                 ThreadsafeFunctionCallMode::NonBlocking,
             );
             if !matches!(status, Status::Ok) {

--- a/crates/napi/src/next_api/utils.rs
+++ b/crates/napi/src/next_api/utils.rs
@@ -315,8 +315,9 @@ pub fn subscribe<T: 'static + Send + Sync, F: Future<Output = Result<T>> + Send,
 
             let status = func.call(
                 result.map_err(|e| {
-                    log_internal_error_and_inform(&e);
-                    napi::Error::from_reason(PrettyPrintError(&e).to_string())
+                    let error = PrettyPrintError(&e).to_string();
+                    log_internal_error_and_inform(&error);
+                    napi::Error::from_reason(error)
                 }),
                 ThreadsafeFunctionCallMode::NonBlocking,
             );

--- a/crates/napi/src/util.rs
+++ b/crates/napi/src/util.rs
@@ -52,7 +52,7 @@ static PANIC_LOG: Lazy<PathBuf> = Lazy::new(|| {
     path
 });
 
-pub fn log_panic_and_inform(err_info: impl Debug) {
+pub fn log_internal_error_and_inform(err_info: impl Debug) {
     if cfg!(debug_assertions)
         || env::var("SWC_DEBUG") == Ok("1".to_string())
         || env::var("CI").is_ok_and(|v| !v.is_empty())

--- a/crates/napi/src/util.rs
+++ b/crates/napi/src/util.rs
@@ -29,7 +29,7 @@ DEALINGS IN THE SOFTWARE.
 use std::{
     cell::RefCell,
     env,
-    fmt::Debug,
+    fmt::{Debug, Display},
     fs::OpenOptions,
     io::{self, BufRead, Write},
     path::PathBuf,
@@ -52,13 +52,13 @@ static PANIC_LOG: Lazy<PathBuf> = Lazy::new(|| {
     path
 });
 
-pub fn log_internal_error_and_inform(err_info: impl Debug) {
+pub fn log_internal_error_and_inform(err_info: &str) {
     if cfg!(debug_assertions)
         || env::var("SWC_DEBUG") == Ok("1".to_string())
         || env::var("CI").is_ok_and(|v| !v.is_empty())
     {
         eprintln!(
-            "{}: An unexpected Turbopack error occurred:\n{:?}",
+            "{}: An unexpected Turbopack error occurred:\n{}",
             "FATAL".red().bold(),
             err_info
         );
@@ -121,7 +121,7 @@ pub fn log_internal_error_and_inform(err_info: impl Debug) {
         .open(PANIC_LOG.as_path())
         .unwrap_or_else(|_| panic!("Failed to open {}", PANIC_LOG.to_string_lossy()));
 
-    writeln!(log_file, "{}\n{:?}", LOG_DIVIDER, err_info).unwrap();
+    writeln!(log_file, "{}\n{}", LOG_DIVIDER, err_info).unwrap();
     eprintln!("{}: An unexpected Turbopack error occurred. Please report the content of {} to https://github.com/vercel/next.js/issues/new", "FATAL".red().bold(), PANIC_LOG.to_string_lossy());
 }
 

--- a/crates/napi/src/util.rs
+++ b/crates/napi/src/util.rs
@@ -29,7 +29,6 @@ DEALINGS IN THE SOFTWARE.
 use std::{
     cell::RefCell,
     env,
-    fmt::{Debug, Display},
     fs::OpenOptions,
     io::{self, BufRead, Write},
     path::PathBuf,

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -60,6 +60,7 @@ import {
   isWellKnownError,
   printNonFatalIssue,
   normalizedPageToTurbopackStructureRoute,
+  TurbopackInternalError,
 } from './turbopack-utils'
 import {
   propagateServerField,
@@ -465,6 +466,23 @@ export async function createHotReloaderTurbopack(
         }
       }
     } catch (e) {
+      if (e instanceof TurbopackInternalError) {
+        sendToClient(client, {
+          action: HMR_ACTIONS_SENT_TO_BROWSER.SYNC,
+          errors: [
+            {
+              message:
+                'An unexpected Turbopack error occurred. Please see the output of `next dev` for more details.',
+            },
+          ],
+          hash: String(++hmrHash),
+          warnings: [],
+          versionInfo: await versionInfoPromise,
+        })
+        client.close()
+        return
+      }
+
       // The client might be using an HMR session from a previous server, tell them
       // to fully reload the page to resolve the issue. We can't use
       // `hotReloader.send` since that would force every connected client to


### PR DESCRIPTION
### What?

If a Rust Error Result is returned by an hmr update, then an unexpected internal error unrelated to the user’s code has occurred. This also reports the error to the user into the error overlay.

Closes PACK-4390