### PR TITLE
[Draft] add ga component options

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/12-third-party-libraries.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/12-third-party-libraries.mdx
@@ -334,19 +334,25 @@ enabled in your Admin panel and the _“Page changes based on browser history ev
 selected.
 
 > **Note**: If you decide to manually send pageview events, make sure to disable the default
-> pageview measurement to avoid having duplicate data. Refer to the Google Analytics [developer
-> documentation](https://developers.google.com/analytics/devguides/collection/ga4/views?client_type=gtag#manual_pageviews)
-> to learn more.
+> pageview measurement to avoid having duplicate data. You can disable the default behavior by
+> setting `send_page_view` to `false` in the `gaOptions` argument. 
+> 
+> For more detailed information on manually sending pageview events, please refer to the Google Analytics 
+> [developer documentation](https://developers.google.com/analytics/devguides/collection/ga4/views?client_type=gtag#manual_pageviews).
+>
+> Additionally, `gaOptions` allows you to configure other default parameters, such as `anonymize_ip` 
+> or custom dimensions.
 
 #### Options
 
 Options to pass to the `<GoogleAnalytics>` component.
 
-| Name            | Type     | Description                                                                                            |
-| --------------- | -------- | ------------------------------------------------------------------------------------------------------ |
-| `gaId`          | Required | Your [measurement ID](https://support.google.com/analytics/answer/12270356). Usually starts with `G-`. |
-| `dataLayerName` | Optional | Name of the data layer. Defaults to `dataLayer`.                                                       |
-| `nonce`         | Optional | A [nonce](/docs/app/building-your-application/configuring/content-security-policy#nonces).             |
+| Name            | Type     | Description                                                                                                                                                                                                                                               |
+| --------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `gaId`          | Required | Your [measurement ID](https://support.google.com/analytics/answer/12270356). Usually starts with `G-`.                                                                                                                                                    |
+| `gaOptions`     | Optional | Object containing options for Google Analytics configuration, such as `send_page_view`, and other default parameters you want to set. These options will be passed to the `gtag('config')` function. Eg `{ send_page_view: false, customParam: 'value' }` |
+| `dataLayerName` | Optional | Name of the data layer. Defaults to `dataLayer`.                                                                                                                                                                                                          |
+| `nonce`         | Optional | A [nonce](/docs/app/building-your-application/configuring/content-security-policy#nonces).                                                                                                                                                                |
 
 ### Google Maps Embed
 

--- a/docs/02-app/01-building-your-application/06-optimizing/12-third-party-libraries.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/12-third-party-libraries.mdx
@@ -335,12 +335,12 @@ selected.
 
 > **Note**: If you decide to manually send pageview events, make sure to disable the default
 > pageview measurement to avoid having duplicate data. You can disable the default behavior by
-> setting `send_page_view` to `false` in the `gaOptions` argument. 
-> 
-> For more detailed information on manually sending pageview events, please refer to the Google Analytics 
+> setting `send_page_view` to `false` in the `gaOptions` argument.
+>
+> For more detailed information on manually sending pageview events, please refer to the Google Analytics
 > [developer documentation](https://developers.google.com/analytics/devguides/collection/ga4/views?client_type=gtag#manual_pageviews).
 >
-> Additionally, `gaOptions` allows you to configure other default parameters, such as `anonymize_ip` 
+> Additionally, `gaOptions` allows you to configure other default parameters, such as `anonymize_ip`
 > or custom dimensions.
 
 #### Options

--- a/packages/third-parties/src/google/ga.tsx
+++ b/packages/third-parties/src/google/ga.tsx
@@ -14,7 +14,7 @@ declare global {
 let currDataLayerName: string | undefined = undefined
 
 export function GoogleAnalytics(props: GAParams) {
-  const { gaId, dataLayerName = 'dataLayer', nonce } = props
+  const { gaId, gaOptions = {}, dataLayerName = 'dataLayer', nonce } = props
 
   if (currDataLayerName === undefined) {
     currDataLayerName = dataLayerName
@@ -43,7 +43,7 @@ export function GoogleAnalytics(props: GAParams) {
           function gtag(){window['${dataLayerName}'].push(arguments);}
           gtag('js', new Date());
 
-          gtag('config', '${gaId}');`,
+          gtag('config', '${gaId}', ${JSON.stringify(gaOptions)});`,
         }}
         nonce={nonce}
       />

--- a/packages/third-parties/src/types/google.ts
+++ b/packages/third-parties/src/types/google.ts
@@ -25,6 +25,7 @@ export type GAParams = {
   gaId: string
   dataLayerName?: string
   nonce?: string
+  gaOptions?: { [key: string]: JSONValue }
 }
 
 export type GoogleMapsEmbed = {


### PR DESCRIPTION
## What?
In this PR, we have implemented the process to add `gaOptions` to the `gtag.js` `config`. This allows flexible options to be passed directly to Google Analytics tracking settings. Additionally, the relevant documentation has been updated.

## Why?
The current implementation of `gtag.js` in Next.js does not support flexible options like disabling automatic pageview tracking or passing custom parameters. This change allows developers to have more control over Google Analytics settings.

For further details, please refer to the related discussion
fixes #68801

## How?
1. Implemented the addition of `gaOptions` to the `gtag.js` `config`

- The passed options are applied directly to the `config`.
- Example: Options like `{ sendPageView: false }` or `{ customParam: 'value' }` can now be applied.

2. Updated Documentation

- Added documentation explaining the usage of `gaOptions`, along with usage examples.




<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
