### PR TITLE
Turbopack: improve edge runtime checker

### DIFF
--- a/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
+++ b/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs
@@ -31,6 +31,16 @@ pub fn warn_for_edge_runtime(
     }
 }
 
+/// This is a very simple visitor that currently only checks if a condition (be it an if-statement
+/// or ternary expression) contains a reference to disallowed globals/etc.
+/// It does not know the difference between
+/// ```js
+/// if(typeof clearImmediate === "function") clearImmediate();
+/// ```
+/// and
+/// ```js
+/// if(typeof clearImmediate !== "function") clearImmediate();
+/// ```
 struct WarnForEdgeRuntime {
     cm: Arc<SourceMap>,
     ctx: ExprCtx,

--- a/crates/next-custom-transforms/tests/fixture/edge-assert/guarded-runtime-process/input.js
+++ b/crates/next-custom-transforms/tests/fixture/edge-assert/guarded-runtime-process/input.js
@@ -1,0 +1,5 @@
+if (process.env.NEXT_RUNTIME === 'edge') {
+  setTimeout(cb, 0)
+} else {
+  setImmediate(cb)
+}

--- a/crates/next-custom-transforms/tests/fixture/edge-assert/guarded-runtime-process/output.js
+++ b/crates/next-custom-transforms/tests/fixture/edge-assert/guarded-runtime-process/output.js
@@ -1,0 +1,5 @@
+if (process.env.NEXT_RUNTIME === 'edge') {
+    setTimeout(cb, 0);
+} else {
+    setImmediate(cb);
+}

--- a/crates/next-custom-transforms/tests/fixture/edge-assert/mixed-process-api/input.js
+++ b/crates/next-custom-transforms/tests/fixture/edge-assert/mixed-process-api/input.js
@@ -1,0 +1,7 @@
+if (typeof process.loadEnvFile === 'function') {
+  console.log(process.loadEnvFile())
+}
+
+typeof process.loadEnvFile === 'function' && process.loadEnvFile()
+
+console.log(process.loadEnvFile())

--- a/crates/next-custom-transforms/tests/fixture/edge-assert/mixed-process-api/output.js
+++ b/crates/next-custom-transforms/tests/fixture/edge-assert/mixed-process-api/output.js
@@ -1,0 +1,5 @@
+if (typeof process.loadEnvFile === 'function') {
+    console.log(process.loadEnvFile());
+}
+typeof process.loadEnvFile === 'function' && process.loadEnvFile();
+console.log(process.loadEnvFile());

--- a/crates/next-custom-transforms/tests/fixture/edge-assert/mixed-process-api/output.stderr
+++ b/crates/next-custom-transforms/tests/fixture/edge-assert/mixed-process-api/output.stderr
@@ -1,0 +1,7 @@
+  x A Node.js API is used (process.loadEnvFile at line: 7) which is not supported in the Edge Runtime.
+  | Learn more: https://nextjs.org/docs/api-reference/edge-runtime
+   ,-[input.js:7:1]
+ 6 | 
+ 7 | console.log(process.loadEnvFile())
+   :             ^^^^^^^^^^^^^^^^^^^
+   `----


### PR DESCRIPTION
Closes PACK-3254

1. Previously, guards were never removed, so a single if statement containing `if(clearImmediate)` would mean that it's valid in the whole file to use `clearImmediate` anywhere. Now it's only valid inside the bodies of conditional. I haven't seen any additional lints caused by this.
2.  `if(process.env.NEXT_RUNTIME === 'edge')` guards are now respected

There are new test cases for each of these.

One new warning from this is the following from `react/cjs/react.development.js` where the unrelated `typeof` doesn't silence the error for `new MessageChannel()` anymore
```
    function enqueueTask(task) {
      if (null === enqueueTaskImpl)
        try {
          var requireString = ("require" + Math.random()).slice(0, 7);
          enqueueTaskImpl = (module && module[requireString]).call(
            module,
            "timers"
          ).setImmediate;
        } catch (_err) {
          enqueueTaskImpl = function (callback) {
            !1 === didWarnAboutMessageChannel &&
              ((didWarnAboutMessageChannel = !0),
              "undefined" === typeof MessageChannel &&
                console.error(
                  "This browser does not have a MessageChannel implementation, so enqueuing tasks via await act(async () => ...) will fail. Please file an issue at https://github.com/facebook/react/issues if you encounter this warning."
                ));
            var channel = new MessageChannel();  /// <---------
            channel.port1.onmessage = callback;
            channel.port2.postMessage(void 0);
          };
        }
      return enqueueTaskImpl(task);
    }
```