### PR TITLE
docs(revalidate): add not about revalidate in Development

### DIFF
--- a/docs/02-app/02-api-reference/02-file-conventions/route-segment-config.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/route-segment-config.mdx
@@ -110,6 +110,7 @@ export const revalidate = false
 >
 > - The revalidate value needs to be statically analyzable. For example `revalidate = 600` is valid, but `revalidate = 60 * 10` is not.
 > - The revalidate value is not available when using `runtime = 'edge'`.
+> - In Development, Pages are _always_ rendered on-demand and are never cached. This allows you to see changes immediately without waiting for a revalidation period to pass.
 
 #### Revalidation Frequency
 


### PR DESCRIPTION
## Why?

There is no mention that Pages are rendered on demand in Development, regardless if you use this route segment config.

```
export const revalidate = 10
```