### PR TITLE
Fix missing cache-control on SSR app route

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -3119,10 +3119,7 @@ export default abstract class Server<
       isRoutePPREnabled
     ) {
       revalidate = 0
-    } else if (
-      typeof cacheEntry.revalidate !== 'undefined' &&
-      (!this.renderOpts.dev || (hasServerProps && !isNextDataRequest))
-    ) {
+    } else if (!this.renderOpts.dev || (hasServerProps && !isNextDataRequest)) {
       // If this is a preview mode request, we shouldn't cache it
       if (isPreviewMode) {
         revalidate = 0

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -20,15 +20,17 @@ describe('app dir - basic', () => {
       },
     })
 
-  it('should have correct cache-control for SSR routes', async () => {
-    for (const path of ['/catch-all/first', '/ssr']) {
-      const res = await next.fetch(path)
-      expect(res.status).toBe(200)
-      expect(res.headers.get('Cache-Control')).toBe(
-        'private, no-cache, no-store, max-age=0, must-revalidate'
-      )
-    }
-  })
+  if (isNextStart) {
+    it('should have correct cache-control for SSR routes', async () => {
+      for (const path of ['/catch-all/first', '/ssr']) {
+        const res = await next.fetch(path)
+        expect(res.status).toBe(200)
+        expect(res.headers.get('Cache-Control')).toBe(
+          'private, no-cache, no-store, max-age=0, must-revalidate'
+        )
+      }
+    })
+  }
 
   if (process.env.NEXT_EXPERIMENTAL_COMPILE) {
     it('should provide query for getStaticProps page correctly', async () => {

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -20,6 +20,16 @@ describe('app dir - basic', () => {
       },
     })
 
+  it('should have correct cache-control for SSR routes', async () => {
+    for (const path of ['/catch-all/first', '/ssr']) {
+      const res = await next.fetch(path)
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Cache-Control')).toBe(
+        'private, no-cache, no-store, max-age=0, must-revalidate'
+      )
+    }
+  })
+
   if (process.env.NEXT_EXPERIMENTAL_COMPILE) {
     it('should provide query for getStaticProps page correctly', async () => {
       const res = await next.fetch('/ssg?hello=world')

--- a/test/e2e/app-dir/app/pages/ssr.js
+++ b/test/e2e/app-dir/app/pages/ssr.js
@@ -1,0 +1,16 @@
+import { useRouter } from 'next/router'
+
+export default function Page(props) {
+  return (
+    <>
+      <p>hello from ssr</p>
+      <p id="query">{JSON.stringify(useRouter().query)}</p>
+    </>
+  )
+}
+
+export function getServerSideProps() {
+  return {
+    props: {},
+  }
+}


### PR DESCRIPTION
This removes an inaccurate check that doesn't set a revalidate value if revalidate is `undefined` which can be the case for SSR app route pages. Also adds a regression test to ensure this doesn't break again. 

Fixes: https://github.com/vercel/next.js/issues/70213