### PR TITLE
fix(turbo-tasks): Remove `T: Serialize` bound from ResolveVc

### DIFF
--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -45,6 +45,8 @@ use crate::{
 /// some_ref.some_method_on_t();
 /// ```
 #[must_use]
+#[derive(Serialize, Deserialize)]
+#[serde(transparent, bound = "")]
 pub struct Vc<T>
 where
     T: ?Sized + Send,
@@ -230,27 +232,6 @@ where
 }
 
 impl<T> Eq for Vc<T> where T: ?Sized + Send {}
-
-impl<T> Serialize for Vc<T>
-where
-    T: ?Sized + Send,
-{
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        self.node.serialize(serializer)
-    }
-}
-
-impl<'de, T> Deserialize<'de> for Vc<T>
-where
-    T: ?Sized + Send,
-{
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Ok(Vc {
-            node: RawVc::deserialize(deserializer)?,
-            _t: PhantomData,
-        })
-    }
-}
 
 // TODO(alexkirsz) This should not be implemented for Vc. Instead, users should
 // use the `ValueDebug` implementation to get a `D: Debug`.

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -27,8 +27,6 @@ use crate::{
     RcStr, VcRead, VcTransparentRead, VcValueType,
 };
 
-#[derive(Serialize, Deserialize)]
-#[serde(transparent)]
 pub struct ResolvedVc<T>
 where
     T: ?Sized + Send,
@@ -139,6 +137,26 @@ where
 {
     fn trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
         TraceRawVcs::trace_raw_vcs(&self.node, trace_context);
+    }
+}
+
+impl<T> Serialize for ResolvedVc<T>
+where
+    T: ?Sized + Send,
+{
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.node.serialize(serializer)
+    }
+}
+
+impl<'de, T> Deserialize<'de> for ResolvedVc<T>
+where
+    T: ?Sized + Send,
+{
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(ResolvedVc {
+            node: Vc::deserialize(deserializer)?,
+        })
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -27,6 +27,8 @@ use crate::{
     RcStr, VcRead, VcTransparentRead, VcValueType,
 };
 
+#[derive(Serialize, Deserialize)]
+#[serde(transparent, bound = "")]
 pub struct ResolvedVc<T>
 where
     T: ?Sized + Send,
@@ -137,26 +139,6 @@ where
 {
     fn trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
         TraceRawVcs::trace_raw_vcs(&self.node, trace_context);
-    }
-}
-
-impl<T> Serialize for ResolvedVc<T>
-where
-    T: ?Sized + Send,
-{
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        self.node.serialize(serializer)
-    }
-}
-
-impl<'de, T> Deserialize<'de> for ResolvedVc<T>
-where
-    T: ?Sized + Send,
-{
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Ok(ResolvedVc {
-            node: Vc::deserialize(deserializer)?,
-        })
     }
 }
 


### PR DESCRIPTION
With the default derived implementation, serde would inject a `T: Serialize` or `T: Deserialize` bound.
    
However, like `Vc`, `ResolvedVc` is serialized as a couple numeric IDs (the type of `T` doesn't matter), so we shouldn't have this restriction on `ResolvedVc`.

Also, clean up `Vc<T>` using the same `bound = ""` trick with the derive macro.