### PR TITLE
[Turbopack] Introduce OperationVc that wraps operations

### DIFF
--- a/crates/next-api/src/operation.rs
+++ b/crates/next-api/src/operation.rs
@@ -1,0 +1,138 @@
+use anyhow::Result;
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+use turbo_tasks::{debug::ValueDebugFormat, trace::TraceRawVcs, OperationVc, RcStr, Vc};
+
+use crate::{
+    entrypoints::Entrypoints,
+    route::{Endpoint, Route},
+};
+
+/// A derived type of Entrypoints, but with OperationVc<Endpoint> for every endpoint.
+///
+/// This is needed to call `write_to_disk` which expects an `OperationVc<Endpoint>`.
+/// This is important as OperationVcs can be stored in the VersionedContentMap and can be exposed to
+/// JS via napi.
+#[turbo_tasks::value(shared)]
+pub struct EntrypointsOperation {
+    pub routes: IndexMap<RcStr, RouteOperation>,
+    pub middleware: Option<MiddlewareOperation>,
+    pub instrumentation: Option<InstrumentationOperation>,
+    pub pages_document_endpoint: OperationVc<Box<dyn Endpoint>>,
+    pub pages_app_endpoint: OperationVc<Box<dyn Endpoint>>,
+    pub pages_error_endpoint: OperationVc<Box<dyn Endpoint>>,
+}
+
+#[turbo_tasks::value_impl]
+impl EntrypointsOperation {
+    #[turbo_tasks::function]
+    pub async fn new(entrypoints: OperationVc<Entrypoints>) -> Result<Vc<Self>> {
+        let e = entrypoints.connect().await?;
+        Ok(Self {
+            routes: e
+                .routes
+                .iter()
+                .map(|(k, v)| (k.clone(), wrap_route(v, entrypoints)))
+                .collect(),
+            middleware: e.middleware.as_ref().map(|m| MiddlewareOperation {
+                endpoint: wrap(m.endpoint, entrypoints),
+            }),
+            instrumentation: e
+                .instrumentation
+                .as_ref()
+                .map(|i| InstrumentationOperation {
+                    node_js: wrap(i.node_js, entrypoints),
+                    edge: wrap(i.edge, entrypoints),
+                }),
+            pages_document_endpoint: wrap(e.pages_document_endpoint, entrypoints),
+            pages_app_endpoint: wrap(e.pages_app_endpoint, entrypoints),
+            pages_error_endpoint: wrap(e.pages_error_endpoint, entrypoints),
+        }
+        .cell())
+    }
+}
+
+fn wrap_route(route: &Route, entrypoints: OperationVc<Entrypoints>) -> RouteOperation {
+    match route {
+        Route::Page {
+            html_endpoint,
+            data_endpoint,
+        } => RouteOperation::Page {
+            html_endpoint: wrap(*html_endpoint, entrypoints),
+            data_endpoint: wrap(*data_endpoint, entrypoints),
+        },
+        Route::PageApi { endpoint } => RouteOperation::PageApi {
+            endpoint: wrap(*endpoint, entrypoints),
+        },
+        Route::AppPage(pages) => RouteOperation::AppPage(
+            pages
+                .iter()
+                .map(|p| AppPageRouteOperation {
+                    original_name: p.original_name.clone(),
+                    html_endpoint: wrap(p.html_endpoint, entrypoints),
+                    rsc_endpoint: wrap(p.rsc_endpoint, entrypoints),
+                })
+                .collect(),
+        ),
+        Route::AppRoute {
+            original_name,
+            endpoint,
+        } => RouteOperation::AppRoute {
+            original_name: original_name.clone(),
+            endpoint: wrap(*endpoint, entrypoints),
+        },
+        Route::Conflict => RouteOperation::Conflict,
+    }
+}
+
+#[turbo_tasks::function]
+fn wrap_endpoint(
+    endpoint: Vc<Box<dyn Endpoint>>,
+    op: OperationVc<Entrypoints>,
+) -> Vc<Box<dyn Endpoint>> {
+    let _ = op.connect();
+    endpoint
+}
+
+fn wrap(
+    endpoint: Vc<Box<dyn Endpoint>>,
+    op: OperationVc<Entrypoints>,
+) -> OperationVc<Box<dyn Endpoint>> {
+    OperationVc::new(wrap_endpoint(endpoint, op))
+}
+
+#[derive(Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, ValueDebugFormat)]
+pub struct InstrumentationOperation {
+    pub node_js: OperationVc<Box<dyn Endpoint>>,
+    pub edge: OperationVc<Box<dyn Endpoint>>,
+}
+
+#[derive(Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, ValueDebugFormat)]
+pub struct MiddlewareOperation {
+    pub endpoint: OperationVc<Box<dyn Endpoint>>,
+}
+
+#[turbo_tasks::value(shared)]
+#[derive(Clone, Debug)]
+pub enum RouteOperation {
+    Page {
+        html_endpoint: OperationVc<Box<dyn Endpoint>>,
+        data_endpoint: OperationVc<Box<dyn Endpoint>>,
+    },
+    PageApi {
+        endpoint: OperationVc<Box<dyn Endpoint>>,
+    },
+    AppPage(Vec<AppPageRouteOperation>),
+    AppRoute {
+        original_name: String,
+        endpoint: OperationVc<Box<dyn Endpoint>>,
+    },
+    Conflict,
+}
+
+#[derive(TraceRawVcs, Serialize, Deserialize, PartialEq, Eq, ValueDebugFormat, Clone, Debug)]
+pub struct AppPageRouteOperation {
+    pub original_name: String,
+    pub html_endpoint: OperationVc<Box<dyn Endpoint>>,
+    pub rsc_endpoint: OperationVc<Box<dyn Endpoint>>,
+}

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -120,9 +120,9 @@ pub use turbo_tasks_macros::{function, value_impl, value_trait, KeyValuePair, Ta
 pub use value::{TransientInstance, TransientValue, Value};
 pub use value_type::{TraitMethod, TraitType, ValueType};
 pub use vc::{
-    Dynamic, ResolvedValue, ResolvedVc, TypedForInput, Upcast, ValueDefault, Vc, VcCast,
-    VcCellNewMode, VcCellSharedMode, VcDefaultRead, VcRead, VcTransparentRead, VcValueTrait,
-    VcValueTraitCast, VcValueType, VcValueTypeCast,
+    Dynamic, OperationVc, ResolvedValue, ResolvedVc, TypedForInput, Upcast, ValueDefault, Vc,
+    VcCast, VcCellNewMode, VcCellSharedMode, VcDefaultRead, VcRead, VcTransparentRead,
+    VcValueTrait, VcValueTraitCast, VcValueType, VcValueTypeCast,
 };
 
 pub type FxIndexSet<T> = indexmap::IndexSet<T, BuildHasherDefault<FxHasher>>;

--- a/turbopack/crates/turbo-tasks/src/task/function.rs
+++ b/turbopack/crates/turbo-tasks/src/task/function.rs
@@ -26,7 +26,7 @@ use std::{future::Future, marker::PhantomData, pin::Pin};
 use anyhow::Result;
 
 use super::{TaskInput, TaskOutput};
-use crate::{magic_any::MagicAny, RawVc, Vc, VcRead, VcValueType};
+use crate::{magic_any::MagicAny, OperationVc, RawVc, Vc, VcRead, VcValueType};
 
 pub type NativeTaskFuture = Pin<Box<dyn Future<Output = Result<RawVc>> + Send>>;
 
@@ -151,6 +151,12 @@ impl TaskFnMode for FunctionMode {}
 pub struct AsyncFunctionMode;
 impl TaskFnMode for AsyncFunctionMode {}
 
+pub struct OperationMode;
+impl TaskFnMode for OperationMode {}
+
+pub struct AsyncOperationMode;
+impl TaskFnMode for AsyncOperationMode {}
+
 pub struct MethodMode;
 impl TaskFnMode for MethodMode {}
 
@@ -273,6 +279,29 @@ macro_rules! task_fn_impl {
             }
         }
 
