### PR TITLE
docs(route-handlers): add note about caching with other support HTTP methods in Route Handlers

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/13-route-handlers.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/13-route-handlers.mdx
@@ -46,7 +46,7 @@ In addition to supporting the native [Request](https://developer.mozilla.org/doc
 
 ### Caching
 
-Route Handlers are not cached by default. You can, however, opt into caching for `GET` methods. Other support HTTP methods are **not** cached. To do so, use a [route config option](/docs/app/api-reference/file-conventions/route-segment-config#dynamic) such as `export const dynamic = 'force-static'` in your Route Handler file.
+Route Handlers are not cached by default. You can, however, opt into caching for `GET` methods. Other support HTTP methods are **not** cached. To cache a `GET` method, use a [route config option](/docs/app/api-reference/file-conventions/route-segment-config#dynamic) such as `export const dynamic = 'force-static'` in your Route Handler file.
 
 ```ts filename="app/items/route.ts" switcher
 export const dynamic = 'force-static'

--- a/docs/02-app/01-building-your-application/01-routing/13-route-handlers.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/13-route-handlers.mdx
@@ -46,7 +46,7 @@ In addition to supporting the native [Request](https://developer.mozilla.org/doc
 
 ### Caching
 
-Route Handlers are not cached by default. You can, however, opt into caching for `GET` methods. To do so, use a [route config option](/docs/app/api-reference/file-conventions/route-segment-config#dynamic) such as `export const dynamic = 'force-static'` in your Route Handler file.
+Route Handlers are not cached by default. You can, however, opt into caching for `GET` methods. Other support HTTP methods are **not** cached. To do so, use a [route config option](/docs/app/api-reference/file-conventions/route-segment-config#dynamic) such as `export const dynamic = 'force-static'` in your Route Handler file.
 
 ```ts filename="app/items/route.ts" switcher
 export const dynamic = 'force-static'
@@ -80,7 +80,7 @@ export async function GET() {
 }
 ```
 
-> **Good to know**: Other supported HTTP methods cannot be **not** cached. This remains true if they are placed alongside a `GET` method that is cached, in the same file.
+> **Good to know**: Other supported HTTP methods are **not** cached, even if they are placed alongside a `GET` method that is cached, in the same file.
 
 ### Special Route Handlers
 

--- a/docs/02-app/01-building-your-application/01-routing/13-route-handlers.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/13-route-handlers.mdx
@@ -46,7 +46,7 @@ In addition to supporting the native [Request](https://developer.mozilla.org/doc
 
 ### Caching
 
-Route Handlers are not cached by default. You can, however, opt into caching for `GET` methods. Other support HTTP methods are **not** cached. To cache a `GET` method, use a [route config option](/docs/app/api-reference/file-conventions/route-segment-config#dynamic) such as `export const dynamic = 'force-static'` in your Route Handler file.
+Route Handlers are not cached by default. You can, however, opt into caching for `GET` methods. Other supported HTTP methods are **not** cached. To cache a `GET` method, use a [route config option](/docs/app/api-reference/file-conventions/route-segment-config#dynamic) such as `export const dynamic = 'force-static'` in your Route Handler file.
 
 ```ts filename="app/items/route.ts" switcher
 export const dynamic = 'force-static'

--- a/docs/02-app/01-building-your-application/01-routing/13-route-handlers.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/13-route-handlers.mdx
@@ -80,6 +80,8 @@ export async function GET() {
 }
 ```
 
+> **Good to know**: Other supported HTTP methods cannot be **not** cached. This remains true if they are placed alongside a `GET` method that is cached, in the same file.
+
 ### Special Route Handlers
 
 Special Route Handlers like [`sitemap.ts`](/docs/app/api-reference/file-conventions/metadata/sitemap), [`opengraph-image.tsx`](/docs/app/api-reference/file-conventions/metadata/opengraph-image), and [`icon.tsx`](/docs/app/api-reference/file-conventions/metadata/app-icons), and other [metadata files](/docs/app/api-reference/file-conventions/metadata) remain static by default unless they use dynamic functions or dynamic config options.


### PR DESCRIPTION
## Why?

We currently do not clarify that other supported HTTP Methods (all other besides `GET`) in Route Handlers are not cached. This remains true even if they are placed alongside a `GET` that is cached.