### PR TITLE
feat(turbopack): Preserve used server actions while tree shaking

### DIFF
--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -6,7 +6,14 @@ use next_core::{
     next_manifests::{ActionLayer, ActionManifestWorkerEntry, ServerReferenceManifest},
     util::NextRuntime,
 };
-use swc_core::{common::comments::Comments, ecma::ast::Program};
+use swc_core::{
+    atoms::Atom,
+    common::comments::Comments,
+    ecma::{
+        ast::{Decl, ExportSpecifier, Id, ModuleDecl, ModuleItem, Program},
+        utils::find_pat_ids,
+    },
+};
 use tracing::Instrument;
 use turbo_tasks::{
     graph::{GraphTraversal, NonDeterministic},
@@ -22,11 +29,13 @@ use turbopack_core::{
     output::OutputAsset,
     reference::primary_referenced_modules,
     reference_type::{EcmaScriptModulesReferenceSubType, ReferenceType},
+    resolve::ModulePart,
     virtual_output::VirtualOutputAsset,
     virtual_source::VirtualSource,
 };
 use turbopack_ecmascript::{
-    chunk::EcmascriptChunkPlaceable, parse::ParseResult, EcmascriptParsable,
+    chunk::EcmascriptChunkPlaceable, parse::ParseResult,
+    tree_shake::asset::EcmascriptModulePartAsset, EcmascriptParsable,
 };
 
 /// Scans the RSC entry point's full module graph looking for exported Server
@@ -249,9 +258,9 @@ async fn get_referenced_modules(
 ///
 /// Action names are stored in a leading BlockComment prefixed by
 /// `__next_internal_action_entry_do_not_use__`.
-pub fn parse_server_actions<C: Comments>(
+pub fn parse_server_actions(
     program: &Program,
-    comments: C,
+    comments: &dyn Comments,
 ) -> Option<BTreeMap<String, String>> {
     let byte_pos = match program {
         Program::Module(m) => m.span.lo,
@@ -268,35 +277,122 @@ pub fn parse_server_actions<C: Comments>(
         })
     })
 }
-
 /// Inspects the comments inside [Module] looking for the magic actions comment.
 /// If found, we return the mapping of every action's hashed id to the name of
 /// the exported action function. If not, we return a None.
 #[turbo_tasks::function]
 async fn parse_actions(module: Vc<Box<dyn Module>>) -> Result<Vc<OptionActionMap>> {
-    let parsed = if let Some(ecmascript_asset) =
+    let Some(ecmascript_asset) =
         Vc::try_resolve_sidecast::<Box<dyn EcmascriptParsable>>(module).await?
-    {
-        ecmascript_asset.parse_original()
-    } else {
+    else {
         return Ok(OptionActionMap::none());
     };
 
+    if let Some(module) = Vc::try_resolve_downcast_type::<EcmascriptModulePartAsset>(module).await?
+    {
+        if matches!(
+            &*module.await?.part.await?,
+            ModulePart::Evaluation
+                | ModulePart::Exports
+                | ModulePart::Facade
+                | ModulePart::Internal(..)
+        ) {
+            return Ok(OptionActionMap::none());
+        }
+    }
+
+    let original_parsed = ecmascript_asset.parse_original().resolve().await?;
+
     let ParseResult::Ok {
-        comments, program, ..
-    } = &*parsed.await?
+        program: original,
+        comments,
+        ..
+    } = &*original_parsed.await?
     else {
         // The file might be parse-able, but this is reported separately.
         return Ok(OptionActionMap::none());
     };
 
-    let Some(actions) = parse_server_actions(program, comments.clone()) else {
+    let Some(mut actions) = parse_server_actions(original, comments) else {
         return Ok(OptionActionMap::none());
     };
+
+    let fragment = ecmascript_asset.failsafe_parse().resolve().await?;
+
+    if fragment != original_parsed {
+        let ParseResult::Ok {
+            program: fragment, ..
+        } = &*fragment.await?
+        else {
+            // The file might be be parse-able, but this is reported separately.
+            return Ok(OptionActionMap::none());
+        };
+
+        let all_exports = all_export_names(fragment);
+        actions.retain(|_, name| all_exports.iter().any(|export| export == name));
+    }
 
     let mut actions = IndexMap::from_iter(actions.into_iter());
     actions.sort_keys();
     Ok(Vc::cell(Some(Vc::cell(actions))))
+}
+
+fn all_export_names(program: &Program) -> Vec<Atom> {
+    match program {
+        Program::Module(m) => {
+            let mut exports = Vec::new();
+            for item in m.body.iter() {
+                match item {
+                    ModuleItem::ModuleDecl(
+                        ModuleDecl::ExportDefaultExpr(..) | ModuleDecl::ExportDefaultDecl(..),
+                    ) => {
+                        exports.push("default".into());
+                    }
+                    ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(decl)) => match &decl.decl {
+                        Decl::Class(c) => {
+                            exports.push(c.ident.sym.clone());
+                        }
+                        Decl::Fn(f) => {
+                            exports.push(f.ident.sym.clone());
+                        }
+                        Decl::Var(v) => {
+                            let ids: Vec<Id> = find_pat_ids(v);
+                            exports.extend(ids.into_iter().map(|id| id.0));
+                        }
+                        _ => {}
+                    },
+                    ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(decl)) => {
+                        for s in decl.specifiers.iter() {
+                            match s {
+                                ExportSpecifier::Named(named) => {
+                                    exports.push(
+                                        named
+                                            .exported
+                                            .as_ref()
+                                            .unwrap_or(&named.orig)
+                                            .atom()
+                                            .clone(),
+                                    );
+                                }
+                                ExportSpecifier::Default(_) => {
+                                    exports.push("default".into());
+                                }
+                                ExportSpecifier::Namespace(e) => {
+                                    exports.push(e.name.atom().clone());
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            exports
+        }
+
+        _ => {
+            vec![]
+        }
+    }
 }
 
 /// Converts our cached [parse_actions] call into a data type suitable for

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -42,6 +42,7 @@ use crate::{
         get_next_client_resolved_map,
     },
     next_shared::{
+        next_js_special_exports,
         resolve::{
             get_invalid_server_only_resolve_plugin, ModuleFeatureReportResolvePlugin,
             NextSharedRuntimeResolvePlugin,
@@ -289,6 +290,7 @@ pub async fn get_client_module_options_context(
         tree_shaking_mode: tree_shaking_mode_for_user_code,
         enable_postcss_transform,
         side_effect_free_packages: next_config.optimize_package_imports().await?.clone_value(),
+        special_exports: Some(next_js_special_exports()),
         ..Default::default()
     };
 

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -216,7 +216,7 @@ pub enum ActionManifestWorkerEntry<'a> {
     Serialize,
     Deserialize,
 )]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "kebab-case")]
 pub enum ActionLayer {
     Rsc,
     ActionBrowser,

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -47,6 +47,7 @@ use crate::{
     next_import_map::get_next_server_import_map,
     next_server::resolve::ExternalPredicate,
     next_shared::{
+        next_js_special_exports,
         resolve::{
             get_invalid_client_only_resolve_plugin, get_invalid_styled_jsx_resolve_plugin,
             ModuleFeatureReportResolvePlugin, NextExternalResolvePlugin,
@@ -500,6 +501,7 @@ pub async fn get_server_module_options_context(
         },
         tree_shaking_mode: tree_shaking_mode_for_user_code,
         side_effect_free_packages: next_config.optimize_package_imports().await?.clone_value(),
+        special_exports: Some(next_js_special_exports()),
         ..Default::default()
     };
 

--- a/crates/next-core/src/next_shared/mod.rs
+++ b/crates/next-core/src/next_shared/mod.rs
@@ -1,3 +1,31 @@
+use turbo_tasks::{RcStr, Vc};
+
 pub(crate) mod resolve;
 pub(crate) mod transforms;
 pub(crate) mod webpack_rules;
+
+#[turbo_tasks::function]
+pub fn next_js_special_exports() -> Vc<Vec<RcStr>> {
+    Vc::cell(
+        [
+            "config",
+            "middleware",
+            "runtime",
+            "revalidate",
+            "dynamic",
+            "dynamicParams",
+            "fetchCache",
+            "preferredRegion",
+            "maxDuration",
+            "generateStaticParams",
+            "metadata",
+            "generateMetadata",
+            "getServerSideProps",
+            "getInitialProps",
+            "getStaticProps",
+        ]
+        .into_iter()
+        .map(RcStr::from)
+        .collect::<Vec<RcStr>>(),
+    )
+}

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -143,6 +143,14 @@ pub struct EcmascriptOptions {
     /// If false, they will reference the whole directory. If true, they won't
     /// reference anything and lead to an runtime error instead.
     pub ignore_dynamic_requests: bool,
+    /// The list of export names that should make tree shaking bail off. This is
+    /// required because tree shaking can split imports like `export const
+    /// runtime = 'edge'` as a separate module.
+    ///
+    /// Currently the analysis of these exports are performed from JS (See get-page-static-info.ts)
+    /// using SWC AST, so we can't use original module for that. Instead, we just disable tree
+    /// shaking for those modules.
+    pub special_exports: Vc<Vec<RcStr>>,
 }
 
 #[turbo_tasks::value(serialization = "auto_for_input")]
@@ -436,7 +444,6 @@ impl EcmascriptModuleAsset {
         asset_context: Vc<Box<dyn AssetContext>>,
         ty: Value<EcmascriptModuleAssetType>,
         transforms: Vc<EcmascriptInputTransforms>,
-
         options: Vc<EcmascriptOptions>,
         compile_time_info: Vc<CompileTimeInfo>,
         inner_assets: Vc<InnerAssets>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -451,7 +451,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
 
     let parsed = if let Some(part) = part {
         let parsed = parse(source, ty, transforms);
-        let split_data = split(source.ident(), source, parsed);
+        let split_data = split(source.ident(), source, parsed, options.special_exports);
         part_of_module(split_data, part)
     } else {
         module.failsafe_parse()

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -37,7 +37,12 @@ impl EcmascriptParsable for EcmascriptModulePartAsset {
         let this = self.await?;
 
         let parsed = this.full_module.failsafe_parse();
-        let split_data = split(this.full_module.ident(), this.full_module.source(), parsed);
+        let split_data = split(
+            this.full_module.ident(),
+            this.full_module.source(),
+            parsed,
+            this.full_module.options().await?.special_exports,
+        );
         Ok(part_of_module(split_data, this.part))
     }
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -329,10 +329,13 @@ impl DepGraph {
                 }
             }
 
+            let mut use_export_instead_of_declarator = false;
+
             for item in group {
                 match item {
                     ItemId::Group(ItemIdGroupKind::Export(..)) => {
                         if let Some(export) = &data[item].export {
+                            use_export_instead_of_declarator = true;
                             exports.insert(Key::Export(export.as_str().into()), ix as u32);
 
                             let s = ExportSpecifier::Named(ExportNamedSpecifier {
@@ -383,6 +386,71 @@ impl DepGraph {
                         )))),
                         phase: Default::default(),
                     })));
+            }
+
+            // Workaround for implcit export issue of server actions.
+            //
+            // Inline server actions require the generated `$$ACTION_0` to be **exported**.
+            //
+            // But tree shaking works by removing unused code, and the **export** of $$ACTION_0 is
+            // cleary not used from the external module as it does not exist at all in the user
+            // code.
+            //
+            // So we need to add an import for $$ACTION_0 to the module, so that the export is
+            // preserved.
+            if use_export_instead_of_declarator {
+                for (other_ix, other_group) in groups.graph_ix.iter().enumerate() {
+                    if other_ix == ix {
+                        continue;
+                    }
+
+                    let deps = part_deps.entry(ix as u32).or_default();
+
+                    for other_item in other_group {
+                        if let ItemId::Group(ItemIdGroupKind::Export(export, _)) = other_item {
+                            if !export.0.as_str().starts_with("$$ACTION_") {
+                                continue;
+                            }
+
+                            let Some(&declarator) = declarator.get(export) else {
+                                continue;
+                            };
+
+                            if declarator == ix as u32 {
+                                continue;
+                            }
+
+                            if !has_path_connecting(&groups.idx_graph, ix as u32, declarator, None)
+                            {
+                                continue;
+                            }
+
+                            let s = ImportSpecifier::Named(ImportNamedSpecifier {
+                                span: DUMMY_SP,
+                                local: export.clone().into(),
+                                imported: None,
+                                is_type_only: false,
+                            });
+
+                            required_vars.remove(export);
+
+                            deps.push(PartId::Export(export.0.as_str().into()));
+
+                            chunk.body.push(ModuleItem::ModuleDecl(ModuleDecl::Import(
+                                ImportDecl {
+                                    span: DUMMY_SP,
+                                    specifiers: vec![s],
+                                    src: Box::new(TURBOPACK_PART_IMPORT_SOURCE.into()),
+                                    type_only: false,
+                                    with: Some(Box::new(create_turbopack_part_id_assert(
+                                        PartId::Export(export.0.as_str().into()),
+                                    ))),
+                                    phase: Default::default(),
+                                },
+                            )));
+                        }
+                    }
+                }
             }
 
             // Import variables

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -419,7 +419,12 @@ impl PartialEq for SplitResult {
 
 #[turbo_tasks::function]
 pub(super) async fn split_module(asset: Vc<EcmascriptModuleAsset>) -> Result<Vc<SplitResult>> {
-    Ok(split(asset.source().ident(), asset.source(), asset.parse()))
+    Ok(split(
+        asset.source().ident(),
+        asset.source(),
+        asset.parse(),
+        asset.options().await?.special_exports,
+    ))
 }
 
 #[turbo_tasks::function]
@@ -427,6 +432,7 @@ pub(super) async fn split(
     ident: Vc<AssetIdent>,
     source: Vc<Box<dyn Source>>,
     parsed: Vc<ParseResult>,
+    special_exports: Vc<Vec<RcStr>>,
 ) -> Result<Vc<SplitResult>> {
     let parse_result = parsed.await?;
 
@@ -440,7 +446,7 @@ pub(super) async fn split(
             ..
         } => {
             // If the script file is a common js file, we cannot split the module
-            if util::should_skip_tree_shaking(program) {
+            if util::should_skip_tree_shaking(program, &special_exports.await?) {
                 return Ok(SplitResult::Failed {
                     parse_result: parsed,
                 }

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/util.rs
@@ -14,6 +14,7 @@ use swc_core::{
         visit::{noop_visit_type, Visit, VisitWith},
     },
 };
+use turbo_tasks::RcStr;
 
 use crate::TURBOPACK_HELPER;
 
@@ -392,7 +393,7 @@ where
     v.bindings
 }
 
-pub fn should_skip_tree_shaking(m: &Program) -> bool {
+pub fn should_skip_tree_shaking(m: &Program, special_exports: &[RcStr]) -> bool {
     if let Program::Module(m) = m {
         for item in m.body.iter() {
             match item {
@@ -436,6 +437,30 @@ pub fn should_skip_tree_shaking(m: &Program) -> bool {
                     }
                 }
 
+                // Skip special reexports that are recognized by next.js
+                ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                    decl: Decl::Var(box VarDecl { decls, .. }),
+                    ..
+                })) => {
+                    for decl in decls {
+                        if let Pat::Ident(name) = &decl.name {
+                            if special_exports.iter().any(|s| **s == *name.sym) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+
+                // Skip special reexports that are recognized by next.js
+                ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                    decl: Decl::Fn(f),
+                    ..
+                })) => {
+                    if special_exports.iter().any(|s| **s == *f.ident.sym) {
+                        return true;
+                    }
+                }
+
                 _ => {}
             }
         }
@@ -462,14 +487,6 @@ struct ShouldSkip {
 }
 
 impl Visit for ShouldSkip {
-    fn visit_stmt(&mut self, n: &Stmt) {
-        if self.skip {
-            return;
-        }
-
-        n.visit_children_with(self);
-    }
-
     fn visit_await_expr(&mut self, n: &AwaitExpr) {
         // __turbopack_wasm_module__ is not analyzable because __turbopack_wasm_module__
         // is injected global.
@@ -482,6 +499,14 @@ impl Visit for ShouldSkip {
                 self.skip = true;
                 return;
             }
+        }
+
+        n.visit_children_with(self);
+    }
+
+    fn visit_stmt(&mut self, n: &Stmt) {
+        if self.skip {
+            return;
         }
 
         n.visit_children_with(self);

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -93,6 +93,7 @@ impl ModuleOptions {
             execution_context,
             ref rules,
             tree_shaking_mode,
+            special_exports,
             ..
         } = *module_options_context.await?;
 
@@ -135,6 +136,7 @@ impl ModuleOptions {
             import_externals,
             ignore_dynamic_requests,
             refresh,
+            special_exports: special_exports.unwrap_or_else(|| Vc::cell(vec![])),
             ..Default::default()
         };
         let ecmascript_options_vc = ecmascript_options.cell();


### PR DESCRIPTION
### What?

Add logic to filter/preserve `$$ACTION_*` to turbopack tree shaking.

Note: This PR depends on https://github.com/vercel/next.js/pull/70015

### Why?

To compare CI results with https://github.com/vercel/next.js/pull/70114

### How?
