### PR TITLE
[ppr] Allow fallback pages to be revalidated

### DIFF
--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -135,6 +135,11 @@ export interface RequestMeta {
    * Whether the request is a middleware invocation
    */
   middlewareInvoke?: boolean
+
+  /**
+   * Whether the default route matches were set on the request during routing.
+   */
+  didSetDefaultRouteMatches?: boolean
 }
 
 /**

--- a/test/production/standalone-mode/required-server-files/app/postpone/isr/[slug]/loading.js
+++ b/test/production/standalone-mode/required-server-files/app/postpone/isr/[slug]/loading.js
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p id="loading">/postpone/isr/[slug]</p>
+}

--- a/test/production/standalone-mode/required-server-files/app/postpone/isr/[slug]/page.js
+++ b/test/production/standalone-mode/required-server-files/app/postpone/isr/[slug]/page.js
@@ -1,0 +1,9 @@
+export default async function Page({ params }) {
+  return (
+    <>
+      <p id="page">/postpone/isr/[slug]</p>
+      <p id="params">{JSON.stringify(params)}</p>
+      <p id="now">{Date.now()}</p>
+    </>
+  )
+}

--- a/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
@@ -379,4 +379,27 @@ describe('required server files app router', () => {
     expect(res.headers.get('content-type')).toEqual('text/x-component')
     expect(res.headers.has('x-nextjs-postponed')).toBeTrue()
   })
+
+  it('should handle revalidating the fallback page', async () => {
+    const res = await fetchViaHTTP(appPort, '/postpone/isr/[slug]', undefined, {
+      headers: {
+        'x-matched-path': '/postpone/isr/[slug]',
+        // We don't include the `x-now-route-matches` header because we want to
+        // test that the fallback route params are correctly set.
+      },
+    })
+
+    expect(res.status).toBe(200)
+
+    const html = await res.text()
+
+    expect(html).not.toContain('</html>')
+
+    const $ = cheerio.load(html)
+
+    expect($('#page').text()).toBeEmpty()
+    expect($('#params').text()).toBeEmpty()
+    expect($('#now').text()).toBeEmpty()
+    expect($('#loading').text()).toBe('/postpone/isr/[slug]')
+  })
 })

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -16612,7 +16612,8 @@
         "required server files app router should send cache tags in minimal mode for ISR",
         "required server files app router should still render when postponed is corrupted",
         "required server files app router should still render when postponed is corrupted with Next-Resume",
-        "required server files app router should still render when postponed is corrupted without Next-Resume"
+        "required server files app router should still render when postponed is corrupted without Next-Resume",
+        "required server files app router should handle revalidating the fallback page"
       ],
       "pending": [],
       "flakey": [],


### PR DESCRIPTION
### What?

This allows fallback pages that have Partial Prerendering enabled to be revalidated in minimal mode.

### How?

When a request comes in without any `x-now-route-matches` headers and has partial prerendering enabled, it will consider it a revalidation request for the fallback page.