### PR TITLE
feat(turbo-tasks): Allow `#[turbo_tasks::function]`s to accept ResolvedVc types as arguments

### DIFF
--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_resolved_vc_input.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_resolved_vc_input.rs
@@ -1,0 +1,40 @@
+#![feature(arbitrary_self_types)]
+#![allow(dead_code)]
+
+use anyhow::Result;
+use turbo_tasks::{ResolvedVc, Vc};
+
+#[derive(Clone)]
+#[turbo_tasks::value(resolved)]
+struct ExampleStruct {
+    items: Vec<ResolvedVc<u32>>,
+}
+
+#[turbo_tasks::value_impl]
+impl ExampleStruct {
+    #[turbo_tasks::function]
+    fn constructor_one(item: ResolvedVc<u32>) -> Vc<Self> {
+        ExampleStruct { items: vec![item] }.cell()
+    }
+
+    #[turbo_tasks::function]
+    fn constructor_vec(items: Vec<turbo_tasks::ResolvedVc<u32>>) -> Vc<Self> {
+        ExampleStruct { items }.cell()
+    }
+}
+
+#[turbo_tasks::value(resolved, transparent)]
+struct MaybeExampleStruct(Option<ExampleStruct>);
+
+#[turbo_tasks::function]
+async fn caller_uses_unresolved_vc(items: Option<Vec<Vc<u32>>>) -> Result<Vc<MaybeExampleStruct>> {
+    if let Some(items) = items {
+        // call `constructor_vec` with `Vc` (not `ResolvedVc`)
+        let inner = ExampleStruct::constructor_vec(items).await?;
+        Ok(Vc::cell(Some((*inner).clone())))
+    } else {
+        Ok(Vc::cell(None))
+    }
+}
+
+fn main() {}

--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -377,7 +377,8 @@ impl TurboFn<'_> {
                             Default::default(),
                             // we know the argument implements `FromTaskInput` because
                             // `expand_task_input_type` returned `Cow::Owned`
