### PR TITLE
[Turbopack] fix a bunch of bugs and inefficiencies in the call graph

### DIFF
--- a/turbopack/crates/turbo-tasks-memory/src/edges_set.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/edges_set.rs
@@ -194,7 +194,7 @@ impl EdgesDataEntry {
                 | EdgesDataEntry::OutputAndCell0(type_id)
                 | EdgesDataEntry::ChildAndCell0(type_id)
                 | EdgesDataEntry::ChildOutputAndCell0(type_id),
-            ) => *type_id == cell_id.type_id,
+            ) => cell_id.index == 0 && *type_id == cell_id.type_id,
             (entry, EdgesDataEntry::Complex(set)) => set.contains(&entry),
             _ => false,
         }
@@ -330,26 +330,26 @@ impl EdgesDataEntry {
                 }
                 _ => {}
             },
-            EdgeEntry::Cell(_) => match self {
-                EdgesDataEntry::Cell0(_) => {
+            EdgeEntry::Cell(cell_id) if cell_id.index == 0 => match self {
+                EdgesDataEntry::Cell0(value_ty) if cell_id.type_id == *value_ty => {
                     *self = EdgesDataEntry::Empty;
                     return true;
                 }
-                EdgesDataEntry::OutputAndCell0(_) => {
+                EdgesDataEntry::OutputAndCell0(value_ty) if cell_id.type_id == *value_ty => {
                     *self = EdgesDataEntry::Output;
                     return true;
                 }
-                EdgesDataEntry::ChildAndCell0(_) => {
+                EdgesDataEntry::ChildAndCell0(value_ty) if cell_id.type_id == *value_ty => {
                     *self = EdgesDataEntry::Child;
                     return true;
                 }
-                EdgesDataEntry::ChildOutputAndCell0(_) => {
+                EdgesDataEntry::ChildOutputAndCell0(value_ty) if cell_id.type_id == *value_ty => {
                     *self = EdgesDataEntry::ChildAndOutput;
                     return true;
                 }
                 _ => {}
             },
-            EdgeEntry::Collectibles(_) => {}
+            EdgeEntry::Cell(_) | EdgeEntry::Collectibles(_) => {}
         }
         if let EdgesDataEntry::Complex(set) = self {
             if set.remove(&entry) {

--- a/turbopack/crates/turbo-tasks-memory/src/task.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/task.rs
@@ -1028,7 +1028,6 @@ impl Task {
                     outdated_edges.remove_all(&new_edges);
                     for child in new_children {
                         new_edges.insert(TaskEdge::Child(child));
-                        outdated_edges.remove(TaskEdge::Child(child));
                     }
                     if !backend.has_gc() {
                         // This will stay here for longer, so make sure to not consume too

--- a/turbopack/crates/turbo-tasks-memory/src/task.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/task.rs
@@ -834,11 +834,11 @@ impl Task {
             let remove_job = if outdated_children.is_empty() {
                 None
             } else {
-                Some(state.aggregation_node.handle_lost_edges(
+                state.aggregation_node.handle_lost_edges(
                     &aggregation_context,
                     &self.id,
                     outdated_children,
-                ))
+                )
             };
 
             let mut change = TaskChange {

--- a/turbopack/crates/turbo-tasks-memory/src/task/aggregation.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/task/aggregation.rs
@@ -574,7 +574,7 @@ impl<'l> AggregationNodeGuard for TaskGuard<'l> {
                     for (&(trait_type_id, collectible), count) in collectibles.iter() {
                         change
                             .collectibles
-                            .push((trait_type_id, collectible, -count));
+                            .push((trait_type_id, collectible, -*count));
                     }
                 }
                 if let TaskStateType::InProgress(box InProgressState {


### PR DESCRIPTION
### What?

* switch remove vs change order
* take_collectibles does not need to return an Option
* avoid double Option
* fix edges set bugs
* remove collectibles from outdated collectibles
* remove unneccessary remove
