### PR TITLE
Extend support of Pages router to React 18

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -202,10 +202,12 @@ jobs:
       fail-fast: false
       matrix:
         group: [1/5, 2/5, 3/5, 4/5, 5/5]
+        # Empty value uses default
+        react: ['', '18.3.1']
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: RUST_BACKTRACE=0 NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-dev-tests-manifest.json" TURBOPACK=1 TURBOPACK_DEV=1  NEXT_E2E_TEST_TIMEOUT=240000 NEXT_TEST_MODE=dev node run-tests.js --test-pattern '^(test\/(development|e2e))/.*\.test\.(js|jsx|ts|tsx)$' --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY}
-      stepName: 'test-turbopack-dev-${{ matrix.group }}'
+      afterBuild: RUST_BACKTRACE=0 NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-dev-tests-manifest.json" TURBOPACK=1 TURBOPACK_DEV=1  NEXT_E2E_TEST_TIMEOUT=240000 NEXT_TEST_MODE=dev NEXT_TEST_REACT_VERSION="${{ matrix.react }}" node run-tests.js --test-pattern '^(test\/(development|e2e))/.*\.test\.(js|jsx|ts|tsx)$' --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY}
+      stepName: 'test-turbopack-dev-react-${{ matrix.react }}-${{ matrix.group }}'
     secrets: inherit
 
   test-turbopack-integration:
@@ -217,11 +219,13 @@ jobs:
       fail-fast: false
       matrix:
         group: [1/5, 2/5, 3/5, 4/5, 5/5]
+        # Empty value uses default
+        react: ['']
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: 18.18.2
-      afterBuild: RUST_BACKTRACE=0 NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-dev-tests-manifest.json" TURBOPACK=1 TURBOPACK_DEV=1 node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type integration
-      stepName: 'test-turbopack-integration-${{ matrix.group }}'
+      afterBuild: RUST_BACKTRACE=0 NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-dev-tests-manifest.json" TURBOPACK=1 TURBOPACK_DEV=1 NEXT_TEST_REACT_VERSION="${{ matrix.react }}" node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type integration
+      stepName: 'test-turbopack-integration-react-${{ matrix.react }}-${{ matrix.group }}'
     secrets: inherit
 
   test-turbopack-production:
@@ -233,11 +237,17 @@ jobs:
       fail-fast: false
       matrix:
         group: [1/5, 2/5, 3/5, 4/5, 5/5]
+        # Empty value uses default
+        # TODO: Run with React 18.
+        # Integration tests use the installed React version in next/package.json.include:
+        # We can't easily switch like we do for e2e tests.
+        # Skipping this dimensions until we can figure out a way to test multiple React versions.
+        react: ['', '18.3.1']
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: 18.18.2
-      afterBuild: RUST_BACKTRACE=0 NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-build-tests-manifest.json" TURBOPACK=1 TURBOPACK_BUILD=1 NEXT_TEST_MODE=start node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type production
-      stepName: 'test-turbopack-production-${{ matrix.group }}'
+      afterBuild: RUST_BACKTRACE=0 NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-build-tests-manifest.json" TURBOPACK=1 TURBOPACK_BUILD=1 NEXT_TEST_MODE=start NEXT_TEST_REACT_VERSION="${{ matrix.react }}" node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type production
+      stepName: 'test-turbopack-production-react-${{ matrix.react }}-${{ matrix.group }}'
     secrets: inherit
 
   test-turbopack-production-integration:
@@ -362,10 +372,12 @@ jobs:
       fail-fast: false
       matrix:
         group: [1/4, 2/4, 3/4, 4/4]
+        # Empty value uses default
+        react: ['', '18.3.1']
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: NEXT_TEST_MODE=dev node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type development
-      stepName: 'test-dev-${{ matrix.group }}'
+      afterBuild: NEXT_TEST_MODE=dev NEXT_TEST_REACT_VERSION="${{ matrix.react }}" node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type development
+      stepName: 'test-dev-react-${{ matrix.react }}-${{ matrix.group }}'
     secrets: inherit
 
   test-prod:
@@ -377,10 +389,12 @@ jobs:
       fail-fast: false
       matrix:
         group: [1/5, 2/5, 3/5, 4/5, 5/5]
+        # Empty value uses default
+        react: ['', '18.3.1']
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: NEXT_TEST_MODE=start node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type production
-      stepName: 'test-prod-${{ matrix.group }}'
+      afterBuild: NEXT_TEST_MODE=start NEXT_TEST_REACT_VERSION="${{ matrix.react }}" node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type production
+      stepName: 'test-prod-react-${{ matrix.react }}-${{ matrix.group }}'
     secrets: inherit
 
   test-integration:
@@ -404,11 +418,18 @@ jobs:
           - 10/12
           - 11/12
           - 12/12
+          # Empty value uses default
+          # TODO: Run with React 18.
+          # Integration tests use the installed React version in next/package.json.include:
+          -
+        # We can't easily switch like we do for e2e tests.
+        # Skipping this dimensions until we can figure out a way to test multiple React versions.
+        react: ['']
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: 18.18.2
-      afterBuild: node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type integration
-      stepName: 'test-integration-${{ matrix.group }}'
+      afterBuild: NEXT_TEST_REACT_VERSION="${{ matrix.react }}" node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type integration
+      stepName: 'test-integration-${{ matrix.group }}-react-${{ matrix.react }}'
     secrets: inherit
 
   test-firefox-safari:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -421,7 +421,6 @@ jobs:
           # Empty value uses default
           # TODO: Run with React 18.
           # Integration tests use the installed React version in next/package.json.include:
