### PR TITLE
Docs: Update landing page

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,57 +1,50 @@
 ---
-title: Introduction
-description: Welcome to the Next.js Documentation.
+title: Next.js Documentation
+description: Welcome to the Next.js documentation, learn how to create full-stack web applications with our step-by-step examples and API reference.
 ---
 
 Welcome to the Next.js documentation!
 
 ## What is Next.js?
 
-Next.js is a React framework for building full-stack web applications. You use React Components to build user interfaces, and Next.js for additional features and optimizations.
+Next.js is a React framework that enables you to build high-quality applications with React components.
 
-Under the hood, Next.js also abstracts and automatically configures tooling needed for React, like bundling, compiling, and more. This allows you to focus on building your application instead of spending time with configuration.
+As a framework, Next.js handles the tooling and configuration needed to build with React, and provides additional features and optimizations.
 
-Whether you're an individual developer or part of a larger team, Next.js can help you build interactive, dynamic, and fast React applications.
+You can use React to build your UI, and incrementally adopt Next.js features to solve common application requirements such as routing, data fetching, and caching - all while improving the developer and end-user experience.
 
-## Main Features
-
-Some of the main Next.js features include:
-
-| Feature                                                                  | Description                                                                                                                                                                                      |
-| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [Routing](/docs/app/building-your-application/routing)                   | A file-system based router built on top of Server Components that supports layouts, nested routing, loading states, error handling, and more.                                                    |
-| [Rendering](/docs/app/building-your-application/rendering)               | Client-side and Server-side Rendering with Client and Server Components. Further optimized with Static and Dynamic Rendering on the server with Next.js. Streaming on Edge and Node.js runtimes. |
-| [Data Fetching](/docs/app/building-your-application/data-fetching)       | Simplified data fetching with async/await in Server Components, and an extended `fetch` API for request memoization, data caching and revalidation.                                              |
-| [Styling](/docs/app/building-your-application/styling)                   | Support for your preferred styling methods, including CSS Modules, Tailwind CSS, and CSS-in-JS                                                                                                   |
-| [Optimizations](/docs/app/building-your-application/optimizing)          | Image, Fonts, and Script Optimizations to improve your application's Core Web Vitals and User Experience.                                                                                        |
-| [TypeScript](/docs/app/building-your-application/configuring/typescript) | Improved support for TypeScript, with better type checking and more efficient compilation, as well as custom TypeScript Plugin and type checker.                                                 |
-
-## How to Use These Docs
-
-On the left side of the screen, you'll find the docs navbar. The pages of the docs are organized sequentially, from basic to advanced, so you can follow them step-by-step when building your application. However, you can read them in any order or skip to the pages that apply to your use case.
-
-On the right side of the screen, you'll see a table of contents that makes it easier to navigate between sections of a page. If you need to quickly find a page, you can use the search bar at the top, or the search shortcut (`Ctrl+K` or `Cmd+K`).
-
-To get started, check out the [Installation](/docs/getting-started/installation) guide.
-
-## App Router vs Pages Router
-
-Next.js has two different routers: the App Router and the Pages Router. The App Router is a newer router that allows you to use React's latest features, such as Server Components and Streaming. The Pages Router is the original Next.js router, which allowed you to build server-rendered React applications and continues to be supported for older Next.js applications.
-
-At the top of the sidebar, you'll notice a dropdown menu that allows you to switch between the **App Router** and the **Pages Router** features. Since there are features that are unique to each directory, it's important to keep track of which tab is selected.
-
-The breadcrumbs at the top of the page will also indicate whether you're viewing App Router docs or Pages Router docs.
+Whether you're an individual developer or part of a large team, Next.js can help you build interactive, dynamic, and performant applications.
 
 ## Pre-Requisite Knowledge
 
