### PR TITLE
fix(turbopack): Improve analyzer of tree-shaking pass

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -55,9 +55,10 @@ pub async fn minify(path: Vc<FileSystemPath>, code: Vc<Code>) -> Result<Vc<Code>
             let program = match parser.parse_program() {
                 Ok(program) => program,
                 Err(err) => {
+                    err.into_diagnostic(handler).emit();
                     // TODO should emit an issue
                     bail!(
-                        "failed to parse source code\n{err:?}\n{}",
+                        "failed to parse source code\n{}",
                         code.source_code().to_str()?
                     )
                 }

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -49,14 +49,13 @@ pub async fn minify(path: Vc<FileSystemPath>, code: Vc<Code>) -> Result<Vc<Code>
         None,
     );
     let mut parser = Parser::new_from(lexer);
-    // TODO should use our own handler that emits issues instead.
+
     let program = try_with_handler(cm.clone(), Default::default(), |handler| {
         GLOBALS.set(&Default::default(), || {
             let program = match parser.parse_program() {
                 Ok(program) => program,
                 Err(err) => {
                     err.into_diagnostic(handler).emit();
-                    // TODO should emit an issue
                     bail!(
                         "failed to parse source code\n{}",
                         code.source_code().to_str()?

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     collections::{BTreeMap, HashSet},
     ops::ControlFlow,
 };
@@ -499,14 +500,14 @@ impl CodeGenerateable for EsmExports {
                 )),
                 EsmExport::LocalBinding(name, mutable) => {
                     let local = if name == "default" {
-                        magic_identifier::mangle("default export").into()
+                        Cow::Owned(magic_identifier::mangle("default export"))
                     } else {
-                        name.clone()
+                        Cow::Borrowed(name.as_str())
                     };
                     if *mutable {
                         Some(quote!(
                             "([() => $local, ($new) => $local = $new])" as Expr,
-                            local = Ident::new(local.as_str().into(), DUMMY_SP, Default::default()),
+                            local = Ident::new(local.into(), DUMMY_SP, Default::default()),
                             new = Ident::new(
                                 format!("new_{name}").into(),
                                 DUMMY_SP,

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -37,12 +37,7 @@ impl EcmascriptParsable for EcmascriptModulePartAsset {
         let this = self.await?;
 
         let parsed = this.full_module.failsafe_parse();
-        let split_data = split(
-            this.full_module.ident(),
-            this.full_module.source(),
-            parsed,
-            this.full_module.options().await?.special_exports,
-        );
+        let split_data = split(this.full_module.ident(), this.full_module.source(), parsed);
         Ok(part_of_module(split_data, this.part))
     }
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -204,8 +204,9 @@ impl Module for EcmascriptModulePartAsset {
                         match part_id {
                             PartId::Internal(part_id) => ModulePart::internal(*part_id),
                             PartId::Export(name) => ModulePart::export(name.clone()),
-                            PartId::ModuleEvaluation => ModulePart::evaluation(),
-                            PartId::Exports => ModulePart::exports(),
+                            _ => unreachable!(
+                                "PartId other than Internal and Export should not be used here"
+                            ),
                         },
                     )),
                     Vc::cell("ecmascript module part".into()),

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -41,14 +41,13 @@ impl EcmascriptParsable for EcmascriptModulePartAsset {
         Ok(part_of_module(split_data, this.part))
     }
     #[turbo_tasks::function]
-    async fn parse_original(self: Vc<Self>) -> Result<Vc<ParseResult>> {
-        let this = self.await?;
-        Ok(this.full_module.parse_original())
+    fn parse_original(&self) -> Result<Vc<ParseResult>> {
+        Ok(self.full_module.parse_original())
     }
 
     #[turbo_tasks::function]
-    async fn ty(self: Vc<Self>) -> Result<Vc<EcmascriptModuleAssetType>> {
-        Ok(self.await?.full_module.ty())
+    async fn ty(&self) -> Result<Vc<EcmascriptModuleAssetType>> {
+        Ok(self.full_module.ty())
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -289,13 +289,6 @@ impl DepGraph {
         let mut mangle_count = 0;
         let mut mangled_vars = FxHashMap::default();
         let mut mangle = |var: &Id| {
-            // For react hooks.
-            // We need to preserve `use*` to make error reporting logic work.
-            // We catch `useXxx is not a function`, and report it with a hint about 'use client'.
-            if var.0.starts_with("use") {
-                return var.0.clone();
-            }
-
             mangled_vars
                 .entry(var.clone())
                 .or_insert_with(|| encode_base54(&mut mangle_count, true))

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -14,11 +14,11 @@ use swc_core::{
     common::{comments::Comments, util::take::Take, Spanned, SyntaxContext, DUMMY_SP},
     ecma::{
         ast::{
-            op, ClassDecl, ClassExpr, Decl, DefaultDecl, EsReserved, ExportAll, ExportDecl,
-            ExportNamedSpecifier, ExportSpecifier, Expr, ExprStmt, FnDecl, FnExpr, Id, Ident,
-            IdentName, ImportDecl, ImportNamedSpecifier, ImportSpecifier, ImportStarAsSpecifier,
-            KeyValueProp, Lit, Module, ModuleDecl, ModuleExportName, ModuleItem, NamedExport,
-            ObjectLit, Prop, PropName, PropOrSpread, Stmt, VarDecl, VarDeclKind, VarDeclarator,
+            op, ClassDecl, Decl, DefaultDecl, EsReserved, ExportAll, ExportDecl,
+            ExportNamedSpecifier, ExportSpecifier, Expr, ExprStmt, FnDecl, Id, Ident, IdentName,
+            ImportDecl, ImportNamedSpecifier, ImportSpecifier, ImportStarAsSpecifier, KeyValueProp,
+            Lit, Module, ModuleDecl, ModuleExportName, ModuleItem, NamedExport, ObjectLit, Prop,
+            PropName, PropOrSpread, Stmt, VarDecl, VarDeclKind, VarDeclarator,
         },
         atoms::JsWord,
         utils::{find_pat_ids, private_ident, quote_ident, ExprCtx, ExprExt},
@@ -736,35 +736,21 @@ impl DepGraph {
                                 write_vars: used_ids.write,
                                 eventual_write_vars: captured_ids.write,
                                 var_decls: [default_var.to_id()].into_iter().collect(),
-                                content: ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(
-                                    VarDecl {
-                                        span: DUMMY_SP,
-                                        kind: VarDeclKind::Const,
-                                        decls: vec![VarDeclarator {
-                                            span: DUMMY_SP,
-                                            name: default_var.clone().into(),
-                                            init: Some(match &export.decl {
-                                                DefaultDecl::Class(c) => ClassExpr {
-                                                    ident: default_var.clone().into(),
-                                                    class: c.class.clone(),
-                                                }
-                                                .into(),
-                                                DefaultDecl::Fn(f) => FnExpr {
-                                                    ident: default_var.clone().into(),
-                                                    function: f.function.clone(),
-                                                }
-                                                .into(),
-                                                DefaultDecl::TsInterfaceDecl(_) => unreachable!(),
-                                            }),
-                                            definite: false,
-                                        }],
-                                        ..Default::default()
-                                    },
-                                )))),
-                                side_effects: true,
+                                content: ModuleItem::Stmt(Stmt::Decl(match &export.decl {
+                                    DefaultDecl::Class(c) => Decl::Class(ClassDecl {
+                                        ident: default_var.clone(),
+                                        declare: false,
+                                        class: c.class.clone(),
+                                    }),
+                                    DefaultDecl::Fn(f) => Decl::Fn(FnDecl {
+                                        ident: default_var.clone(),
+                                        declare: false,
+                                        function: f.function.clone(),
+                                    }),
+                                    DefaultDecl::TsInterfaceDecl(_) => unreachable!(),
+                                })),
                                 ..Default::default()
                             };
-
                             let id = ItemId::Item {
                                 index,
                                 kind: ItemIdItemKind::Normal,

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -336,13 +336,10 @@ impl DepGraph {
                 }
             }
 
-            let mut use_export_instead_of_declarator = false;
-
             for item in group {
                 match item {
                     ItemId::Group(ItemIdGroupKind::Export(..)) => {
                         if let Some(export) = &data[item].export {
-                            use_export_instead_of_declarator = true;
                             exports.insert(Key::Export(export.as_str().into()), ix as u32);
 
                             let s = ExportSpecifier::Named(ExportNamedSpecifier {
@@ -393,67 +390,6 @@ impl DepGraph {
                         )))),
                         phase: Default::default(),
                     })));
-            }
-
-            // Workaround for implcit export issue of server actions.
-            //
-            // Inline server actions require the generated `$$ACTION_0` to be **exported**.
-            //
-            // But tree shaking works by removing unused code, and the **export** of $$ACTION_0 is
-            // cleary not used from the external module as it does not exist at all in the user
-            // code.
-            //
-            // So we need to add an import for $$ACTION_0 to the module, so that the export is
-            // preserved.
-            if use_export_instead_of_declarator {
-                for (other_ix, other_group) in groups.graph_ix.iter().enumerate() {
-                    if other_ix == ix {
-                        continue;
-                    }
-
-                    let deps = part_deps.entry(ix as u32).or_default();
-
-                    for other_item in other_group {
-                        if let ItemId::Group(ItemIdGroupKind::Export(export, _)) = other_item {
-                            let Some(&declarator) = declarator.get(export) else {
-                                continue;
-                            };
-
-                            if declarator == ix as u32 {
-                                continue;
-                            }
-
-                            if !has_path_connecting(&groups.idx_graph, ix as u32, declarator, None)
-                            {
-                                continue;
-                            }
-
-                            let s = ImportSpecifier::Named(ImportNamedSpecifier {
-                                span: DUMMY_SP,
-                                local: export.clone().into(),
-                                imported: None,
-                                is_type_only: false,
-                            });
-
-                            required_vars.remove(export);
-
-                            deps.push(PartId::Export(export.0.as_str().into()));
-
-                            chunk.body.push(ModuleItem::ModuleDecl(ModuleDecl::Import(
-                                ImportDecl {
-                                    span: DUMMY_SP,
-                                    specifiers: vec![s],
-                                    src: Box::new(TURBOPACK_PART_IMPORT_SOURCE.into()),
-                                    type_only: false,
-                                    with: Some(Box::new(create_turbopack_part_id_assert(
-                                        PartId::Export(export.0.as_str().into()),
-                                    ))),
-                                    phase: Default::default(),
-                                },
-                            )));
-                        }
-                    }
-                }
             }
 
             // Import variables

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -329,10 +329,13 @@ impl DepGraph {
                 }
             }
 
+            let mut use_export_instead_of_declarator = false;
+
             for item in group {
                 match item {
                     ItemId::Group(ItemIdGroupKind::Export(..)) => {
                         if let Some(export) = &data[item].export {
+                            use_export_instead_of_declarator = true;
                             exports.insert(Key::Export(export.as_str().into()), ix as u32);
 
                             let s = ExportSpecifier::Named(ExportNamedSpecifier {
@@ -383,6 +386,67 @@ impl DepGraph {
                         )))),
                         phase: Default::default(),
                     })));
+            }
+
+            // Workaround for implcit export issue of server actions.
+            //
+            // Inline server actions require the generated `$$ACTION_0` to be **exported**.
+            //
+            // But tree shaking works by removing unused code, and the **export** of $$ACTION_0 is
+            // cleary not used from the external module as it does not exist at all in the user
+            // code.
+            //
+            // So we need to add an import for $$ACTION_0 to the module, so that the export is
+            // preserved.
+            if use_export_instead_of_declarator {
+                for (other_ix, other_group) in groups.graph_ix.iter().enumerate() {
+                    if other_ix == ix {
+                        continue;
+                    }
+
+                    let deps = part_deps.entry(ix as u32).or_default();
+
+                    for other_item in other_group {
+                        if let ItemId::Group(ItemIdGroupKind::Export(export, _)) = other_item {
+                            let Some(&declarator) = declarator.get(export) else {
+                                continue;
+                            };
+
+                            if declarator == ix as u32 {
+                                continue;
+                            }
+
+                            if !has_path_connecting(&groups.idx_graph, ix as u32, declarator, None)
+                            {
+                                continue;
+                            }
+
+                            let s = ImportSpecifier::Named(ImportNamedSpecifier {
+                                span: DUMMY_SP,
+                                local: export.clone().into(),
+                                imported: None,
+                                is_type_only: false,
+                            });
+
+                            required_vars.remove(export);
+
+                            deps.push(PartId::Export(export.0.as_str().into()));
+
+                            chunk.body.push(ModuleItem::ModuleDecl(ModuleDecl::Import(
+                                ImportDecl {
+                                    span: DUMMY_SP,
+                                    specifiers: vec![s],
+                                    src: Box::new(TURBOPACK_PART_IMPORT_SOURCE.into()),
+                                    type_only: false,
+                                    with: Some(Box::new(create_turbopack_part_id_assert(
+                                        PartId::Export(export.0.as_str().into()),
+                                    ))),
+                                    phase: Default::default(),
+                                },
+                            )));
+                        }
+                    }
+                }
             }
 
             // Import variables

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -11,17 +11,17 @@ use petgraph::{
 };
 use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 use swc_core::{
-    common::{util::take::Take, SyntaxContext, DUMMY_SP},
+    common::{comments::Comments, util::take::Take, Spanned, SyntaxContext, DUMMY_SP},
     ecma::{
         ast::{
-            op, ClassDecl, Decl, DefaultDecl, EsReserved, ExportAll, ExportDecl,
-            ExportNamedSpecifier, ExportSpecifier, Expr, ExprStmt, FnDecl, Id, Ident, IdentName,
-            ImportDecl, ImportNamedSpecifier, ImportSpecifier, ImportStarAsSpecifier, KeyValueProp,
-            Lit, Module, ModuleDecl, ModuleExportName, ModuleItem, NamedExport, ObjectLit, Prop,
-            PropName, PropOrSpread, Stmt, VarDecl, VarDeclKind, VarDeclarator,
+            op, ClassDecl, ClassExpr, Decl, DefaultDecl, EsReserved, ExportAll, ExportDecl,
+            ExportNamedSpecifier, ExportSpecifier, Expr, ExprStmt, FnDecl, FnExpr, Id, Ident,
+            IdentName, ImportDecl, ImportNamedSpecifier, ImportSpecifier, ImportStarAsSpecifier,
+            KeyValueProp, Lit, Module, ModuleDecl, ModuleExportName, ModuleItem, NamedExport,
+            ObjectLit, Prop, PropName, PropOrSpread, Stmt, VarDecl, VarDeclKind, VarDeclarator,
         },
         atoms::JsWord,
-        utils::{find_pat_ids, private_ident, quote_ident},
+        utils::{find_pat_ids, private_ident, quote_ident, ExprCtx, ExprExt},
     },
 };
 use turbo_tasks::RcStr;
@@ -207,7 +207,7 @@ pub(super) struct SplitModuleResult {
     pub entrypoints: FxHashMap<Key, u32>,
 
     /// Dependency between parts.
-    pub part_deps: FxHashMap<u32, Vec<u32>>,
+    pub part_deps: FxHashMap<u32, Vec<PartId>>,
     pub modules: Vec<Module>,
 
     pub star_reexports: Vec<ExportAll>,
@@ -241,10 +241,14 @@ impl DepGraph {
     /// a usage side, `import` and `export` will be added.
     ///
     /// Note: ESM imports are immutable, but we do not handle it.
-    pub(super) fn split_module(&self, data: &FxHashMap<ItemId, ItemData>) -> SplitModuleResult {
-        let groups = self.finalize();
+    pub(super) fn split_module(
+        &self,
+        directives: &[ModuleItem],
+        data: &FxHashMap<ItemId, ItemData>,
+    ) -> SplitModuleResult {
+        let groups = self.finalize(data);
         let mut exports = FxHashMap::default();
-        let mut part_deps = FxHashMap::<_, Vec<_>>::default();
+        let mut part_deps = FxHashMap::<_, Vec<PartId>>::default();
 
         let star_reexports: Vec<_> = data
             .values()
@@ -253,6 +257,7 @@ impl DepGraph {
             .collect();
         let mut modules = vec![];
         let mut exports_module = Module::dummy();
+        exports_module.body.extend(directives.iter().cloned());
 
         if groups.graph_ix.is_empty() {
             // If there's no dependency, all nodes are in the module evaluaiotn group.
@@ -265,6 +270,7 @@ impl DepGraph {
         }
 
         let mut declarator = FxHashMap::default();
+        let mut exporter = FxHashMap::default();
 
         for (ix, group) in groups.graph_ix.iter().enumerate() {
             for id in group {
@@ -273,12 +279,23 @@ impl DepGraph {
                 for var in item.var_decls.iter() {
                     declarator.entry(var.clone()).or_insert_with(|| ix as u32);
                 }
+
+                if let Some(export) = &item.export {
+                    exporter.insert(export.clone(), ix as u32);
+                }
             }
         }
 
         let mut mangle_count = 0;
         let mut mangled_vars = FxHashMap::default();
         let mut mangle = |var: &Id| {
+            // For react hooks.
+            // We need to preserve `use*` to make error reporting logic work.
+            // We catch `useXxx is not a function`, and report it with a hint about 'use client'.
+            if var.0.starts_with("use") {
+                return var.0.clone();
+            }
+
             mangled_vars
                 .entry(var.clone())
                 .or_insert_with(|| encode_base54(&mut mangle_count, true))
@@ -288,7 +305,7 @@ impl DepGraph {
         for (ix, group) in groups.graph_ix.iter().enumerate() {
             let mut chunk = Module {
                 span: DUMMY_SP,
-                body: vec![],
+                body: directives.to_vec(),
                 shebang: None,
             };
 
@@ -319,10 +336,13 @@ impl DepGraph {
                 }
             }
 
+            let mut use_export_instead_of_declarator = false;
+
             for item in group {
                 match item {
                     ItemId::Group(ItemIdGroupKind::Export(..)) => {
                         if let Some(export) = &data[item].export {
+                            use_export_instead_of_declarator = true;
                             exports.insert(Key::Export(export.as_str().into()), ix as u32);
 
                             let s = ExportSpecifier::Named(ExportNamedSpecifier {
@@ -342,7 +362,7 @@ impl DepGraph {
                                     src: Some(Box::new(TURBOPACK_PART_IMPORT_SOURCE.into())),
                                     type_only: false,
                                     with: Some(Box::new(create_turbopack_part_id_assert(
-                                        PartId::Export(export.to_string().into()),
+                                        PartId::Export(export.as_str().into()),
                                     ))),
                                 }),
                             ));
@@ -375,8 +395,69 @@ impl DepGraph {
                     })));
             }
 
+            // Workaround for implcit export issue of server actions.
+            //
+            // Inline server actions require the generated `$$ACTION_0` to be **exported**.
+            //
+            // But tree shaking works by removing unused code, and the **export** of $$ACTION_0 is
+            // cleary not used from the external module as it does not exist at all in the user
+            // code.
+            //
+            // So we need to add an import for $$ACTION_0 to the module, so that the export is
+            // preserved.
+            if use_export_instead_of_declarator {
+                for (other_ix, other_group) in groups.graph_ix.iter().enumerate() {
+                    if other_ix == ix {
+                        continue;
+                    }
+
+                    let deps = part_deps.entry(ix as u32).or_default();
+
+                    for other_item in other_group {
+                        if let ItemId::Group(ItemIdGroupKind::Export(export, _)) = other_item {
+                            let Some(&declarator) = declarator.get(export) else {
+                                continue;
+                            };
+
+                            if declarator == ix as u32 {
+                                continue;
+                            }
+
+                            if !has_path_connecting(&groups.idx_graph, ix as u32, declarator, None)
+                            {
+                                continue;
+                            }
+
+                            let s = ImportSpecifier::Named(ImportNamedSpecifier {
+                                span: DUMMY_SP,
+                                local: export.clone().into(),
+                                imported: None,
+                                is_type_only: false,
+                            });
+
+                            required_vars.remove(export);
+
+                            deps.push(PartId::Export(export.0.as_str().into()));
+
+                            chunk.body.push(ModuleItem::ModuleDecl(ModuleDecl::Import(
+                                ImportDecl {
+                                    span: DUMMY_SP,
+                                    specifiers: vec![s],
+                                    src: Box::new(TURBOPACK_PART_IMPORT_SOURCE.into()),
+                                    type_only: false,
+                                    with: Some(Box::new(create_turbopack_part_id_assert(
+                                        PartId::Export(export.0.as_str().into()),
+                                    ))),
+                                    phase: Default::default(),
+                                },
+                            )));
+                        }
+                    }
+                }
+            }
+
             // Import variables
-            for var in required_vars {
+            for &var in &required_vars {
                 let Some(&dep) = declarator.get(var) else {
                     continue;
                 };
@@ -395,7 +476,10 @@ impl DepGraph {
                     is_type_only: false,
                 })];
 
-                part_deps.entry(ix as u32).or_default().push(dep);
+                part_deps
+                    .entry(ix as u32)
+                    .or_default()
+                    .push(PartId::Internal(dep));
 
                 chunk
                     .body
@@ -412,6 +496,17 @@ impl DepGraph {
             }
 
             for g in group {
+                // Skip directives, as we copy them to each modules.
+                if let ModuleItem::Stmt(Stmt::Expr(ExprStmt {
+                    expr: box Expr::Lit(Lit::Str(s)),
+                    ..
+                })) = &data[g].content
+                {
+                    if s.value.starts_with("use ") {
+                        continue;
+                    }
+                }
+
                 chunk.body.push(data[g].content.clone());
             }
 
@@ -481,7 +576,10 @@ impl DepGraph {
     ///
     /// Note that [ModuleItem] and [Module] are represented as [ItemId] for
     /// performance.
-    pub(super) fn finalize(&self) -> InternedGraph<Vec<ItemId>> {
+    pub(super) fn finalize(
+        &self,
+        _data: &FxHashMap<ItemId, ItemData>,
+    ) -> InternedGraph<Vec<ItemId>> {
         let graph = self.g.idx_graph.clone().into_graph::<u32>();
 
         let condensed = condensation(graph, false);
@@ -528,6 +626,7 @@ impl DepGraph {
     pub(super) fn init(
         &mut self,
         module: &Module,
+        comments: &dyn Comments,
         unresolved_ctxt: SyntaxContext,
         top_level_ctxt: SyntaxContext,
     ) -> (Vec<ItemId>, FxHashMap<ItemId, ItemData>) {
@@ -542,13 +641,13 @@ impl DepGraph {
                 match item {
                     ModuleDecl::ExportDecl(item) => match &item.decl {
                         Decl::Fn(FnDecl { ident, .. }) | Decl::Class(ClassDecl { ident, .. }) => {
-                            exports.push((ident.to_id(), None));
+                            exports.push((ident.to_id(), ident.sym.clone()));
                         }
                         Decl::Var(v) => {
                             for decl in &v.decls {
                                 let ids: Vec<Id> = find_pat_ids(&decl.name);
                                 for id in ids {
-                                    exports.push((id, None));
+                                    exports.push((id.clone(), id.0));
                                 }
                             }
                         }
@@ -587,7 +686,7 @@ impl DepGraph {
                                         ModuleExportName::Ident(i) => i.clone(),
                                         ModuleExportName::Str(..) => quote_ident!("_tmp").into(),
                                     },
-                                    Some(s.exported.clone().unwrap_or_else(|| s.orig.clone())),
+                                    s.exported.clone().unwrap_or_else(|| s.orig.clone()),
                                 ),
                                 ExportSpecifier::Default(s) => (
                                     Some(ModuleExportName::Ident(Ident::new(
@@ -596,7 +695,7 @@ impl DepGraph {
                                         Default::default(),
                                     ))),
                                     quote_ident!("default").into(),
-                                    Some(ModuleExportName::Ident(s.exported.clone())),
+                                    ModuleExportName::Ident(s.exported.clone()),
                                 ),
                                 ExportSpecifier::Namespace(s) => (
                                     None,
@@ -604,7 +703,7 @@ impl DepGraph {
                                         ModuleExportName::Ident(i) => i.clone(),
                                         ModuleExportName::Str(..) => quote_ident!("_tmp").into(),
                                     },
-                                    Some(s.name.clone()),
+                                    s.name.clone(),
                                 ),
                             };
 
@@ -615,7 +714,7 @@ impl DepGraph {
                                 local = local.into_private();
                             }
 
-                            exports.push((local.to_id(), exported.clone()));
+                            exports.push((local.to_id(), exported.atom().clone()));
 
                             if let Some(src) = &item.src {
                                 let id = ItemId::Item {
@@ -708,7 +807,32 @@ impl DepGraph {
                                 write_vars: used_ids.write,
                                 eventual_write_vars: captured_ids.write,
                                 var_decls: [default_var.to_id()].into_iter().collect(),
-                                content: ModuleItem::ModuleDecl(item.clone()),
+                                content: ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(
+                                    VarDecl {
+                                        span: DUMMY_SP,
+                                        kind: VarDeclKind::Const,
+                                        decls: vec![VarDeclarator {
+                                            span: DUMMY_SP,
+                                            name: default_var.clone().into(),
+                                            init: Some(match &export.decl {
+                                                DefaultDecl::Class(c) => ClassExpr {
+                                                    ident: default_var.clone().into(),
+                                                    class: c.class.clone(),
+                                                }
+                                                .into(),
+                                                DefaultDecl::Fn(f) => FnExpr {
+                                                    ident: default_var.clone().into(),
+                                                    function: f.function.clone(),
+                                                }
+                                                .into(),
+                                                DefaultDecl::TsInterfaceDecl(_) => unreachable!(),
+                                            }),
+                                            definite: false,
+                                        }],
+                                        ..Default::default()
+                                    },
+                                )))),
+                                side_effects: true,
                                 ..Default::default()
                             };
 
@@ -720,10 +844,7 @@ impl DepGraph {
                             items.insert(id, data);
                         }
 
-                        exports.push((
-                            default_var.to_id(),
-                            Some(ModuleExportName::Ident(quote_ident!("default").into())),
-                        ));
+                        exports.push((default_var.to_id(), "default".into()));
                     }
                     ModuleDecl::ExportDefaultExpr(export) => {
                         let default_var =
@@ -782,10 +903,7 @@ impl DepGraph {
                         {
                             // For export default __TURBOPACK__default__export__
 
-                            exports.push((
-                                default_var.to_id(),
-                                Some(ModuleExportName::Ident(quote_ident!("default").into())),
-                            ));
+                            exports.push((default_var.to_id(), "default".into()));
                         }
                     }
 
@@ -938,6 +1056,11 @@ impl DepGraph {
                         };
                         ids.push(id.clone());
 
+                        let has_explicit_pure = match &decl.init {
+                            Some(e) => comments.has_flag(e.span().lo, "PURE"),
+                            _ => false,
+                        };
+
                         let decl_ids: Vec<Id> = find_pat_ids(&decl.name);
                         let mut vars = ids_used_by_ignoring_nested(
                             &decl.init,
@@ -955,7 +1078,14 @@ impl DepGraph {
                         vars.read.retain(|id| !decl_ids.contains(id));
                         eventual_vars.read.retain(|id| !decl_ids.contains(id));
 
-                        let side_effects = vars.found_unresolved;
+                        let side_effects = !has_explicit_pure
+                            && (vars.found_unresolved
+                                || decl.init.as_deref().map_or(false, |e| {
+                                    e.may_have_side_effects(&ExprCtx {
+                                        unresolved_ctxt,
+                                        is_unresolved_ref_safe: false,
+                                    })
+                                }));
 
                         let var_decl = Box::new(VarDecl {
                             decls: vec![decl.clone()],
@@ -966,10 +1096,15 @@ impl DepGraph {
                         items.insert(
                             id,
                             ItemData {
+                                pure: has_explicit_pure,
                                 var_decls: decl_ids.clone().into_iter().collect(),
                                 read_vars: vars.read,
+                                write_vars: if has_explicit_pure {
+                                    Default::default()
+                                } else {
+                                    vars.write
+                                },
                                 eventual_read_vars: eventual_vars.read,
-                                write_vars: vars.write,
                                 eventual_write_vars: eventual_vars.write,
                                 content,
                                 side_effects,
@@ -1081,11 +1216,7 @@ impl DepGraph {
         }
 
         for (local, export_name) in exports {
-            let name = match &export_name {
-                Some(ModuleExportName::Ident(v)) => v.sym.clone(),
-                _ => local.0.clone(),
-            };
-            let id = ItemId::Group(ItemIdGroupKind::Export(local.clone(), name.clone()));
+            let id = ItemId::Group(ItemIdGroupKind::Export(local.clone(), export_name.clone()));
             ids.push(id.clone());
             items.insert(
                 id.clone(),
@@ -1095,7 +1226,11 @@ impl DepGraph {
                         specifiers: vec![ExportSpecifier::Named(ExportNamedSpecifier {
                             span: DUMMY_SP,
                             orig: ModuleExportName::Ident(local.clone().into()),
-                            exported: export_name,
+                            exported: if local.0 == export_name {
+                                None
+                            } else {
+                                Some(ModuleExportName::Ident(export_name.clone().into()))
+                            },
                             is_type_only: false,
                         })],
                         src: None,
@@ -1103,7 +1238,7 @@ impl DepGraph {
                         with: None,
                     })),
                     read_vars: [local.clone()].into_iter().collect(),
-                    export: Some(name),
+                    export: Some(export_name),
                     ..Default::default()
                 },
             );

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -4,11 +4,11 @@ use anyhow::{bail, Result};
 use indexmap::IndexSet;
 use rustc_hash::FxHashMap;
 use swc_core::{
-    common::{util::take::Take, SyntaxContext, DUMMY_SP, GLOBALS},
+    common::{comments::Comments, util::take::Take, SyntaxContext, DUMMY_SP, GLOBALS},
     ecma::{
         ast::{
-            ExportAll, ExportNamedSpecifier, Id, Ident, ImportDecl, Module, ModuleDecl,
-            ModuleExportName, ModuleItem, NamedExport, Program,
+            ExportAll, ExportNamedSpecifier, Expr, ExprStmt, Id, Ident, ImportDecl, Lit, Module,
+            ModuleDecl, ModuleExportName, ModuleItem, NamedExport, Program, Stmt,
         },
         codegen::to_code,
     },
@@ -65,11 +65,12 @@ fn get_var<'a>(map: &'a FxHashMap<Id, VarState>, id: &Id) -> Cow<'a, VarState> {
 impl Analyzer<'_> {
     pub(super) fn analyze(
         module: &Module,
+        comments: &dyn Comments,
         unresolved_ctxt: SyntaxContext,
         top_level_ctxt: SyntaxContext,
     ) -> (DepGraph, FxHashMap<ItemId, ItemData>) {
         let mut g = DepGraph::default();
-        let (item_ids, mut items) = g.init(module, unresolved_ctxt, top_level_ctxt);
+        let (item_ids, mut items) = g.init(module, comments, unresolved_ctxt, top_level_ctxt);
 
         let mut analyzer = Analyzer {
             g: &mut g,
@@ -397,7 +398,7 @@ pub(crate) enum SplitResult {
         modules: Vec<Vc<ParseResult>>,
 
         #[turbo_tasks(trace_ignore)]
-        deps: FxHashMap<u32, Vec<u32>>,
+        deps: FxHashMap<u32, Vec<PartId>>,
 
         #[turbo_tasks(debug_ignore, trace_ignore)]
         star_reexports: Vec<ExportAll>,
@@ -418,7 +419,12 @@ impl PartialEq for SplitResult {
 
 #[turbo_tasks::function]
 pub(super) async fn split_module(asset: Vc<EcmascriptModuleAsset>) -> Result<Vc<SplitResult>> {
-    Ok(split(asset.source().ident(), asset.source(), asset.parse()))
+    Ok(split(
+        asset.source().ident(),
+        asset.source(),
+        asset.parse(),
+        asset.options().await?.special_exports,
+    ))
 }
 
 #[turbo_tasks::function]
@@ -426,7 +432,26 @@ pub(super) async fn split(
     ident: Vc<AssetIdent>,
     source: Vc<Box<dyn Source>>,
     parsed: Vc<ParseResult>,
+    special_exports: Vc<Vec<RcStr>>,
 ) -> Result<Vc<SplitResult>> {
+    // Do not split already split module
+    if ident.await?.part.is_some() {
+        return Ok(SplitResult::Failed {
+            parse_result: parsed,
+        }
+        .cell());
+    }
+
+    // Turbopack has a bug related to parsing of CJS files where the package.json has
+    // a `"type": "module"` and the file is a CJS file.
+    let name = ident.to_string().await?;
+    if name.ends_with(".cjs") {
+        return Ok(SplitResult::Failed {
+            parse_result: parsed,
+        }
+        .cell());
+    }
+
     let parse_result = parsed.await?;
 
     match &*parse_result {
@@ -436,10 +461,11 @@ pub(super) async fn split(
             eval_context,
             source_map,
             globals,
+            top_level_mark,
             ..
         } => {
             // If the script file is a common js file, we cannot split the module
-            if util::should_skip_tree_shaking(program) {
+            if util::should_skip_tree_shaking(program, &special_exports.await?) {
                 return Ok(SplitResult::Failed {
                     parse_result: parsed,
                 }
@@ -451,9 +477,26 @@ pub(super) async fn split(
                 Program::Script(..) => unreachable!("CJS is already handled"),
             };
 
+            // We copy directives like `use client` or `use server` to each module
+            let directives = module
+                .body
+                .iter()
+                .take_while(|item| {
+                    matches!(
+                        item,
+                        ModuleItem::Stmt(Stmt::Expr(ExprStmt {
+                            expr: box Expr::Lit(Lit::Str(..)),
+                            ..
+                        }))
+                    )
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+
             let (mut dep_graph, items) = GLOBALS.set(globals, || {
                 Analyzer::analyze(
                     module,
+                    comments,
                     SyntaxContext::empty().apply_mark(eval_context.unresolved_mark),
                     SyntaxContext::empty().apply_mark(eval_context.top_level_mark),
                 )
@@ -466,7 +509,16 @@ pub(super) async fn split(
                 part_deps,
                 modules,
                 star_reexports,
-            } = dep_graph.split_module(&items);
+            } = dep_graph.split_module(&directives, &items);
+
+            // let name = ident.to_string().await?;
+            // if !name.contains("node_modules") {
+            //     eprintln!("# Program ({name}):\n{}", to_code(&program));
+
+            //     for (idx, module) in modules.iter().enumerate() {
+            //         eprintln!("# Module ({name})#{idx}:\n{}", to_code(&module));
+            //     }
+            // }
 
             assert_ne!(modules.len(), 0, "modules.len() == 0;\nModule: {module:?}",);
 
@@ -496,6 +548,7 @@ pub(super) async fn split(
                         comments: comments.clone(),
                         source_map: source_map.clone(),
                         eval_context,
+                        top_level_mark: *top_level_mark,
                     })
                 })
                 .collect();
@@ -518,7 +571,7 @@ pub(super) async fn split(
 }
 
 #[turbo_tasks::function]
-pub(super) async fn part_of_module(
+pub(crate) async fn part_of_module(
     split_data: Vc<SplitResult>,
     part: Vc<ModulePart>,
 ) -> Result<Vc<ParseResult>> {
@@ -541,6 +594,7 @@ pub(super) async fn part_of_module(
                     eval_context,
                     globals,
                     source_map,
+                    top_level_mark,
                     ..
                 } = &*modules[0].await?
                 {
@@ -620,83 +674,7 @@ pub(super) async fn part_of_module(
                         eval_context,
                         globals: globals.clone(),
                         source_map: source_map.clone(),
-                    }
-                    .cell());
-                } else {
-                    unreachable!()
-                }
-            }
-
-            if matches!(&*part.await?, ModulePart::Exports) {
-                if let ParseResult::Ok {
-                    comments,
-                    eval_context,
-                    globals,
-                    source_map,
-                    ..
-                } = &*modules[0].await?
-                {
-                    let mut export_names = entrypoints
-                        .keys()
-                        .filter_map(|key| {
-                            if let Key::Export(v) = key {
-                                Some(v.clone())
-                            } else {
-                                None
-                            }
-                        })
-                        .collect::<Vec<_>>();
-                    export_names.sort();
-
-                    let mut module = Module::dummy();
-
-                    for export_name in export_names {
-                        // We can't use quote! as `with` is not standard yet
-                        let chunk_prop =
-                            create_turbopack_part_id_assert(PartId::Export(export_name.clone()));
-
-                        let specifier =
-                            swc_core::ecma::ast::ExportSpecifier::Named(ExportNamedSpecifier {
-                                span: DUMMY_SP,
-                                orig: ModuleExportName::Ident(Ident::new(
-                                    export_name.as_str().into(),
-                                    DUMMY_SP,
-                                    Default::default(),
-                                )),
-                                exported: None,
-                                is_type_only: false,
-                            });
-                        module
-                            .body
-                            .push(ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(
-                                NamedExport {
-                                    span: DUMMY_SP,
-                                    specifiers: vec![specifier],
-                                    src: Some(Box::new(TURBOPACK_PART_IMPORT_SOURCE.into())),
-                                    type_only: false,
-                                    with: Some(Box::new(chunk_prop)),
-                                },
-                            )));
-                    }
-
-                    module.body.extend(star_reexports.iter().map(|export_all| {
-                        ModuleItem::ModuleDecl(ModuleDecl::ExportAll(export_all.clone()))
-                    }));
-
-                    let program = Program::Module(module);
-                    let eval_context = EvalContext::new(
-                        &program,
-                        eval_context.unresolved_mark,
-                        eval_context.top_level_mark,
-                        None,
-                        None,
-                    );
-                    return Ok(ParseResult::Ok {
-                        program,
-                        comments: comments.clone(),
-                        eval_context,
-                        globals: globals.clone(),
-                        source_map: source_map.clone(),
+                        top_level_mark: *top_level_mark,
                     }
                     .cell());
                 } else {

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/app-route/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/app-route/output.md
@@ -458,7 +458,7 @@ export { _patchFetch as b } from "__TURBOPACK_VAR__" assert {
 ## Part 3
 ```js
 import * as userland from 'VAR_USERLAND';
-export { userland as userland } from "__TURBOPACK_VAR__" assert {
+export { userland as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -466,7 +466,7 @@ export { userland as userland } from "__TURBOPACK_VAR__" assert {
 ## Part 4
 ```js
 import { RouteKind } from '../../server/future/route-kind';
-export { RouteKind as c } from "__TURBOPACK_VAR__" assert {
+export { RouteKind as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -474,7 +474,7 @@ export { RouteKind as c } from "__TURBOPACK_VAR__" assert {
 ## Part 5
 ```js
 import { AppRouteRouteModule } from '../../server/future/route-modules/app-route/module.compiled';
-export { AppRouteRouteModule as d } from "__TURBOPACK_VAR__" assert {
+export { AppRouteRouteModule as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -543,13 +543,13 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-import { d as AppRouteRouteModule } from "__TURBOPACK_PART__" assert {
+import { e as AppRouteRouteModule } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { c as RouteKind } from "__TURBOPACK_PART__" assert {
+import { d as RouteKind } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { c as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
 const routeModule = new AppRouteRouteModule({
@@ -564,7 +564,7 @@ const routeModule = new AppRouteRouteModule({
     nextConfigOutput,
     userland
 });
-export { routeModule as e } from "__TURBOPACK_VAR__" assert {
+export { routeModule as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -594,7 +594,7 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
-import { e as routeModule } from "__TURBOPACK_PART__" assert {
+import { f as routeModule } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
 export { routeModule };
@@ -605,17 +605,17 @@ export { routeModule };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
-import { e as routeModule } from "__TURBOPACK_PART__" assert {
+import { f as routeModule } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
 const { requestAsyncStorage, staticGenerationAsyncStorage, serverHooks } = routeModule;
-export { requestAsyncStorage as f } from "__TURBOPACK_VAR__" assert {
+export { requestAsyncStorage as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
-export { staticGenerationAsyncStorage as g } from "__TURBOPACK_VAR__" assert {
+export { staticGenerationAsyncStorage as h } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
-export { serverHooks as h } from "__TURBOPACK_VAR__" assert {
+export { serverHooks as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -625,7 +625,7 @@ export { serverHooks as h } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
-import { h as serverHooks } from "__TURBOPACK_PART__" assert {
+import { i as serverHooks } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
 export { serverHooks };
@@ -636,7 +636,7 @@ export { serverHooks };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
-import { g as staticGenerationAsyncStorage } from "__TURBOPACK_PART__" assert {
+import { h as staticGenerationAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
 export { staticGenerationAsyncStorage };
@@ -656,13 +656,13 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 15
 };
-import { g as staticGenerationAsyncStorage } from "__TURBOPACK_PART__" assert {
+import { h as staticGenerationAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
 import { b as _patchFetch } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-import { h as serverHooks } from "__TURBOPACK_PART__" assert {
+import { i as serverHooks } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
 function patchFetch() {
@@ -671,7 +671,7 @@ function patchFetch() {
         staticGenerationAsyncStorage
     });
 }
-export { patchFetch as i } from "__TURBOPACK_VAR__" assert {
+export { patchFetch as j } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -681,7 +681,7 @@ export { patchFetch as i } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 16
 };
-import { i as patchFetch } from "__TURBOPACK_PART__" assert {
+import { j as patchFetch } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 16
 };
 export { patchFetch };
@@ -692,7 +692,7 @@ export { patchFetch };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
-import { f as requestAsyncStorage } from "__TURBOPACK_PART__" assert {
+import { g as requestAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
 export { requestAsyncStorage };
@@ -799,7 +799,7 @@ export { _patchFetch as b } from "__TURBOPACK_VAR__" assert {
 ## Part 3
 ```js
 import * as userland from 'VAR_USERLAND';
-export { userland as userland } from "__TURBOPACK_VAR__" assert {
+export { userland as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -807,7 +807,7 @@ export { userland as userland } from "__TURBOPACK_VAR__" assert {
 ## Part 4
 ```js
 import { RouteKind } from '../../server/future/route-kind';
-export { RouteKind as c } from "__TURBOPACK_VAR__" assert {
+export { RouteKind as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -815,7 +815,7 @@ export { RouteKind as c } from "__TURBOPACK_VAR__" assert {
 ## Part 5
 ```js
 import { AppRouteRouteModule } from '../../server/future/route-modules/app-route/module.compiled';
-export { AppRouteRouteModule as d } from "__TURBOPACK_VAR__" assert {
+export { AppRouteRouteModule as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -881,13 +881,13 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
-import { d as AppRouteRouteModule } from "__TURBOPACK_PART__" assert {
+import { e as AppRouteRouteModule } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { c as RouteKind } from "__TURBOPACK_PART__" assert {
+import { d as RouteKind } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { c as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
 const routeModule = new AppRouteRouteModule({
@@ -902,7 +902,7 @@ const routeModule = new AppRouteRouteModule({
     nextConfigOutput,
     userland
 });
-export { routeModule as e } from "__TURBOPACK_VAR__" assert {
+export { routeModule as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -912,7 +912,7 @@ export { routeModule as e } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
-import { e as routeModule } from "__TURBOPACK_PART__" assert {
+import { f as routeModule } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
 export { routeModule };
@@ -923,17 +923,17 @@ export { routeModule };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
-import { e as routeModule } from "__TURBOPACK_PART__" assert {
+import { f as routeModule } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
 const { requestAsyncStorage, staticGenerationAsyncStorage, serverHooks } = routeModule;
-export { requestAsyncStorage as f } from "__TURBOPACK_VAR__" assert {
+export { requestAsyncStorage as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
-export { staticGenerationAsyncStorage as g } from "__TURBOPACK_VAR__" assert {
+export { staticGenerationAsyncStorage as h } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
-export { serverHooks as h } from "__TURBOPACK_VAR__" assert {
+export { serverHooks as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -946,13 +946,13 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
-import { g as staticGenerationAsyncStorage } from "__TURBOPACK_PART__" assert {
+import { h as staticGenerationAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
 import { b as _patchFetch } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-import { h as serverHooks } from "__TURBOPACK_PART__" assert {
+import { i as serverHooks } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
 function patchFetch() {
@@ -961,7 +961,7 @@ function patchFetch() {
         staticGenerationAsyncStorage
     });
 }
-export { patchFetch as i } from "__TURBOPACK_VAR__" assert {
+export { patchFetch as j } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -971,7 +971,7 @@ export { patchFetch as i } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
-import { i as patchFetch } from "__TURBOPACK_PART__" assert {
+import { j as patchFetch } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
 export { patchFetch };
@@ -982,7 +982,7 @@ export { patchFetch };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
-import { h as serverHooks } from "__TURBOPACK_PART__" assert {
+import { i as serverHooks } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
 export { serverHooks };
@@ -993,7 +993,7 @@ export { serverHooks };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
-import { g as staticGenerationAsyncStorage } from "__TURBOPACK_PART__" assert {
+import { h as staticGenerationAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
 export { staticGenerationAsyncStorage };
@@ -1004,7 +1004,7 @@ export { staticGenerationAsyncStorage };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
-import { f as requestAsyncStorage } from "__TURBOPACK_PART__" assert {
+import { g as requestAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
 export { requestAsyncStorage };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/app-route/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/app-route/output.md
@@ -444,7 +444,7 @@ import "__TURBOPACK_PART__" assert {
 import { a as originalPathname } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
 };
-export { originalPathname as originalPathname };
+export { originalPathname };
 
 ```
 ## Part 2
@@ -458,7 +458,7 @@ export { _patchFetch as b } from "__TURBOPACK_VAR__" assert {
 ## Part 3
 ```js
 import * as userland from 'VAR_USERLAND';
-export { userland as c } from "__TURBOPACK_VAR__" assert {
+export { userland as userland } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -466,7 +466,7 @@ export { userland as c } from "__TURBOPACK_VAR__" assert {
 ## Part 4
 ```js
 import { RouteKind } from '../../server/future/route-kind';
-export { RouteKind as d } from "__TURBOPACK_VAR__" assert {
+export { RouteKind as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -474,7 +474,7 @@ export { RouteKind as d } from "__TURBOPACK_VAR__" assert {
 ## Part 5
 ```js
 import { AppRouteRouteModule } from '../../server/future/route-modules/app-route/module.compiled';
-export { AppRouteRouteModule as e } from "__TURBOPACK_VAR__" assert {
+export { AppRouteRouteModule as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -543,13 +543,13 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-import { e as AppRouteRouteModule } from "__TURBOPACK_PART__" assert {
+import { d as AppRouteRouteModule } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { d as RouteKind } from "__TURBOPACK_PART__" assert {
+import { c as RouteKind } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-import { c as userland } from "__TURBOPACK_PART__" assert {
+import { userland as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
 const routeModule = new AppRouteRouteModule({
@@ -564,7 +564,7 @@ const routeModule = new AppRouteRouteModule({
     nextConfigOutput,
     userland
 });
-export { routeModule as f } from "__TURBOPACK_VAR__" assert {
+export { routeModule as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -594,10 +594,10 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
-import { f as routeModule } from "__TURBOPACK_PART__" assert {
+import { e as routeModule } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
-export { routeModule as routeModule };
+export { routeModule };
 
 ```
 ## Part 13
@@ -605,17 +605,17 @@ export { routeModule as routeModule };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
-import { f as routeModule } from "__TURBOPACK_PART__" assert {
+import { e as routeModule } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
 const { requestAsyncStorage, staticGenerationAsyncStorage, serverHooks } = routeModule;
-export { requestAsyncStorage as g } from "__TURBOPACK_VAR__" assert {
+export { requestAsyncStorage as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
-export { staticGenerationAsyncStorage as h } from "__TURBOPACK_VAR__" assert {
+export { staticGenerationAsyncStorage as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
-export { serverHooks as i } from "__TURBOPACK_VAR__" assert {
+export { serverHooks as h } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -625,10 +625,10 @@ export { serverHooks as i } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
-import { i as serverHooks } from "__TURBOPACK_PART__" assert {
+import { h as serverHooks } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
-export { serverHooks as serverHooks };
+export { serverHooks };
 
 ```
 ## Part 15
@@ -636,10 +636,10 @@ export { serverHooks as serverHooks };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
-import { h as staticGenerationAsyncStorage } from "__TURBOPACK_PART__" assert {
+import { g as staticGenerationAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
-export { staticGenerationAsyncStorage as staticGenerationAsyncStorage };
+export { staticGenerationAsyncStorage };
 
 ```
 ## Part 16
@@ -656,13 +656,13 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 15
 };
-import { h as staticGenerationAsyncStorage } from "__TURBOPACK_PART__" assert {
+import { g as staticGenerationAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
 import { b as _patchFetch } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-import { i as serverHooks } from "__TURBOPACK_PART__" assert {
+import { h as serverHooks } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
 function patchFetch() {
@@ -671,7 +671,7 @@ function patchFetch() {
         staticGenerationAsyncStorage
     });
 }
-export { patchFetch as j } from "__TURBOPACK_VAR__" assert {
+export { patchFetch as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -681,10 +681,10 @@ export { patchFetch as j } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 16
 };
-import { j as patchFetch } from "__TURBOPACK_PART__" assert {
+import { i as patchFetch } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 16
 };
-export { patchFetch as patchFetch };
+export { patchFetch };
 
 ```
 ## Part 18
@@ -692,10 +692,10 @@ export { patchFetch as patchFetch };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
-import { g as requestAsyncStorage } from "__TURBOPACK_PART__" assert {
+import { f as requestAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
-export { requestAsyncStorage as requestAsyncStorage };
+export { requestAsyncStorage };
 
 ```
 ## Part 19
@@ -785,7 +785,7 @@ import "__TURBOPACK_PART__" assert {
 import { a as originalPathname } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
 };
-export { originalPathname as originalPathname };
+export { originalPathname };
 
 ```
 ## Part 2
@@ -799,7 +799,7 @@ export { _patchFetch as b } from "__TURBOPACK_VAR__" assert {
 ## Part 3
 ```js
 import * as userland from 'VAR_USERLAND';
-export { userland as c } from "__TURBOPACK_VAR__" assert {
+export { userland as userland } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -807,7 +807,7 @@ export { userland as c } from "__TURBOPACK_VAR__" assert {
 ## Part 4
 ```js
 import { RouteKind } from '../../server/future/route-kind';
-export { RouteKind as d } from "__TURBOPACK_VAR__" assert {
+export { RouteKind as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -815,7 +815,7 @@ export { RouteKind as d } from "__TURBOPACK_VAR__" assert {
 ## Part 5
 ```js
 import { AppRouteRouteModule } from '../../server/future/route-modules/app-route/module.compiled';
-export { AppRouteRouteModule as e } from "__TURBOPACK_VAR__" assert {
+export { AppRouteRouteModule as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -881,13 +881,13 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
-import { e as AppRouteRouteModule } from "__TURBOPACK_PART__" assert {
+import { d as AppRouteRouteModule } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { d as RouteKind } from "__TURBOPACK_PART__" assert {
+import { c as RouteKind } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-import { c as userland } from "__TURBOPACK_PART__" assert {
+import { userland as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
 const routeModule = new AppRouteRouteModule({
@@ -902,7 +902,7 @@ const routeModule = new AppRouteRouteModule({
     nextConfigOutput,
     userland
 });
-export { routeModule as f } from "__TURBOPACK_VAR__" assert {
+export { routeModule as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -912,10 +912,10 @@ export { routeModule as f } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
-import { f as routeModule } from "__TURBOPACK_PART__" assert {
+import { e as routeModule } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
-export { routeModule as routeModule };
+export { routeModule };
 
 ```
 ## Part 12
@@ -923,17 +923,17 @@ export { routeModule as routeModule };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
-import { f as routeModule } from "__TURBOPACK_PART__" assert {
+import { e as routeModule } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
 const { requestAsyncStorage, staticGenerationAsyncStorage, serverHooks } = routeModule;
-export { requestAsyncStorage as g } from "__TURBOPACK_VAR__" assert {
+export { requestAsyncStorage as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
-export { staticGenerationAsyncStorage as h } from "__TURBOPACK_VAR__" assert {
+export { staticGenerationAsyncStorage as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
-export { serverHooks as i } from "__TURBOPACK_VAR__" assert {
+export { serverHooks as h } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -946,13 +946,13 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
-import { h as staticGenerationAsyncStorage } from "__TURBOPACK_PART__" assert {
+import { g as staticGenerationAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
 import { b as _patchFetch } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-import { i as serverHooks } from "__TURBOPACK_PART__" assert {
+import { h as serverHooks } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
 function patchFetch() {
@@ -961,7 +961,7 @@ function patchFetch() {
         staticGenerationAsyncStorage
     });
 }
-export { patchFetch as j } from "__TURBOPACK_VAR__" assert {
+export { patchFetch as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -971,10 +971,10 @@ export { patchFetch as j } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
-import { j as patchFetch } from "__TURBOPACK_PART__" assert {
+import { i as patchFetch } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
-export { patchFetch as patchFetch };
+export { patchFetch };
 
 ```
 ## Part 15
@@ -982,10 +982,10 @@ export { patchFetch as patchFetch };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
-import { i as serverHooks } from "__TURBOPACK_PART__" assert {
+import { h as serverHooks } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
-export { serverHooks as serverHooks };
+export { serverHooks };
 
 ```
 ## Part 16
@@ -993,10 +993,10 @@ export { serverHooks as serverHooks };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
-import { h as staticGenerationAsyncStorage } from "__TURBOPACK_PART__" assert {
+import { g as staticGenerationAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
-export { staticGenerationAsyncStorage as staticGenerationAsyncStorage };
+export { staticGenerationAsyncStorage };
 
 ```
 ## Part 17
@@ -1004,10 +1004,10 @@ export { staticGenerationAsyncStorage as staticGenerationAsyncStorage };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
-import { g as requestAsyncStorage } from "__TURBOPACK_PART__" assert {
+import { f as requestAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
-export { requestAsyncStorage as requestAsyncStorage };
+export { requestAsyncStorage };
 
 ```
 ## Part 18

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/combined-export/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/combined-export/output.md
@@ -120,7 +120,7 @@ import "__TURBOPACK_PART__" assert {
 import { a as b } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
 };
-export { b as b };
+export { b };
 
 ```
 ## Part 2
@@ -139,7 +139,7 @@ import "__TURBOPACK_PART__" assert {
 import { b as a } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-export { a as a };
+export { a };
 
 ```
 ## Part 4
@@ -195,7 +195,7 @@ import "__TURBOPACK_PART__" assert {
 import { a as b } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
 };
-export { b as b };
+export { b };
 
 ```
 ## Part 2
@@ -214,7 +214,7 @@ import "__TURBOPACK_PART__" assert {
 import { b as a } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-export { a as a };
+export { a };
 
 ```
 ## Part 4

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-2/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-2/output.md
@@ -89,6 +89,7 @@ const hasPostpone = typeof React.unstable_postpone === 'function';
 
 ```
 
+- Side effects
 - Declares: `hasPostpone`
 - Reads: `React`
 - Write: `React`, `hasPostpone`
@@ -389,6 +390,15 @@ graph TD
     Item4 --> Item2;
     Item4 --> Item3;
     Item9 --> Item5;
+    Item9 --> Item1;
+    Item9 --> Item2;
+    Item9 --> Item3;
+    Item9 --> Item4;
+    Item9 -.-> Item8;
+    Item9 -.-> Item7;
+    Item9 -.-> Item15;
+    Item9 -.-> Item6;
+    Item9 -.-> Item18;
     Item21 --> Item10;
     Item22 --> Item11;
     Item23 --> Item12;
@@ -445,6 +455,15 @@ graph TD
     Item4 --> Item2;
     Item4 --> Item3;
     Item9 --> Item5;
+    Item9 --> Item1;
+    Item9 --> Item2;
+    Item9 --> Item3;
+    Item9 --> Item4;
+    Item9 -.-> Item8;
+    Item9 -.-> Item7;
+    Item9 -.-> Item15;
+    Item9 -.-> Item6;
+    Item9 -.-> Item18;
     Item21 --> Item10;
     Item22 --> Item11;
     Item23 --> Item12;
@@ -518,6 +537,15 @@ graph TD
     Item4 --> Item2;
     Item4 --> Item3;
     Item9 --> Item5;
+    Item9 --> Item1;
+    Item9 --> Item2;
+    Item9 --> Item3;
+    Item9 --> Item4;
+    Item9 -.-> Item8;
+    Item9 -.-> Item7;
+    Item9 -.-> Item15;
+    Item9 -.-> Item6;
+    Item9 -.-> Item18;
     Item21 --> Item10;
     Item22 --> Item11;
     Item23 --> Item12;
@@ -547,74 +575,77 @@ graph TD
     Item20 --> Item2;
     Item20 --> Item3;
     Item20 --> Item4;
+    Item20 --> Item9;
 ```
 # Final
 ```mermaid
 graph TD
-    N0["Items: [ItemId(1, ImportBinding(0))]"];
-    N1["Items: [ItemId(2, ImportBinding(0))]"];
-    N2["Items: [ItemId(3, ImportBinding(0))]"];
-    N3["Items: [ItemId(12, Normal)]"];
-    N4["Items: [ItemId(Export((&quot;formatDynamicAPIAccesses&quot;, #2), &quot;formatDynamicAPIAccesses&quot;))]"];
-    N5["Items: [ItemId(11, Normal)]"];
-    N6["Items: [ItemId(Export((&quot;usedDynamicAPIs&quot;, #2), &quot;usedDynamicAPIs&quot;))]"];
-    N7["Items: [ItemId(5, Normal)]"];
-    N8["Items: [ItemId(Export((&quot;createPrerenderState&quot;, #2), &quot;createPrerenderState&quot;))]"];
+    N0["Items: [ItemId(12, Normal)]"];
+    N1["Items: [ItemId(Export((&quot;formatDynamicAPIAccesses&quot;, #2), &quot;formatDynamicAPIAccesses&quot;))]"];
+    N2["Items: [ItemId(11, Normal)]"];
+    N3["Items: [ItemId(Export((&quot;usedDynamicAPIs&quot;, #2), &quot;usedDynamicAPIs&quot;))]"];
+    N4["Items: [ItemId(5, Normal)]"];
+    N5["Items: [ItemId(Export((&quot;createPrerenderState&quot;, #2), &quot;createPrerenderState&quot;))]"];
+    N6["Items: [ItemId(1, ImportBinding(0))]"];
+    N7["Items: [ItemId(2, ImportBinding(0))]"];
+    N8["Items: [ItemId(3, ImportBinding(0))]"];
     N9["Items: [ItemId(0, ImportBinding(0))]"];
-    N10["Items: [ItemId(4, VarDeclarator(0))]"];
-    N11["Items: [ItemId(13, Normal)]"];
-    N12["Items: [ItemId(14, Normal)]"];
-    N13["Items: [ItemId(Export((&quot;createPostponedAbortSignal&quot;, #2), &quot;createPostponedAbortSignal&quot;))]"];
-    N14["Items: [ItemId(10, Normal)]"];
-    N15["Items: [ItemId(9, Normal)]"];
-    N16["Items: [ItemId(Export((&quot;trackDynamicFetch&quot;, #2), &quot;trackDynamicFetch&quot;))]"];
-    N17["Items: [ItemId(8, Normal)]"];
-    N18["Items: [ItemId(Export((&quot;Postpone&quot;, #2), &quot;Postpone&quot;))]"];
-    N19["Items: [ItemId(7, Normal)]"];
-    N20["Items: [ItemId(Export((&quot;trackDynamicDataAccessed&quot;, #2), &quot;trackDynamicDataAccessed&quot;))]"];
-    N21["Items: [ItemId(6, Normal)]"];
-    N22["Items: [ItemId(Export((&quot;markCurrentScopeAsDynamic&quot;, #2), &quot;markCurrentScopeAsDynamic&quot;))]"];
-    N23["Items: [ItemId(0, ImportOfModule)]"];
-    N24["Items: [ItemId(1, ImportOfModule)]"];
-    N25["Items: [ItemId(2, ImportOfModule)]"];
-    N26["Items: [ItemId(3, ImportOfModule)]"];
-    N27["Items: [ItemId(ModuleEvaluation)]"];
-    N24 --> N23;
-    N25 --> N23;
-    N25 --> N24;
-    N26 --> N23;
-    N26 --> N24;
-    N26 --> N25;
-    N10 --> N9;
-    N8 --> N7;
-    N22 --> N21;
-    N20 --> N19;
-    N18 --> N17;
-    N16 --> N15;
-    N6 --> N5;
-    N4 --> N3;
-    N13 --> N12;
-    N21 --> N2;
-    N21 --> N1;
-    N21 --> N14;
-    N21 --> N0;
-    N19 --> N2;
-    N19 --> N1;
-    N19 --> N14;
-    N19 --> N0;
-    N17 --> N14;
-    N15 --> N14;
-    N14 --> N11;
-    N14 --> N10;
-    N14 --> N9;
+    N10["Items: [ItemId(0, ImportOfModule)]"];
+    N11["Items: [ItemId(1, ImportOfModule)]"];
+    N12["Items: [ItemId(2, ImportOfModule)]"];
+    N13["Items: [ItemId(3, ImportOfModule)]"];
+    N14["Items: [ItemId(4, VarDeclarator(0)), ItemId(10, Normal), ItemId(13, Normal)]"];
+    N15["Items: [ItemId(ModuleEvaluation)]"];
+    N16["Items: [ItemId(14, Normal)]"];
+    N17["Items: [ItemId(Export((&quot;createPostponedAbortSignal&quot;, #2), &quot;createPostponedAbortSignal&quot;))]"];
+    N18["Items: [ItemId(9, Normal)]"];
+    N19["Items: [ItemId(Export((&quot;trackDynamicFetch&quot;, #2), &quot;trackDynamicFetch&quot;))]"];
+    N20["Items: [ItemId(8, Normal)]"];
+    N21["Items: [ItemId(Export((&quot;Postpone&quot;, #2), &quot;Postpone&quot;))]"];
+    N22["Items: [ItemId(7, Normal)]"];
+    N23["Items: [ItemId(Export((&quot;trackDynamicDataAccessed&quot;, #2), &quot;trackDynamicDataAccessed&quot;))]"];
+    N24["Items: [ItemId(6, Normal)]"];
+    N25["Items: [ItemId(Export((&quot;markCurrentScopeAsDynamic&quot;, #2), &quot;markCurrentScopeAsDynamic&quot;))]"];
     N11 --> N10;
-    N12 --> N11;
     N12 --> N10;
-    N12 --> N9;
-    N27 --> N23;
-    N27 --> N24;
-    N27 --> N25;
-    N27 --> N26;
+    N12 --> N11;
+    N13 --> N10;
+    N13 --> N11;
+    N13 --> N12;
+    N14 --> N9;
+    N14 --> N10;
+    N14 --> N11;
+    N14 --> N12;
+    N14 --> N13;
+    N14 -.-> N8;
+    N14 -.-> N7;
+    N14 --> N14;
+    N14 -.-> N6;
+    N5 --> N4;
+    N25 --> N24;
+    N23 --> N22;
+    N21 --> N20;
+    N19 --> N18;
+    N3 --> N2;
+    N1 --> N0;
+    N17 --> N16;
+    N24 --> N8;
+    N24 --> N7;
+    N24 --> N14;
+    N24 --> N6;
+    N22 --> N8;
+    N22 --> N7;
+    N22 --> N14;
+    N22 --> N6;
+    N20 --> N14;
+    N18 --> N14;
+    N16 --> N14;
+    N16 --> N9;
+    N15 --> N10;
+    N15 --> N11;
+    N15 --> N12;
+    N15 --> N13;
+    N15 --> N14;
 ```
 # Entrypoints
 
@@ -622,60 +653,36 @@ graph TD
 {
     Export(
         "createPrerenderState",
-    ): 8,
-    ModuleEvaluation: 27,
+    ): 5,
+    ModuleEvaluation: 15,
     Export(
         "markCurrentScopeAsDynamic",
-    ): 22,
+    ): 25,
     Export(
         "usedDynamicAPIs",
-    ): 6,
+    ): 3,
     Export(
         "trackDynamicFetch",
-    ): 16,
+    ): 19,
     Export(
         "Postpone",
-    ): 18,
+    ): 21,
     Export(
         "trackDynamicDataAccessed",
-    ): 20,
+    ): 23,
     Export(
         "createPostponedAbortSignal",
-    ): 13,
+    ): 17,
     Export(
         "formatDynamicAPIAccesses",
-    ): 4,
-    Exports: 28,
+    ): 1,
+    Exports: 26,
 }
 ```
 
 
 # Modules (dev)
 ## Part 0
-```js
-import { DynamicServerError } from '../../client/components/hooks-server-context';
-export { DynamicServerError as a } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 1
-```js
-import { StaticGenBailoutError } from '../../client/components/static-generation-bailout';
-export { StaticGenBailoutError as b } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 2
-```js
-import { getPathname } from '../../lib/url';
-export { getPathname as c } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 3
 ```js
 function formatDynamicAPIAccesses(prerenderState) {
     return prerenderState.dynamicAccesses.filter((access)=>typeof access.stack === 'string' && access.stack.length > 0).map(({ expression, stack })=>{
@@ -694,44 +701,44 @@ function formatDynamicAPIAccesses(prerenderState) {
         return `Dynamic API Usage Debug - ${expression}:\n${stack}`;
     });
 }
-export { formatDynamicAPIAccesses as d } from "__TURBOPACK_VAR__" assert {
+export { formatDynamicAPIAccesses as a } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
-## Part 4
+## Part 1
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+    __turbopack_part__: 0
 };
-import { d as formatDynamicAPIAccesses } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+import { a as formatDynamicAPIAccesses } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 0
 };
 export { formatDynamicAPIAccesses };
 
 ```
-## Part 5
+## Part 2
 ```js
 function usedDynamicAPIs(prerenderState) {
     return prerenderState.dynamicAccesses.length > 0;
 }
-export { usedDynamicAPIs as e } from "__TURBOPACK_VAR__" assert {
+export { usedDynamicAPIs as usedDynamicAPIs } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
-## Part 6
+## Part 3
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: 2
 };
-import { e as usedDynamicAPIs } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+import { usedDynamicAPIs as usedDynamicAPIs } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
 };
 export { usedDynamicAPIs };
 
 ```
-## Part 7
+## Part 4
 ```js
 function createPrerenderState(isDebugSkeleton) {
     return {
@@ -739,42 +746,57 @@ function createPrerenderState(isDebugSkeleton) {
         dynamicAccesses: []
     };
 }
-export { createPrerenderState as f } from "__TURBOPACK_VAR__" assert {
+export { createPrerenderState as b } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 5
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+import { b as createPrerenderState } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+export { createPrerenderState };
+
+```
+## Part 6
+```js
+import { DynamicServerError } from '../../client/components/hooks-server-context';
+export { DynamicServerError as c } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 7
+```js
+import { StaticGenBailoutError } from '../../client/components/static-generation-bailout';
+export { StaticGenBailoutError as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
+import { getPathname } from '../../lib/url';
+export { getPathname as e } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
 };
-import { f as createPrerenderState } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-export { createPrerenderState };
 
 ```
 ## Part 9
 ```js
 import React from 'react';
-export { React as g } from "__TURBOPACK_VAR__" assert {
+export { React as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
 ## Part 10
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
-};
-import { g as React } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
-};
-const hasPostpone = typeof React.unstable_postpone === 'function';
-export { hasPostpone as h } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
+import 'react';
 
 ```
 ## Part 11
@@ -782,35 +804,125 @@ export { hasPostpone as h } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
-import { h as hasPostpone } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 10
-};
-function assertPostpone() {
-    if (!hasPostpone) {
-        throw new Error(`Invariant: React.unstable_postpone is not defined. This suggests the wrong version of React was loaded. This is a bug in Next.js`);
-    }
-}
-export { assertPostpone as i } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
+import '../../client/components/hooks-server-context';
 
 ```
 ## Part 12
 ```js
 import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 11
+};
+import '../../client/components/static-generation-bailout';
+
+```
+## Part 13
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import '../../lib/url';
+
+```
+## Part 14
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
 import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import { f as React } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
-import { g as React } from "__TURBOPACK_PART__" assert {
+const hasPostpone = typeof React.unstable_postpone === 'function';
+function postponeWithTracking(prerenderState, expression, pathname) {
+    assertPostpone();
+    const reason = `Route ${pathname} needs to bail out of prerendering at this point because it used ${expression}. ` + `React throws this special object to indicate where. It should not be caught by ` + `your own try/catch. Learn more: https://nextjs.org/docs/messages/ppr-caught-error`;
+    prerenderState.dynamicAccesses.push({
+        stack: prerenderState.isDebugSkeleton ? new Error().stack : undefined,
+        expression
+    });
+    React.unstable_postpone(reason);
+}
+function assertPostpone() {
+    if (!hasPostpone) {
+        throw new Error(`Invariant: React.unstable_postpone is not defined. This suggests the wrong version of React was loaded. This is a bug in Next.js`);
+    }
+}
+export { hasPostpone as g } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+export { postponeWithTracking as h } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+export { assertPostpone as i } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 15
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+"module evaluation";
+
+```
+## Part 16
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import { f as React } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
 import { i as assertPostpone } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
+    __turbopack_part__: 14
 };
 function createPostponedAbortSignal(reason) {
     assertPostpone();
@@ -827,127 +939,96 @@ export { createPostponedAbortSignal as j } from "__TURBOPACK_VAR__" assert {
 };
 
 ```
-## Part 13
+## Part 17
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 12
+    __turbopack_part__: 16
 };
 import { j as createPostponedAbortSignal } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 12
+    __turbopack_part__: 16
 };
 export { createPostponedAbortSignal };
 
 ```
-## Part 14
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 10
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
-};
-import { g as React } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
-};
-import { i as assertPostpone } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
-};
-function postponeWithTracking(prerenderState, expression, pathname) {
-    assertPostpone();
-    const reason = `Route ${pathname} needs to bail out of prerendering at this point because it used ${expression}. ` + `React throws this special object to indicate where. It should not be caught by ` + `your own try/catch. Learn more: https://nextjs.org/docs/messages/ppr-caught-error`;
-    prerenderState.dynamicAccesses.push({
-        stack: prerenderState.isDebugSkeleton ? new Error().stack : undefined,
-        expression
-    });
-    React.unstable_postpone(reason);
-}
-export { postponeWithTracking as k } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 15
+## Part 18
 ```js
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
-import { k as postponeWithTracking } from "__TURBOPACK_PART__" assert {
+import { h as postponeWithTracking } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
 function trackDynamicFetch(store, expression) {
     if (!store.prerenderState || store.isUnstableCacheCallback) return;
     postponeWithTracking(store.prerenderState, expression, store.urlPathname);
 }
-export { trackDynamicFetch as l } from "__TURBOPACK_VAR__" assert {
+export { trackDynamicFetch as k } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
-
-```
-## Part 16
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
-};
-import { l as trackDynamicFetch } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
-};
-export { trackDynamicFetch };
-
-```
-## Part 17
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
-import { k as postponeWithTracking } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
-function Postpone({ reason, prerenderState, pathname }) {
-    postponeWithTracking(prerenderState, reason, pathname);
-}
-export { Postpone as m } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 18
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
-};
-import { m as Postpone } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
-};
-export { Postpone };
 
 ```
 ## Part 19
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: 18
+};
+import { k as trackDynamicFetch } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+export { trackDynamicFetch };
+
+```
+## Part 20
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import { h as postponeWithTracking } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+function Postpone({ reason, prerenderState, pathname }) {
+    postponeWithTracking(prerenderState, reason, pathname);
+}
+export { Postpone as l } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 21
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+import { l as Postpone } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+export { Postpone };
+
+```
+## Part 22
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+    __turbopack_part__: 7
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
+    __turbopack_part__: 6
 };
-import { a as DynamicServerError } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
+import { c as DynamicServerError } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
-import { c as getPathname } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+import { e as getPathname } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
 };
-import { b as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+import { d as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
 };
-import { k as postponeWithTracking } from "__TURBOPACK_PART__" assert {
+import { h as postponeWithTracking } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
 function trackDynamicDataAccessed(store, expression) {
@@ -968,46 +1049,46 @@ function trackDynamicDataAccessed(store, expression) {
         }
     }
 }
-export { trackDynamicDataAccessed as n } from "__TURBOPACK_VAR__" assert {
+export { trackDynamicDataAccessed as m } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
-## Part 20
+## Part 23
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 19
+    __turbopack_part__: 22
 };
-import { n as trackDynamicDataAccessed } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 19
+import { m as trackDynamicDataAccessed } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 22
 };
 export { trackDynamicDataAccessed };
 
 ```
-## Part 21
+## Part 24
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: 8
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+    __turbopack_part__: 7
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
+    __turbopack_part__: 6
 };
-import { a as DynamicServerError } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
+import { c as DynamicServerError } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
-import { c as getPathname } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+import { e as getPathname } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
 };
-import { b as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+import { d as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
 };
-import { k as postponeWithTracking } from "__TURBOPACK_PART__" assert {
+import { h as postponeWithTracking } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
 function markCurrentScopeAsDynamic(store, expression) {
@@ -1028,78 +1109,23 @@ function markCurrentScopeAsDynamic(store, expression) {
         }
     }
 }
-export { markCurrentScopeAsDynamic as o } from "__TURBOPACK_VAR__" assert {
+export { markCurrentScopeAsDynamic as n } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
-
-```
-## Part 22
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
-};
-import { o as markCurrentScopeAsDynamic } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
-};
-export { markCurrentScopeAsDynamic };
-
-```
-## Part 23
-```js
-import 'react';
-
-```
-## Part 24
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
-};
-import '../../client/components/hooks-server-context';
 
 ```
 ## Part 25
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 24
 };
-import '../../client/components/static-generation-bailout';
+import { n as markCurrentScopeAsDynamic } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 24
+};
+export { markCurrentScopeAsDynamic };
 
 ```
 ## Part 26
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
-};
-import '../../lib/url';
-
-```
-## Part 27
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
-};
-"module evaluation";
-
-```
-## Part 28
 ```js
 export { formatDynamicAPIAccesses } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: "export formatDynamicAPIAccesses"
@@ -1130,16 +1156,19 @@ export { markCurrentScopeAsDynamic } from "__TURBOPACK_PART__" assert {
 ## Merged (module eval)
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: 10
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
+    __turbopack_part__: 11
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
+    __turbopack_part__: 12
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
 };
 "module evaluation";
 
@@ -1150,29 +1179,29 @@ import "__TURBOPACK_PART__" assert {
 {
     Export(
         "createPrerenderState",
-    ): 8,
+    ): 5,
     ModuleEvaluation: 27,
     Export(
         "markCurrentScopeAsDynamic",
-    ): 22,
+    ): 26,
     Export(
         "usedDynamicAPIs",
-    ): 6,
+    ): 3,
     Export(
         "trackDynamicFetch",
-    ): 16,
-    Export(
-        "Postpone",
-    ): 18,
-    Export(
-        "trackDynamicDataAccessed",
     ): 20,
     Export(
+        "Postpone",
+    ): 22,
+    Export(
+        "trackDynamicDataAccessed",
+    ): 24,
+    Export(
         "createPostponedAbortSignal",
-    ): 13,
+    ): 17,
     Export(
         "formatDynamicAPIAccesses",
-    ): 4,
+    ): 1,
     Exports: 28,
 }
 ```
@@ -1181,30 +1210,6 @@ import "__TURBOPACK_PART__" assert {
 # Modules (prod)
 ## Part 0
 ```js
-import { DynamicServerError } from '../../client/components/hooks-server-context';
-export { DynamicServerError as a } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 1
-```js
-import { StaticGenBailoutError } from '../../client/components/static-generation-bailout';
-export { StaticGenBailoutError as b } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 2
-```js
-import { getPathname } from '../../lib/url';
-export { getPathname as c } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 3
-```js
 function formatDynamicAPIAccesses(prerenderState) {
     return prerenderState.dynamicAccesses.filter((access)=>typeof access.stack === 'string' && access.stack.length > 0).map(({ expression, stack })=>{
         stack = stack.split('\n').slice(4).filter((line)=>{
@@ -1222,44 +1227,44 @@ function formatDynamicAPIAccesses(prerenderState) {
         return `Dynamic API Usage Debug - ${expression}:\n${stack}`;
     });
 }
-export { formatDynamicAPIAccesses as d } from "__TURBOPACK_VAR__" assert {
+export { formatDynamicAPIAccesses as a } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
-## Part 4
+## Part 1
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+    __turbopack_part__: 0
 };
-import { d as formatDynamicAPIAccesses } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+import { a as formatDynamicAPIAccesses } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 0
 };
 export { formatDynamicAPIAccesses };
 
 ```
-## Part 5
+## Part 2
 ```js
 function usedDynamicAPIs(prerenderState) {
     return prerenderState.dynamicAccesses.length > 0;
 }
-export { usedDynamicAPIs as e } from "__TURBOPACK_VAR__" assert {
+export { usedDynamicAPIs as usedDynamicAPIs } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
-## Part 6
+## Part 3
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: 2
 };
-import { e as usedDynamicAPIs } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+import { usedDynamicAPIs as usedDynamicAPIs } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
 };
 export { usedDynamicAPIs };
 
 ```
-## Part 7
+## Part 4
 ```js
 function createPrerenderState(isDebugSkeleton) {
     return {
@@ -1267,42 +1272,57 @@ function createPrerenderState(isDebugSkeleton) {
         dynamicAccesses: []
     };
 }
-export { createPrerenderState as f } from "__TURBOPACK_VAR__" assert {
+export { createPrerenderState as b } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 5
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+import { b as createPrerenderState } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+export { createPrerenderState };
+
+```
+## Part 6
+```js
+import { DynamicServerError } from '../../client/components/hooks-server-context';
+export { DynamicServerError as c } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 7
+```js
+import { StaticGenBailoutError } from '../../client/components/static-generation-bailout';
+export { StaticGenBailoutError as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
+import { getPathname } from '../../lib/url';
+export { getPathname as e } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
 };
-import { f as createPrerenderState } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-export { createPrerenderState };
 
 ```
 ## Part 9
 ```js
 import React from 'react';
-export { React as g } from "__TURBOPACK_VAR__" assert {
+export { React as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
 ## Part 10
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
-};
-import { g as React } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
-};
-const hasPostpone = typeof React.unstable_postpone === 'function';
-export { hasPostpone as h } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
+import 'react';
 
 ```
 ## Part 11
@@ -1310,35 +1330,94 @@ export { hasPostpone as h } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
-import { h as hasPostpone } from "__TURBOPACK_PART__" assert {
+import '../../client/components/hooks-server-context';
+
+```
+## Part 12
+```js
+import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import '../../client/components/static-generation-bailout';
+
+```
+## Part 13
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import '../../lib/url';
+
+```
+## Part 14
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import { f as React } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+const hasPostpone = typeof React.unstable_postpone === 'function';
+export { hasPostpone as g } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 15
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import { g as hasPostpone } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
 };
 function assertPostpone() {
     if (!hasPostpone) {
         throw new Error(`Invariant: React.unstable_postpone is not defined. This suggests the wrong version of React was loaded. This is a bug in Next.js`);
     }
 }
-export { assertPostpone as i } from "__TURBOPACK_VAR__" assert {
+export { assertPostpone as h } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
-## Part 12
+## Part 16
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
+    __turbopack_part__: 15
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 10
+    __turbopack_part__: 14
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
-import { g as React } from "__TURBOPACK_PART__" assert {
+import { f as React } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
-import { i as assertPostpone } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
+import { h as assertPostpone } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
 };
 function createPostponedAbortSignal(reason) {
     assertPostpone();
@@ -1350,38 +1429,38 @@ function createPostponedAbortSignal(reason) {
     }
     return controller.signal;
 }
-export { createPostponedAbortSignal as j } from "__TURBOPACK_VAR__" assert {
+export { createPostponedAbortSignal as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
-## Part 13
+## Part 17
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 12
+    __turbopack_part__: 16
 };
-import { j as createPostponedAbortSignal } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 12
+import { i as createPostponedAbortSignal } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
 };
 export { createPostponedAbortSignal };
 
 ```
-## Part 14
+## Part 18
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
+    __turbopack_part__: 15
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 10
+    __turbopack_part__: 14
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
-import { g as React } from "__TURBOPACK_PART__" assert {
+import { f as React } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
-import { i as assertPostpone } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
+import { h as assertPostpone } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
 };
 function postponeWithTracking(prerenderState, expression, pathname) {
     assertPostpone();
@@ -1392,91 +1471,91 @@ function postponeWithTracking(prerenderState, expression, pathname) {
     });
     React.unstable_postpone(reason);
 }
-export { postponeWithTracking as k } from "__TURBOPACK_VAR__" assert {
+export { postponeWithTracking as j } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
-
-```
-## Part 15
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
-import { k as postponeWithTracking } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
-function trackDynamicFetch(store, expression) {
-    if (!store.prerenderState || store.isUnstableCacheCallback) return;
-    postponeWithTracking(store.prerenderState, expression, store.urlPathname);
-}
-export { trackDynamicFetch as l } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 16
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
-};
-import { l as trackDynamicFetch } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
-};
-export { trackDynamicFetch };
-
-```
-## Part 17
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
-import { k as postponeWithTracking } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
-function Postpone({ reason, prerenderState, pathname }) {
-    postponeWithTracking(prerenderState, reason, pathname);
-}
-export { Postpone as m } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 18
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
-};
-import { m as Postpone } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
-};
-export { Postpone };
 
 ```
 ## Part 19
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: 18
+};
+import { j as postponeWithTracking } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+function trackDynamicFetch(store, expression) {
+    if (!store.prerenderState || store.isUnstableCacheCallback) return;
+    postponeWithTracking(store.prerenderState, expression, store.urlPathname);
+}
+export { trackDynamicFetch as k } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 20
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import { k as trackDynamicFetch } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+export { trackDynamicFetch };
+
+```
+## Part 21
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+import { j as postponeWithTracking } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+function Postpone({ reason, prerenderState, pathname }) {
+    postponeWithTracking(prerenderState, reason, pathname);
+}
+export { Postpone as l } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 22
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import { l as Postpone } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+export { Postpone };
+
+```
+## Part 23
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+    __turbopack_part__: 7
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+    __turbopack_part__: 18
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
+    __turbopack_part__: 6
 };
-import { a as DynamicServerError } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
+import { c as DynamicServerError } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
-import { c as getPathname } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+import { e as getPathname } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
 };
-import { b as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+import { d as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
 };
-import { k as postponeWithTracking } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+import { j as postponeWithTracking } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
 };
 function trackDynamicDataAccessed(store, expression) {
     const pathname = getPathname(store.urlPathname);
@@ -1496,47 +1575,47 @@ function trackDynamicDataAccessed(store, expression) {
         }
     }
 }
-export { trackDynamicDataAccessed as n } from "__TURBOPACK_VAR__" assert {
+export { trackDynamicDataAccessed as m } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
-## Part 20
+## Part 24
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 19
+    __turbopack_part__: 23
 };
-import { n as trackDynamicDataAccessed } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 19
+import { m as trackDynamicDataAccessed } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
 export { trackDynamicDataAccessed };
 
 ```
-## Part 21
+## Part 25
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: 8
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+    __turbopack_part__: 7
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+    __turbopack_part__: 18
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
+    __turbopack_part__: 6
 };
-import { a as DynamicServerError } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
+import { c as DynamicServerError } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
-import { c as getPathname } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+import { e as getPathname } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
 };
-import { b as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+import { d as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
 };
-import { k as postponeWithTracking } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+import { j as postponeWithTracking } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
 };
 function markCurrentScopeAsDynamic(store, expression) {
     const pathname = getPathname(store.urlPathname);
@@ -1556,73 +1635,38 @@ function markCurrentScopeAsDynamic(store, expression) {
         }
     }
 }
-export { markCurrentScopeAsDynamic as o } from "__TURBOPACK_VAR__" assert {
+export { markCurrentScopeAsDynamic as n } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
-
-```
-## Part 22
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
-};
-import { o as markCurrentScopeAsDynamic } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
-};
-export { markCurrentScopeAsDynamic };
-
-```
-## Part 23
-```js
-import 'react';
-
-```
-## Part 24
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
-};
-import '../../client/components/hooks-server-context';
-
-```
-## Part 25
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
-};
-import '../../client/components/static-generation-bailout';
 
 ```
 ## Part 26
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 25
 };
-import '../../lib/url';
+import { n as markCurrentScopeAsDynamic } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 25
+};
+export { markCurrentScopeAsDynamic };
 
 ```
 ## Part 27
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: 12
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
+    __turbopack_part__: 13
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
+    __turbopack_part__: 11
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
 };
 "module evaluation";
 
@@ -1658,16 +1702,19 @@ export { markCurrentScopeAsDynamic } from "__TURBOPACK_PART__" assert {
 ## Merged (module eval)
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: 12
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
+    __turbopack_part__: 13
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
+    __turbopack_part__: 11
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
 };
 "module evaluation";
 

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-2/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-2/output.md
@@ -722,7 +722,7 @@ export { formatDynamicAPIAccesses };
 function usedDynamicAPIs(prerenderState) {
     return prerenderState.dynamicAccesses.length > 0;
 }
-export { usedDynamicAPIs as usedDynamicAPIs } from "__TURBOPACK_VAR__" assert {
+export { usedDynamicAPIs as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -732,7 +732,7 @@ export { usedDynamicAPIs as usedDynamicAPIs } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-import { usedDynamicAPIs as usedDynamicAPIs } from "__TURBOPACK_PART__" assert {
+import { b as usedDynamicAPIs } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
 export { usedDynamicAPIs };
@@ -746,7 +746,7 @@ function createPrerenderState(isDebugSkeleton) {
         dynamicAccesses: []
     };
 }
-export { createPrerenderState as b } from "__TURBOPACK_VAR__" assert {
+export { createPrerenderState as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -756,7 +756,7 @@ export { createPrerenderState as b } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-import { b as createPrerenderState } from "__TURBOPACK_PART__" assert {
+import { c as createPrerenderState } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 export { createPrerenderState };
@@ -765,7 +765,7 @@ export { createPrerenderState };
 ## Part 6
 ```js
 import { DynamicServerError } from '../../client/components/hooks-server-context';
-export { DynamicServerError as c } from "__TURBOPACK_VAR__" assert {
+export { DynamicServerError as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -773,7 +773,7 @@ export { DynamicServerError as c } from "__TURBOPACK_VAR__" assert {
 ## Part 7
 ```js
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout';
-export { StaticGenBailoutError as d } from "__TURBOPACK_VAR__" assert {
+export { StaticGenBailoutError as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -781,7 +781,7 @@ export { StaticGenBailoutError as d } from "__TURBOPACK_VAR__" assert {
 ## Part 8
 ```js
 import { getPathname } from '../../lib/url';
-export { getPathname as e } from "__TURBOPACK_VAR__" assert {
+export { getPathname as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -789,7 +789,7 @@ export { getPathname as e } from "__TURBOPACK_VAR__" assert {
 ## Part 9
 ```js
 import React from 'react';
-export { React as f } from "__TURBOPACK_VAR__" assert {
+export { React as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -861,7 +861,7 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import { f as React } from "__TURBOPACK_PART__" assert {
+import { g as React } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
 const hasPostpone = typeof React.unstable_postpone === 'function';
@@ -879,13 +879,13 @@ function assertPostpone() {
         throw new Error(`Invariant: React.unstable_postpone is not defined. This suggests the wrong version of React was loaded. This is a bug in Next.js`);
     }
 }
-export { hasPostpone as g } from "__TURBOPACK_VAR__" assert {
+export { hasPostpone as h } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
-export { postponeWithTracking as h } from "__TURBOPACK_VAR__" assert {
+export { postponeWithTracking as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
-export { assertPostpone as i } from "__TURBOPACK_VAR__" assert {
+export { assertPostpone as j } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -918,10 +918,10 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
-import { f as React } from "__TURBOPACK_PART__" assert {
+import { g as React } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
-import { i as assertPostpone } from "__TURBOPACK_PART__" assert {
+import { j as assertPostpone } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
 function createPostponedAbortSignal(reason) {
@@ -934,7 +934,7 @@ function createPostponedAbortSignal(reason) {
     }
     return controller.signal;
 }
-export { createPostponedAbortSignal as j } from "__TURBOPACK_VAR__" assert {
+export { createPostponedAbortSignal as k } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -944,7 +944,7 @@ export { createPostponedAbortSignal as j } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 16
 };
-import { j as createPostponedAbortSignal } from "__TURBOPACK_PART__" assert {
+import { k as createPostponedAbortSignal } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 16
 };
 export { createPostponedAbortSignal };
@@ -955,14 +955,14 @@ export { createPostponedAbortSignal };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
-import { h as postponeWithTracking } from "__TURBOPACK_PART__" assert {
+import { i as postponeWithTracking } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
 function trackDynamicFetch(store, expression) {
     if (!store.prerenderState || store.isUnstableCacheCallback) return;
     postponeWithTracking(store.prerenderState, expression, store.urlPathname);
 }
-export { trackDynamicFetch as k } from "__TURBOPACK_VAR__" assert {
+export { trackDynamicFetch as l } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -972,7 +972,7 @@ export { trackDynamicFetch as k } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
-import { k as trackDynamicFetch } from "__TURBOPACK_PART__" assert {
+import { l as trackDynamicFetch } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
 export { trackDynamicFetch };
@@ -983,13 +983,13 @@ export { trackDynamicFetch };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
-import { h as postponeWithTracking } from "__TURBOPACK_PART__" assert {
+import { i as postponeWithTracking } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
 function Postpone({ reason, prerenderState, pathname }) {
     postponeWithTracking(prerenderState, reason, pathname);
 }
-export { Postpone as l } from "__TURBOPACK_VAR__" assert {
+export { Postpone as m } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -999,7 +999,7 @@ export { Postpone as l } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 20
 };
-import { l as Postpone } from "__TURBOPACK_PART__" assert {
+import { m as Postpone } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 20
 };
 export { Postpone };
@@ -1019,16 +1019,16 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import { c as DynamicServerError } from "__TURBOPACK_PART__" assert {
+import { d as DynamicServerError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import { e as getPathname } from "__TURBOPACK_PART__" assert {
+import { f as getPathname } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
-import { d as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
+import { e as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 7
 };
-import { h as postponeWithTracking } from "__TURBOPACK_PART__" assert {
+import { i as postponeWithTracking } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
 function trackDynamicDataAccessed(store, expression) {
@@ -1049,7 +1049,7 @@ function trackDynamicDataAccessed(store, expression) {
         }
     }
 }
-export { trackDynamicDataAccessed as m } from "__TURBOPACK_VAR__" assert {
+export { trackDynamicDataAccessed as n } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1059,7 +1059,7 @@ export { trackDynamicDataAccessed as m } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 22
 };
-import { m as trackDynamicDataAccessed } from "__TURBOPACK_PART__" assert {
+import { n as trackDynamicDataAccessed } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 22
 };
 export { trackDynamicDataAccessed };
@@ -1079,16 +1079,16 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import { c as DynamicServerError } from "__TURBOPACK_PART__" assert {
+import { d as DynamicServerError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import { e as getPathname } from "__TURBOPACK_PART__" assert {
+import { f as getPathname } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
-import { d as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
+import { e as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 7
 };
-import { h as postponeWithTracking } from "__TURBOPACK_PART__" assert {
+import { i as postponeWithTracking } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
 function markCurrentScopeAsDynamic(store, expression) {
@@ -1109,7 +1109,7 @@ function markCurrentScopeAsDynamic(store, expression) {
         }
     }
 }
-export { markCurrentScopeAsDynamic as n } from "__TURBOPACK_VAR__" assert {
+export { markCurrentScopeAsDynamic as o } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1119,7 +1119,7 @@ export { markCurrentScopeAsDynamic as n } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 24
 };
-import { n as markCurrentScopeAsDynamic } from "__TURBOPACK_PART__" assert {
+import { o as markCurrentScopeAsDynamic } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 24
 };
 export { markCurrentScopeAsDynamic };
@@ -1248,7 +1248,7 @@ export { formatDynamicAPIAccesses };
 function usedDynamicAPIs(prerenderState) {
     return prerenderState.dynamicAccesses.length > 0;
 }
-export { usedDynamicAPIs as usedDynamicAPIs } from "__TURBOPACK_VAR__" assert {
+export { usedDynamicAPIs as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1258,7 +1258,7 @@ export { usedDynamicAPIs as usedDynamicAPIs } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-import { usedDynamicAPIs as usedDynamicAPIs } from "__TURBOPACK_PART__" assert {
+import { b as usedDynamicAPIs } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
 export { usedDynamicAPIs };
@@ -1272,7 +1272,7 @@ function createPrerenderState(isDebugSkeleton) {
         dynamicAccesses: []
     };
 }
-export { createPrerenderState as b } from "__TURBOPACK_VAR__" assert {
+export { createPrerenderState as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1282,7 +1282,7 @@ export { createPrerenderState as b } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-import { b as createPrerenderState } from "__TURBOPACK_PART__" assert {
+import { c as createPrerenderState } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 export { createPrerenderState };
@@ -1291,7 +1291,7 @@ export { createPrerenderState };
 ## Part 6
 ```js
 import { DynamicServerError } from '../../client/components/hooks-server-context';
-export { DynamicServerError as c } from "__TURBOPACK_VAR__" assert {
+export { DynamicServerError as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1299,7 +1299,7 @@ export { DynamicServerError as c } from "__TURBOPACK_VAR__" assert {
 ## Part 7
 ```js
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout';
-export { StaticGenBailoutError as d } from "__TURBOPACK_VAR__" assert {
+export { StaticGenBailoutError as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1307,7 +1307,7 @@ export { StaticGenBailoutError as d } from "__TURBOPACK_VAR__" assert {
 ## Part 8
 ```js
 import { getPathname } from '../../lib/url';
-export { getPathname as e } from "__TURBOPACK_VAR__" assert {
+export { getPathname as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1315,7 +1315,7 @@ export { getPathname as e } from "__TURBOPACK_VAR__" assert {
 ## Part 9
 ```js
 import React from 'react';
-export { React as f } from "__TURBOPACK_VAR__" assert {
+export { React as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1375,11 +1375,11 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
-import { f as React } from "__TURBOPACK_PART__" assert {
+import { g as React } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
 const hasPostpone = typeof React.unstable_postpone === 'function';
-export { hasPostpone as g } from "__TURBOPACK_VAR__" assert {
+export { hasPostpone as h } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1389,7 +1389,7 @@ export { hasPostpone as g } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
-import { g as hasPostpone } from "__TURBOPACK_PART__" assert {
+import { h as hasPostpone } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
 function assertPostpone() {
@@ -1397,7 +1397,7 @@ function assertPostpone() {
         throw new Error(`Invariant: React.unstable_postpone is not defined. This suggests the wrong version of React was loaded. This is a bug in Next.js`);
     }
 }
-export { assertPostpone as h } from "__TURBOPACK_VAR__" assert {
+export { assertPostpone as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1413,10 +1413,10 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
-import { f as React } from "__TURBOPACK_PART__" assert {
+import { g as React } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
-import { h as assertPostpone } from "__TURBOPACK_PART__" assert {
+import { i as assertPostpone } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 15
 };
 function createPostponedAbortSignal(reason) {
@@ -1429,7 +1429,7 @@ function createPostponedAbortSignal(reason) {
     }
     return controller.signal;
 }
-export { createPostponedAbortSignal as i } from "__TURBOPACK_VAR__" assert {
+export { createPostponedAbortSignal as j } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1439,7 +1439,7 @@ export { createPostponedAbortSignal as i } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 16
 };
-import { i as createPostponedAbortSignal } from "__TURBOPACK_PART__" assert {
+import { j as createPostponedAbortSignal } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 16
 };
 export { createPostponedAbortSignal };
@@ -1456,10 +1456,10 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
-import { f as React } from "__TURBOPACK_PART__" assert {
+import { g as React } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
-import { h as assertPostpone } from "__TURBOPACK_PART__" assert {
+import { i as assertPostpone } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 15
 };
 function postponeWithTracking(prerenderState, expression, pathname) {
@@ -1471,7 +1471,7 @@ function postponeWithTracking(prerenderState, expression, pathname) {
     });
     React.unstable_postpone(reason);
 }
-export { postponeWithTracking as j } from "__TURBOPACK_VAR__" assert {
+export { postponeWithTracking as k } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1481,14 +1481,14 @@ export { postponeWithTracking as j } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
-import { j as postponeWithTracking } from "__TURBOPACK_PART__" assert {
+import { k as postponeWithTracking } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
 function trackDynamicFetch(store, expression) {
     if (!store.prerenderState || store.isUnstableCacheCallback) return;
     postponeWithTracking(store.prerenderState, expression, store.urlPathname);
 }
-export { trackDynamicFetch as k } from "__TURBOPACK_VAR__" assert {
+export { trackDynamicFetch as l } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1498,7 +1498,7 @@ export { trackDynamicFetch as k } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 19
 };
-import { k as trackDynamicFetch } from "__TURBOPACK_PART__" assert {
+import { l as trackDynamicFetch } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 19
 };
 export { trackDynamicFetch };
@@ -1509,13 +1509,13 @@ export { trackDynamicFetch };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
-import { j as postponeWithTracking } from "__TURBOPACK_PART__" assert {
+import { k as postponeWithTracking } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
 function Postpone({ reason, prerenderState, pathname }) {
     postponeWithTracking(prerenderState, reason, pathname);
 }
-export { Postpone as l } from "__TURBOPACK_VAR__" assert {
+export { Postpone as m } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1525,7 +1525,7 @@ export { Postpone as l } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 21
 };
-import { l as Postpone } from "__TURBOPACK_PART__" assert {
+import { m as Postpone } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 21
 };
 export { Postpone };
@@ -1545,16 +1545,16 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import { c as DynamicServerError } from "__TURBOPACK_PART__" assert {
+import { d as DynamicServerError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import { e as getPathname } from "__TURBOPACK_PART__" assert {
+import { f as getPathname } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
-import { d as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
+import { e as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 7
 };
-import { j as postponeWithTracking } from "__TURBOPACK_PART__" assert {
+import { k as postponeWithTracking } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
 function trackDynamicDataAccessed(store, expression) {
@@ -1575,7 +1575,7 @@ function trackDynamicDataAccessed(store, expression) {
         }
     }
 }
-export { trackDynamicDataAccessed as m } from "__TURBOPACK_VAR__" assert {
+export { trackDynamicDataAccessed as n } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1585,7 +1585,7 @@ export { trackDynamicDataAccessed as m } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 23
 };
-import { m as trackDynamicDataAccessed } from "__TURBOPACK_PART__" assert {
+import { n as trackDynamicDataAccessed } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 23
 };
 export { trackDynamicDataAccessed };
@@ -1605,16 +1605,16 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import { c as DynamicServerError } from "__TURBOPACK_PART__" assert {
+import { d as DynamicServerError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import { e as getPathname } from "__TURBOPACK_PART__" assert {
+import { f as getPathname } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
-import { d as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
+import { e as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 7
 };
-import { j as postponeWithTracking } from "__TURBOPACK_PART__" assert {
+import { k as postponeWithTracking } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
 function markCurrentScopeAsDynamic(store, expression) {
@@ -1635,7 +1635,7 @@ function markCurrentScopeAsDynamic(store, expression) {
         }
     }
 }
-export { markCurrentScopeAsDynamic as n } from "__TURBOPACK_VAR__" assert {
+export { markCurrentScopeAsDynamic as o } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1645,7 +1645,7 @@ export { markCurrentScopeAsDynamic as n } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 25
 };
-import { n as markCurrentScopeAsDynamic } from "__TURBOPACK_PART__" assert {
+import { o as markCurrentScopeAsDynamic } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 25
 };
 export { markCurrentScopeAsDynamic };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/grouping/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/grouping/output.md
@@ -471,7 +471,7 @@ import "__TURBOPACK_PART__" assert {
 import { a as x } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
 };
-export { x as x };
+export { x };
 
 ```
 ## Part 10
@@ -701,7 +701,7 @@ import "__TURBOPACK_PART__" assert {
 import { a as x } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
 };
-export { x as x };
+export { x };
 
 ```
 ## Part 11

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/mui-sys/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/mui-sys/output.md
@@ -259,6 +259,7 @@ export const gridColumn = style({
 
 ```
 
+- Side effects
 - Declares: `gridColumn`
 - Reads: `style`
 - Write: `gridColumn`
@@ -272,6 +273,7 @@ export const gridRow = style({
 
 ```
 
+- Side effects
 - Declares: `gridRow`
 - Reads: `style`
 - Write: `gridRow`
@@ -285,6 +287,7 @@ export const gridAutoFlow = style({
 
 ```
 
+- Side effects
 - Declares: `gridAutoFlow`
 - Reads: `style`
 - Write: `gridAutoFlow`
@@ -298,6 +301,7 @@ export const gridAutoColumns = style({
 
 ```
 
+- Side effects
 - Declares: `gridAutoColumns`
 - Reads: `style`
 - Write: `gridAutoColumns`
@@ -311,6 +315,7 @@ export const gridAutoRows = style({
 
 ```
 
+- Side effects
 - Declares: `gridAutoRows`
 - Reads: `style`
 - Write: `gridAutoRows`
@@ -324,6 +329,7 @@ export const gridTemplateColumns = style({
 
 ```
 
+- Side effects
 - Declares: `gridTemplateColumns`
 - Reads: `style`
 - Write: `gridTemplateColumns`
@@ -337,6 +343,7 @@ export const gridTemplateRows = style({
 
 ```
 
+- Side effects
 - Declares: `gridTemplateRows`
 - Reads: `style`
 - Write: `gridTemplateRows`
@@ -350,6 +357,7 @@ export const gridTemplateAreas = style({
 
 ```
 
+- Side effects
 - Declares: `gridTemplateAreas`
 - Reads: `style`
 - Write: `gridTemplateAreas`
@@ -363,6 +371,7 @@ export const gridArea = style({
 
 ```
 
+- Side effects
 - Declares: `gridArea`
 - Reads: `style`
 - Write: `gridArea`
@@ -374,6 +383,7 @@ const grid = compose(gap, columnGap, rowGap, gridColumn, gridRow, gridAutoFlow, 
 
 ```
 
+- Side effects
 - Declares: `grid`
 - Reads: `compose`, `gap`, `columnGap`, `rowGap`, `gridColumn`, `gridRow`, `gridAutoFlow`, `gridAutoColumns`, `gridAutoRows`, `gridTemplateColumns`, `gridTemplateRows`, `gridTemplateAreas`, `gridArea`
 - Write: `grid`
@@ -599,14 +609,149 @@ graph TD
     Item20 --> Item19;
     Item20 --> Item18;
     Item21 --> Item6;
+    Item21 --> Item1;
+    Item21 --> Item2;
+    Item21 --> Item3;
+    Item21 --> Item4;
+    Item21 --> Item5;
+    Item21 --> Item12;
+    Item21 --> Item13;
+    Item21 --> Item15;
+    Item21 --> Item16;
+    Item21 --> Item18;
+    Item21 --> Item19;
     Item22 --> Item6;
+    Item22 --> Item1;
+    Item22 --> Item2;
+    Item22 --> Item3;
+    Item22 --> Item4;
+    Item22 --> Item5;
+    Item22 --> Item12;
+    Item22 --> Item13;
+    Item22 --> Item15;
+    Item22 --> Item16;
+    Item22 --> Item18;
+    Item22 --> Item19;
+    Item22 --> Item21;
     Item23 --> Item6;
+    Item23 --> Item1;
+    Item23 --> Item2;
+    Item23 --> Item3;
+    Item23 --> Item4;
+    Item23 --> Item5;
+    Item23 --> Item12;
+    Item23 --> Item13;
+    Item23 --> Item15;
+    Item23 --> Item16;
+    Item23 --> Item18;
+    Item23 --> Item19;
+    Item23 --> Item21;
+    Item23 --> Item22;
     Item24 --> Item6;
+    Item24 --> Item1;
+    Item24 --> Item2;
+    Item24 --> Item3;
+    Item24 --> Item4;
+    Item24 --> Item5;
+    Item24 --> Item12;
+    Item24 --> Item13;
+    Item24 --> Item15;
+    Item24 --> Item16;
+    Item24 --> Item18;
+    Item24 --> Item19;
+    Item24 --> Item21;
+    Item24 --> Item22;
+    Item24 --> Item23;
     Item25 --> Item6;
+    Item25 --> Item1;
+    Item25 --> Item2;
+    Item25 --> Item3;
+    Item25 --> Item4;
+    Item25 --> Item5;
+    Item25 --> Item12;
+    Item25 --> Item13;
+    Item25 --> Item15;
+    Item25 --> Item16;
+    Item25 --> Item18;
+    Item25 --> Item19;
+    Item25 --> Item21;
+    Item25 --> Item22;
+    Item25 --> Item23;
+    Item25 --> Item24;
     Item26 --> Item6;
+    Item26 --> Item1;
+    Item26 --> Item2;
+    Item26 --> Item3;
+    Item26 --> Item4;
+    Item26 --> Item5;
+    Item26 --> Item12;
+    Item26 --> Item13;
+    Item26 --> Item15;
+    Item26 --> Item16;
+    Item26 --> Item18;
+    Item26 --> Item19;
+    Item26 --> Item21;
+    Item26 --> Item22;
+    Item26 --> Item23;
+    Item26 --> Item24;
+    Item26 --> Item25;
     Item27 --> Item6;
+    Item27 --> Item1;
+    Item27 --> Item2;
+    Item27 --> Item3;
+    Item27 --> Item4;
+    Item27 --> Item5;
+    Item27 --> Item12;
+    Item27 --> Item13;
+    Item27 --> Item15;
+    Item27 --> Item16;
+    Item27 --> Item18;
+    Item27 --> Item19;
+    Item27 --> Item21;
+    Item27 --> Item22;
+    Item27 --> Item23;
+    Item27 --> Item24;
+    Item27 --> Item25;
+    Item27 --> Item26;
     Item28 --> Item6;
+    Item28 --> Item1;
+    Item28 --> Item2;
+    Item28 --> Item3;
+    Item28 --> Item4;
+    Item28 --> Item5;
+    Item28 --> Item12;
+    Item28 --> Item13;
+    Item28 --> Item15;
+    Item28 --> Item16;
+    Item28 --> Item18;
+    Item28 --> Item19;
+    Item28 --> Item21;
+    Item28 --> Item22;
+    Item28 --> Item23;
+    Item28 --> Item24;
+    Item28 --> Item25;
+    Item28 --> Item26;
+    Item28 --> Item27;
     Item29 --> Item6;
+    Item29 --> Item1;
+    Item29 --> Item2;
+    Item29 --> Item3;
+    Item29 --> Item4;
+    Item29 --> Item5;
+    Item29 --> Item12;
+    Item29 --> Item13;
+    Item29 --> Item15;
+    Item29 --> Item16;
+    Item29 --> Item18;
+    Item29 --> Item19;
+    Item29 --> Item21;
+    Item29 --> Item22;
+    Item29 --> Item23;
+    Item29 --> Item24;
+    Item29 --> Item25;
+    Item29 --> Item26;
+    Item29 --> Item27;
+    Item29 --> Item28;
     Item30 --> Item7;
     Item30 --> Item14;
     Item30 --> Item12;
@@ -623,6 +768,14 @@ graph TD
     Item30 --> Item27;
     Item30 --> Item28;
     Item30 --> Item29;
+    Item30 --> Item1;
+    Item30 --> Item2;
+    Item30 --> Item3;
+    Item30 --> Item4;
+    Item30 --> Item5;
+    Item30 --> Item13;
+    Item30 --> Item16;
+    Item30 --> Item19;
     Item31 --> Item30;
     Item31 --> Item1;
     Item31 --> Item2;
@@ -635,6 +788,15 @@ graph TD
     Item31 --> Item16;
     Item31 --> Item18;
     Item31 --> Item19;
+    Item31 --> Item21;
+    Item31 --> Item22;
+    Item31 --> Item23;
+    Item31 --> Item24;
+    Item31 --> Item25;
+    Item31 --> Item26;
+    Item31 --> Item27;
+    Item31 --> Item28;
+    Item31 --> Item29;
     Item33 --> Item14;
     Item33 --> Item12;
     Item34 --> Item17;
@@ -788,14 +950,149 @@ graph TD
     Item20 --> Item19;
     Item20 --> Item18;
     Item21 --> Item6;
+    Item21 --> Item1;
+    Item21 --> Item2;
+    Item21 --> Item3;
+    Item21 --> Item4;
+    Item21 --> Item5;
+    Item21 --> Item12;
+    Item21 --> Item13;
+    Item21 --> Item15;
+    Item21 --> Item16;
+    Item21 --> Item18;
+    Item21 --> Item19;
     Item22 --> Item6;
+    Item22 --> Item1;
+    Item22 --> Item2;
+    Item22 --> Item3;
+    Item22 --> Item4;
+    Item22 --> Item5;
+    Item22 --> Item12;
+    Item22 --> Item13;
+    Item22 --> Item15;
+    Item22 --> Item16;
+    Item22 --> Item18;
+    Item22 --> Item19;
+    Item22 --> Item21;
     Item23 --> Item6;
+    Item23 --> Item1;
+    Item23 --> Item2;
+    Item23 --> Item3;
+    Item23 --> Item4;
+    Item23 --> Item5;
+    Item23 --> Item12;
+    Item23 --> Item13;
+    Item23 --> Item15;
+    Item23 --> Item16;
+    Item23 --> Item18;
+    Item23 --> Item19;
+    Item23 --> Item21;
+    Item23 --> Item22;
     Item24 --> Item6;
+    Item24 --> Item1;
+    Item24 --> Item2;
+    Item24 --> Item3;
+    Item24 --> Item4;
+    Item24 --> Item5;
+    Item24 --> Item12;
+    Item24 --> Item13;
+    Item24 --> Item15;
+    Item24 --> Item16;
+    Item24 --> Item18;
+    Item24 --> Item19;
+    Item24 --> Item21;
+    Item24 --> Item22;
+    Item24 --> Item23;
     Item25 --> Item6;
+    Item25 --> Item1;
+    Item25 --> Item2;
+    Item25 --> Item3;
+    Item25 --> Item4;
+    Item25 --> Item5;
+    Item25 --> Item12;
+    Item25 --> Item13;
+    Item25 --> Item15;
+    Item25 --> Item16;
+    Item25 --> Item18;
+    Item25 --> Item19;
+    Item25 --> Item21;
+    Item25 --> Item22;
+    Item25 --> Item23;
+    Item25 --> Item24;
     Item26 --> Item6;
+    Item26 --> Item1;
+    Item26 --> Item2;
+    Item26 --> Item3;
+    Item26 --> Item4;
+    Item26 --> Item5;
+    Item26 --> Item12;
+    Item26 --> Item13;
+    Item26 --> Item15;
+    Item26 --> Item16;
+    Item26 --> Item18;
+    Item26 --> Item19;
+    Item26 --> Item21;
+    Item26 --> Item22;
+    Item26 --> Item23;
+    Item26 --> Item24;
+    Item26 --> Item25;
     Item27 --> Item6;
+    Item27 --> Item1;
+    Item27 --> Item2;
+    Item27 --> Item3;
+    Item27 --> Item4;
+    Item27 --> Item5;
+    Item27 --> Item12;
+    Item27 --> Item13;
+    Item27 --> Item15;
+    Item27 --> Item16;
+    Item27 --> Item18;
+    Item27 --> Item19;
+    Item27 --> Item21;
+    Item27 --> Item22;
+    Item27 --> Item23;
+    Item27 --> Item24;
+    Item27 --> Item25;
+    Item27 --> Item26;
     Item28 --> Item6;
+    Item28 --> Item1;
+    Item28 --> Item2;
+    Item28 --> Item3;
+    Item28 --> Item4;
+    Item28 --> Item5;
+    Item28 --> Item12;
+    Item28 --> Item13;
+    Item28 --> Item15;
+    Item28 --> Item16;
+    Item28 --> Item18;
+    Item28 --> Item19;
+    Item28 --> Item21;
+    Item28 --> Item22;
+    Item28 --> Item23;
+    Item28 --> Item24;
+    Item28 --> Item25;
+    Item28 --> Item26;
+    Item28 --> Item27;
     Item29 --> Item6;
+    Item29 --> Item1;
+    Item29 --> Item2;
+    Item29 --> Item3;
+    Item29 --> Item4;
+    Item29 --> Item5;
+    Item29 --> Item12;
+    Item29 --> Item13;
+    Item29 --> Item15;
+    Item29 --> Item16;
+    Item29 --> Item18;
+    Item29 --> Item19;
+    Item29 --> Item21;
+    Item29 --> Item22;
+    Item29 --> Item23;
+    Item29 --> Item24;
+    Item29 --> Item25;
+    Item29 --> Item26;
+    Item29 --> Item27;
+    Item29 --> Item28;
     Item30 --> Item7;
     Item30 --> Item14;
     Item30 --> Item12;
@@ -812,6 +1109,14 @@ graph TD
     Item30 --> Item27;
     Item30 --> Item28;
     Item30 --> Item29;
+    Item30 --> Item1;
+    Item30 --> Item2;
+    Item30 --> Item3;
+    Item30 --> Item4;
+    Item30 --> Item5;
+    Item30 --> Item13;
+    Item30 --> Item16;
+    Item30 --> Item19;
     Item31 --> Item30;
     Item31 --> Item1;
     Item31 --> Item2;
@@ -824,6 +1129,15 @@ graph TD
     Item31 --> Item16;
     Item31 --> Item18;
     Item31 --> Item19;
+    Item31 --> Item21;
+    Item31 --> Item22;
+    Item31 --> Item23;
+    Item31 --> Item24;
+    Item31 --> Item25;
+    Item31 --> Item26;
+    Item31 --> Item27;
+    Item31 --> Item28;
+    Item31 --> Item29;
     Item33 --> Item14;
     Item33 --> Item12;
     Item34 --> Item17;
@@ -977,14 +1291,149 @@ graph TD
     Item20 --> Item19;
     Item20 --> Item18;
     Item21 --> Item6;
+    Item21 --> Item1;
+    Item21 --> Item2;
+    Item21 --> Item3;
+    Item21 --> Item4;
+    Item21 --> Item5;
+    Item21 --> Item12;
+    Item21 --> Item13;
+    Item21 --> Item15;
+    Item21 --> Item16;
+    Item21 --> Item18;
+    Item21 --> Item19;
     Item22 --> Item6;
+    Item22 --> Item1;
+    Item22 --> Item2;
+    Item22 --> Item3;
+    Item22 --> Item4;
+    Item22 --> Item5;
+    Item22 --> Item12;
+    Item22 --> Item13;
+    Item22 --> Item15;
+    Item22 --> Item16;
+    Item22 --> Item18;
+    Item22 --> Item19;
+    Item22 --> Item21;
     Item23 --> Item6;
+    Item23 --> Item1;
+    Item23 --> Item2;
+    Item23 --> Item3;
+    Item23 --> Item4;
+    Item23 --> Item5;
+    Item23 --> Item12;
+    Item23 --> Item13;
+    Item23 --> Item15;
+    Item23 --> Item16;
+    Item23 --> Item18;
+    Item23 --> Item19;
+    Item23 --> Item21;
+    Item23 --> Item22;
     Item24 --> Item6;
+    Item24 --> Item1;
+    Item24 --> Item2;
+    Item24 --> Item3;
+    Item24 --> Item4;
+    Item24 --> Item5;
+    Item24 --> Item12;
+    Item24 --> Item13;
+    Item24 --> Item15;
+    Item24 --> Item16;
+    Item24 --> Item18;
+    Item24 --> Item19;
+    Item24 --> Item21;
+    Item24 --> Item22;
+    Item24 --> Item23;
     Item25 --> Item6;
+    Item25 --> Item1;
+    Item25 --> Item2;
+    Item25 --> Item3;
+    Item25 --> Item4;
+    Item25 --> Item5;
+    Item25 --> Item12;
+    Item25 --> Item13;
+    Item25 --> Item15;
+    Item25 --> Item16;
+    Item25 --> Item18;
+    Item25 --> Item19;
+    Item25 --> Item21;
+    Item25 --> Item22;
+    Item25 --> Item23;
+    Item25 --> Item24;
     Item26 --> Item6;
+    Item26 --> Item1;
+    Item26 --> Item2;
+    Item26 --> Item3;
+    Item26 --> Item4;
+    Item26 --> Item5;
+    Item26 --> Item12;
+    Item26 --> Item13;
+    Item26 --> Item15;
+    Item26 --> Item16;
+    Item26 --> Item18;
+    Item26 --> Item19;
+    Item26 --> Item21;
+    Item26 --> Item22;
+    Item26 --> Item23;
+    Item26 --> Item24;
+    Item26 --> Item25;
     Item27 --> Item6;
+    Item27 --> Item1;
+    Item27 --> Item2;
+    Item27 --> Item3;
+    Item27 --> Item4;
+    Item27 --> Item5;
+    Item27 --> Item12;
+    Item27 --> Item13;
+    Item27 --> Item15;
+    Item27 --> Item16;
+    Item27 --> Item18;
+    Item27 --> Item19;
+    Item27 --> Item21;
+    Item27 --> Item22;
+    Item27 --> Item23;
+    Item27 --> Item24;
+    Item27 --> Item25;
+    Item27 --> Item26;
     Item28 --> Item6;
+    Item28 --> Item1;
+    Item28 --> Item2;
+    Item28 --> Item3;
+    Item28 --> Item4;
+    Item28 --> Item5;
+    Item28 --> Item12;
+    Item28 --> Item13;
+    Item28 --> Item15;
+    Item28 --> Item16;
+    Item28 --> Item18;
+    Item28 --> Item19;
+    Item28 --> Item21;
+    Item28 --> Item22;
+    Item28 --> Item23;
+    Item28 --> Item24;
+    Item28 --> Item25;
+    Item28 --> Item26;
+    Item28 --> Item27;
     Item29 --> Item6;
+    Item29 --> Item1;
+    Item29 --> Item2;
+    Item29 --> Item3;
+    Item29 --> Item4;
+    Item29 --> Item5;
+    Item29 --> Item12;
+    Item29 --> Item13;
+    Item29 --> Item15;
+    Item29 --> Item16;
+    Item29 --> Item18;
+    Item29 --> Item19;
+    Item29 --> Item21;
+    Item29 --> Item22;
+    Item29 --> Item23;
+    Item29 --> Item24;
+    Item29 --> Item25;
+    Item29 --> Item26;
+    Item29 --> Item27;
+    Item29 --> Item28;
     Item30 --> Item7;
     Item30 --> Item14;
     Item30 --> Item12;
@@ -1001,6 +1450,14 @@ graph TD
     Item30 --> Item27;
     Item30 --> Item28;
     Item30 --> Item29;
+    Item30 --> Item1;
+    Item30 --> Item2;
+    Item30 --> Item3;
+    Item30 --> Item4;
+    Item30 --> Item5;
+    Item30 --> Item13;
+    Item30 --> Item16;
+    Item30 --> Item19;
     Item31 --> Item30;
     Item31 --> Item1;
     Item31 --> Item2;
@@ -1013,6 +1470,15 @@ graph TD
     Item31 --> Item16;
     Item31 --> Item18;
     Item31 --> Item19;
+    Item31 --> Item21;
+    Item31 --> Item22;
+    Item31 --> Item23;
+    Item31 --> Item24;
+    Item31 --> Item25;
+    Item31 --> Item26;
+    Item31 --> Item27;
+    Item31 --> Item28;
+    Item31 --> Item29;
     Item33 --> Item14;
     Item33 --> Item12;
     Item34 --> Item17;
@@ -1040,6 +1506,16 @@ graph TD
     Item32 --> Item16;
     Item32 --> Item18;
     Item32 --> Item19;
+    Item32 --> Item21;
+    Item32 --> Item22;
+    Item32 --> Item23;
+    Item32 --> Item24;
+    Item32 --> Item25;
+    Item32 --> Item26;
+    Item32 --> Item27;
+    Item32 --> Item28;
+    Item32 --> Item29;
+    Item32 --> Item30;
     Item32 --> Item31;
 ```
 # Final
@@ -1047,39 +1523,39 @@ graph TD
 graph TD
     N0["Items: [ItemId(1, ImportBinding(0))]"];
     N1["Items: [ItemId(0, ImportBinding(0))]"];
-    N2["Items: [ItemId(22, VarDeclarator(0))]"];
-    N3["Items: [ItemId(Export((&quot;gridArea&quot;, #2), &quot;gridArea&quot;))]"];
-    N4["Items: [ItemId(21, VarDeclarator(0))]"];
-    N5["Items: [ItemId(Export((&quot;gridTemplateAreas&quot;, #2), &quot;gridTemplateAreas&quot;))]"];
-    N6["Items: [ItemId(20, VarDeclarator(0))]"];
-    N7["Items: [ItemId(Export((&quot;gridTemplateRows&quot;, #2), &quot;gridTemplateRows&quot;))]"];
-    N8["Items: [ItemId(19, VarDeclarator(0))]"];
-    N9["Items: [ItemId(Export((&quot;gridTemplateColumns&quot;, #2), &quot;gridTemplateColumns&quot;))]"];
-    N10["Items: [ItemId(18, VarDeclarator(0))]"];
-    N11["Items: [ItemId(Export((&quot;gridAutoRows&quot;, #2), &quot;gridAutoRows&quot;))]"];
-    N12["Items: [ItemId(17, VarDeclarator(0))]"];
-    N13["Items: [ItemId(Export((&quot;gridAutoColumns&quot;, #2), &quot;gridAutoColumns&quot;))]"];
-    N14["Items: [ItemId(16, VarDeclarator(0))]"];
-    N15["Items: [ItemId(Export((&quot;gridAutoFlow&quot;, #2), &quot;gridAutoFlow&quot;))]"];
-    N16["Items: [ItemId(15, VarDeclarator(0))]"];
-    N17["Items: [ItemId(Export((&quot;gridRow&quot;, #2), &quot;gridRow&quot;))]"];
-    N18["Items: [ItemId(14, VarDeclarator(0))]"];
-    N19["Items: [ItemId(Export((&quot;gridColumn&quot;, #2), &quot;gridColumn&quot;))]"];
-    N20["Items: [ItemId(4, ImportBinding(0))]"];
-    N21["Items: [ItemId(3, ImportBinding(0))]"];
-    N22["Items: [ItemId(2, ImportBinding(1))]"];
-    N23["Items: [ItemId(2, ImportBinding(0))]"];
-    N24["Items: [ItemId(0, ImportOfModule)]"];
-    N25["Items: [ItemId(1, ImportOfModule)]"];
-    N26["Items: [ItemId(2, ImportOfModule)]"];
-    N27["Items: [ItemId(3, ImportOfModule)]"];
-    N28["Items: [ItemId(4, ImportOfModule)]"];
-    N29["Items: [ItemId(5, VarDeclarator(0))]"];
-    N30["Items: [ItemId(6, Normal)]"];
-    N31["Items: [ItemId(8, VarDeclarator(0))]"];
-    N32["Items: [ItemId(9, Normal)]"];
-    N33["Items: [ItemId(11, VarDeclarator(0))]"];
-    N34["Items: [ItemId(12, Normal)]"];
+    N2["Items: [ItemId(4, ImportBinding(0))]"];
+    N3["Items: [ItemId(3, ImportBinding(0))]"];
+    N4["Items: [ItemId(2, ImportBinding(1))]"];
+    N5["Items: [ItemId(2, ImportBinding(0))]"];
+    N6["Items: [ItemId(0, ImportOfModule)]"];
+    N7["Items: [ItemId(1, ImportOfModule)]"];
+    N8["Items: [ItemId(2, ImportOfModule)]"];
+    N9["Items: [ItemId(3, ImportOfModule)]"];
+    N10["Items: [ItemId(4, ImportOfModule)]"];
+    N11["Items: [ItemId(5, VarDeclarator(0))]"];
+    N12["Items: [ItemId(6, Normal)]"];
+    N13["Items: [ItemId(8, VarDeclarator(0))]"];
+    N14["Items: [ItemId(9, Normal)]"];
+    N15["Items: [ItemId(11, VarDeclarator(0))]"];
+    N16["Items: [ItemId(12, Normal)]"];
+    N17["Items: [ItemId(14, VarDeclarator(0))]"];
+    N18["Items: [ItemId(Export((&quot;gridColumn&quot;, #2), &quot;gridColumn&quot;))]"];
+    N19["Items: [ItemId(15, VarDeclarator(0))]"];
+    N20["Items: [ItemId(Export((&quot;gridRow&quot;, #2), &quot;gridRow&quot;))]"];
+    N21["Items: [ItemId(16, VarDeclarator(0))]"];
+    N22["Items: [ItemId(Export((&quot;gridAutoFlow&quot;, #2), &quot;gridAutoFlow&quot;))]"];
+    N23["Items: [ItemId(17, VarDeclarator(0))]"];
+    N24["Items: [ItemId(Export((&quot;gridAutoColumns&quot;, #2), &quot;gridAutoColumns&quot;))]"];
+    N25["Items: [ItemId(18, VarDeclarator(0))]"];
+    N26["Items: [ItemId(Export((&quot;gridAutoRows&quot;, #2), &quot;gridAutoRows&quot;))]"];
+    N27["Items: [ItemId(19, VarDeclarator(0))]"];
+    N28["Items: [ItemId(Export((&quot;gridTemplateColumns&quot;, #2), &quot;gridTemplateColumns&quot;))]"];
+    N29["Items: [ItemId(20, VarDeclarator(0))]"];
+    N30["Items: [ItemId(Export((&quot;gridTemplateRows&quot;, #2), &quot;gridTemplateRows&quot;))]"];
+    N31["Items: [ItemId(21, VarDeclarator(0))]"];
+    N32["Items: [ItemId(Export((&quot;gridTemplateAreas&quot;, #2), &quot;gridTemplateAreas&quot;))]"];
+    N33["Items: [ItemId(22, VarDeclarator(0))]"];
+    N34["Items: [ItemId(Export((&quot;gridArea&quot;, #2), &quot;gridArea&quot;))]"];
     N35["Items: [ItemId(13, Normal)]"];
     N36["Items: [ItemId(Export((&quot;rowGap&quot;, #2), &quot;rowGap&quot;))]"];
     N37["Items: [ItemId(10, Normal)]"];
@@ -1090,143 +1566,305 @@ graph TD
     N42["Items: [ItemId(24, Normal)]"];
     N43["Items: [ItemId(ModuleEvaluation)]"];
     N44["Items: [ItemId(Export((&quot;__TURBOPACK__default__export__&quot;, #12), &quot;default&quot;))]"];
-    N25 --> N24;
-    N26 --> N24;
-    N26 --> N25;
-    N27 --> N24;
+    N7 --> N6;
+    N8 --> N6;
+    N8 --> N7;
+    N9 --> N6;
+    N9 --> N7;
+    N9 --> N8;
+    N10 --> N6;
+    N10 --> N7;
+    N10 --> N8;
+    N10 --> N9;
+    N11 --> N5;
+    N11 --> N4;
+    N11 --> N3;
+    N11 --> N6;
+    N11 --> N7;
+    N11 --> N8;
+    N11 --> N9;
+    N11 --> N10;
+    N12 --> N11;
+    N12 --> N2;
+    N12 --> N6;
+    N12 --> N7;
+    N12 --> N8;
+    N12 --> N9;
+    N12 --> N10;
+    N39 --> N12;
+    N39 --> N11;
+    N13 --> N5;
+    N13 --> N4;
+    N13 --> N3;
+    N13 --> N6;
+    N13 --> N7;
+    N13 --> N8;
+    N13 --> N9;
+    N13 --> N10;
+    N13 --> N11;
+    N13 --> N12;
+    N14 --> N13;
+    N14 --> N2;
+    N14 --> N6;
+    N14 --> N7;
+    N14 --> N8;
+    N14 --> N9;
+    N14 --> N10;
+    N14 --> N11;
+    N14 --> N12;
+    N37 --> N14;
+    N37 --> N13;
+    N15 --> N5;
+    N15 --> N4;
+    N15 --> N3;
+    N15 --> N6;
+    N15 --> N7;
+    N15 --> N8;
+    N15 --> N9;
+    N15 --> N10;
+    N15 --> N11;
+    N15 --> N12;
+    N15 --> N13;
+    N15 --> N14;
+    N16 --> N15;
+    N16 --> N2;
+    N16 --> N6;
+    N16 --> N7;
+    N16 --> N8;
+    N16 --> N9;
+    N16 --> N10;
+    N16 --> N11;
+    N16 --> N12;
+    N16 --> N13;
+    N16 --> N14;
+    N35 --> N16;
+    N35 --> N15;
+    N17 --> N1;
+    N17 --> N6;
+    N17 --> N7;
+    N17 --> N8;
+    N17 --> N9;
+    N17 --> N10;
+    N17 --> N11;
+    N17 --> N12;
+    N17 --> N13;
+    N17 --> N14;
+    N17 --> N15;
+    N17 --> N16;
+    N19 --> N1;
+    N19 --> N6;
+    N19 --> N7;
+    N19 --> N8;
+    N19 --> N9;
+    N19 --> N10;
+    N19 --> N11;
+    N19 --> N12;
+    N19 --> N13;
+    N19 --> N14;
+    N19 --> N15;
+    N19 --> N16;
+    N19 --> N17;
+    N21 --> N1;
+    N21 --> N6;
+    N21 --> N7;
+    N21 --> N8;
+    N21 --> N9;
+    N21 --> N10;
+    N21 --> N11;
+    N21 --> N12;
+    N21 --> N13;
+    N21 --> N14;
+    N21 --> N15;
+    N21 --> N16;
+    N21 --> N17;
+    N21 --> N19;
+    N23 --> N1;
+    N23 --> N6;
+    N23 --> N7;
+    N23 --> N8;
+    N23 --> N9;
+    N23 --> N10;
+    N23 --> N11;
+    N23 --> N12;
+    N23 --> N13;
+    N23 --> N14;
+    N23 --> N15;
+    N23 --> N16;
+    N23 --> N17;
+    N23 --> N19;
+    N23 --> N21;
+    N25 --> N1;
+    N25 --> N6;
+    N25 --> N7;
+    N25 --> N8;
+    N25 --> N9;
+    N25 --> N10;
+    N25 --> N11;
+    N25 --> N12;
+    N25 --> N13;
+    N25 --> N14;
+    N25 --> N15;
+    N25 --> N16;
+    N25 --> N17;
+    N25 --> N19;
+    N25 --> N21;
+    N25 --> N23;
+    N27 --> N1;
+    N27 --> N6;
+    N27 --> N7;
+    N27 --> N8;
+    N27 --> N9;
+    N27 --> N10;
+    N27 --> N11;
+    N27 --> N12;
+    N27 --> N13;
+    N27 --> N14;
+    N27 --> N15;
+    N27 --> N16;
+    N27 --> N17;
+    N27 --> N19;
+    N27 --> N21;
+    N27 --> N23;
     N27 --> N25;
-    N27 --> N26;
-    N28 --> N24;
-    N28 --> N25;
-    N28 --> N26;
-    N28 --> N27;
-    N29 --> N23;
-    N29 --> N22;
+    N29 --> N1;
+    N29 --> N6;
+    N29 --> N7;
+    N29 --> N8;
+    N29 --> N9;
+    N29 --> N10;
+    N29 --> N11;
+    N29 --> N12;
+    N29 --> N13;
+    N29 --> N14;
+    N29 --> N15;
+    N29 --> N16;
+    N29 --> N17;
+    N29 --> N19;
     N29 --> N21;
-    N29 --> N24;
+    N29 --> N23;
     N29 --> N25;
-    N29 --> N26;
     N29 --> N27;
-    N29 --> N28;
-    N30 --> N29;
-    N30 --> N20;
-    N30 --> N24;
-    N30 --> N25;
-    N30 --> N26;
-    N30 --> N27;
-    N30 --> N28;
-    N39 --> N30;
-    N39 --> N29;
-    N31 --> N23;
-    N31 --> N22;
+    N31 --> N1;
+    N31 --> N6;
+    N31 --> N7;
+    N31 --> N8;
+    N31 --> N9;
+    N31 --> N10;
+    N31 --> N11;
+    N31 --> N12;
+    N31 --> N13;
+    N31 --> N14;
+    N31 --> N15;
+    N31 --> N16;
+    N31 --> N17;
+    N31 --> N19;
     N31 --> N21;
-    N31 --> N24;
+    N31 --> N23;
     N31 --> N25;
-    N31 --> N26;
     N31 --> N27;
-    N31 --> N28;
     N31 --> N29;
-    N31 --> N30;
-    N32 --> N31;
-    N32 --> N20;
-    N32 --> N24;
-    N32 --> N25;
-    N32 --> N26;
-    N32 --> N27;
-    N32 --> N28;
-    N32 --> N29;
-    N32 --> N30;
-    N37 --> N32;
-    N37 --> N31;
-    N33 --> N23;
-    N33 --> N22;
+    N33 --> N1;
+    N33 --> N6;
+    N33 --> N7;
+    N33 --> N8;
+    N33 --> N9;
+    N33 --> N10;
+    N33 --> N11;
+    N33 --> N12;
+    N33 --> N13;
+    N33 --> N14;
+    N33 --> N15;
+    N33 --> N16;
+    N33 --> N17;
+    N33 --> N19;
     N33 --> N21;
-    N33 --> N24;
+    N33 --> N23;
     N33 --> N25;
-    N33 --> N26;
     N33 --> N27;
-    N33 --> N28;
     N33 --> N29;
-    N33 --> N30;
     N33 --> N31;
-    N33 --> N32;
-    N34 --> N33;
-    N34 --> N20;
-    N34 --> N24;
-    N34 --> N25;
-    N34 --> N26;
-    N34 --> N27;
-    N34 --> N28;
-    N34 --> N29;
-    N34 --> N30;
-    N34 --> N31;
-    N34 --> N32;
-    N35 --> N34;
-    N35 --> N33;
-    N18 --> N1;
-    N16 --> N1;
-    N14 --> N1;
-    N12 --> N1;
-    N10 --> N1;
-    N8 --> N1;
-    N6 --> N1;
-    N4 --> N1;
-    N2 --> N1;
     N41 --> N0;
     N41 --> N39;
-    N41 --> N29;
+    N41 --> N11;
     N41 --> N37;
-    N41 --> N31;
+    N41 --> N13;
     N41 --> N35;
+    N41 --> N15;
+    N41 --> N17;
+    N41 --> N19;
+    N41 --> N21;
+    N41 --> N23;
+    N41 --> N25;
+    N41 --> N27;
+    N41 --> N29;
+    N41 --> N31;
     N41 --> N33;
-    N41 --> N18;
-    N41 --> N16;
-    N41 --> N14;
-    N41 --> N12;
-    N41 --> N10;
-    N41 --> N8;
     N41 --> N6;
-    N41 --> N4;
-    N41 --> N2;
+    N41 --> N7;
+    N41 --> N8;
+    N41 --> N9;
+    N41 --> N10;
+    N41 --> N12;
+    N41 --> N14;
+    N41 --> N16;
     N42 --> N41;
-    N42 --> N24;
+    N42 --> N6;
+    N42 --> N7;
+    N42 --> N8;
+    N42 --> N9;
+    N42 --> N10;
+    N42 --> N11;
+    N42 --> N12;
+    N42 --> N13;
+    N42 --> N14;
+    N42 --> N15;
+    N42 --> N16;
+    N42 --> N17;
+    N42 --> N19;
+    N42 --> N21;
+    N42 --> N23;
     N42 --> N25;
-    N42 --> N26;
     N42 --> N27;
-    N42 --> N28;
     N42 --> N29;
-    N42 --> N30;
     N42 --> N31;
-    N42 --> N32;
     N42 --> N33;
-    N42 --> N34;
     N40 --> N39;
-    N40 --> N29;
+    N40 --> N11;
     N38 --> N37;
-    N38 --> N31;
+    N38 --> N13;
     N36 --> N35;
-    N36 --> N33;
-    N19 --> N18;
-    N17 --> N16;
-    N15 --> N14;
-    N13 --> N12;
-    N11 --> N10;
-    N9 --> N8;
-    N7 --> N6;
-    N5 --> N4;
-    N3 --> N2;
+    N36 --> N15;
+    N18 --> N17;
+    N20 --> N19;
+    N22 --> N21;
+    N24 --> N23;
+    N26 --> N25;
+    N28 --> N27;
+    N30 --> N29;
+    N32 --> N31;
+    N34 --> N33;
     N44 --> N42;
-    N43 --> N24;
+    N43 --> N6;
+    N43 --> N7;
+    N43 --> N8;
+    N43 --> N9;
+    N43 --> N10;
+    N43 --> N11;
+    N43 --> N12;
+    N43 --> N13;
+    N43 --> N14;
+    N43 --> N15;
+    N43 --> N16;
+    N43 --> N17;
+    N43 --> N19;
+    N43 --> N21;
+    N43 --> N23;
     N43 --> N25;
-    N43 --> N26;
     N43 --> N27;
-    N43 --> N28;
     N43 --> N29;
-    N43 --> N30;
     N43 --> N31;
-    N43 --> N32;
     N43 --> N33;
-    N43 --> N34;
+    N43 --> N41;
     N43 --> N42;
 ```
 # Entrypoints
@@ -1239,41 +1877,41 @@ graph TD
     ): 40,
     Export(
         "gridTemplateColumns",
-    ): 9,
+    ): 28,
     Export(
         "gridAutoRows",
-    ): 11,
+    ): 26,
     Export(
         "columnGap",
     ): 38,
     Export(
         "gridArea",
-    ): 3,
+    ): 34,
     Exports: 45,
     Export(
         "gridAutoFlow",
-    ): 15,
+    ): 22,
     Export(
         "gridColumn",
-    ): 19,
+    ): 18,
     Export(
         "gridAutoColumns",
-    ): 13,
+    ): 24,
     Export(
         "rowGap",
     ): 36,
     Export(
         "gridTemplateRows",
-    ): 7,
+    ): 30,
     Export(
         "gridTemplateAreas",
-    ): 5,
+    ): 32,
     Export(
         "default",
     ): 44,
     Export(
         "gridRow",
-    ): 17,
+    ): 20,
 }
 ```
 
@@ -1297,72 +1935,39 @@ export { style as b } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 2
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-import { b as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-const gridArea = style({
-    prop: 'gridArea'
-});
-export { gridArea as c } from "__TURBOPACK_VAR__" assert {
+import responsivePropType from './responsivePropType';
+export { responsivePropType as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
 ## Part 3
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+import { handleBreakpoints } from './breakpoints';
+export { handleBreakpoints as d } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
 };
-import { c as gridArea } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
-export { gridArea };
 
 ```
 ## Part 4
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-import { b as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-const gridTemplateAreas = style({
-    prop: 'gridTemplateAreas'
-});
-export { gridTemplateAreas as d } from "__TURBOPACK_VAR__" assert {
+import { getValue } from './spacing';
+export { getValue as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
 ## Part 5
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+import { createUnaryUnit } from './spacing';
+export { createUnaryUnit as f } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
 };
-import { d as gridTemplateAreas } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-export { gridTemplateAreas };
 
 ```
 ## Part 6
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-import { b as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-const gridTemplateRows = style({
-    prop: 'gridTemplateRows'
-});
-export { gridTemplateRows as e } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
+import './style';
 
 ```
 ## Part 7
@@ -1370,295 +1975,85 @@ export { gridTemplateRows as e } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import { e as gridTemplateRows } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
-export { gridTemplateRows };
+import './compose';
 
 ```
 ## Part 8
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+    __turbopack_part__: 6
 };
-import { b as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
 };
-const gridTemplateColumns = style({
-    prop: 'gridTemplateColumns'
-});
-export { gridTemplateColumns as f } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
+import './spacing';
 
 ```
 ## Part 9
 ```js
 import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
-import { f as gridTemplateColumns } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
-};
-export { gridTemplateColumns };
+import './breakpoints';
 
 ```
 ## Part 10
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+    __turbopack_part__: 6
 };
-import { b as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
 };
-const gridAutoRows = style({
-    prop: 'gridAutoRows'
-});
-export { gridAutoRows as g } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import './responsivePropType';
 
 ```
 ## Part 11
 ```js
 import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
-import { g as gridAutoRows } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 10
+import { f as createUnaryUnit } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
 };
-export { gridAutoRows };
-
-```
-## Part 12
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+import { e as getValue } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
 };
-import { b as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-const gridAutoColumns = style({
-    prop: 'gridAutoColumns'
-});
-export { gridAutoColumns as h } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 13
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 12
-};
-import { h as gridAutoColumns } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 12
-};
-export { gridAutoColumns };
-
-```
-## Part 14
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-import { b as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-const gridAutoFlow = style({
-    prop: 'gridAutoFlow'
-});
-export { gridAutoFlow as i } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 15
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
-import { i as gridAutoFlow } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
-export { gridAutoFlow };
-
-```
-## Part 16
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-import { b as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-const gridRow = style({
-    prop: 'gridRow'
-});
-export { gridRow as j } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 17
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
-};
-import { j as gridRow } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
-};
-export { gridRow };
-
-```
-## Part 18
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-import { b as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-const gridColumn = style({
-    prop: 'gridColumn'
-});
-export { gridColumn as k } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 19
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
-};
-import { k as gridColumn } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
-};
-export { gridColumn };
-
-```
-## Part 20
-```js
-import responsivePropType from './responsivePropType';
-export { responsivePropType as l } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 21
-```js
-import { handleBreakpoints } from './breakpoints';
-export { handleBreakpoints as m } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 22
-```js
-import { getValue } from './spacing';
-export { getValue as n } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 23
-```js
-import { createUnaryUnit } from './spacing';
-export { createUnaryUnit as o } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 24
-```js
-import './style';
-
-```
-## Part 25
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
-};
-import './compose';
-
-```
-## Part 26
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
-};
-import './spacing';
-
-```
-## Part 27
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
-};
-import './breakpoints';
-
-```
-## Part 28
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 27
-};
-import './responsivePropType';
-
-```
-## Part 29
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 22
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 27
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
-};
-import { o as createUnaryUnit } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
-};
-import { n as getValue } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 22
-};
-import { m as handleBreakpoints } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+import { d as handleBreakpoints } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
 const gap = (props)=>{
     if (props.gap !== undefined && props.gap !== null) {
@@ -1670,85 +2065,85 @@ const gap = (props)=>{
     }
     return null;
 };
-export { gap as p } from "__TURBOPACK_VAR__" assert {
+export { gap as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
-## Part 30
+## Part 12
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
+    __turbopack_part__: 11
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 20
+    __turbopack_part__: 2
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
+    __turbopack_part__: 6
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
+    __turbopack_part__: 7
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
+    __turbopack_part__: 8
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 27
+    __turbopack_part__: 9
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
+    __turbopack_part__: 10
 };
-import { p as gap } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
+import { g as gap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
 };
-import { l as responsivePropType } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 20
+import { c as responsivePropType } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
 };
 gap.propTypes = process.env.NODE_ENV !== 'production' ? {
     gap: responsivePropType
 } : {};
 
 ```
-## Part 31
+## Part 13
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: 5
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 22
+    __turbopack_part__: 4
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+    __turbopack_part__: 3
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
+    __turbopack_part__: 6
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
+    __turbopack_part__: 7
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
+    __turbopack_part__: 8
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 27
+    __turbopack_part__: 9
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
+    __turbopack_part__: 10
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
+    __turbopack_part__: 11
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 30
+    __turbopack_part__: 12
 };
-import { o as createUnaryUnit } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { f as createUnaryUnit } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
 };
-import { n as getValue } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 22
+import { e as getValue } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
 };
-import { m as handleBreakpoints } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+import { d as handleBreakpoints } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
 const columnGap = (props)=>{
     if (props.columnGap !== undefined && props.columnGap !== null) {
@@ -1760,97 +2155,97 @@ const columnGap = (props)=>{
     }
     return null;
 };
-export { columnGap as q } from "__TURBOPACK_VAR__" assert {
+export { columnGap as h } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
-## Part 32
+## Part 14
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
+    __turbopack_part__: 13
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 20
+    __turbopack_part__: 2
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
+    __turbopack_part__: 6
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
+    __turbopack_part__: 7
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
+    __turbopack_part__: 8
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 27
+    __turbopack_part__: 9
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
+    __turbopack_part__: 10
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
+    __turbopack_part__: 11
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 30
+    __turbopack_part__: 12
 };
-import { q as columnGap } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
+import { h as columnGap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
 };
-import { l as responsivePropType } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 20
+import { c as responsivePropType } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
 };
 columnGap.propTypes = process.env.NODE_ENV !== 'production' ? {
     columnGap: responsivePropType
 } : {};
 
 ```
-## Part 33
+## Part 15
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: 5
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 22
+    __turbopack_part__: 4
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+    __turbopack_part__: 3
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
+    __turbopack_part__: 6
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
+    __turbopack_part__: 7
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
+    __turbopack_part__: 8
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 27
+    __turbopack_part__: 9
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
+    __turbopack_part__: 10
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
+    __turbopack_part__: 11
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 30
+    __turbopack_part__: 12
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
+    __turbopack_part__: 13
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 32
+    __turbopack_part__: 14
 };
-import { o as createUnaryUnit } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { f as createUnaryUnit } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
 };
-import { n as getValue } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 22
+import { e as getValue } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
 };
-import { m as handleBreakpoints } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+import { d as handleBreakpoints } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
 const rowGap = (props)=>{
     if (props.rowGap !== undefined && props.rowGap !== null) {
@@ -1862,7 +2257,690 @@ const rowGap = (props)=>{
     }
     return null;
 };
-export { rowGap as r } from "__TURBOPACK_VAR__" assert {
+export { rowGap as i } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 16
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import { i as rowGap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import { c as responsivePropType } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
+rowGap.propTypes = process.env.NODE_ENV !== 'production' ? {
+    rowGap: responsivePropType
+} : {};
+
+```
+## Part 17
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import { b as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+const gridColumn = style({
+    prop: 'gridColumn'
+});
+export { gridColumn as j } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 18
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import { j as gridColumn } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+export { gridColumn };
+
+```
+## Part 19
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import { b as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+const gridRow = style({
+    prop: 'gridRow'
+});
+export { gridRow as k } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 20
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import { k as gridRow } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+export { gridRow };
+
+```
+## Part 21
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import { b as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+const gridAutoFlow = style({
+    prop: 'gridAutoFlow'
+});
+export { gridAutoFlow as l } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 22
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import { l as gridAutoFlow } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+export { gridAutoFlow };
+
+```
+## Part 23
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import { b as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+const gridAutoColumns = style({
+    prop: 'gridAutoColumns'
+});
+export { gridAutoColumns as m } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 24
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
+};
+import { m as gridAutoColumns } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
+};
+export { gridAutoColumns };
+
+```
+## Part 25
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
+};
+import { b as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+const gridAutoRows = style({
+    prop: 'gridAutoRows'
+});
+export { gridAutoRows as n } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 26
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 25
+};
+import { n as gridAutoRows } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 25
+};
+export { gridAutoRows };
+
+```
+## Part 27
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 25
+};
+import { b as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+const gridTemplateColumns = style({
+    prop: 'gridTemplateColumns'
+});
+export { gridTemplateColumns as o } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 28
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 27
+};
+import { o as gridTemplateColumns } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 27
+};
+export { gridTemplateColumns };
+
+```
+## Part 29
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 25
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 27
+};
+import { b as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+const gridTemplateRows = style({
+    prop: 'gridTemplateRows'
+});
+export { gridTemplateRows as p } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 30
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 29
+};
+import { p as gridTemplateRows } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 29
+};
+export { gridTemplateRows };
+
+```
+## Part 31
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 25
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 27
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 29
+};
+import { b as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+const gridTemplateAreas = style({
+    prop: 'gridTemplateAreas'
+});
+export { gridTemplateAreas as q } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 32
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 31
+};
+import { q as gridTemplateAreas } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 31
+};
+export { gridTemplateAreas };
+
+```
+## Part 33
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 25
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 27
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 29
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 31
+};
+import { b as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+const gridArea = style({
+    prop: 'gridArea'
+});
+export { gridArea as r } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1872,57 +2950,22 @@ export { rowGap as r } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 33
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 20
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 27
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 30
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 32
-};
-import { r as rowGap } from "__TURBOPACK_PART__" assert {
+import { r as gridArea } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 33
 };
-import { l as responsivePropType } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 20
-};
-rowGap.propTypes = process.env.NODE_ENV !== 'production' ? {
-    rowGap: responsivePropType
-} : {};
+export { gridArea };
 
 ```
 ## Part 35
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 34
+    __turbopack_part__: 16
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 33
+    __turbopack_part__: 15
 };
-import { r as rowGap } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 33
+import { i as rowGap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
 };
 rowGap.filterProps = [
     'rowGap'
@@ -1935,10 +2978,10 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 35
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 33
+    __turbopack_part__: 15
 };
-import { r as rowGap } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 33
+import { i as rowGap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
 };
 export { rowGap };
 
@@ -1946,13 +2989,13 @@ export { rowGap };
 ## Part 37
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 32
+    __turbopack_part__: 14
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
+    __turbopack_part__: 13
 };
-import { q as columnGap } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
+import { h as columnGap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
 };
 columnGap.filterProps = [
     'columnGap'
@@ -1965,10 +3008,10 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 37
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
+    __turbopack_part__: 13
 };
-import { q as columnGap } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
+import { h as columnGap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
 };
 export { columnGap };
 
@@ -1976,13 +3019,13 @@ export { columnGap };
 ## Part 39
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 30
+    __turbopack_part__: 12
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
+    __turbopack_part__: 11
 };
-import { p as gap } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
+import { g as gap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
 };
 gap.filterProps = [
     'gap'
@@ -1995,10 +3038,10 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 39
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
+    __turbopack_part__: 11
 };
-import { p as gap } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
+import { g as gap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
 };
 export { gap };
 
@@ -2012,85 +3055,109 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 39
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
+    __turbopack_part__: 11
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 37
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
+    __turbopack_part__: 13
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 35
 };
 import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 25
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 27
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 29
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 31
+};
+import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 33
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 12
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 10
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+    __turbopack_part__: 7
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
 };
 import { a as compose } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
 };
-import { p as gap } from "__TURBOPACK_PART__" assert {
+import { g as gap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import { h as columnGap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import { i as rowGap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import { j as gridColumn } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import { k as gridRow } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import { l as gridAutoFlow } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import { m as gridAutoColumns } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
+};
+import { n as gridAutoRows } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 25
+};
+import { o as gridTemplateColumns } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 27
+};
+import { p as gridTemplateRows } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 29
 };
-import { q as columnGap } from "__TURBOPACK_PART__" assert {
+import { q as gridTemplateAreas } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 31
 };
-import { r as rowGap } from "__TURBOPACK_PART__" assert {
+import { r as gridArea } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 33
-};
-import { k as gridColumn } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
-};
-import { j as gridRow } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
-};
-import { i as gridAutoFlow } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
-import { h as gridAutoColumns } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 12
-};
-import { g as gridAutoRows } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 10
-};
-import { f as gridTemplateColumns } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
-};
-import { e as gridTemplateRows } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
-import { d as gridTemplateAreas } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-import { c as gridArea } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
 };
 const grid = compose(gap, columnGap, rowGap, gridColumn, gridRow, gridAutoFlow, gridAutoColumns, gridAutoRows, gridTemplateColumns, gridTemplateRows, gridTemplateAreas, gridArea);
 export { grid as s } from "__TURBOPACK_VAR__" assert {
@@ -2104,37 +3171,64 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 41
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 25
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 27
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 29
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 30
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 31
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 32
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 33
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 34
 };
 import { s as grid } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 41
@@ -2148,37 +3242,67 @@ export { __TURBOPACK__default__export__ as t } from "__TURBOPACK_VAR__" assert {
 ## Part 43
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 25
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 27
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 29
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 30
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 31
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 32
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 33
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 34
+    __turbopack_part__: 41
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 42
@@ -2199,32 +3323,32 @@ export { __TURBOPACK__default__export__ as default };
 ```
 ## Part 45
 ```js
-export { gridArea } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export gridArea"
-};
-export { gridTemplateAreas } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export gridTemplateAreas"
-};
-export { gridTemplateRows } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export gridTemplateRows"
-};
-export { gridTemplateColumns } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export gridTemplateColumns"
-};
-export { gridAutoRows } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export gridAutoRows"
-};
-export { gridAutoColumns } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export gridAutoColumns"
-};
-export { gridAutoFlow } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export gridAutoFlow"
+export { gridColumn } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export gridColumn"
 };
 export { gridRow } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: "export gridRow"
 };
-export { gridColumn } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export gridColumn"
+export { gridAutoFlow } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export gridAutoFlow"
+};
+export { gridAutoColumns } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export gridAutoColumns"
+};
+export { gridAutoRows } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export gridAutoRows"
+};
+export { gridTemplateColumns } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export gridTemplateColumns"
+};
+export { gridTemplateRows } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export gridTemplateRows"
+};
+export { gridTemplateAreas } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export gridTemplateAreas"
+};
+export { gridArea } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export gridArea"
 };
 export { rowGap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: "export rowGap"
@@ -2243,37 +3367,67 @@ export { default } from "__TURBOPACK_PART__" assert {
 ## Merged (module eval)
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 25
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 27
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 29
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 30
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 31
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 32
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 33
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 34
+    __turbopack_part__: 41
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 42
@@ -2291,41 +3445,41 @@ import "__TURBOPACK_PART__" assert {
     ): 40,
     Export(
         "gridTemplateColumns",
-    ): 9,
+    ): 28,
     Export(
         "gridAutoRows",
-    ): 11,
+    ): 26,
     Export(
         "columnGap",
     ): 38,
     Export(
         "gridArea",
-    ): 3,
+    ): 34,
     Exports: 45,
     Export(
         "gridAutoFlow",
-    ): 15,
+    ): 22,
     Export(
         "gridColumn",
-    ): 19,
+    ): 18,
     Export(
         "gridAutoColumns",
-    ): 13,
+    ): 24,
     Export(
         "rowGap",
     ): 36,
     Export(
         "gridTemplateRows",
-    ): 7,
+    ): 30,
     Export(
         "gridTemplateAreas",
-    ): 5,
+    ): 32,
     Export(
         "default",
     ): 44,
     Export(
         "gridRow",
-    ): 17,
+    ): 20,
 }
 ```
 
@@ -2349,72 +3503,39 @@ export { style as b } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 2
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-import { b as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-const gridArea = style({
-    prop: 'gridArea'
-});
-export { gridArea as c } from "__TURBOPACK_VAR__" assert {
+import responsivePropType from './responsivePropType';
+export { responsivePropType as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
 ## Part 3
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+import { handleBreakpoints } from './breakpoints';
+export { handleBreakpoints as d } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
 };
-import { c as gridArea } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
-export { gridArea };
 
 ```
 ## Part 4
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-import { b as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-const gridTemplateAreas = style({
-    prop: 'gridTemplateAreas'
-});
-export { gridTemplateAreas as d } from "__TURBOPACK_VAR__" assert {
+import { getValue } from './spacing';
+export { getValue as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
 ## Part 5
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+import { createUnaryUnit } from './spacing';
+export { createUnaryUnit as f } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
 };
-import { d as gridTemplateAreas } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-export { gridTemplateAreas };
 
 ```
 ## Part 6
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-import { b as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-const gridTemplateRows = style({
-    prop: 'gridTemplateRows'
-});
-export { gridTemplateRows as e } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
+import './style';
 
 ```
 ## Part 7
@@ -2422,295 +3543,85 @@ export { gridTemplateRows as e } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import { e as gridTemplateRows } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
-export { gridTemplateRows };
+import './compose';
 
 ```
 ## Part 8
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+    __turbopack_part__: 6
 };
-import { b as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
 };
-const gridTemplateColumns = style({
-    prop: 'gridTemplateColumns'
-});
-export { gridTemplateColumns as f } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
+import './spacing';
 
 ```
 ## Part 9
 ```js
 import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
-import { f as gridTemplateColumns } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
-};
-export { gridTemplateColumns };
+import './breakpoints';
 
 ```
 ## Part 10
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+    __turbopack_part__: 6
 };
-import { b as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
 };
-const gridAutoRows = style({
-    prop: 'gridAutoRows'
-});
-export { gridAutoRows as g } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import './responsivePropType';
 
 ```
 ## Part 11
 ```js
 import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
-import { g as gridAutoRows } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 10
+import { f as createUnaryUnit } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
 };
-export { gridAutoRows };
-
-```
-## Part 12
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+import { e as getValue } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
 };
-import { b as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-const gridAutoColumns = style({
-    prop: 'gridAutoColumns'
-});
-export { gridAutoColumns as h } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 13
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 12
-};
-import { h as gridAutoColumns } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 12
-};
-export { gridAutoColumns };
-
-```
-## Part 14
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-import { b as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-const gridAutoFlow = style({
-    prop: 'gridAutoFlow'
-});
-export { gridAutoFlow as i } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 15
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
-import { i as gridAutoFlow } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
-export { gridAutoFlow };
-
-```
-## Part 16
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-import { b as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-const gridRow = style({
-    prop: 'gridRow'
-});
-export { gridRow as j } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 17
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
-};
-import { j as gridRow } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
-};
-export { gridRow };
-
-```
-## Part 18
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-import { b as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-const gridColumn = style({
-    prop: 'gridColumn'
-});
-export { gridColumn as k } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 19
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
-};
-import { k as gridColumn } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
-};
-export { gridColumn };
-
-```
-## Part 20
-```js
-import responsivePropType from './responsivePropType';
-export { responsivePropType as l } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 21
-```js
-import { handleBreakpoints } from './breakpoints';
-export { handleBreakpoints as m } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 22
-```js
-import { getValue } from './spacing';
-export { getValue as n } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 23
-```js
-import { createUnaryUnit } from './spacing';
-export { createUnaryUnit as o } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 24
-```js
-import './style';
-
-```
-## Part 25
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
-};
-import './compose';
-
-```
-## Part 26
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
-};
-import './spacing';
-
-```
-## Part 27
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
-};
-import './breakpoints';
-
-```
-## Part 28
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 27
-};
-import './responsivePropType';
-
-```
-## Part 29
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 22
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 27
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
-};
-import { o as createUnaryUnit } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
-};
-import { n as getValue } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 22
-};
-import { m as handleBreakpoints } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+import { d as handleBreakpoints } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
 const gap = (props)=>{
     if (props.gap !== undefined && props.gap !== null) {
@@ -2722,85 +3633,85 @@ const gap = (props)=>{
     }
     return null;
 };
-export { gap as p } from "__TURBOPACK_VAR__" assert {
+export { gap as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
-## Part 30
+## Part 12
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
+    __turbopack_part__: 11
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 20
+    __turbopack_part__: 2
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
+    __turbopack_part__: 6
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
+    __turbopack_part__: 7
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
+    __turbopack_part__: 8
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 27
+    __turbopack_part__: 9
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
+    __turbopack_part__: 10
 };
-import { p as gap } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
+import { g as gap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
 };
-import { l as responsivePropType } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 20
+import { c as responsivePropType } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
 };
 gap.propTypes = process.env.NODE_ENV !== 'production' ? {
     gap: responsivePropType
 } : {};
 
 ```
-## Part 31
+## Part 13
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: 5
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 22
+    __turbopack_part__: 4
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+    __turbopack_part__: 3
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
+    __turbopack_part__: 6
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
+    __turbopack_part__: 7
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
+    __turbopack_part__: 8
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 27
+    __turbopack_part__: 9
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
+    __turbopack_part__: 10
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
+    __turbopack_part__: 11
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 30
+    __turbopack_part__: 12
 };
-import { o as createUnaryUnit } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { f as createUnaryUnit } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
 };
-import { n as getValue } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 22
+import { e as getValue } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
 };
-import { m as handleBreakpoints } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+import { d as handleBreakpoints } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
 const columnGap = (props)=>{
     if (props.columnGap !== undefined && props.columnGap !== null) {
@@ -2812,97 +3723,97 @@ const columnGap = (props)=>{
     }
     return null;
 };
-export { columnGap as q } from "__TURBOPACK_VAR__" assert {
+export { columnGap as h } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
-## Part 32
+## Part 14
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
+    __turbopack_part__: 13
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 20
+    __turbopack_part__: 2
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
+    __turbopack_part__: 6
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
+    __turbopack_part__: 7
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
+    __turbopack_part__: 8
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 27
+    __turbopack_part__: 9
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
+    __turbopack_part__: 10
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
+    __turbopack_part__: 11
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 30
+    __turbopack_part__: 12
 };
-import { q as columnGap } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
+import { h as columnGap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
 };
-import { l as responsivePropType } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 20
+import { c as responsivePropType } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
 };
 columnGap.propTypes = process.env.NODE_ENV !== 'production' ? {
     columnGap: responsivePropType
 } : {};
 
 ```
-## Part 33
+## Part 15
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+    __turbopack_part__: 5
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 22
+    __turbopack_part__: 4
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+    __turbopack_part__: 3
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
+    __turbopack_part__: 6
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
+    __turbopack_part__: 7
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
+    __turbopack_part__: 8
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 27
+    __turbopack_part__: 9
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
+    __turbopack_part__: 10
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
+    __turbopack_part__: 11
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 30
+    __turbopack_part__: 12
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
+    __turbopack_part__: 13
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 32
+    __turbopack_part__: 14
 };
-import { o as createUnaryUnit } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { f as createUnaryUnit } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
 };
-import { n as getValue } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 22
+import { e as getValue } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
 };
-import { m as handleBreakpoints } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+import { d as handleBreakpoints } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
 const rowGap = (props)=>{
     if (props.rowGap !== undefined && props.rowGap !== null) {
@@ -2914,7 +3825,690 @@ const rowGap = (props)=>{
     }
     return null;
 };
-export { rowGap as r } from "__TURBOPACK_VAR__" assert {
+export { rowGap as i } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 16
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import { i as rowGap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import { c as responsivePropType } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
+rowGap.propTypes = process.env.NODE_ENV !== 'production' ? {
+    rowGap: responsivePropType
+} : {};
+
+```
+## Part 17
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import { b as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+const gridColumn = style({
+    prop: 'gridColumn'
+});
+export { gridColumn as j } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 18
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import { j as gridColumn } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+export { gridColumn };
+
+```
+## Part 19
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import { b as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+const gridRow = style({
+    prop: 'gridRow'
+});
+export { gridRow as k } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 20
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import { k as gridRow } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+export { gridRow };
+
+```
+## Part 21
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import { b as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+const gridAutoFlow = style({
+    prop: 'gridAutoFlow'
+});
+export { gridAutoFlow as l } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 22
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import { l as gridAutoFlow } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+export { gridAutoFlow };
+
+```
+## Part 23
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import { b as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+const gridAutoColumns = style({
+    prop: 'gridAutoColumns'
+});
+export { gridAutoColumns as m } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 24
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
+};
+import { m as gridAutoColumns } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
+};
+export { gridAutoColumns };
+
+```
+## Part 25
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
+};
+import { b as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+const gridAutoRows = style({
+    prop: 'gridAutoRows'
+});
+export { gridAutoRows as n } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 26
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 25
+};
+import { n as gridAutoRows } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 25
+};
+export { gridAutoRows };
+
+```
+## Part 27
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 25
+};
+import { b as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+const gridTemplateColumns = style({
+    prop: 'gridTemplateColumns'
+});
+export { gridTemplateColumns as o } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 28
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 27
+};
+import { o as gridTemplateColumns } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 27
+};
+export { gridTemplateColumns };
+
+```
+## Part 29
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 25
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 27
+};
+import { b as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+const gridTemplateRows = style({
+    prop: 'gridTemplateRows'
+});
+export { gridTemplateRows as p } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 30
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 29
+};
+import { p as gridTemplateRows } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 29
+};
+export { gridTemplateRows };
+
+```
+## Part 31
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 25
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 27
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 29
+};
+import { b as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+const gridTemplateAreas = style({
+    prop: 'gridTemplateAreas'
+});
+export { gridTemplateAreas as q } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 32
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 31
+};
+import { q as gridTemplateAreas } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 31
+};
+export { gridTemplateAreas };
+
+```
+## Part 33
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 25
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 27
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 29
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 31
+};
+import { b as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+const gridArea = style({
+    prop: 'gridArea'
+});
+export { gridArea as r } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -2924,57 +4518,22 @@ export { rowGap as r } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 33
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 20
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 25
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 27
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 30
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 32
-};
-import { r as rowGap } from "__TURBOPACK_PART__" assert {
+import { r as gridArea } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 33
 };
-import { l as responsivePropType } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 20
-};
-rowGap.propTypes = process.env.NODE_ENV !== 'production' ? {
-    rowGap: responsivePropType
-} : {};
+export { gridArea };
 
 ```
 ## Part 35
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 34
+    __turbopack_part__: 16
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 33
+    __turbopack_part__: 15
 };
-import { r as rowGap } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 33
+import { i as rowGap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
 };
 rowGap.filterProps = [
     'rowGap'
@@ -2987,10 +4546,10 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 35
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 33
+    __turbopack_part__: 15
 };
-import { r as rowGap } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 33
+import { i as rowGap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
 };
 export { rowGap };
 
@@ -2998,13 +4557,13 @@ export { rowGap };
 ## Part 37
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 32
+    __turbopack_part__: 14
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
+    __turbopack_part__: 13
 };
-import { q as columnGap } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
+import { h as columnGap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
 };
 columnGap.filterProps = [
     'columnGap'
@@ -3017,10 +4576,10 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 37
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
+    __turbopack_part__: 13
 };
-import { q as columnGap } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
+import { h as columnGap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
 };
 export { columnGap };
 
@@ -3028,13 +4587,13 @@ export { columnGap };
 ## Part 39
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 30
+    __turbopack_part__: 12
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
+    __turbopack_part__: 11
 };
-import { p as gap } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
+import { g as gap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
 };
 gap.filterProps = [
     'gap'
@@ -3047,10 +4606,10 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 39
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
+    __turbopack_part__: 11
 };
-import { p as gap } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
+import { g as gap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
 };
 export { gap };
 
@@ -3064,85 +4623,109 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 39
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
+    __turbopack_part__: 11
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 37
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
+    __turbopack_part__: 13
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 35
 };
 import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 25
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 27
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 29
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 31
+};
+import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 33
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 12
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 10
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+    __turbopack_part__: 7
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
 };
 import { a as compose } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
 };
-import { p as gap } from "__TURBOPACK_PART__" assert {
+import { g as gap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import { h as columnGap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import { i as rowGap } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import { j as gridColumn } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import { k as gridRow } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import { l as gridAutoFlow } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import { m as gridAutoColumns } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
+};
+import { n as gridAutoRows } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 25
+};
+import { o as gridTemplateColumns } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 27
+};
+import { p as gridTemplateRows } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 29
 };
-import { q as columnGap } from "__TURBOPACK_PART__" assert {
+import { q as gridTemplateAreas } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 31
 };
-import { r as rowGap } from "__TURBOPACK_PART__" assert {
+import { r as gridArea } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 33
-};
-import { k as gridColumn } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
-};
-import { j as gridRow } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
-};
-import { i as gridAutoFlow } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
-import { h as gridAutoColumns } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 12
-};
-import { g as gridAutoRows } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 10
-};
-import { f as gridTemplateColumns } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
-};
-import { e as gridTemplateRows } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
-import { d as gridTemplateAreas } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-import { c as gridArea } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
 };
 const grid = compose(gap, columnGap, rowGap, gridColumn, gridRow, gridAutoFlow, gridAutoColumns, gridAutoRows, gridTemplateColumns, gridTemplateRows, gridTemplateAreas, gridArea);
 export { grid as s } from "__TURBOPACK_VAR__" assert {
@@ -3156,37 +4739,64 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 41
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 25
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 27
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 29
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 30
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 31
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 32
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 33
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 34
 };
 import { s as grid } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 41
@@ -3200,37 +4810,67 @@ export { __TURBOPACK__default__export__ as t } from "__TURBOPACK_VAR__" assert {
 ## Part 43
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 25
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 27
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 29
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 30
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 31
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 32
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 33
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 34
+    __turbopack_part__: 41
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 42
@@ -3251,32 +4891,32 @@ export { __TURBOPACK__default__export__ as default };
 ```
 ## Part 45
 ```js
-export { gridArea } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export gridArea"
-};
-export { gridTemplateAreas } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export gridTemplateAreas"
-};
-export { gridTemplateRows } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export gridTemplateRows"
-};
-export { gridTemplateColumns } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export gridTemplateColumns"
-};
-export { gridAutoRows } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export gridAutoRows"
-};
-export { gridAutoColumns } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export gridAutoColumns"
-};
-export { gridAutoFlow } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export gridAutoFlow"
+export { gridColumn } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export gridColumn"
 };
 export { gridRow } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: "export gridRow"
 };
-export { gridColumn } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export gridColumn"
+export { gridAutoFlow } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export gridAutoFlow"
+};
+export { gridAutoColumns } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export gridAutoColumns"
+};
+export { gridAutoRows } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export gridAutoRows"
+};
+export { gridTemplateColumns } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export gridTemplateColumns"
+};
+export { gridTemplateRows } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export gridTemplateRows"
+};
+export { gridTemplateAreas } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export gridTemplateAreas"
+};
+export { gridArea } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export gridArea"
 };
 export { rowGap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: "export rowGap"
@@ -3295,37 +4935,67 @@ export { default } from "__TURBOPACK_PART__" assert {
 ## Merged (module eval)
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 25
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 27
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 29
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 30
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 31
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 32
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 33
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 34
+    __turbopack_part__: 41
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 42

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/multi-export/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/multi-export/output.md
@@ -120,7 +120,7 @@ import "__TURBOPACK_PART__" assert {
 import { a as cat } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
 };
-export { cat as cat };
+export { cat };
 
 ```
 ## Part 2
@@ -195,7 +195,7 @@ import "__TURBOPACK_PART__" assert {
 import { a as cat } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
 };
-export { cat as cat };
+export { cat };
 
 ```
 ## Part 2

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nanoid/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nanoid/output.md
@@ -592,7 +592,7 @@ import "__TURBOPACK_PART__" assert {
 import { g as customRandom } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
-export { customRandom as customRandom };
+export { customRandom };
 
 ```
 ## Part 11
@@ -632,7 +632,7 @@ import "__TURBOPACK_PART__" assert {
 import { h as random } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 11
 };
-export { random as random };
+export { random };
 
 ```
 ## Part 13
@@ -688,7 +688,7 @@ import "__TURBOPACK_PART__" assert {
 import { a as urlAlphabet } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
 };
-export { urlAlphabet as urlAlphabet };
+export { urlAlphabet };
 
 ```
 ## Part 15
@@ -699,7 +699,7 @@ import "__TURBOPACK_PART__" assert {
 import { i as nanoid } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
-export { nanoid as nanoid };
+export { nanoid };
 
 ```
 ## Part 16
@@ -730,7 +730,7 @@ import "__TURBOPACK_PART__" assert {
 import { j as customAlphabet } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 16
 };
-export { customAlphabet as customAlphabet };
+export { customAlphabet };
 
 ```
 ## Part 18
@@ -952,7 +952,7 @@ import "__TURBOPACK_PART__" assert {
 import { g as customRandom } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
-export { customRandom as customRandom };
+export { customRandom };
 
 ```
 ## Part 11
@@ -992,7 +992,7 @@ import "__TURBOPACK_PART__" assert {
 import { h as random } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 11
 };
-export { random as random };
+export { random };
 
 ```
 ## Part 13
@@ -1048,7 +1048,7 @@ import "__TURBOPACK_PART__" assert {
 import { a as urlAlphabet } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
 };
-export { urlAlphabet as urlAlphabet };
+export { urlAlphabet };
 
 ```
 ## Part 15
@@ -1059,7 +1059,7 @@ import "__TURBOPACK_PART__" assert {
 import { i as nanoid } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
-export { nanoid as nanoid };
+export { nanoid };
 
 ```
 ## Part 16
@@ -1090,7 +1090,7 @@ import "__TURBOPACK_PART__" assert {
 import { j as customAlphabet } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 16
 };
-export { customAlphabet as customAlphabet };
+export { customAlphabet };
 
 ```
 ## Part 18

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nextjs-tracer/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nextjs-tracer/output.md
@@ -156,6 +156,7 @@ const rootSpanIdKey = api.createContextKey('next.rootSpanId');
 
 ```
 
+- Side effects
 - Declares: `rootSpanIdKey`
 - Reads: `api`
 - Write: `api`, `rootSpanIdKey`
@@ -356,6 +357,7 @@ const getTracer = (()=>{
 
 ```
 
+- Side effects
 - Declares: `getTracer`
 - Reads: `NextTracerImpl`
 - Write: `getTracer`
@@ -437,6 +439,9 @@ graph TD
     Item12 --> Item5;
     Item12 --> Item4;
     Item12 -.-> Item6;
+    Item12 --> Item1;
+    Item12 --> Item11;
+    Item12 -.-> Item8;
     Item14 --> Item13;
     Item16 --> Item6;
     Item16 --> Item15;
@@ -448,6 +453,11 @@ graph TD
     Item16 --> Item10;
     Item16 --> Item7;
     Item17 --> Item16;
+    Item17 --> Item1;
+    Item17 --> Item5;
+    Item17 --> Item11;
+    Item17 --> Item12;
+    Item17 -.-> Item8;
     Item19 --> Item8;
     Item20 --> Item9;
     Item21 --> Item17;
@@ -499,6 +509,9 @@ graph TD
     Item12 --> Item5;
     Item12 --> Item4;
     Item12 -.-> Item6;
+    Item12 --> Item1;
+    Item12 --> Item11;
+    Item12 -.-> Item8;
     Item14 --> Item13;
     Item16 --> Item6;
     Item16 --> Item15;
@@ -510,6 +523,11 @@ graph TD
     Item16 --> Item10;
     Item16 --> Item7;
     Item17 --> Item16;
+    Item17 --> Item1;
+    Item17 --> Item5;
+    Item17 --> Item11;
+    Item17 --> Item12;
+    Item17 -.-> Item8;
     Item19 --> Item8;
     Item20 --> Item9;
     Item21 --> Item17;
@@ -562,6 +580,9 @@ graph TD
     Item12 --> Item5;
     Item12 --> Item4;
     Item12 -.-> Item6;
+    Item12 --> Item1;
+    Item12 --> Item11;
+    Item12 -.-> Item8;
     Item14 --> Item13;
     Item16 --> Item6;
     Item16 --> Item15;
@@ -573,6 +594,11 @@ graph TD
     Item16 --> Item10;
     Item16 --> Item7;
     Item17 --> Item16;
+    Item17 --> Item1;
+    Item17 --> Item5;
+    Item17 --> Item11;
+    Item17 --> Item12;
+    Item17 -.-> Item8;
     Item19 --> Item8;
     Item20 --> Item9;
     Item21 --> Item17;
@@ -583,6 +609,8 @@ graph TD
     Item18 --> Item1;
     Item18 --> Item5;
     Item18 --> Item11;
+    Item18 --> Item12;
+    Item18 --> Item17;
 ```
 # Final
 ```mermaid
@@ -601,48 +629,58 @@ graph TD
     N11["Items: [ItemId(1, VarDeclarator(0))]"];
     N12["Items: [ItemId(2, Normal)]"];
     N13["Items: [ItemId(8, VarDeclarator(0))]"];
-    N14["Items: [ItemId(ModuleEvaluation)]"];
-    N15["Items: [ItemId(3, VarDeclarator(0))]"];
-    N16["Items: [ItemId(Export((&quot;SpanKind&quot;, #2), &quot;SpanKind&quot;))]"];
-    N17["Items: [ItemId(9, VarDeclarator(0))]"];
-    N18["Items: [ItemId(7, VarDeclarator(0))]"];
-    N19["Items: [ItemId(Export((&quot;SpanStatusCode&quot;, #2), &quot;SpanStatusCode&quot;))]"];
-    N20["Items: [ItemId(13, Normal)]"];
-    N21["Items: [ItemId(14, VarDeclarator(0))]"];
+    N14["Items: [ItemId(3, VarDeclarator(0))]"];
+    N15["Items: [ItemId(Export((&quot;SpanKind&quot;, #2), &quot;SpanKind&quot;))]"];
+    N16["Items: [ItemId(9, VarDeclarator(0))]"];
+    N17["Items: [ItemId(7, VarDeclarator(0))]"];
+    N18["Items: [ItemId(Export((&quot;SpanStatusCode&quot;, #2), &quot;SpanStatusCode&quot;))]"];
+    N19["Items: [ItemId(13, Normal)]"];
+    N20["Items: [ItemId(14, VarDeclarator(0))]"];
+    N21["Items: [ItemId(ModuleEvaluation)]"];
     N22["Items: [ItemId(Export((&quot;getTracer&quot;, #2), &quot;getTracer&quot;))]"];
     N12 --> N11;
     N12 --> N10;
-    N15 --> N12;
-    N15 --> N11;
-    N18 --> N8;
-    N18 --> N15;
+    N14 --> N12;
+    N14 --> N11;
+    N17 --> N8;
+    N17 --> N14;
     N13 --> N10;
     N13 --> N12;
     N13 -.-> N6;
-    N17 --> N12;
-    N17 --> N11;
-    N17 -.-> N15;
+    N16 --> N12;
+    N16 --> N11;
+    N16 -.-> N14;
+    N16 --> N10;
+    N16 --> N13;
+    N16 -.-> N6;
     N5 --> N4;
-    N20 --> N15;
-    N20 --> N3;
-    N20 --> N2;
-    N20 --> N5;
-    N20 --> N17;
+    N19 --> N14;
+    N19 --> N3;
+    N19 --> N2;
+    N19 --> N5;
+    N19 --> N16;
+    N19 --> N13;
+    N19 --> N1;
+    N19 --> N17;
+    N19 --> N0;
+    N20 --> N19;
+    N20 --> N10;
+    N20 --> N12;
     N20 --> N13;
-    N20 --> N1;
-    N20 --> N18;
-    N20 --> N0;
-    N21 --> N20;
+    N20 --> N16;
+    N20 -.-> N6;
     N7 --> N6;
     N9 --> N8;
-    N22 --> N21;
-    N19 --> N18;
-    N19 --> N15;
-    N16 --> N15;
+    N22 --> N20;
+    N18 --> N17;
+    N18 --> N14;
+    N15 --> N14;
     N8 --> N6;
-    N14 --> N10;
-    N14 --> N12;
-    N14 --> N13;
+    N21 --> N10;
+    N21 --> N12;
+    N21 --> N13;
+    N21 --> N16;
+    N21 --> N20;
 ```
 # Entrypoints
 
@@ -651,14 +689,14 @@ graph TD
     Export(
         "isBubbledError",
     ): 9,
-    ModuleEvaluation: 14,
     Export(
         "SpanKind",
-    ): 16,
+    ): 15,
+    ModuleEvaluation: 21,
     Exports: 23,
     Export(
         "SpanStatusCode",
-    ): 19,
+    ): 18,
     Export(
         "BubbledError",
     ): 7,
@@ -841,20 +879,6 @@ export { rootSpanAttributesStore as j } from "__TURBOPACK_VAR__" assert {
 ## Part 14
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 10
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 12
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
-};
-"module evaluation";
-
-```
-## Part 15
-```js
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
 import "__TURBOPACK_PART__" assert {
@@ -884,18 +908,18 @@ export { ROOT_CONTEXT as p } from "__TURBOPACK_VAR__" assert {
 };
 
 ```
-## Part 16
+## Part 15
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
+    __turbopack_part__: 14
 };
 import { o as SpanKind } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
+    __turbopack_part__: 14
 };
-export { SpanKind as SpanKind };
+export { SpanKind };
 
 ```
-## Part 17
+## Part 16
 ```js
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
@@ -904,7 +928,16 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 11
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
 import { i as api } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 11
@@ -915,19 +948,19 @@ export { rootSpanIdKey as q } from "__TURBOPACK_VAR__" assert {
 };
 
 ```
-## Part 18
+## Part 17
 ```js
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
+    __turbopack_part__: 14
 };
 import { h as isBubbledError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
 import { n as SpanStatusCode } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
+    __turbopack_part__: 14
 };
 const closeSpanWithError = (span, error)=>{
     if (isBubbledError(error) && error.bubble) {
@@ -948,24 +981,24 @@ export { closeSpanWithError as r } from "__TURBOPACK_VAR__" assert {
 };
 
 ```
+## Part 18
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import { n as SpanStatusCode } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+export { SpanStatusCode };
+
+```
 ## Part 19
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
-};
-import { n as SpanStatusCode } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
-};
-export { SpanStatusCode as SpanStatusCode };
-
-```
-## Part 20
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
+    __turbopack_part__: 14
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
@@ -977,7 +1010,7 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: 16
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
@@ -986,19 +1019,19 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+    __turbopack_part__: 17
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
 };
 import { m as trace } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
+    __turbopack_part__: 14
 };
 import { k as context } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
+    __turbopack_part__: 14
 };
 import { l as propagation } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
+    __turbopack_part__: 14
 };
 import { d as clientTraceDataSetter } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
@@ -1007,13 +1040,13 @@ import { c as NextVanillaSpanAllowlist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
 import { p as ROOT_CONTEXT } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
+    __turbopack_part__: 14
 };
 import { f as getSpanId } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
 import { q as rootSpanIdKey } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+    __turbopack_part__: 16
 };
 import { j as rootSpanAttributesStore } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
@@ -1022,7 +1055,7 @@ import { b as LogSpanAllowList } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
 import { r as closeSpanWithError } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+    __turbopack_part__: 17
 };
 import { a as isPromise } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
@@ -1170,13 +1203,28 @@ export { NextTracerImpl as s } from "__TURBOPACK_VAR__" assert {
 };
 
 ```
-## Part 21
+## Part 20
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 20
+    __turbopack_part__: 19
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
 import { s as NextTracerImpl } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 20
+    __turbopack_part__: 19
 };
 const getTracer = (()=>{
     const tracer = new NextTracerImpl();
@@ -1187,15 +1235,35 @@ export { getTracer as t } from "__TURBOPACK_VAR__" assert {
 };
 
 ```
+## Part 21
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+"module evaluation";
+
+```
 ## Part 22
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+    __turbopack_part__: 20
 };
 import { t as getTracer } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+    __turbopack_part__: 20
 };
-export { getTracer as getTracer };
+export { getTracer };
 
 ```
 ## Part 23
@@ -1228,6 +1296,12 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
 "module evaluation";
 
 ```
@@ -1238,20 +1312,20 @@ import "__TURBOPACK_PART__" assert {
     Export(
         "isBubbledError",
     ): 9,
-    ModuleEvaluation: 15,
     Export(
         "SpanKind",
-    ): 17,
+    ): 16,
+    ModuleEvaluation: 22,
     Exports: 23,
     Export(
         "SpanStatusCode",
-    ): 19,
+    ): 18,
     Export(
         "BubbledError",
     ): 7,
     Export(
         "getTracer",
-    ): 22,
+    ): 21,
 }
 ```
 
@@ -1411,16 +1485,13 @@ if (process.env.NEXT_RUNTIME === 'edge') {
 ## Part 13
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 12
+    __turbopack_part__: 10
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
+    __turbopack_part__: 12
 };
-import { i as api } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
-};
-const rootSpanIdKey = api.createContextKey('next.rootSpanId');
-export { rootSpanIdKey as j } from "__TURBOPACK_VAR__" assert {
+const rootSpanAttributesStore = new Map();
+export { rootSpanAttributesStore as j } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1428,32 +1499,27 @@ export { rootSpanIdKey as j } from "__TURBOPACK_VAR__" assert {
 ## Part 14
 ```js
 import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 12
+    __turbopack_part__: 13
 };
-const rootSpanAttributesStore = new Map();
-export { rootSpanAttributesStore as k } from "__TURBOPACK_VAR__" assert {
+import { i as api } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+const rootSpanIdKey = api.createContextKey('next.rootSpanId');
+export { rootSpanIdKey as k } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
 ## Part 15
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 12
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 10
-};
-"module evaluation";
-
-```
-## Part 16
 ```js
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
@@ -1485,30 +1551,30 @@ export { ROOT_CONTEXT as q } from "__TURBOPACK_VAR__" assert {
 };
 
 ```
-## Part 17
+## Part 16
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
+    __turbopack_part__: 15
 };
 import { p as SpanKind } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
+    __turbopack_part__: 15
 };
-export { SpanKind as SpanKind };
+export { SpanKind };
 
 ```
-## Part 18
+## Part 17
 ```js
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
+    __turbopack_part__: 15
 };
 import { h as isBubbledError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
 import { o as SpanStatusCode } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
+    __turbopack_part__: 15
 };
 const closeSpanWithError = (span, error)=>{
     if (isBubbledError(error) && error.bubble) {
@@ -1529,24 +1595,24 @@ export { closeSpanWithError as r } from "__TURBOPACK_VAR__" assert {
 };
 
 ```
+## Part 18
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+import { o as SpanStatusCode } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
+};
+export { SpanStatusCode };
+
+```
 ## Part 19
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
-};
-import { o as SpanStatusCode } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
-};
-export { SpanStatusCode as SpanStatusCode };
-
-```
-## Part 20
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
+    __turbopack_part__: 15
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
@@ -1558,28 +1624,28 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
+    __turbopack_part__: 14
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+    __turbopack_part__: 13
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+    __turbopack_part__: 17
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
 };
 import { n as trace } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
+    __turbopack_part__: 15
 };
 import { l as context } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
+    __turbopack_part__: 15
 };
 import { m as propagation } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
+    __turbopack_part__: 15
 };
 import { d as clientTraceDataSetter } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
@@ -1588,22 +1654,22 @@ import { c as NextVanillaSpanAllowlist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
 import { q as ROOT_CONTEXT } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
+    __turbopack_part__: 15
 };
 import { f as getSpanId } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { j as rootSpanIdKey } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
-};
-import { k as rootSpanAttributesStore } from "__TURBOPACK_PART__" assert {
+import { k as rootSpanIdKey } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
+};
+import { j as rootSpanAttributesStore } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
 };
 import { b as LogSpanAllowList } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
 import { r as closeSpanWithError } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+    __turbopack_part__: 17
 };
 import { a as isPromise } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
@@ -1751,13 +1817,25 @@ export { NextTracerImpl as s } from "__TURBOPACK_VAR__" assert {
 };
 
 ```
-## Part 21
+## Part 20
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 20
+    __turbopack_part__: 19
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
 };
 import { s as NextTracerImpl } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 20
+    __turbopack_part__: 19
 };
 const getTracer = (()=>{
     const tracer = new NextTracerImpl();
@@ -1768,15 +1846,35 @@ export { getTracer as t } from "__TURBOPACK_VAR__" assert {
 };
 
 ```
+## Part 21
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+import { t as getTracer } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+export { getTracer };
+
+```
 ## Part 22
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+    __turbopack_part__: 20
 };
-import { t as getTracer } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
 };
-export { getTracer as getTracer };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+"module evaluation";
 
 ```
 ## Part 23
@@ -1801,7 +1899,13 @@ export { getTracer } from "__TURBOPACK_PART__" assert {
 ## Merged (module eval)
 ```js
 import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/node-fetch/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/node-fetch/output.md
@@ -29,6 +29,7 @@ const streamDestructionSupported = 'destroy' in Stream.Readable.prototype;
 
 ```
 
+- Side effects
 - Declares: `streamDestructionSupported`
 - Reads: `Stream`
 - Write: `Stream`, `streamDestructionSupported`
@@ -82,8 +83,10 @@ graph TD
     Item7;
     Item7["export default"];
     Item3 --> Item2;
+    Item3 --> Item1;
     Item5 --> Item4;
     Item5 --> Item1;
+    Item5 --> Item3;
     Item7 --> Item5;
 ```
 # Phase 3
@@ -99,8 +102,10 @@ graph TD
     Item7;
     Item7["export default"];
     Item3 --> Item2;
+    Item3 --> Item1;
     Item5 --> Item4;
     Item5 --> Item1;
+    Item5 --> Item3;
     Item7 --> Item5;
 ```
 # Phase 4
@@ -116,37 +121,43 @@ graph TD
     Item7;
     Item7["export default"];
     Item3 --> Item2;
+    Item3 --> Item1;
     Item5 --> Item4;
     Item5 --> Item1;
+    Item5 --> Item3;
     Item7 --> Item5;
     Item6 --> Item1;
+    Item6 --> Item3;
     Item6 --> Item5;
 ```
 # Final
 ```mermaid
 graph TD
-    N0["Items: [ItemId(0, ImportOfModule)]"];
-    N1["Items: [ItemId(2, Normal)]"];
-    N2["Items: [ItemId(3, Normal)]"];
-    N3["Items: [ItemId(ModuleEvaluation)]"];
-    N4["Items: [ItemId(Export((&quot;__TURBOPACK__default__export__&quot;, #4), &quot;default&quot;))]"];
-    N5["Items: [ItemId(0, ImportBinding(0))]"];
-    N6["Items: [ItemId(1, VarDeclarator(0))]"];
-    N6 --> N5;
-    N2 --> N1;
-    N2 --> N0;
-    N4 --> N2;
-    N3 --> N0;
+    N0["Items: [ItemId(2, Normal)]"];
+    N1["Items: [ItemId(0, ImportOfModule)]"];
+    N2["Items: [ItemId(0, ImportBinding(0))]"];
+    N3["Items: [ItemId(1, VarDeclarator(0))]"];
+    N4["Items: [ItemId(3, Normal)]"];
+    N5["Items: [ItemId(ModuleEvaluation)]"];
+    N6["Items: [ItemId(Export((&quot;__TURBOPACK__default__export__&quot;, #4), &quot;default&quot;))]"];
     N3 --> N2;
+    N3 --> N1;
+    N4 --> N0;
+    N4 --> N1;
+    N4 --> N3;
+    N6 --> N4;
+    N5 --> N1;
+    N5 --> N3;
+    N5 --> N4;
 ```
 # Entrypoints
 
 ```
 {
-    ModuleEvaluation: 3,
+    ModuleEvaluation: 5,
     Export(
         "default",
-    ): 4,
+    ): 6,
     Exports: 7,
 }
 ```
@@ -155,30 +166,21 @@ graph TD
 # Modules (dev)
 ## Part 0
 ```js
-import 'node:stream';
-
-```
-## Part 1
-```js
 function fetch() {}
 export { fetch as a } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
+## Part 1
+```js
+import 'node:stream';
+
+```
 ## Part 2
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
-};
-import { a as fetch } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-const __TURBOPACK__default__export__ = fetch;
-export { __TURBOPACK__default__export__ as b } from "__TURBOPACK_VAR__" assert {
+import Stream from 'node:stream';
+export { Stream as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -186,45 +188,63 @@ export { __TURBOPACK__default__export__ as b } from "__TURBOPACK_VAR__" assert {
 ## Part 3
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-"module evaluation";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+import { b as Stream } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
+const streamDestructionSupported = 'destroy' in Stream.Readable.prototype;
+export { streamDestructionSupported as c } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
 
 ```
 ## Part 4
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: 0
 };
-import { b as __TURBOPACK__default__export__ } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
 };
-export { __TURBOPACK__default__export__ as default };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
+import { a as fetch } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 0
+};
+const __TURBOPACK__default__export__ = fetch;
+export { __TURBOPACK__default__export__ as d } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
 
 ```
 ## Part 5
 ```js
-import Stream from 'node:stream';
-export { Stream as c } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+"module evaluation";
 
 ```
 ## Part 6
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: 4
 };
-import { c as Stream } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+import { d as __TURBOPACK__default__export__ } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
 };
-const streamDestructionSupported = 'destroy' in Stream.Readable.prototype;
-export { streamDestructionSupported as d } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
+export { __TURBOPACK__default__export__ as default };
 
 ```
 ## Part 7
@@ -237,10 +257,13 @@ export { default } from "__TURBOPACK_PART__" assert {
 ## Merged (module eval)
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
+    __turbopack_part__: 1
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: 3
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
 };
 "module evaluation";
 
@@ -249,10 +272,10 @@ import "__TURBOPACK_PART__" assert {
 
 ```
 {
-    ModuleEvaluation: 3,
+    ModuleEvaluation: 5,
     Export(
         "default",
-    ): 4,
+    ): 6,
     Exports: 7,
 }
 ```
@@ -261,30 +284,21 @@ import "__TURBOPACK_PART__" assert {
 # Modules (prod)
 ## Part 0
 ```js
-import 'node:stream';
-
-```
-## Part 1
-```js
 function fetch() {}
 export { fetch as a } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
+## Part 1
+```js
+import 'node:stream';
+
+```
 ## Part 2
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
-};
-import { a as fetch } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-const __TURBOPACK__default__export__ = fetch;
-export { __TURBOPACK__default__export__ as b } from "__TURBOPACK_VAR__" assert {
+import Stream from 'node:stream';
+export { Stream as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -292,45 +306,63 @@ export { __TURBOPACK__default__export__ as b } from "__TURBOPACK_VAR__" assert {
 ## Part 3
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-"module evaluation";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+import { b as Stream } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
+const streamDestructionSupported = 'destroy' in Stream.Readable.prototype;
+export { streamDestructionSupported as c } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
 
 ```
 ## Part 4
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: 0
 };
-import { b as __TURBOPACK__default__export__ } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
 };
-export { __TURBOPACK__default__export__ as default };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
+import { a as fetch } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 0
+};
+const __TURBOPACK__default__export__ = fetch;
+export { __TURBOPACK__default__export__ as d } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
 
 ```
 ## Part 5
 ```js
-import Stream from 'node:stream';
-export { Stream as c } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+"module evaluation";
 
 ```
 ## Part 6
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: 4
 };
-import { c as Stream } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+import { d as __TURBOPACK__default__export__ } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
 };
-const streamDestructionSupported = 'destroy' in Stream.Readable.prototype;
-export { streamDestructionSupported as d } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
+export { __TURBOPACK__default__export__ as default };
 
 ```
 ## Part 7
@@ -343,10 +375,13 @@ export { default } from "__TURBOPACK_PART__" assert {
 ## Merged (module eval)
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
+    __turbopack_part__: 1
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: 3
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
 };
 "module evaluation";
 

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/shared-2/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/shared-2/output.md
@@ -44,6 +44,7 @@ const shared = {
 
 ```
 
+- Side effects
 - Declares: `shared`
 - Reads: `random`, `order`
 - Write: `random`, `order`, `shared`
@@ -212,6 +213,7 @@ graph TD
     Item11 --> Item7;
     Item8 --> Item2;
     Item8 --> Item3;
+    Item8 --> Item4;
     Item8 --> Item5;
 ```
 # Final
@@ -246,6 +248,7 @@ graph TD
     N7 --> N6;
     N9 --> N1;
     N9 --> N2;
+    N9 --> N3;
     N9 --> N8;
 ```
 # Entrypoints
@@ -412,6 +415,9 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
 import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
+import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
 "module evaluation";
@@ -451,6 +457,9 @@ import "__TURBOPACK_PART__" assert {
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
@@ -622,6 +631,9 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
 import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
+import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
 "module evaluation";
@@ -661,6 +673,9 @@ import "__TURBOPACK_PART__" assert {
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/shared-and-side-effects/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/shared-and-side-effects/output.md
@@ -49,9 +49,7 @@ const value3 = externalFunction();
 
 ```
 
-- Side effects
 - Declares: `value3`
-- Write: `value3`
 
 ## Item 6: Stmt 5, `VarDeclarator(0)`
 
@@ -149,10 +147,6 @@ graph TD
     Item4 --> Item1;
     Item4 --> Item2;
     Item4 --> Item3;
-    Item5 --> Item1;
-    Item5 --> Item2;
-    Item5 --> Item3;
-    Item5 --> Item4;
     Item6 --> Item2;
     Item6 --> Item3;
     Item6 --> Item5;
@@ -161,7 +155,6 @@ graph TD
     Item7 --> Item2;
     Item7 --> Item3;
     Item7 --> Item4;
-    Item7 --> Item5;
     Item8 --> Item6;
     Item8 -.-> Item7;
     Item9 --> Item8;
@@ -194,10 +187,6 @@ graph TD
     Item4 --> Item1;
     Item4 --> Item2;
     Item4 --> Item3;
-    Item5 --> Item1;
-    Item5 --> Item2;
-    Item5 --> Item3;
-    Item5 --> Item4;
     Item6 --> Item2;
     Item6 --> Item3;
     Item6 --> Item5;
@@ -206,7 +195,6 @@ graph TD
     Item7 --> Item2;
     Item7 --> Item3;
     Item7 --> Item4;
-    Item7 --> Item5;
     Item8 --> Item6;
     Item8 -.-> Item7;
     Item9 --> Item8;
@@ -239,10 +227,6 @@ graph TD
     Item4 --> Item1;
     Item4 --> Item2;
     Item4 --> Item3;
-    Item5 --> Item1;
-    Item5 --> Item2;
-    Item5 --> Item3;
-    Item5 --> Item4;
     Item6 --> Item2;
     Item6 --> Item3;
     Item6 --> Item5;
@@ -251,7 +235,6 @@ graph TD
     Item7 --> Item2;
     Item7 --> Item3;
     Item7 --> Item4;
-    Item7 --> Item5;
     Item8 --> Item6;
     Item8 -.-> Item7;
     Item9 --> Item8;
@@ -263,55 +246,48 @@ graph TD
     Item10 --> Item2;
     Item10 --> Item3;
     Item10 --> Item4;
-    Item10 --> Item5;
     Item10 --> Item7;
 ```
 # Final
 ```mermaid
 graph TD
-    N0["Items: [ItemId(0, Normal)]"];
-    N1["Items: [ItemId(1, VarDeclarator(0))]"];
-    N2["Items: [ItemId(2, VarDeclarator(0))]"];
-    N3["Items: [ItemId(3, Normal)]"];
-    N4["Items: [ItemId(4, VarDeclarator(0))]"];
-    N5["Items: [ItemId(5, VarDeclarator(0))]"];
+    N0["Items: [ItemId(4, VarDeclarator(0))]"];
+    N1["Items: [ItemId(0, Normal)]"];
+    N2["Items: [ItemId(1, VarDeclarator(0))]"];
+    N3["Items: [ItemId(2, VarDeclarator(0))]"];
+    N4["Items: [ItemId(5, VarDeclarator(0))]"];
+    N5["Items: [ItemId(3, Normal)]"];
     N6["Items: [ItemId(6, Normal)]"];
     N7["Items: [ItemId(ModuleEvaluation)]"];
     N8["Items: [ItemId(7, VarDeclarator(0))]"];
     N9["Items: [ItemId(Export((&quot;a&quot;, #2), &quot;a&quot;))]"];
     N10["Items: [ItemId(8, VarDeclarator(0))]"];
     N11["Items: [ItemId(Export((&quot;b&quot;, #2), &quot;b&quot;))]"];
-    N1 --> N0;
-    N2 --> N0;
     N2 --> N1;
-    N3 --> N0;
     N3 --> N1;
     N3 --> N2;
-    N4 --> N0;
-    N4 --> N1;
-    N4 --> N2;
-    N4 --> N3;
     N5 --> N1;
     N5 --> N2;
-    N5 --> N4;
-    N6 --> N5;
-    N6 --> N0;
+    N5 --> N3;
+    N4 --> N2;
+    N4 --> N3;
+    N4 --> N0;
+    N6 --> N4;
     N6 --> N1;
     N6 --> N2;
     N6 --> N3;
-    N6 --> N4;
-    N8 --> N5;
+    N6 --> N5;
+    N8 --> N4;
     N8 -.-> N6;
     N10 --> N8;
-    N10 --> N5;
+    N10 --> N4;
     N10 -.-> N6;
     N9 --> N8;
     N11 --> N10;
-    N7 --> N0;
     N7 --> N1;
     N7 --> N2;
     N7 --> N3;
-    N7 --> N4;
+    N7 --> N5;
     N7 --> N6;
 ```
 # Entrypoints
@@ -333,30 +309,24 @@ graph TD
 # Modules (dev)
 ## Part 0
 ```js
-console.log("Hello");
+const value3 = externalFunction();
+export { value3 as a } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
 
 ```
 ## Part 1
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
-};
-const value = externalFunction();
-export { value as a } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
+console.log("Hello");
 
 ```
 ## Part 2
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
-const value2 = externalObject.propertyWithGetter;
-export { value2 as b } from "__TURBOPACK_VAR__" assert {
+const value = externalFunction();
+export { value as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -364,33 +334,43 @@ export { value2 as b } from "__TURBOPACK_VAR__" assert {
 ## Part 3
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-externalObject.propertyWithSetter = 42;
+const value2 = externalObject.propertyWithGetter;
+export { value2 as c } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
 
 ```
 ## Part 4
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
-const value3 = externalFunction();
-export { value3 as c } from "__TURBOPACK_VAR__" assert {
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 0
+};
+import { b as value } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
+import { c as value2 } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
+import { a as value3 } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 0
+};
+const shared = {
+    value,
+    value2,
+    value3
+};
+export { shared as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -404,34 +384,15 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+    __turbopack_part__: 3
 };
-import { a as value } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-import { b as value2 } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
-import { c as value3 } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-const shared = {
-    value,
-    value2,
-    value3
-};
-export { shared as d } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
+externalObject.propertyWithSetter = 42;
 
 ```
 ## Part 6
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
+    __turbopack_part__: 4
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
@@ -443,10 +404,10 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+    __turbopack_part__: 5
 };
 import { d as shared } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: 4
 };
 console.log(shared);
 
@@ -454,9 +415,6 @@ console.log(shared);
 ## Part 7
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
 import "__TURBOPACK_PART__" assert {
@@ -466,7 +424,7 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+    __turbopack_part__: 5
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
@@ -477,13 +435,13 @@ import "__TURBOPACK_PART__" assert {
 ## Part 8
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: 4
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
 import { d as shared } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: 4
 };
 const a = {
     shared,
@@ -511,13 +469,13 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: 4
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
 import { d as shared } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: 4
 };
 const b = {
     shared,
@@ -552,9 +510,6 @@ export { b } from "__TURBOPACK_PART__" assert {
 ## Merged (module eval)
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
 import "__TURBOPACK_PART__" assert {
@@ -564,7 +519,7 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+    __turbopack_part__: 5
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
@@ -580,10 +535,10 @@ import "__TURBOPACK_PART__" assert {
     Exports: 12,
     Export(
         "b",
-    ): 9,
+    ): 8,
     Export(
         "a",
-    ): 7,
+    ): 6,
 }
 ```
 
@@ -591,30 +546,24 @@ import "__TURBOPACK_PART__" assert {
 # Modules (prod)
 ## Part 0
 ```js
-console.log("Hello");
+const value3 = externalFunction();
+export { value3 as a } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
 
 ```
 ## Part 1
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
-};
-const value = externalFunction();
-export { value as a } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
+console.log("Hello");
 
 ```
 ## Part 2
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
-const value2 = externalObject.propertyWithGetter;
-export { value2 as b } from "__TURBOPACK_VAR__" assert {
+const value = externalFunction();
+export { value as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -622,56 +571,36 @@ export { value2 as b } from "__TURBOPACK_VAR__" assert {
 ## Part 3
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-externalObject.propertyWithSetter = 42;
+const value2 = externalObject.propertyWithGetter;
+export { value2 as c } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
 
 ```
 ## Part 4
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
-const value3 = externalFunction();
-export { value3 as c } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 5
-```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+    __turbopack_part__: 0
 };
-import "__TURBOPACK_PART__" assert {
+import { b as value } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+import { c as value2 } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
-import { a as value } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-import { b as value2 } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
-};
-import { c as value3 } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+import { a as value3 } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 0
 };
 const shared = {
     value,
@@ -683,13 +612,13 @@ export { shared as d } from "__TURBOPACK_VAR__" assert {
 };
 
 ```
-## Part 6
+## Part 5
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: 4
 };
 import { d as shared } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: 4
 };
 const a = {
     shared,
@@ -700,27 +629,27 @@ export { a as e } from "__TURBOPACK_VAR__" assert {
 };
 
 ```
-## Part 7
+## Part 6
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: 5
 };
 import { e as a } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: 5
 };
 export { a };
 
 ```
-## Part 8
+## Part 7
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: 5
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: 4
 };
 import { d as shared } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: 4
 };
 const b = {
     shared,
@@ -731,24 +660,35 @@ export { b as f } from "__TURBOPACK_VAR__" assert {
 };
 
 ```
+## Part 8
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import { f as b } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+export { b };
+
+```
 ## Part 9
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
+    __turbopack_part__: 1
 };
-import { f as b } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
 };
-export { b };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
+externalObject.propertyWithSetter = 42;
 
 ```
 ## Part 10
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
+    __turbopack_part__: 4
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
@@ -760,10 +700,10 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+    __turbopack_part__: 9
 };
 import { d as shared } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: 4
 };
 console.log(shared);
 
@@ -774,10 +714,7 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
+    __turbopack_part__: 9
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
@@ -807,10 +744,7 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
+    __turbopack_part__: 9
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/shared-regression/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/shared-regression/output.md
@@ -44,6 +44,7 @@ const shared = {
 
 ```
 
+- Side effects
 - Declares: `shared`
 - Reads: `random`, `order`
 - Write: `random`, `order`, `shared`
@@ -212,6 +213,7 @@ graph TD
     Item11 --> Item7;
     Item8 --> Item2;
     Item8 --> Item3;
+    Item8 --> Item4;
     Item8 --> Item5;
 ```
 # Final
@@ -246,6 +248,7 @@ graph TD
     N7 --> N6;
     N9 --> N1;
     N9 --> N2;
+    N9 --> N3;
     N9 --> N8;
 ```
 # Entrypoints
@@ -412,6 +415,9 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
 import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
+import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
 "module evaluation";
@@ -451,6 +457,9 @@ import "__TURBOPACK_PART__" assert {
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
@@ -622,6 +631,9 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
 import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
+import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
 "module evaluation";
@@ -661,6 +673,9 @@ import "__TURBOPACK_PART__" assert {
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/simple-vars-1/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/simple-vars-1/output.md
@@ -120,7 +120,7 @@ import "__TURBOPACK_PART__" assert {
 import { a as b } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
 };
-export { b as b };
+export { b };
 
 ```
 ## Part 2
@@ -139,7 +139,7 @@ import "__TURBOPACK_PART__" assert {
 import { b as a } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-export { a as a };
+export { a };
 
 ```
 ## Part 4
@@ -195,7 +195,7 @@ import "__TURBOPACK_PART__" assert {
 import { a as b } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
 };
-export { b as b };
+export { b };
 
 ```
 ## Part 2
@@ -214,7 +214,7 @@ import "__TURBOPACK_PART__" assert {
 import { b as a } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-export { a as a };
+export { a };
 
 ```
 ## Part 4

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/template-pages/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/template-pages/output.md
@@ -141,6 +141,7 @@ export const getStaticProps = hoist(userland, 'getStaticProps');
 
 ```
 
+- Side effects
 - Declares: `getStaticProps`
 - Reads: `hoist`, `userland`
 - Write: `getStaticProps`
@@ -152,6 +153,7 @@ export const getStaticPaths = hoist(userland, 'getStaticPaths');
 
 ```
 
+- Side effects
 - Declares: `getStaticPaths`
 - Reads: `hoist`, `userland`
 - Write: `getStaticPaths`
@@ -163,6 +165,7 @@ export const getServerSideProps = hoist(userland, 'getServerSideProps');
 
 ```
 
+- Side effects
 - Declares: `getServerSideProps`
 - Reads: `hoist`, `userland`
 - Write: `getServerSideProps`
@@ -174,6 +177,7 @@ export const config = hoist(userland, 'config');
 
 ```
 
+- Side effects
 - Declares: `config`
 - Reads: `hoist`, `userland`
 - Write: `config`
@@ -185,6 +189,7 @@ export const reportWebVitals = hoist(userland, 'reportWebVitals');
 
 ```
 
+- Side effects
 - Declares: `reportWebVitals`
 - Reads: `hoist`, `userland`
 - Write: `reportWebVitals`
@@ -196,6 +201,7 @@ export const unstable_getStaticProps = hoist(userland, 'unstable_getStaticProps'
 
 ```
 
+- Side effects
 - Declares: `unstable_getStaticProps`
 - Reads: `hoist`, `userland`
 - Write: `unstable_getStaticProps`
@@ -207,6 +213,7 @@ export const unstable_getStaticPaths = hoist(userland, 'unstable_getStaticPaths'
 
 ```
 
+- Side effects
 - Declares: `unstable_getStaticPaths`
 - Reads: `hoist`, `userland`
 - Write: `unstable_getStaticPaths`
@@ -218,6 +225,7 @@ export const unstable_getStaticParams = hoist(userland, 'unstable_getStaticParam
 
 ```
 
+- Side effects
 - Declares: `unstable_getStaticParams`
 - Reads: `hoist`, `userland`
 - Write: `unstable_getStaticParams`
@@ -229,6 +237,7 @@ export const unstable_getServerProps = hoist(userland, 'unstable_getServerProps'
 
 ```
 
+- Side effects
 - Declares: `unstable_getServerProps`
 - Reads: `hoist`, `userland`
 - Write: `unstable_getServerProps`
@@ -240,6 +249,7 @@ export const unstable_getServerSideProps = hoist(userland, 'unstable_getServerSi
 
 ```
 
+- Side effects
 - Declares: `unstable_getServerSideProps`
 - Reads: `hoist`, `userland`
 - Write: `unstable_getServerSideProps`
@@ -264,6 +274,7 @@ export const routeModule = new PagesRouteModule({
 
 ```
 
+- Side effects
 - Declares: `routeModule`
 - Reads: `PagesRouteModule`, `RouteKind`, `App`, `Document`, `userland`
 - Write: `RouteKind`, `App`, `Document`, `userland`, `routeModule`
@@ -415,40 +426,161 @@ graph TD
     Item13 --> Item6;
     Item14 --> Item9;
     Item14 --> Item12;
+    Item14 --> Item1;
+    Item14 --> Item2;
+    Item14 --> Item3;
+    Item14 --> Item4;
+    Item14 --> Item5;
+    Item14 --> Item6;
+    Item14 --> Item13;
     Item15 --> Item9;
     Item15 --> Item12;
+    Item15 --> Item1;
+    Item15 --> Item2;
+    Item15 --> Item3;
+    Item15 --> Item4;
+    Item15 --> Item5;
+    Item15 --> Item6;
+    Item15 --> Item13;
+    Item15 --> Item14;
     Item16 --> Item9;
     Item16 --> Item12;
+    Item16 --> Item1;
+    Item16 --> Item2;
+    Item16 --> Item3;
+    Item16 --> Item4;
+    Item16 --> Item5;
+    Item16 --> Item6;
+    Item16 --> Item13;
+    Item16 --> Item14;
+    Item16 --> Item15;
     Item17 --> Item9;
     Item17 --> Item12;
+    Item17 --> Item1;
+    Item17 --> Item2;
+    Item17 --> Item3;
+    Item17 --> Item4;
+    Item17 --> Item5;
+    Item17 --> Item6;
+    Item17 --> Item13;
+    Item17 --> Item14;
+    Item17 --> Item15;
+    Item17 --> Item16;
     Item18 --> Item9;
     Item18 --> Item12;
+    Item18 --> Item1;
+    Item18 --> Item2;
+    Item18 --> Item3;
+    Item18 --> Item4;
+    Item18 --> Item5;
+    Item18 --> Item6;
+    Item18 --> Item13;
+    Item18 --> Item14;
+    Item18 --> Item15;
+    Item18 --> Item16;
+    Item18 --> Item17;
     Item19 --> Item9;
     Item19 --> Item12;
+    Item19 --> Item1;
+    Item19 --> Item2;
+    Item19 --> Item3;
+    Item19 --> Item4;
+    Item19 --> Item5;
+    Item19 --> Item6;
+    Item19 --> Item13;
+    Item19 --> Item14;
+    Item19 --> Item15;
+    Item19 --> Item16;
+    Item19 --> Item17;
+    Item19 --> Item18;
     Item20 --> Item9;
     Item20 --> Item12;
+    Item20 --> Item1;
+    Item20 --> Item2;
+    Item20 --> Item3;
+    Item20 --> Item4;
+    Item20 --> Item5;
+    Item20 --> Item6;
+    Item20 --> Item13;
+    Item20 --> Item14;
+    Item20 --> Item15;
+    Item20 --> Item16;
+    Item20 --> Item17;
+    Item20 --> Item18;
+    Item20 --> Item19;
     Item21 --> Item9;
     Item21 --> Item12;
+    Item21 --> Item1;
+    Item21 --> Item2;
+    Item21 --> Item3;
+    Item21 --> Item4;
+    Item21 --> Item5;
+    Item21 --> Item6;
+    Item21 --> Item13;
+    Item21 --> Item14;
+    Item21 --> Item15;
+    Item21 --> Item16;
+    Item21 --> Item17;
+    Item21 --> Item18;
+    Item21 --> Item19;
+    Item21 --> Item20;
     Item22 --> Item9;
     Item22 --> Item12;
+    Item22 --> Item1;
+    Item22 --> Item2;
+    Item22 --> Item3;
+    Item22 --> Item4;
+    Item22 --> Item5;
+    Item22 --> Item6;
+    Item22 --> Item13;
+    Item22 --> Item14;
+    Item22 --> Item15;
+    Item22 --> Item16;
+    Item22 --> Item17;
+    Item22 --> Item18;
+    Item22 --> Item19;
+    Item22 --> Item20;
+    Item22 --> Item21;
     Item23 --> Item9;
     Item23 --> Item12;
+    Item23 --> Item1;
+    Item23 --> Item2;
+    Item23 --> Item3;
+    Item23 --> Item4;
+    Item23 --> Item5;
+    Item23 --> Item6;
+    Item23 --> Item13;
+    Item23 --> Item14;
+    Item23 --> Item15;
+    Item23 --> Item16;
+    Item23 --> Item17;
+    Item23 --> Item18;
+    Item23 --> Item19;
+    Item23 --> Item20;
+    Item23 --> Item21;
+    Item23 --> Item22;
     Item24 --> Item7;
     Item24 --> Item8;
     Item24 --> Item11;
     Item24 --> Item10;
     Item24 --> Item12;
-    Item24 -.-> Item13;
-    Item24 -.-> Item14;
-    Item24 -.-> Item15;
-    Item24 -.-> Item16;
-    Item24 -.-> Item17;
-    Item24 -.-> Item18;
-    Item24 -.-> Item19;
-    Item24 -.-> Item20;
-    Item24 -.-> Item21;
-    Item24 -.-> Item22;
-    Item24 -.-> Item23;
+    Item24 --> Item23;
+    Item24 --> Item1;
+    Item24 --> Item2;
+    Item24 --> Item3;
+    Item24 --> Item4;
+    Item24 --> Item5;
+    Item24 --> Item6;
+    Item24 --> Item13;
+    Item24 --> Item14;
+    Item24 --> Item15;
+    Item24 --> Item16;
+    Item24 --> Item17;
+    Item24 --> Item18;
+    Item24 --> Item19;
+    Item24 --> Item20;
+    Item24 --> Item21;
+    Item24 --> Item22;
     Item26 --> Item13;
     Item27 --> Item14;
     Item28 --> Item15;
@@ -540,40 +672,161 @@ graph TD
     Item13 --> Item6;
     Item14 --> Item9;
     Item14 --> Item12;
+    Item14 --> Item1;
+    Item14 --> Item2;
+    Item14 --> Item3;
+    Item14 --> Item4;
+    Item14 --> Item5;
+    Item14 --> Item6;
+    Item14 --> Item13;
     Item15 --> Item9;
     Item15 --> Item12;
+    Item15 --> Item1;
+    Item15 --> Item2;
+    Item15 --> Item3;
+    Item15 --> Item4;
+    Item15 --> Item5;
+    Item15 --> Item6;
+    Item15 --> Item13;
+    Item15 --> Item14;
     Item16 --> Item9;
     Item16 --> Item12;
+    Item16 --> Item1;
+    Item16 --> Item2;
+    Item16 --> Item3;
+    Item16 --> Item4;
+    Item16 --> Item5;
+    Item16 --> Item6;
+    Item16 --> Item13;
+    Item16 --> Item14;
+    Item16 --> Item15;
     Item17 --> Item9;
     Item17 --> Item12;
+    Item17 --> Item1;
+    Item17 --> Item2;
+    Item17 --> Item3;
+    Item17 --> Item4;
+    Item17 --> Item5;
+    Item17 --> Item6;
+    Item17 --> Item13;
+    Item17 --> Item14;
+    Item17 --> Item15;
+    Item17 --> Item16;
     Item18 --> Item9;
     Item18 --> Item12;
+    Item18 --> Item1;
+    Item18 --> Item2;
+    Item18 --> Item3;
+    Item18 --> Item4;
+    Item18 --> Item5;
+    Item18 --> Item6;
+    Item18 --> Item13;
+    Item18 --> Item14;
+    Item18 --> Item15;
+    Item18 --> Item16;
+    Item18 --> Item17;
     Item19 --> Item9;
     Item19 --> Item12;
+    Item19 --> Item1;
+    Item19 --> Item2;
+    Item19 --> Item3;
+    Item19 --> Item4;
+    Item19 --> Item5;
+    Item19 --> Item6;
+    Item19 --> Item13;
+    Item19 --> Item14;
+    Item19 --> Item15;
+    Item19 --> Item16;
+    Item19 --> Item17;
+    Item19 --> Item18;
     Item20 --> Item9;
     Item20 --> Item12;
+    Item20 --> Item1;
+    Item20 --> Item2;
+    Item20 --> Item3;
+    Item20 --> Item4;
+    Item20 --> Item5;
+    Item20 --> Item6;
+    Item20 --> Item13;
+    Item20 --> Item14;
+    Item20 --> Item15;
+    Item20 --> Item16;
+    Item20 --> Item17;
+    Item20 --> Item18;
+    Item20 --> Item19;
     Item21 --> Item9;
     Item21 --> Item12;
+    Item21 --> Item1;
+    Item21 --> Item2;
+    Item21 --> Item3;
+    Item21 --> Item4;
+    Item21 --> Item5;
+    Item21 --> Item6;
+    Item21 --> Item13;
+    Item21 --> Item14;
+    Item21 --> Item15;
+    Item21 --> Item16;
+    Item21 --> Item17;
+    Item21 --> Item18;
+    Item21 --> Item19;
+    Item21 --> Item20;
     Item22 --> Item9;
     Item22 --> Item12;
+    Item22 --> Item1;
+    Item22 --> Item2;
+    Item22 --> Item3;
+    Item22 --> Item4;
+    Item22 --> Item5;
+    Item22 --> Item6;
+    Item22 --> Item13;
+    Item22 --> Item14;
+    Item22 --> Item15;
+    Item22 --> Item16;
+    Item22 --> Item17;
+    Item22 --> Item18;
+    Item22 --> Item19;
+    Item22 --> Item20;
+    Item22 --> Item21;
     Item23 --> Item9;
     Item23 --> Item12;
+    Item23 --> Item1;
+    Item23 --> Item2;
+    Item23 --> Item3;
+    Item23 --> Item4;
+    Item23 --> Item5;
+    Item23 --> Item6;
+    Item23 --> Item13;
+    Item23 --> Item14;
+    Item23 --> Item15;
+    Item23 --> Item16;
+    Item23 --> Item17;
+    Item23 --> Item18;
+    Item23 --> Item19;
+    Item23 --> Item20;
+    Item23 --> Item21;
+    Item23 --> Item22;
     Item24 --> Item7;
     Item24 --> Item8;
     Item24 --> Item11;
     Item24 --> Item10;
     Item24 --> Item12;
-    Item24 -.-> Item13;
-    Item24 -.-> Item14;
-    Item24 -.-> Item15;
-    Item24 -.-> Item16;
-    Item24 -.-> Item17;
-    Item24 -.-> Item18;
-    Item24 -.-> Item19;
-    Item24 -.-> Item20;
-    Item24 -.-> Item21;
-    Item24 -.-> Item22;
-    Item24 -.-> Item23;
+    Item24 --> Item23;
+    Item24 --> Item1;
+    Item24 --> Item2;
+    Item24 --> Item3;
+    Item24 --> Item4;
+    Item24 --> Item5;
+    Item24 --> Item6;
+    Item24 --> Item13;
+    Item24 --> Item14;
+    Item24 --> Item15;
+    Item24 --> Item16;
+    Item24 --> Item17;
+    Item24 --> Item18;
+    Item24 --> Item19;
+    Item24 --> Item20;
+    Item24 --> Item21;
+    Item24 --> Item22;
     Item26 --> Item13;
     Item27 --> Item14;
     Item28 --> Item15;
@@ -665,40 +918,161 @@ graph TD
     Item13 --> Item6;
     Item14 --> Item9;
     Item14 --> Item12;
+    Item14 --> Item1;
+    Item14 --> Item2;
+    Item14 --> Item3;
+    Item14 --> Item4;
+    Item14 --> Item5;
+    Item14 --> Item6;
+    Item14 --> Item13;
     Item15 --> Item9;
     Item15 --> Item12;
+    Item15 --> Item1;
+    Item15 --> Item2;
+    Item15 --> Item3;
+    Item15 --> Item4;
+    Item15 --> Item5;
+    Item15 --> Item6;
+    Item15 --> Item13;
+    Item15 --> Item14;
     Item16 --> Item9;
     Item16 --> Item12;
+    Item16 --> Item1;
+    Item16 --> Item2;
+    Item16 --> Item3;
+    Item16 --> Item4;
+    Item16 --> Item5;
+    Item16 --> Item6;
+    Item16 --> Item13;
+    Item16 --> Item14;
+    Item16 --> Item15;
     Item17 --> Item9;
     Item17 --> Item12;
+    Item17 --> Item1;
+    Item17 --> Item2;
+    Item17 --> Item3;
+    Item17 --> Item4;
+    Item17 --> Item5;
+    Item17 --> Item6;
+    Item17 --> Item13;
+    Item17 --> Item14;
+    Item17 --> Item15;
+    Item17 --> Item16;
     Item18 --> Item9;
     Item18 --> Item12;
+    Item18 --> Item1;
+    Item18 --> Item2;
+    Item18 --> Item3;
+    Item18 --> Item4;
+    Item18 --> Item5;
+    Item18 --> Item6;
+    Item18 --> Item13;
+    Item18 --> Item14;
+    Item18 --> Item15;
+    Item18 --> Item16;
+    Item18 --> Item17;
     Item19 --> Item9;
     Item19 --> Item12;
+    Item19 --> Item1;
+    Item19 --> Item2;
+    Item19 --> Item3;
+    Item19 --> Item4;
+    Item19 --> Item5;
+    Item19 --> Item6;
+    Item19 --> Item13;
+    Item19 --> Item14;
+    Item19 --> Item15;
+    Item19 --> Item16;
+    Item19 --> Item17;
+    Item19 --> Item18;
     Item20 --> Item9;
     Item20 --> Item12;
+    Item20 --> Item1;
+    Item20 --> Item2;
+    Item20 --> Item3;
+    Item20 --> Item4;
+    Item20 --> Item5;
+    Item20 --> Item6;
+    Item20 --> Item13;
+    Item20 --> Item14;
+    Item20 --> Item15;
+    Item20 --> Item16;
+    Item20 --> Item17;
+    Item20 --> Item18;
+    Item20 --> Item19;
     Item21 --> Item9;
     Item21 --> Item12;
+    Item21 --> Item1;
+    Item21 --> Item2;
+    Item21 --> Item3;
+    Item21 --> Item4;
+    Item21 --> Item5;
+    Item21 --> Item6;
+    Item21 --> Item13;
+    Item21 --> Item14;
+    Item21 --> Item15;
+    Item21 --> Item16;
+    Item21 --> Item17;
+    Item21 --> Item18;
+    Item21 --> Item19;
+    Item21 --> Item20;
     Item22 --> Item9;
     Item22 --> Item12;
+    Item22 --> Item1;
+    Item22 --> Item2;
+    Item22 --> Item3;
+    Item22 --> Item4;
+    Item22 --> Item5;
+    Item22 --> Item6;
+    Item22 --> Item13;
+    Item22 --> Item14;
+    Item22 --> Item15;
+    Item22 --> Item16;
+    Item22 --> Item17;
+    Item22 --> Item18;
+    Item22 --> Item19;
+    Item22 --> Item20;
+    Item22 --> Item21;
     Item23 --> Item9;
     Item23 --> Item12;
+    Item23 --> Item1;
+    Item23 --> Item2;
+    Item23 --> Item3;
+    Item23 --> Item4;
+    Item23 --> Item5;
+    Item23 --> Item6;
+    Item23 --> Item13;
+    Item23 --> Item14;
+    Item23 --> Item15;
+    Item23 --> Item16;
+    Item23 --> Item17;
+    Item23 --> Item18;
+    Item23 --> Item19;
+    Item23 --> Item20;
+    Item23 --> Item21;
+    Item23 --> Item22;
     Item24 --> Item7;
     Item24 --> Item8;
     Item24 --> Item11;
     Item24 --> Item10;
     Item24 --> Item12;
-    Item24 -.-> Item13;
-    Item24 -.-> Item14;
-    Item24 -.-> Item15;
-    Item24 -.-> Item16;
-    Item24 -.-> Item17;
-    Item24 -.-> Item18;
-    Item24 -.-> Item19;
-    Item24 -.-> Item20;
-    Item24 -.-> Item21;
-    Item24 -.-> Item22;
-    Item24 -.-> Item23;
+    Item24 --> Item23;
+    Item24 --> Item1;
+    Item24 --> Item2;
+    Item24 --> Item3;
+    Item24 --> Item4;
+    Item24 --> Item5;
+    Item24 --> Item6;
+    Item24 --> Item13;
+    Item24 --> Item14;
+    Item24 --> Item15;
+    Item24 --> Item16;
+    Item24 --> Item17;
+    Item24 --> Item18;
+    Item24 --> Item19;
+    Item24 --> Item20;
+    Item24 --> Item21;
+    Item24 --> Item22;
     Item26 --> Item13;
     Item27 --> Item14;
     Item28 --> Item15;
@@ -718,6 +1092,17 @@ graph TD
     Item25 --> Item5;
     Item25 --> Item6;
     Item25 --> Item13;
+    Item25 --> Item14;
+    Item25 --> Item15;
+    Item25 --> Item16;
+    Item25 --> Item17;
+    Item25 --> Item18;
+    Item25 --> Item19;
+    Item25 --> Item20;
+    Item25 --> Item21;
+    Item25 --> Item22;
+    Item25 --> Item23;
+    Item25 --> Item24;
 ```
 # Final
 ```mermaid
@@ -728,158 +1113,290 @@ graph TD
     N3["Items: [ItemId(0, ImportBinding(0))]"];
     N4["Items: [ItemId(5, ImportBinding(0))]"];
     N5["Items: [ItemId(2, ImportBinding(0))]"];
-    N6["Items: [ItemId(16, VarDeclarator(0))]"];
-    N7["Items: [ItemId(Export((&quot;unstable_getServerSideProps&quot;, #2), &quot;unstable_getServerSideProps&quot;))]"];
-    N8["Items: [ItemId(15, VarDeclarator(0))]"];
-    N9["Items: [ItemId(Export((&quot;unstable_getServerProps&quot;, #2), &quot;unstable_getServerProps&quot;))]"];
-    N10["Items: [ItemId(14, VarDeclarator(0))]"];
-    N11["Items: [ItemId(Export((&quot;unstable_getStaticParams&quot;, #2), &quot;unstable_getStaticParams&quot;))]"];
-    N12["Items: [ItemId(13, VarDeclarator(0))]"];
-    N13["Items: [ItemId(Export((&quot;unstable_getStaticPaths&quot;, #2), &quot;unstable_getStaticPaths&quot;))]"];
-    N14["Items: [ItemId(12, VarDeclarator(0))]"];
-    N15["Items: [ItemId(Export((&quot;unstable_getStaticProps&quot;, #2), &quot;unstable_getStaticProps&quot;))]"];
-    N16["Items: [ItemId(11, VarDeclarator(0))]"];
-    N17["Items: [ItemId(Export((&quot;reportWebVitals&quot;, #2), &quot;reportWebVitals&quot;))]"];
-    N18["Items: [ItemId(10, VarDeclarator(0))]"];
-    N19["Items: [ItemId(Export((&quot;config&quot;, #2), &quot;config&quot;))]"];
-    N20["Items: [ItemId(9, VarDeclarator(0))]"];
-    N21["Items: [ItemId(Export((&quot;getServerSideProps&quot;, #2), &quot;getServerSideProps&quot;))]"];
-    N22["Items: [ItemId(8, VarDeclarator(0))]"];
-    N23["Items: [ItemId(Export((&quot;getStaticPaths&quot;, #2), &quot;getStaticPaths&quot;))]"];
-    N24["Items: [ItemId(7, VarDeclarator(0))]"];
-    N25["Items: [ItemId(Export((&quot;getStaticProps&quot;, #2), &quot;getStaticProps&quot;))]"];
-    N26["Items: [ItemId(0, ImportOfModule)]"];
-    N27["Items: [ItemId(1, ImportOfModule)]"];
-    N28["Items: [ItemId(2, ImportOfModule)]"];
-    N29["Items: [ItemId(3, ImportOfModule)]"];
-    N30["Items: [ItemId(4, ImportOfModule)]"];
-    N31["Items: [ItemId(5, ImportOfModule)]"];
-    N32["Items: [ItemId(6, Normal)]"];
-    N33["Items: [ItemId(ModuleEvaluation)]"];
-    N34["Items: [ItemId(Export((&quot;__TURBOPACK__default__export__&quot;, #3), &quot;default&quot;))]"];
-    N35["Items: [ItemId(17, VarDeclarator(0))]"];
+    N6["Items: [ItemId(0, ImportOfModule)]"];
+    N7["Items: [ItemId(1, ImportOfModule)]"];
+    N8["Items: [ItemId(2, ImportOfModule)]"];
+    N9["Items: [ItemId(3, ImportOfModule)]"];
+    N10["Items: [ItemId(4, ImportOfModule)]"];
+    N11["Items: [ItemId(5, ImportOfModule)]"];
+    N12["Items: [ItemId(6, Normal)]"];
+    N13["Items: [ItemId(Export((&quot;__TURBOPACK__default__export__&quot;, #3), &quot;default&quot;))]"];
+    N14["Items: [ItemId(7, VarDeclarator(0))]"];
+    N15["Items: [ItemId(Export((&quot;getStaticProps&quot;, #2), &quot;getStaticProps&quot;))]"];
+    N16["Items: [ItemId(8, VarDeclarator(0))]"];
+    N17["Items: [ItemId(Export((&quot;getStaticPaths&quot;, #2), &quot;getStaticPaths&quot;))]"];
+    N18["Items: [ItemId(9, VarDeclarator(0))]"];
+    N19["Items: [ItemId(Export((&quot;getServerSideProps&quot;, #2), &quot;getServerSideProps&quot;))]"];
+    N20["Items: [ItemId(10, VarDeclarator(0))]"];
+    N21["Items: [ItemId(Export((&quot;config&quot;, #2), &quot;config&quot;))]"];
+    N22["Items: [ItemId(11, VarDeclarator(0))]"];
+    N23["Items: [ItemId(Export((&quot;reportWebVitals&quot;, #2), &quot;reportWebVitals&quot;))]"];
+    N24["Items: [ItemId(12, VarDeclarator(0))]"];
+    N25["Items: [ItemId(Export((&quot;unstable_getStaticProps&quot;, #2), &quot;unstable_getStaticProps&quot;))]"];
+    N26["Items: [ItemId(13, VarDeclarator(0))]"];
+    N27["Items: [ItemId(Export((&quot;unstable_getStaticPaths&quot;, #2), &quot;unstable_getStaticPaths&quot;))]"];
+    N28["Items: [ItemId(14, VarDeclarator(0))]"];
+    N29["Items: [ItemId(Export((&quot;unstable_getStaticParams&quot;, #2), &quot;unstable_getStaticParams&quot;))]"];
+    N30["Items: [ItemId(15, VarDeclarator(0))]"];
+    N31["Items: [ItemId(Export((&quot;unstable_getServerProps&quot;, #2), &quot;unstable_getServerProps&quot;))]"];
+    N32["Items: [ItemId(16, VarDeclarator(0))]"];
+    N33["Items: [ItemId(Export((&quot;unstable_getServerSideProps&quot;, #2), &quot;unstable_getServerSideProps&quot;))]"];
+    N34["Items: [ItemId(17, VarDeclarator(0))]"];
+    N35["Items: [ItemId(ModuleEvaluation)]"];
     N36["Items: [ItemId(Export((&quot;routeModule&quot;, #2), &quot;routeModule&quot;))]"];
-    N27 --> N26;
-    N28 --> N26;
-    N28 --> N27;
-    N29 --> N26;
-    N29 --> N27;
-    N29 --> N28;
-    N30 --> N26;
-    N30 --> N27;
-    N30 --> N28;
-    N30 --> N29;
-    N31 --> N26;
-    N31 --> N27;
-    N31 --> N28;
-    N31 --> N29;
-    N31 --> N30;
-    N32 --> N5;
-    N32 --> N4;
-    N32 --> N26;
-    N32 --> N27;
-    N32 --> N28;
-    N32 --> N29;
-    N32 --> N30;
-    N32 --> N31;
-    N24 --> N5;
-    N24 --> N4;
-    N22 --> N5;
-    N22 --> N4;
-    N20 --> N5;
-    N20 --> N4;
-    N18 --> N5;
-    N18 --> N4;
-    N16 --> N5;
-    N16 --> N4;
-    N14 --> N5;
-    N14 --> N4;
+    N7 --> N6;
+    N8 --> N6;
+    N8 --> N7;
+    N9 --> N6;
+    N9 --> N7;
+    N9 --> N8;
+    N10 --> N6;
+    N10 --> N7;
+    N10 --> N8;
+    N10 --> N9;
+    N11 --> N6;
+    N11 --> N7;
+    N11 --> N8;
+    N11 --> N9;
+    N11 --> N10;
     N12 --> N5;
     N12 --> N4;
-    N10 --> N5;
-    N10 --> N4;
-    N8 --> N5;
-    N8 --> N4;
-    N6 --> N5;
-    N6 --> N4;
-    N35 --> N3;
-    N35 --> N2;
-    N35 --> N1;
-    N35 --> N0;
-    N35 --> N4;
-    N35 -.-> N32;
-    N35 -.-> N24;
-    N35 -.-> N22;
-    N35 -.-> N20;
-    N35 -.-> N18;
-    N35 -.-> N16;
-    N35 -.-> N14;
-    N35 -.-> N12;
-    N35 -.-> N10;
-    N35 -.-> N8;
-    N35 -.-> N6;
+    N12 --> N6;
+    N12 --> N7;
+    N12 --> N8;
+    N12 --> N9;
+    N12 --> N10;
+    N12 --> N11;
+    N14 --> N5;
+    N14 --> N4;
+    N14 --> N6;
+    N14 --> N7;
+    N14 --> N8;
+    N14 --> N9;
+    N14 --> N10;
+    N14 --> N11;
+    N14 --> N12;
+    N16 --> N5;
+    N16 --> N4;
+    N16 --> N6;
+    N16 --> N7;
+    N16 --> N8;
+    N16 --> N9;
+    N16 --> N10;
+    N16 --> N11;
+    N16 --> N12;
+    N16 --> N14;
+    N18 --> N5;
+    N18 --> N4;
+    N18 --> N6;
+    N18 --> N7;
+    N18 --> N8;
+    N18 --> N9;
+    N18 --> N10;
+    N18 --> N11;
+    N18 --> N12;
+    N18 --> N14;
+    N18 --> N16;
+    N20 --> N5;
+    N20 --> N4;
+    N20 --> N6;
+    N20 --> N7;
+    N20 --> N8;
+    N20 --> N9;
+    N20 --> N10;
+    N20 --> N11;
+    N20 --> N12;
+    N20 --> N14;
+    N20 --> N16;
+    N20 --> N18;
+    N22 --> N5;
+    N22 --> N4;
+    N22 --> N6;
+    N22 --> N7;
+    N22 --> N8;
+    N22 --> N9;
+    N22 --> N10;
+    N22 --> N11;
+    N22 --> N12;
+    N22 --> N14;
+    N22 --> N16;
+    N22 --> N18;
+    N22 --> N20;
+    N24 --> N5;
+    N24 --> N4;
+    N24 --> N6;
+    N24 --> N7;
+    N24 --> N8;
+    N24 --> N9;
+    N24 --> N10;
+    N24 --> N11;
+    N24 --> N12;
+    N24 --> N14;
+    N24 --> N16;
+    N24 --> N18;
+    N24 --> N20;
+    N24 --> N22;
+    N26 --> N5;
+    N26 --> N4;
+    N26 --> N6;
+    N26 --> N7;
+    N26 --> N8;
+    N26 --> N9;
+    N26 --> N10;
+    N26 --> N11;
+    N26 --> N12;
+    N26 --> N14;
+    N26 --> N16;
+    N26 --> N18;
+    N26 --> N20;
+    N26 --> N22;
+    N26 --> N24;
+    N28 --> N5;
+    N28 --> N4;
+    N28 --> N6;
+    N28 --> N7;
+    N28 --> N8;
+    N28 --> N9;
+    N28 --> N10;
+    N28 --> N11;
+    N28 --> N12;
+    N28 --> N14;
+    N28 --> N16;
+    N28 --> N18;
+    N28 --> N20;
+    N28 --> N22;
+    N28 --> N24;
+    N28 --> N26;
+    N30 --> N5;
+    N30 --> N4;
+    N30 --> N6;
+    N30 --> N7;
+    N30 --> N8;
+    N30 --> N9;
+    N30 --> N10;
+    N30 --> N11;
+    N30 --> N12;
+    N30 --> N14;
+    N30 --> N16;
+    N30 --> N18;
+    N30 --> N20;
+    N30 --> N22;
+    N30 --> N24;
+    N30 --> N26;
+    N30 --> N28;
+    N32 --> N5;
+    N32 --> N4;
+    N32 --> N6;
+    N32 --> N7;
+    N32 --> N8;
+    N32 --> N9;
+    N32 --> N10;
+    N32 --> N11;
+    N32 --> N12;
+    N32 --> N14;
+    N32 --> N16;
+    N32 --> N18;
+    N32 --> N20;
+    N32 --> N22;
+    N32 --> N24;
+    N32 --> N26;
+    N32 --> N28;
+    N32 --> N30;
+    N34 --> N3;
+    N34 --> N2;
+    N34 --> N1;
+    N34 --> N0;
+    N34 --> N4;
     N34 --> N32;
-    N25 --> N24;
-    N23 --> N22;
-    N21 --> N20;
-    N19 --> N18;
-    N17 --> N16;
-    N15 --> N14;
+    N34 --> N6;
+    N34 --> N7;
+    N34 --> N8;
+    N34 --> N9;
+    N34 --> N10;
+    N34 --> N11;
+    N34 --> N12;
+    N34 --> N14;
+    N34 --> N16;
+    N34 --> N18;
+    N34 --> N20;
+    N34 --> N22;
+    N34 --> N24;
+    N34 --> N26;
+    N34 --> N28;
+    N34 --> N30;
     N13 --> N12;
-    N11 --> N10;
-    N9 --> N8;
-    N7 --> N6;
-    N36 --> N35;
-    N33 --> N26;
-    N33 --> N27;
-    N33 --> N28;
-    N33 --> N29;
-    N33 --> N30;
-    N33 --> N31;
+    N15 --> N14;
+    N17 --> N16;
+    N19 --> N18;
+    N21 --> N20;
+    N23 --> N22;
+    N25 --> N24;
+    N27 --> N26;
+    N29 --> N28;
+    N31 --> N30;
     N33 --> N32;
+    N36 --> N34;
+    N35 --> N6;
+    N35 --> N7;
+    N35 --> N8;
+    N35 --> N9;
+    N35 --> N10;
+    N35 --> N11;
+    N35 --> N12;
+    N35 --> N14;
+    N35 --> N16;
+    N35 --> N18;
+    N35 --> N20;
+    N35 --> N22;
+    N35 --> N24;
+    N35 --> N26;
+    N35 --> N28;
+    N35 --> N30;
+    N35 --> N32;
+    N35 --> N34;
 ```
 # Entrypoints
 
 ```
 {
     Export(
+        "unstable_getStaticPaths",
+    ): 27,
+    Export(
         "unstable_getServerSideProps",
-    ): 7,
-    ModuleEvaluation: 33,
-    Export(
-        "default",
-    ): 34,
-    Export(
-        "unstable_getServerProps",
-    ): 9,
+    ): 33,
+    ModuleEvaluation: 35,
     Export(
         "reportWebVitals",
-    ): 17,
+    ): 23,
+    Export(
+        "unstable_getServerProps",
+    ): 31,
     Export(
         "routeModule",
     ): 36,
     Export(
-        "unstable_getStaticParams",
-    ): 11,
+        "getStaticProps",
+    ): 15,
     Export(
         "config",
-    ): 19,
-    Export(
-        "getStaticProps",
-    ): 25,
-    Export(
-        "unstable_getStaticProps",
-    ): 15,
-    Exports: 37,
-    Export(
-        "unstable_getStaticPaths",
-    ): 13,
-    Export(
-        "getServerSideProps",
     ): 21,
     Export(
+        "unstable_getStaticParams",
+    ): 29,
+    Export(
+        "unstable_getStaticProps",
+    ): 25,
+    Exports: 37,
+    Export(
+        "default",
+    ): 13,
+    Export(
         "getStaticPaths",
-    ): 23,
+    ): 17,
+    Export(
+        "getServerSideProps",
+    ): 19,
 }
 ```
 
@@ -920,7 +1437,7 @@ export { PagesRouteModule as d } from "__TURBOPACK_VAR__" assert {
 ## Part 4
 ```js
 import * as userland from 'VAR_USERLAND';
-export { userland as e } from "__TURBOPACK_VAR__" assert {
+export { userland as userland } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -928,29 +1445,14 @@ export { userland as e } from "__TURBOPACK_VAR__" assert {
 ## Part 5
 ```js
 import { hoist } from './helpers';
-export { hoist as f } from "__TURBOPACK_VAR__" assert {
+export { hoist as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
 ## Part 6
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-import { f as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
-import { e as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-const unstable_getServerSideProps = hoist(userland, 'unstable_getServerSideProps');
-export { unstable_getServerSideProps as g } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
+import '../../server/future/route-modules/pages/module.compiled';
 
 ```
 ## Part 7
@@ -958,72 +1460,69 @@ export { unstable_getServerSideProps as g } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
-import { g as unstable_getServerSideProps } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
-};
-export { unstable_getServerSideProps };
+import '../../server/future/route-kind';
 
 ```
 ## Part 8
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: 6
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+    __turbopack_part__: 7
 };
-import { f as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
-import { e as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-const unstable_getServerProps = hoist(userland, 'unstable_getServerProps');
-export { unstable_getServerProps as h } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
+import './helpers';
 
 ```
 ## Part 9
 ```js
 import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
-import { h as unstable_getServerProps } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
-};
-export { unstable_getServerProps };
+import 'VAR_MODULE_DOCUMENT';
 
 ```
 ## Part 10
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: 6
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+    __turbopack_part__: 7
 };
-import { f as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
 };
-import { e as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
 };
-const unstable_getStaticParams = hoist(userland, 'unstable_getStaticParams');
-export { unstable_getStaticParams as i } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
+import 'VAR_MODULE_APP';
 
 ```
 ## Part 11
 ```js
 import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
-import { i as unstable_getStaticParams } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 10
-};
-export { unstable_getStaticParams };
+import 'VAR_USERLAND';
 
 ```
 ## Part 12
@@ -1034,14 +1533,32 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-import { f as hoist } from "__TURBOPACK_PART__" assert {
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import { e as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { e as userland } from "__TURBOPACK_PART__" assert {
+import { userland as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-const unstable_getStaticPaths = hoist(userland, 'unstable_getStaticPaths');
-export { unstable_getStaticPaths as j } from "__TURBOPACK_VAR__" assert {
+const __TURBOPACK__default__export__ = hoist(userland, 'default');
+export { __TURBOPACK__default__export__ as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1051,10 +1568,10 @@ export { unstable_getStaticPaths as j } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
-import { j as unstable_getStaticPaths } from "__TURBOPACK_PART__" assert {
+import { f as __TURBOPACK__default__export__ } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
-export { unstable_getStaticPaths };
+export { __TURBOPACK__default__export__ as default };
 
 ```
 ## Part 14
@@ -1065,14 +1582,35 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-import { f as hoist } from "__TURBOPACK_PART__" assert {
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import { e as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { e as userland } from "__TURBOPACK_PART__" assert {
+import { userland as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-const unstable_getStaticProps = hoist(userland, 'unstable_getStaticProps');
-export { unstable_getStaticProps as k } from "__TURBOPACK_VAR__" assert {
+const getStaticProps = hoist(userland, 'getStaticProps');
+export { getStaticProps as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1082,10 +1620,10 @@ export { unstable_getStaticProps as k } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
-import { k as unstable_getStaticProps } from "__TURBOPACK_PART__" assert {
+import { g as getStaticProps } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
-export { unstable_getStaticProps };
+export { getStaticProps };
 
 ```
 ## Part 16
@@ -1096,14 +1634,38 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-import { f as hoist } from "__TURBOPACK_PART__" assert {
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import { e as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { e as userland } from "__TURBOPACK_PART__" assert {
+import { userland as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-const reportWebVitals = hoist(userland, 'reportWebVitals');
-export { reportWebVitals as l } from "__TURBOPACK_VAR__" assert {
+const getStaticPaths = hoist(userland, 'getStaticPaths');
+export { getStaticPaths as h } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1113,10 +1675,10 @@ export { reportWebVitals as l } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 16
 };
-import { l as reportWebVitals } from "__TURBOPACK_PART__" assert {
+import { h as getStaticPaths } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 16
 };
-export { reportWebVitals };
+export { getStaticPaths };
 
 ```
 ## Part 18
@@ -1127,14 +1689,41 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-import { f as hoist } from "__TURBOPACK_PART__" assert {
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import { e as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { e as userland } from "__TURBOPACK_PART__" assert {
+import { userland as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-const config = hoist(userland, 'config');
-export { config as m } from "__TURBOPACK_VAR__" assert {
+const getServerSideProps = hoist(userland, 'getServerSideProps');
+export { getServerSideProps as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1144,10 +1733,10 @@ export { config as m } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
-import { m as config } from "__TURBOPACK_PART__" assert {
+import { i as getServerSideProps } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
-export { config };
+export { getServerSideProps };
 
 ```
 ## Part 20
@@ -1158,14 +1747,44 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-import { f as hoist } from "__TURBOPACK_PART__" assert {
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+import { e as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { e as userland } from "__TURBOPACK_PART__" assert {
+import { userland as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-const getServerSideProps = hoist(userland, 'getServerSideProps');
-export { getServerSideProps as n } from "__TURBOPACK_VAR__" assert {
+const config = hoist(userland, 'config');
+export { config as j } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1175,10 +1794,10 @@ export { getServerSideProps as n } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 20
 };
-import { n as getServerSideProps } from "__TURBOPACK_PART__" assert {
+import { j as config } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 20
 };
-export { getServerSideProps };
+export { config };
 
 ```
 ## Part 22
@@ -1189,14 +1808,47 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-import { f as hoist } from "__TURBOPACK_PART__" assert {
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+import { e as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { e as userland } from "__TURBOPACK_PART__" assert {
+import { userland as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-const getStaticPaths = hoist(userland, 'getStaticPaths');
-export { getStaticPaths as o } from "__TURBOPACK_VAR__" assert {
+const reportWebVitals = hoist(userland, 'reportWebVitals');
+export { reportWebVitals as k } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1206,10 +1858,10 @@ export { getStaticPaths as o } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 22
 };
-import { o as getStaticPaths } from "__TURBOPACK_PART__" assert {
+import { k as reportWebVitals } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 22
 };
-export { getStaticPaths };
+export { reportWebVitals };
 
 ```
 ## Part 24
@@ -1220,14 +1872,50 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-import { f as hoist } from "__TURBOPACK_PART__" assert {
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 22
+};
+import { e as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { e as userland } from "__TURBOPACK_PART__" assert {
+import { userland as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-const getStaticProps = hoist(userland, 'getStaticProps');
-export { getStaticProps as p } from "__TURBOPACK_VAR__" assert {
+const unstable_getStaticProps = hoist(userland, 'unstable_getStaticProps');
+export { unstable_getStaticProps as l } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1237,15 +1925,69 @@ export { getStaticProps as p } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 24
 };
-import { p as getStaticProps } from "__TURBOPACK_PART__" assert {
+import { l as unstable_getStaticProps } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 24
 };
-export { getStaticProps };
+export { unstable_getStaticProps };
 
 ```
 ## Part 26
 ```js
-import '../../server/future/route-modules/pages/module.compiled';
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 22
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 24
+};
+import { e as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import { userland as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+const unstable_getStaticPaths = hoist(userland, 'unstable_getStaticPaths');
+export { unstable_getStaticPaths as m } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
 
 ```
 ## Part 27
@@ -1253,69 +1995,159 @@ import '../../server/future/route-modules/pages/module.compiled';
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 26
 };
-import '../../server/future/route-kind';
+import { m as unstable_getStaticPaths } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 26
+};
+export { unstable_getStaticPaths };
 
 ```
 ## Part 28
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
+    __turbopack_part__: 5
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 27
+    __turbopack_part__: 4
 };
-import './helpers';
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 22
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 24
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 26
+};
+import { e as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import { userland as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+const unstable_getStaticParams = hoist(userland, 'unstable_getStaticParams');
+export { unstable_getStaticParams as n } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
 
 ```
 ## Part 29
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 27
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 28
 };
-import 'VAR_MODULE_DOCUMENT';
+import { n as unstable_getStaticParams } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 28
+};
+export { unstable_getStaticParams };
 
 ```
 ## Part 30
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
+    __turbopack_part__: 5
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 27
+    __turbopack_part__: 4
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 22
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 24
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 26
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 28
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
+import { e as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
 };
-import 'VAR_MODULE_APP';
+import { userland as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+const unstable_getServerProps = hoist(userland, 'unstable_getServerProps');
+export { unstable_getServerProps as o } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
 
 ```
 ## Part 31
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 27
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 30
 };
-import 'VAR_USERLAND';
+import { o as unstable_getServerProps } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 30
+};
+export { unstable_getServerProps };
 
 ```
 ## Part 32
@@ -1327,31 +2159,61 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
+    __turbopack_part__: 6
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 27
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 22
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 24
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 26
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 28
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 30
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
-};
-import { f as hoist } from "__TURBOPACK_PART__" assert {
+import { e as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { e as userland } from "__TURBOPACK_PART__" assert {
+import { userland as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-const __TURBOPACK__default__export__ = hoist(userland, 'default');
-export { __TURBOPACK__default__export__ as q } from "__TURBOPACK_VAR__" assert {
+const unstable_getServerSideProps = hoist(userland, 'unstable_getServerSideProps');
+export { unstable_getServerSideProps as p } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1359,41 +2221,15 @@ export { __TURBOPACK__default__export__ as q } from "__TURBOPACK_VAR__" assert {
 ## Part 33
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 27
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 30
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 32
 };
-"module evaluation";
+import { p as unstable_getServerSideProps } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 32
+};
+export { unstable_getServerSideProps };
 
 ```
 ## Part 34
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 32
-};
-import { q as __TURBOPACK__default__export__ } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 32
-};
-export { __TURBOPACK__default__export__ as default };
-
-```
-## Part 35
 ```js
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
@@ -1414,34 +2250,52 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 32
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
+    __turbopack_part__: 6
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 22
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 20
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 12
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 10
+    __turbopack_part__: 7
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 22
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 24
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 26
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 28
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 30
 };
 import { d as PagesRouteModule } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
@@ -1455,7 +2309,7 @@ import { b as App } from "__TURBOPACK_PART__" assert {
 import { a as Document } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
 };
-import { e as userland } from "__TURBOPACK_PART__" assert {
+import { userland as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const routeModule = new PagesRouteModule({
@@ -1472,56 +2326,115 @@ const routeModule = new PagesRouteModule({
     },
     userland
 });
-export { routeModule as r } from "__TURBOPACK_VAR__" assert {
+export { routeModule as q } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
+
+```
+## Part 35
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 22
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 24
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 26
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 28
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 30
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 32
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 34
+};
+"module evaluation";
 
 ```
 ## Part 36
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 35
+    __turbopack_part__: 34
 };
-import { r as routeModule } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 35
+import { q as routeModule } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 34
 };
 export { routeModule };
 
 ```
 ## Part 37
 ```js
-export { unstable_getServerSideProps } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export unstable_getServerSideProps"
-};
-export { unstable_getServerProps } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export unstable_getServerProps"
-};
-export { unstable_getStaticParams } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export unstable_getStaticParams"
-};
-export { unstable_getStaticPaths } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export unstable_getStaticPaths"
-};
-export { unstable_getStaticProps } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export unstable_getStaticProps"
-};
-export { reportWebVitals } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export reportWebVitals"
-};
-export { config } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export config"
-};
-export { getServerSideProps } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export getServerSideProps"
-};
-export { getStaticPaths } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export getStaticPaths"
+export { default } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export default"
 };
 export { getStaticProps } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: "export getStaticProps"
 };
-export { default } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export default"
+export { getStaticPaths } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export getStaticPaths"
+};
+export { getServerSideProps } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export getServerSideProps"
+};
+export { config } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export config"
+};
+export { reportWebVitals } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export reportWebVitals"
+};
+export { unstable_getStaticProps } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export unstable_getStaticProps"
+};
+export { unstable_getStaticPaths } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export unstable_getStaticPaths"
+};
+export { unstable_getStaticParams } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export unstable_getStaticParams"
+};
+export { unstable_getServerProps } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export unstable_getServerProps"
+};
+export { unstable_getServerSideProps } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export unstable_getServerSideProps"
 };
 export { routeModule } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: "export routeModule"
@@ -1531,25 +2444,58 @@ export { routeModule } from "__TURBOPACK_PART__" assert {
 ## Merged (module eval)
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
+    __turbopack_part__: 6
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 27
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 22
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 24
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 26
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 28
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 30
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
+    __turbopack_part__: 32
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 32
+    __turbopack_part__: 34
 };
 "module evaluation";
 
@@ -1559,43 +2505,43 @@ import "__TURBOPACK_PART__" assert {
 ```
 {
     Export(
+        "unstable_getStaticPaths",
+    ): 27,
+    Export(
         "unstable_getServerSideProps",
-    ): 9,
-    Export(
-        "default",
-    ): 35,
-    ModuleEvaluation: 36,
-    Export(
-        "unstable_getServerProps",
-    ): 11,
+    ): 33,
+    ModuleEvaluation: 35,
     Export(
         "reportWebVitals",
-    ): 19,
+    ): 23,
+    Export(
+        "unstable_getServerProps",
+    ): 31,
     Export(
         "routeModule",
-    ): 6,
+    ): 36,
     Export(
-        "unstable_getStaticParams",
-    ): 13,
+        "getStaticProps",
+    ): 15,
     Export(
         "config",
     ): 21,
     Export(
-        "getStaticProps",
-    ): 27,
+        "unstable_getStaticParams",
+    ): 29,
     Export(
         "unstable_getStaticProps",
-    ): 17,
+    ): 25,
     Exports: 37,
     Export(
-        "unstable_getStaticPaths",
-    ): 15,
-    Export(
-        "getServerSideProps",
-    ): 23,
+        "default",
+    ): 13,
     Export(
         "getStaticPaths",
-    ): 25,
+    ): 17,
+    Export(
+        "getServerSideProps",
+    ): 19,
 }
 ```
 
@@ -1636,12 +2582,799 @@ export { PagesRouteModule as d } from "__TURBOPACK_VAR__" assert {
 ## Part 4
 ```js
 import * as userland from 'VAR_USERLAND';
-export { userland as e } from "__TURBOPACK_VAR__" assert {
+export { userland as userland } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
 ## Part 5
+```js
+import { hoist } from './helpers';
+export { hoist as e } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 6
+```js
+import '../../server/future/route-modules/pages/module.compiled';
+
+```
+## Part 7
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import '../../server/future/route-kind';
+
+```
+## Part 8
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import './helpers';
+
+```
+## Part 9
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import 'VAR_MODULE_DOCUMENT';
+
+```
+## Part 10
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import 'VAR_MODULE_APP';
+
+```
+## Part 11
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import 'VAR_USERLAND';
+
+```
+## Part 12
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import { e as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import { userland as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+const __TURBOPACK__default__export__ = hoist(userland, 'default');
+export { __TURBOPACK__default__export__ as f } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 13
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import { f as __TURBOPACK__default__export__ } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+export { __TURBOPACK__default__export__ as default };
+
+```
+## Part 14
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import { e as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import { userland as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+const getStaticProps = hoist(userland, 'getStaticProps');
+export { getStaticProps as g } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 15
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import { g as getStaticProps } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+export { getStaticProps };
+
+```
+## Part 16
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import { e as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import { userland as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+const getStaticPaths = hoist(userland, 'getStaticPaths');
+export { getStaticPaths as h } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 17
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import { h as getStaticPaths } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+export { getStaticPaths };
+
+```
+## Part 18
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import { e as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import { userland as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+const getServerSideProps = hoist(userland, 'getServerSideProps');
+export { getServerSideProps as i } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 19
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+import { i as getServerSideProps } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+export { getServerSideProps };
+
+```
+## Part 20
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+import { e as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import { userland as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+const config = hoist(userland, 'config');
+export { config as j } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 21
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+import { j as config } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+export { config };
+
+```
+## Part 22
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+import { e as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import { userland as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+const reportWebVitals = hoist(userland, 'reportWebVitals');
+export { reportWebVitals as k } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 23
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 22
+};
+import { k as reportWebVitals } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 22
+};
+export { reportWebVitals };
+
+```
+## Part 24
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 22
+};
+import { e as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import { userland as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+const unstable_getStaticProps = hoist(userland, 'unstable_getStaticProps');
+export { unstable_getStaticProps as l } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 25
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 24
+};
+import { l as unstable_getStaticProps } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 24
+};
+export { unstable_getStaticProps };
+
+```
+## Part 26
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 22
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 24
+};
+import { e as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import { userland as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+const unstable_getStaticPaths = hoist(userland, 'unstable_getStaticPaths');
+export { unstable_getStaticPaths as m } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 27
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 26
+};
+import { m as unstable_getStaticPaths } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 26
+};
+export { unstable_getStaticPaths };
+
+```
+## Part 28
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 22
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 24
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 26
+};
+import { e as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import { userland as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+const unstable_getStaticParams = hoist(userland, 'unstable_getStaticParams');
+export { unstable_getStaticParams as n } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 29
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 28
+};
+import { n as unstable_getStaticParams } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 28
+};
+export { unstable_getStaticParams };
+
+```
+## Part 30
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 22
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 24
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 26
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 28
+};
+import { e as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import { userland as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+const unstable_getServerProps = hoist(userland, 'unstable_getServerProps');
+export { unstable_getServerProps as o } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 31
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 30
+};
+import { o as unstable_getServerProps } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 30
+};
+export { unstable_getServerProps };
+
+```
+## Part 32
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 22
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 24
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 26
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 28
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 30
+};
+import { e as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
+};
+import { userland as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
+};
+const unstable_getServerSideProps = hoist(userland, 'unstable_getServerSideProps');
+export { unstable_getServerSideProps as p } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
+};
+
+```
+## Part 33
+```js
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 32
+};
+import { p as unstable_getServerSideProps } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 32
+};
+export { unstable_getServerSideProps };
+
+```
+## Part 34
 ```js
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
@@ -1658,6 +3391,57 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 32
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 22
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 24
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 26
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 28
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 30
+};
 import { d as PagesRouteModule } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 3
 };
@@ -1670,7 +3454,7 @@ import { b as App } from "__TURBOPACK_PART__" assert {
 import { a as Document } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
 };
-import { e as userland } from "__TURBOPACK_PART__" assert {
+import { userland as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const routeModule = new PagesRouteModule({
@@ -1687,449 +3471,7 @@ const routeModule = new PagesRouteModule({
     },
     userland
 });
-export { routeModule as f } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 6
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
-import { f as routeModule } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
-};
-export { routeModule };
-
-```
-## Part 7
-```js
-import { hoist } from './helpers';
-export { hoist as g } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 8
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-import { g as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-import { e as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-const unstable_getServerSideProps = hoist(userland, 'unstable_getServerSideProps');
-export { unstable_getServerSideProps as h } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 9
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
-};
-import { h as unstable_getServerSideProps } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
-};
-export { unstable_getServerSideProps };
-
-```
-## Part 10
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-import { g as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-import { e as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-const unstable_getServerProps = hoist(userland, 'unstable_getServerProps');
-export { unstable_getServerProps as i } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 11
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 10
-};
-import { i as unstable_getServerProps } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 10
-};
-export { unstable_getServerProps };
-
-```
-## Part 12
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-import { g as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-import { e as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-const unstable_getStaticParams = hoist(userland, 'unstable_getStaticParams');
-export { unstable_getStaticParams as j } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 13
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 12
-};
-import { j as unstable_getStaticParams } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 12
-};
-export { unstable_getStaticParams };
-
-```
-## Part 14
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-import { g as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-import { e as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-const unstable_getStaticPaths = hoist(userland, 'unstable_getStaticPaths');
-export { unstable_getStaticPaths as k } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 15
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
-import { k as unstable_getStaticPaths } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
-export { unstable_getStaticPaths };
-
-```
-## Part 16
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-import { g as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-import { e as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-const unstable_getStaticProps = hoist(userland, 'unstable_getStaticProps');
-export { unstable_getStaticProps as l } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 17
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
-};
-import { l as unstable_getStaticProps } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
-};
-export { unstable_getStaticProps };
-
-```
-## Part 18
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-import { g as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-import { e as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-const reportWebVitals = hoist(userland, 'reportWebVitals');
-export { reportWebVitals as m } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 19
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
-};
-import { m as reportWebVitals } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
-};
-export { reportWebVitals };
-
-```
-## Part 20
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-import { g as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-import { e as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-const config = hoist(userland, 'config');
-export { config as n } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 21
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 20
-};
-import { n as config } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 20
-};
-export { config };
-
-```
-## Part 22
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-import { g as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-import { e as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-const getServerSideProps = hoist(userland, 'getServerSideProps');
-export { getServerSideProps as o } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 23
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 22
-};
-import { o as getServerSideProps } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 22
-};
-export { getServerSideProps };
-
-```
-## Part 24
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-import { g as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-import { e as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-const getStaticPaths = hoist(userland, 'getStaticPaths');
-export { getStaticPaths as p } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 25
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
-};
-import { p as getStaticPaths } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 24
-};
-export { getStaticPaths };
-
-```
-## Part 26
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-import { g as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-import { e as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-const getStaticProps = hoist(userland, 'getStaticProps');
-export { getStaticProps as q } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
-};
-
-```
-## Part 27
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
-};
-import { q as getStaticProps } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 26
-};
-export { getStaticProps };
-
-```
-## Part 28
-```js
-import '../../server/future/route-modules/pages/module.compiled';
-
-```
-## Part 29
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
-};
-import '../../server/future/route-kind';
-
-```
-## Part 30
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
-};
-import './helpers';
-
-```
-## Part 31
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 30
-};
-import 'VAR_MODULE_DOCUMENT';
-
-```
-## Part 32
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 30
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
-};
-import 'VAR_MODULE_APP';
-
-```
-## Part 33
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 30
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 32
-};
-import 'VAR_USERLAND';
-
-```
-## Part 34
-```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 30
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 32
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 33
-};
-import { g as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
-};
-import { e as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
-};
-const __TURBOPACK__default__export__ = hoist(userland, 'default');
-export { __TURBOPACK__default__export__ as r } from "__TURBOPACK_VAR__" assert {
+export { routeModule as q } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -2137,12 +3479,60 @@ export { __TURBOPACK__default__export__ as r } from "__TURBOPACK_VAR__" assert {
 ## Part 35
 ```js
 import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 22
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 24
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 26
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 28
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 30
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 32
+};
+import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 34
 };
-import { r as __TURBOPACK__default__export__ } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 34
-};
-export { __TURBOPACK__default__export__ as default };
+"module evaluation";
 
 ```
 ## Part 36
@@ -2150,89 +3540,107 @@ export { __TURBOPACK__default__export__ as default };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 34
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 33
+import { q as routeModule } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 34
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 32
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 30
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
-};
-"module evaluation";
+export { routeModule };
 
 ```
 ## Part 37
 ```js
-export { routeModule } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export routeModule"
-};
-export { unstable_getServerSideProps } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export unstable_getServerSideProps"
-};
-export { unstable_getServerProps } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export unstable_getServerProps"
-};
-export { unstable_getStaticParams } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export unstable_getStaticParams"
-};
-export { unstable_getStaticPaths } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export unstable_getStaticPaths"
-};
-export { unstable_getStaticProps } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export unstable_getStaticProps"
-};
-export { reportWebVitals } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export reportWebVitals"
-};
-export { config } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export config"
-};
-export { getServerSideProps } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export getServerSideProps"
-};
-export { getStaticPaths } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export getStaticPaths"
+export { default } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export default"
 };
 export { getStaticProps } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: "export getStaticProps"
 };
-export { default } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export default"
+export { getStaticPaths } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export getStaticPaths"
+};
+export { getServerSideProps } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export getServerSideProps"
+};
+export { config } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export config"
+};
+export { reportWebVitals } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export reportWebVitals"
+};
+export { unstable_getStaticProps } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export unstable_getStaticProps"
+};
+export { unstable_getStaticPaths } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export unstable_getStaticPaths"
+};
+export { unstable_getStaticParams } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export unstable_getStaticParams"
+};
+export { unstable_getServerProps } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export unstable_getServerProps"
+};
+export { unstable_getServerSideProps } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export unstable_getServerSideProps"
+};
+export { routeModule } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export routeModule"
 };
 
 ```
 ## Merged (module eval)
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 34
+    __turbopack_part__: 6
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 33
+    __turbopack_part__: 7
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 32
+    __turbopack_part__: 8
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 31
+    __turbopack_part__: 9
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 10
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 12
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 20
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 22
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 24
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 26
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 28
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 30
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 29
+    __turbopack_part__: 32
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 28
+    __turbopack_part__: 34
 };
 "module evaluation";
 

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/template-pages/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/template-pages/output.md
@@ -1437,7 +1437,7 @@ export { PagesRouteModule as d } from "__TURBOPACK_VAR__" assert {
 ## Part 4
 ```js
 import * as userland from 'VAR_USERLAND';
-export { userland as userland } from "__TURBOPACK_VAR__" assert {
+export { userland as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1445,7 +1445,7 @@ export { userland as userland } from "__TURBOPACK_VAR__" assert {
 ## Part 5
 ```js
 import { hoist } from './helpers';
-export { hoist as e } from "__TURBOPACK_VAR__" assert {
+export { hoist as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1551,14 +1551,14 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 11
 };
-import { e as hoist } from "__TURBOPACK_PART__" assert {
+import { f as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const __TURBOPACK__default__export__ = hoist(userland, 'default');
-export { __TURBOPACK__default__export__ as f } from "__TURBOPACK_VAR__" assert {
+export { __TURBOPACK__default__export__ as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1568,7 +1568,7 @@ export { __TURBOPACK__default__export__ as f } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
-import { f as __TURBOPACK__default__export__ } from "__TURBOPACK_PART__" assert {
+import { g as __TURBOPACK__default__export__ } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
 export { __TURBOPACK__default__export__ as default };
@@ -1603,14 +1603,14 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
-import { e as hoist } from "__TURBOPACK_PART__" assert {
+import { f as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const getStaticProps = hoist(userland, 'getStaticProps');
-export { getStaticProps as g } from "__TURBOPACK_VAR__" assert {
+export { getStaticProps as h } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1620,7 +1620,7 @@ export { getStaticProps as g } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
-import { g as getStaticProps } from "__TURBOPACK_PART__" assert {
+import { h as getStaticProps } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
 export { getStaticProps };
@@ -1658,14 +1658,14 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
-import { e as hoist } from "__TURBOPACK_PART__" assert {
+import { f as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const getStaticPaths = hoist(userland, 'getStaticPaths');
-export { getStaticPaths as h } from "__TURBOPACK_VAR__" assert {
+export { getStaticPaths as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1675,7 +1675,7 @@ export { getStaticPaths as h } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 16
 };
-import { h as getStaticPaths } from "__TURBOPACK_PART__" assert {
+import { i as getStaticPaths } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 16
 };
 export { getStaticPaths };
@@ -1716,14 +1716,14 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 16
 };
-import { e as hoist } from "__TURBOPACK_PART__" assert {
+import { f as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const getServerSideProps = hoist(userland, 'getServerSideProps');
-export { getServerSideProps as i } from "__TURBOPACK_VAR__" assert {
+export { getServerSideProps as j } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1733,7 +1733,7 @@ export { getServerSideProps as i } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
-import { i as getServerSideProps } from "__TURBOPACK_PART__" assert {
+import { j as getServerSideProps } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
 export { getServerSideProps };
@@ -1777,14 +1777,14 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
-import { e as hoist } from "__TURBOPACK_PART__" assert {
+import { f as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const config = hoist(userland, 'config');
-export { config as j } from "__TURBOPACK_VAR__" assert {
+export { config as k } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1794,7 +1794,7 @@ export { config as j } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 20
 };
-import { j as config } from "__TURBOPACK_PART__" assert {
+import { k as config } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 20
 };
 export { config };
@@ -1841,14 +1841,14 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 20
 };
-import { e as hoist } from "__TURBOPACK_PART__" assert {
+import { f as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const reportWebVitals = hoist(userland, 'reportWebVitals');
-export { reportWebVitals as k } from "__TURBOPACK_VAR__" assert {
+export { reportWebVitals as l } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1858,7 +1858,7 @@ export { reportWebVitals as k } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 22
 };
-import { k as reportWebVitals } from "__TURBOPACK_PART__" assert {
+import { l as reportWebVitals } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 22
 };
 export { reportWebVitals };
@@ -1908,14 +1908,14 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 22
 };
-import { e as hoist } from "__TURBOPACK_PART__" assert {
+import { f as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const unstable_getStaticProps = hoist(userland, 'unstable_getStaticProps');
-export { unstable_getStaticProps as l } from "__TURBOPACK_VAR__" assert {
+export { unstable_getStaticProps as m } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1925,7 +1925,7 @@ export { unstable_getStaticProps as l } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 24
 };
-import { l as unstable_getStaticProps } from "__TURBOPACK_PART__" assert {
+import { m as unstable_getStaticProps } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 24
 };
 export { unstable_getStaticProps };
@@ -1978,14 +1978,14 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 24
 };
-import { e as hoist } from "__TURBOPACK_PART__" assert {
+import { f as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const unstable_getStaticPaths = hoist(userland, 'unstable_getStaticPaths');
-export { unstable_getStaticPaths as m } from "__TURBOPACK_VAR__" assert {
+export { unstable_getStaticPaths as n } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -1995,7 +1995,7 @@ export { unstable_getStaticPaths as m } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 26
 };
-import { m as unstable_getStaticPaths } from "__TURBOPACK_PART__" assert {
+import { n as unstable_getStaticPaths } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 26
 };
 export { unstable_getStaticPaths };
@@ -2051,14 +2051,14 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 26
 };
-import { e as hoist } from "__TURBOPACK_PART__" assert {
+import { f as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const unstable_getStaticParams = hoist(userland, 'unstable_getStaticParams');
-export { unstable_getStaticParams as n } from "__TURBOPACK_VAR__" assert {
+export { unstable_getStaticParams as o } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -2068,7 +2068,7 @@ export { unstable_getStaticParams as n } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 28
 };
-import { n as unstable_getStaticParams } from "__TURBOPACK_PART__" assert {
+import { o as unstable_getStaticParams } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 28
 };
 export { unstable_getStaticParams };
@@ -2127,14 +2127,14 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 28
 };
-import { e as hoist } from "__TURBOPACK_PART__" assert {
+import { f as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const unstable_getServerProps = hoist(userland, 'unstable_getServerProps');
-export { unstable_getServerProps as o } from "__TURBOPACK_VAR__" assert {
+export { unstable_getServerProps as p } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -2144,7 +2144,7 @@ export { unstable_getServerProps as o } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 30
 };
-import { o as unstable_getServerProps } from "__TURBOPACK_PART__" assert {
+import { p as unstable_getServerProps } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 30
 };
 export { unstable_getServerProps };
@@ -2206,14 +2206,14 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 30
 };
-import { e as hoist } from "__TURBOPACK_PART__" assert {
+import { f as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const unstable_getServerSideProps = hoist(userland, 'unstable_getServerSideProps');
-export { unstable_getServerSideProps as p } from "__TURBOPACK_VAR__" assert {
+export { unstable_getServerSideProps as q } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -2223,7 +2223,7 @@ export { unstable_getServerSideProps as p } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 32
 };
-import { p as unstable_getServerSideProps } from "__TURBOPACK_PART__" assert {
+import { q as unstable_getServerSideProps } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 32
 };
 export { unstable_getServerSideProps };
@@ -2309,7 +2309,7 @@ import { b as App } from "__TURBOPACK_PART__" assert {
 import { a as Document } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const routeModule = new PagesRouteModule({
@@ -2326,7 +2326,7 @@ const routeModule = new PagesRouteModule({
     },
     userland
 });
-export { routeModule as q } from "__TURBOPACK_VAR__" assert {
+export { routeModule as r } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -2395,7 +2395,7 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 34
 };
-import { q as routeModule } from "__TURBOPACK_PART__" assert {
+import { r as routeModule } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 34
 };
 export { routeModule };
@@ -2582,7 +2582,7 @@ export { PagesRouteModule as d } from "__TURBOPACK_VAR__" assert {
 ## Part 4
 ```js
 import * as userland from 'VAR_USERLAND';
-export { userland as userland } from "__TURBOPACK_VAR__" assert {
+export { userland as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -2590,7 +2590,7 @@ export { userland as userland } from "__TURBOPACK_VAR__" assert {
 ## Part 5
 ```js
 import { hoist } from './helpers';
-export { hoist as e } from "__TURBOPACK_VAR__" assert {
+export { hoist as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -2696,14 +2696,14 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 11
 };
-import { e as hoist } from "__TURBOPACK_PART__" assert {
+import { f as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const __TURBOPACK__default__export__ = hoist(userland, 'default');
-export { __TURBOPACK__default__export__ as f } from "__TURBOPACK_VAR__" assert {
+export { __TURBOPACK__default__export__ as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -2713,7 +2713,7 @@ export { __TURBOPACK__default__export__ as f } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
-import { f as __TURBOPACK__default__export__ } from "__TURBOPACK_PART__" assert {
+import { g as __TURBOPACK__default__export__ } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
 export { __TURBOPACK__default__export__ as default };
@@ -2748,14 +2748,14 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
-import { e as hoist } from "__TURBOPACK_PART__" assert {
+import { f as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const getStaticProps = hoist(userland, 'getStaticProps');
-export { getStaticProps as g } from "__TURBOPACK_VAR__" assert {
+export { getStaticProps as h } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -2765,7 +2765,7 @@ export { getStaticProps as g } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
-import { g as getStaticProps } from "__TURBOPACK_PART__" assert {
+import { h as getStaticProps } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
 export { getStaticProps };
@@ -2803,14 +2803,14 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 14
 };
-import { e as hoist } from "__TURBOPACK_PART__" assert {
+import { f as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const getStaticPaths = hoist(userland, 'getStaticPaths');
-export { getStaticPaths as h } from "__TURBOPACK_VAR__" assert {
+export { getStaticPaths as i } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -2820,7 +2820,7 @@ export { getStaticPaths as h } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 16
 };
-import { h as getStaticPaths } from "__TURBOPACK_PART__" assert {
+import { i as getStaticPaths } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 16
 };
 export { getStaticPaths };
@@ -2861,14 +2861,14 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 16
 };
-import { e as hoist } from "__TURBOPACK_PART__" assert {
+import { f as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const getServerSideProps = hoist(userland, 'getServerSideProps');
-export { getServerSideProps as i } from "__TURBOPACK_VAR__" assert {
+export { getServerSideProps as j } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -2878,7 +2878,7 @@ export { getServerSideProps as i } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
-import { i as getServerSideProps } from "__TURBOPACK_PART__" assert {
+import { j as getServerSideProps } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
 export { getServerSideProps };
@@ -2922,14 +2922,14 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 18
 };
-import { e as hoist } from "__TURBOPACK_PART__" assert {
+import { f as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const config = hoist(userland, 'config');
-export { config as j } from "__TURBOPACK_VAR__" assert {
+export { config as k } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -2939,7 +2939,7 @@ export { config as j } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 20
 };
-import { j as config } from "__TURBOPACK_PART__" assert {
+import { k as config } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 20
 };
 export { config };
@@ -2986,14 +2986,14 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 20
 };
-import { e as hoist } from "__TURBOPACK_PART__" assert {
+import { f as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const reportWebVitals = hoist(userland, 'reportWebVitals');
-export { reportWebVitals as k } from "__TURBOPACK_VAR__" assert {
+export { reportWebVitals as l } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -3003,7 +3003,7 @@ export { reportWebVitals as k } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 22
 };
-import { k as reportWebVitals } from "__TURBOPACK_PART__" assert {
+import { l as reportWebVitals } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 22
 };
 export { reportWebVitals };
@@ -3053,14 +3053,14 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 22
 };
-import { e as hoist } from "__TURBOPACK_PART__" assert {
+import { f as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const unstable_getStaticProps = hoist(userland, 'unstable_getStaticProps');
-export { unstable_getStaticProps as l } from "__TURBOPACK_VAR__" assert {
+export { unstable_getStaticProps as m } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -3070,7 +3070,7 @@ export { unstable_getStaticProps as l } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 24
 };
-import { l as unstable_getStaticProps } from "__TURBOPACK_PART__" assert {
+import { m as unstable_getStaticProps } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 24
 };
 export { unstable_getStaticProps };
@@ -3123,14 +3123,14 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 24
 };
-import { e as hoist } from "__TURBOPACK_PART__" assert {
+import { f as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const unstable_getStaticPaths = hoist(userland, 'unstable_getStaticPaths');
-export { unstable_getStaticPaths as m } from "__TURBOPACK_VAR__" assert {
+export { unstable_getStaticPaths as n } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -3140,7 +3140,7 @@ export { unstable_getStaticPaths as m } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 26
 };
-import { m as unstable_getStaticPaths } from "__TURBOPACK_PART__" assert {
+import { n as unstable_getStaticPaths } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 26
 };
 export { unstable_getStaticPaths };
@@ -3196,14 +3196,14 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 26
 };
-import { e as hoist } from "__TURBOPACK_PART__" assert {
+import { f as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const unstable_getStaticParams = hoist(userland, 'unstable_getStaticParams');
-export { unstable_getStaticParams as n } from "__TURBOPACK_VAR__" assert {
+export { unstable_getStaticParams as o } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -3213,7 +3213,7 @@ export { unstable_getStaticParams as n } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 28
 };
-import { n as unstable_getStaticParams } from "__TURBOPACK_PART__" assert {
+import { o as unstable_getStaticParams } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 28
 };
 export { unstable_getStaticParams };
@@ -3272,14 +3272,14 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 28
 };
-import { e as hoist } from "__TURBOPACK_PART__" assert {
+import { f as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const unstable_getServerProps = hoist(userland, 'unstable_getServerProps');
-export { unstable_getServerProps as o } from "__TURBOPACK_VAR__" assert {
+export { unstable_getServerProps as p } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -3289,7 +3289,7 @@ export { unstable_getServerProps as o } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 30
 };
-import { o as unstable_getServerProps } from "__TURBOPACK_PART__" assert {
+import { p as unstable_getServerProps } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 30
 };
 export { unstable_getServerProps };
@@ -3351,14 +3351,14 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 30
 };
-import { e as hoist } from "__TURBOPACK_PART__" assert {
+import { f as hoist } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 5
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const unstable_getServerSideProps = hoist(userland, 'unstable_getServerSideProps');
-export { unstable_getServerSideProps as p } from "__TURBOPACK_VAR__" assert {
+export { unstable_getServerSideProps as q } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -3368,7 +3368,7 @@ export { unstable_getServerSideProps as p } from "__TURBOPACK_VAR__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 32
 };
-import { p as unstable_getServerSideProps } from "__TURBOPACK_PART__" assert {
+import { q as unstable_getServerSideProps } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 32
 };
 export { unstable_getServerSideProps };
@@ -3454,7 +3454,7 @@ import { b as App } from "__TURBOPACK_PART__" assert {
 import { a as Document } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
 };
-import { userland as userland } from "__TURBOPACK_PART__" assert {
+import { e as userland } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
 const routeModule = new PagesRouteModule({
@@ -3471,7 +3471,7 @@ const routeModule = new PagesRouteModule({
     },
     userland
 });
-export { routeModule as q } from "__TURBOPACK_VAR__" assert {
+export { routeModule as r } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -3540,7 +3540,7 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 34
 };
-import { q as routeModule } from "__TURBOPACK_PART__" assert {
+import { r as routeModule } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 34
 };
 export { routeModule };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/write-order/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/write-order/output.md
@@ -69,6 +69,7 @@ export const shared = {
 
 ```
 
+- Side effects
 - Declares: `shared`
 - Reads: `order`
 - Write: `order`, `shared`
@@ -127,6 +128,8 @@ graph TD
     Item5 --> Item4;
     Item6 --> Item3;
     Item6 --> Item1;
+    Item6 --> Item4;
+    Item6 --> Item5;
     Item7 --> Item6;
     Item7 --> Item1;
     Item7 --> Item3;
@@ -161,6 +164,8 @@ graph TD
     Item5 --> Item4;
     Item6 --> Item3;
     Item6 --> Item1;
+    Item6 --> Item4;
+    Item6 --> Item5;
     Item7 --> Item6;
     Item7 --> Item1;
     Item7 --> Item3;
@@ -198,6 +203,8 @@ graph TD
     Item5 --> Item4;
     Item6 --> Item3;
     Item6 --> Item1;
+    Item6 --> Item4;
+    Item6 --> Item5;
     Item7 --> Item6;
     Item7 --> Item1;
     Item7 --> Item3;
@@ -213,6 +220,7 @@ graph TD
     Item8 --> Item3;
     Item8 --> Item4;
     Item8 --> Item5;
+    Item8 --> Item6;
     Item8 --> Item7;
 ```
 # Final
@@ -220,36 +228,39 @@ graph TD
 graph TD
     N0["Items: [ItemId(0, VarDeclarator(0))]"];
     N1["Items: [ItemId(2, Normal)]"];
-    N2["Items: [ItemId(5, VarDeclarator(0))]"];
-    N3["Items: [ItemId(Export((&quot;shared&quot;, #2), &quot;shared&quot;))]"];
-    N4["Items: [ItemId(3, VarDeclarator(0))]"];
-    N5["Items: [ItemId(4, VarDeclarator(0))]"];
+    N2["Items: [ItemId(3, VarDeclarator(0))]"];
+    N3["Items: [ItemId(4, VarDeclarator(0))]"];
+    N4["Items: [ItemId(5, VarDeclarator(0))]"];
+    N5["Items: [ItemId(Export((&quot;shared&quot;, #2), &quot;shared&quot;))]"];
     N6["Items: [ItemId(6, Normal)]"];
     N7["Items: [ItemId(ModuleEvaluation)]"];
     N8["Items: [ItemId(Export((&quot;order&quot;, #2), &quot;order&quot;))]"];
     N9["Items: [ItemId(1, Normal)]"];
     N10["Items: [ItemId(Export((&quot;func&quot;, #2), &quot;func&quot;))]"];
     N1 --> N0;
-    N4 --> N1;
-    N5 --> N1;
-    N5 --> N4;
     N2 --> N1;
-    N2 --> N0;
-    N6 --> N2;
+    N3 --> N1;
+    N3 --> N2;
+    N4 --> N1;
+    N4 --> N0;
+    N4 --> N2;
+    N4 --> N3;
+    N6 --> N4;
     N6 --> N0;
     N6 --> N1;
-    N6 --> N4;
-    N6 --> N5;
+    N6 --> N2;
+    N6 --> N3;
     N8 --> N6;
     N8 --> N0;
     N10 --> N9;
-    N3 --> N2;
+    N5 --> N4;
     N9 --> N6;
     N9 --> N0;
     N9 -.-> N8;
     N7 --> N1;
+    N7 --> N2;
+    N7 --> N3;
     N7 --> N4;
-    N7 --> N5;
     N7 --> N6;
 ```
 # Entrypoints
@@ -266,7 +277,7 @@ graph TD
     ): 10,
     Export(
         "shared",
-    ): 3,
+    ): 5,
 }
 ```
 
@@ -296,16 +307,8 @@ order.push("a");
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
-};
-import { a as order } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
-};
-const shared = {
-    effect: order.push("b")
-};
-export { shared as b } from "__TURBOPACK_VAR__" assert {
+const x1 = externalFunction();
+export { x1 as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -313,12 +316,15 @@ export { shared as b } from "__TURBOPACK_VAR__" assert {
 ## Part 3
 ```js
 import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-import { b as shared } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+const x2 = externalFunction();
+export { x2 as c } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
 };
-export { shared };
 
 ```
 ## Part 4
@@ -326,8 +332,22 @@ export { shared };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
-const x1 = externalFunction();
-export { x1 as c } from "__TURBOPACK_VAR__" assert {
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 0
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
+import { a as order } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 0
+};
+const shared = {
+    effect: order.push("b")
+};
+export { shared as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -335,21 +355,18 @@ export { x1 as c } from "__TURBOPACK_VAR__" assert {
 ## Part 5
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-const x2 = externalFunction();
-export { x2 as d } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
+import { d as shared } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
 };
+export { shared };
 
 ```
 ## Part 6
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: 4
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
@@ -358,10 +375,10 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+    __turbopack_part__: 2
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: 3
 };
 import { a as order } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
@@ -375,10 +392,13 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+    __turbopack_part__: 2
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: 3
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
@@ -452,10 +472,13 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+    __turbopack_part__: 2
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: 3
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
@@ -477,7 +500,7 @@ import "__TURBOPACK_PART__" assert {
     ): 9,
     Export(
         "shared",
-    ): 3,
+    ): 5,
 }
 ```
 
@@ -507,16 +530,8 @@ order.push("a");
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
-};
-import { a as order } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 0
-};
-const shared = {
-    effect: order.push("b")
-};
-export { shared as b } from "__TURBOPACK_VAR__" assert {
+const x1 = externalFunction();
+export { x1 as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -524,12 +539,15 @@ export { shared as b } from "__TURBOPACK_VAR__" assert {
 ## Part 3
 ```js
 import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
+};
+import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
-import { b as shared } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+const x2 = externalFunction();
+export { x2 as c } from "__TURBOPACK_VAR__" assert {
+    __turbopack_var__: true
 };
-export { shared };
 
 ```
 ## Part 4
@@ -537,8 +555,22 @@ export { shared };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
-const x1 = externalFunction();
-export { x1 as c } from "__TURBOPACK_VAR__" assert {
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 0
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
+};
+import { a as order } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 0
+};
+const shared = {
+    effect: order.push("b")
+};
+export { shared as d } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -546,21 +578,18 @@ export { x1 as c } from "__TURBOPACK_VAR__" assert {
 ## Part 5
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 4
 };
-const x2 = externalFunction();
-export { x2 as d } from "__TURBOPACK_VAR__" assert {
-    __turbopack_var__: true
+import { d as shared } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
 };
+export { shared };
 
 ```
 ## Part 6
 ```js
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+    __turbopack_part__: 4
 };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
@@ -569,10 +598,10 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+    __turbopack_part__: 2
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: 3
 };
 import { a as order } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 0
@@ -589,10 +618,13 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+    __turbopack_part__: 2
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: 3
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
 };
 "module evaluation";
 
@@ -663,10 +695,13 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+    __turbopack_part__: 2
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+    __turbopack_part__: 3
+};
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
 };
 "module evaluation";
 

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_dynamic-import_input_lib_e521f1.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_dynamic-import_input_lib_e521f1.js
@@ -6,7 +6,7 @@
 __turbopack_esm__({
     "c": [
         ()=>dog,
-        (dog_new_value)=>dog = dog_new_value
+        (new_dog)=>dog = new_dog
     ]
 });
 let dog = "dog";
@@ -115,7 +115,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "a": [
         ()=>cat,
-        (cat_new_value)=>cat = cat_new_value
+        (new_cat)=>cat = new_cat
     ]
 });
 let cat = "cat";
@@ -141,7 +141,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "f": [
         ()=>getDog,
-        (getDog_new_value)=>getDog = getDog_new_value
+        (new_getDog)=>getDog = new_getDog
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$dynamic$2d$import$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__8$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js [test] (ecmascript) <internal part 8>");
@@ -162,7 +162,7 @@ function getDog() {
 __turbopack_esm__({
     "d": [
         ()=>setDog,
-        (setDog_new_value)=>setDog = setDog_new_value
+        (new_setDog)=>setDog = new_setDog
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$dynamic$2d$import$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__4$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js [test] (ecmascript) <internal part 4>");
@@ -181,7 +181,7 @@ function setDog(newDog) {
 __turbopack_esm__({
     "g": [
         ()=>dogRef,
-        (dogRef_new_value)=>dogRef = dogRef_new_value
+        (new_dogRef)=>dogRef = new_dogRef
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$dynamic$2d$import$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__8$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js [test] (ecmascript) <internal part 8>");
@@ -223,7 +223,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "e": [
         ()=>getChimera,
-        (getChimera_new_value)=>getChimera = getChimera_new_value
+        (new_getChimera)=>getChimera = new_getChimera
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$dynamic$2d$import$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__4$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js [test] (ecmascript) <internal part 4>");
@@ -260,7 +260,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "b": [
         ()=>initialCat,
-        (initialCat_new_value)=>initialCat = initialCat_new_value
+        (new_initialCat)=>initialCat = new_initialCat
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$dynamic$2d$import$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__0$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js [test] (ecmascript) <internal part 0>");

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_1823b4._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_1823b4._.js
@@ -6,7 +6,7 @@
 __turbopack_esm__({
     "c": [
         ()=>dog,
-        (dog_new_value)=>dog = dog_new_value
+        (new_dog)=>dog = new_dog
     ]
 });
 let dog = "dog";
@@ -143,7 +143,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "a": [
         ()=>cat,
-        (cat_new_value)=>cat = cat_new_value
+        (new_cat)=>cat = new_cat
     ]
 });
 let cat = "cat";
@@ -169,7 +169,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "a": [
         ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$named$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$export__cat$3e$__["cat"],
-        (cat_new_value)=>$expr = cat_new_value
+        (new_cat)=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$named$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$export__cat$3e$__["cat"] = new_cat
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$named$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$module__evaluation$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js [test] (ecmascript) <module evaluation>");
@@ -198,7 +198,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "a": [
         ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$named$2f$input$2f$module$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$export__fakeCat$3e$__["fakeCat"],
-        (fakeCat_new_value)=>$expr = fakeCat_new_value
+        (new_fakeCat)=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$named$2f$input$2f$module$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$export__fakeCat$3e$__["fakeCat"] = new_fakeCat
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$named$2f$input$2f$module$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$module__evaluation$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/module.js [test] (ecmascript) <module evaluation>");

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-namespace_input_6b9ee3._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_export-namespace_input_6b9ee3._.js
@@ -6,7 +6,7 @@
 __turbopack_esm__({
     "c": [
         ()=>dog,
-        (dog_new_value)=>dog = dog_new_value
+        (new_dog)=>dog = new_dog
     ]
 });
 let dog = "dog";
@@ -143,7 +143,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "a": [
         ()=>cat,
-        (cat_new_value)=>cat = cat_new_value
+        (new_cat)=>cat = new_cat
     ]
 });
 let cat = "cat";
@@ -169,7 +169,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "f": [
         ()=>getDog,
-        (getDog_new_value)=>getDog = getDog_new_value
+        (new_getDog)=>getDog = new_getDog
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$namespace$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__8$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js [test] (ecmascript) <internal part 8>");
@@ -190,7 +190,7 @@ function getDog() {
 __turbopack_esm__({
     "d": [
         ()=>setDog,
-        (setDog_new_value)=>setDog = setDog_new_value
+        (new_setDog)=>setDog = new_setDog
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$namespace$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__4$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js [test] (ecmascript) <internal part 4>");
@@ -209,7 +209,7 @@ function setDog(newDog) {
 __turbopack_esm__({
     "g": [
         ()=>dogRef,
-        (dogRef_new_value)=>dogRef = dogRef_new_value
+        (new_dogRef)=>dogRef = new_dogRef
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$namespace$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__8$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js [test] (ecmascript) <internal part 8>");
@@ -251,7 +251,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "e": [
         ()=>getChimera,
-        (getChimera_new_value)=>getChimera = getChimera_new_value
+        (new_getChimera)=>getChimera = new_getChimera
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$namespace$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__4$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js [test] (ecmascript) <internal part 4>");
@@ -288,7 +288,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "b": [
         ()=>initialCat,
-        (initialCat_new_value)=>initialCat = initialCat_new_value
+        (new_initialCat)=>initialCat = new_initialCat
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$namespace$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__0$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js [test] (ecmascript) <internal part 0>");
@@ -364,7 +364,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "a": [
         ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$namespace$2f$input$2f$module$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$export__lib$3e$__["lib"],
-        (lib_new_value)=>$expr = lib_new_value
+        (new_lib)=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$namespace$2f$input$2f$module$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$export__lib$3e$__["lib"] = new_lib
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$namespace$2f$input$2f$module$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$module__evaluation$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/module.js [test] (ecmascript) <module evaluation>");

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-named-all_input_84a6ca._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-named-all_input_84a6ca._.js
@@ -6,7 +6,7 @@
 __turbopack_esm__({
     "c": [
         ()=>dog,
-        (dog_new_value)=>dog = dog_new_value
+        (new_dog)=>dog = new_dog
     ]
 });
 let dog = "dog";
@@ -124,7 +124,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "a": [
         ()=>cat,
-        (cat_new_value)=>cat = cat_new_value
+        (new_cat)=>cat = new_cat
     ]
 });
 let cat = "cat";
@@ -150,7 +150,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "a": [
         ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$import$2d$named$2d$all$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$export__cat$3e$__["cat"],
-        (cat_new_value)=>$expr = cat_new_value
+        (new_cat)=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$import$2d$named$2d$all$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$export__cat$3e$__["cat"] = new_cat
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$import$2d$named$2d$all$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$module__evaluation$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js [test] (ecmascript) <module evaluation>");

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-named_input_4f48a0._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-named_input_4f48a0._.js
@@ -6,7 +6,7 @@
 __turbopack_esm__({
     "c": [
         ()=>dog,
-        (dog_new_value)=>dog = dog_new_value
+        (new_dog)=>dog = new_dog
     ]
 });
 let dog = "dog";
@@ -124,7 +124,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "a": [
         ()=>cat,
-        (cat_new_value)=>cat = cat_new_value
+        (new_cat)=>cat = new_cat
     ]
 });
 let cat = "cat";
@@ -150,7 +150,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "a": [
         ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$import$2d$named$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$export__cat$3e$__["cat"],
-        (cat_new_value)=>$expr = cat_new_value
+        (new_cat)=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$import$2d$named$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$export__cat$3e$__["cat"] = new_cat
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$import$2d$named$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$module__evaluation$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js [test] (ecmascript) <module evaluation>");

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-namespace_input_519014._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-namespace_input_519014._.js
@@ -6,7 +6,7 @@
 __turbopack_esm__({
     "c": [
         ()=>dog,
-        (dog_new_value)=>dog = dog_new_value
+        (new_dog)=>dog = new_dog
     ]
 });
 let dog = "dog";
@@ -124,7 +124,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "a": [
         ()=>cat,
-        (cat_new_value)=>cat = cat_new_value
+        (new_cat)=>cat = new_cat
     ]
 });
 let cat = "cat";
@@ -150,7 +150,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "f": [
         ()=>getDog,
-        (getDog_new_value)=>getDog = getDog_new_value
+        (new_getDog)=>getDog = new_getDog
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$import$2d$namespace$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__8$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js [test] (ecmascript) <internal part 8>");
@@ -171,7 +171,7 @@ function getDog() {
 __turbopack_esm__({
     "d": [
         ()=>setDog,
-        (setDog_new_value)=>setDog = setDog_new_value
+        (new_setDog)=>setDog = new_setDog
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$import$2d$namespace$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__4$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js [test] (ecmascript) <internal part 4>");
@@ -190,7 +190,7 @@ function setDog(newDog) {
 __turbopack_esm__({
     "g": [
         ()=>dogRef,
-        (dogRef_new_value)=>dogRef = dogRef_new_value
+        (new_dogRef)=>dogRef = new_dogRef
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$import$2d$namespace$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__8$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js [test] (ecmascript) <internal part 8>");
@@ -232,7 +232,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "e": [
         ()=>getChimera,
-        (getChimera_new_value)=>getChimera = getChimera_new_value
+        (new_getChimera)=>getChimera = new_getChimera
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$import$2d$namespace$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__4$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js [test] (ecmascript) <internal part 4>");
@@ -269,7 +269,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "b": [
         ()=>initialCat,
-        (initialCat_new_value)=>initialCat = initialCat_new_value
+        (new_initialCat)=>initialCat = new_initialCat
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$import$2d$namespace$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__0$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js [test] (ecmascript) <internal part 0>");

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-side-effect_input_55cb06._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/output/b1abf_turbopack-tests_tests_snapshot_basic-tree-shake_import-side-effect_input_55cb06._.js
@@ -6,7 +6,7 @@
 __turbopack_esm__({
     "c": [
         ()=>dog,
-        (dog_new_value)=>dog = dog_new_value
+        (new_dog)=>dog = new_dog
     ]
 });
 let dog = "dog";

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_require-side-effect_input_c7b81e._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/output/4c35f_tests_snapshot_basic-tree-shake_require-side-effect_input_c7b81e._.js
@@ -6,7 +6,7 @@
 __turbopack_esm__({
     "c": [
         ()=>dog,
-        (dog_new_value)=>dog = dog_new_value
+        (new_dog)=>dog = new_dog
     ]
 });
 let dog = "dog";
@@ -115,7 +115,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "a": [
         ()=>cat,
-        (cat_new_value)=>cat = cat_new_value
+        (new_cat)=>cat = new_cat
     ]
 });
 let cat = "cat";
@@ -141,7 +141,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "f": [
         ()=>getDog,
-        (getDog_new_value)=>getDog = getDog_new_value
+        (new_getDog)=>getDog = new_getDog
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$require$2d$side$2d$effect$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__8$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js [test] (ecmascript) <internal part 8>");
@@ -162,7 +162,7 @@ function getDog() {
 __turbopack_esm__({
     "d": [
         ()=>setDog,
-        (setDog_new_value)=>setDog = setDog_new_value
+        (new_setDog)=>setDog = new_setDog
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$require$2d$side$2d$effect$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__4$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js [test] (ecmascript) <internal part 4>");
@@ -181,7 +181,7 @@ function setDog(newDog) {
 __turbopack_esm__({
     "g": [
         ()=>dogRef,
-        (dogRef_new_value)=>dogRef = dogRef_new_value
+        (new_dogRef)=>dogRef = new_dogRef
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$require$2d$side$2d$effect$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__8$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js [test] (ecmascript) <internal part 8>");
@@ -223,7 +223,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "e": [
         ()=>getChimera,
-        (getChimera_new_value)=>getChimera = getChimera_new_value
+        (new_getChimera)=>getChimera = new_getChimera
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$require$2d$side$2d$effect$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__4$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js [test] (ecmascript) <internal part 4>");
@@ -260,7 +260,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "b": [
         ()=>initialCat,
-        (initialCat_new_value)=>initialCat = initialCat_new_value
+        (new_initialCat)=>initialCat = new_initialCat
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$require$2d$side$2d$effect$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__0$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js [test] (ecmascript) <internal part 0>");

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_basic-tree-shake_tree-shake-test-1_input_index_950e23.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/output/4c35f_tests_snapshot_basic-tree-shake_tree-shake-test-1_input_index_950e23.js
@@ -6,7 +6,7 @@
 __turbopack_esm__({
     "c": [
         ()=>dog,
-        (dog_new_value)=>dog = dog_new_value
+        (new_dog)=>dog = new_dog
     ]
 });
 let dog = "dog";
@@ -115,7 +115,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "a": [
         ()=>cat,
-        (cat_new_value)=>cat = cat_new_value
+        (new_cat)=>cat = new_cat
     ]
 });
 let cat = "cat";
@@ -141,7 +141,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "f": [
         ()=>getDog,
-        (getDog_new_value)=>getDog = getDog_new_value
+        (new_getDog)=>getDog = new_getDog
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__8$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js [test] (ecmascript) <internal part 8>");
@@ -162,7 +162,7 @@ function getDog() {
 __turbopack_esm__({
     "d": [
         ()=>setDog,
-        (setDog_new_value)=>setDog = setDog_new_value
+        (new_setDog)=>setDog = new_setDog
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__4$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js [test] (ecmascript) <internal part 4>");
@@ -181,7 +181,7 @@ function setDog(newDog) {
 __turbopack_esm__({
     "g": [
         ()=>dogRef,
-        (dogRef_new_value)=>dogRef = dogRef_new_value
+        (new_dogRef)=>dogRef = new_dogRef
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__8$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js [test] (ecmascript) <internal part 8>");
@@ -223,7 +223,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "e": [
         ()=>getChimera,
-        (getChimera_new_value)=>getChimera = getChimera_new_value
+        (new_getChimera)=>getChimera = new_getChimera
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__4$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js [test] (ecmascript) <internal part 4>");
@@ -260,7 +260,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 __turbopack_esm__({
     "b": [
         ()=>initialCat,
-        (initialCat_new_value)=>initialCat = initialCat_new_value
+        (new_initialCat)=>initialCat = new_initialCat
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__0$3e$__ = __turbopack_import__("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js [test] (ecmascript) <internal part 0>");


### PR DESCRIPTION
### What?

Improve the graph analyzer of the tree-shaking pass. This PR does **not** server-action specific changes for tree shaking.

### Why?

This is part of [the tree-shaking PR](https://github.com/vercel/next.js/pull/69344).

### How?

