### PR TITLE
unskip middleware deploy test

### DIFF
--- a/test/e2e/app-dir/app-middleware/app-middleware.test.ts
+++ b/test/e2e/app-dir/app-middleware/app-middleware.test.ts
@@ -6,14 +6,9 @@ import { nextTestSetup, FileRef } from 'e2e-utils'
 import type { Response } from 'node-fetch'
 
 describe('app-dir with middleware', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should filter correctly after middleware rewrite', async () => {
     const browser = await next.browser('/start')
@@ -179,8 +174,10 @@ describe('app-dir with middleware', () => {
 
     await browser.elementById('submit-server-action').click()
 
-    await retry(() => {
-      expect(next.cliOutput).toMatch(/\[Cookie From Action\]: \d+\.\d+/)
+    await retry(async () => {
+      expect(await browser.elementById('action-result').text()).toMatch(
+        /Action Result: \d+\.\d+/
+      )
     })
 
     // ensure that we still can't read the secure cookie
@@ -210,8 +207,10 @@ describe('app-dir with middleware', () => {
 
     await browser.elementById('submit-server-action').click()
 
-    await retry(() => {
-      expect(next.cliOutput).toMatch(/\[Cookie From Action\]: \d+\.\d+/)
+    await retry(async () => {
+      expect(await browser.elementById('action-result').text()).toMatch(
+        /Action Result: \d+\.\d+/
+      )
     })
 
     await browser.deleteCookies()
@@ -219,7 +218,7 @@ describe('app-dir with middleware', () => {
 })
 
 describe('app dir - middleware without pages dir', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: {
       app: new FileRef(path.join(__dirname, 'app')),
       'next.config.js': new FileRef(path.join(__dirname, 'next.config.js')),
@@ -235,12 +234,7 @@ describe('app dir - middleware without pages dir', () => {
       }
     `,
     },
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   // eslint-disable-next-line jest/no-identical-title
   it('Updates headers', async () => {
@@ -251,7 +245,7 @@ describe('app dir - middleware without pages dir', () => {
 })
 
 describe('app dir - middleware with middleware in src dir', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: {
       'src/app': new FileRef(path.join(__dirname, 'app')),
       'next.config.js': new FileRef(path.join(__dirname, 'next.config.js')),
@@ -265,12 +259,7 @@ describe('app dir - middleware with middleware in src dir', () => {
       }
     `,
     },
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('works without crashing when using requestAsyncStorage', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/app-middleware/app/rsc-cookies/cookie-options/page.js
+++ b/test/e2e/app-dir/app-middleware/app/rsc-cookies/cookie-options/page.js
@@ -1,5 +1,6 @@
 import { cookies } from 'next/headers'
 import Link from 'next/link'
+import { Form } from '../form'
 
 export default function Page() {
   return (
@@ -7,19 +8,12 @@ export default function Page() {
       <p id="total-cookies">Total Cookie Length: {cookies().size}</p>
       <Link href="/rsc-cookies-delete">To Delete Cookies Route</Link>
 
-      <form
+      <Form
         action={async () => {
           'use server'
-          console.log(
-            '[Cookie From Action]:',
-            cookies().get('rsc-secure-cookie').value
-          )
+          return cookies().get('rsc-secure-cookie').value
         }}
-      >
-        <button type="submit" id="submit-server-action">
-          server action
-        </button>
-      </form>
+      />
     </div>
   )
 }

--- a/test/e2e/app-dir/app-middleware/app/rsc-cookies/form.js
+++ b/test/e2e/app-dir/app-middleware/app/rsc-cookies/form.js
@@ -1,0 +1,16 @@
+'use client'
+
+import { useActionState } from 'react'
+
+export function Form({ action }) {
+  const [state, formAction] = useActionState(action, null)
+
+  return (
+    <form action={formAction}>
+      <div id="action-result">Action Result: {state}</div>
+      <button type="submit" id="submit-server-action">
+        server action
+      </button>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/app-middleware/app/rsc-cookies/page.js
+++ b/test/e2e/app-dir/app-middleware/app/rsc-cookies/page.js
@@ -1,5 +1,6 @@
 import { cookies } from 'next/headers'
 import Link from 'next/link'
+import { Form } from './form'
 
 export default function Page() {
   const rscCookie1 = cookies().get('rsc-cookie-value-1')?.value
@@ -11,20 +12,13 @@ export default function Page() {
       <p id="rsc-cookie-2">Cookie 2: {rscCookie2}</p>
       <p id="total-cookies">Total Cookie Length: {cookies().size}</p>
       <Link href="/rsc-cookies-delete">To Delete Cookies Route</Link>
-
-      <form
+      <Form
         action={async () => {
           'use server'
-          console.log(
-            '[Cookie From Action]:',
-            cookies().get('rsc-cookie-value-1').value
-          )
+
+          return cookies().get('rsc-cookie-value-1')?.value
         }}
-      >
-        <button type="submit" id="submit-server-action">
-          server action
-        </button>
-      </form>
+      />
     </div>
   )
 }


### PR DESCRIPTION
This whole test suite was disabled but only 2 tests rely on runtime logs, so this refactors the test to remove the runtime log dependency in favor of returning the output from the action and reading from the DOM.