### PR TITLE
avoid duplicate page in test

### DIFF
--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -1125,7 +1125,7 @@ export async function serverAction(a) {
 }`,
         ],
         [
-          'app/page.tsx',
+          'app/page.js',
           `"use client";
 import { serverAction } from "./actions";
 
@@ -1174,7 +1174,7 @@ export async function serverAction(a) {
 }`,
         ],
         [
-          'app/page.tsx',
+          'app/page.js',
           `import { serverAction } from "./actions";
 
 export default function Home() {


### PR DESCRIPTION
### What?

the template uses page.js, but the case adds a `page.tsx`, causing a duplicate page error
