### PR TITLE
Add sentry/nextjs to server externals list

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/serverExternalPackages.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/serverExternalPackages.mdx
@@ -32,6 +32,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `@prisma/client`
 - `@react-pdf/renderer`
 - `@sentry/profiling-node`
+- `@sentry/nextjs`
 - `@sparticuz/chromium`
 - `@swc/core`
 - `argon2`

--- a/docs/03-pages/02-api-reference/04-next-config-js/serverExternalPackages.mdx
+++ b/docs/03-pages/02-api-reference/04-next-config-js/serverExternalPackages.mdx
@@ -32,6 +32,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `@prisma/client`
 - `@react-pdf/renderer`
 - `@sentry/profiling-node`
+- `@sentry/nextjs`
 - `@sparticuz/chromium`
 - `@swc/core`
 - `argon2`

--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -13,6 +13,7 @@
   "@prisma/client",
   "@react-pdf/renderer",
   "@sentry/profiling-node",
+  "@sentry/nextjs",
   "@sparticuz/chromium",
   "@swc/core",
   "argon2",


### PR DESCRIPTION
Adds the `@sentry/nextjs` package to the list of server externals that use conditional module loading.

ref https://github.com/vercel/next.js/pull/68785
ref https://github.com/getsentry/sentry-javascript/issues/12077