### PR TITLE
Await `killApp` in integration tests

### DIFF
--- a/test/integration/api-body-parser/test/index.test.js
+++ b/test/integration/api-body-parser/test/index.test.js
@@ -24,21 +24,21 @@ function runTests() {
     app = await launchApp(appDir, appPort, {})
     const data = await makeRequest()
     expect(data).toEqual([{ title: 'Nextjs' }])
-    killApp(app)
+    await killApp(app)
   })
 
   it('should not throw if request body is already parsed in custom middleware', async () => {
     await startServer()
     const data = await makeRequest()
     expect(data).toEqual([{ title: 'Nextjs' }])
-    killApp(server)
+    await killApp(server)
   })
 
   it("should not throw if request's content-type is invalid", async () => {
     await startServer()
     const status = await makeRequestWithInvalidContentType()
     expect(status).toBe(200)
-    killApp(server)
+    await killApp(server)
   })
 }
 

--- a/test/integration/config-experimental-warning/test/index.test.js
+++ b/test/integration/config-experimental-warning/test/index.test.js
@@ -38,13 +38,13 @@ async function collectStdoutFromBuild(appDir) {
 }
 
 describe('Config Experimental Warning', () => {
-  afterEach(() => {
+  afterEach(async () => {
     configFile.write('')
     configFile.delete()
     configFileMjs.write('')
     configFileMjs.delete()
     if (app) {
-      killApp(app)
+      await killApp(app)
       app = undefined
     }
   })

--- a/test/integration/config-mjs/test/index.test.js
+++ b/test/integration/config-mjs/test/index.test.js
@@ -29,8 +29,8 @@ describe('Configuration', () => {
     ])
   })
 
-  afterAll(() => {
-    killApp(context.server)
+  afterAll(async () => {
+    await killApp(context.server)
   })
 
   async function get$(path, query) {

--- a/test/integration/config/test/index.test.js
+++ b/test/integration/config/test/index.test.js
@@ -29,8 +29,8 @@ describe('Configuration', () => {
     ])
   })
 
-  afterAll(() => {
-    killApp(context.server)
+  afterAll(async () => {
+    await killApp(context.server)
   })
 
   async function get$(path, query) {

--- a/test/integration/custom-server/test/index.test.js
+++ b/test/integration/custom-server/test/index.test.js
@@ -174,8 +174,8 @@ describe.each([
   if (!useHttps) {
     describe('HMR with custom server', () => {
       beforeAll(() => startServer())
-      afterAll(() => {
-        killApp(server)
+      afterAll(async () => {
+        await killApp(server)
         indexPg.restore()
       })
 

--- a/test/integration/edge-runtime-configurable-guards/test/index.test.js
+++ b/test/integration/edge-runtime-configurable-guards/test/index.test.js
@@ -45,9 +45,9 @@ describe('Edge runtime configurable guards', () => {
     context.logs = { output: '', stdout: '', stderr: '' }
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     if (context.app) {
-      killApp(context.app)
+      await killApp(context.app)
     }
     context.api.restore()
     context.middleware.restore()

--- a/test/integration/edge-runtime-response-error/test/index.test.js
+++ b/test/integration/edge-runtime-response-error/test/index.test.js
@@ -44,9 +44,9 @@ describe('Edge runtime code with imports', () => {
     await remove(join(__dirname, '../.next'))
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     if (context.app) {
-      killApp(context.app)
+      await killApp(context.app)
     }
     context.api.restore()
     context.middleware.restore()

--- a/test/integration/empty-project/test/index.test.js
+++ b/test/integration/empty-project/test/index.test.js
@@ -20,8 +20,8 @@ describe('Empty Project', () => {
     expect(res.status).toBe(404)
   })
 
-  afterAll(() => {
-    killApp(context.server)
+  afterAll(async () => {
+    await killApp(context.server)
     fs.closeSync(fs.openSync(join(__dirname, '..', 'pages', '.gitkeep'), 'w'))
   })
 })

--- a/test/integration/middleware-dev-update/test/index.test.js
+++ b/test/integration/middleware-dev-update/test/index.test.js
@@ -32,10 +32,10 @@ describe('Middleware development errors', () => {
     })
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     context.middleware.restore()
     if (context.app) {
-      killApp(context.app)
+      await killApp(context.app)
     }
   })
 

--- a/test/integration/next-image-legacy/base-path/test/static.test.ts
+++ b/test/integration/next-image-legacy/base-path/test/static.test.ts
@@ -133,8 +133,8 @@ describe('Static Image Component Tests for basePath', () => {
         html = await renderViaHTTP(appPort, '/docs/static-img')
         browser = await webdriver(appPort, '/docs/static-img')
       })
-      afterAll(() => {
-        killApp(app)
+      afterAll(async () => {
+        await killApp(app)
       })
       runTests()
     }
@@ -148,8 +148,8 @@ describe('Static Image Component Tests for basePath', () => {
         html = await renderViaHTTP(appPort, '/docs/static-img')
         browser = await webdriver(appPort, '/docs/static-img')
       })
-      afterAll(() => {
-        killApp(app)
+      afterAll(async () => {
+        await killApp(app)
       })
       runTests(true)
     }

--- a/test/integration/next-image-legacy/default/test/static.test.ts
+++ b/test/integration/next-image-legacy/default/test/static.test.ts
@@ -153,8 +153,8 @@ describe('Static Image Component Tests', () => {
         html = await renderViaHTTP(appPort, '/static-img')
         browser = await webdriver(appPort, '/static-img')
       })
-      afterAll(() => {
-        killApp(app)
+      afterAll(async () => {
+        await killApp(app)
       })
       runTests()
     }

--- a/test/integration/next-image-legacy/unicode/test/index.test.ts
+++ b/test/integration/next-image-legacy/unicode/test/index.test.ts
@@ -76,8 +76,8 @@ describe('Image Component Unicode Image URL', () => {
         app = await launchApp(appDir, appPort)
         browser = await webdriver(appPort, '/')
       })
-      afterAll(() => {
-        killApp(app)
+      afterAll(async () => {
+        await killApp(app)
         if (browser) {
           browser.close()
         }
@@ -94,8 +94,8 @@ describe('Image Component Unicode Image URL', () => {
         app = await nextStart(appDir, appPort)
         browser = await webdriver(appPort, '/')
       })
-      afterAll(() => {
-        killApp(app)
+      afterAll(async () => {
+        await killApp(app)
         if (browser) {
           browser.close()
         }

--- a/test/integration/next-image-new/app-dir/test/static.test.ts
+++ b/test/integration/next-image-new/app-dir/test/static.test.ts
@@ -262,8 +262,8 @@ describe('Static Image Component Tests', () => {
         $ = cheerio.load(html)
         browser = await webdriver(appPort, '/static-img')
       })
-      afterAll(() => {
-        killApp(app)
+      afterAll(async () => {
+        await killApp(app)
       })
       runTests(false)
     }
@@ -278,8 +278,8 @@ describe('Static Image Component Tests', () => {
         $ = cheerio.load(html)
         browser = await webdriver(appPort, '/static-img')
       })
-      afterAll(() => {
-        killApp(app)
+      afterAll(async () => {
+        await killApp(app)
       })
       runTests(true)
     }

--- a/test/integration/next-image-new/base-path/test/static.test.js
+++ b/test/integration/next-image-new/base-path/test/static.test.js
@@ -207,8 +207,8 @@ describe('Static Image Component Tests for basePath', () => {
         $ = cheerio.load(html)
         browser = await webdriver(appPort, '/docs/static-img')
       })
-      afterAll(() => {
-        killApp(app)
+      afterAll(async () => {
+        await killApp(app)
       })
       runTests(false)
     }
@@ -223,8 +223,8 @@ describe('Static Image Component Tests for basePath', () => {
         $ = cheerio.load(html)
         browser = await webdriver(appPort, '/docs/static-img')
       })
-      afterAll(() => {
-        killApp(app)
+      afterAll(async () => {
+        await killApp(app)
       })
       runTests(true)
     }

--- a/test/integration/next-image-new/default/test/static.test.ts
+++ b/test/integration/next-image-new/default/test/static.test.ts
@@ -269,8 +269,8 @@ describe('Static Image Component Tests', () => {
         $ = cheerio.load(html)
         browser = await webdriver(appPort, '/static-img')
       })
-      afterAll(() => {
-        killApp(app)
+      afterAll(async () => {
+        await killApp(app)
       })
       runTests(false)
     }
@@ -285,8 +285,8 @@ describe('Static Image Component Tests', () => {
         $ = cheerio.load(html)
         browser = await webdriver(appPort, '/static-img')
       })
-      afterAll(() => {
-        killApp(app)
+      afterAll(async () => {
+        await killApp(app)
       })
       runTests(true)
     }

--- a/test/integration/next-image-new/loader-config-default-loader-with-file/test/index.test.ts
+++ b/test/integration/next-image-new/loader-config-default-loader-with-file/test/index.test.ts
@@ -50,8 +50,8 @@ describe('Image Loader Config', () => {
       appPort = await findPort()
       app = await launchApp(appDir, appPort)
     })
-    afterAll(() => {
-      killApp(app)
+    afterAll(async () => {
+      await killApp(app)
     })
     runTests('/')
   })
@@ -63,8 +63,8 @@ describe('Image Loader Config', () => {
         appPort = await findPort()
         app = await nextStart(appDir, appPort)
       })
-      afterAll(() => {
-        killApp(app)
+      afterAll(async () => {
+        await killApp(app)
       })
       runTests('/')
     }
@@ -74,8 +74,8 @@ describe('Image Loader Config', () => {
       appPort = await findPort()
       app = await launchApp(appDir, appPort)
     })
-    afterAll(() => {
-      killApp(app)
+    afterAll(async () => {
+      await killApp(app)
     })
     runTests('/get-img-props')
   })
@@ -87,8 +87,8 @@ describe('Image Loader Config', () => {
         appPort = await findPort()
         app = await nextStart(appDir, appPort)
       })
-      afterAll(() => {
-        killApp(app)
+      afterAll(async () => {
+        await killApp(app)
       })
       runTests('/get-img-props')
     }

--- a/test/integration/next-image-new/loader-config-edge-runtime/test/index.test.ts
+++ b/test/integration/next-image-new/loader-config-edge-runtime/test/index.test.ts
@@ -51,8 +51,8 @@ describe('Image Loader Config with Edge Runtime', () => {
         app = await launchApp(appDir, appPort)
         browser = await webdriver(appPort, '/')
       })
-      afterAll(() => {
-        killApp(app)
+      afterAll(async () => {
+        await killApp(app)
         if (browser) {
           browser.close()
         }
@@ -69,8 +69,8 @@ describe('Image Loader Config with Edge Runtime', () => {
         app = await nextStart(appDir, appPort)
         browser = await webdriver(appPort, '/')
       })
-      afterAll(() => {
-        killApp(app)
+      afterAll(async () => {
+        await killApp(app)
         if (browser) {
           browser.close()
         }

--- a/test/integration/next-image-new/loader-config/test/index.test.ts
+++ b/test/integration/next-image-new/loader-config/test/index.test.ts
@@ -43,8 +43,8 @@ describe('Image Loader Config new', () => {
       appPort = await findPort()
       app = await launchApp(appDir, appPort)
     })
-    afterAll(() => {
-      killApp(app)
+    afterAll(async () => {
+      await killApp(app)
     })
     runTests('/')
   })
@@ -56,8 +56,8 @@ describe('Image Loader Config new', () => {
         appPort = await findPort()
         app = await nextStart(appDir, appPort)
       })
-      afterAll(() => {
-        killApp(app)
+      afterAll(async () => {
+        await killApp(app)
       })
       runTests('/')
     }
@@ -67,8 +67,8 @@ describe('Image Loader Config new', () => {
       appPort = await findPort()
       app = await launchApp(appDir, appPort)
     })
-    afterAll(() => {
-      killApp(app)
+    afterAll(async () => {
+      await killApp(app)
     })
     runTests('/get-img-props')
   })
@@ -80,8 +80,8 @@ describe('Image Loader Config new', () => {
         appPort = await findPort()
         app = await nextStart(appDir, appPort)
       })
-      afterAll(() => {
-        killApp(app)
+      afterAll(async () => {
+        await killApp(app)
       })
       runTests('/get-img-props')
     }

--- a/test/integration/next-image-new/unicode/test/index.test.ts
+++ b/test/integration/next-image-new/unicode/test/index.test.ts
@@ -76,8 +76,8 @@ describe('Image Component Unicode Image URL', () => {
         app = await launchApp(appDir, appPort)
         browser = await webdriver(appPort, '/')
       })
-      afterAll(() => {
-        killApp(app)
+      afterAll(async () => {
+        await killApp(app)
         if (browser) {
           browser.close()
         }
@@ -94,8 +94,8 @@ describe('Image Component Unicode Image URL', () => {
         app = await nextStart(appDir, appPort)
         browser = await webdriver(appPort, '/')
       })
-      afterAll(() => {
-        killApp(app)
+      afterAll(async () => {
+        await killApp(app)
         if (browser) {
           browser.close()
         }

--- a/test/integration/ondemand/test/index.test.js
+++ b/test/integration/ondemand/test/index.test.js
@@ -34,8 +34,8 @@ const startServer = async (optEnv = {}, opts) => {
   beforeAll(async () => {
     await startServer()
   })
-  afterAll(() => {
-    killApp(context.server)
+  afterAll(async () => {
+    await killApp(context.server)
   })
 
   it('should compile pages for SSR', async () => {

--- a/test/integration/plugin-mdx-rs/test/index.test.js
+++ b/test/integration/plugin-mdx-rs/test/index.test.js
@@ -18,8 +18,8 @@ describe('MDX-rs Configuration', () => {
       context.appPort = await findPort()
       context.server = await launchApp(join(__dirname, '../'), context.appPort)
     })
-    afterAll(() => {
-      killApp(context.server)
+    afterAll(async () => {
+      await killApp(context.server)
     })
     it('should render an MDX page correctly', async () => {
       expect(await renderViaHTTP(context.appPort, '/')).toMatch(/Hello MDX/)
@@ -60,8 +60,8 @@ describe('MDX-rs Configuration', () => {
       context.appPort = await findPort()
       context.server = await launchApp(join(__dirname, '../'), context.appPort)
     })
-    afterAll(() => {
-      killApp(context.server)
+    afterAll(async () => {
+      await killApp(context.server)
       nextConfig.restore()
     })
 


### PR DESCRIPTION
I'm not sure whether this will help with the flakiness of our integration tests, but it surely should be done either way.