### PR TITLE
Fix eslint root dirs test on Windows

### DIFF
--- a/packages/eslint-plugin-next/src/utils/get-root-dirs.ts
+++ b/packages/eslint-plugin-next/src/utils/get-root-dirs.ts
@@ -5,7 +5,7 @@ import type { Rule } from 'eslint'
  * Process a Next.js root directory glob.
  */
 const processRootDir = (rootDir: string): string[] => {
-  return globSync(rootDir, {
+  return globSync(rootDir.replace(/\\/g, '/'), {
     onlyDirectories: true,
   })
 }


### PR DESCRIPTION
The root dirs tests have been failing on Windows since https://github.com/vercel/next.js/pull/68773 so this fixes to ensure we normalize the slashes passed to `fast-glob` so it looks up as expected. 

x-ref: https://dev.azure.com/nextjs/next.js/_build/results?buildId=98629&view=logs&j=8af7cf9c-43a1-584d-6f5c-57bad8880974&t=7ae70e63-3625-50f4-6764-5b3e72b4bd7a