### PR TITLE
Only wait for metadata when dynamicIO experiment is on

### DIFF
--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -294,6 +294,7 @@ async function createComponentTreeInternal({
           notFound={
             NotFoundComponent ? (
               <Segment
+                isDynamicIO={experimental.dynamicIO}
                 isStaticGeneration={isStaticGeneration}
                 ready={getMetadataReady}
               >
@@ -500,6 +501,7 @@ async function createComponentTreeInternal({
       actualSegment,
       <Segment
         key={cacheNodeKey}
+        isDynamicIO={experimental.dynamicIO}
         isStaticGeneration={isStaticGeneration}
         ready={getMetadataReady}
       >
@@ -530,6 +532,7 @@ async function createComponentTreeInternal({
     return [
       actualSegment,
       <Segment
+        isDynamicIO={experimental.dynamicIO}
         key={cacheNodeKey}
         isStaticGeneration={isStaticGeneration}
         ready={getMetadataReady}
@@ -585,6 +588,7 @@ async function createComponentTreeInternal({
       <React.Fragment key={cacheNodeKey}>
         <MetadataOutlet ready={getMetadataReady} />
         <Segment
+          isDynamicIO={experimental.dynamicIO}
           isStaticGeneration={isStaticGeneration}
           ready={getMetadataReady}
         >
@@ -608,6 +612,7 @@ async function createComponentTreeInternal({
       // a lazy hole rather than null
       <Segment
         key={cacheNodeKey}
+        isDynamicIO={experimental.dynamicIO}
         isStaticGeneration={isStaticGeneration}
         ready={getMetadataReady}
       >
@@ -636,15 +641,17 @@ async function MetadataOutlet({
 }
 
 async function Segment({
+  isDynamicIO,
   isStaticGeneration,
   ready,
   children,
 }: {
+  isDynamicIO: boolean
   isStaticGeneration: boolean
   ready?: () => Promise<void>
   children: React.ReactNode
 }) {
-  if (isStaticGeneration && ready) {
+  if (isDynamicIO && isStaticGeneration && ready) {
     // During static generation we wait for metadata to complete before rendering segments.
     // This is slower but it allows us to ensure that metadata is finished before we start
     // rendering the segment which can synchronously abort the render in certain circumstances

--- a/test/lib/e2e-utils/index.ts
+++ b/test/lib/e2e-utils/index.ts
@@ -15,7 +15,7 @@ export type { NextInstance }
 // this is due to current --turbo test have a lot of tests fails with timeouts, ends up the whole
 // test job exceeds the 6 hours limit.
 let testTimeout = shouldRunTurboDevTest()
-  ? (240 * 1000) / 4
+  ? (240 * 1000) / 2
   : (process.platform === 'win32' ? 240 : 120) * 1000
 
 if (process.env.NEXT_E2E_TEST_TIMEOUT) {


### PR DESCRIPTION
waiting for metadata is only necessary when `dynamicIO` is enabled. In the long run we will get rid of this waiting anyway when we have async dynamic APIs so we condition this behavior to be only when dynamicIO is on for now