### PR TITLE
Add new experimentalHttpsHostname option

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -43,6 +43,7 @@ export type NextDevOptions = {
   port: number
   hostname?: string
   experimentalHttps?: boolean
+  experimentalHttpsHostname?: string
   experimentalHttpsKey?: string
   experimentalHttpsCert?: string
   experimentalHttpsCa?: string
@@ -340,7 +341,7 @@ const nextDev = async (
             rootCA: rootCA ? path.resolve(rootCA) : undefined,
           }
         } else {
-          certificate = await createSelfSignedCertificate(host)
+          certificate = await createSelfSignedCertificate(options.experimentalHttpsHostname ?? host)
         }
 
         await startServer({


### PR DESCRIPTION
Hi, I would like to propose a new `--experimental-https-hostname` option to allow to set a custom hostname just for the SSL certificate. This is needed because binding ports lower than 1024 on mac without root permissions is only possible when the hostname is left to `0.0.0.0`, other values will result in the root permissions to be required.

My use case is to run `next dev -p 443 --experimental-https` while a custom `/etc/hosts` entry resolvers to 127.0.0.1.

This means developers working on my project should be able to run `yarn dev` and be able to start `custom.local` to run the app with a valid self-signed certificate.

Right now this requires root permissions, because of the attempt to bind to `custom.local` through `next dev -p 443 --hostname custom.local --experimental-https`. But I don't really need to bind the dev server to `custom.local`, I just need the port 443 and the self-signed certificate for `custom.local`.