### PR TITLE
chore: add comments for polyfill imports and file paths

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1876,6 +1876,7 @@ export default async function getBaseWebpackConfig(
       new WellKnownErrorsPlugin(),
       isClient &&
         new CopyFilePlugin({
+          // file path to build output of `@next/polyfill-nomodule`
           filePath: require.resolve('./polyfills/polyfill-nomodule'),
           cacheKey: process.env.__NEXT_VERSION as string,
           name: `static/chunks/polyfills${dev ? '' : '-[hash]'}.js`,

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -1,3 +1,4 @@
+// imports polyfill from `@next/polyfill-module` after build.
 import '../build/polyfills/polyfill-module'
 import ReactDOMClient from 'react-dom/client'
 import React, { use } from 'react'

--- a/packages/next/src/client/index.tsx
+++ b/packages/next/src/client/index.tsx
@@ -1,4 +1,5 @@
 /* global location */
+// imports polyfill from `@next/polyfill-module` after build.
 import '../build/polyfills/polyfill-module'
 
 import type Router from '../shared/lib/router/router'


### PR DESCRIPTION
### Why?

As the file paths to the build outputs of `@next/polyfill-module` & `@next/polyfill-nomodule` may not be intuitive without context, added comments that describes it.