### PR TITLE
Rename app directory "components" to "modules"

### DIFF
--- a/crates/next-core/src/app_segment_config.rs
+++ b/crates/next-core/src/app_segment_config.rs
@@ -495,12 +495,12 @@ pub async fn parse_segment_config_from_loader_tree_internal(
         config.apply_parallel_config(&tree)?;
     }
 
-    let components = &loader_tree.components;
-    for component in [components.page, components.default, components.layout]
+    let modules = &loader_tree.modules;
+    for path in [modules.page, modules.default, modules.layout]
         .into_iter()
         .flatten()
     {
-        let source = Vc::upcast(FileSource::new(component));
+        let source = Vc::upcast(FileSource::new(path));
         config.apply_parent_config(&*parse_segment_config_from_source(source).await?);
     }
 

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -32,7 +32,7 @@ use crate::{
 /// A final route in the app directory.
 #[turbo_tasks::value]
 #[derive(Default, Debug, Clone)]
-pub struct Components {
+pub struct AppDirModules {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<Vc<FileSystemPath>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -55,7 +55,7 @@ pub struct Components {
     pub metadata: Metadata,
 }
 
-impl Components {
+impl AppDirModules {
     fn without_leafs(&self) -> Self {
         Self {
             page: None,
@@ -204,7 +204,7 @@ impl GlobalMetadata {
 pub struct DirectoryTree {
     /// key is e.g. "dashboard", "(dashboard)", "@slot"
     pub subdirectories: BTreeMap<RcStr, Vc<DirectoryTree>>,
-    pub components: Components,
+    pub modules: AppDirModules,
 }
 
 #[turbo_tasks::value]
@@ -212,7 +212,7 @@ pub struct DirectoryTree {
 struct PlainDirectoryTree {
     /// key is e.g. "dashboard", "(dashboard)", "@slot"
     pub subdirectories: BTreeMap<RcStr, PlainDirectoryTree>,
-    pub components: Components,
+    pub modules: AppDirModules,
 }
 
 #[turbo_tasks::value_impl]
@@ -227,7 +227,7 @@ impl DirectoryTree {
 
         Ok(PlainDirectoryTree {
             subdirectories,
-            components: self.components.clone(),
+            modules: self.modules.clone(),
         }
         .cell())
     }
@@ -278,14 +278,14 @@ async fn get_directory_tree_internal(
         // so we just return an empty tree here.
         return Ok(DirectoryTree {
             subdirectories: Default::default(),
-            components: Components::default(),
+            modules: AppDirModules::default(),
         }
         .cell());
     };
     let page_extensions_value = page_extensions.await?;
 
     let mut subdirectories = BTreeMap::new();
-    let mut components = Components::default();
+    let mut modules = AppDirModules::default();
 
     let mut metadata_icon = Vec::new();
     let mut metadata_apple = Vec::new();
@@ -304,15 +304,15 @@ async fn get_directory_tree_internal(
                 if let Some((stem, ext)) = basename.split_once('.') {
                     if page_extensions_value.iter().any(|e| e == ext) {
                         match stem {
-                            "page" => components.page = Some(file),
-                            "layout" => components.layout = Some(file),
-                            "error" => components.error = Some(file),
-                            "global-error" => components.global_error = Some(file),
-                            "loading" => components.loading = Some(file),
-                            "template" => components.template = Some(file),
-                            "not-found" => components.not_found = Some(file),
-                            "default" => components.default = Some(file),
-                            "route" => components.route = Some(file),
+                            "page" => modules.page = Some(file),
+                            "layout" => modules.layout = Some(file),
+                            "error" => modules.error = Some(file),
+                            "global-error" => modules.global_error = Some(file),
+                            "loading" => modules.loading = Some(file),
+                            "template" => modules.template = Some(file),
+                            "not-found" => modules.not_found = Some(file),
+                            "default" => modules.default = Some(file),
+                            "route" => modules.route = Some(file),
                             _ => {}
                         }
                     }
@@ -334,10 +334,9 @@ async fn get_directory_tree_internal(
                     "opengraph-image" => &mut metadata_open_graph,
                     "sitemap" => {
                         if dynamic {
-                            components.metadata.sitemap =
-                                Some(MetadataItem::Dynamic { path: file });
+                            modules.metadata.sitemap = Some(MetadataItem::Dynamic { path: file });
                         } else {
-                            components.metadata.sitemap = Some(MetadataItem::Static { path: file });
+                            modules.metadata.sitemap = Some(MetadataItem::Static { path: file });
                         }
                         continue;
                     }
@@ -384,14 +383,14 @@ async fn get_directory_tree_internal(
         list.into_iter().map(|(_, item)| item).collect()
     }
 
-    components.metadata.icon = sort(metadata_icon);
-    components.metadata.apple = sort(metadata_apple);
-    components.metadata.twitter = sort(metadata_twitter);
-    components.metadata.open_graph = sort(metadata_open_graph);
+    modules.metadata.icon = sort(metadata_icon);
+    modules.metadata.apple = sort(metadata_apple);
+    modules.metadata.twitter = sort(metadata_twitter);
+    modules.metadata.open_graph = sort(metadata_open_graph);
 
     Ok(DirectoryTree {
         subdirectories,
-        components,
+        modules,
     }
     .cell())
 }
@@ -402,7 +401,7 @@ pub struct AppPageLoaderTree {
     pub page: AppPage,
     pub segment: RcStr,
     pub parallel_routes: IndexMap<RcStr, AppPageLoaderTree>,
-    pub components: Components,
+    pub modules: AppDirModules,
     pub global_metadata: Vc<GlobalMetadata>,
 }
 
@@ -764,7 +763,7 @@ fn page_path_except_parallel(loader_tree: &AppPageLoaderTree) -> Option<AppPage>
         return None;
     }
 
-    if loader_tree.components.page.is_some() {
+    if loader_tree.modules.page.is_some() {
         return Some(loader_tree.page.clone());
     }
 
@@ -836,20 +835,20 @@ fn directory_tree_to_loader_tree_internal(
         return Ok(None);
     }
 
-    let mut components = directory_tree.components.clone();
+    let mut modules = directory_tree.modules.clone();
 
     // Capture the current page for the metadata to calculate segment relative to
     // the corresponding page for the static metadata files.
-    components.metadata.base_page = Some(app_page.clone());
+    modules.metadata.base_page = Some(app_page.clone());
 
     // the root directory in the app dir.
     let is_root_directory = app_page.is_root();
     // an alternative root layout (in a route group which affects the page, but not
     // the path).
-    let is_root_layout = app_path.is_root() && components.layout.is_some();
+    let is_root_layout = app_path.is_root() && modules.layout.is_some();
 
-    if (is_root_directory || is_root_layout) && components.not_found.is_none() {
-        components.not_found = Some(
+    if (is_root_directory || is_root_layout) && modules.not_found.is_none() {
+        modules.not_found = Some(
             get_next_package(app_dir).join("dist/client/components/not-found-error.js".into()),
         );
     }
@@ -858,7 +857,7 @@ fn directory_tree_to_loader_tree_internal(
         page: app_page.clone(),
         segment: directory_name.clone(),
         parallel_routes: IndexMap::new(),
-        components: components.without_leafs(),
+        modules: modules.without_leafs(),
         global_metadata,
     };
 
@@ -869,7 +868,7 @@ fn directory_tree_to_loader_tree_internal(
     }
 
     if let Some(page) = (app_path == for_app_path || app_path.is_catchall())
-        .then_some(components.page)
+        .then_some(modules.page)
         .flatten()
     {
         tree.parallel_routes.insert(
@@ -878,9 +877,9 @@ fn directory_tree_to_loader_tree_internal(
                 page: app_page.clone(),
                 segment: "__PAGE__".into(),
                 parallel_routes: IndexMap::new(),
-                components: Components {
+                modules: AppDirModules {
                     page: Some(page),
-                    metadata: components.metadata,
+                    metadata: modules.metadata,
                     ..Default::default()
                 },
                 global_metadata,
@@ -974,9 +973,9 @@ fn directory_tree_to_loader_tree_internal(
             let subdir_name: RcStr = format!("@{}", key).into();
 
             let default = if key == "children" {
-                components.default
+                modules.default
             } else if let Some(subdirectory) = directory_tree.subdirectories.get(&subdir_name) {
-                subdirectory.components.default
+                subdirectory.modules.default
             } else {
                 None
             };
@@ -989,15 +988,15 @@ fn directory_tree_to_loader_tree_internal(
     }
 
     if tree.parallel_routes.is_empty() {
-        if components.default.is_some() || current_level_is_parallel_route {
-            tree = default_route_tree(app_dir, global_metadata, app_page, components.default);
+        if modules.default.is_some() || current_level_is_parallel_route {
+            tree = default_route_tree(app_dir, global_metadata, app_page, modules.default);
         } else {
             return Ok(None);
         }
     } else if tree.parallel_routes.get("children").is_none() {
         tree.parallel_routes.insert(
             "children".into(),
-            default_route_tree(app_dir, global_metadata, app_page, components.default),
+            default_route_tree(app_dir, global_metadata, app_page, modules.default),
         );
     }
 
@@ -1022,14 +1021,14 @@ fn default_route_tree(
         page: app_page.clone(),
         segment: "__DEFAULT__".into(),
         parallel_routes: IndexMap::new(),
-        components: if let Some(default) = default_component {
-            Components {
+        modules: if let Some(default) = default_component {
+            AppDirModules {
                 default: Some(default),
                 ..Default::default()
             }
         } else {
             // default fallback component
-            Components {
+            AppDirModules {
                 default: Some(
                     get_next_package(app_dir)
                         .join("dist/client/components/parallel-route-default.js".into()),
@@ -1077,11 +1076,11 @@ async fn directory_tree_to_entrypoints_internal_untraced(
     let directory_tree = &*directory_tree.await?;
 
     let subdirectories = &directory_tree.subdirectories;
-    let components = &directory_tree.components;
+    let modules = &directory_tree.modules;
     // Route can have its own segment config, also can inherit from the layout root
     // segment config. https://nextjs.org/docs/app/building-your-application/rendering/edge-and-nodejs-runtimes#segment-runtime-option
     // Pass down layouts from each tree to apply segment config when adding route.
-    let root_layouts = if let Some(layout) = components.layout {
+    let root_layouts = if let Some(layout) = modules.layout {
         let mut layouts = (*root_layouts.await?).clone();
         layouts.push(layout);
         Vc::cell(layouts)
@@ -1089,7 +1088,7 @@ async fn directory_tree_to_entrypoints_internal_untraced(
         root_layouts
     };
 
-    if components.page.is_some() {
+    if modules.page.is_some() {
         let app_path = AppPath::from(app_page.clone());
 
         let loader_tree = *directory_tree_to_loader_tree(
@@ -1110,7 +1109,7 @@ async fn directory_tree_to_entrypoints_internal_untraced(
         );
     }
 
-    if let Some(route) = components.route {
+    if let Some(route) = modules.route {
         add_app_route(
             app_dir,
             &mut result,
@@ -1127,7 +1126,7 @@ async fn directory_tree_to_entrypoints_internal_untraced(
         open_graph,
         sitemap,
         base_page: _,
-    } = &components.metadata;
+    } = &modules.metadata;
 
     for meta in sitemap
         .iter()
@@ -1180,18 +1179,18 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                                 page: app_page.clone(),
                                 segment: "__PAGE__".into(),
                                 parallel_routes: IndexMap::new(),
-                                components: Components {
-                                    page: components.not_found.or_else(|| Some(get_next_package(app_dir).join("dist/client/components/not-found-error.js".into()))),
+                                modules: AppDirModules {
+                                    page: modules.not_found.or_else(|| Some(get_next_package(app_dir).join("dist/client/components/not-found-error.js".into()))),
                                     ..Default::default()
                                 },
                                 global_metadata
                             }
                         },
-                        components: Components::default(),
+                        modules: AppDirModules::default(),
                         global_metadata,
                     },
                 },
-                components: components.without_leafs(),
+                modules: modules.without_leafs(),
                 global_metadata,
             }.cell();
 

--- a/crates/next-core/src/base_loader_tree.rs
+++ b/crates/next-core/src/base_loader_tree.rs
@@ -20,7 +20,7 @@ pub struct BaseLoaderTreeBuilder {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ComponentType {
+pub enum AppDirModuleType {
     Page,
     DefaultPage,
     Error,
@@ -30,16 +30,16 @@ pub enum ComponentType {
     NotFound,
 }
 
-impl ComponentType {
+impl AppDirModuleType {
     pub fn name(&self) -> &'static str {
         match self {
-            ComponentType::Page => "page",
-            ComponentType::DefaultPage => "defaultPage",
-            ComponentType::Error => "error",
-            ComponentType::Layout => "layout",
-            ComponentType::Loading => "loading",
-            ComponentType::Template => "template",
-            ComponentType::NotFound => "not-found",
+            AppDirModuleType::Page => "page",
+            AppDirModuleType::DefaultPage => "defaultPage",
+            AppDirModuleType::Error => "error",
+            AppDirModuleType::Layout => "layout",
+            AppDirModuleType::Loading => "loading",
+            AppDirModuleType::Template => "template",
+            AppDirModuleType::NotFound => "not-found",
         }
     }
 }
@@ -76,19 +76,19 @@ impl BaseLoaderTreeBuilder {
             .module()
     }
 
-    pub async fn create_component_tuple_code(
+    pub async fn create_module_tuple_code(
         &mut self,
-        component_type: ComponentType,
+        module_type: AppDirModuleType,
         path: Vc<FileSystemPath>,
     ) -> Result<String> {
-        let name = component_type.name();
+        let name = module_type.name();
         let i = self.unique_number();
         let identifier = magic_identifier::mangle(&format!("{name} #{i}"));
 
         self.imports.push(
             formatdoc!(
                 r#"
-                import * as {} from "COMPONENT_{}";
+                import * as {} from "MODULE_{}";
                 "#,
                 identifier,
                 i
@@ -99,7 +99,7 @@ impl BaseLoaderTreeBuilder {
         let module = self.process_module(path);
 
         self.inner_assets
-            .insert(format!("COMPONENT_{i}").into(), module);
+            .insert(format!("MODULE_{i}").into(), module);
 
         let module_path = module.ident().path().to_string().await?;
 

--- a/packages/next/src/build/webpack/loaders/metadata/types.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/types.ts
@@ -1,9 +1,7 @@
 // TODO-APP: check if this can be narrowed.
-export type ComponentModule = () => any
-export type ModuleReference = [
-  componentModule: ComponentModule,
-  filePath: string,
-]
+export type ModuleGetter = () => any
+
+export type ModuleTuple = [getModule: ModuleGetter, filePath: string]
 
 // Contain the collecting image module paths
 export type CollectingMetadata = {
@@ -16,10 +14,10 @@ export type CollectingMetadata = {
 
 // Contain the collecting evaluated image module
 export type CollectedMetadata = {
-  icon: ComponentModule[]
-  apple: ComponentModule[]
-  twitter: ComponentModule[] | null
-  openGraph: ComponentModule[] | null
+  icon: ModuleGetter[]
+  apple: ModuleGetter[]
+  twitter: ModuleGetter[] | null
+  openGraph: ModuleGetter[] | null
   manifest?: string
 }
 

--- a/packages/next/src/build/webpack/loaders/next-app-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader.ts
@@ -4,7 +4,7 @@ import {
   UNDERSCORE_NOT_FOUND_ROUTE_ENTRY,
   type ValueOf,
 } from '../../../shared/lib/constants'
-import type { ModuleReference, CollectedMetadata } from './metadata/types'
+import type { ModuleTuple, CollectedMetadata } from './metadata/types'
 
 import path from 'path'
 import { stringify } from 'querystring'
@@ -83,14 +83,14 @@ export type MetadataResolver = (
   extensions: readonly string[]
 ) => Promise<string | undefined>
 
-export type ComponentsType = {
-  readonly [componentKey in ValueOf<typeof FILE_TYPES>]?: ModuleReference
+export type AppDirModules = {
+  readonly [moduleKey in ValueOf<typeof FILE_TYPES>]?: ModuleTuple
 } & {
-  readonly page?: ModuleReference
+  readonly page?: ModuleTuple
 } & {
   readonly metadata?: CollectedMetadata
 } & {
-  readonly defaultPage?: ModuleReference
+  readonly defaultPage?: ModuleTuple
 }
 
 async function createAppRouteCode({
@@ -436,10 +436,10 @@ async function createTreeCodeFromPath(
         }`
       }
 
-      const componentsCode = `{
+      const modulesCode = `{
         ${definedFilePaths
           .map(([file, filePath]) => {
-            const varName = `component${nestedCollectedDeclarations.length}`
+            const varName = `module${nestedCollectedDeclarations.length}`
             nestedCollectedDeclarations.push([varName, filePath])
             return `'${file}': [${varName}, ${JSON.stringify(filePath)}],`
           })
@@ -460,7 +460,7 @@ async function createTreeCodeFromPath(
       props[normalizedParallelKey] = `[
         '${parallelSegmentKey}',
         ${subtreeCode},
-        ${componentsCode}
+        ${modulesCode}
       ]`
     }
 

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -10,7 +10,7 @@ import type { MetadataImageModule } from '../../build/webpack/loaders/metadata/t
 import type { GetDynamicParamFromSegment } from '../../server/app-render/app-render'
 import type { Twitter } from './types/twitter-types'
 import type { OpenGraph } from './types/opengraph-types'
-import type { ComponentsType } from '../../build/webpack/loaders/next-app-loader'
+import type { AppDirModules } from '../../build/webpack/loaders/next-app-loader'
 import type { MetadataContext } from './types/resolvers'
 import type { LoaderTree } from '../../server/lib/app-dir-module'
 import type {
@@ -371,9 +371,9 @@ async function getDefinedMetadata(
 }
 
 async function collectStaticImagesFiles(
-  metadata: ComponentsType['metadata'],
+  metadata: AppDirModules['metadata'],
   props: any,
-  type: keyof NonNullable<ComponentsType['metadata']>
+  type: keyof NonNullable<AppDirModules['metadata']>
 ) {
   if (!metadata?.[type]) return undefined
 
@@ -388,10 +388,10 @@ async function collectStaticImagesFiles(
 }
 
 async function resolveStaticMetadata(
-  components: ComponentsType,
+  modules: AppDirModules,
   props: any
 ): Promise<StaticMetadata> {
-  const { metadata } = components
+  const { metadata } = modules
   if (!metadata) return null
 
   const [icon, apple, openGraph, twitter] = await Promise.all([

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -102,10 +102,10 @@ async function createComponentTreeInternal({
     query,
   } = ctx
 
-  const { page, layoutOrPagePath, segment, components, parallelRoutes } =
+  const { page, layoutOrPagePath, segment, modules, parallelRoutes } =
     parseLoaderTree(tree)
 
-  const { layout, template, error, loading, 'not-found': notFound } = components
+  const { layout, template, error, loading, 'not-found': notFound } = modules
 
   const injectedCSSWithCurrentLayout = new Set(injectedCSS)
   const injectedJSWithCurrentLayout = new Set(injectedJS)

--- a/packages/next/src/server/app-render/parse-loader-tree.ts
+++ b/packages/next/src/server/app-render/parse-loader-tree.ts
@@ -2,19 +2,19 @@ import { DEFAULT_SEGMENT_KEY } from '../../shared/lib/segment'
 import type { LoaderTree } from '../lib/app-dir-module'
 
 export function parseLoaderTree(tree: LoaderTree) {
-  const [segment, parallelRoutes, components] = tree
-  const { layout } = components
-  let { page } = components
+  const [segment, parallelRoutes, modules] = tree
+  const { layout } = modules
+  let { page } = modules
   // a __DEFAULT__ segment means that this route didn't match any of the
   // segments in the route, so we should use the default page
-  page = segment === DEFAULT_SEGMENT_KEY ? components.defaultPage : page
+  page = segment === DEFAULT_SEGMENT_KEY ? modules.defaultPage : page
 
   const layoutOrPagePath = layout?.[1] || page?.[1]
 
   return {
     page,
     segment,
-    components,
+    modules,
     layoutOrPagePath,
     parallelRoutes,
   }

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -65,11 +65,11 @@ export async function walkTreeWithFlightRouterState({
     componentMod: { tree: loaderTree },
   } = ctx
 
-  const [segment, parallelRoutes, components] = loaderTreeToFilter
+  const [segment, parallelRoutes, modules] = loaderTreeToFilter
 
   const parallelRoutesKeys = Object.keys(parallelRoutes)
 
-  const { layout } = components
+  const { layout } = modules
   const isLayout = typeof layout !== 'undefined'
 
   /**
@@ -117,7 +117,7 @@ export async function walkTreeWithFlightRouterState({
   const shouldSkipComponentTree =
     !experimental.isRoutePPREnabled &&
     isPrefetch &&
-    !Boolean(components.loading) &&
+    !Boolean(modules.loading) &&
     !hasLoadingComponentInTree(loaderTree)
 
   if (!parentRendered && renderComponentsOnThisLevel) {

--- a/packages/next/src/server/lib/app-dir-module.ts
+++ b/packages/next/src/server/lib/app-dir-module.ts
@@ -1,4 +1,4 @@
-import type { ComponentsType } from '../../build/webpack/loaders/next-app-loader'
+import type { AppDirModules } from '../../build/webpack/loaders/next-app-loader'
 import { DEFAULT_SEGMENT_KEY } from '../../shared/lib/segment'
 
 /**
@@ -7,7 +7,7 @@ import { DEFAULT_SEGMENT_KEY } from '../../shared/lib/segment'
 export type LoaderTree = [
   segment: string,
   parallelRoutes: { [parallelRouterKey: string]: LoaderTree },
-  components: ComponentsType,
+  modules: AppDirModules,
 ]
 
 export async function getLayoutOrPageModule(loaderTree: LoaderTree) {
@@ -36,11 +36,11 @@ export async function getLayoutOrPageModule(loaderTree: LoaderTree) {
 
 export async function getComponentTypeModule(
   loaderTree: LoaderTree,
-  componentType: 'layout' | 'not-found'
+  moduleType: 'layout' | 'not-found'
 ) {
-  const { [componentType]: component } = loaderTree[2]
-  if (typeof component !== 'undefined') {
-    return await component[0]()
+  const { [moduleType]: module } = loaderTree[2]
+  if (typeof module !== 'undefined') {
+    return await module[0]()
   }
   return undefined
 }


### PR DESCRIPTION
This is a pure refactoring. Not every reserved file in the app directory represents a component module. Currently, `route` is the only exception, but a future PR will introduce another one.