### PR TITLE
[Turbopack] stable Vcs without TraitRef::cell

### DIFF
--- a/crates/next-api/src/empty.rs
+++ b/crates/next-api/src/empty.rs
@@ -1,0 +1,39 @@
+use anyhow::{bail, Result};
+use turbo_tasks::{Completion, Vc};
+use turbopack_core::module::Modules;
+
+use crate::route::{Endpoint, WrittenEndpoint};
+
+#[turbo_tasks::value]
+pub struct EmptyEndpoint;
+
+#[turbo_tasks::value_impl]
+impl EmptyEndpoint {
+    #[turbo_tasks::function]
+    pub fn new() -> Vc<Self> {
+        EmptyEndpoint.cell()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Endpoint for EmptyEndpoint {
+    #[turbo_tasks::function]
+    fn write_to_disk(self: Vc<Self>) -> Result<Vc<WrittenEndpoint>> {
+        bail!("Empty endpoint can't be written to disk")
+    }
+
+    #[turbo_tasks::function]
+    fn server_changed(self: Vc<Self>) -> Vc<Completion> {
+        Completion::new()
+    }
+
+    #[turbo_tasks::function]
+    fn client_changed(self: Vc<Self>) -> Vc<Completion> {
+        Completion::new()
+    }
+
+    #[turbo_tasks::function]
+    fn root_modules(self: Vc<Self>) -> Vc<Modules> {
+        Vc::cell(vec![])
+    }
+}

--- a/crates/next-api/src/lib.rs
+++ b/crates/next-api/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod app;
 mod dynamic_imports;
+mod empty;
 pub mod entrypoints;
 mod font;
 pub mod global_module_id_strategy;

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -834,6 +834,9 @@ export async function createHotReloaderTurbopack(
         return
       }
 
+      await currentEntriesHandling
+
+      // TODO We shouldn't look into the filesystem again. This should use the information from entrypoints
       let routeDef: Pick<RouteDefinition, 'filename' | 'bundlePath' | 'page'> =
         definition ??
         (await findPagePathData(
@@ -891,8 +894,6 @@ export async function createHotReloaderTurbopack(
         }
         return
       }
-
-      await currentEntriesHandling
 
       const isInsideAppDir = routeDef.bundlePath.startsWith('app/')
       const normalizedAppPage = normalizedPageToTurbopackStructureRoute(

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -307,7 +307,8 @@ export type StartChangeSubscription = (
   endpoint: Endpoint,
   makePayload: (
     change: TurbopackResult
-  ) => Promise<HMR_ACTION_TYPES> | HMR_ACTION_TYPES | void
+  ) => Promise<HMR_ACTION_TYPES> | HMR_ACTION_TYPES | void,
+  onError?: (e: Error) => Promise<HMR_ACTION_TYPES> | HMR_ACTION_TYPES | void
 ) => Promise<void>
 
 export type StopChangeSubscription = (key: EntryKey) => Promise<void>
@@ -449,6 +450,9 @@ export async function handleRouteType({
                 event: HMR_ACTIONS_SENT_TO_BROWSER.SERVER_ONLY_CHANGES,
                 pages: [page],
               }
+            },
+            () => {
+              return { action: HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE }
             }
           )
           hooks?.subscribeToChanges(
@@ -459,6 +463,9 @@ export async function handleRouteType({
               return {
                 event: HMR_ACTIONS_SENT_TO_BROWSER.CLIENT_CHANGES,
               }
+            },
+            () => {
+              return { action: HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE }
             }
           )
           if (entrypoints.global.document) {
@@ -466,6 +473,9 @@ export async function handleRouteType({
               getEntryKey('pages', 'server', '_document'),
               false,
               entrypoints.global.document,
+              () => {
+                return { action: HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE }
+              },
               () => {
                 return { action: HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE }
               }
@@ -511,18 +521,28 @@ export async function handleRouteType({
       if (dev) {
         // TODO subscriptions should only be caused by the WebSocket connections
         // otherwise we don't known when to unsubscribe and this leaking
-        hooks?.subscribeToChanges(key, true, route.rscEndpoint, (change) => {
-          if (change.issues.some((issue) => issue.severity === 'error')) {
-            // Ignore any updates that has errors
-            // There will be another update without errors eventually
-            return
+        hooks?.subscribeToChanges(
+          key,
+          true,
+          route.rscEndpoint,
+          (change) => {
+            if (change.issues.some((issue) => issue.severity === 'error')) {
+              // Ignore any updates that has errors
+              // There will be another update without errors eventually
+              return
+            }
+            // Report the next compilation again
+            readyIds?.delete(pathname)
+            return {
+              action: HMR_ACTIONS_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
+            }
+          },
+          () => {
+            return {
+              action: HMR_ACTIONS_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
+            }
           }
-          // Report the next compilation again
-          readyIds?.delete(pathname)
-          return {
-            action: HMR_ACTIONS_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
-          }
-        })
+        )
       }
 
       const type = writtenEndpoint.type
@@ -866,30 +886,40 @@ export async function handleEntrypoints({
     await processMiddleware()
 
     if (dev) {
-      dev?.hooks.subscribeToChanges(key, false, endpoint, async () => {
-        const finishBuilding = dev.hooks.startBuilding(
-          'middleware',
-          undefined,
-          true
-        )
-        await processMiddleware()
-        await dev.hooks.propagateServerField(
-          'actualMiddlewareFile',
-          dev.serverFields.actualMiddlewareFile
-        )
-        await dev.hooks.propagateServerField(
-          'middleware',
-          dev.serverFields.middleware
-        )
-        await manifestLoader.writeManifests({
-          devRewrites,
-          productionRewrites,
-          entrypoints: currentEntrypoints,
-        })
+      dev?.hooks.subscribeToChanges(
+        key,
+        false,
+        endpoint,
+        async () => {
+          const finishBuilding = dev.hooks.startBuilding(
+            'middleware',
+            undefined,
+            true
+          )
+          await processMiddleware()
+          await dev.hooks.propagateServerField(
+            'actualMiddlewareFile',
+            dev.serverFields.actualMiddlewareFile
+          )
+          await dev.hooks.propagateServerField(
+            'middleware',
+            dev.serverFields.middleware
+          )
+          await manifestLoader.writeManifests({
+            devRewrites,
+            productionRewrites,
+            entrypoints: currentEntrypoints,
+          })
 
-        finishBuilding?.()
-        return { event: HMR_ACTIONS_SENT_TO_BROWSER.MIDDLEWARE_CHANGES }
-      })
+          finishBuilding?.()
+          return { event: HMR_ACTIONS_SENT_TO_BROWSER.MIDDLEWARE_CHANGES }
+        },
+        () => {
+          return {
+            event: HMR_ACTIONS_SENT_TO_BROWSER.MIDDLEWARE_CHANGES,
+          }
+        }
+      )
     }
   } else {
     manifestLoader.deleteMiddlewareManifest(
@@ -1000,11 +1030,21 @@ export async function handlePagesErrorRoute({
     const writtenEndpoint = await entrypoints.global.app.writeToDisk()
     hooks?.handleWrittenEndpoint(key, writtenEndpoint)
     if (dev) {
-      hooks?.subscribeToChanges(key, false, entrypoints.global.app, () => {
-        // There's a special case for this in `../client/page-bootstrap.ts`.
-        // https://github.com/vercel/next.js/blob/08d7a7e5189a835f5dcb82af026174e587575c0e/packages/next/src/client/page-bootstrap.ts#L69-L71
-        return { event: HMR_ACTIONS_SENT_TO_BROWSER.CLIENT_CHANGES }
-      })
+      hooks?.subscribeToChanges(
+        key,
+        false,
+        entrypoints.global.app,
+        () => {
+          // There's a special case for this in `../client/page-bootstrap.ts`.
+          // https://github.com/vercel/next.js/blob/08d7a7e5189a835f5dcb82af026174e587575c0e/packages/next/src/client/page-bootstrap.ts#L69-L71
+          return { event: HMR_ACTIONS_SENT_TO_BROWSER.CLIENT_CHANGES }
+        },
+        () => {
+          return {
+            action: HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE,
+          }
+        }
+      )
     }
     processIssues(currentEntryIssues, key, writtenEndpoint, false, logErrors)
   }
@@ -1018,9 +1058,17 @@ export async function handlePagesErrorRoute({
     const writtenEndpoint = await entrypoints.global.document.writeToDisk()
     hooks?.handleWrittenEndpoint(key, writtenEndpoint)
     if (dev) {
-      hooks?.subscribeToChanges(key, false, entrypoints.global.document, () => {
-        return { action: HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE }
-      })
+      hooks?.subscribeToChanges(
+        key,
+        false,
+        entrypoints.global.document,
+        () => {
+          return { action: HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE }
+        },
+        () => {
+          return { action: HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE }
+        }
+      )
     }
     processIssues(currentEntryIssues, key, writtenEndpoint, false, logErrors)
   }
@@ -1032,11 +1080,19 @@ export async function handlePagesErrorRoute({
     const writtenEndpoint = await entrypoints.global.error.writeToDisk()
     hooks?.handleWrittenEndpoint(key, writtenEndpoint)
     if (dev) {
-      hooks?.subscribeToChanges(key, false, entrypoints.global.error, () => {
-        // There's a special case for this in `../client/page-bootstrap.ts`.
-        // https://github.com/vercel/next.js/blob/08d7a7e5189a835f5dcb82af026174e587575c0e/packages/next/src/client/page-bootstrap.ts#L69-L71
-        return { event: HMR_ACTIONS_SENT_TO_BROWSER.CLIENT_CHANGES }
-      })
+      hooks?.subscribeToChanges(
+        key,
+        false,
+        entrypoints.global.error,
+        () => {
+          // There's a special case for this in `../client/page-bootstrap.ts`.
+          // https://github.com/vercel/next.js/blob/08d7a7e5189a835f5dcb82af026174e587575c0e/packages/next/src/client/page-bootstrap.ts#L69-L71
+          return { event: HMR_ACTIONS_SENT_TO_BROWSER.CLIENT_CHANGES }
+        },
+        () => {
+          return { action: HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE }
+        }
+      )
     }
     processIssues(currentEntryIssues, key, writtenEndpoint, false, logErrors)
   }


### PR DESCRIPTION
### What?

* stable Vcs without TraitRef::cell
* move entrypoints awaiting earlier
* consistent middleware and instrumentation endpoint using a empty endpoint to avoid errors
* handle error when subscribing to changes
