### PR TITLE
Fix not-found case with incremental tracing

### DIFF
--- a/packages/next/src/build/flying-shuttle/detect-changed-entries.ts
+++ b/packages/next/src/build/flying-shuttle/detect-changed-entries.ts
@@ -241,7 +241,10 @@ export async function detectChangedEntries({
           console.error('missing trace data', traceFile, normalizedEntry)
         }
       } catch (err) {
-        console.error(`Failed to detect change for ${entry}`, err)
+        console.error(
+          `Failed to detect change for ${entry} ${normalizedEntry}`,
+          err
+        )
       }
     }
 
@@ -275,7 +278,11 @@ export async function detectChangedEntries({
   }
 
   for (const entry of appPaths || []) {
-    const normalizedEntry = getPageFromPath(entry, pageExtensions)
+    let normalizedEntry = getPageFromPath(entry, pageExtensions)
+
+    if (normalizedEntry === '/not-found') {
+      normalizedEntry = '/_not-found/page'
+    }
     await detectChange({ entry, normalizedEntry, type: 'app' })
   }
 

--- a/packages/next/src/build/flying-shuttle/stitch-builds.ts
+++ b/packages/next/src/build/flying-shuttle/stitch-builds.ts
@@ -141,6 +141,9 @@ export async function stitchBuilds(
           if (normalizedEntry === '/') {
             normalizedEntry = '/index'
           }
+          if (normalizedEntry === '/not-found') {
+            normalizedEntry = '/_not-found/page'
+          }
           await copyPageChunk(normalizedEntry, type)
         } finally {
           copySema.release()
@@ -148,8 +151,6 @@ export async function stitchBuilds(
       })
     )
   }
-  // always attempt copying not-found chunk
-  await copyPageChunk('/_not-found/page', 'app').catch(() => {})
 
   // merge dynamic/static routes in routes-manifest
   const [restoreRoutesManifest, currentRoutesManifest] = await Promise.all(

--- a/test/e2e/app-dir/app/app/not-found.js
+++ b/test/e2e/app-dir/app/app/not-found.js
@@ -1,0 +1,9 @@
+import * as styles from './not-found.module.css'
+
+export default function Page() {
+  return (
+    <>
+      <p className={styles.text}>top-level not found page</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app/app/not-found.js
+++ b/test/e2e/app-dir/app/app/not-found.js
@@ -3,7 +3,7 @@ import * as styles from './not-found.module.css'
 export default function Page() {
   return (
     <>
-      <p className={styles.text}>top-level not found page</p>
+      <p className={styles.text}>This page could not be found</p>
     </>
   )
 }

--- a/test/e2e/app-dir/app/app/not-found.module.css
+++ b/test/e2e/app-dir/app/app/not-found.module.css
@@ -1,0 +1,3 @@
+.text {
+  color: cyan;
+}

--- a/test/e2e/app-dir/app/flying-shuttle.test.ts
+++ b/test/e2e/app-dir/app/flying-shuttle.test.ts
@@ -214,7 +214,7 @@ import { nextTestSetup, isNextStart } from 'e2e-utils'
         },
         {
           path: '/non-existent/path',
-          content: 'top-level not found page',
+          content: 'This page could not be found',
           type: 'app',
           status: 404,
         },

--- a/test/e2e/app-dir/app/flying-shuttle.test.ts
+++ b/test/e2e/app-dir/app/flying-shuttle.test.ts
@@ -37,6 +37,11 @@ import { nextTestSetup, isNextStart } from 'e2e-utils'
       initialConfig = manifest.config
     })
 
+    function checkErrorLogs() {
+      expect(next.cliOutput).not.toContain('ENOENT')
+      expect(next.cliOutput).not.toContain('Failed to detect change')
+    }
+
     async function checkShuttleManifest() {
       const manifest = await next.readJSON(
         '.next/cache/shuttle/shuttle-manifest.json'
@@ -46,6 +51,14 @@ import { nextTestSetup, isNextStart } from 'e2e-utils'
         nextVersion,
         config: initialConfig,
       })
