### PR TITLE
generateCacheKey: better heuristic for FormData and URLSearchParams

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -348,7 +348,10 @@ export class IncrementalCache implements IncrementalCacheType {
           console.error('Problem reading body', err)
         }
       } // handle FormData or URLSearchParams bodies
-      else if (typeof (init.body as any).keys === 'function') {
+      else if (
+        typeof (init.body as any).keys === 'function' &&
+        typeof (init.body as any).getAll === 'function'
+      ) {
         const formData = init.body as FormData
         ;(init as any)._ogBody = init.body
         for (const key of new Set([...formData.keys()])) {

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -4063,6 +4063,7 @@ describe('app-dir static/dynamic handling', () => {
       const dataBody2 = $('#data-body2').text()
       const dataBody3 = $('#data-body3').text()
       const dataBody4 = $('#data-body4').text()
+      const dataBody5 = $('#data-body5').text()
 
       const res2 = await fetchViaHTTP(
         next.url,
@@ -4078,6 +4079,7 @@ describe('app-dir static/dynamic handling', () => {
       expect($2('#data-body2').text()).toBe(dataBody2)
       expect($2('#data-body3').text()).toBe(dataBody3)
       expect($2('#data-body4').text()).toBe(dataBody4)
+      expect($2('#data-body5').text()).toBe(dataBody5)
       return 'success'
     }, 'success')
   })

--- a/test/e2e/app-dir/app-static/app/variable-revalidate-edge/post-method/page.js
+++ b/test/e2e/app-dir/app-static/app/variable-revalidate-edge/post-method/page.js
@@ -68,6 +68,17 @@ export default async function Page() {
     }
   ).then((res) => res.text())
 
+  const dataWithBody5 = await fetchRetry(
+    'https://next-data-api-endpoint.vercel.app/api/random',
+    {
+      method: 'POST',
+      body: new Headers({ hello: 'world' }),
+      next: {
+        revalidate: 30,
+      },
+    }
+  ).then((res) => res.text())
+
   return (
     <>
       <p id="page">/variable-revalidate/post-method-cached</p>
@@ -76,6 +87,7 @@ export default async function Page() {
       <p id="data-body2">{dataWithBody2}</p>
       <p id="data-body3">{dataWithBody3}</p>
       <p id="data-body4">{dataWithBody4}</p>
+      <p id="data-body5">{dataWithBody5}</p>
     </>
   )
 }


### PR DESCRIPTION
Problem: `FormData`/`URLSearchParams` code branch of `generateCacheKey()` accesses `keys()` and `getAll()` methods of the body, but it only checks that `keys` is a function and skips the `getAll`.

This causes an error when e.g. body is an [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array), which implements [`keys()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/keys), but not `getAll()`:

```
Failed to generate cache key for [...]
```

Related to https://github.com/connectrpc/connect-es/issues/914.

Solution:  check that `getAll` is also a function before accessing it.