-                            parse_quote! {
+                            parse_quote_spanned! {
+                                pat_type.span() =>
                                 <#orig_ty as turbo_tasks::task::FromTaskInput>::from_task_input(
                                     #arg_ident
                                 )

--- a/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
@@ -1,7 +1,6 @@
 use proc_macro::TokenStream;
-use proc_macro2::Ident;
 use quote::quote;
-use syn::{parse_macro_input, parse_quote, ExprPath, ItemFn};
+use syn::{parse_macro_input, parse_quote, ItemFn};
 use turbo_tasks_macros_shared::{get_native_function_id_ident, get_native_function_ident};
 
 use crate::func::{DefinitionContext, FunctionArguments, NativeFn, TurboFn};
@@ -40,7 +39,7 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
         .unwrap_or_default();
     let local_cells = args.local_cells.is_some();
 
-    let Some(turbo_fn) = TurboFn::new(&sig, DefinitionContext::NakedFn, args) else {
+    let Some(turbo_fn) = TurboFn::new(&sig, DefinitionContext::NakedFn, args, *block) else {
         return quote! {
             // An error occurred while parsing the function signature.
         }
@@ -49,14 +48,13 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
 
     let ident = &sig.ident;
 
-    let inline_function_ident = Ident::new(&format!("{ident}_inline_function"), ident.span());
-    let inline_function_path: ExprPath = parse_quote! { #inline_function_ident };
-    let mut inline_signature = sig.clone();
-    inline_signature.ident = inline_function_ident;
+    let inline_function_ident = turbo_fn.inline_ident();
+    let inline_signature = turbo_fn.inline_signature();
+    let inline_block = turbo_fn.inline_block();
 
     let native_fn = NativeFn::new(
         &ident.to_string(),
-        &inline_function_path,
+        &parse_quote! { #inline_function_ident },
         turbo_fn.is_method(),
         local_cells,
     );
@@ -77,7 +75,7 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
 
         #(#attrs)*
         #[doc(hidden)]
-        #inline_signature #block
+        #inline_signature #inline_block
 
         #[doc(hidden)]
         pub(crate) static #native_function_ident: #native_function_ty = #native_function_def;

--- a/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
@@ -39,7 +39,7 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
         .unwrap_or_default();
     let local_cells = args.local_cells.is_some();
 
-    let Some(turbo_fn) = TurboFn::new(&sig, DefinitionContext::NakedFn, args, *block) else {
+    let Some(turbo_fn) = TurboFn::new(&sig, DefinitionContext::NakedFn, args) else {
         return quote! {
             // An error occurred while parsing the function signature.
         }
@@ -49,8 +49,7 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
     let ident = &sig.ident;
 
     let inline_function_ident = turbo_fn.inline_ident();
-    let inline_signature = turbo_fn.inline_signature();
-    let inline_block = turbo_fn.inline_block();
+    let (inline_signature, inline_block) = turbo_fn.inline_signature_and_block(&*block);
 
     let native_fn = NativeFn::new(
         &ident.to_string(),

--- a/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
@@ -49,7 +49,7 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
     let ident = &sig.ident;
 
     let inline_function_ident = turbo_fn.inline_ident();
-    let (inline_signature, inline_block) = turbo_fn.inline_signature_and_block(&*block);
+    let (inline_signature, inline_block) = turbo_fn.inline_signature_and_block(&block);
 
     let native_fn = NativeFn::new(
         &ident.to_string(),

--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -6,7 +6,7 @@ use syn::{
     parse_macro_input, parse_quote,
     punctuated::Punctuated,
     spanned::Spanned,
-    Attribute, Error, ExprPath, Generics, ImplItem, ImplItemMethod, ItemImpl, Lit, LitStr, Meta,
+    Attribute, Error, Generics, ImplItem, ImplItemMethod, ItemImpl, Lit, LitStr, Meta,
     MetaNameValue, Path, Result, Token, Type,
 };
 use turbo_tasks_macros_shared::{
@@ -121,24 +121,23 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                     .unwrap_or_default();
                 let local_cells = func_args.local_cells.is_some();
 
-                // TODO(alexkirsz) These should go into their own utilities.
-                let inline_function_ident: Ident =
-                    Ident::new(&format!("{}_inline", ident), ident.span());
-                let inline_function_path: ExprPath = parse_quote! { <#ty>::#inline_function_ident };
-                let mut inline_signature = sig.clone();
-                inline_signature.ident = inline_function_ident;
-
-                let Some(turbo_fn) =
-                    TurboFn::new(sig, DefinitionContext::ValueInherentImpl, func_args)
-                else {
+                let Some(turbo_fn) = TurboFn::new(
+                    sig,
+                    DefinitionContext::ValueInherentImpl,
+                    func_args,
+                    block.clone(),
+                ) else {
                     return quote! {
                         // An error occurred while parsing the function signature.
                     };
                 };
+                let inline_function_ident = turbo_fn.inline_ident();
+                let inline_signature = turbo_fn.inline_signature();
+                let inline_block = turbo_fn.inline_block();
 
                 let native_fn = NativeFn::new(
                     &format!("{ty}::{ident}", ty = ty.to_token_stream()),
-                    &inline_function_path,
+                    &parse_quote! { <#ty>::#inline_function_ident },
                     turbo_fn.is_method(),
                     local_cells,
                 );
@@ -175,7 +174,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                         #(#attrs)*
                         #[doc(hidden)]
                         #[deprecated(note = "This function is only exposed for use in macros. Do not call it directly.")]
-                        pub(self) #inline_signature #block
+                        pub(self) #inline_signature #inline_block
                     }
 
                     #[doc(hidden)]
@@ -227,25 +226,24 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                     .unwrap_or_default();
                 let local_cells = func_args.local_cells.is_some();
 
-                let Some(turbo_fn) =
-                    TurboFn::new(sig, DefinitionContext::ValueTraitImpl, func_args)
-                else {
+                let Some(turbo_fn) = TurboFn::new(
+                    sig,
+                    DefinitionContext::ValueTraitImpl,
+                    func_args,
+                    block.clone(),
+                ) else {
                     return quote! {
                         // An error occurred while parsing the function signature.
                     };
                 };
 
-                // TODO(alexkirsz) These should go into their own utilities.
-                let inline_function_ident: Ident =
-                    Ident::new(&format!("{}_inline", ident), ident.span());
+                let inline_function_ident = turbo_fn.inline_ident();
                 let inline_extension_trait_ident = Ident::new(
                     &format!("{}_{}_{}_inline", ty_ident, trait_ident, ident),
                     ident.span(),
                 );
-                let inline_function_path: ExprPath =
-                    parse_quote! { <#ty as #inline_extension_trait_ident>::#inline_function_ident };
-                let mut inline_signature = sig.clone();
-                inline_signature.ident = inline_function_ident;
+                let inline_signature = turbo_fn.inline_signature();
+                let inline_block = turbo_fn.inline_block();
 
                 let native_fn = NativeFn::new(
                     &format!(
@@ -253,7 +251,9 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                         ty = ty.to_token_stream(),
                         trait_path = trait_path.to_token_stream()
                     ),
-                    &inline_function_path,
+                    &parse_quote! {
+                        <#ty as #inline_extension_trait_ident>::#inline_function_ident
+                    },
                     turbo_fn.is_method(),
                     local_cells,
                 );
@@ -306,7 +306,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                         #(#attrs)*
                         #[doc(hidden)]
                         #[deprecated(note = "This function is only exposed for use in macros. Do not call it directly.")]
-                        #inline_signature #block
+                        #inline_signature #inline_block
                     }
 
                     #[doc(hidden)]

--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -121,19 +121,15 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                     .unwrap_or_default();
                 let local_cells = func_args.local_cells.is_some();
 
-                let Some(turbo_fn) = TurboFn::new(
-                    sig,
-                    DefinitionContext::ValueInherentImpl,
-                    func_args,
-                    block.clone(),
-                ) else {
+                let Some(turbo_fn) =
+                    TurboFn::new(sig, DefinitionContext::ValueInherentImpl, func_args)
+                else {
                     return quote! {
                         // An error occurred while parsing the function signature.
                     };
                 };
                 let inline_function_ident = turbo_fn.inline_ident();
-                let inline_signature = turbo_fn.inline_signature();
-                let inline_block = turbo_fn.inline_block();
+                let (inline_signature, inline_block) = turbo_fn.inline_signature_and_block(block);
 
                 let native_fn = NativeFn::new(
                     &format!("{ty}::{ident}", ty = ty.to_token_stream()),
@@ -226,12 +222,9 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                     .unwrap_or_default();
                 let local_cells = func_args.local_cells.is_some();
 
-                let Some(turbo_fn) = TurboFn::new(
-                    sig,
-                    DefinitionContext::ValueTraitImpl,
-                    func_args,
-                    block.clone(),
-                ) else {
+                let Some(turbo_fn) =
+                    TurboFn::new(sig, DefinitionContext::ValueTraitImpl, func_args)
+                else {
                     return quote! {
                         // An error occurred while parsing the function signature.
                     };
@@ -242,8 +235,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                     &format!("{}_{}_{}_inline", ty_ident, trait_ident, ident),
                     ident.span(),
                 );
-                let inline_signature = turbo_fn.inline_signature();
-                let inline_block = turbo_fn.inline_block();
+                let (inline_signature, inline_block) = turbo_fn.inline_signature_and_block(block);
 
                 let native_fn = NativeFn::new(
                     &format!(

--- a/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -2,8 +2,7 @@ use proc_macro::TokenStream;
 use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::{quote, quote_spanned};
 use syn::{
-    parse_macro_input, parse_quote, spanned::Spanned, ExprPath, ItemTrait, TraitItem,
-    TraitItemMethod,
+    parse_macro_input, parse_quote, spanned::Spanned, ItemTrait, TraitItem, TraitItemMethod,
 };
 use turbo_tasks_macros_shared::{
     get_trait_default_impl_function_id_ident, get_trait_default_impl_function_ident,
@@ -92,9 +91,6 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
             sig,
             DefinitionContext::ValueTrait,
             FunctionArguments::default(),
-            default.clone().unwrap_or_else(|| {
-                parse_quote!({ ::std::compile_error!("default block should not exist") })
-            }),
         ) else {
             return quote! {
                 // An error occurred while parsing the function signature.
@@ -109,18 +105,17 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
             #turbo_signature #dynamic_block
         });
 
-        let default = if default.is_some() {
-            // TODO(alexkirsz) These should go into their own utilities.
+        let default = if let Some(default) = default {
             let inline_function_ident = turbo_fn.inline_ident();
             let inline_extension_trait_ident =
                 Ident::new(&format!("{}_{}_inline", trait_ident, ident), ident.span());
-            let inline_function_path: ExprPath = parse_quote! { <Box<dyn #trait_ident> as #inline_extension_trait_ident>::#inline_function_ident };
-            let inline_signature = turbo_fn.inline_signature();
-            let inline_block = turbo_fn.inline_block();
+            let (inline_signature, inline_block) = turbo_fn.inline_signature_and_block(default);
 
             let native_function = NativeFn::new(
                 &format!("{trait_ident}::{ident}"),
-                &inline_function_path,
+                &parse_quote! {
+                    <Box<dyn #trait_ident> as #inline_extension_trait_ident>::#inline_function_ident
+                },
                 turbo_fn.is_method(),
                 // `inline_cells` is currently unsupported here because:
                 // - The `#[turbo_tasks::function]` macro needs to be present for us to read this

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -9,8 +9,9 @@ pub use super::{
     manager::{find_cell_by_type, notify_scheduled_tasks, spawn_detached_for_testing},
 };
 use crate::{
-    debug::ValueDebugFormatString, task::TaskOutput, RawVc, ResolvedValue, TaskInput,
-    TaskPersistence, Vc,
+    debug::ValueDebugFormatString,
+    task::{FromTaskInput, TaskOutput},
+    RawVc, ResolvedValue, TaskInput, TaskPersistence, Vc,
 };
 
 #[inline(never)]
@@ -55,4 +56,25 @@ macro_rules! stringify_path {
     ($path:path) => {
         stringify!($path)
     };
+}
+
+pub struct AutoFromTaskInput<T>(pub T);
+
+impl<T> AutoFromTaskInput<T>
+where
+    T: TaskInput,
+{
+    pub fn from_task_input(from: T) -> Self {
+        AutoFromTaskInput(from)
+    }
+}
+
+impl<T> FromTaskInput for AutoFromTaskInput<T>
+where
+    T: FromTaskInput,
+{
+    type TaskInput = T::TaskInput;
+    fn from_task_input(from: T::TaskInput) -> Self {
+        AutoFromTaskInput(FromTaskInput::from_task_input(from))
+    }
 }

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -9,9 +9,8 @@ pub use super::{
     manager::{find_cell_by_type, notify_scheduled_tasks, spawn_detached_for_testing},
 };
 use crate::{
-    debug::ValueDebugFormatString,
-    task::{FromTaskInput, TaskOutput},
-    RawVc, ResolvedValue, TaskInput, TaskPersistence, Vc,
+    debug::ValueDebugFormatString, task::TaskOutput, RawVc, ResolvedValue, TaskInput,
+    TaskPersistence, Vc,
 };
 
 #[inline(never)]
@@ -56,25 +55,4 @@ macro_rules! stringify_path {
     ($path:path) => {
         stringify!($path)
     };
-}
-
-pub struct AutoFromTaskInput<T>(pub T);
-
-impl<T> AutoFromTaskInput<T>
-where
-    T: TaskInput,
-{
-    pub fn from_task_input(from: T) -> Self {
-        AutoFromTaskInput(from)
-    }
-}
-
-impl<T> FromTaskInput for AutoFromTaskInput<T>
-where
-    T: FromTaskInput,
-{
-    type TaskInput = T::TaskInput;
-    fn from_task_input(from: T::TaskInput) -> Self {
-        AutoFromTaskInput(FromTaskInput::from_task_input(from))
-    }
 }

--- a/turbopack/crates/turbo-tasks/src/task/from_task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/from_task_input.rs
@@ -15,7 +15,6 @@ mod private {
     impl<T> Sealed for ResolvedVc<T> where T: Send {}
     impl<T> Sealed for Vec<T> where T: FromTaskInput {}
     impl<T> Sealed for Option<T> where T: FromTaskInput {}
-    impl<T> Sealed for crate::macro_helpers::AutoFromTaskInput<T> where T: FromTaskInput {}
 }
 
 impl<T> FromTaskInput for ResolvedVc<T>

--- a/turbopack/crates/turbo-tasks/src/task/from_task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/from_task_input.rs
@@ -1,0 +1,57 @@
+use crate::{ResolvedVc, TaskInput, Vc};
+
+// NOTE: If you add new implementations of this trait, you'll need to modify
+// `expand_task_input_type` in `turbo-tasks-macros/src/func.rs`.
+pub trait FromTaskInput: private::Sealed {
+    type TaskInput: TaskInput;
+    fn from_task_input(from: Self::TaskInput) -> Self;
+}
+
+mod private {
+    use super::*;
+    /// Implements the sealed trait pattern:
+    /// <https://rust-lang.github.io/api-guidelines/future-proofing.html>
+    pub trait Sealed {}
+    impl<T> Sealed for ResolvedVc<T> where T: Send {}
+    impl<T> Sealed for Vec<T> where T: FromTaskInput {}
+    impl<T> Sealed for Option<T> where T: FromTaskInput {}
+    impl<T> Sealed for crate::macro_helpers::AutoFromTaskInput<T> where T: FromTaskInput {}
+}
+
+impl<T> FromTaskInput for ResolvedVc<T>
+where
+    T: Send,
+{
+    type TaskInput = Vc<T>;
+    fn from_task_input(from: Vc<T>) -> ResolvedVc<T> {
+        debug_assert!(
+            from.is_resolved(),
+            "Outer `Vc`s are always resolved before this is called"
+        );
+        ResolvedVc { node: from }
+    }
+}
+
+impl<T> FromTaskInput for Vec<T>
+where
+    T: FromTaskInput,
+{
+    type TaskInput = Vec<T::TaskInput>;
+    fn from_task_input(from: Vec<T::TaskInput>) -> Vec<T> {
+        let mut converted = Vec::with_capacity(from.len());
+        for value in from {
+            converted.push(T::from_task_input(value));
+        }
+        converted
+    }
+}
+
+impl<T> FromTaskInput for Option<T>
+where
+    T: FromTaskInput,
+{
+    type TaskInput = Option<T::TaskInput>;
+    fn from_task_input(from: Option<T::TaskInput>) -> Option<T> {
+        from.map(T::from_task_input)
+    }
+}

--- a/turbopack/crates/turbo-tasks/src/task/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/task/mod.rs
@@ -1,8 +1,10 @@
+mod from_task_input;
 pub(crate) mod function;
 pub(crate) mod shared_reference;
 pub(crate) mod task_input;
 pub(crate) mod task_output;
 
+pub use from_task_input::FromTaskInput;
 pub use function::{AsyncFunctionMode, FunctionMode, IntoTaskFn, TaskFn};
 pub use shared_reference::SharedReference;
 pub use task_input::TaskInput;

--- a/turbopack/crates/turbo-tasks/src/task/task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_input.rs
@@ -3,9 +3,7 @@ use std::{any::Any, fmt::Debug, future::Future, hash::Hash};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    MagicAny, RcStr, ResolvedVc, TaskId, TransientInstance, TransientValue, Value, ValueTypeId, Vc,
-};
+use crate::{MagicAny, RcStr, TaskId, TransientInstance, TransientValue, Value, ValueTypeId, Vc};
 
 /// Trait to implement in order for a type to be accepted as a
 /// [`#[turbo_tasks::function]`][crate::function] argument.
@@ -106,19 +104,6 @@ where
 
     async fn resolve(&self) -> Result<Self> {
         Vc::resolve(*self).await
-    }
-}
-
-impl<T> TaskInput for ResolvedVc<T>
-where
-    T: Send,
-{
-    fn is_resolved(&self) -> bool {
-        true
-    }
-
-    fn is_transient(&self) -> bool {
-        self.node.node.get_task_id().is_transient()
     }
 }
 


### PR DESCRIPTION
## Why?

[We want to codemod structs to use `ResolvedVc<...>` for all of their field types instead of `Vc<...>`.](https://www.notion.so/vercel/Resolved-Vcs-Vc-Lifetimes-Local-Vcs-and-Vc-Refcounts-49d666d3f9594017b5b312b87ddc5bff?pvs=4)

There are many constructor-like functions (see #70133) where we must accept an argument of type `Vc<...>`, and then explicitly call `.to_resolved().await?`.

However, internally `#[turbo_tasks::function]` arguments are guaranteed to be resolved by the time the function runs. So we can do a cheap conversion here.

## What

Instead of needing to do:

```diff
 #[turbo_tasks::value_impl]
 impl CustomProcessEnv {
     #[turbo_tasks::function]
-    pub fn new(prior: Vc<Box<dyn ProcessEnv>>, custom: Vc<EnvMap>) -> Vc<Self> {
-        CustomProcessEnv { prior, custom }.cell()
+    pub async fn new(prior: Vc<Box<dyn ProcessEnv>>, custom: Vc<EnvMap>) -> Result<Vc<Self>> {
+        let prior = prior.to_resolved().await?;
+        let custom = custom.to_resolved().await?;
+        Ok(CustomProcessEnv { prior, custom }.cell())
    }
}
```

It should now just be possible to accept `ResolvedVc` instead. The exposed function signature will be unchanged, still accepting `Vc` arguments, and a conversion will happen internally.

```diff
 #[turbo_tasks::value_impl]
 impl CustomProcessEnv {
     #[turbo_tasks::function]
-    pub fn new(prior: Vc<Box<dyn ProcessEnv>>, custom: Vc<EnvMap>) -> Vc<Self> {
+    pub fn new(prior: ResolvedVc<Box<dyn ProcessEnv>>, custom: ResolvedVc<EnvMap>) ->Vc<Self> {
         CustomProcessEnv { prior, custom }.cell()
    }
}
```

This should also work for arguments where `Vc` is inside of a `Vec` or `Option` (other collection types are not currently supported).

This PR does not support `self` arguments. That is handled by #70367.

## How

- The macro inspects the argument type and rewrites it to replace `ResolvedVc` with `Vc` to get the exposed function's signature.
- The `FromTaskInput` trait does the actual conversion.

### Why do this type expansion and conversion in the macro, and not as part of [the `TaskFn` trait](https://github.com/vercel/next.js/blob/8f9c6a86177513026ab4bc4fdc3575ca1efe025c/turbopack/crates/turbo-tasks/src/task/function.rs)?

Without [specialization](https://github.com/rust-lang/rfcs/blob/master/text/1210-impl-specialization.md) it's not possible to implement the `FromTaskInput` trait for all `TaskInput` types, as we'd end up with overlapping impls for `Option<T>` and `Vec<T>`.

There are specialization hacks ([inherent method specialization](https://github.com/dtolnay/case-studies/issues/14), [autoref-specialization, and autoderef-specialization](http://lukaskalbertodt.github.io/2019/12/05/generalized-autoref-based-specialization.html)) but those hacks are mostly for macros, not for generic code:

> One thing might be worth clarifying up front: the adopted version described here does not solve *the* main limitation of autoref-based specialization, namely specializing in a generic context. For example, given `fn foo<T: Clone>()`, you cannot specialize for `T: Copy` in that function with autoref-based specialization. For these kinds of parametricity-destroying cases, “real” specialization is still required. As such, the whole autoref-based specialization technique is still mainly relevant for usage with macros.

So we need the macro to determine if a type implements `FromTaskInput` or `TaskInput`. We can't do this inside of generic function.

Aside from that, even though it's not as technically correct, expanding the types inside the macro results in *much* more readable types in rustdoc, which is why we do this in `expand_vc_return_type` as well, even though we could use a trait's associated type instead: https://github.com/vercel/turborepo/pull/8096

## Test Plan

```
cargo nextest r -p turbo-tasks-memory test_resolved_vc
cargo nextest r -p turbo-tasks-macros-tests function
```

Modify some code to use this, and use `rust-analyzer`'s macro expansion feature (after telling RA to rebuild proc macros).