### PR TITLE
bugfix: actions that redirect should reject the action promise

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -58,6 +58,12 @@ import type { FlightRouterState } from '../../server/app-render/types'
 import { useNavFailureHandler } from './nav-failure-handler'
 import { useServerActionDispatcher } from '../app-call-server'
 import type { AppRouterActionQueue } from '../../shared/lib/router/action-queue'
+import {
+  getRedirectTypeFromError,
+  getURLFromRedirectError,
+  isRedirectError,
+  RedirectType,
+} from './redirect'
 
 const globalMutable: {
   pendingMpaPath?: string
@@ -368,6 +374,31 @@ function Router({
       window.removeEventListener('pageshow', handlePageShow)
     }
   }, [dispatch])
+
+  useEffect(() => {
+    // Ensure that any redirect errors that bubble up outside of the RedirectBoundary
+    // are caught and handled by the router.
+    function handle(event: ErrorEvent | PromiseRejectionEvent) {
+      const error = 'reason' in event ? event.reason : event.error
+      if (isRedirectError(error)) {
+        event.preventDefault()
+        const url = getURLFromRedirectError(error)
+        const redirectType = getRedirectTypeFromError(error)
+        if (redirectType === RedirectType.push) {
+          appRouter.push(url, {})
+        } else {
+          appRouter.replace(url, {})
+        }
+      }
+    }
+    window.addEventListener('error', handle)
+    window.addEventListener('unhandledrejection', handle)
+
+    return () => {
+      window.removeEventListener('error', handle)
+      window.removeEventListener('unhandledrejection', handle)
+    }
+  }, [appRouter])
 
   // When mpaNavigation flag is set do a hard navigation to the new url.
   // Infinitely suspend because we don't actually want to rerender any child

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -378,7 +378,9 @@ function Router({
   useEffect(() => {
     // Ensure that any redirect errors that bubble up outside of the RedirectBoundary
     // are caught and handled by the router.
-    function handle(event: ErrorEvent | PromiseRejectionEvent) {
+    function handleUnhandledRedirect(
+      event: ErrorEvent | PromiseRejectionEvent
+    ) {
       const error = 'reason' in event ? event.reason : event.error
       if (isRedirectError(error)) {
         event.preventDefault()
@@ -391,12 +393,12 @@ function Router({
         }
       }
     }
-    window.addEventListener('error', handle)
-    window.addEventListener('unhandledrejection', handle)
+    window.addEventListener('error', handleUnhandledRedirect)
+    window.addEventListener('unhandledrejection', handleUnhandledRedirect)
 
     return () => {
-      window.removeEventListener('error', handle)
-      window.removeEventListener('unhandledrejection', handle)
+      window.removeEventListener('error', handleUnhandledRedirect)
+      window.removeEventListener('unhandledrejection', handleUnhandledRedirect)
     }
   }, [appRouter])
 

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/use-error-handler.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/use-error-handler.ts
@@ -58,6 +58,11 @@ if (typeof window !== 'undefined') {
     'unhandledrejection',
     (ev: WindowEventMap['unhandledrejection']): void => {
       const reason = ev?.reason
+      if (isNextRouterError(reason)) {
+        ev.preventDefault()
+        return
+      }
+
       if (
         !reason ||
         !(reason instanceof Error) ||

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -4,8 +4,8 @@ import type { FlightDataPath } from '../../../server/app-render/types'
 import { createHrefFromUrl } from './create-href-from-url'
 import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-head'
 import { extractPathFromFlightRouterState } from './compute-changed-path'
-import { createPrefetchCacheEntryForInitialLoad } from './prefetch-cache-utils'
-import type { PrefetchCacheEntry } from './router-reducer-types'
+import { createSeededPrefetchCacheEntry } from './prefetch-cache-utils'
+import { PrefetchKind, type PrefetchCacheEntry } from './router-reducer-types'
 import { addRefreshMarkerToActiveParallelSegments } from './refetch-inactive-parallel-segments'
 import { getFlightDataPartsFromPath } from '../../flight-data-helpers'
 
@@ -112,7 +112,7 @@ export function createInitialRouterState({
       location.origin
     )
 
-    createPrefetchCacheEntryForInitialLoad({
+    createSeededPrefetchCacheEntry({
       url,
       data: {
         flightData: [normalizedFlightData],
@@ -125,6 +125,7 @@ export function createInitialRouterState({
       tree: initialState.tree,
       prefetchCache: initialState.prefetchCache,
       nextUrl: initialState.nextUrl,
+      kind: PrefetchKind.AUTO,
     })
   }
 

--- a/packages/next/src/client/components/router-reducer/prefetch-cache-utils.ts
+++ b/packages/next/src/client/components/router-reducer/prefetch-cache-utils.ts
@@ -249,19 +249,20 @@ function prefixExistingPrefetchCacheEntry({
 /**
  * Use to seed the prefetch cache with data that has already been fetched.
  */
-export function createPrefetchCacheEntryForInitialLoad({
+export function createSeededPrefetchCacheEntry({
   nextUrl,
   tree,
   prefetchCache,
   url,
   data,
+  kind,
 }: Pick<ReadonlyReducerState, 'nextUrl' | 'tree' | 'prefetchCache'> & {
   url: URL
   data: FetchServerResponseResult
+  kind: PrefetchKind
 }) {
   // The initial cache entry technically includes full data, but it isn't explicitly prefetched -- we just seed the
   // prefetch cache so that we can skip an extra prefetch request later, since we already have the data.
-  const kind = PrefetchKind.AUTO
   // if the prefetch corresponds with an interception route, we use the nextUrl to prefix the cache key
   const prefetchCacheKey = data.couldBeIntercepted
     ? createPrefetchCacheKey(url, kind, nextUrl)

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -3068,25 +3068,26 @@ export default abstract class Server<
 
     if (
       isSSG &&
-      !this.minimalMode &&
       // We don't want to send a cache header for requests that contain dynamic
       // data. If this is a Dynamic RSC request or wasn't a Prefetch RSC
       // request, then we should set the cache header.
       !isDynamicRSCRequest &&
       (!didPostpone || isPrefetchRSCRequest)
     ) {
-      // set x-nextjs-cache header to match the header
-      // we set for the image-optimizer
-      res.setHeader(
-        'x-nextjs-cache',
-        isOnDemandRevalidate
-          ? 'REVALIDATED'
-          : cacheEntry.isMiss
-            ? 'MISS'
-            : cacheEntry.isStale
-              ? 'STALE'
-              : 'HIT'
-      )
+      if (!this.minimalMode) {
+        // set x-nextjs-cache header to match the header
+        // we set for the image-optimizer
+        res.setHeader(
+          'x-nextjs-cache',
+          isOnDemandRevalidate
+            ? 'REVALIDATED'
+            : cacheEntry.isMiss
+              ? 'MISS'
+              : cacheEntry.isStale
+                ? 'STALE'
+                : 'HIT'
+        )
+      }
       // Set a header used by the client router to signal the response is static
       // and should respect the `static` cache staleTime value.
       res.setHeader(NEXT_IS_PRERENDER_HEADER, '1')

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -564,6 +564,64 @@ describe('app-dir action handling', () => {
     await check(() => browser.elementByCss('h1').text(), 'Transition is: idle')
   })
 
+  it('should reset the form state when the action redirects to a page that contains the same form', async () => {
+    const browser = await next.browser('/redirect')
+    const input = await browser.elementByCss('input[name="name"]')
+    const submit = await browser.elementByCss('button')
+
+    expect(await browser.hasElementByCssSelector('#error')).toBe(false)
+
+    await input.fill('foo')
+    await submit.click()
+
+    // The server action will fail validation and will return error state
+    // verify that the error state is displayed
+    await retry(async () => {
+      expect(await browser.hasElementByCssSelector('#error')).toBe(true)
+      expect(await browser.elementByCss('#error').text()).toBe(
+        "Only 'justputit' is accepted."
+      )
+    })
+
+    // The server action won't return an error state, it will just call redirect to itself
+    // Validate that the form state is reset
+    await input.fill('justputit')
+    await submit.click()
+
+    await retry(async () => {
+      expect(await browser.hasElementByCssSelector('#error')).toBe(false)
+    })
+  })
+
+  it('should reset the form state when the action redirects to itself', async () => {
+    const browser = await next.browser('/self-redirect')
+    const input = await browser.elementByCss('input[name="name"]')
+    const submit = await browser.elementByCss('button')
+
+    expect(await browser.hasElementByCssSelector('#error')).toBe(false)
+
+    await input.fill('foo')
+    await submit.click()
+
+    // The server action will fail validation and will return error state
+    // verify that the error state is displayed
+    await retry(async () => {
+      expect(await browser.hasElementByCssSelector('#error')).toBe(true)
+      expect(await browser.elementByCss('#error').text()).toBe(
+        "Only 'justputit' is accepted."
+      )
+    })
+
+    // The server action won't return an error state, it will just call redirect to itself
+    // Validate that the form state is reset
+    await input.fill('justputit')
+    await submit.click()
+
+    await retry(async () => {
+      expect(await browser.hasElementByCssSelector('#error')).toBe(false)
+    })
+  })
+
   // This is disabled when deployed because the 404 page will be served as a static route
   // which will not support POST requests, and will return a 405 instead.
   if (!isNextDeploy) {

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -957,9 +957,13 @@ describe('app-dir action handling', () => {
           'redirected'
         )
 
-        // no other requests should be made
-        expect(requests).toHaveLength(1)
-        expect(responses).toHaveLength(1)
+        // This verifies the redirect & server response happens in a single roundtrip,
+        // if the redirect resource was static. In development, these responses are always
+        // dynamically generated, so we only expect a single request for build/deploy.
+        if (!isNextDev) {
+          expect(requests).toHaveLength(1)
+          expect(responses).toHaveLength(1)
+        }
 
         const request = requests[0]
         const response = responses[0]
@@ -1056,9 +1060,13 @@ describe('app-dir action handling', () => {
         await browser.elementById(`redirect-${redirectType}`).click()
         await check(() => browser.url(), `${next.url}${destinationPagePath}`)
 
-        // no other requests should be made
-        expect(requests).toHaveLength(1)
-        expect(responses).toHaveLength(1)
+        // This verifies the redirect & server response happens in a single roundtrip,
+        // if the redirect resource was static. In development, these responses are always
+        // dynamically generated, so we only expect a single request for build/deploy.
+        if (!isNextDev) {
+          expect(requests).toHaveLength(1)
+          expect(responses).toHaveLength(1)
+        }
 
         const request = requests[0]
         const response = responses[0]

--- a/test/e2e/app-dir/actions/app/redirect/actions.ts
+++ b/test/e2e/app-dir/actions/app/redirect/actions.ts
@@ -1,0 +1,17 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+
+type State = {
+  errors: Record<string, string>
+}
+
+export async function action(previousState: State, formData: FormData) {
+  const name = formData.get('name')
+
+  if (name !== 'justputit') {
+    return { errors: { name: "Only 'justputit' is accepted." } }
+  }
+
+  redirect('/redirect/other')
+}

--- a/test/e2e/app-dir/actions/app/redirect/layout.tsx
+++ b/test/e2e/app-dir/actions/app/redirect/layout.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import React, { useActionState } from 'react'
+import { action } from './actions'
+
+export default function Page({ children }) {
+  const [{ errors }, dispatch] = useActionState(action, {
+    errors: { name: '' },
+  })
+
+  return (
+    <div>
+      <form action={dispatch}>
+        <input type="text" name="name" />
+        <button type="submit">Submit</button>
+        {errors.name && <p id="error">{errors.name}</p>}
+      </form>
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/actions/app/redirect/other/page.tsx
+++ b/test/e2e/app-dir/actions/app/redirect/other/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Other Page</div>
+}

--- a/test/e2e/app-dir/actions/app/redirect/page.tsx
+++ b/test/e2e/app-dir/actions/app/redirect/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Main Page</div>
+}

--- a/test/e2e/app-dir/actions/app/self-redirect/actions.ts
+++ b/test/e2e/app-dir/actions/app/self-redirect/actions.ts
@@ -1,0 +1,17 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+
+type State = {
+  errors: Record<string, string>
+}
+
+export async function action(previousState: State, formData: FormData) {
+  const name = formData.get('name')
+
+  if (name !== 'justputit') {
+    return { errors: { name: "Only 'justputit' is accepted." } }
+  }
+
+  redirect('/self-redirect')
+}

--- a/test/e2e/app-dir/actions/app/self-redirect/layout.tsx
+++ b/test/e2e/app-dir/actions/app/self-redirect/layout.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import React, { useActionState } from 'react'
+import { action } from './actions'
+
+export default function Page({ children }) {
+  const [{ errors }, dispatch] = useActionState(action, {
+    errors: { name: '' },
+  })
+
+  return (
+    <div>
+      <form action={dispatch}>
+        <input type="text" name="name" />
+        <button type="submit">Submit</button>
+        {errors.name && <p id="error">{errors.name}</p>}
+      </form>
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/actions/app/self-redirect/other/page.tsx
+++ b/test/e2e/app-dir/actions/app/self-redirect/other/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Other Page</div>
+}

--- a/test/e2e/app-dir/actions/app/self-redirect/page.tsx
+++ b/test/e2e/app-dir/actions/app/self-redirect/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Main Page</div>
+}

--- a/test/e2e/app-dir/app-basepath/index.test.ts
+++ b/test/e2e/app-dir/app-basepath/index.test.ts
@@ -3,7 +3,7 @@ import { check, retry } from 'next-test-utils'
 import type { Request, Response } from 'playwright'
 
 describe('app dir - basepath', () => {
-  const { next } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     dependencies: {
       sass: 'latest',
@@ -132,9 +132,13 @@ describe('app dir - basepath', () => {
 
       expect(await browser.waitForElementByCss('#page-2').text()).toBe(`Page 2`)
 
-      // verify that the POST request was only made to the action handler
-      expect(requests).toHaveLength(1)
-      expect(responses).toHaveLength(1)
+      // This verifies the redirect & server response happens in a single roundtrip,
+      // if the redirect resource was static. In development, these responses are always
+      // dynamically generated, so we only expect a single request for build/deploy.
+      if (!isNextDev) {
+        expect(requests).toHaveLength(1)
+        expect(responses).toHaveLength(1)
+      }
 
       const request = requests[0]
       const response = responses[0]

--- a/test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts
+++ b/test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts
@@ -2,7 +2,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { check, retry } from 'next-test-utils'
 
 describe('parallel-routes-revalidation', () => {
-  const { next, isNextStart, isNextDeploy } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })
 
@@ -447,7 +447,9 @@ describe('parallel-routes-revalidation', () => {
       await browser.waitForIdleNetwork()
 
       await retry(async () => {
-        expect(rscRequests.length).toBe(0)
+        if (!isNextDev) {
+          expect(rscRequests.length).toBe(0)
+        }
 
         if (isNextStart) {
           expect(prefetchRequests.length).toBe(4)


### PR DESCRIPTION
When calling `redirect` in a server action, the action handler will invoke a worker to fetch the RSC payload from the URL being redirected to, and will return it in the action request. This allows the redirect to be handled in a single request rather than requiring a second request to fetch the RSC payload on the URL being redirected to. As part of this special redirection handling, no action result is returned, so the action promise is resolved with `undefined`.

As a result of this behavior, if your server action redirects to a page that has the same form that was just submitted, and you're leveraging `useActionState`, the updated state value will be undefined rather than being reset to the initial state. **More generally, redirect errors are handled by the client currently by simply resolving the promise with undefined, which isn't the correct behavior.**

This PR will reject the server action promise with a redirect error, so that it'll be caught by our `RedirectBoundary`. Since React will remount the tree as part of the error boundary recovery, this effectively resets the form to it's initial state. 

If the action is rejected in a global `startTransition`, then it'll be handled by a global `error` handler, which will perform the redirect. And if it occurs outside of a transition, the redirect will be handled by a `unhandledrejection` handler.

Because we're not able to apply the flight data as-is in the server action reducer (and instead defer to the navigation action), we seed the prefetch cache for the target page with the flight data from the action result so that we do not need to make another server roundtrip. We apply the same static/dynamic cache staleTime heuristics for these cache entries. 

Fixes #68549
Closes NDX-229