### PR TITLE
ensure prefetch entry is not mutated

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -172,23 +172,26 @@ export function navigateReducer(
       let scrollableSegments: FlightSegmentPath[] = []
       for (const normalizedFlightData of flightData) {
         const {
-          tree: treePatch,
           pathToSegment: flightSegmentPath,
           seedData,
           head,
           isRootRender,
         } = normalizedFlightData
+        let treePatch = normalizedFlightData.tree
 
         // TODO-APP: remove ''
         const flightSegmentPathWithLeadingEmpty = ['', ...flightSegmentPath]
 
-        // Segments are keyed by searchParams (e.g. __PAGE__?{"foo":"bar"}), so if we returned an aliased entry,
-        // we need to ensure the correct searchParams are provided in the updated FlightRouterState tree.
+        // Segments are keyed by searchParams (e.g. __PAGE__?{"foo":"bar"}). We might return a less specific, param-less entry,
+        // so we ensure that the final tree contains the correct searchParams (reflected in the URL) are provided in the updated FlightRouterState tree.
         if (prefetchValues.aliased) {
-          treePatch[0] = addSearchParamsIfPageSegment(
-            treePatch[0],
+          const [segment, ...rest] = treePatch
+          const finalSegment = addSearchParamsIfPageSegment(
+            segment,
             Object.fromEntries(url.searchParams)
           )
+
+          treePatch = [finalSegment, ...rest]
         }
 
         // Create new tree based on the flightSegmentPath and router state patch

--- a/test/e2e/app-dir/searchparams-reuse-loading/app/page.tsx
+++ b/test/e2e/app-dir/searchparams-reuse-loading/app/page.tsx
@@ -25,8 +25,13 @@ export default function Page({ searchParams }) {
           </Link>
         </li>
         <li>
-          <Link href="/other-page" prefetch={false}>
-            /other-page
+          <Link href="/params-first" prefetch={false}>
+            /params-first
+          </Link>
+        </li>
+        <li>
+          <Link href="/root-page-first" prefetch={false}>
+            /root-page-first
           </Link>
         </li>
       </ul>

--- a/test/e2e/app-dir/searchparams-reuse-loading/app/params-first/page.tsx
+++ b/test/e2e/app-dir/searchparams-reuse-loading/app/params-first/page.tsx
@@ -1,0 +1,36 @@
+import Link from 'next/link'
+
+export default async function Home({ searchParams }) {
+  return (
+    <div>
+      <h1>
+        {searchParams.page ? (
+          <>You are on page {JSON.stringify(searchParams.page)}.</>
+        ) : (
+          <>You are on the root page.</>
+        )}
+      </h1>
+
+      <div>
+        <Link href="/params-first?page=2" replace>
+          page 2
+        </Link>
+      </div>
+      <div>
+        <Link href="/params-first?page=3" replace>
+          page 3
+        </Link>
+      </div>
+      <div>
+        <Link href="/params-first?page=4" replace>
+          page 4
+        </Link>
+      </div>
+      <div>
+        <Link href="/params-first" replace>
+          No Params
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/searchparams-reuse-loading/app/root-page-first/page.tsx
+++ b/test/e2e/app-dir/searchparams-reuse-loading/app/root-page-first/page.tsx
@@ -12,23 +12,13 @@ export default async function Home({ searchParams }) {
       </h1>
 
       <div>
-        <Link href="/other-page?page=2" replace>
-          page 2
-        </Link>
-      </div>
-      <div>
-        <Link href="/other-page?page=3" replace>
-          page 3
-        </Link>
-      </div>
-      <div>
-        <Link href="/other-page?page=4" replace>
-          page 4
-        </Link>
-      </div>
-      <div>
-        <Link href="/other-page" replace>
+        <Link href="/root-page-first" replace>
           No Params
+        </Link>
+      </div>
+      <div>
+        <Link href="/root-page-first?page=2" replace>
+          page 2
         </Link>
       </div>
     </div>

--- a/test/e2e/app-dir/searchparams-reuse-loading/searchparams-reuse-loading.test.ts
+++ b/test/e2e/app-dir/searchparams-reuse-loading/searchparams-reuse-loading.test.ts
@@ -40,26 +40,46 @@ describe('searchparams-reuse-loading', () => {
   })
 
   it('should reflect the correct searchParams when re-using the same page segment', async () => {
-    const browser = await next.browser('/other-page')
-    await browser.elementByCss("[href='/other-page?page=2']").click()
+    const browser = await next.browser('/')
+    await browser.elementByCss("[href='/params-first']").click()
+    await browser.elementByCss("[href='/params-first?page=2']").click()
     await retry(async () => {
-      expect(await browser.url()).toContain('/other-page?page=2')
+      expect(await browser.url()).toContain('/params-first?page=2')
     })
     expect(await browser.elementByCss('h1').text()).toBe('You are on page "2".')
-    await browser.elementByCss("[href='/other-page?page=3']").click()
+    await browser.elementByCss("[href='/params-first?page=3']").click()
     await retry(async () => {
-      expect(await browser.url()).toContain('/other-page?page=3')
+      expect(await browser.url()).toContain('/params-first?page=3')
     })
     expect(await browser.elementByCss('h1').text()).toBe('You are on page "3".')
-    await browser.elementByCss("[href='/other-page?page=4']").click()
+    await browser.elementByCss("[href='/params-first?page=4']").click()
     await retry(async () => {
-      expect(await browser.url()).toContain('/other-page?page=4')
+      expect(await browser.url()).toContain('/params-first?page=4')
     })
     expect(await browser.elementByCss('h1').text()).toBe('You are on page "4".')
-    await browser.elementByCss("[href='/other-page']").click()
+    await browser.elementByCss("[href='/params-first']").click()
     await retry(async () => {
       const currentUrl = new URL(await browser.url())
-      expect(currentUrl.pathname).toBe('/other-page')
+      expect(currentUrl.pathname).toBe('/params-first')
+      expect(currentUrl.search).toBe('')
+    })
+    expect(await browser.elementByCss('h1').text()).toBe(
+      'You are on the root page.'
+    )
+  })
+
+  it('should reflect the correct searchParams when the root page is prefetched first', async () => {
+    const browser = await next.browser('/')
+    await browser.elementByCss("[href='/root-page-first']").click()
+    await browser.elementByCss("[href='/root-page-first?page=2']").click()
+    await retry(async () => {
+      expect(await browser.url()).toContain('/root-page-first?page=2')
+    })
+    expect(await browser.elementByCss('h1').text()).toBe('You are on page "2".')
+    await browser.elementByCss("[href='/root-page-first']").click()
+    await retry(async () => {
+      const currentUrl = new URL(await browser.url())
+      expect(currentUrl.pathname).toBe('/root-page-first')
       expect(currentUrl.search).toBe('')
     })
     expect(await browser.elementByCss('h1').text()).toBe(


### PR DESCRIPTION
Follow up to #69850: I was unintentionally mutating the prefetch entries data property, causing the wrong params to persist on an aliased entry. This does a shallow copy on the treePatch with the updated segment data as the intent was for this to be ephemeral.