-          -
         # We can't easily switch like we do for e2e tests.
         # Skipping this dimensions until we can figure out a way to test multiple React versions.
         react: ['']

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -568,6 +568,15 @@ async fn insert_next_server_special_aliases(
     );
 
     import_map.insert_exact_alias(
+        "next/dist/server/ReactDOMServerPages",
+        ImportMapping::Alternatives(vec![
+            request_to_import_mapping(project_path, "react-dom/server.edge"),
+            request_to_import_mapping(project_path, "react-dom/server.browser"),
+        ])
+        .cell(),
+    );
+
+    import_map.insert_exact_alias(
         "@opentelemetry/api",
         // It needs to prefer the local version of @opentelemetry/api
         ImportMapping::Alternatives(vec![

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -107,8 +107,8 @@
     "@opentelemetry/api": "^1.1.0",
     "@playwright/test": "^1.41.2",
     "babel-plugin-react-compiler": "*",
-    "react": "19.0.0-rc-5d19e1c8-20240923",
-    "react-dom": "19.0.0-rc-5d19e1c8-20240923",
+    "react": "^18.2.0 || 19.0.0-rc-5d19e1c8-20240923",
+    "react-dom": "^18.2.0 || 19.0.0-rc-5d19e1c8-20240923",
     "sass": "^1.3.0"
   },
   "peerDependenciesMeta": {

--- a/packages/next/src/build/create-compiler-aliases.ts
+++ b/packages/next/src/build/create-compiler-aliases.ts
@@ -1,4 +1,5 @@
 import path from 'path'
+import * as React from 'react'
 import {
   DOT_NEXT_ALIAS,
   PAGES_DIR_ALIAS,
@@ -20,6 +21,8 @@ import { isWebpackServerOnlyLayer } from './utils'
 interface CompilerAliases {
   [alias: string]: string | string[]
 }
+
+const isReact19 = typeof React.use === 'function'
 
 export function createWebpackAliases({
   distDir,
@@ -89,6 +92,12 @@ export function createWebpackAliases({
 
   return {
     '@vercel/og$': 'next/dist/server/og/image-response',
+
+    // Avoid bundling both entrypoints in React 19 when we just need one.
+    // Also avoids bundler warnings in React 18 where react-dom/server.edge doesn't exist.
+    'next/dist/server/ReactDOMServerPages': isReact19
+      ? 'react-dom/server.edge'
+      : 'react-dom/server.browser',
 
     // Alias next/dist imports to next/dist/esm assets,
     // let this alias hit before `next` alias.

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -107,8 +107,8 @@ const NEXT_PROJECT_ROOT_DIST_CLIENT = path.join(
   'client'
 )
 
-if (parseInt(React.version) < 19) {
-  throw new Error('Next.js requires react >= 19.0.0 to be installed.')
+if (parseInt(React.version) < 18) {
+  throw new Error('Next.js requires react >= 18.2.0 to be installed.')
 }
 
 export const babelIncludeRegexes: RegExp[] = [

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1974,6 +1974,14 @@ export default async function getBaseWebpackConfig(
           )
         ),
     ].filter(Boolean as any as ExcludesFalse),
+    ignoreWarnings: [
+      (warning) => {
+        // require('react-dom/server.edge') is wrapped in try-catch so save to ignore.
+        return warning.message.startsWith(
+          'Module not found: Error: Package path ./server.edge is not exported from package'
+        )
+      },
+    ],
   }
 
   // Support tsconfig and jsconfig baseUrl

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1974,14 +1974,6 @@ export default async function getBaseWebpackConfig(
           )
         ),
     ].filter(Boolean as any as ExcludesFalse),
-    ignoreWarnings: [
-      (warning) => {
-        // require('react-dom/server.edge') is wrapped in try-catch so save to ignore.
-        return warning.message.startsWith(
-          'Module not found: Error: Package path ./server.edge is not exported from package'
-        )
-      },
-    ],
   }
 
   // Support tsconfig and jsconfig baseUrl

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/component-stack-pseudo-html.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/component-stack-pseudo-html.tsx
@@ -66,7 +66,7 @@ export function PseudoHtmlDiff({
   firstContent: string
   secondContent: string
   reactOutputComponentDiff: string | undefined
-  hydrationMismatchType: 'tag' | 'text'
+  hydrationMismatchType: 'tag' | 'text' | 'text-in-tag'
 } & React.HTMLAttributes<HTMLPreElement>) {
   const isHtmlTagsWarning = hydrationMismatchType === 'tag'
   const isReactHydrationDiff = !!reactOutputComponentDiff

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/hydration-error-info.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/hydration-error-info.ts
@@ -17,21 +17,62 @@ export const hydrationErrorState: HydrationErrorState = {}
 
 // https://github.com/facebook/react/blob/main/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js used as a reference
 const htmlTagsWarnings = new Set([
-  'In HTML, %s cannot be a child of <%s>.%s\nThis will cause a hydration error.%s',
-  'In HTML, %s cannot be a descendant of <%s>.\nThis will cause a hydration error.%s',
-  'In HTML, text nodes cannot be a child of <%s>.\nThis will cause a hydration error.',
-  "In HTML, whitespace text nodes cannot be a child of <%s>. Make sure you don't have any extra whitespace between tags on each line of your source code.\nThis will cause a hydration error.",
+  'Warning: In HTML, %s cannot be a child of <%s>.%s\nThis will cause a hydration error.%s',
+  'Warning: In HTML, %s cannot be a descendant of <%s>.\nThis will cause a hydration error.%s',
+  'Warning: In HTML, text nodes cannot be a child of <%s>.\nThis will cause a hydration error.',
+  "Warning: In HTML, whitespace text nodes cannot be a child of <%s>. Make sure you don't have any extra whitespace between tags on each line of your source code.\nThis will cause a hydration error.",
+  'Warning: Expected server HTML to contain a matching <%s> in <%s>.%s',
+  'Warning: Did not expect server HTML to contain a <%s> in <%s>.%s',
 ])
+const textAndTagsMismatchWarnings = new Set([
+  'Warning: Expected server HTML to contain a matching text node for "%s" in <%s>.%s',
+  'Warning: Did not expect server HTML to contain the text node "%s" in <%s>.%s',
+])
+const textMismatchWarning =
+  'Warning: Text content did not match. Server: "%s" Client: "%s"%s'
 
-export const getHydrationWarningType = (msg: NullableText): 'tag' | 'text' => {
-  if (isHtmlTagsWarning(msg)) return 'tag'
+export const getHydrationWarningType = (
+  message: NullableText
+): 'tag' | 'text' | 'text-in-tag' => {
+  if (typeof message !== 'string') {
+    // TODO: Doesn't make sense to treat no message as a hydration error message.
+    // We should bail out somewhere earlier.
+    return 'text'
+  }
+
+  const normalizedMessage = message.startsWith('Warning: ')
+    ? message
+    : `Warning: ${message}`
+
+  if (isHtmlTagsWarning(normalizedMessage)) return 'tag'
+  if (isTextInTagsMismatchWarning(normalizedMessage)) return 'text-in-tag'
+
   return 'text'
 }
 
-const isHtmlTagsWarning = (msg: NullableText) =>
-  Boolean(msg && htmlTagsWarnings.has(msg))
+const isHtmlTagsWarning = (message: string) => htmlTagsWarnings.has(message)
 
-const isKnownHydrationWarning = (msg: NullableText) => isHtmlTagsWarning(msg)
+const isTextMismatchWarning = (message: string) =>
+  textMismatchWarning === message
+const isTextInTagsMismatchWarning = (msg: string) =>
+  textAndTagsMismatchWarnings.has(msg)
+
+const isKnownHydrationWarning = (message: NullableText) => {
+  if (typeof message !== 'string') {
+    return false
+  }
+  // React 18 has the `Warning: ` prefix.
+  // React 19 does not.
+  const normalizedMessage = message.startsWith('Warning: ')
+    ? message
+    : `Warning: ${message}`
+
+  return (
+    isHtmlTagsWarning(normalizedMessage) ||
+    isTextInTagsMismatchWarning(normalizedMessage) ||
+    isTextMismatchWarning(normalizedMessage)
+  )
+}
 
 export const getReactHydrationDiffSegments = (msg: NullableText) => {
   if (msg) {

--- a/packages/next/src/client/legacy/image.tsx
+++ b/packages/next/src/client/legacy/image.tsx
@@ -9,6 +9,8 @@ import React, {
   useState,
   type JSX,
 } from 'react'
+import * as ReactDOM from 'react-dom'
+import Head from '../../shared/lib/head'
 import {
   imageConfigDefault,
   VALID_LOADERS,
@@ -25,6 +27,8 @@ import { normalizePathTrailingSlash } from '../normalize-trailing-slash'
 function normalizeSrc(src: string): string {
   return src[0] === '/' ? src.slice(1) : src
 }
+
+const supportsFloat = typeof ReactDOM.preload === 'function'
 
 const configEnv = process.env.__NEXT_IMAGE_OPTS as any as ImageConfigComplete
 const loadedImageURLs = new Set<string>()
@@ -978,6 +982,20 @@ export default function Image({
     }
   }
 
+  const linkProps:
+    | React.DetailedHTMLProps<
+        React.LinkHTMLAttributes<HTMLLinkElement>,
+        HTMLLinkElement
+      >
+    | undefined = supportsFloat
+    ? undefined
+    : {
+        imageSrcSet: imgAttributes.srcSet,
+        imageSizes: imgAttributes.sizes,
+        crossOrigin: rest.crossOrigin,
+        referrerPolicy: rest.referrerPolicy,
+      }
+
   const useLayoutEffect =
     typeof window === 'undefined' ? React.useEffect : React.useLayoutEffect
   const onLoadingCompleteRef = useRef(onLoadingComplete)
@@ -1044,6 +1062,27 @@ export default function Image({
         ) : null}
         <ImageElement {...imgElementArgs} />
       </span>
+      {!supportsFloat && priority ? (
+        // Note how we omit the `href` attribute, as it would only be relevant
+        // for browsers that do not support `imagesrcset`, and in those cases
+        // it would likely cause the incorrect image to be preloaded.
+        //
+        // https://html.spec.whatwg.org/multipage/semantics.html#attr-link-imagesrcset
+        <Head>
+          <link
+            key={
+              '__nimg-' +
+              imgAttributes.src +
+              imgAttributes.srcSet +
+              imgAttributes.sizes
+            }
+            rel="preload"
+            as="image"
+            href={imgAttributes.srcSet ? undefined : imgAttributes.src}
+            {...linkProps}
+          />
+        </Head>
+      ) : null}
     </>
   )
 }

--- a/packages/next/src/server/ReactDOMServerPages.d.ts
+++ b/packages/next/src/server/ReactDOMServerPages.d.ts
@@ -1,0 +1,1 @@
+export * from 'react-dom/server.edge'

--- a/packages/next/src/server/ReactDOMServerPages.js
+++ b/packages/next/src/server/ReactDOMServerPages.js
@@ -1,0 +1,17 @@
+let ReactDOMServer
+
+try {
+  ReactDOMServer = require('react-dom/server.edge')
+} catch (error) {
+  if (
+    error.code !== 'MODULE_NOT_FOUND' &&
+    error.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED'
+  ) {
+    throw error
+  }
+  // In React versions without react-dom/server.edge, the browser build works in Node.js.
+  // The Node.js build does not support renderToReadableStream.
+  ReactDOMServer = require('react-dom/server.browser')
+}
+
+module.exports = ReactDOMServer

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -40,7 +40,7 @@ import type { Revalidate, SwrDelta } from './lib/revalidate'
 import type { COMPILER_NAMES } from '../shared/lib/constants'
 
 import React, { type JSX } from 'react'
-import ReactDOMServerBrowser from 'react-dom/server.browser'
+import ReactDOMServerPages from './ReactDOMServerPages'
 import { StyleRegistry, createStyleRegistry } from 'styled-jsx'
 import {
   GSP_NO_RETURNED_VALUE,
@@ -127,8 +127,7 @@ function noRouter() {
 }
 
 async function renderToString(element: React.ReactElement) {
-  const renderStream =
-    await ReactDOMServerBrowser.renderToReadableStream(element)
+  const renderStream = await ReactDOMServerPages.renderToReadableStream(element)
   await renderStream.allReady
   return streamToString(renderStream)
 }
@@ -1327,7 +1326,7 @@ export async function renderToHTMLImpl(
     ) => {
       const content = renderContent(EnhancedApp, EnhancedComponent)
       return await renderToInitialFizzStream({
-        ReactDOMServer: ReactDOMServerBrowser,
+        ReactDOMServer: ReactDOMServerPages,
         element: content,
       })
     }

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -40,7 +40,7 @@ import type { Revalidate, SwrDelta } from './lib/revalidate'
 import type { COMPILER_NAMES } from '../shared/lib/constants'
 
 import React, { type JSX } from 'react'
-import ReactDOMServerEdge from 'react-dom/server.edge'
+import ReactDOMServerBrowser from 'react-dom/server.browser'
 import { StyleRegistry, createStyleRegistry } from 'styled-jsx'
 import {
   GSP_NO_RETURNED_VALUE,
@@ -127,7 +127,8 @@ function noRouter() {
 }
 
 async function renderToString(element: React.ReactElement) {
-  const renderStream = await ReactDOMServerEdge.renderToReadableStream(element)
+  const renderStream =
+    await ReactDOMServerBrowser.renderToReadableStream(element)
   await renderStream.allReady
   return streamToString(renderStream)
 }
@@ -1326,7 +1327,7 @@ export async function renderToHTMLImpl(
     ) => {
       const content = renderContent(EnhancedApp, EnhancedComponent)
       return await renderToInitialFizzStream({
-        ReactDOMServer: ReactDOMServerEdge,
+        ReactDOMServer: ReactDOMServerBrowser,
         element: content,
       })
     }

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -40,7 +40,7 @@ import type { Revalidate, SwrDelta } from './lib/revalidate'
 import type { COMPILER_NAMES } from '../shared/lib/constants'
 
 import React, { type JSX } from 'react'
-import ReactDOMServerPages from './ReactDOMServerPages'
+import ReactDOMServerPages from 'next/dist/server/ReactDOMServerPages'
 import { StyleRegistry, createStyleRegistry } from 'styled-jsx'
 import {
   GSP_NO_RETURNED_VALUE,

--- a/packages/next/types/$$compiled.internal.d.ts
+++ b/packages/next/types/$$compiled.internal.d.ts
@@ -37,6 +37,10 @@ declare module 'VAR_USERLAND'
 declare module 'VAR_MODULE_DOCUMENT'
 declare module 'VAR_MODULE_APP'
 
+declare module 'next/dist/server/ReactDOMServerPages' {
+  export * from 'react-dom/server.edge'
+}
+
 declare module 'next/dist/compiled/@napi-rs/triples' {
   export * from '@napi-rs/triples'
 }

--- a/packages/next/types/react-dom.d.ts
+++ b/packages/next/types/react-dom.d.ts
@@ -70,6 +70,10 @@ declare module 'react-dom/server.edge' {
   >
 }
 
+declare module 'react-dom/server.browser' {
+  export * from 'react-dom/server.edge'
+}
+
 declare module 'react-dom/static.edge' {
   import type { JSX } from 'react'
   /**

--- a/packages/next/types/react-dom.d.ts
+++ b/packages/next/types/react-dom.d.ts
@@ -70,10 +70,6 @@ declare module 'react-dom/server.edge' {
   >
 }
 
-declare module 'react-dom/server.browser' {
-  export * from 'react-dom/server.edge'
-}
-
 declare module 'react-dom/static.edge' {
   import type { JSX } from 'react'
   /**

--- a/packages/next/webpack.config.js
+++ b/packages/next/webpack.config.js
@@ -13,6 +13,7 @@ const pagesExternals = [
   'react-dom/package.json',
   'react-dom/client',
   'react-dom/server',
+  'react-dom/server.browser',
   'react-dom/server.edge',
   'react-server-dom-webpack/client',
   'react-server-dom-webpack/client.edge',

--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -330,8 +330,9 @@ Or, run this command with no arguments to use the most recently published versio
   const nextjsPackageJson = JSON.parse(
     await fsp.readFile(nextjsPackageJsonPath, 'utf-8')
   )
-  nextjsPackageJson.peerDependencies.react = `${newVersionStr}`
-  nextjsPackageJson.peerDependencies['react-dom'] = `${newVersionStr}`
+  nextjsPackageJson.peerDependencies.react = `^18.2.0 || ${newVersionStr}`
+  nextjsPackageJson.peerDependencies['react-dom'] =
+    `^18.2.0 || ${newVersionStr}`
   await fsp.writeFile(
     nextjsPackageJsonPath,
     JSON.stringify(nextjsPackageJson, null, 2) +

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import { outdent } from 'outdent'
 import { getRedboxTotalErrorCount } from 'next-test-utils'
 
+const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 // https://github.com/facebook/react/blob/main/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js used as a reference
 
 describe('Error overlay for hydration errors in Pages router', () => {
@@ -39,10 +40,13 @@ describe('Error overlay for hydration errors in Pages router', () => {
     expect(logs).toEqual(
       expect.arrayContaining([
         {
-          // TODO: Should probably link to https://nextjs.org/docs/messages/react-hydration-error instead.
-          message: expect.stringContaining(
-            'https://react.dev/link/hydration-mismatch'
-          ),
+          message: isReact18
+            ? // React 18 has no link in the hydration message
+              expect.stringContaining('Warning: Text content did not match.')
+            : // TODO: Should probably link to https://nextjs.org/docs/messages/react-hydration-error instead.
+              expect.stringContaining(
+                'https://react.dev/link/hydration-mismatch'
+              ),
           source: 'error',
         },
       ])

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -74,48 +74,85 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    expect(await getRedboxTotalErrorCount(browser)).toBe(1)
+    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 2 : 1)
 
-    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
-      "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
-      See more info here: https://nextjs.org/docs/messages/react-hydration-error"
-    `)
+    if (isReact18) {
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+        `"Text content did not match. Server: "server" Client: "client""`
+      )
+    } else {
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
+        "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
+        See more info here: https://nextjs.org/docs/messages/react-hydration-error"
+      `)
+    }
 
-    expect(await session.getRedboxDescriptionWarning()).toMatchInlineSnapshot(`
-      "- A server/client branch \`if (typeof window !== 'undefined')\`.
-      - Variable input such as \`Date.now()\` or \`Math.random()\` which changes each time it's called.
-      - Date formatting in a user's locale which doesn't match the server.
-      - External changing data without sending a snapshot of it along with the HTML.
-      - Invalid HTML tag nesting.
+    if (isReact18) {
+      expect(await session.getRedboxDescriptionWarning()).toMatchInlineSnapshot(
+        `undefined`
+      )
+    } else {
+      expect(await session.getRedboxDescriptionWarning())
+        .toMatchInlineSnapshot(`
+          "- A server/client branch \`if (typeof window !== 'undefined')\`.
+          - Variable input such as \`Date.now()\` or \`Math.random()\` which changes each time it's called.
+          - Date formatting in a user's locale which doesn't match the server.
+          - External changing data without sending a snapshot of it along with the HTML.
+          - Invalid HTML tag nesting.
 
-      It can also happen if the client has a browser extension installed which messes with the HTML before React loaded."
-    `)
+          It can also happen if the client has a browser extension installed which messes with the HTML before React loaded."
+        `)
+    }
 
     const pseudoHtml = await session.getRedboxComponentStack()
 
     if (isTurbopack) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
-          <AppContainer>
-            <Container fn={function fn}>
-              <ReactDevOverlay>
-                <ErrorBoundary globalOverlay={undefined} isMounted={false} onError={function}>
-                  <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-                    <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
-                      <Mismatch>
-                        <div className="parent">
-                          <main className="child">
-        +                    client
-        -                    server"
-      `)
+      if (isReact18) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <ErrorBoundary>
+              <PathnameContextProviderAdapter>
+                <App>
+                  <Mismatch>
+                    <div>
+                      <main>
+                        "server"
+                        "client""
+        `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <AppContainer>
+              <Container fn={function fn}>
+                <ReactDevOverlay>
+                  <ErrorBoundary globalOverlay={undefined} isMounted={false} onError={function}>
+                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
+                      <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+                        <Mismatch>
+                          <div className="parent">
+                            <main className="child">
+          +                    client
+          -                    server"
+        `)
+      }
     } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
-          <div className="parent">
-            <main className="child">
-        +      client
-        -      server"
-      `)
+      if (isReact18) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "<Mismatch>
+            <div>
+              <main>
+                "server"
+                "client""
+        `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <div className="parent">
+              <main className="child">
+          +      client
+          -      server"
+        `)
+      }
     }
 
     await session.patch(
@@ -160,36 +197,63 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    expect(await getRedboxTotalErrorCount(browser)).toBe(1)
+    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
 
     const pseudoHtml = await session.getRedboxComponentStack()
     if (isTurbopack) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
-          <AppContainer>
-            <Container fn={function fn}>
-              <ReactDevOverlay>
-                <ErrorBoundary globalOverlay={undefined} isMounted={false} onError={function}>
-                  <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-                    <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
-                      <Mismatch>
-                        <div className="parent">
-                          ...
-        +                  <main className="only">"
-      `)
+      if (isReact18) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <Mismatch>
+              <div>
+              ^^^^^
+                <main>
+                ^^^^^^"
+        `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <AppContainer>
+              <Container fn={function fn}>
+                <ReactDevOverlay>
+                  <ErrorBoundary globalOverlay={undefined} isMounted={false} onError={function}>
+                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
+                      <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+                        <Mismatch>
+                          <div className="parent">
+                            ...
+          +                  <main className="only">"
+        `)
+      }
     } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
-          <div className="parent">
-            ...
-        +    <main className="only">"
-      `)
+      if (isReact18) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "<Mismatch>
+            <div>
+            ^^^^^
+              <main>
+              ^^^^^^"
+        `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <div className="parent">
+              ...
+          +    <main className="only">"
+        `)
+      }
     }
 
-    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
-      "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
-      See more info here: https://nextjs.org/docs/messages/react-hydration-error"
-    `)
+    if (isReact18) {
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+        `"Expected server HTML to contain a matching <main> in <div>."`
+      )
+    } else {
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
+        "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
+        See more info here: https://nextjs.org/docs/messages/react-hydration-error"
+      `)
+    }
 
     await cleanup()
   })
@@ -217,36 +281,65 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    expect(await getRedboxTotalErrorCount(browser)).toBe(1)
+    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
 
     const pseudoHtml = await session.getRedboxComponentStack()
     if (isTurbopack) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
-          <AppContainer>
-            <Container fn={function fn}>
-              <ReactDevOverlay>
-                <ErrorBoundary globalOverlay={undefined} isMounted={false} onError={function}>
-                  <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-                    <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
-                      <Mismatch>
-                        <div className="parent">
-        +                  second
-        -                  <footer className="3">"
-      `)
+      if (isReact18) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <ReactDevOverlay>
+              <ErrorBoundary>
+                <PathnameContextProviderAdapter>
+                  <App>
+                    <Mismatch>
+                      <div>
+                        <div>
+                          "second""
+        `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <AppContainer>
+              <Container fn={function fn}>
+                <ReactDevOverlay>
+                  <ErrorBoundary globalOverlay={undefined} isMounted={false} onError={function}>
+                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
+                      <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+                        <Mismatch>
+                          <div className="parent">
+          +                  second
+          -                  <footer className="3">"
+        `)
+      }
     } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
-          <div className="parent">
-        +    second
-        -    <footer className="3">"
-      `)
+      if (isReact18) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "<Mismatch>
+            <div>
+              <div>
+                "second""
+        `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <div className="parent">
+          +    second
+          -    <footer className="3">"
+        `)
+      }
     }
 
-    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
-      "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
-      See more info here: https://nextjs.org/docs/messages/react-hydration-error"
-    `)
+    if (isReact18) {
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+        `"Expected server HTML to contain a matching text node for "second" in <div>."`
+      )
+    } else {
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
+        "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
+        See more info here: https://nextjs.org/docs/messages/react-hydration-error"
+      `)
+    }
 
     await cleanup()
   })
@@ -272,34 +365,54 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    expect(await getRedboxTotalErrorCount(browser)).toBe(1)
+    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 2 : 1)
 
     const pseudoHtml = await session.getRedboxComponentStack()
     if (isTurbopack) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "<Root callbacks={[...]}>
-          <AppContainer>
-            <Container fn={function fn}>
-              <ReactDevOverlay>
-                <ErrorBoundary globalOverlay={undefined} isMounted={false} onError={function}>
-                  <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-                    <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
-                      <Mismatch>
-                        <div className="parent">
-        -                  <main className="only">"
-      `)
+      if (isReact18) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "<Root>
+            ..."
+        `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "<Root callbacks={[...]}>
+            <AppContainer>
+              <Container fn={function fn}>
+                <ReactDevOverlay>
+                  <ErrorBoundary globalOverlay={undefined} isMounted={false} onError={function}>
+                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
+                      <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+                        <Mismatch>
+                          <div className="parent">
+          -                  <main className="only">"
+        `)
+      }
     } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "<Mismatch>
-          <div className="parent">
-        -    <main className="only">"
-      `)
+      if (isReact18) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "<Mismatch>
+            ..."
+        `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "<Mismatch>
+            <div className="parent">
+          -    <main className="only">"
+        `)
+      }
     }
 
-    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
-      "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
-      See more info here: https://nextjs.org/docs/messages/react-hydration-error"
-    `)
+    if (isReact18) {
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+        `"Did not expect server HTML to contain a <main> in <div>."`
+      )
+    } else {
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
+        "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
+        See more info here: https://nextjs.org/docs/messages/react-hydration-error"
+      `)
+    }
 
     await cleanup()
   })
@@ -321,34 +434,63 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    expect(await getRedboxTotalErrorCount(browser)).toBe(1)
+    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 2 : 1)
 
-    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
-      "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
-      See more info here: https://nextjs.org/docs/messages/react-hydration-error"
-    `)
+    if (isReact18) {
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+        `"Did not expect server HTML to contain the text node "only" in <div>."`
+      )
+    } else {
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
+        "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
+        See more info here: https://nextjs.org/docs/messages/react-hydration-error"
+      `)
+    }
 
     const pseudoHtml = await session.getRedboxComponentStack()
 
     if (isTurbopack) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "<Root callbacks={[...]}>
-          <AppContainer>
-            <Container fn={function fn}>
-              <ReactDevOverlay>
-                <ErrorBoundary globalOverlay={undefined} isMounted={false} onError={function}>
-                  <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-                    <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
-                      <Mismatch>
-                        <div className="parent">
-        -                  only"
-      `)
+      if (isReact18) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <ReactDevOverlay>
+              <ErrorBoundary>
+                <PathnameContextProviderAdapter>
+                  <App>
+                    <Mismatch>
+                      <div>
+                        <div>
+                          "only""
+        `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "<Root callbacks={[...]}>
+            <AppContainer>
+              <Container fn={function fn}>
+                <ReactDevOverlay>
+                  <ErrorBoundary globalOverlay={undefined} isMounted={false} onError={function}>
+                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
+                      <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+                        <Mismatch>
+                          <div className="parent">
+          -                  only"
+        `)
+      }
     } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "<Mismatch>
-          <div className="parent">
-        -    only"
-      `)
+      if (isReact18) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "<Mismatch>
+            <div>
+              <div>
+                "only""
+        `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "<Mismatch>
+            <div className="parent">
+          -    only"
+        `)
+      }
     }
 
     await cleanup()
@@ -376,37 +518,66 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    // FIXME: Should be 2
-    expect(await getRedboxTotalErrorCount(browser)).toBe(1)
+
+    expect(await getRedboxTotalErrorCount(browser)).toBe(
+      isReact18
+        ? 3
+        : // FIXME: Should be 2
+          1
+    )
 
     // FIXME: Should also have "text nodes cannot be a child of tr"
-    expect(await session.getRedboxDescription()).toEqual(outdent`
-      Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
-      See more info here: https://nextjs.org/docs/messages/react-hydration-error
-    `)
+    if (isReact18) {
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+        `"Expected server HTML to contain a matching <table> in <div>."`
+      )
+    } else {
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
+        "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
+        See more info here: https://nextjs.org/docs/messages/react-hydration-error"
+      `)
+    }
 
     const pseudoHtml = await session.getRedboxComponentStack()
     if (isTurbopack) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "<Root callbacks={[...]}>
-          <AppContainer>
-            <Container fn={function fn}>
-              <ReactDevOverlay>
-                <ErrorBoundary globalOverlay={undefined} isMounted={false} onError={function}>
-                  <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-                    <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
-                      <Page>
-                        ...
-        +                <table>
-        -                test"
-      `)
+      if (isReact18) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "<Root>
+            ...
+              <Page>
+                <table>
+                ^^^^^^^"
+        `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "<Root callbacks={[...]}>
+            <AppContainer>
+              <Container fn={function fn}>
+                <ReactDevOverlay>
+                  <ErrorBoundary globalOverlay={undefined} isMounted={false} onError={function}>
+                    <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
+                      <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+                        <Page>
+                          ...
+          +                <table>
+          -                test"
+        `)
+      }
     } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "<Page>
-          ...
-        +  <table>
-        -  test"
-      `)
+      if (isReact18) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "<Page>
+            <table>
+            ^^^^^^^"
+        `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "<Page>
+            ...
+          +  <table>
+          -  test"
+        `)
+      }
     }
 
     await cleanup()
@@ -479,28 +650,57 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     const pseudoHtml = await session.getRedboxComponentStack()
     if (isTurbopack) {
-      expect(pseudoHtml).toEqual(outdent`
-      ...
-        ...
-          ...
-      +  <main className="second">
-      -  <footer className="3">
-    `)
-    } else {
-      expect(pseudoHtml).toEqual(outdent`
-      ...
-        <div className="parent">
-          <Suspense fallback={<p>}>
+      if (isReact18) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <Mismatch>
+              <div>
+              ^^^^^
+                <Suspense>
+                  <main>
+                  ^^^^^^"
+        `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
             ...
-      +      <main className="second">
-      -      <footer className="3">
-    `)
+              ...
+          +  <main className="second">
+          -  <footer className="3">"
+        `)
+      }
+    } else {
+      if (isReact18) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "<Mismatch>
+            <div>
+            ^^^^^
+              <Suspense>
+                <main>
+                ^^^^^^"
+        `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <div className="parent">
+              <Suspense fallback={<p>}>
+                ...
+          +      <main className="second">
+          -      <footer className="3">"
+        `)
+      }
     }
 
-    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
-      "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
-      See more info here: https://nextjs.org/docs/messages/react-hydration-error"
-    `)
+    if (isReact18) {
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+        `"Expected server HTML to contain a matching <main> in <div>."`
+      )
+    } else {
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
+        "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
+        See more info here: https://nextjs.org/docs/messages/react-hydration-error"
+      `)
+    }
 
     await cleanup()
   })
@@ -564,33 +764,61 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    expect(await getRedboxTotalErrorCount(browser)).toBe(1)
+    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
 
     const description = await session.getRedboxDescription()
-    expect(description).toContain(
-      'In HTML, <p> cannot be a descendant of <p>.\nThis will cause a hydration error.'
-    )
+    if (isReact18) {
+      expect(description).toMatchInlineSnapshot(
+        `"Expected server HTML to contain a matching <p> in <p>."`
+      )
+    } else {
+      expect(description).toMatchInlineSnapshot(`
+        "In HTML, <p> cannot be a descendant of <p>.
+        This will cause a hydration error."
+      `)
+    }
 
     const pseudoHtml = await session.getRedboxComponentStack()
 
     // Turbopack currently has longer component stack trace
     if (isTurbopack) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
-          <Page>
+      if (isReact18) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <Page>
+              <p>
+              ^^^
+                <p>
+                ^^^"
+        `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <Page>
+              <p>
+              ^^^
+                <p>
+                ^^^"
+        `)
+      }
+    } else {
+      if (isReact18) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "<Page>
             <p>
             ^^^
               <p>
               ^^^"
-      `)
-    } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "<Page>
-          <p>
-          ^^^
+        `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "<Page>
             <p>
-            ^^^"
-      `)
+            ^^^
+              <p>
+              ^^^"
+        `)
+      }
     }
 
     await cleanup()
@@ -622,23 +850,41 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    expect(await getRedboxTotalErrorCount(browser)).toBe(1)
+    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
 
     const description = await session.getRedboxDescription()
-    expect(description).toContain(
-      'In HTML, <div> cannot be a descendant of <p>.\nThis will cause a hydration error.'
-    )
+    if (isReact18) {
+      expect(description).toMatchInlineSnapshot(
+        `"Expected server HTML to contain a matching <div> in <p>."`
+      )
+    } else {
+      expect(description).toMatchInlineSnapshot(`
+        "In HTML, <div> cannot be a descendant of <p>.
+        This will cause a hydration error."
+      `)
+    }
 
     const pseudoHtml = await session.getRedboxComponentStack()
 
-    expect(pseudoHtml).toMatchInlineSnapshot(`
-      "...
-        <div>
-          <p>
-          ^^^
-            <div>
-            ^^^^^"
-    `)
+    if (isReact18) {
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+        "...
+          <div>
+            <p>
+            ^^^
+              <div>
+              ^^^^^"
+      `)
+    } else {
+      expect(pseudoHtml).toMatchInlineSnapshot(`
+        "...
+          <div>
+            <p>
+            ^^^
+              <div>
+              ^^^^^"
+      `)
+    }
 
     await cleanup()
   })
@@ -659,34 +905,61 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    expect(await getRedboxTotalErrorCount(browser)).toBe(1)
+    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
 
     const description = await session.getRedboxDescription()
-    expect(description).toEqual(outdent`
-      In HTML, <tr> cannot be a child of <div>.
-      This will cause a hydration error.
-    `)
+    if (isReact18) {
+      expect(description).toMatchInlineSnapshot(
+        `"Expected server HTML to contain a matching <tr> in <div>."`
+      )
+    } else {
+      expect(description).toMatchInlineSnapshot(`
+        "In HTML, <tr> cannot be a child of <div>.
+        This will cause a hydration error."
+      `)
+    }
 
     const pseudoHtml = await session.getRedboxComponentStack()
 
     // Turbopack currently has longer component stack trace
     if (isTurbopack) {
-      expect(pseudoHtml).toEqual(outdent`
-        ...
-          <Page>
+      if (isReact18) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <Page>
+              <div>
+              ^^^^^
+                <tr>
+                ^^^^"
+        `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <Page>
+              <div>
+              ^^^^^
+                <tr>
+                ^^^^"
+        `)
+      }
+    } else {
+      if (isReact18) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "<Page>
             <div>
             ^^^^^
               <tr>
-              ^^^^
-      `)
-    } else {
-      expect(pseudoHtml).toEqual(outdent`
-        <Page>
-          <div>
-          ^^^^^
-            <tr>
-            ^^^^
-      `)
+              ^^^^"
+        `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "<Page>
+            <div>
+            ^^^^^
+              <tr>
+              ^^^^"
+        `)
+      }
     }
 
     await cleanup()
@@ -712,20 +985,59 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    expect(await getRedboxTotalErrorCount(browser)).toBe(1)
+    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
 
     const description = await session.getRedboxDescription()
-    expect(description).toContain(
-      'In HTML, <p> cannot be a descendant of <p>.\nThis will cause a hydration error.'
-    )
+    if (isReact18) {
+      expect(description).toMatchInlineSnapshot(
+        `"Expected server HTML to contain a matching <p> in <span>."`
+      )
+    } else {
+      expect(description).toMatchInlineSnapshot(`
+        "In HTML, <p> cannot be a descendant of <p>.
+        This will cause a hydration error."
+      `)
+    }
 
     const pseudoHtml = await session.getRedboxComponentStack()
 
     // Turbopack currently has longer component stack trace
     if (isTurbopack) {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
-          <Page>
+      if (isReact18) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <span>
+              <span>
+              ^^^^^^
+                <p>
+                ^^^"
+        `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <Page>
+              <p>
+              ^^^
+                <span>
+                  ...
+                    <span>
+                      <p>
+                      ^^^"
+        `)
+      }
+    } else {
+      if (isReact18) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <span>
+              <span>
+              ^^^^^^
+                <p>
+                ^^^"
+        `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "<Page>
             <p>
             ^^^
               <span>
@@ -733,18 +1045,8 @@ describe('Error overlay for hydration errors in Pages router', () => {
                   <span>
                     <p>
                     ^^^"
-      `)
-    } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "<Page>
-          <p>
-          ^^^
-            <span>
-              ...
-                <span>
-                  <p>
-                  ^^^"
-      `)
+        `)
+      }
     }
 
     await cleanup()
@@ -833,68 +1135,133 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    expect(await getRedboxTotalErrorCount(browser)).toBe(1)
+    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 2 : 1)
 
     const pseudoHtml = await session.getRedboxComponentStack()
     if (isTurbopack) {
       // FIXME: Should not fork on Turbopack i.e. match the snapshot in the else-branch
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
-          ...
-        +  client
-        -  server"
-      `)
-    } else {
-      expect(pseudoHtml).toMatchInlineSnapshot(`
-        "...
-          <div>
+      if (isReact18) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
             <div>
               <div>
                 <div>
                   <Mismatch>
                     <p>
                       <span>
-        +                client
-        -                server"
-      `)
+                        "server"
+                        "client""
+        `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
+            ...
+          +  client
+          -  server"
+        `)
+      }
+    } else {
+      if (isReact18) {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <div>
+              <div>
+                <div>
+                  <Mismatch>
+                    <p>
+                      <span>
+                        "server"
+                        "client""
+        `)
+      } else {
+        expect(pseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <div>
+              <div>
+                <div>
+                  <div>
+                    <Mismatch>
+                      <p>
+                        <span>
+          +                client
+          -                server"
+        `)
+      }
     }
 
     await session.toggleCollapseComponentStack()
 
     const fullPseudoHtml = await session.getRedboxComponentStack()
     if (isTurbopack) {
-      expect(fullPseudoHtml).toMatchInlineSnapshot(`
-        "...
-          <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-            <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
-              <Page>
-                <div>
+      if (isReact18) {
+        expect(fullPseudoHtml).toMatchInlineSnapshot(`
+          "<Root>
+            <AppContainer>
+              <Container>
+                <ReactDevOverlay>
+                  <ErrorBoundary>
+                    <PathnameContextProviderAdapter>
+                      <App>
+                        <Page>
+                          <div>
+                            <div>
+                              <div>
+                                <div>
+                                  <Mismatch>
+                                    <p>
+                                      <span>
+                                        "server"
+                                        "client""
+        `)
+      } else {
+        expect(fullPseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
+              <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+                <Page>
                   <div>
                     <div>
                       <div>
-                        <Mismatch>
-                          <p>
-                            <span>
-                              ...
-        +                      client
-        -                      server"
-      `)
+                        <div>
+                          <Mismatch>
+                            <p>
+                              <span>
+                                ...
+          +                      client
+          -                      server"
+        `)
+      }
     } else {
-      expect(fullPseudoHtml).toMatchInlineSnapshot(`
-        "...
-          <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-            <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
-              <Page>
+      if (isReact18) {
+        expect(fullPseudoHtml).toMatchInlineSnapshot(`
+          "<Page>
+            <div>
+              <div>
                 <div>
+                  <div>
+                    <Mismatch>
+                      <p>
+                        <span>
+                          "server"
+                          "client""
+        `)
+      } else {
+        expect(fullPseudoHtml).toMatchInlineSnapshot(`
+          "...
+            <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
+              <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+                <Page>
                   <div>
                     <div>
                       <div>
-                        <Mismatch>
-                          <p>
-                            <span>
-        +                      client
-        -                      server"
-      `)
+                        <div>
+                          <Mismatch>
+                            <p>
+                              <span>
+          +                      client
+          -                      server"
+        `)
+      }
     }
 
     await cleanup()

--- a/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
+++ b/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
@@ -8,6 +8,7 @@ import {
 } from 'next-test-utils'
 
 const isReactExperimental = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 
 describe('react-dom/server in React Server environment', () => {
   const dependencies = (global as any).isNextDeploy
@@ -317,23 +318,45 @@ describe('react-dom/server in React Server environment', () => {
       source: await getRedboxSource(browser),
     }
     if (isTurbopack) {
-      expect(redbox).toMatchInlineSnapshot(`
-        {
-          "description": "Error: react-dom/server is not supported in React Server Components.",
-          "source": "app/exports/app-code/react-dom-server-node-explicit/page.js (0:0) @ [project]/app/exports/app-code/react-dom-server-node-explicit/page.js [app-rsc] (ecmascript)
+      if (isReact18) {
+        expect(redbox).toMatchInlineSnapshot(`
+          {
+            "description": "TypeError: Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
+            "source": "app/exports/app-code/react-dom-server-node-explicit/page.js (0:0) @ [project]/app/exports/app-code/react-dom-server-node-explicit/page.js [app-rsc] (ecmascript)
 
-          1 | import * as ReactDOMServerNode from 'react-dom/server.node'
-          2 | // Fine to drop once React is on ESM
-          3 | import ReactDOMServerNodeDefault from 'react-dom/server.node'",
-        }
-      `)
+            1 | import * as ReactDOMServerNode from 'react-dom/server.node'
+            2 | // Fine to drop once React is on ESM
+            3 | import ReactDOMServerNodeDefault from 'react-dom/server.node'",
+          }
+        `)
+      } else {
+        expect(redbox).toMatchInlineSnapshot(`
+          {
+            "description": "Error: react-dom/server is not supported in React Server Components.",
+            "source": "app/exports/app-code/react-dom-server-node-explicit/page.js (0:0) @ [project]/app/exports/app-code/react-dom-server-node-explicit/page.js [app-rsc] (ecmascript)
+
+            1 | import * as ReactDOMServerNode from 'react-dom/server.node'
+            2 | // Fine to drop once React is on ESM
+            3 | import ReactDOMServerNodeDefault from 'react-dom/server.node'",
+          }
+        `)
+      }
     } else {
-      expect(redbox).toMatchInlineSnapshot(`
-        {
-          "description": "Error: react-dom/server is not supported in React Server Components.",
-          "source": null,
-        }
-      `)
+      if (isReact18) {
+        expect(redbox).toMatchInlineSnapshot(`
+          {
+            "description": "TypeError: Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
+            "source": null,
+          }
+        `)
+      } else {
+        expect(redbox).toMatchInlineSnapshot(`
+          {
+            "description": "Error: react-dom/server is not supported in React Server Components.",
+            "source": null,
+          }
+        `)
+      }
     }
   })
 
@@ -404,23 +427,45 @@ describe('react-dom/server in React Server environment', () => {
       source: await getRedboxSource(browser),
     }
     if (isTurbopack) {
-      expect(redbox).toMatchInlineSnapshot(`
-        {
-          "description": "Error: react-dom/server is not supported in React Server Components.",
-          "source": "internal-pkg/server.node.js (0:0) @ [project]/internal-pkg/server.node.js [app-rsc] (ecmascript)
+      if (isReact18) {
+        expect(redbox).toMatchInlineSnapshot(`
+          {
+            "description": "TypeError: Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
+            "source": "internal-pkg/server.node.js (0:0) @ [project]/internal-pkg/server.node.js [app-rsc] (ecmascript)
 
-          1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
-          2 | // Fine to drop once React is on ESM
-          3 | import ReactDOMServerEdgeDefault from 'react-dom/server.node'",
-        }
-      `)
+            1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
+            2 | // Fine to drop once React is on ESM
+            3 | import ReactDOMServerEdgeDefault from 'react-dom/server.node'",
+          }
+        `)
+      } else {
+        expect(redbox).toMatchInlineSnapshot(`
+          {
+            "description": "Error: react-dom/server is not supported in React Server Components.",
+            "source": "internal-pkg/server.node.js (0:0) @ [project]/internal-pkg/server.node.js [app-rsc] (ecmascript)
+
+            1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
+            2 | // Fine to drop once React is on ESM
+            3 | import ReactDOMServerEdgeDefault from 'react-dom/server.node'",
+          }
+        `)
+      }
     } else {
-      expect(redbox).toMatchInlineSnapshot(`
-        {
-          "description": "Error: react-dom/server is not supported in React Server Components.",
-          "source": null,
-        }
-      `)
+      if (isReact18) {
+        expect(redbox).toMatchInlineSnapshot(`
+          {
+            "description": "TypeError: Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
+            "source": null,
+          }
+        `)
+      } else {
+        expect(redbox).toMatchInlineSnapshot(`
+          {
+            "description": "Error: react-dom/server is not supported in React Server Components.",
+            "source": null,
+          }
+        `)
+      }
     }
   })
 
@@ -501,26 +546,27 @@ describe('react-dom/server in React Server environment', () => {
           }"
         `)
       } else {
+        await assertNoRedbox(browser)
         expect(await browser.elementByCss('main').text())
           .toMatchInlineSnapshot(`
-          "{
-            "default": {
-              "default": [
-                "renderToReadableStream",
-                "renderToStaticMarkup",
-                "renderToString",
-                "version"
-              ],
-              "named": [
-                "default",
-                "renderToReadableStream",
-                "renderToStaticMarkup",
-                "renderToString",
-                "version"
-              ]
-            }
-          }"
-        `)
+            "{
+              "default": {
+                "default": [
+                  "renderToReadableStream",
+                  "renderToStaticMarkup",
+                  "renderToString",
+                  "version"
+                ],
+                "named": [
+                  "default",
+                  "renderToReadableStream",
+                  "renderToStaticMarkup",
+                  "renderToString",
+                  "version"
+                ]
+              }
+            }"
+          `)
       }
     }
     const redbox = {
@@ -675,23 +721,45 @@ describe('react-dom/server in React Server environment', () => {
       source: await getRedboxSource(browser),
     }
     if (isTurbopack) {
-      expect(redbox).toMatchInlineSnapshot(`
-        {
-          "description": "Error: react-dom/server is not supported in React Server Components.",
-          "source": "internal-pkg/server.node.js (0:0) @ [project]/internal-pkg/server.node.js [app-rsc] (ecmascript)
+      if (isReact18) {
+        expect(redbox).toMatchInlineSnapshot(`
+          {
+            "description": "TypeError: Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
+            "source": "internal-pkg/server.node.js (0:0) @ [project]/internal-pkg/server.node.js [app-rsc] (ecmascript)
 
-          1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
-          2 | // Fine to drop once React is on ESM
-          3 | import ReactDOMServerEdgeDefault from 'react-dom/server.node'",
-        }
-      `)
+            1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
+            2 | // Fine to drop once React is on ESM
+            3 | import ReactDOMServerEdgeDefault from 'react-dom/server.node'",
+          }
+        `)
+      } else {
+        expect(redbox).toMatchInlineSnapshot(`
+          {
+            "description": "Error: react-dom/server is not supported in React Server Components.",
+            "source": "internal-pkg/server.node.js (0:0) @ [project]/internal-pkg/server.node.js [app-rsc] (ecmascript)
+
+            1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
+            2 | // Fine to drop once React is on ESM
+            3 | import ReactDOMServerEdgeDefault from 'react-dom/server.node'",
+          }
+        `)
+      }
     } else {
-      expect(redbox).toMatchInlineSnapshot(`
-        {
-          "description": "Error: react-dom/server is not supported in React Server Components.",
-          "source": null,
-        }
-      `)
+      if (isReact18) {
+        expect(redbox).toMatchInlineSnapshot(`
+          {
+            "description": "TypeError: Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
+            "source": null,
+          }
+        `)
+      } else {
+        expect(redbox).toMatchInlineSnapshot(`
+          {
+            "description": "Error: react-dom/server is not supported in React Server Components.",
+            "source": null,
+          }
+        `)
+      }
     }
   })
 
@@ -707,23 +775,45 @@ describe('react-dom/server in React Server environment', () => {
     }
 
     if (isTurbopack) {
-      expect(redbox).toMatchInlineSnapshot(`
-        {
-          "description": "Error: react-dom/server is not supported in React Server Components.",
-          "source": "internal-pkg/server.node.js (0:0) @ [project]/internal-pkg/server.node.js [app-rsc] (ecmascript)
+      if (isReact18) {
+        expect(redbox).toMatchInlineSnapshot(`
+          {
+            "description": "TypeError: Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
+            "source": "internal-pkg/server.node.js (0:0) @ [project]/internal-pkg/server.node.js [app-rsc] (ecmascript)
 
-          1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
-          2 | // Fine to drop once React is on ESM
-          3 | import ReactDOMServerEdgeDefault from 'react-dom/server.node'",
-        }
-      `)
+            1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
+            2 | // Fine to drop once React is on ESM
+            3 | import ReactDOMServerEdgeDefault from 'react-dom/server.node'",
+          }
+        `)
+      } else {
+        expect(redbox).toMatchInlineSnapshot(`
+          {
+            "description": "Error: react-dom/server is not supported in React Server Components.",
+            "source": "internal-pkg/server.node.js (0:0) @ [project]/internal-pkg/server.node.js [app-rsc] (ecmascript)
+
+            1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
+            2 | // Fine to drop once React is on ESM
+            3 | import ReactDOMServerEdgeDefault from 'react-dom/server.node'",
+          }
+        `)
+      }
     } else {
-      expect(redbox).toMatchInlineSnapshot(`
-        {
-          "description": "Error: react-dom/server is not supported in React Server Components.",
-          "source": null,
-        }
-      `)
+      if (isReact18) {
+        expect(redbox).toMatchInlineSnapshot(`
+          {
+            "description": "TypeError: Cannot read properties of undefined (reading 'ReactCurrentDispatcher')",
+            "source": null,
+          }
+        `)
+      } else {
+        expect(redbox).toMatchInlineSnapshot(`
+          {
+            "description": "Error: react-dom/server is not supported in React Server Components.",
+            "source": null,
+          }
+        `)
+      }
     }
   })
 })

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -14,8 +14,6 @@ import type {
 import loadConfig from 'next/dist/server/config'
 import path from 'path'
 
-const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
-
 function normalizePath(path: string) {
   return path
     .replace(/\[project\].+\/node_modules\//g, '[project]/.../node_modules/')
@@ -42,21 +40,6 @@ function styledStringToMarkdown(styled: StyledString): string {
   }
 }
 
-function isReactDOMServerEdgeConditionalBundlingIssue(issue: {
-  description?: Issue['description']
-  filePath: string
-}) {
-  return (
-    isReact18 &&
-    issue.filePath ===
-      '[project]/.../node_modules/next/dist/esm/server/ReactDOMServerPages.js' &&
-    issue.description?.type === 'text' &&
-    issue.description?.value.includes(
-      'Import map: aliased to module "react-dom" with subpath "/server.edge" inside of [project]/'
-    )
-  )
-}
-
 function normalizeIssues(issues: Issue[]) {
   return issues
     .map((issue) => ({
@@ -69,11 +52,6 @@ function normalizeIssues(issues: Issue[]) {
         source: normalizePath(issue.source.source.ident),
       },
     }))
-    .filter((issue) => {
-      // The conditional bundling is wrapped in a try-catch.
-      // It doesn't surface to the user, so it's safe to ignore here.
-      return !isReactDOMServerEdgeConditionalBundlingIssue(issue)
-    })
     .sort((a, b) => {
       const a_ = JSON.stringify(a)
       const b_ = JSON.stringify(b)

--- a/test/development/pages-dir/client-navigation/index.test.ts
+++ b/test/development/pages-dir/client-navigation/index.test.ts
@@ -13,6 +13,8 @@ import webdriver from 'next-webdriver'
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
+const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
+
 describe('Client Navigation', () => {
   const { next } = nextTestSetup({
     files: path.join(__dirname, 'fixture'),
@@ -1669,19 +1671,19 @@ describe.each([[false], [true]])(
         expect(
           Number(await browser.eval('window.__test_async_executions'))
         ).toBe(
-          strictNextHead
+          strictNextHead || isReact18
             ? 1
             : // <meta name="next-head-count" /> is floated before <script />.
-              // head-manager thinks it needs t add these again resulting in another execution.
+              // head-manager thinks it needs to add these again resulting in another execution.
               2
         )
         expect(
           Number(await browser.eval('window.__test_defer_executions'))
         ).toBe(
-          strictNextHead
+          strictNextHead || isReact18
             ? 1
             : // <meta name="next-head-count" /> is floated before <script defer />.
-              // head-manager thinks it needs t add these again resulting in another execution.
+              // head-manager thinks it needs to add these again resulting in another execution.
               2
         )
 
@@ -1690,20 +1692,20 @@ describe.each([[false], [true]])(
 
         expect(
           Number(await browser.eval('window.__test_async_executions'))
-        ).toBe(strictNextHead ? 1 : 2)
+        ).toBe(strictNextHead || isReact18 ? 1 : 2)
         expect(
           Number(await browser.eval('window.__test_defer_executions'))
-        ).toBe(strictNextHead ? 1 : 2)
+        ).toBe(strictNextHead || isReact18 ? 1 : 2)
 
         await browser.elementByCss('#toggleScript').click()
         await waitFor(2000)
 
         expect(
           Number(await browser.eval('window.__test_async_executions'))
-        ).toBe(strictNextHead ? 1 : 2)
+        ).toBe(strictNextHead || isReact18 ? 1 : 2)
         expect(
           Number(await browser.eval('window.__test_defer_executions'))
-        ).toBe(strictNextHead ? 1 : 2)
+        ).toBe(strictNextHead || isReact18 ? 1 : 2)
       } finally {
         if (browser) {
           await browser.close()

--- a/test/development/pages-dir/client-navigation/rendering.test.ts
+++ b/test/development/pages-dir/client-navigation/rendering.test.ts
@@ -13,6 +13,8 @@ import { BUILD_MANIFEST, REACT_LOADABLE_MANIFEST } from 'next/constants'
 import path from 'path'
 import url from 'url'
 
+const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
+
 describe('Client Navigation rendering', () => {
   const { next } = nextTestSetup({
     files: path.join(__dirname, 'fixture'),
@@ -609,7 +611,13 @@ describe.each([[false], [true]])(
       const documentHeadElement =
         '<meta name="keywords" content="document head test"/>'
 
-      expect(html).toContain(`<head>${nextHeadElement}${documentHeadElement}`)
+      expect(html).toContain(
+        isReact18
+          ? // charset is not actually at the top.
+            // data-next-hide-fouc comes first
+            `</style></noscript>${nextHeadElement}${documentHeadElement}`
+          : `<head>${nextHeadElement}${documentHeadElement}`
+      )
     })
   }
 )

--- a/test/e2e/prerender-native-module.test.ts
+++ b/test/e2e/prerender-native-module.test.ts
@@ -3,6 +3,8 @@ import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 
+const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
+
 describe('prerender native module', () => {
   let next: NextInstance
 
@@ -70,7 +72,9 @@ describe('prerender native module', () => {
             /webpack-runtime\.js/,
             /node_modules\/react\/index\.js/,
             /node_modules\/react\/package\.json/,
-            /node_modules\/react\/cjs\/react\.production\.js/,
+            isReact18
+              ? /node_modules\/react\/cjs\/react\.production\.min\.js/
+              : /node_modules\/react\/cjs\/react\.production\.js/,
           ],
           notTests: [],
         },
@@ -80,7 +84,9 @@ describe('prerender native module', () => {
             /webpack-runtime\.js/,
             /node_modules\/react\/index\.js/,
             /node_modules\/react\/package\.json/,
-            /node_modules\/react\/cjs\/react\.production\.js/,
+            isReact18
+              ? /node_modules\/react\/cjs\/react\.production\.min\.js/
+              : /node_modules\/react\/cjs\/react\.production\.js/,
             /node_modules\/sqlite3\/.*?\.js/,
             /node_modules\/sqlite3\/.*?\.node/,
             /node_modules\/sqlite\/.*?\.js/,

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -19,6 +19,8 @@ import {
 import webdriver from 'next-webdriver'
 import stripAnsi from 'strip-ansi'
 
+const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
+
 describe('Prerender', () => {
   let next: NextInstance
 
@@ -2062,7 +2064,9 @@ describe('Prerender', () => {
               /webpack-runtime\.js/,
               /node_modules\/react\/index\.js/,
               /node_modules\/react\/package\.json/,
-              /node_modules\/react\/cjs\/react\.production\.js/,
+              isReact18
+                ? /node_modules\/react\/cjs\/react\.production\.min\.js/
+                : /node_modules\/react\/cjs\/react\.production\.js/,
             ],
             notTests: [],
           },
@@ -2073,7 +2077,9 @@ describe('Prerender', () => {
               /chunks\/.*?\.js/,
               /node_modules\/react\/index\.js/,
               /node_modules\/react\/package\.json/,
-              /node_modules\/react\/cjs\/react\.production\.js/,
+              isReact18
+                ? /node_modules\/react\/cjs\/react\.production\.min\.js/
+                : /node_modules\/react\/cjs\/react\.production\.js/,
               /\/world.txt/,
             ],
             notTests: [
@@ -2088,7 +2094,9 @@ describe('Prerender', () => {
               /chunks\/.*?\.js/,
               /node_modules\/react\/index\.js/,
               /node_modules\/react\/package\.json/,
-              /node_modules\/react\/cjs\/react\.production\.js/,
+              isReact18
+                ? /node_modules\/react\/cjs\/react\.production\.min\.js/
+                : /node_modules\/react\/cjs\/react\.production\.js/,
               /node_modules\/@firebase\/firestore\/.*?\.js/,
             ],
             notTests: [/\/world.txt/],
@@ -2109,7 +2117,7 @@ describe('Prerender', () => {
               )
             )
           } catch (error) {
-            error.message += `\n\nFiles:\n${files.join('\n')}`
+            error.message += `\n\nPage: ${check.page}\nFiles:\n${files.join('\n')}`
             throw error
           }
 

--- a/test/integration/next-image-new/default/test/index.test.ts
+++ b/test/integration/next-image-new/default/test/index.test.ts
@@ -21,6 +21,8 @@ import { join } from 'path'
 import fs from 'fs/promises'
 import { pathExists } from 'fs-extra'
 
+const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
+
 const appDir = join(__dirname, '../')
 
 let appPort
@@ -1180,7 +1182,9 @@ function runTests(mode) {
 
       expect(warnings).toEqual([])
 
-      expect(await browser.elementById('img').getAttribute('src')).toBe(null)
+      expect(await browser.elementById('img').getAttribute('src')).toBe(
+        isReact18 ? '' : null
+      )
       expect(await browser.elementById('img').getAttribute('srcset')).toBe(null)
       expect(await browser.elementById('img').getAttribute('width')).toBe('200')
       expect(await browser.elementById('img').getAttribute('height')).toBe(
@@ -1195,7 +1199,9 @@ function runTests(mode) {
       )
       expect(warnings).toEqual([])
 
-      expect(await browser.elementById('img').getAttribute('src')).toBe(null)
+      expect(await browser.elementById('img').getAttribute('src')).toBe(
+        isReact18 ? '' : null
+      )
       expect(await browser.elementById('img').getAttribute('srcset')).toBe(null)
       expect(await browser.elementById('img').getAttribute('width')).toBe('200')
       expect(await browser.elementById('img').getAttribute('height')).toBe(

--- a/test/production/custom-server/custom-server.test.ts
+++ b/test/production/custom-server/custom-server.test.ts
@@ -1,5 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
+const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
+
 describe('custom server', () => {
   const { next } = nextTestSetup({
     files: __dirname,
@@ -28,7 +30,11 @@ describe('custom server', () => {
 
     it('should render pages with installed react', async () => {
       const $ = await next.render$(`/2`)
-      expect($('body').text()).toMatch(/pages: 19.0.0/)
+      if (isReact18) {
+        expect($('body').text()).toMatch(/pages: 18\.\d+\.\d+\{/)
+      } else {
+        expect($('body').text()).toMatch(/pages: 19.0.0/)
+      }
     })
   })
 })

--- a/test/production/pages-dir/production/test/index.test.ts
+++ b/test/production/pages-dir/production/test/index.test.ts
@@ -29,6 +29,8 @@ if (process.env.TEST_WASM) {
   jest.setTimeout(120 * 1000)
 }
 
+const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
+
 describe('Production Usage', () => {
   const { next } = nextTestSetup({
     files: path.join(__dirname, '../fixture'),
@@ -181,7 +183,9 @@ describe('Production Usage', () => {
           /webpack-runtime\.js/,
           /node_modules\/react\/index\.js/,
           /node_modules\/react\/package\.json/,
-          /node_modules\/react\/cjs\/react\.production\.js/,
+          isReact18
+            ? /node_modules\/react\/cjs\/react\.production\.min\.js/
+            : /node_modules\/react\/cjs\/react\.production\.js/,
         ],
         notTests: [/\0/, /\?/, /!/],
       },
@@ -192,7 +196,9 @@ describe('Production Usage', () => {
           /chunks\/.*?\.js/,
           /node_modules\/react\/index\.js/,
           /node_modules\/react\/package\.json/,
-          /node_modules\/react\/cjs\/react\.production\.js/,
+          isReact18
+            ? /node_modules\/react\/cjs\/react\.production\.min\.js/
+            : /node_modules\/react\/cjs\/react\.production\.js/,
           /node_modules\/next/,
         ],
         notTests: [/\0/, /\?/, /!/],
@@ -204,7 +210,9 @@ describe('Production Usage', () => {
           /chunks\/.*?\.js/,
           /node_modules\/react\/index\.js/,
           /node_modules\/react\/package\.json/,
-          /node_modules\/react\/cjs\/react\.production\.js/,
+          isReact18
+            ? /node_modules\/react\/cjs\/react\.production\.min\.js/
+            : /node_modules\/react\/cjs\/react\.production\.js/,
           /node_modules\/next/,
           /node_modules\/nanoid\/index\.js/,
           /node_modules\/nanoid\/url-alphabet\/index\.js/,
@@ -219,7 +227,9 @@ describe('Production Usage', () => {
           /chunks\/.*?\.js/,
           /node_modules\/react\/index\.js/,
           /node_modules\/react\/package\.json/,
-          /node_modules\/react\/cjs\/react\.production\.js/,
+          isReact18
+            ? /node_modules\/react\/cjs\/react\.production\.min\.js/
+            : /node_modules\/react\/cjs\/react\.production\.js/,
           /node_modules\/next/,
         ],
         notTests: [


### PR DESCRIPTION
Relands https://github.com/vercel/next.js/pull/69484

dev, prod, turbopack dev, and turbopack prod now run an additional time with React 18 installed. It's not trivial to find tests that are relevant to React 18 so we just increase our CI spending for now.

Integration tests don't run with React 18 since those tests use the React version that's installed in `~/package.json`. It's not trivial to run with a different version like it is for e2e tests. If we find bugs that integration tests would've found, we should just move those to e2e tests.

Hydration errors are worth in React 18 with Pages router but it's hard to tell if that is new or old since we didn't have those tests back then. If hydration errors are a big issue, a upgrade to React 19 should be preferred.

Closes NDX-303