### PR TITLE
Improve the transform and re-enable optimizeServerReact 

### DIFF
--- a/crates/napi/src/minify.rs
+++ b/crates/napi/src/minify.rs
@@ -110,6 +110,13 @@ impl Task for MinifyTask {
 fn patch_opts(opts: &mut JsMinifyOptions) {
     opts.compress = BoolOrDataConfig::from_obj(TerserCompressorOptions {
         inline: Some(TerserInlineOption::Num(2)),
+        global_defs: [(
+            "process.env.__NEXT_OPTIMIZE_DEC_FALSE".into(),
+            "production".into(),
+        )]
+        .iter()
+        .cloned()
+        .collect(),
         ..Default::default()
     });
     opts.mangle = BoolOrDataConfig::from_obj(MangleOptions {

--- a/crates/napi/src/minify.rs
+++ b/crates/napi/src/minify.rs
@@ -111,7 +111,7 @@ fn patch_opts(opts: &mut JsMinifyOptions) {
     opts.compress = BoolOrDataConfig::from_obj(TerserCompressorOptions {
         inline: Some(TerserInlineOption::Num(2)),
         global_defs: [(
-            "process.env.__NEXT_OPTIMIZE_DEC_FALSE".into(),
+            "process.env.__NEXT_OPTIMIZE_FALSE".into(),
             "production".into(),
         )]
         .iter()

--- a/crates/napi/src/minify.rs
+++ b/crates/napi/src/minify.rs
@@ -111,7 +111,7 @@ fn patch_opts(opts: &mut JsMinifyOptions) {
     opts.compress = BoolOrDataConfig::from_obj(TerserCompressorOptions {
         inline: Some(TerserInlineOption::Num(2)),
         global_defs: [(
-            "process.env.__NEXT_OPTIMIZE_FALSE".into(),
+            "process.env.__NEXT_PRIVATE_MINIMIZE_MARCO_FALSE".into(),
             "production".into(),
         )]
         .iter()

--- a/crates/next-custom-transforms/src/transforms/optimize_server_react.rs
+++ b/crates/next-custom-transforms/src/transforms/optimize_server_react.rs
@@ -62,11 +62,11 @@ fn effect_has_side_effect_deps(call: &CallExpr) -> bool {
 
 fn wrap_expr_with_env_prod_condition(call: CallExpr) -> Expr {
     // Wrap the call expression with the condition
-    // turn it into `process.env.__NEXT_OPTIMIZE_DEC_FALSE` && <call>.
-    // And `process.env.__NEXT_OPTIMIZE_DEC_FALSE`` will be treated as `false` in minification.
+    // turn it into `process.env.__NEXT_OPTIMIZE_FALSE` && <call>.
+    // And `process.env.__NEXT_OPTIMIZE_FALSE`` will be treated as `false` in minification.
     // In this way the expression and dependencies are still available in compilation during
     // bundling, but will be removed in the final DEC.
-    return Expr::Bin(BinExpr {
+    Expr::Bin(BinExpr {
         span: DUMMY_SP,
         left: Box::new(Expr::Member(MemberExpr {
             obj: (Box::new(Expr::Member(MemberExpr {
@@ -83,15 +83,14 @@ fn wrap_expr_with_env_prod_condition(call: CallExpr) -> Expr {
                 span: DUMMY_SP,
             }))),
             prop: (MemberProp::Ident(IdentName {
-                sym: "__NEXT_OPTIMIZE_DEC_FALSE".into(),
+                sym: "__NEXT_OPTIMIZE_FALSE".into(),
                 span: DUMMY_SP,
-                ..Default::default()
             })),
             span: DUMMY_SP,
         })),
         op: op!("&&"),
         right: Box::new(Expr::Call(call)),
-    });
+    })
 }
 
 impl Fold for OptimizeServerReact {

--- a/crates/next-custom-transforms/src/transforms/optimize_server_react.rs
+++ b/crates/next-custom-transforms/src/transforms/optimize_server_react.rs
@@ -62,10 +62,10 @@ fn effect_has_side_effect_deps(call: &CallExpr) -> bool {
 
 fn wrap_expr_with_env_prod_condition(call: CallExpr) -> Expr {
     // Wrap the call expression with the condition
-    // turn it into `process.env.__NEXT_OPTIMIZE_FALSE` && <call>.
-    // And `process.env.__NEXT_OPTIMIZE_FALSE`` will be treated as `false` in minification.
-    // In this way the expression and dependencies are still available in compilation during
-    // bundling, but will be removed in the final DEC.
+    // turn it into `process.env.__NEXT_PRIVATE_MINIMIZE_MARCO_FALSE` && <call>.
+    // And `process.env.__NEXT_PRIVATE_MINIMIZE_MARCO_FALSE`` will be treated as `false` in
+    // minification. In this way the expression and dependencies are still available in
+    // compilation during bundling, but will be removed in the final DEC.
     Expr::Bin(BinExpr {
         span: DUMMY_SP,
         left: Box::new(Expr::Member(MemberExpr {
@@ -83,7 +83,7 @@ fn wrap_expr_with_env_prod_condition(call: CallExpr) -> Expr {
                 span: DUMMY_SP,
             }))),
             prop: (MemberProp::Ident(IdentName {
-                sym: "__NEXT_OPTIMIZE_FALSE".into(),
+                sym: "__NEXT_PRIVATE_MINIMIZE_MARCO_FALSE".into(),
                 span: DUMMY_SP,
             })),
             span: DUMMY_SP,

--- a/crates/next-custom-transforms/tests/fixture/optimize_server_react/1/output.js
+++ b/crates/next-custom-transforms/tests/fixture/optimize_server_react/1/output.js
@@ -1,10 +1,10 @@
 import { useEffect, useLayoutEffect, useMemo } from 'react';
 import React from 'react';
 export default function App() {
-    process.env.__NEXT_OPTIMIZE_FALSE && useEffect(()=>{
+    process.env.__NEXT_PRIVATE_MINIMIZE_MARCO_FALSE && useEffect(()=>{
         console.log('Hello World');
     }, []);
-    process.env.__NEXT_OPTIMIZE_FALSE && useLayoutEffect(()=>{
+    process.env.__NEXT_PRIVATE_MINIMIZE_MARCO_FALSE && useLayoutEffect(()=>{
         function foo() {}
         return ()=>{};
     }, [
@@ -24,7 +24,7 @@ export default function App() {
     const a = useMemo(()=>{
         return 1;
     }, []);
-    process.env.__NEXT_OPTIMIZE_FALSE && React.useEffect(()=>{
+    process.env.__NEXT_PRIVATE_MINIMIZE_MARCO_FALSE && React.useEffect(()=>{
         console.log('Hello World');
     });
     return <div>

--- a/crates/next-custom-transforms/tests/fixture/optimize_server_react/1/output.js
+++ b/crates/next-custom-transforms/tests/fixture/optimize_server_react/1/output.js
@@ -1,8 +1,17 @@
 import { useEffect, useLayoutEffect, useMemo } from 'react';
 import React from 'react';
 export default function App() {
-    null;
-    null;
+    process.env.NODE_ENV !== "production" ? useEffect(()=>{
+        console.log('Hello World');
+    }, []) : null;
+    process.env.NODE_ENV !== "production" ? useLayoutEffect(()=>{
+        function foo() {}
+        return ()=>{};
+    }, [
+        1,
+        2,
+        App
+    ]) : null;
     useLayoutEffect(()=>{}, [
         runSideEffect()
     ]);
@@ -15,7 +24,9 @@ export default function App() {
     const a = useMemo(()=>{
         return 1;
     }, []);
-    null;
+    process.env.NODE_ENV !== "production" ? React.useEffect(()=>{
+        console.log('Hello World');
+    }) : null;
     return <div>
       <h1>Hello World</h1>
     </div>;

--- a/crates/next-custom-transforms/tests/fixture/optimize_server_react/1/output.js
+++ b/crates/next-custom-transforms/tests/fixture/optimize_server_react/1/output.js
@@ -1,17 +1,17 @@
 import { useEffect, useLayoutEffect, useMemo } from 'react';
 import React from 'react';
 export default function App() {
-    process.env.NODE_ENV !== "production" ? useEffect(()=>{
+    process.env.__NEXT_OPTIMIZE_FALSE && useEffect(()=>{
         console.log('Hello World');
-    }, []) : null;
-    process.env.NODE_ENV !== "production" ? useLayoutEffect(()=>{
+    }, []);
+    process.env.__NEXT_OPTIMIZE_FALSE && useLayoutEffect(()=>{
         function foo() {}
         return ()=>{};
     }, [
         1,
         2,
         App
-    ]) : null;
+    ]);
     useLayoutEffect(()=>{}, [
         runSideEffect()
     ]);
@@ -24,9 +24,9 @@ export default function App() {
     const a = useMemo(()=>{
         return 1;
     }, []);
-    process.env.NODE_ENV !== "production" ? React.useEffect(()=>{
+    process.env.__NEXT_OPTIMIZE_FALSE && React.useEffect(()=>{
         console.log('Hello World');
-    }) : null;
+    });
     return <div>
       <h1>Hello World</h1>
     </div>;

--- a/crates/next-custom-transforms/tests/fixture/optimize_server_react/2/output.js
+++ b/crates/next-custom-transforms/tests/fixture/optimize_server_react/2/output.js
@@ -16,7 +16,7 @@ export default function FilterItemDropdown({ list }) {
         ()=>null
     ];
     const ref = useRef(null);
-    process.env.NODE_ENV !== "production" ? useEffect(()=>{
+    process.env.__NEXT_OPTIMIZE_FALSE && useEffect(()=>{
         const handleClickOutside = (event)=>{
             if (ref.current && !ref.current.contains(event.target)) {
                 setOpenSelect(false);
@@ -24,8 +24,8 @@ export default function FilterItemDropdown({ list }) {
         };
         window.addEventListener('click', handleClickOutside);
         return ()=>window.removeEventListener('click', handleClickOutside);
-    }, []) : null;
-    process.env.NODE_ENV !== "production" ? useEffect(()=>{
+    }, []);
+    process.env.__NEXT_OPTIMIZE_FALSE && useEffect(()=>{
         list.forEach((listItem)=>{
             if ('path' in listItem && pathname === listItem.path || 'slug' in listItem && searchParams.get('sort') === listItem.slug) {
                 setActive(listItem.title);
@@ -35,7 +35,7 @@ export default function FilterItemDropdown({ list }) {
         pathname,
         list,
         searchParams
-    ]) : null;
+    ]);
     return <div className="relative" ref={ref}>
       <div onClick={()=>{
         setOpenSelect(!openSelect);

--- a/crates/next-custom-transforms/tests/fixture/optimize_server_react/2/output.js
+++ b/crates/next-custom-transforms/tests/fixture/optimize_server_react/2/output.js
@@ -16,7 +16,7 @@ export default function FilterItemDropdown({ list }) {
         ()=>null
     ];
     const ref = useRef(null);
-    process.env.__NEXT_OPTIMIZE_FALSE && useEffect(()=>{
+    process.env.__NEXT_PRIVATE_MINIMIZE_MARCO_FALSE && useEffect(()=>{
         const handleClickOutside = (event)=>{
             if (ref.current && !ref.current.contains(event.target)) {
                 setOpenSelect(false);
@@ -25,7 +25,7 @@ export default function FilterItemDropdown({ list }) {
         window.addEventListener('click', handleClickOutside);
         return ()=>window.removeEventListener('click', handleClickOutside);
     }, []);
-    process.env.__NEXT_OPTIMIZE_FALSE && useEffect(()=>{
+    process.env.__NEXT_PRIVATE_MINIMIZE_MARCO_FALSE && useEffect(()=>{
         list.forEach((listItem)=>{
             if ('path' in listItem && pathname === listItem.path || 'slug' in listItem && searchParams.get('sort') === listItem.slug) {
                 setActive(listItem.title);

--- a/crates/next-custom-transforms/tests/fixture/optimize_server_react/2/output.js
+++ b/crates/next-custom-transforms/tests/fixture/optimize_server_react/2/output.js
@@ -16,8 +16,26 @@ export default function FilterItemDropdown({ list }) {
         ()=>null
     ];
     const ref = useRef(null);
-    null;
-    null;
+    process.env.NODE_ENV !== "production" ? useEffect(()=>{
+        const handleClickOutside = (event)=>{
+            if (ref.current && !ref.current.contains(event.target)) {
+                setOpenSelect(false);
+            }
+        };
+        window.addEventListener('click', handleClickOutside);
+        return ()=>window.removeEventListener('click', handleClickOutside);
+    }, []) : null;
+    process.env.NODE_ENV !== "production" ? useEffect(()=>{
+        list.forEach((listItem)=>{
+            if ('path' in listItem && pathname === listItem.path || 'slug' in listItem && searchParams.get('sort') === listItem.slug) {
+                setActive(listItem.title);
+            }
+        });
+    }, [
+        pathname,
+        list,
+        searchParams
+    ]) : null;
     return <div className="relative" ref={ref}>
       <div onClick={()=>{
         setOpenSelect(!openSelect);

--- a/crates/next-custom-transforms/tests/fixture/optimize_server_react/4/output.js
+++ b/crates/next-custom-transforms/tests/fixture/optimize_server_react/4/output.js
@@ -5,7 +5,7 @@ export default function App() {
     useEffect(()=>{
         console.log('Hello World');
     }, []);
-    process.env.__NEXT_OPTIMIZE_FALSE && useLayoutEffect(()=>{
+    process.env.__NEXT_PRIVATE_MINIMIZE_MARCO_FALSE && useLayoutEffect(()=>{
         function foo() {}
         return ()=>{};
     }, [

--- a/crates/next-custom-transforms/tests/fixture/optimize_server_react/4/output.js
+++ b/crates/next-custom-transforms/tests/fixture/optimize_server_react/4/output.js
@@ -5,7 +5,14 @@ export default function App() {
     useEffect(()=>{
         console.log('Hello World');
     }, []);
-    null;
+    process.env.NODE_ENV !== "production" ? useLayoutEffect(()=>{
+        function foo() {}
+        return ()=>{};
+    }, [
+        1,
+        2,
+        App
+    ]) : null;
     const a = useMemo(()=>{
         return 1;
     }, []);

--- a/crates/next-custom-transforms/tests/fixture/optimize_server_react/4/output.js
+++ b/crates/next-custom-transforms/tests/fixture/optimize_server_react/4/output.js
@@ -5,14 +5,14 @@ export default function App() {
     useEffect(()=>{
         console.log('Hello World');
     }, []);
-    process.env.NODE_ENV !== "production" ? useLayoutEffect(()=>{
+    process.env.__NEXT_OPTIMIZE_FALSE && useLayoutEffect(()=>{
         function foo() {}
         return ()=>{};
     }, [
         1,
         2,
         App
-    ]) : null;
+    ]);
     const a = useMemo(()=>{
         return 1;
     }, []);

--- a/crates/next-custom-transforms/tests/fixture/optimize_server_react/6/output.js
+++ b/crates/next-custom-transforms/tests/fixture/optimize_server_react/6/output.js
@@ -5,7 +5,7 @@ const Component = ({ children, fallback })=>{
         false,
         ()=>null
     ];
-    null;
+    process.env.NODE_ENV !== "production" ? useEffect(()=>setMounted(true), []) : null;
     if (!mounted) {
         return fallback ?? /* @__PURE__ */ jsx(Fragment, {});
     }

--- a/crates/next-custom-transforms/tests/fixture/optimize_server_react/6/output.js
+++ b/crates/next-custom-transforms/tests/fixture/optimize_server_react/6/output.js
@@ -5,7 +5,7 @@ const Component = ({ children, fallback })=>{
         false,
         ()=>null
     ];
-    process.env.__NEXT_OPTIMIZE_FALSE && useEffect(()=>setMounted(true), []);
+    process.env.__NEXT_PRIVATE_MINIMIZE_MARCO_FALSE && useEffect(()=>setMounted(true), []);
     if (!mounted) {
         return fallback ?? /* @__PURE__ */ jsx(Fragment, {});
     }

--- a/crates/next-custom-transforms/tests/fixture/optimize_server_react/6/output.js
+++ b/crates/next-custom-transforms/tests/fixture/optimize_server_react/6/output.js
@@ -5,7 +5,7 @@ const Component = ({ children, fallback })=>{
         false,
         ()=>null
     ];
-    process.env.NODE_ENV !== "production" ? useEffect(()=>setMounted(true), []) : null;
+    process.env.__NEXT_OPTIMIZE_FALSE && useEffect(()=>setMounted(true), []);
     if (!mounted) {
         return fallback ?? /* @__PURE__ */ jsx(Fragment, {});
     }

--- a/crates/next-custom-transforms/tests/fixture/optimize_server_react/7/output.js
+++ b/crates/next-custom-transforms/tests/fixture/optimize_server_react/7/output.js
@@ -1,17 +1,17 @@
 import { useEffect, useLayoutEffect, useMemo } from 'react';
 import * as React from 'react';
 export default function App() {
-    process.env.NODE_ENV !== "production" ? useEffect(()=>{
+    process.env.__NEXT_OPTIMIZE_FALSE && useEffect(()=>{
         console.log('Hello World');
-    }, []) : null;
-    process.env.NODE_ENV !== "production" ? useLayoutEffect(()=>{
+    }, []);
+    process.env.__NEXT_OPTIMIZE_FALSE && useLayoutEffect(()=>{
         function foo() {}
         return ()=>{};
     }, [
         1,
         2,
         App
-    ]) : null;
+    ]);
     useLayoutEffect(()=>{}, [
         runSideEffect()
     ]);

--- a/crates/next-custom-transforms/tests/fixture/optimize_server_react/7/output.js
+++ b/crates/next-custom-transforms/tests/fixture/optimize_server_react/7/output.js
@@ -1,8 +1,17 @@
 import { useEffect, useLayoutEffect, useMemo } from 'react';
 import * as React from 'react';
 export default function App() {
-    null;
-    null;
+    process.env.NODE_ENV !== "production" ? useEffect(()=>{
+        console.log('Hello World');
+    }, []) : null;
+    process.env.NODE_ENV !== "production" ? useLayoutEffect(()=>{
+        function foo() {}
+        return ()=>{};
+    }, [
+        1,
+        2,
+        App
+    ]) : null;
     useLayoutEffect(()=>{}, [
         runSideEffect()
     ]);

--- a/crates/next-custom-transforms/tests/fixture/optimize_server_react/7/output.js
+++ b/crates/next-custom-transforms/tests/fixture/optimize_server_react/7/output.js
@@ -1,10 +1,10 @@
 import { useEffect, useLayoutEffect, useMemo } from 'react';
 import * as React from 'react';
 export default function App() {
-    process.env.__NEXT_OPTIMIZE_FALSE && useEffect(()=>{
+    process.env.__NEXT_PRIVATE_MINIMIZE_MARCO_FALSE && useEffect(()=>{
         console.log('Hello World');
     }, []);
-    process.env.__NEXT_OPTIMIZE_FALSE && useLayoutEffect(()=>{
+    process.env.__NEXT_PRIVATE_MINIMIZE_MARCO_FALSE && useLayoutEffect(()=>{
         function foo() {}
         return ()=>{};
     }, [

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -400,7 +400,7 @@ export function getLoaderSWCOptions({
     },
   }
 
-  if (optimizeServerReact && isServer /* && !development*/) {
+  if (optimizeServerReact && isServer && !development) {
     baseOptions.optimizeServerReact = {
       optimize_use_state: false,
     }

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -400,7 +400,7 @@ export function getLoaderSWCOptions({
     },
   }
 
-  if (optimizeServerReact && isServer && !development) {
+  if (optimizeServerReact && isServer /* && !development*/) {
     baseOptions.optimizeServerReact = {
       optimize_use_state: false,
     }

--- a/packages/next/src/build/webpack/plugins/minify-webpack-plugin/src/index.ts
+++ b/packages/next/src/build/webpack/plugins/minify-webpack-plugin/src/index.ts
@@ -111,7 +111,7 @@ export class MinifyPlugin {
                   : {}),
                 compress: {
                   global_defs: {
-                    'process.env.__NEXT_OPTIMIZE_FALSE': false,
+                    'process.env.__NEXT_PRIVATE_MINIMIZE_MARCO_FALSE': false,
                   },
                 },
                 mangle: true,

--- a/packages/next/src/build/webpack/plugins/minify-webpack-plugin/src/index.ts
+++ b/packages/next/src/build/webpack/plugins/minify-webpack-plugin/src/index.ts
@@ -111,7 +111,7 @@ export class MinifyPlugin {
                   : {}),
                 compress: {
                   global_defs: {
-                    'process.env.__NEXT_OPTIMIZE_DEC_FALSE': false,
+                    'process.env.__NEXT_OPTIMIZE_FALSE': false,
                   },
                 },
                 mangle: true,

--- a/packages/next/src/build/webpack/plugins/minify-webpack-plugin/src/index.ts
+++ b/packages/next/src/build/webpack/plugins/minify-webpack-plugin/src/index.ts
@@ -109,7 +109,11 @@ export class MinifyPlugin {
                       },
                     }
                   : {}),
-                compress: true,
+                compress: {
+                  global_defs: {
+                    'process.env.__NEXT_OPTIMIZE_DEC_FALSE': false,
+                  },
+                },
                 mangle: true,
                 module: 'unknown',
                 output: {

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1072,7 +1072,7 @@ export const defaultConfig: NextConfig = {
       ),
     webpackBuildWorker: undefined,
     webpackMemoryOptimizations: false,
-    optimizeServerReact: false,
+    optimizeServerReact: true,
     useEarlyImport: false,
     staleTimes: {
       dynamic: 0,

--- a/test/production/app-dir/actions-tree-shaking/use-effect-actions/app/mixed/page.tsx
+++ b/test/production/app-dir/actions-tree-shaking/use-effect-actions/app/mixed/page.tsx
@@ -12,10 +12,10 @@ export default function Page() {
 
   // calling action1 fails!!
   useEffect(() => {
+    action1().then((obj) => {
+      console.log('action1 returned:', obj)
+    })
     if (globalThis.DO_NOT_TREE_SHAKE) {
-      action1().then((obj) => {
-        console.log('action1 returned:', obj)
-      })
     }
   }, [])
 

--- a/test/production/app-dir/actions-tree-shaking/use-effect-actions/app/mixed/page.tsx
+++ b/test/production/app-dir/actions-tree-shaking/use-effect-actions/app/mixed/page.tsx
@@ -12,11 +12,9 @@ export default function Page() {
 
   // calling action1 fails!!
   useEffect(() => {
-    if (globalThis.DO_NOT_TREE_SHAKE) {
-      action1().then((obj) => {
-        console.log('action1 returned:', obj)
-      })
-    }
+    action1().then((obj) => {
+      console.log('action1 returned:', obj)
+    })
   }, [])
 
   return <MyComponent />

--- a/test/production/app-dir/actions-tree-shaking/use-effect-actions/app/mixed/page.tsx
+++ b/test/production/app-dir/actions-tree-shaking/use-effect-actions/app/mixed/page.tsx
@@ -12,9 +12,11 @@ export default function Page() {
 
   // calling action1 fails!!
   useEffect(() => {
-    action1().then((obj) => {
-      console.log('action1 returned:', obj)
-    })
+    if (globalThis.DO_NOT_TREE_SHAKE) {
+      action1().then((obj) => {
+        console.log('action1 returned:', obj)
+      })
+    }
   }, [])
 
   return <MyComponent />


### PR DESCRIPTION
### What

Revert the temporary disabling of #69788, use a different transform that using an process env variable as condition to `&&` with react hooks in SSR layer, and remove drop the call by DCE during minification phase.

Introduce a new internal env `process.env.__NEXT_PRIVATE_MINIMIZE_MARCO_FALSE` as a condition in the SWC transform of `optimizeServerReact` and then it will be replaced as `false` in minification, minifier can identify it as a condition that able to be dropped. The react hook call after it will also get dropped. This is similar to the swc transform erasing but just a bit late : )

### Why

We originally disable the config in #69788 because react actions are dropped too early along with the react hooks useEffect on server side transform. Since we still need to go through the module graph to collect action modules and imported exports, they still need to be present but we can still remove them later.

#### Solution Evaluation Phases

During compilation phase, most simple env replacement and literals can be optimized by SWC (compiler) and webpack (bundler). Using anything like numbers (`1`, `0`), booleans or `process.env.NODE_ENV` will get early optimized.

```js
process.env.NODE_ENV !== 'production' && useEffect(() => { ... })
```

Will be instantly transpiled to `false` during bundling as the optimization can be applied before the module graph is created.

Hence I switched to a new transform below, ensure that `useEffect` and its callback body are still presented while gathering modules.

```js
process.env.__NEXT_PRIVATE_MINIMIZE_MARCO_FALSE && useEffect(() => { ... })
```

Then minifier will replace the env var as `false`, also drop the following hook call with DCE.