### PR TITLE
Add support for `dynamicIO` experiment to `route.ts` modules

### DIFF
--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -96,7 +96,15 @@ export async function exportAppRoute(
     const normalizedPage = normalizeAppPath(page)
     const isMetadataRoute = isMetadataRouteFile(normalizedPage, [], false)
 
-    if (!isStaticGenEnabled(userland) && !isMetadataRoute) {
+    if (
+      !isStaticGenEnabled(userland) &&
+      !isMetadataRoute &&
+      // We don't disable static gen when dynamicIO is enabled because we
+      // expect that anything dynamic in the GET handler will make it dynamic
+      // and thus avoid the cache surprises that led to us removing static gen
+      // unless specifically opted into
+      experimental.dynamicIO !== true
+    ) {
       return { revalidate: 0 }
     }
 

--- a/test/e2e/app-dir/dynamic-io/app/routes/dynamic-cookies/route.ts
+++ b/test/e2e/app-dir/dynamic-io/app/routes/dynamic-cookies/route.ts
@@ -1,0 +1,16 @@
+import type { NextRequest } from 'next/server'
+
+import { cookies } from 'next/headers'
+
+import { getSentinelValue } from '../../getSentinelValue'
+
+export async function GET(request: NextRequest, { params }: { params: {} }) {
+  const sentinel = cookies().get('x-sentinel')
+  return new Response(
+    JSON.stringify({
+      value: getSentinelValue(),
+      type: 'cookies',
+      'x-sentinel': sentinel,
+    })
+  )
+}

--- a/test/e2e/app-dir/dynamic-io/app/routes/dynamic-headers/route.ts
+++ b/test/e2e/app-dir/dynamic-io/app/routes/dynamic-headers/route.ts
@@ -1,0 +1,16 @@
+import type { NextRequest } from 'next/server'
+
+import { headers } from 'next/headers'
+
+import { getSentinelValue } from '../../getSentinelValue'
+
+export async function GET(request: NextRequest, { params }: { params: {} }) {
+  const sentinel = headers().get('x-sentinel')
+  return new Response(
+    JSON.stringify({
+      value: getSentinelValue(),
+      type: 'headers',
+      'x-sentinel': sentinel,
+    })
+  )
+}

--- a/test/e2e/app-dir/dynamic-io/app/routes/dynamic-stream/route.ts
+++ b/test/e2e/app-dir/dynamic-io/app/routes/dynamic-stream/route.ts
@@ -1,0 +1,27 @@
+import type { NextRequest } from 'next/server'
+
+import { getSentinelValue } from '../../getSentinelValue'
+
+export async function GET(request: NextRequest, { params }: { params: {} }) {
+  const result = JSON.stringify({
+    value: getSentinelValue(),
+    message: 'dynamic stream',
+  })
+  const part1 = result.slice(0, result.length / 2)
+  const part2 = result.slice(result.length / 2)
+
+  const encoder = new TextEncoder()
+  const chunks = [encoder.encode(part1), encoder.encode(part2)]
+
+  let sent = 0
+  const stream = new ReadableStream({
+    async pull(controller) {
+      controller.enqueue(chunks[sent++])
+      await new Promise((r) => setTimeout(r, 1))
+      if (sent === chunks.length) {
+        controller.close()
+      }
+    },
+  })
+  return new Response(stream)
+}

--- a/test/e2e/app-dir/dynamic-io/app/routes/dynamic-url/route.ts
+++ b/test/e2e/app-dir/dynamic-io/app/routes/dynamic-url/route.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from 'next/server'
+
+import { getSentinelValue } from '../../getSentinelValue'
+
+export async function GET(request: NextRequest, { params }: { params: {} }) {
+  const search = request.nextUrl.search
+  return new Response(
+    JSON.stringify({
+      value: getSentinelValue(),
+      search,
+    })
+  )
+}

--- a/test/e2e/app-dir/dynamic-io/app/routes/fetch-cached/route.ts
+++ b/test/e2e/app-dir/dynamic-io/app/routes/fetch-cached/route.ts
@@ -1,0 +1,23 @@
+import type { NextRequest } from 'next/server'
+
+import { getSentinelValue } from '../../getSentinelValue'
+
+export async function GET(request: NextRequest, { params }: { params: {} }) {
+  const fetcheda = await fetchRandomCached('a')
+  const fetchedb = await fetchRandomCached('b')
+  return new Response(
+    JSON.stringify({
+      value: getSentinelValue(),
+      random1: fetcheda,
+      random2: fetchedb,
+    })
+  )
+}
+
+const fetchRandomCached = async (entropy: string) => {
+  const response = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?b=' + entropy,
+    { cache: 'force-cache' }
+  )
+  return response.text()
+}

--- a/test/e2e/app-dir/dynamic-io/app/routes/fetch-mixed/route.ts
+++ b/test/e2e/app-dir/dynamic-io/app/routes/fetch-mixed/route.ts
@@ -1,0 +1,30 @@
+import type { NextRequest } from 'next/server'
+
+import { getSentinelValue } from '../../getSentinelValue'
+
+export async function GET(request: NextRequest, { params }: { params: {} }) {
+  const fetcheda = await fetchRandomCached('a')
+  const fetchedb = await fetchRandomUncached('b')
+  return new Response(
+    JSON.stringify({
+      value: getSentinelValue(),
+      random1: fetcheda,
+      random2: fetchedb,
+    })
+  )
+}
+
+const fetchRandomCached = async (entropy: string) => {
+  const response = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?b=' + entropy,
+    { cache: 'force-cache' }
+  )
+  return response.text()
+}
+
+const fetchRandomUncached = async (entropy: string) => {
+  const response = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?b=' + entropy
+  )
+  return response.text()
+}

