### PR TITLE
Replace URL.canParse

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/get-socket-url.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/get-socket-url.ts
@@ -1,3 +1,4 @@
+import { canParseUrl } from '../../../../../lib/url'
 import { normalizedAssetPrefix } from '../../../../../shared/lib/normalized-asset-prefix'
 
 function getSocketProtocol(assetPrefix: string): string {
@@ -15,7 +16,7 @@ export function getSocketUrl(assetPrefix: string | undefined): string {
   const prefix = normalizedAssetPrefix(assetPrefix)
   const protocol = getSocketProtocol(assetPrefix || '')
 
-  if (URL.canParse(prefix)) {
+  if (canParseUrl(prefix)) {
     // since normalized asset prefix is ensured to be a URL format,
     // we can safely replace the protocol
     return prefix.replace(/^http/, 'ws')

--- a/packages/next/src/lib/url.ts
+++ b/packages/next/src/lib/url.ts
@@ -20,3 +20,15 @@ export function stripNextRscUnionQuery(relativeUrl: string): string {
 
   return urlInstance.pathname + urlInstance.search
 }
+
+export function canParseUrl(url: string): boolean {
+  if (typeof URL.canParse === 'function') {
+    return URL.canParse(url)
+  }
+  try {
+    new URL(url)
+    return true
+  } catch {}
+
+  return false
+}

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -47,6 +47,7 @@ import {
 } from '../dev/hot-reloader-types'
 import { normalizedAssetPrefix } from '../../shared/lib/normalized-asset-prefix'
 import { NEXT_PATCH_SYMBOL } from './patch-fetch'
+import { canParseUrl } from '../../lib/url'
 
 const debug = setupDebug('next:router-server:main')
 const isNextFont = (pathname: string | null) =>
@@ -676,7 +677,7 @@ export async function initialize(opts: {
         if (assetPrefix) {
           hmrPrefix = normalizedAssetPrefix(assetPrefix)
 
-          if (URL.canParse(hmrPrefix)) {
+          if (canParseUrl(hmrPrefix)) {
             // remove trailing slash from pathname
             // return empty string if pathname is '/'
             // to avoid conflicts with '/_next' below

--- a/packages/next/src/shared/lib/normalized-asset-prefix.ts
+++ b/packages/next/src/shared/lib/normalized-asset-prefix.ts
@@ -1,3 +1,5 @@
+import { canParseUrl } from '../../lib/url'
+
 export function normalizedAssetPrefix(assetPrefix: string | undefined): string {
   // remove all leading slashes and trailing slashes
   const escapedAssetPrefix = assetPrefix?.replace(/^\/+|\/+$/g, '') || false
@@ -8,7 +10,7 @@ export function normalizedAssetPrefix(assetPrefix: string | undefined): string {
     return ''
   }
 
-  if (URL.canParse(escapedAssetPrefix)) {
+  if (canParseUrl(escapedAssetPrefix)) {
     const url = new URL(escapedAssetPrefix).toString()
     return url.endsWith('/') ? url.slice(0, -1) : url
   }


### PR DESCRIPTION
### What

Replace `URL.canParse` as it's not generally available right now

Fixes the issue reported in https://github.com/vercel/next.js/discussions/70166

