### PR TITLE
[ppr] Support fallback params for client layouts

### DIFF
--- a/packages/next/src/client/components/client-segment.tsx
+++ b/packages/next/src/client/components/client-segment.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+type ClientSegmentRootProps = {
+  Component: React.ComponentType
+  props: { [props: string]: any }
+}
+
+export function ClientSegmentRoot({
+  Component,
+  props,
+}: ClientSegmentRootProps) {
+  if (typeof window === 'undefined') {
+    const { createDynamicallyTrackedParams } =
+      require('../../server/request/fallback-params') as typeof import('../../server/request/fallback-params')
+
+    props.params = props.params
+      ? createDynamicallyTrackedParams(props.params)
+      : {}
+  }
+  return <Component {...props} />
+}

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -90,6 +90,7 @@ async function createComponentTreeInternal({
       LayoutRouter,
       RenderFromTemplateContext,
       ClientPageRoot,
+      ClientSegmentRoot,
       createUntrackedSearchParams,
       createDynamicallyTrackedSearchParams,
       createDynamicallyTrackedParams,
@@ -555,22 +556,27 @@ async function createComponentTreeInternal({
           isStaticGeneration={isStaticGeneration}
           ready={getMetadataReady}
         >
-          {pageElement}
           {layerAssets}
+          {pageElement}
         </Segment>
       </React.Fragment>,
       parallelRouteCacheNodeSeedData,
       loadingData,
     ]
   } else {
-    props.params = createDynamicallyTrackedParams(currentParams)
+    let layoutElement: React.ReactNode
+    if (isClientComponent) {
+      props.params = currentParams
+      layoutElement = <ClientSegmentRoot props={props} Component={Component} />
+    } else {
+      props.params = createDynamicallyTrackedParams(currentParams)
+      layoutElement = <Component {...props} />
+    }
 
     const isRootLayoutWithChildrenSlotAndAtLeastOneMoreSlot =
       rootLayoutAtThisLevel &&
       'children' in parallelRoutes &&
       Object.keys(parallelRoutes).length > 1
-
-    let serverSegment = <Component {...props} />
 
     let segmentNode: React.ReactNode
     if (isRootLayoutWithChildrenSlotAndAtLeastOneMoreSlot) {
@@ -599,7 +605,7 @@ async function createComponentTreeInternal({
             }
           >
             {layerAssets}
-            {serverSegment}
+            {layoutElement}
           </NotFoundBoundary>
         </Segment>
       )
@@ -612,7 +618,7 @@ async function createComponentTreeInternal({
           ready={getMetadataReady}
         >
           {layerAssets}
-          {serverSegment}
+          {layoutElement}
         </Segment>
       )
     }

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -276,52 +276,13 @@ async function createComponentTreeInternal({
   /**
    * The React Component to render.
    */
-  let Component = LayoutOrPage
-  const parallelKeys = Object.keys(parallelRoutes)
-  const hasSlotKey = parallelKeys.length > 1
-
-  // TODO-APP: This is a hack to support unmatched parallel routes, which will throw `notFound()`.
-  // This ensures that a `NotFoundBoundary` is available for when that happens,
-  // but it's not ideal, as it needlessly invokes the `NotFound` component and renders the `RootLayout` twice.
-  // We should instead look into handling the fallback behavior differently in development mode so that it doesn't
-  // rely on the `NotFound` behavior.
-  if (hasSlotKey && rootLayoutAtThisLevel && LayoutOrPage) {
-    Component = (componentProps: { params: Params }) => {
-      const NotFoundComponent = NotFound
-      const RootLayoutComponent = LayoutOrPage
-      return (
-        <NotFoundBoundary
-          notFound={
-            NotFoundComponent ? (
-              <Segment
-                isDynamicIO={experimental.dynamicIO}
-                isStaticGeneration={isStaticGeneration}
-                ready={getMetadataReady}
-              >
-                {layerAssets}
-                {/*
-                 * We are intentionally only forwarding params to the root layout, as passing any of the parallel route props
-                 * might trigger `notFound()`, which is not currently supported in the root layout.
-                 */}
-                <RootLayoutComponent params={componentProps.params}>
-                  {notFoundStyles}
-                  <NotFoundComponent />
-                </RootLayoutComponent>
-              </Segment>
-            ) : undefined
-          }
-        >
-          <RootLayoutComponent {...componentProps} />
-        </NotFoundBoundary>
-      )
-    }
-  }
+  let MaybeComponent = LayoutOrPage
 
   if (process.env.NODE_ENV === 'development') {
     const { isValidElementType } = require('next/dist/compiled/react-is')
     if (
-      (isPage || typeof Component !== 'undefined') &&
-      !isValidElementType(Component)
+      (isPage || typeof MaybeComponent !== 'undefined') &&
+      !isValidElementType(MaybeComponent)
     ) {
       errorMissingDefaultExport(pagePath, 'page')
     }
@@ -387,7 +348,7 @@ async function createComponentTreeInternal({
           // prefetch everything up to the first route segment that defines a
           // loading.tsx boundary. (We do the same if there's no loading
           // boundary in the entire tree, because we don't want to prefetch too
-          // much) The rest of the tree is defered until the actual navigation.
+          // much) The rest of the tree is deferred until the actual navigation.
           // It does not take into account whether the data is dynamic — even if
           // the tree is completely static, it will still defer everything
           // inside the loading boundary.
@@ -496,7 +457,7 @@ async function createComponentTreeInternal({
     : null
 
   // When the segment does not have a layout or page we still have to add the layout router to ensure the path holds the loading component
-  if (!Component) {
+  if (!MaybeComponent) {
     return [
       actualSegment,
       <Segment
@@ -512,6 +473,8 @@ async function createComponentTreeInternal({
       loadingData,
     ]
   }
+
+  const Component = MaybeComponent
 
   // If force-dynamic is used and the current render supports postponing, we
   // replace it with a node that will postpone the render. This ensures that the
@@ -602,23 +565,62 @@ async function createComponentTreeInternal({
   } else {
     props.params = createDynamicallyTrackedParams(currentParams)
 
+    const isRootLayoutWithChildrenSlotAndAtLeastOneMoreSlot =
+      rootLayoutAtThisLevel &&
+      'children' in parallelRoutes &&
+      Object.keys(parallelRoutes).length > 1
+
+    let serverSegment = <Component {...props} />
+
+    let segmentNode: React.ReactNode
+    if (isRootLayoutWithChildrenSlotAndAtLeastOneMoreSlot) {
+      // TODO-APP: This is a hack to support unmatched parallel routes, which will throw `notFound()`.
+      // This ensures that a `NotFoundBoundary` is available for when that happens,
+      // but it's not ideal, as it needlessly invokes the `NotFound` component and renders the `RootLayout` twice.
+      // We should instead look into handling the fallback behavior differently in development mode so that it doesn't
+      // rely on the `NotFound` behavior.
+      segmentNode = (
+        <Segment
+          isDynamicIO={experimental.dynamicIO}
+          isStaticGeneration={isStaticGeneration}
+          ready={getMetadataReady}
+        >
+          <NotFoundBoundary
+            notFound={
+              NotFound ? (
+                <>
+                  {layerAssets}
+                  <Component params={props.params}>
+                    {notFoundStyles}
+                    <NotFound />
+                  </Component>
+                </>
+              ) : undefined
+            }
+          >
+            {layerAssets}
+            {serverSegment}
+          </NotFoundBoundary>
+        </Segment>
+      )
+    } else {
+      segmentNode = (
+        <Segment
+          key={cacheNodeKey}
+          isDynamicIO={experimental.dynamicIO}
+          isStaticGeneration={isStaticGeneration}
+          ready={getMetadataReady}
+        >
+          {layerAssets}
+          {serverSegment}
+        </Segment>
+      )
+    }
+
     // For layouts we just render the component
     return [
       actualSegment,
-      // It is critical that this tree render something other than `null` because the client router uses
-      // null to represent an lazy hole. The current implementation satisfies this because the two inner slots
-      // ensure there is a fragment even if both slots render null. If we ever refactor this to only render the component
-      // or similar we need to ensure there is a fragment. Long term we should move to using a Symbol to communicate
-      // a lazy hole rather than null
-      <Segment
-        key={cacheNodeKey}
-        isDynamicIO={experimental.dynamicIO}
-        isStaticGeneration={isStaticGeneration}
-        ready={getMetadataReady}
-      >
-        {layerAssets}
-        <Component {...props} />
-      </Segment>,
+      segmentNode,
       parallelRouteCacheNodeSeedData,
       loadingData,
     ]

--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -16,6 +16,7 @@ import { requestAsyncStorage } from '../../client/components/request-async-stora
 import { prerenderAsyncStorage } from './prerender-async-storage.external'
 import { actionAsyncStorage } from '../../client/components/action-async-storage.external'
 import { ClientPageRoot } from '../../client/components/client-page'
+import { ClientSegmentRoot } from '../../client/components/client-segment'
 import {
   createUntrackedSearchParams,
   createDynamicallyTrackedSearchParams,
@@ -57,6 +58,7 @@ export {
   Postpone,
   taintObjectReference,
   ClientPageRoot,
+  ClientSegmentRoot,
   NotFoundBoundary,
   patchFetch,
 }

--- a/test/e2e/app-dir/ppr-full/app/fallback/client/params/[slug]/dynamic.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/client/params/[slug]/dynamic.jsx
@@ -1,0 +1,7 @@
+export default function Dynamic({ params }) {
+  return (
+    <div data-file="app/fallback/client/params/[slug]/dynamic">
+      {params.slug}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/ppr-full/app/fallback/client/params/[slug]/layout.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/client/params/[slug]/layout.jsx
@@ -1,0 +1,7 @@
+'use client'
+
+export default function Layout({ children }) {
+  return (
+    <div data-file="app/fallback/client/params/[slug]/layout">{children}</div>
+  )
+}

--- a/test/e2e/app-dir/ppr-full/app/fallback/client/params/[slug]/loading.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/client/params/[slug]/loading.jsx
@@ -1,0 +1,5 @@
+export default function Loading() {
+  return (
+    <div data-file="app/fallback/client/params/[slug]/loading">Loading...</div>
+  )
+}

--- a/test/e2e/app-dir/ppr-full/app/fallback/client/params/[slug]/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/client/params/[slug]/page.jsx
@@ -1,0 +1,9 @@
+import Dynamic from './dynamic'
+
+export default function Page({ params }) {
+  return (
+    <div data-file="app/fallback/client/params/[slug]/page">
+      <Dynamic params={params} />
+    </div>
+  )
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

@gnoff discovered in his #70081 PR that client layouts were triggering the fallback param case during static rendering. this isolates the change to PPR and pulls it out so we can land it earlier as it relates to the early postponing.