### PR TITLE
Rename `loader_tree` to `app_page_loader_tree`

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -4,8 +4,8 @@ use next_core::{
     all_assets_from_entries,
     app_segment_config::NextSegmentConfig,
     app_structure::{
-        get_entrypoints, Entrypoint as AppEntrypoint, Entrypoints as AppEntrypoints, LoaderTree,
-        MetadataItem,
+        get_entrypoints, AppPageLoaderTree, Entrypoint as AppEntrypoint,
+        Entrypoints as AppEntrypoints, MetadataItem,
     },
     get_edge_resolve_options_context, get_next_package,
     next_app::{
@@ -696,7 +696,7 @@ enum AppPageEndpointType {
 enum AppEndpointType {
     Page {
         ty: AppPageEndpointType,
-        loader_tree: Vc<LoaderTree>,
+        loader_tree: Vc<AppPageLoaderTree>,
     },
     Route {
         path: Vc<FileSystemPath>,
@@ -717,7 +717,7 @@ struct AppEndpoint {
 #[turbo_tasks::value_impl]
 impl AppEndpoint {
     #[turbo_tasks::function]
-    fn app_page_entry(&self, loader_tree: Vc<LoaderTree>) -> Vc<AppEntry> {
+    fn app_page_entry(&self, loader_tree: Vc<AppPageLoaderTree>) -> Vc<AppEntry> {
         get_app_page_entry(
             self.app_project.rsc_module_context(),
             self.app_project.edge_rsc_module_context(),

--- a/crates/next-core/src/app_segment_config.rs
+++ b/crates/next-core/src/app_segment_config.rs
@@ -24,7 +24,7 @@ use turbopack_ecmascript::{
     EcmascriptInputTransforms, EcmascriptModuleAssetType,
 };
 
-use crate::{app_structure::LoaderTree, util::NextRuntime};
+use crate::{app_structure::AppPageLoaderTree, util::NextRuntime};
 
 #[derive(Default, PartialEq, Eq, Clone, Copy, Debug, TraceRawVcs, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -468,7 +468,7 @@ fn parse_config_value(
 
 #[turbo_tasks::function]
 pub async fn parse_segment_config_from_loader_tree(
-    loader_tree: Vc<LoaderTree>,
+    loader_tree: Vc<AppPageLoaderTree>,
 ) -> Result<Vc<NextSegmentConfig>> {
     let loader_tree = &*loader_tree.await?;
 
@@ -478,7 +478,7 @@ pub async fn parse_segment_config_from_loader_tree(
 }
 
 pub async fn parse_segment_config_from_loader_tree_internal(
-    loader_tree: &LoaderTree,
+    loader_tree: &AppPageLoaderTree,
 ) -> Result<NextSegmentConfig> {
     let mut config = NextSegmentConfig::default();
 

--- a/crates/next-core/src/lib.rs
+++ b/crates/next-core/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(arbitrary_self_types)]
 #![feature(iter_intersperse)]
 
+mod app_page_loader_tree;
 pub mod app_segment_config;
 pub mod app_structure;
 mod bootstrap;
@@ -11,7 +12,6 @@ mod embed_js;
 mod emit;
 pub mod hmr_entry;
 pub mod instrumentation;
-mod loader_tree;
 pub mod middleware;
 pub mod mode;
 pub mod next_app;

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -17,8 +17,8 @@ use turbopack_ecmascript::utils::StringifyJs;
 
 use super::app_entry::AppEntry;
 use crate::{
-    app_structure::LoaderTree,
-    loader_tree::{LoaderTreeModule, GLOBAL_ERROR},
+    app_page_loader_tree::{AppPageLoaderTreeModule, GLOBAL_ERROR},
+    app_structure::AppPageLoaderTree,
     next_app::{AppPage, AppPath},
     next_config::NextConfig,
     next_edge::entry::wrap_edge_entry,
@@ -32,7 +32,7 @@ use crate::{
 pub async fn get_app_page_entry(
     nodejs_context: Vc<ModuleAssetContext>,
     edge_context: Vc<ModuleAssetContext>,
-    loader_tree: Vc<LoaderTree>,
+    loader_tree: Vc<AppPageLoaderTree>,
     page: AppPage,
     project_root: Vc<FileSystemPath>,
     next_config: Vc<NextConfig>,
@@ -48,7 +48,7 @@ pub async fn get_app_page_entry(
     let server_component_transition = Vc::upcast(NextServerComponentTransition::new());
 
     let base_path = next_config.await?.base_path.clone();
-    let loader_tree = LoaderTreeModule::build(
+    let loader_tree = AppPageLoaderTreeModule::build(
         loader_tree,
         module_asset_context,
         server_component_transition,
@@ -56,7 +56,7 @@ pub async fn get_app_page_entry(
     )
     .await?;
 
-    let LoaderTreeModule {
+    let AppPageLoaderTreeModule {
         inner_assets,
         imports,
         loader_tree_code,

--- a/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
@@ -24,8 +24,8 @@ interface Options {
   basePath: string
 }
 
-// [NOTE] For turbopack
-// refer loader_tree's write_static|dynamic_metadata for corresponding features
+// [NOTE] For turbopack, refer to app_page_loader_tree's write_metadata_item for
+// corresponding features.
 async function nextMetadataImageLoader(
   this: webpack.LoaderContext<Options>,
   content: Buffer


### PR DESCRIPTION
This is a pure refactoring in preparation for introducing an `app_route_loader_tree` in a future PR.

The `app_page_loader_tree` collects information from the app directory for app _page_ entries, whereas the upcoming `app_route_loader_tree` will collect information from the app directory tailored to app _route_ entries.