### PR TITLE
chore: Update lightningcss

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8989,7 +8989,7 @@ dependencies = [
  "indoc",
  "lightningcss",
  "once_cell",
- "parcel_selectors 0.26.6",
+ "parcel_selectors 0.27.0",
  "parcel_sourcemap",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3523,9 +3523,9 @@ dependencies = [
 
 [[package]]
 name = "lightningcss"
-version = "1.0.0-alpha.58"
+version = "1.0.0-alpha.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec380ca49dc7f6a1cafbdd2de5e587958eac0f67ab26b1e56727fcc60a0c3d4d"
+checksum = "53e225b3fa0a8bd5562c8833b1a32afa88761c4e661d3177b8cdc4e13cbf078e"
 dependencies = [
  "ahash 0.8.11",
  "bitflags 2.5.0",
@@ -3538,7 +3538,7 @@ dependencies = [
  "itertools 0.10.5",
  "lazy_static",
  "lightningcss-derive",
- "parcel_selectors",
+ "parcel_selectors 0.27.0",
  "parcel_sourcemap",
  "paste",
  "pathdiff",
@@ -4617,6 +4617,22 @@ name = "parcel_selectors"
 version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512215cb1d3814e276ace4ec2dbc2cac16726ea3fcac20c22ae1197e16fdd72d"
+dependencies = [
+ "bitflags 2.5.0",
+ "cssparser",
+ "fxhash",
+ "log",
+ "phf 0.10.1",
+ "phf_codegen",
+ "precomputed-hash",
+ "smallvec",
+]
+
+[[package]]
+name = "parcel_selectors"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4d26c18a8377a64728c04bf3b2e48ec43b0c77e687a18e03eb837d65e08a14"
 dependencies = [
  "bitflags 2.5.0",
  "cssparser",
@@ -6441,7 +6457,7 @@ checksum = "7c5086faeb1ee982b0f2bebcbde73c8cfb009b1adafc7f9c6644d13fec77d407"
 dependencies = [
  "anyhow",
  "lightningcss",
- "parcel_selectors",
+ "parcel_selectors 0.26.6",
  "preset_env_base",
  "serde",
  "swc_common",
@@ -8973,7 +8989,7 @@ dependencies = [
  "indoc",
  "lightningcss",
  "once_cell",
- "parcel_selectors",
+ "parcel_selectors 0.26.6",
  "parcel_sourcemap",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3538,7 +3538,7 @@ dependencies = [
  "itertools 0.10.5",
  "lazy_static",
  "lightningcss-derive",
- "parcel_selectors 0.27.0",
+ "parcel_selectors",
  "parcel_sourcemap",
  "paste",
  "pathdiff",
@@ -4610,22 +4610,6 @@ dependencies = [
  "bytecount",
  "fnv",
  "unicode-width",
-]
-
-[[package]]
-name = "parcel_selectors"
-version = "0.26.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512215cb1d3814e276ace4ec2dbc2cac16726ea3fcac20c22ae1197e16fdd72d"
-dependencies = [
- "bitflags 2.5.0",
- "cssparser",
- "fxhash",
- "log",
- "phf 0.10.1",
- "phf_codegen",
- "precomputed-hash",
- "smallvec",
 ]
 
 [[package]]
@@ -6451,13 +6435,13 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.73.33"
+version = "0.73.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5086faeb1ee982b0f2bebcbde73c8cfb009b1adafc7f9c6644d13fec77d407"
+checksum = "a62ac47cfa03c8c78fa89f5169cbe4c26faaaf4c9d721df2fc9c0d09070c4311"
 dependencies = [
  "anyhow",
  "lightningcss",
- "parcel_selectors 0.26.6",
+ "parcel_selectors",
  "preset_env_base",
  "serde",
  "swc_common",
@@ -8989,7 +8973,7 @@ dependencies = [
  "indoc",
  "lightningcss",
  "once_cell",
- "parcel_selectors 0.27.0",
+ "parcel_selectors",
  "parcel_sourcemap",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3562,9 +3562,9 @@ dependencies = [
 
 [[package]]
 name = "lightningcss-napi"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6517fd00c4d56ef4ab207d346614715c472db7a144d6aaf522dc9eaabfa47b05"
+checksum = "a82ad688d068cca159908db83e9f48ba53f96470546560e1ae2469c784656cb6"
 dependencies = [
  "cssparser",
  "lightningcss",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ lightningcss = { version = "1.0.0-alpha.59", features = [
   "visitor",
   "into_owned",
 ] }
-lightningcss-napi = { version = "0.2.0", default-features = false, features = [
+lightningcss-napi = { version = "0.3.0", default-features = false, features = [
   "visitor"
 ]}
 markdown = "1.0.0-alpha.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,7 @@ nohash-hasher = "0.2.0"
 notify = "6.1.1"
 once_cell = "1.17.1"
 owo-colors = "3.5.0"
-parcel_selectors = "0.26.0"
+parcel_selectors = "0.27.0"
 parking_lot = "0.12.1"
 pathdiff = "0.2.1"
 # Temporary: Reference the latest git minor version of pathfinder_simd until it's published.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ miette = { version = "5.10.0", features = ["fancy"] }
 mdxjs = "0.2.9"
 modularize_imports = { version = "0.68.25" }
 styled_components = { version = "0.96.23" }
-styled_jsx = { version = "0.73.33" }
+styled_jsx = { version = "0.73.34" }
 swc_emotion = { version = "0.72.22" }
 swc_relay = { version = "0.44.25" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ indoc = "2.0.0"
 itertools = "0.10.5"
 lazy_static = "1.4.0"
 log = "0.4.17"
-lightningcss = { version = "1.0.0-alpha.58", features = [
+lightningcss = { version = "1.0.0-alpha.59", features = [
   "serde",
   "visitor",
   "into_owned",


### PR DESCRIPTION
### What?

Update `lightningcss`

### Why?

To apply https://github.com/parcel-bundler/lightningcss/pull/796 and https://github.com/parcel-bundler/lightningcss/pull/797

### How?

 - Closes PACK-3190
 - Closes PACK-3191