### PR TITLE
test: lock ts type check

### DIFF
--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -173,7 +173,9 @@ export class NextInstance {
           'react-dom': reactVersion,
           '@types/react': 'latest',
           '@types/react-dom': 'latest',
-          typescript: 'latest',
+          // TODO: fix the TS error with the TS 5.6
+          // x-ref: https://github.com/vercel/next.js/actions/runs/10777104696/job/29887663970?pr=69784
+          typescript: '5.5.4',
           '@types/node': 'latest',
           ...this.dependencies,
           ...this.packageJson?.dependencies,

--- a/test/production/middleware-typescript/test/index.test.ts
+++ b/test/production/middleware-typescript/test/index.test.ts
@@ -5,6 +5,11 @@ import { nextTestSetup } from 'e2e-utils'
 describe('middleware-typescript', () => {
   const { next } = nextTestSetup({
     files: join(__dirname, '../app'),
+    dependencies: {
+      // TODO: fix the TS error with the TS 5.6
+      // x-ref: https://github.com/vercel/next.js/actions/runs/10777104696/job/29887663970?pr=69784
+      typescript: '5.5.4',
+    },
   })
 
   it('should have built and started', async () => {

--- a/test/production/middleware-typescript/test/index.test.ts
+++ b/test/production/middleware-typescript/test/index.test.ts
@@ -5,11 +5,6 @@ import { nextTestSetup } from 'e2e-utils'
 describe('middleware-typescript', () => {
   const { next } = nextTestSetup({
     files: join(__dirname, '../app'),
-    dependencies: {
-      // TODO: fix the TS error with the TS 5.6
-      // x-ref: https://github.com/vercel/next.js/actions/runs/10777104696/job/29887663970?pr=69784
-      typescript: '5.5.4',
-    },
   })
 
   it('should have built and started', async () => {


### PR DESCRIPTION
lock the TS version to 5.5 to avoid the errors with 5.6 on CI, will fix it later in a separate PR. This is to unblock the release