### PR TITLE
fix: match file path url escaping during build and serve

### DIFF
--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -25,6 +25,7 @@ import {
   getModuleReferencesInOrder,
 } from '../utils'
 import type { ChunkGroup } from 'webpack'
+import { encodeURIPath } from '../../../shared/lib/encode-uri-path'
 
 interface Options {
   dev: boolean
@@ -117,7 +118,10 @@ function getAppPathRequiredChunks(
         // previously done for dynamic chunks by patching the webpack runtime but we want
         // these filenames to be managed by React's Flight runtime instead and so we need
         // to implement any special handling of the file name here.
-        return chunks.push(chunkId, encodeURI(file + deploymentIdChunkQuery))
+        return chunks.push(
+          chunkId,
+          encodeURIPath(file) + deploymentIdChunkQuery
+        )
       })
     }
   })
@@ -143,7 +147,7 @@ function entryNameToGroupName(entryName: string) {
     // Remove catch-all routes since they should be part of the parent group that the catch-all would apply to.
     // This is necessary to support parallel routes since multiple page components can be rendered on the same page.
     // In order to do that, we need to ensure that the manifests are merged together by putting them in the same group.
-    .replace(/\/\[?\[\.\.\.[^\]]*\]\]?/g, '')
+    .replace(/\/\[?\[\.\.\.[^\]]*]]?/g, '')
 
   // Interception routes
   groupName = groupName

--- a/packages/next/src/client/app-webpack.ts
+++ b/packages/next/src/client/app-webpack.ts
@@ -2,6 +2,7 @@
 // https://github.com/webpack/webpack/blob/2738eebc7880835d88c727d364ad37f3ec557593/lib/RuntimeGlobals.js#L204
 
 import { getDeploymentIdQueryOrEmptyString } from '../build/deployment-id'
+import { encodeURIPath } from '../shared/lib/encode-uri-path'
 
 declare const __webpack_require__: any
 
