### PR TITLE
(backport) fix(eslint): allow typescript-eslint v8

### DIFF
--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "@next/eslint-plugin-next": "14.2.11",
     "@rushstack/eslint-patch": "^1.3.3",
-    "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || 7.0.0 - 7.2.0",
-    "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || 7.0.0 - 7.2.0",
+    "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+    "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-import-resolver-typescript": "^3.5.2",
     "eslint-plugin-import": "^2.28.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -750,10 +750,10 @@ importers:
         specifier: ^1.3.3
         version: 1.3.3
       '@typescript-eslint/eslint-plugin':
-        specifier: ^5.4.2 || ^6.0.0 || 7.0.0 - 7.2.0
+        specifier: ^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0
         version: 6.14.0(@typescript-eslint/parser@6.14.0)(eslint@8.31.0)(typescript@4.8.2)
       '@typescript-eslint/parser':
-        specifier: ^5.4.2 || ^6.0.0 || 7.0.0 - 7.2.0
+        specifier: ^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0
         version: 6.14.0(eslint@8.31.0)(typescript@4.8.2)
       eslint:
         specifier: ^7.23.0 || ^8.0.0
@@ -3696,11 +3696,11 @@ packages:
   /@eslint-community/regexpp@4.10.0:
     resolution: {integrity: sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-    dev: true
 
   /@eslint-community/regexpp@4.5.1:
     resolution: {integrity: sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+    dev: true
 
   /@eslint/eslintrc@0.4.3:
     resolution: {integrity: sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==}
@@ -7240,7 +7240,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@eslint-community/regexpp': 4.5.1
+      '@eslint-community/regexpp': 4.10.0
       '@typescript-eslint/parser': 6.14.0(eslint@8.31.0)(typescript@4.8.2)
       '@typescript-eslint/scope-manager': 6.14.0
       '@typescript-eslint/type-utils': 6.14.0(eslint@8.31.0)(typescript@4.8.2)
@@ -7251,7 +7251,7 @@ packages:
       graphemer: 1.4.0
       ignore: 5.2.4
       natural-compare: 1.4.0
-      semver: 7.5.4
+      semver: 7.6.2
       ts-api-utils: 1.0.1(typescript@4.8.2)
       typescript: 4.8.2
     transitivePeerDependencies:
@@ -7428,7 +7428,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.4
+      semver: 7.6.2
       ts-api-utils: 1.0.1(typescript@4.8.2)
       typescript: 4.8.2
     transitivePeerDependencies:
@@ -7449,7 +7449,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.4
+      semver: 7.6.2
       ts-api-utils: 1.0.1(typescript@5.2.2)
       typescript: 5.2.2
     transitivePeerDependencies:
@@ -12099,7 +12099,7 @@ packages:
     dependencies:
       acorn: 8.11.3
       acorn-jsx: 5.3.2(acorn@8.11.3)
-      eslint-visitor-keys: 3.4.1
+      eslint-visitor-keys: 3.4.3
     dev: false
 
   /espree@9.6.1:
@@ -14320,7 +14320,7 @@ packages:
       run-async: 2.4.1
       rxjs: 7.8.1
       string-width: 4.2.3
-      strip-ansi: 6.0.1
+      strip-ansi: 6.0.0
       through: 2.3.8
     dev: true
 
@@ -15080,7 +15080,7 @@ packages:
       '@babel/parser': 7.22.5
       '@istanbuljs/schema': 0.1.2
       istanbul-lib-coverage: 3.2.0
-      semver: 7.5.4
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -15795,7 +15795,7 @@ packages:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.5.4
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -16854,6 +16854,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
+    dev: true
 
   /lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
@@ -22359,6 +22360,7 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+    dev: true
 
   /semver@7.6.2:
     resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
@@ -25446,6 +25448,7 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    dev: true
 
   /yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}

--- a/test/production/eslint/test/__snapshots__/next-build-and-lint.test.ts.snap
+++ b/test/production/eslint/test/__snapshots__/next-build-and-lint.test.ts.snap
@@ -299,22 +299,19 @@ exports[`Next Build production mode first time setup with TypeScript 1`] = `
     "@typescript-eslint/ban-ts-comment": [
       "error",
     ],
-    "@typescript-eslint/ban-types": [
-      "error",
-    ],
     "@typescript-eslint/no-array-constructor": [
       "error",
     ],
     "@typescript-eslint/no-duplicate-enum-values": [
       "error",
     ],
+    "@typescript-eslint/no-empty-object-type": [
+      "error",
+    ],
     "@typescript-eslint/no-explicit-any": [
       "error",
     ],
     "@typescript-eslint/no-extra-non-null-assertion": [
-      "error",
-    ],
-    "@typescript-eslint/no-loss-of-precision": [
       "error",
     ],
     "@typescript-eslint/no-misused-new": [
@@ -326,6 +323,9 @@ exports[`Next Build production mode first time setup with TypeScript 1`] = `
     "@typescript-eslint/no-non-null-asserted-optional-chain": [
       "error",
     ],
+    "@typescript-eslint/no-require-imports": [
+      "error",
+    ],
     "@typescript-eslint/no-this-alias": [
       "error",
     ],
@@ -335,13 +335,22 @@ exports[`Next Build production mode first time setup with TypeScript 1`] = `
     "@typescript-eslint/no-unsafe-declaration-merging": [
       "error",
     ],
+    "@typescript-eslint/no-unsafe-function-type": [
+      "error",
+    ],
+    "@typescript-eslint/no-unused-expressions": [
+      "error",
+    ],
     "@typescript-eslint/no-unused-vars": [
       "error",
     ],
-    "@typescript-eslint/no-var-requires": [
+    "@typescript-eslint/no-wrapper-object-types": [
       "error",
     ],
     "@typescript-eslint/prefer-as-const": [
+      "error",
+    ],
+    "@typescript-eslint/prefer-namespace-keyword": [
       "error",
     ],
     "@typescript-eslint/triple-slash-reference": [
@@ -403,7 +412,7 @@ exports[`Next Build production mode first time setup with TypeScript 1`] = `
     "no-import-assign": [
       "off",
     ],
-    "no-loss-of-precision": [
+    "no-new-native-nonconstructor": [
       "off",
     ],
     "no-new-symbol": [
@@ -428,6 +437,9 @@ exports[`Next Build production mode first time setup with TypeScript 1`] = `
       "off",
     ],
     "no-unsafe-negation": [
+      "off",
+    ],
+    "no-unused-expressions": [
       "off",
     ],
     "no-unused-vars": [


### PR DESCRIPTION
# What
Backported [fix(eslint): allow typescript-eslint v8 #68807](https://github.com/vercel/next.js/pull/68807)

# Why
Unblocks upgrading eslint-config-next for projects already on typescript-eslint v8