### PR TITLE
docs(link): update scroll docs

### DIFF
--- a/docs/02-app/02-api-reference/01-components/link.mdx
+++ b/docs/02-app/02-api-reference/01-components/link.mdx
@@ -227,7 +227,9 @@ export default function Home() {
 
 ### `scroll`
 
-**Defaults to `true`.** The default behavior of `<Link>` **is to scroll to the top of a new route or to maintain the scroll position for backwards and forwards navigation.** When `false`, `next/link` will _not_ scroll to the top of the page after a navigation.
+**Defaults to `true`.** By default, the scrolling behavior of `<Link>` in Next.js **is to maintain scroll position**, similar to how browsers handle back and fowards navigation. When you navigate to a new [Page](/docs/app/building-your-application/routing/pages), scroll position will stay the same as long as the Page is visible in the viewport. However, if the Page is not visible in the viewport, Next.js will scroll to the top of the first Page element.
+
+When `scroll = {false}`, Next.js will not attempt to scroll to the first Page element.
 
 <AppOnly>
 
@@ -284,10 +286,6 @@ export default function Home() {
 ```
 
 </PagesOnly>
-
-> **Good to know**:
->
-> - Next.js will scroll to the [Page](/docs/app/building-your-application/routing/pages) if it is not visible in the viewport upon navigation.
 
 ### `prefetch`
 


### PR DESCRIPTION
## Why?

The current docs on scrolling behavior when using `<Link>` are misleading and incorrect. This edit correctly documents the expected scrolling behavior (in both `true` or `false` cases).

- https://nextjs.org/docs/app/api-reference/components/link#scroll