### PR TITLE
chore: add next-codemod to jest roots

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,7 @@ const customJestConfig = {
     '<rootDir>',
     '<rootDir>/../packages/next/src/',
     '<rootDir>/../packages/font/src/',
+    '<rootDir>/../packages/next-codemod',
   ],
   modulePathIgnorePatterns: ['/\\.next/'],
   modulePaths: ['<rootDir>/lib'],


### PR DESCRIPTION
As we could not run `pnpm jest <relative-test-path>` for next-codemod, added it to the `roots` of the jest config.