--- a/test/e2e/app-dir/dynamic-io/app/routes/io-cached/route.ts
+++ b/test/e2e/app-dir/dynamic-io/app/routes/io-cached/route.ts
@@ -1,0 +1,25 @@
+import type { NextRequest } from 'next/server'
+
+import { unstable_cache as cache } from 'next/cache'
+
+import { getSentinelValue } from '../../getSentinelValue'
+
+export async function GET(request: NextRequest, { params }: { params: {} }) {
+  const messagea = await getCachedMessage('hello cached fast', 0)
+  const messageb = await getCachedMessage('hello cached slow', 20)
+  return new Response(
+    JSON.stringify({
+      value: getSentinelValue(),
+      message1: messagea,
+      message2: messageb,
+    })
+  )
+}
+
+async function getMessage(echo, delay) {
+  const tag = ((Math.random() * 10000) | 0).toString(16)
+  await new Promise((r) => setTimeout(r, delay))
+  return `${tag}:${echo}`
+}
+
+const getCachedMessage = cache(getMessage)

--- a/test/e2e/app-dir/dynamic-io/app/routes/io-mixed/route.ts
+++ b/test/e2e/app-dir/dynamic-io/app/routes/io-mixed/route.ts
@@ -1,0 +1,25 @@
+import type { NextRequest } from 'next/server'
+
+import { unstable_cache as cache } from 'next/cache'
+
+import { getSentinelValue } from '../../getSentinelValue'
+
+export async function GET(request: NextRequest, { params }: { params: {} }) {
+  const messagea = await getCachedMessage('hello cached fast', 0)
+  const messageb = await getMessage('hello uncached slow', 20)
+  return new Response(
+    JSON.stringify({
+      value: getSentinelValue(),
+      message1: messagea,
+      message2: messageb,
+    })
+  )
+}
+
+async function getMessage(echo, delay) {
+  const tag = ((Math.random() * 10000) | 0).toString(16)
+  await new Promise((r) => setTimeout(r, delay))
+  return `${tag}:${echo}`
+}
+
+const getCachedMessage = cache(getMessage)

--- a/test/e2e/app-dir/dynamic-io/app/routes/microtask/route.ts
+++ b/test/e2e/app-dir/dynamic-io/app/routes/microtask/route.ts
@@ -1,0 +1,12 @@
+import type { NextRequest } from 'next/server'
+
+import { getSentinelValue } from '../../getSentinelValue'
+
+export async function GET(request: NextRequest, { params }: { params: {} }) {
+  await Promise.resolve()
+  const response = JSON.stringify({
+    value: getSentinelValue(),
+    message: 'microtask',
+  })
+  return new Response(response)
+}

