### PR TITLE
chore(turbopack): Remove pathfinder dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,6 @@ dependencies = [
  "log",
  "num-traits",
  "ouroboros",
- "pathfinder_geometry",
  "rustc-hash",
  "tinyvec",
  "ucd-trie",
@@ -4687,24 +4686,6 @@ name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
-
-[[package]]
-name = "pathfinder_geometry"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b7e7b4ea703700ce73ebf128e1450eb69c3a8329199ffbfb9b2a0418e5ad3"
-dependencies = [
- "log",
- "pathfinder_simd",
-]
-
-[[package]]
-name = "pathfinder_simd"
-version = "0.5.3"
-source = "git+https://github.com/vercel/pathfinder?branch=rm-stdarch_arm_crc32#ddc0696d4c8b7d0f7af8de1a271c62aec016d45f"
-dependencies = [
- "rustc_version 0.4.0",
-]
 
 [[package]]
 name = "patricia_tree"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,6 @@ tungstenite = "0.20.1"
 
 # flate2_zlib requires zlib, use flate2_rust
 allsorts = { version = "0.14.0", default-features = false, features = [
-  "outline",
   "flate2_rust",
 ] }
 anyhow = "1.0.69"
@@ -169,8 +168,6 @@ owo-colors = "3.5.0"
 parcel_selectors = "0.27.0"
 parking_lot = "0.12.1"
 pathdiff = "0.2.1"
-# Temporary: Reference the latest git minor version of pathfinder_simd until it's published.
-pathfinder_simd = "0.5.3"
 petgraph = "0.6.3"
 pin-project-lite = "0.2.9"
 postcard = "1.0.4"
@@ -216,8 +213,3 @@ unsize = "1.1.0"
 url = "2.2.2"
 urlencoding = "2.1.2"
 webbrowser = "0.8.7"
-
-# Sync with the entries in turbo's Cargo.toml
-[patch.crates-io]
-# TODO: Use upstream when https://github.com/servo/pathfinder/pull/566 lands
-pathfinder_simd = { git = "https://github.com/vercel/pathfinder", branch = "rm-stdarch_arm_crc32"}


### PR DESCRIPTION
Pathfinder is only needed if [the `allsorts` `outline` feature](https://docs.rs/allsorts/latest/allsorts/#cargo-features) is enabled, but it looks like we don't actually use the `outline` feature?

This should avoid breakages for us whenever the nightly rust simd APIs change.