### PR TITLE
[Turbopack] print invalid message correctly

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
@@ -626,7 +626,10 @@ export default function HotReload({
         )
       } catch (err: any) {
         console.warn(
-          '[HMR] Invalid message: ' + event.data + '\n' + (err?.stack ?? '')
+          '[HMR] Invalid message: ' +
+            JSON.stringify(event.data) +
+            '\n' +
+            (err?.stack ?? '')
         )
       }
     }

--- a/packages/next/src/client/components/react-dev-overlay/pages/hot-reloader-client.ts
+++ b/packages/next/src/client/components/react-dev-overlay/pages/hot-reloader-client.ts
@@ -82,7 +82,10 @@ export default function connect(mode: 'webpack' | 'turbopack') {
       processMessage(payload)
     } catch (err: any) {
       console.warn(
-        '[HMR] Invalid message: ' + payload + '\n' + (err?.stack ?? '')
+        '[HMR] Invalid message: ' +
+          JSON.stringify(payload) +
+          '\n' +
+          (err?.stack ?? '')
       )
     }
   })

--- a/packages/next/src/client/dev/amp-dev.ts
+++ b/packages/next/src/client/dev/amp-dev.ts
@@ -108,7 +108,10 @@ addMessageListener((message) => {
     }
   } catch (err: any) {
     console.warn(
-      '[HMR] Invalid message: ' + message + '\n' + (err?.stack ?? '')
+      '[HMR] Invalid message: ' +
+        JSON.stringify(message) +
+        '\n' +
+        (err?.stack ?? '')
     )
   }
 })


### PR DESCRIPTION
### Why?

'[object: Object]` is not very helpful