--- a/test/e2e/app-dir/dynamic-io/app/routes/static-stream-async/route.ts
+++ b/test/e2e/app-dir/dynamic-io/app/routes/static-stream-async/route.ts
@@ -1,0 +1,26 @@
+import type { NextRequest } from 'next/server'
+
+import { getSentinelValue } from '../../getSentinelValue'
+
+export async function GET(request: NextRequest, { params }: { params: {} }) {
+  const response = JSON.stringify({
+    value: getSentinelValue(),
+    message: 'stream response',
+  })
+  const part1 = response.slice(0, Math.floor(response.length / 2))
+  const part2 = response.slice(Math.floor(response.length / 2))
+
+  const encoder = new TextEncoder()
+  const chunks = [encoder.encode(part1), encoder.encode(part2)]
+
+  let sent = 0
+  const stream = new ReadableStream({
+    pull(controller) {
+      controller.enqueue(chunks[sent++])
+      if (sent === chunks.length) {
+        controller.close()
+      }
+    },
+  })
+  return new Response(stream)
+}

--- a/test/e2e/app-dir/dynamic-io/app/routes/static-stream-sync/route.ts
+++ b/test/e2e/app-dir/dynamic-io/app/routes/static-stream-sync/route.ts
@@ -1,0 +1,26 @@
+import type { NextRequest } from 'next/server'
+
+import { getSentinelValue } from '../../getSentinelValue'
+
+export function GET(request: NextRequest, { params }: { params: {} }) {
+  const response = JSON.stringify({
+    value: getSentinelValue(),
+    message: 'stream response',
+  })
+  const part1 = response.slice(0, Math.floor(response.length / 2))
+  const part2 = response.slice(Math.floor(response.length / 2))
+
+  const encoder = new TextEncoder()
+  const chunks = [encoder.encode(part1), encoder.encode(part2)]
+
+  let sent = 0
+  const stream = new ReadableStream({
+    pull(controller) {
+      controller.enqueue(chunks[sent++])
+      if (sent === chunks.length) {
+        controller.close()
+      }
+    },
+  })
+  return new Response(stream)
+}

--- a/test/e2e/app-dir/dynamic-io/app/routes/static-string-async/route.ts
+++ b/test/e2e/app-dir/dynamic-io/app/routes/static-string-async/route.ts
@@ -1,0 +1,11 @@
+import type { NextRequest } from 'next/server'
+
+import { getSentinelValue } from '../../getSentinelValue'
+
+export async function GET(request: NextRequest, { params }: { params: {} }) {
+  const response = JSON.stringify({
+    value: getSentinelValue(),
+    message: 'string response',
+  })
+  return new Response(response)
+}

--- a/test/e2e/app-dir/dynamic-io/app/routes/static-string-sync/route.ts
+++ b/test/e2e/app-dir/dynamic-io/app/routes/static-string-sync/route.ts
@@ -1,0 +1,11 @@
+import type { NextRequest } from 'next/server'
+
+import { getSentinelValue } from '../../getSentinelValue'
+
+export function GET(request: NextRequest, { params }: { params: {} }) {
+  const response = JSON.stringify({
+    value: getSentinelValue(),
+    message: 'string response',
+  })
+  return new Response(response)
+}

