### PR TITLE
fix(turbopack): Revive `special_exports`

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -42,6 +42,7 @@ use crate::{
         get_next_client_resolved_map,
     },
     next_shared::{
+        next_js_special_exports,
         resolve::{
             get_invalid_server_only_resolve_plugin, ModuleFeatureReportResolvePlugin,
             NextSharedRuntimeResolvePlugin,
@@ -289,6 +290,7 @@ pub async fn get_client_module_options_context(
         tree_shaking_mode: tree_shaking_mode_for_user_code,
         enable_postcss_transform,
         side_effect_free_packages: next_config.optimize_package_imports().await?.clone_value(),
+        special_exports: Some(next_js_special_exports()),
         ..Default::default()
     };
 

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -216,7 +216,7 @@ pub enum ActionManifestWorkerEntry<'a> {
     Serialize,
     Deserialize,
 )]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "kebab-case")]
 pub enum ActionLayer {
     Rsc,
     ActionBrowser,

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -47,6 +47,7 @@ use crate::{
     next_import_map::get_next_server_import_map,
     next_server::resolve::ExternalPredicate,
     next_shared::{
+        next_js_special_exports,
         resolve::{
             get_invalid_client_only_resolve_plugin, get_invalid_styled_jsx_resolve_plugin,
             ModuleFeatureReportResolvePlugin, NextExternalResolvePlugin,
@@ -500,6 +501,7 @@ pub async fn get_server_module_options_context(
         },
         tree_shaking_mode: tree_shaking_mode_for_user_code,
         side_effect_free_packages: next_config.optimize_package_imports().await?.clone_value(),
+        special_exports: Some(next_js_special_exports()),
         ..Default::default()
     };
 

--- a/crates/next-core/src/next_shared/mod.rs
+++ b/crates/next-core/src/next_shared/mod.rs
@@ -1,3 +1,31 @@
+use turbo_tasks::{RcStr, Vc};
+
 pub(crate) mod resolve;
 pub(crate) mod transforms;
 pub(crate) mod webpack_rules;
+
+#[turbo_tasks::function]
+pub fn next_js_special_exports() -> Vc<Vec<RcStr>> {
+    Vc::cell(
+        [
+            "config",
+            "middleware",
+            "runtime",
+            "revalidate",
+            "dynamic",
+            "dynamicParams",
+            "fetchCache",
+            "preferredRegion",
+            "maxDuration",
+            "generateStaticParams",
+            "metadata",
+            "generateMetadata",
+            "getServerSideProps",
+            "getInitialProps",
+            "getStaticProps",
+        ]
+        .into_iter()
+        .map(RcStr::from)
+        .collect::<Vec<RcStr>>(),
+    )
+}

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -143,6 +143,14 @@ pub struct EcmascriptOptions {
     /// If false, they will reference the whole directory. If true, they won't
     /// reference anything and lead to an runtime error instead.
     pub ignore_dynamic_requests: bool,
+    /// The list of export names that should make tree shaking bail off. This is
+    /// required because tree shaking can split imports like `export const
+    /// runtime = 'edge'` as a separate module.
+    ///
+    /// Currently the analysis of these exports are statically verified by `NextPageStaticInfo`,
+    /// which is a `CustomTransformer` implementation and we don't have a way to apply it after
+    /// tree shaking.
+    pub special_exports: Vc<Vec<RcStr>>,
 }
 
 #[turbo_tasks::value(serialization = "auto_for_input")]
@@ -436,7 +444,6 @@ impl EcmascriptModuleAsset {
         asset_context: Vc<Box<dyn AssetContext>>,
         ty: Value<EcmascriptModuleAssetType>,
         transforms: Vc<EcmascriptInputTransforms>,
-
         options: Vc<EcmascriptOptions>,
         compile_time_info: Vc<CompileTimeInfo>,
         inner_assets: Vc<InnerAssets>,

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -147,8 +147,9 @@ pub struct EcmascriptOptions {
     /// required because tree shaking can split imports like `export const
     /// runtime = 'edge'` as a separate module.
     ///
-    /// Currently the analysis of these exports are performed from JS using SWC AST, so we can't
-    /// use original module for that. Instead, we just disable tree shaking for those modules.
+    /// Currently the analysis of these exports are performed from JS (See get-page-static-info.ts)
+    /// using SWC AST, so we can't use original module for that. Instead, we just disable tree
+    /// shaking for those modules.
     pub special_exports: Vc<Vec<RcStr>>,
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -147,9 +147,8 @@ pub struct EcmascriptOptions {
     /// required because tree shaking can split imports like `export const
     /// runtime = 'edge'` as a separate module.
     ///
-    /// Currently the analysis of these exports are statically verified by `NextPageStaticInfo`,
-    /// which is a `CustomTransformer` implementation and we don't have a way to apply it after
-    /// tree shaking.
+    /// Currently the analysis of these exports are performed from JS using SWC AST, so we can't
+    /// use original module for that. Instead, we just disable tree shaking for those modules.
     pub special_exports: Vc<Vec<RcStr>>,
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -451,7 +451,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
 
     let parsed = if let Some(part) = part {
         let parsed = parse(source, ty, transforms);
-        let split_data = split(source.ident(), source, parsed);
+        let split_data = split(source.ident(), source, parsed, options.special_exports);
         part_of_module(split_data, part)
     } else {
         module.failsafe_parse()

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -37,7 +37,12 @@ impl EcmascriptParsable for EcmascriptModulePartAsset {
         let this = self.await?;
 
         let parsed = this.full_module.failsafe_parse();
-        let split_data = split(this.full_module.ident(), this.full_module.source(), parsed);
+        let split_data = split(
+            this.full_module.ident(),
+            this.full_module.source(),
+            parsed,
+            this.full_module.options().await?.special_exports,
+        );
         Ok(part_of_module(split_data, this.part))
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/util.rs
@@ -14,6 +14,7 @@ use swc_core::{
         visit::{noop_visit_type, Visit, VisitWith},
     },
 };
+use turbo_tasks::RcStr;
 
 use crate::TURBOPACK_HELPER;
 
@@ -392,7 +393,7 @@ where
     v.bindings
 }
 
-pub fn should_skip_tree_shaking(m: &Program) -> bool {
+pub fn should_skip_tree_shaking(m: &Program, special_exports: &[RcStr]) -> bool {
     if let Program::Module(m) = m {
         for item in m.body.iter() {
             match item {
@@ -436,6 +437,30 @@ pub fn should_skip_tree_shaking(m: &Program) -> bool {
                     }
                 }
 
+                // Skip special reexports that are recognized by next.js
+                ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                    decl: Decl::Var(box VarDecl { decls, .. }),
+                    ..
+                })) => {
+                    for decl in decls {
+                        if let Pat::Ident(name) = &decl.name {
+                            if special_exports.iter().any(|s| **s == *name.sym) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+
+                // Skip special reexports that are recognized by next.js
+                ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                    decl: Decl::Fn(f),
+                    ..
+                })) => {
+                    if special_exports.iter().any(|s| **s == *f.ident.sym) {
+                        return true;
+                    }
+                }
+
                 _ => {}
             }
         }
@@ -462,14 +487,6 @@ struct ShouldSkip {
 }
 
 impl Visit for ShouldSkip {
-    fn visit_stmt(&mut self, n: &Stmt) {
-        if self.skip {
-            return;
-        }
-
-        n.visit_children_with(self);
-    }
-
     fn visit_await_expr(&mut self, n: &AwaitExpr) {
         // __turbopack_wasm_module__ is not analyzable because __turbopack_wasm_module__
         // is injected global.
@@ -482,6 +499,14 @@ impl Visit for ShouldSkip {
                 self.skip = true;
                 return;
             }
+        }
+
+        n.visit_children_with(self);
+    }
+
+    fn visit_stmt(&mut self, n: &Stmt) {
+        if self.skip {
+            return;
         }
 
         n.visit_children_with(self);

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -93,6 +93,7 @@ impl ModuleOptions {
             execution_context,
             ref rules,
             tree_shaking_mode,
+            special_exports,
             ..
         } = *module_options_context.await?;
 
@@ -135,6 +136,7 @@ impl ModuleOptions {
             import_externals,
             ignore_dynamic_requests,
             refresh,
+            special_exports: special_exports.unwrap_or_else(|| Vc::cell(vec![])),
             ..Default::default()
         };
         let ecmascript_options_vc = ecmascript_options.cell();


### PR DESCRIPTION
### What?

We cannot apply tree shaking to a module if it has a unique export. Detailed description is written at the field definition.

### Why?

This is part of [the tree-shaking PR](https://github.com/vercel/next.js/pull/69344).

### How?

