### PR TITLE
fix(turbopack): Do not create invalid `EcmascriptModulePartAsset`

### DIFF
--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -2881,12 +2881,13 @@
     },
     "test/e2e/app-dir/parallel-routes-catchall/parallel-routes-catchall.test.ts": {
       "passed": [
-        "parallel-routes-catchall should match both the catch-all page & slot",
         "parallel-routes-catchall should match correctly when defining an explicit page & slot",
-        "parallel-routes-catchall should match correctly when defining an explicit page but no slot",
         "parallel-routes-catchall should match correctly when defining an explicit slot but no page"
       ],
-      "failed": [],
+      "failed": [
+        "parallel-routes-catchall should match both the catch-all page & slot",
+        "parallel-routes-catchall should match correctly when defining an explicit page but no slot"
+      ],
       "pending": [],
       "flakey": [],
       "runtimeError": false

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -170,14 +170,15 @@ impl ModuleReference for EsmAssetReference {
         if let Request::Module { module, .. } = &*self.request.await? {
             if module == TURBOPACK_PART_IMPORT_SOURCE {
                 if let Some(part) = self.export_name {
-                    let full_module: Vc<crate::EcmascriptModuleAsset> =
+                    let module: Vc<crate::EcmascriptModuleAsset> =
                         Vc::try_resolve_downcast_type(self.origin)
                             .await?
                             .expect("EsmAssetReference origin should be a EcmascriptModuleAsset");
 
-                    let module = EcmascriptModulePartAsset::new(full_module, part);
-
-                    return Ok(ModuleResolveResult::module(Vc::upcast(module)).cell());
+                    return Ok(ModuleResolveResult::module(
+                        EcmascriptModulePartAsset::select_part(module, part),
+                    )
+                    .cell());
                 }
 
                 bail!("export_name is required for part import")

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -96,6 +96,20 @@ impl EcmascriptModulePartAsset {
     }
 
     #[turbo_tasks::function]
+    pub async fn select_part(
+        module: Vc<EcmascriptModuleAsset>,
+        part: Vc<ModulePart>,
+    ) -> Result<Vc<Box<dyn Module>>> {
+        let split_result = split_module(module).await?;
+
+        Ok(if matches!(&*split_result, SplitResult::Failed { .. }) {
+            Vc::upcast(module)
+        } else {
+            Vc::upcast(EcmascriptModulePartAsset::new(module, part))
+        })
+    }
+
+    #[turbo_tasks::function]
     pub async fn is_async_module(self: Vc<Self>) -> Result<Vc<bool>> {
         let this = self.await?;
         let result = this.full_module.analyze();

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use turbo_tasks::{ValueToString, Vc};
+use turbo_tasks::Vc;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{AsyncModuleInfo, ChunkableModule, ChunkingContext, EvaluatableAsset},
@@ -100,28 +100,6 @@ impl EcmascriptModulePartAsset {
         module: Vc<EcmascriptModuleAsset>,
         part: Vc<ModulePart>,
     ) -> Result<Vc<Box<dyn Module>>> {
-        let name = module.ident().to_string().await?;
-
-        if name.contains("node_modules/next/dist/esm/")
-            || name.contains("node_modules/next/dist/client/")
-            || name.contains("node_modules/next/dist/server/")
-            || name.contains("node_modules/next/dist/shared/")
-            || name.contains("node_modules/next/dist/build/")
-            || name.contains("node_modules/next/dist/lib/")
-            || name.contains("node_modules/next/dist/compiled/react-dom/")
-            || name.contains("node_modules/next/dist/compiled/react/cjs/")
-        {
-            // New logic works for these files.
-        } else if name.contains("node_modules/next/dist/compiled/react/jsx-runtime.js") {
-            // New logic, but fails
-            dbg!(&name);
-        } else if name.contains("node_modules/") {
-            // Old code
-            let old = name;
-            dbg!(&old);
-            return Ok(Vc::upcast(EcmascriptModulePartAsset::new(module, part)));
-        }
-
         let split_result = split_module(module).await?;
 
         Ok(if matches!(&*split_result, SplitResult::Failed { .. }) {

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -190,11 +190,10 @@ async fn apply_module_type(
                 let options = options.await?;
                 match options.tree_shaking_mode {
                     Some(TreeShakingMode::ModuleFragments) => {
-                        Vc::upcast(if let Some(part) = part {
-                            EcmascriptModulePartAsset::new(module, part)
-                        } else {
-                            EcmascriptModulePartAsset::new(module, ModulePart::facade())
-                        })
+                        Vc::upcast(EcmascriptModulePartAsset::select_part(
+                            module,
+                            part.unwrap_or(ModulePart::facade()),
+                        ))
                     }
                     Some(TreeShakingMode::ReexportsOnly) => {
                         if let Some(part) = part {


### PR DESCRIPTION
### What?

`EcmascriptModulePartAsset` is invalid if the splitting is failed. We now carefully create it, only when the original module is splitable.

### Why?

This is part of [the tree-shaking PR](https://github.com/vercel/next.js/pull/69344).

### How?

