### PR TITLE
chore(turbo-tasks): Remove dead md4 support from turbo-tasks-hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3759,15 +3759,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "md4"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da5ac363534dce5fabf69949225e174fbf111a498bf0ff794c8ea1fba9f3dda"
-dependencies = [
- "digest",
-]
-
-[[package]]
 name = "mdxjs"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8692,7 +8683,6 @@ dependencies = [
 name = "turbo-tasks-hash"
 version = "0.1.0"
 dependencies = [
- "md4",
  "turbo-tasks-macros",
  "twox-hash",
 ]

--- a/turbopack/crates/turbo-tasks-hash/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-hash/Cargo.toml
@@ -13,6 +13,5 @@ bench = false
 workspace = true
 
 [dependencies]
-md4 = "0.10.1"
 turbo-tasks-macros = { workspace = true }
 twox-hash = "1.6.3"

--- a/turbopack/crates/turbo-tasks-hash/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-hash/src/lib.rs
@@ -6,12 +6,10 @@
 
 mod deterministic_hash;
 mod hex;
-mod md4;
 mod xxh3_hash64;
 
 pub use crate::{
     deterministic_hash::{DeterministicHash, DeterministicHasher},
     hex::encode_hex,
-    md4::hash_md4,
     xxh3_hash64::{hash_xxh3_hash128, hash_xxh3_hash64, Xxh3Hash64Hasher},
 };

--- a/turbopack/crates/turbo-tasks-hash/src/md4.rs
+++ b/turbopack/crates/turbo-tasks-hash/src/md4.rs
@@ -1,8 +1,0 @@
-use md4::Digest;
-
-/// Hash some content with the MD4 cryptographic hash function.
-///
-/// Returns a 16-byte hash digest.
-pub fn hash_md4(content: &[u8]) -> [u8; 16] {
-    md4::Md4::digest(content).into()
-}


### PR DESCRIPTION
We now use xxh3 for our deterministic non-cryptographic hashing needs.

[![deadcode](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/WjlTemxb6oA4PgZFmj08/fabeefec-6b93-4740-85c6-16e9e66a8e29/deadcode.jpeg)](https://app.graphite.dev//settings/meme-library?org=vercel)