### PR TITLE
fix: correct metadata url suffix

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
@@ -502,6 +502,11 @@ export const metadata = {
         height: 600,
       },
     ],
+    audio: [
+      {
+        url: 'https://nextjs.org/audio.mp3', // Must be an absolute URL
+      },
+    ],
     locale: 'en_US',
     type: 'website',
   },
@@ -521,9 +526,10 @@ export const metadata = {
 <meta property="og:image:width" content="1800" />
 <meta property="og:image:height" content="1600" />
 <meta property="og:image:alt" content="My custom alt" />
-<meta property="og:video:url" content="https://nextjs.org/video.mp4" />
+<meta property="og:video" content="https://nextjs.org/video.mp4" />
 <meta property="og:video:width" content="800" />
 <meta property="og:video:height" content="600" />
+<meta property="og:audio" content="https://nextjs.org/audio.mp3" />
 <meta property="og:type" content="website" />
 ```
 

--- a/packages/next/src/lib/metadata/generate/meta.tsx
+++ b/packages/next/src/lib/metadata/generate/meta.tsx
@@ -55,8 +55,12 @@ function camelToSnake(camelCaseStr: string) {
 
 function getMetaKey(prefix: string, key: string) {
   // Use `twitter:image` and `og:image` instead of `twitter:image:url` and `og:image:url`
-  // to be more compatible as it's a more common format
-  if ((prefix === 'og:image' || prefix === 'twitter:image') && key === 'url') {
+  // to be more compatible as it's a more common format.
+  // `og:video` & `og:audio` do not have a `:url` suffix alias
+  if (
+    ['og:image', 'twitter:image', 'og:video', 'og:audio'].includes(prefix) &&
+    key === 'url'
+  ) {
     return prefix
   }
   if (prefix.startsWith('og:') || prefix.startsWith('twitter:')) {

--- a/packages/next/src/lib/metadata/generate/meta.tsx
+++ b/packages/next/src/lib/metadata/generate/meta.tsx
@@ -53,14 +53,17 @@ function camelToSnake(camelCaseStr: string) {
   })
 }
 
+const aliasPropPrefixes = new Set([
+  'og:image',
+  'twitter:image',
+  'og:video',
+  'og:audio',
+])
 function getMetaKey(prefix: string, key: string) {
   // Use `twitter:image` and `og:image` instead of `twitter:image:url` and `og:image:url`
   // to be more compatible as it's a more common format.
   // `og:video` & `og:audio` do not have a `:url` suffix alias
-  if (
-    ['og:image', 'twitter:image', 'og:video', 'og:audio'].includes(prefix) &&
-    key === 'url'
-  ) {
+  if (aliasPropPrefixes.has(prefix) && key === 'url') {
     return prefix
   }
   if (prefix.startsWith('og:') || prefix.startsWith('twitter:')) {

--- a/test/e2e/app-dir/metadata/app/opengraph/page.tsx
+++ b/test/e2e/app-dir/metadata/app/opengraph/page.tsx
@@ -21,6 +21,18 @@ export const metadata = {
         alt: 'My custom alt',
       },
     ],
+    videos: [
+      {
+        url: 'https://example.com/video.mp4',
+        width: 800,
+        height: 450,
+      },
+    ],
+    audio: [
+      {
+        url: 'https://example.com/audio.mp3',
+      },
+    ],
     locale: 'en-US',
     type: 'website',
   },

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -340,6 +340,10 @@ describe('app dir - metadata', () => {
         'og:image:width': ['800', '1800'],
         'og:image:height': ['600', '1600'],
         'og:image:alt': 'My custom alt',
+        'og:video': 'https://example.com/video.mp4',
+        'og:video:width': '800',
+        'og:video:height': '450',
+        'og:audio': 'https://example.com/audio.mp3',
       })
 
       await matchMultiDom('meta', 'name', 'content', {


### PR DESCRIPTION
## Summary

`og:video` & `og:audio` do not have a `:url` suffix alias; https://ogp.me/#structured

Related thread; https://github.com/vercel/next.js/pull/69644#discussion_r1753479283