### PR TITLE
Remove invalid fallback revalidate value

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2732,7 +2732,7 @@ export default abstract class Server<
           headers,
           status: isAppPath ? res.statusCode : undefined,
         } satisfies CachedPageValue,
-        revalidate: metadata.revalidate ?? 1,
+        revalidate: metadata.revalidate,
         isFallback: query.__nextFallback === 'true',
       }
     }
@@ -2975,7 +2975,7 @@ export default abstract class Server<
 
       return {
         ...result,
-        revalidate: result.revalidate ?? 1,
+        revalidate: result.revalidate,
       }
     }
 

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -1081,6 +1081,7 @@ export async function renderToHTMLImpl(
           })
       )
       canAccessRes = false
+      metadata.revalidate = 0
     } catch (serverSidePropsError: any) {
       // remove not found error code to prevent triggering legacy
       // 404 rendering

--- a/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
@@ -358,7 +358,6 @@ describe('required server files i18n', () => {
         },
       }
     )
-    require('console').error(html3)
     const $3 = cheerio.load(html3)
     const data3 = JSON.parse($3('#props').text())
 

--- a/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
@@ -348,12 +348,17 @@ describe('required server files i18n', () => {
     expect(isNaN(data2.random)).toBe(false)
     expect(data2.random).not.toBe(data.random)
 
-    const html3 = await renderViaHTTP(appPort, '/some-other-path', undefined, {
-      headers: {
-        'x-matched-path': '/dynamic/[slug]?slug=%5Bslug%5D.json',
-        'x-now-route-matches': '1=second&nxtPslug=second',
-      },
-    })
+    const html3 = await renderViaHTTP(
+      appPort,
+      '/some-other-path?nxtPslug=second',
+      undefined,
+      {
+        headers: {
+          'x-matched-path': '/dynamic/[slug]?slug=%5Bslug%5D.json',
+        },
+      }
+    )
+    require('console').error(html3)
     const $3 = cheerio.load(html3)
     const data3 = JSON.parse($3('#props').text())
 

--- a/test/production/standalone-mode/required-server-files/required-server-files.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files.test.ts
@@ -634,12 +634,16 @@ describe('required server files', () => {
     expect(isNaN(data2.random)).toBe(false)
     expect(data2.random).not.toBe(data.random)
 
-    const html3 = await renderViaHTTP(appPort, '/some-other-path', undefined, {
-      headers: {
-        'x-matched-path': '/dynamic/[slug]',
-        'x-now-route-matches': '1=second&nxtPslug=second',
-      },
-    })
+    const html3 = await renderViaHTTP(
+      appPort,
+      '/some-other-path?nxtPslug=second',
+      undefined,
+      {
+        headers: {
+          'x-matched-path': '/dynamic/[slug]',
+        },
+      }
+    )
     const $3 = cheerio.load(html3)
     const data3 = JSON.parse($3('#props').text())
 


### PR DESCRIPTION
This removes our invalid revalidate default fallback when a revalidate value isn't returned from render as render should always return a valid value. We also already have an invariant when an invalid revalidate value is returned we just need to ensure that case could be hit properly. This also fixes some invalid test cases which were sending invalid headers. 

x-ref: [slack thread](https://vercel.slack.com/archives/C0676QZBWKS/p1726061828198529?thread_ts=1720714625.621179&cid=C0676QZBWKS)