@@ -13,9 +14,9 @@ if (process.env.NEXT_DEPLOYMENT_ID) {
   const getChunkScriptFilename = __webpack_require__.u
   // eslint-disable-next-line no-undef
   __webpack_require__.u = (...args: any[]) =>
-    // We enode the chunk filename because our static server matches against and encoded
+    // We encode the chunk filename because our static server matches against and encoded
     // filename path.
-    encodeURI(getChunkScriptFilename(...args) + suffix)
+    encodeURIPath(getChunkScriptFilename(...args)) + suffix
 
   // eslint-disable-next-line no-undef
   const getChunkCssFilename = __webpack_require__.k
@@ -33,9 +34,9 @@ if (process.env.NEXT_DEPLOYMENT_ID) {
   const getChunkScriptFilename = __webpack_require__.u
   // eslint-disable-next-line no-undef
   __webpack_require__.u = (...args: any[]) =>
-    // We enode the chunk filename because our static server matches against and encoded
+    // We encode the chunk filename because our static server matches against and encoded
     // filename path.
-    encodeURI(getChunkScriptFilename(...args))
+    encodeURIPath(getChunkScriptFilename(...args))
 
   // We don't need to override __webpack_require__.k because we don't modify
   // the css chunk name when not using deployment id suffixes

--- a/packages/next/src/client/route-loader.ts
+++ b/packages/next/src/client/route-loader.ts
@@ -4,6 +4,7 @@ import getAssetPathFromRoute from '../shared/lib/router/utils/get-asset-path-fro
 import { __unsafeCreateTrustedScriptURL } from './trusted-types'
 import { requestIdleCallback } from './request-idle-callback'
 import { getDeploymentIdQueryOrEmptyString } from '../build/deployment-id'
+import { encodeURIPath } from '../shared/lib/encode-uri-path'
 
 // 3.8s was arbitrarily chosen as it's what https://web.dev/interactive
 // considers as "Good" time-to-interactive. We must assume something went
@@ -68,11 +69,13 @@ function withFuture<T extends object>(
   const prom: Promise<T> = new Promise<T>((resolve) => {
     resolver = resolve
   })
-  map.set(key, (entry = { resolve: resolver!, future: prom }))
+  map.set(key, { resolve: resolver!, future: prom })
   return generator
     ? generator()
-        // eslint-disable-next-line no-sequences
-        .then((value) => (resolver(value), value))
+        .then((value) => {
+          resolver(value)
+          return value
+        })
         .catch((err) => {
           map.delete(key)
           throw err
@@ -257,7 +260,7 @@ function getFilesForRoute(
     const scriptUrl =
       assetPrefix +
       '/_next/static/chunks/pages' +
-      encodeURI(getAssetPathFromRoute(route, '.js')) +
+      encodeURIPath(getAssetPathFromRoute(route, '.js')) +
       getAssetQueryString()
     return Promise.resolve({
       scripts: [__unsafeCreateTrustedScriptURL(scriptUrl)],
@@ -270,7 +273,7 @@ function getFilesForRoute(
       throw markAssetError(new Error(`Failed to lookup route: ${route}`))
     }
     const allFiles = manifest[route].map(
-      (entry) => assetPrefix + '/_next/' + encodeURI(entry)
+      (entry) => assetPrefix + '/_next/' + encodeURIPath(entry)
     )
     return {
       scripts: allFiles

--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -40,6 +40,7 @@ import { normalizeMetadataRoute } from '../../../lib/metadata/get-metadata-route
 import { RSCPathnameNormalizer } from '../../normalizers/request/rsc'
 import { PostponedPathnameNormalizer } from '../../normalizers/request/postponed'
 import { PrefetchRSCPathnameNormalizer } from '../../normalizers/request/prefetch-rsc'
+import { encodeURIPath } from '../../../shared/lib/encode-uri-path'
 
 export type FsOutput = {
   type:
@@ -162,7 +163,7 @@ export async function setupFsCheck(opts: {
     try {
       for (const file of await recursiveReadDir(publicFolderPath)) {
         // Ensure filename is encoded and normalized.
-        publicFolderItems.add(encodeURI(normalizePathSep(file)))
+        publicFolderItems.add(encodeURIPath(normalizePathSep(file)))
       }
     } catch (err: any) {
       if (err.code !== 'ENOENT') {
@@ -173,7 +174,7 @@ export async function setupFsCheck(opts: {
     try {
       for (const file of await recursiveReadDir(legacyStaticFolderPath)) {
         // Ensure filename is encoded and normalized.
-        legacyStaticFolderItems.add(encodeURI(normalizePathSep(file)))
+        legacyStaticFolderItems.add(encodeURIPath(normalizePathSep(file)))
       }
       Log.warn(
         `The static directory has been deprecated in favor of the public directory. https://nextjs.org/docs/messages/static-dir-deprecated`
@@ -188,7 +189,10 @@ export async function setupFsCheck(opts: {
       for (const file of await recursiveReadDir(nextStaticFolderPath)) {
         // Ensure filename is encoded and normalized.
         nextStaticFolderItems.add(
-          path.posix.join('/_next/static', encodeURI(normalizePathSep(file)))
+          path.posix.join(
+            '/_next/static',
+            encodeURIPath(normalizePathSep(file))
+          )
         )
       }
     } catch (err) {
@@ -565,7 +569,7 @@ export async function setupFsCheck(opts: {
             // encoded version: `/_next/static/chunks/pages/blog/%5Bslug%5D-d4858831b91b69f6.js`
             try {
               // encode the special characters in the path and retrieve again to determine if path exists.
-              const encodedCurItemPath = encodeURI(curItemPath)
+              const encodedCurItemPath = encodeURIPath(curItemPath)
               matchedItem = items.has(encodedCurItemPath)
             } catch {}
           }

--- a/packages/next/src/shared/lib/lazy-dynamic/preload-chunks.tsx
+++ b/packages/next/src/shared/lib/lazy-dynamic/preload-chunks.tsx
@@ -1,7 +1,9 @@
 'use client'
 
-import { getExpectedRequestStore } from '../../../client/components/request-async-storage.external'
 import { preload } from 'react-dom'
+
+import { getExpectedRequestStore } from '../../../client/components/request-async-storage.external'
+import { encodeURIPath } from '../encode-uri-path'
 
 export function PreloadChunks({
   moduleIds,
@@ -34,7 +36,7 @@ export function PreloadChunks({
   return (
     <>
       {allFiles.map((chunk) => {
-        const href = `${requestStore.assetPrefix}/_next/${encodeURI(chunk)}`
+        const href = `${requestStore.assetPrefix}/_next/${encodeURIPath(chunk)}`
         const isCss = chunk.endsWith('.css')
         // If it's stylesheet we use `precedence` o help hoist with React Float.
         // For stylesheets we actually need to render the CSS because nothing else is going to do it so it needs to be part of the component tree.

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -2881,13 +2881,12 @@
     },
     "test/e2e/app-dir/parallel-routes-catchall/parallel-routes-catchall.test.ts": {
       "passed": [
+        "parallel-routes-catchall should match both the catch-all page & slot",
         "parallel-routes-catchall should match correctly when defining an explicit page & slot",
+        "parallel-routes-catchall should match correctly when defining an explicit page but no slot",
         "parallel-routes-catchall should match correctly when defining an explicit slot but no page"
       ],
-      "failed": [
-        "parallel-routes-catchall should match both the catch-all page & slot",
-        "parallel-routes-catchall should match correctly when defining an explicit page but no slot"
-      ],
+      "failed": [],
       "pending": [],
       "flakey": [],
       "runtimeError": false


### PR DESCRIPTION
### What?

This fixes file path encoding differences between build and serve.

Currently, file paths that get encoded via `encodeURIPath` (which uses `encodeURIComponent`):
https://github.com/vercel/next.js/blob/c3475da0686eecbf9acc9b004e579a8e67288d70/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx#L59-L61

But when matching files to serve, we use `encodeURI`:
https://github.com/vercel/next.js/blob/c3475da0686eecbf9acc9b004e579a8e67288d70/packages/next/src/server/lib/router-utils/filesystem.ts#L191

This means that any file which contains reserved characters according to [RFC2396](https://datatracker.ietf.org/doc/html/rfc2396) will not match correctly.

```
reserved    = ";" | "/" | "?" | ":" | "@" | "&" | "=" | "+" | "$" | ","
```

Closes PACK-3266