+        impl<F, Output, Recv, $($arg,)*> TaskFnInputFunctionWithThis<OperationMode, Recv, ($($arg,)*)> for F
+        where
+            Recv: Sync + Send + 'static,
+            $($arg: TaskInput + 'static,)*
+            F: Fn(OperationVc<Recv>, $($arg,)*) -> Output + Send + Sync + Clone + 'static,
+            Output: TaskOutput + 'static,
+        {
+            #[allow(non_snake_case)]
+            fn functor(&self, this: RawVc, arg: &dyn MagicAny) -> Result<NativeTaskFuture> {
+                let task_fn = self.clone();
+                let recv = OperationVc::<Recv>::from(this);
+
+                let ($($arg,)*) = get_args::<($($arg,)*)>(arg)?;
+                $(
+                    let $arg = $arg.clone();
+                )*
+
+                Ok(Box::pin(async move {
+                    Output::try_into_raw_vc((task_fn)(recv, $($arg,)*))
+                }))
+            }
+        }
+
         pub trait $async_fn_trait<A0, $($arg,)*>: Fn(A0, $($arg,)*) -> Self::OutputFuture {
             type OutputFuture: Future<Output = <Self as $async_fn_trait<A0, $($arg,)*>>::Output> + Send;
             type Output: TaskOutput;
@@ -330,6 +359,28 @@ macro_rules! task_fn_impl {
 
                 Ok(Box::pin(async move {
                     <F as $async_fn_trait<Vc<Recv>, $($arg,)*>>::Output::try_into_raw_vc((task_fn)(recv, $($arg,)*).await)
+                }))
+            }
+        }
+
+        impl<F, Recv, $($arg,)*> TaskFnInputFunctionWithThis<AsyncOperationMode, Recv, ($($arg,)*)> for F
+        where
+            Recv: Sync + Send + 'static,
+            $($arg: TaskInput + 'static,)*
+            F: $async_fn_trait<OperationVc<Recv>, $($arg,)*> + Clone + Send + Sync + 'static,
+        {
+            #[allow(non_snake_case)]
+            fn functor(&self, this: RawVc, arg: &dyn MagicAny) -> Result<NativeTaskFuture> {
+                let task_fn = self.clone();
+                let recv = OperationVc::<Recv>::from(this);
+
+                let ($($arg,)*) = get_args::<($($arg,)*)>(arg)?;
+                $(
+                    let $arg = $arg.clone();
+                )*
+
+                Ok(Box::pin(async move {
+                    <F as $async_fn_trait<OperationVc<Recv>, $($arg,)*>>::Output::try_into_raw_vc((task_fn)(recv, $($arg,)*).await)
                 }))
             }
         }

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod cast;
 mod cell_mode;
 pub(crate) mod default;
+pub(crate) mod operation;
 mod read;
 pub(crate) mod resolved;
 mod traits;
@@ -22,6 +23,7 @@ pub use self::{
     cast::{VcCast, VcValueTraitCast, VcValueTypeCast},
     cell_mode::{VcCellMode, VcCellNewMode, VcCellSharedMode},
     default::ValueDefault,
+    operation::OperationVc,
     read::{ReadVcFuture, VcDefaultRead, VcRead, VcTransparentRead},
     resolved::{ResolvedValue, ResolvedVc},
     traits::{Dynamic, TypedForInput, Upcast, VcValueTrait, VcValueType},

--- a/turbopack/crates/turbo-tasks/src/vc/operation.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/operation.rs
@@ -1,0 +1,158 @@
+use std::{fmt::Debug, hash::Hash};
+
+use auto_hash_map::AutoSet;
+use serde::{Deserialize, Serialize};
+
+use crate::{trace::TraceRawVcs, CollectiblesSource, RawVc, TaskInput, Upcast, Vc, VcValueTrait};
+
+#[must_use]
+pub struct OperationVc<T>
+where
+    T: ?Sized,
+{
+    pub(crate) node: Vc<T>,
+}
+
+impl<T: ?Sized> OperationVc<T> {
+    /// Creates a new `OperationVc` from a `Vc`.
+    ///
+    /// The caller must ensure that the `Vc` is not a local task and it points to a a single
+    /// operation.
+    pub fn new(node: Vc<T>) -> Self {
+        // TODO to avoid this runtime check, we should mark functions with `(operation)` and return
+        // a OperationVc directly
+        assert!(
+            matches!(node.node, RawVc::TaskOutput(..)),
+            "OperationVc::new must be called on the immediate return value of a task function"
+        );
+        Self { node }
+    }
+
+    /// Marks this operation's underlying function call as a child of the current task, and returns
+    /// a dereferenced [`Vc`] that can be [resolved][Vc::to_resolved] or read with `.await?`.
+    ///
+    /// By marking this function call as a child of the current task, turbo-tasks will re-run tasks
+    /// as-needed to achieve strong consistency at the root of the function call tree. This explicit
+    /// operation is needed as `OperationVc` types can be stored outside of the call graph as part
+    /// of [`State`][crate::State]s.
+    pub fn connect(self) -> Vc<T> {
+        self.node.node.connect();
+        self.node
+    }
+
+    /// Returns the `RawVc` corresponding to this `Vc`.
+    pub fn into_raw(vc: Self) -> RawVc {
+        vc.node.node
+    }
+
+    /// Upcasts the given `OperationVc<T>` to a `OperationVc<Box<dyn K>>`.
+    ///
+    /// This is also available as an `Into`/`From` conversion.
+    #[inline(always)]
+    pub fn upcast<K>(vc: Self) -> OperationVc<K>
+    where
+        T: Upcast<K>,
+        K: VcValueTrait + ?Sized,
+    {
+        OperationVc {
+            node: Vc::upcast(vc.node),
+        }
+    }
+}
+
+impl<T> Copy for OperationVc<T> where T: ?Sized {}
+
+impl<T> Clone for OperationVc<T>
+where
+    T: ?Sized,
+{
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Hash for OperationVc<T>
+where
+    T: ?Sized,
+{
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.node.hash(state);
+    }
+}
+
+impl<T> PartialEq<OperationVc<T>> for OperationVc<T>
+where
+    T: ?Sized,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.node == other.node
+    }
+}
+
+impl<T> Eq for OperationVc<T> where T: ?Sized {}
+
+impl<T> Debug for OperationVc<T>
+where
+    T: ?Sized,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OperationVc")
+            .field("node", &self.node.node)
+            .finish()
+    }
+}
+
+impl<T> TaskInput for OperationVc<T> where T: ?Sized + Send + Sync {}
+
+impl<T> From<RawVc> for OperationVc<T>
+where
+    T: ?Sized,
+{
+    fn from(raw: RawVc) -> Self {
+        Self {
+            node: Vc::from(raw),
+        }
+    }
+}
+
+impl<T> Serialize for OperationVc<T>
+where
+    T: ?Sized,
+{
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.node.serialize(serializer)
+    }
+}
+
+impl<'de, T> Deserialize<'de> for OperationVc<T>
+where
+    T: ?Sized,
+{
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(OperationVc {
+            node: Vc::deserialize(deserializer)?,
+        })
+    }
+}
+
+impl<T> TraceRawVcs for OperationVc<T>
+where
+    T: ?Sized,
+{
+    fn trace_raw_vcs(&self, trace_context: &mut crate::trace::TraceRawVcsContext) {
+        self.node.trace_raw_vcs(trace_context);
+    }
+}
+
+impl<T> CollectiblesSource for OperationVc<T>
+where
+    T: ?Sized,
+{
+    fn take_collectibles<Vt: VcValueTrait>(self) -> AutoSet<Vc<Vt>> {
+        self.node.node.take_collectibles()
+    }
+
+    fn peek_collectibles<Vt: VcValueTrait>(self) -> AutoSet<Vc<Vt>> {
+        self.node.node.peek_collectibles()
+    }
+}


### PR DESCRIPTION
### What?

Introduce `OperationVc` that wraps operations

*(Note: This was called `VcOperation`, but I changed it to `OperationVc` to better match the `ResolvedVc` naming convention -- @bgw)*

We should only expose `OperationVc` into JS to connect to the whole computation (and be strongly consistent with the whole computation).

~also fix query string~ Fixed in #70461

### Why?

We want operations to be strongly consistent to the whole operation. Also HMR subscriptions should include the whole entrypoints and endpoint operation. The `OperationVc` type makes it easy to track that and enforces connecting to the operation correctly.

In regards of the `ResolvedVc` work, we also want operations to be explicit.


Closes PACK-3628