--- a/test/e2e/app-dir/dynamic-io/app/routes/task/route.ts
+++ b/test/e2e/app-dir/dynamic-io/app/routes/task/route.ts
@@ -1,0 +1,12 @@
+import type { NextRequest } from 'next/server'
+
+import { getSentinelValue } from '../../getSentinelValue'
+
+export async function GET(request: NextRequest, { params }: { params: {} }) {
+  await new Promise((r) => setTimeout(r, 10))
+  const response = JSON.stringify({
+    value: getSentinelValue(),
+    message: 'task',
+  })
+  return new Response(response)
+}

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.routes.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.routes.test.ts
@@ -1,0 +1,227 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('dynamic-io', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should not prerender GET route handlers that use dynamic APIs', async () => {
+    let str = await next.render('/routes/dynamic-cookies', {})
+    let json = JSON.parse(str)
+
+    expect(json.value).toEqual('at runtime')
+    expect(json.type).toEqual('cookies')
+
+    str = await next.render('/routes/dynamic-headers', {})
+    json = JSON.parse(str)
+
+    expect(json.value).toEqual('at runtime')
+    expect(json.type).toEqual('headers')
+
+    str = await next.render('/routes/dynamic-stream', {})
+    json = JSON.parse(str)
+
+    expect(json.value).toEqual('at runtime')
+    expect(json.message).toEqual('dynamic stream')
+
+    str = await next.render('/routes/dynamic-url?foo=bar', {})
+    json = JSON.parse(str)
+
+    expect(json.value).toEqual('at runtime')
+    expect(json.search).toEqual('?foo=bar')
+  })
+
+  it('should prerender GET route handlers that have entirely cached io (fetches)', async () => {
+    let str = await next.render('/routes/fetch-cached', {})
+    let json = JSON.parse(str)
+
+    const random1 = json.random1
+    const random2 = json.random2
+
+    if (isNextDev) {
+      expect(json.value).toEqual('at runtime')
+      expect(typeof random1).toBe('string')
+      expect(typeof random2).toBe('string')
+    } else {
+      expect(json.value).toEqual('at buildtime')
+      expect(typeof random1).toBe('string')
+      expect(typeof random2).toBe('string')
+    }
+
+    str = await next.render('/routes/fetch-cached', {})
+    json = JSON.parse(str)
+
+    if (isNextDev) {
+      expect(json.value).toEqual('at runtime')
+      expect(random1).toEqual(json.random1)
+      expect(random2).toEqual(json.random2)
+    } else {
+      expect(json.value).toEqual('at buildtime')
+      expect(random1).toEqual(json.random1)
+      expect(random2).toEqual(json.random2)
+    }
+  })
+
+  it('should not prerender GET route handlers that have some uncached io (fetches)', async () => {
+    let str = await next.render('/routes/fetch-mixed', {})
+    let json = JSON.parse(str)
+
+    const random1 = json.random1
+    const random2 = json.random2
+
+    if (isNextDev) {
+      expect(json.value).toEqual('at runtime')
+      expect(typeof random1).toBe('string')
+      expect(typeof random2).toBe('string')
+    } else {
+      expect(json.value).toEqual('at runtime')
+      expect(typeof random1).toBe('string')
+      expect(typeof random2).toBe('string')
+    }
+
+    str = await next.render('/routes/fetch-mixed', {})
+    json = JSON.parse(str)
+
+    if (isNextDev) {
+      expect(json.value).toEqual('at runtime')
+      expect(random1).toEqual(json.random1)
+      expect(random2).not.toEqual(json.random2)
+    } else {
+      expect(json.value).toEqual('at runtime')
+      expect(random1).toEqual(json.random1)
+      expect(random2).not.toEqual(json.random2)
+    }
+  })
+
+  it('should prerender GET route handlers that have entirely cached io (unstable_cache)', async () => {
+    let str = await next.render('/routes/io-cached', {})
+    let json = JSON.parse(str)
+
+    const message1 = json.message1
+    const message2 = json.message2
+
+    if (isNextDev) {
+      expect(json.value).toEqual('at runtime')
+      expect(typeof message1).toBe('string')
+      expect(typeof message2).toBe('string')
+    } else {
+      expect(json.value).toEqual('at buildtime')
+      expect(typeof message1).toBe('string')
+      expect(typeof message2).toBe('string')
+    }
+
+    str = await next.render('/routes/io-cached', {})
+    json = JSON.parse(str)
+
+    if (isNextDev) {
+      expect(json.value).toEqual('at runtime')
+      expect(message1).toEqual(json.message1)
+      expect(message2).toEqual(json.message2)
+    } else {
+      expect(json.value).toEqual('at buildtime')
+      expect(message1).toEqual(json.message1)
+      expect(message2).toEqual(json.message2)
+    }
+  })
+
+  it('should not prerender GET route handlers that have some uncached io (unstable_cache)', async () => {
+    let str = await next.render('/routes/io-mixed', {})
+    let json = JSON.parse(str)
+
+    const message1 = json.message1
+    const message2 = json.message2
+
+    if (isNextDev) {
+      expect(json.value).toEqual('at runtime')
+      expect(typeof message1).toBe('string')
+      expect(typeof message2).toBe('string')
+    } else {
+      expect(json.value).toEqual('at runtime')
+      expect(typeof message1).toBe('string')
+      expect(typeof message2).toBe('string')
+    }
+
+    str = await next.render('/routes/io-mixed', {})
+    json = JSON.parse(str)
+
+    if (isNextDev) {
+      expect(json.value).toEqual('at runtime')
+      expect(message1).toEqual(json.message1)
+      expect(message2).not.toEqual(json.message2)
+    } else {
+      expect(json.value).toEqual('at runtime')
+      expect(message1).toEqual(json.message1)
+      expect(message2).not.toEqual(json.message2)
+    }
+  })
+
+  it('should prerender GET route handlers that complete synchronously or in a microtask', async () => {
+    let str = await next.render('/routes/microtask', {})
+    let json = JSON.parse(str)
+
+    if (isNextDev) {
+      expect(json.value).toEqual('at runtime')
+      expect(json.message).toBe('microtask')
+    } else {
+      expect(json.value).toEqual('at buildtime')
+      expect(json.message).toBe('microtask')
+    }
+
+    str = await next.render('/routes/static-stream-sync', {})
+    json = JSON.parse(str)
+
+    if (isNextDev) {
+      expect(json.value).toEqual('at runtime')
+      expect(json.message).toBe('stream response')
+    } else {
+      expect(json.value).toEqual('at buildtime')
+      expect(json.message).toBe('stream response')
+    }
+
+    str = await next.render('/routes/static-stream-async', {})
+    json = JSON.parse(str)
+
+    if (isNextDev) {
+      expect(json.value).toEqual('at runtime')
+      expect(json.message).toBe('stream response')
+    } else {
+      expect(json.value).toEqual('at buildtime')
+      expect(json.message).toBe('stream response')
+    }
+
+    str = await next.render('/routes/static-string-sync', {})
+    json = JSON.parse(str)
+
+    if (isNextDev) {
+      expect(json.value).toEqual('at runtime')
+      expect(json.message).toBe('string response')
+    } else {
+      expect(json.value).toEqual('at buildtime')
+      expect(json.message).toBe('string response')
+    }
+
+    str = await next.render('/routes/static-string-async', {})
+    json = JSON.parse(str)
+
+    if (isNextDev) {
+      expect(json.value).toEqual('at runtime')
+      expect(json.message).toBe('string response')
+    } else {
+      expect(json.value).toEqual('at buildtime')
+      expect(json.message).toBe('string response')
+    }
+  })
+
+  it('should not prerender GET route handlers that complete in a new Task', async () => {
+    let str = await next.render('/routes/task', {})
+    let json = JSON.parse(str)
+
+    expect(json.value).toEqual('at runtime')
+    expect(json.message).toBe('task')
+  })
+})


### PR DESCRIPTION
`dyanmicIO` enables a semantic where any uncached IO will be excluded from prerenders. Before PPR this means any uncached IO would bail out of static generation at build time and during revalidates.

Route handlers have a similar ability to be statically generated at build and revalidate time however we recently changed the behavior to only be enabled if you explicitly opt into this using an API like `export const revalidate` or `export const dynamic = "force-static"`. With dynamic IO though we don't really need to be this restrictive.

If you use `unstable_cache` or `fetch(..., { cache: 'force-cache' })` you are opting into caching so when dynamicIO is on we can infer that the GET handler is valid to cache as long as there is no uncached IO. So in this commit we restore static generation when `dynamicIO` is enabled.
