### PR TITLE
fix(turbopack): Improve guard detection of edge runtime checker

### DIFF
--- a/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
+++ b/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
@@ -223,7 +223,8 @@ Learn more: https://nextjs.org/docs/api-reference/edge-runtime",
             Expr::Bin(BinExpr {
                 left,
                 right,
-                op: op!("===") | op!("==") | op!("!==") | op!("!="),
+                op:
+                    op!("===") | op!("==") | op!("!==") | op!("!=") | op!("||") | op!("&&") | op!("??"),
                 ..
             }) => {
                 self.add_guard_for_test(left);

--- a/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
+++ b/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
@@ -200,7 +200,7 @@ Learn more: https://nextjs.org/docs/api-reference/edge-runtime",
     fn add_guards(&mut self, test: &Expr) {
         let old = self.should_add_guards;
         self.should_add_guards = true;
-        test.visit_children_with(self);
+        test.visit_with(self);
         self.should_add_guards = old;
     }
 
@@ -250,7 +250,7 @@ impl Visit for WarnForEdgeRuntime {
         match node.op {
             op!("&&") | op!("||") | op!("??") => {
                 self.add_guards(&node.left);
-                self.add_guards(&node.right);
+                node.right.visit_with(self);
             }
             _ => {
                 node.visit_children_with(self);

--- a/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
+++ b/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
@@ -223,8 +223,7 @@ Learn more: https://nextjs.org/docs/api-reference/edge-runtime",
             Expr::Bin(BinExpr {
                 left,
                 right,
-                op:
-                    op!("===") | op!("==") | op!("!==") | op!("!=") | op!("||") | op!("&&") | op!("??"),
+                op: op!("===") | op!("==") | op!("!==") | op!("!="),
                 ..
             }) => {
                 self.add_guard_for_test(left);

--- a/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
+++ b/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
@@ -246,6 +246,17 @@ impl Visit for WarnForEdgeRuntime {
         }
     }
 
+    fn visit_bin_expr(&mut self, node: &BinExpr) {
+        match node.op {
+            op!("&&") | op!("||") | op!("??") => {
+                self.add_guards(&node.left);
+                self.add_guards(&node.right);
+            }
+            _ => {
+                node.visit_children_with(self);
+            }
+        }
+    }
     fn visit_cond_expr(&mut self, node: &CondExpr) {
         self.add_guards(&node.test);
 


### PR DESCRIPTION
### What?

Improves guard detection for node.js process so it can handle code like `typeof process.off === "function" && process.off()`.

### Why?

It caused several issues for sites.

x-ref: https://vercel.slack.com/archives/C03S8ED1DKM/p1724702057947199

### How?