+    }
+
+    async function nextStart() {
+      // our initial build was built in store-only mode so
+      // enable full version in successive builds
+      delete next.env['NEXT_PRIVATE_FLYING_SHUTTLE_STORE_ONLY']
+      next.env['NEXT_PRIVATE_FLYING_SHUTTLE'] = '1'
+      await next.start()
     }
 
     it('should have file hashes in trace files', async () => {
@@ -199,14 +212,20 @@ import { nextTestSetup, isNextStart } from 'e2e-utils'
           content: 'hello from app/dashboard/deployments/[id]',
           type: 'app',
         },
+        {
+          path: '/non-existent/path',
+          content: 'top-level not found page',
+          type: 'app',
+          status: 404,
+        },
       ]
 
       for (const testPath of testPaths) {
-        const { path, content } = testPath
+        const { path, content, status } = testPath
         require('console').error('checking', path)
 
         const res = await next.fetch(path)
-        expect(res.status).toBe(200)
+        expect(res.status).toBe(status || 200)
 
         const browser = await next.browser(path)
 
@@ -252,11 +271,6 @@ import { nextTestSetup, isNextStart } from 'e2e-utils'
     }
 
     it('should only rebuild just a changed app route correctly', async () => {
-      // our initial build was built in store-only mode so
-      // enable full version in successive builds
-      delete next.env['NEXT_PRIVATE_FLYING_SHUTTLE_STORE_ONLY']
-      next.env['NEXT_PRIVATE_FLYING_SHUTTLE'] = '1'
-
       await next.stop()
 
       const dataPath = 'app/dashboard/deployments/[id]/data.json'
@@ -264,8 +278,10 @@ import { nextTestSetup, isNextStart } from 'e2e-utils'
 
       try {
         await next.patchFile(dataPath, JSON.stringify({ hello: 'again' }))
-        await next.start()
+        await nextStart()
+        checkErrorLogs()
 
+        expect(next.cliOutput).not.toContain('/not-found')
         expect(next.cliOutput).not.toContain('/catch-all')
         expect(next.cliOutput).not.toContain('/blog/[slug]')
         expect(next.cliOutput).toContain('/dashboard/deployments/[id]')
@@ -291,9 +307,12 @@ import { nextTestSetup, isNextStart } from 'e2e-utils'
             'hello from pages/index!!'
           )
         )
-        await next.start()
+        await nextStart()
+
+        checkErrorLogs()
 
         expect(next.cliOutput).toContain('/')
+        expect(next.cliOutput).not.toContain('/not-found')
         expect(next.cliOutput).not.toContain('/catch-all')
         expect(next.cliOutput).not.toContain('/blog/[slug]')
 
@@ -321,10 +340,13 @@ import { nextTestSetup, isNextStart } from 'e2e-utils'
           )
         )
         await next.patchFile(dataPath, JSON.stringify({ hello: 'again' }))
-        await next.start()
+        await nextStart()
+
+        checkErrorLogs()
 
         expect(next.cliOutput).toContain('/')
         expect(next.cliOutput).toContain('/dashboard/deployments/[id]')
+        expect(next.cliOutput).not.toContain('/not-found')
         expect(next.cliOutput).not.toContain('/catch-all')
         expect(next.cliOutput).not.toContain('/blog/[slug]')
 
@@ -332,6 +354,39 @@ import { nextTestSetup, isNextStart } from 'e2e-utils'
         await checkAppPagesNavigation()
       } finally {
         await next.patchFile(pagePath, originalPageContent)
+        await next.patchFile(dataPath, originalDataContent)
+      }
+    })
+
+    it('should rebuild not-found when it changed', async () => {
+      await next.stop()
+
+      const dataPath = 'app/not-found.module.css'
+      const originalDataContent = await next.readFile(dataPath)
+
+      try {
+        await next.patchFile(
+          dataPath,
+          originalDataContent.replace('cyan', 'pink')
+        )
+        await nextStart()
+
+        checkErrorLogs()
+
+        expect(next.cliOutput).toContain('/not-found')
+
+        const browser = await next.browser('/non-existent/path')
+        await retry(async () => {
+          expect(
+            await browser.eval(
+              'getComputedStyle(document.querySelector("p")).color'
+            )
+          ).toBe('rgb(255, 192, 203)')
+        })
+
+        await checkShuttleManifest()
+        await checkAppPagesNavigation()
+      } finally {
         await next.patchFile(dataPath, originalDataContent)
       }
     })


### PR DESCRIPTION
This ensures we properly handle the `_not-found` remapping of the entry and ensures it invalidates properly when changed with the experimental trace handling. Prior to this you would see `failed to detect changes` on every successive build for the `not-found` route if present. 

Closes: NDX-263