-Although our docs are designed to be beginner-friendly, we need to establish a baseline so that the docs can stay focused on Next.js functionality. We'll make sure to provide links to relevant documentation whenever we introduce a new concept.
+To get started with Next.js, you need a basic understanding of HTML, CSS, and [React](https://react.dev/).
 
-To get the most out of our docs, it's recommended that you have a basic understanding of HTML, CSS, and React. If you need to brush up on your React skills, check out our [React Foundations Course](/learn/react-foundations), which will introduce you to the fundamentals. Then, learn more about Next.js by [building a dashboard application](/learn/dashboard-app).
+If you're new to React, we recommend the [React Foundations Course](/learn/react-foundations) which will walk you through the main principles. Afterwards, you can learn Next.js by [building a dashboard application](/learn/dashboard-app) or walking through the **Getting Started** section (you are here) of these docs.
 
-## Accessibility
+## How to use the docs
 
-For optimal accessibility when using a screen reader while reading the docs, we recommend using Firefox and NVDA, or Safari and VoiceOver.
+### App and pages router switcher
+
+Next.js includes two routers: the [App Router](/docs/app) and the [Pages Router](/docs/pages). The App Router supports newer React features like Server Components and Streaming. The Pages Router is the original Next.js router, still supported for existing projects.
+
+You can switch between these routers using the dropdown menu in the sidebar. The breadcrumbs at the top of each page will also show which router you're viewing.
+
+### Search
+
+You can search the docs using the search bar at the top or with the shortcut (`Ctrl + K` or `Cmd + K`).
+
+### Navigation
+
+The docs are organized into three main sections: **Getting Started** (you are here), [**Examples**](/docs/app/building-your-application), and [**API Reference**](/docs/app/api-reference). You can navigate between these sections..
+
+### Accessibility
+
+For the best experience with screen readers, we recommend using Firefox with [NVDA](https://www.nvaccess.org/about-nvda/) or Safari with [VoiceOver](https://support.apple.com/en-gb/guide/voiceover/welcome/mac).
 
 ## Join our Community
 
 If you have questions about anything related to Next.js, you're always welcome to ask our community on [GitHub Discussions](https://github.com/vercel/next.js/discussions), [Discord](https://discord.com/invite/bUG2bvbtHy), [X (Twitter)](https://x.com/nextjs), and [Reddit](https://www.reddit.com/r/nextjs).
+
+## Next Steps
+
+Get started with Next.js by learning about its main features:

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -35,7 +35,7 @@ You can search the docs using the search bar at the top or with the shortcut (`C
 
 ### Navigation
 
-The docs are organized into three main sections: **Getting Started** (you are here), [**Examples**](/docs/app/building-your-application), and [**API Reference**](/docs/app/api-reference). You can navigate between these sections..
+The docs are organized into three main sections: **Getting Started** (you are here), [**Examples**](/docs/app/building-your-application), and [**API Reference**](/docs/app/api-reference). You can navigate between these sections using the sidebar.
 
 ### Accessibility
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -15,7 +15,7 @@ You can use React to build your UI, and incrementally adopt Next.js features to 
 
 Whether you're an individual developer or part of a large team, Next.js can help you build interactive, dynamic, and performant applications.
 
-## Pre-Requisite Knowledge
+## Pre-Requisite knowledge
 
 To get started with Next.js, you need a basic understanding of HTML, CSS, and [React](https://react.dev/).
 
@@ -41,10 +41,10 @@ The docs are organized into three main sections: **Getting Started** (you are he
 
 For the best experience with screen readers, we recommend using Firefox with [NVDA](https://www.nvaccess.org/about-nvda/) or Safari with [VoiceOver](https://support.apple.com/en-gb/guide/voiceover/welcome/mac).
 
-## Join our Community
+## Join our community
 
 If you have questions about anything related to Next.js, you're always welcome to ask our community on [GitHub Discussions](https://github.com/vercel/next.js/discussions), [Discord](https://discord.com/invite/bUG2bvbtHy), [X (Twitter)](https://x.com/nextjs), and [Reddit](https://www.reddit.com/r/nextjs).
 
-## Next Steps
+## Next steps
 
 Get started with Next.js by learning about its main features:


### PR DESCRIPTION
Closes: https://linear.app/vercel/issue/DOC-3373/landing-page

Reviews and updates landing page, part of the "Getting Started" section rewrite.


- Renames page from "introduction" to "Next.js Documentation" since it's the landing page
- Update headings letter casing 
- Updates "What is Next.js" section to more closely match website copy
- Clearer "How to use these docs" section with subheadings
- Removes main features list in favour of "next steps" which will contain all the getting started pages
- Uses more concise language