### PR TITLE
chore: git ignore tsconfig for `test/production`

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -2,5 +2,7 @@
 .vscode
 
 e2e/**/tsconfig.json
+production/**/tsconfig.json
+
 test-junit-report/
 turbopack-test-junit-report/


### PR DESCRIPTION
When `next build` on the local repo, tsconfig may generated, but is not gitignored for `test/production/` as `test/e2e/` does.

![CleanShot 2024-09-17 at 07 01 40](https://github.com/user-attachments/assets/1a005b4b-1b5f-422d-b4c5-9cbe6bbe7848)
