### PR TITLE
Support fallback params when the layout is a client component

### DIFF
--- a/packages/next/src/client/components/client-segment.tsx
+++ b/packages/next/src/client/components/client-segment.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+type ClientSegmentRootProps = {
+  Component: React.ComponentType
+  props: { [props: string]: any }
+}
+
+export function ClientSegmentRoot({
+  Component,
+  props,
+}: ClientSegmentRootProps) {
+  if (typeof window === 'undefined') {
+    const { createDynamicallyTrackedParams } =
+      require('../../server/request/fallback-params') as typeof import('../../server/request/fallback-params')
+
+    props.params = props.params
+      ? createDynamicallyTrackedParams(props.params)
+      : {}
+  }
+  return <Component {...props} />
+}

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -90,6 +90,7 @@ async function createComponentTreeInternal({
       LayoutRouter,
       RenderFromTemplateContext,
       ClientPageRoot,
+      ClientSegmentRoot,
       createUntrackedSearchParams,
       createDynamicallyTrackedSearchParams,
       createDynamicallyTrackedParams,
@@ -563,14 +564,19 @@ async function createComponentTreeInternal({
       loadingData,
     ]
   } else {
-    props.params = createDynamicallyTrackedParams(currentParams)
-
     const isRootLayoutWithChildrenSlotAndAtLeastOneMoreSlot =
       rootLayoutAtThisLevel &&
       'children' in parallelRoutes &&
       Object.keys(parallelRoutes).length > 1
 
-    let serverSegment = <Component {...props} />
+    let serverSegment: React.ReactNode
+    if (isClientComponent) {
+      props.params = currentParams
+      serverSegment = <ClientSegmentRoot Component={Component} props={props} />
+    } else {
+      props.params = createDynamicallyTrackedParams(currentParams)
+      serverSegment = <Component {...props} />
+    }
 
     let segmentNode: React.ReactNode
     if (isRootLayoutWithChildrenSlotAndAtLeastOneMoreSlot) {

--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -16,6 +16,7 @@ import { requestAsyncStorage } from '../../client/components/request-async-stora
 import { prerenderAsyncStorage } from './prerender-async-storage.external'
 import { actionAsyncStorage } from '../../client/components/action-async-storage.external'
 import { ClientPageRoot } from '../../client/components/client-page'
+import { ClientSegmentRoot } from '../../client/components/client-segment'
 import {
   createUntrackedSearchParams,
   createDynamicallyTrackedSearchParams,
@@ -57,6 +58,7 @@ export {
   Postpone,
   taintObjectReference,
   ClientPageRoot,
+  ClientSegmentRoot,
   NotFoundBoundary,
   patchFetch,
 }

--- a/test/e2e/app-dir/ppr-full/app/fallback/client/params/layout/[slug]/dynamic.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/client/params/layout/[slug]/dynamic.jsx
@@ -1,0 +1,8 @@
+export default function Dynamic({ params }) {
+  console.log('typeof params', typeof params)
+  return (
+    <div data-file="app/fallback/client/params/[slug]/dynamic">
+      {params.slug}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/ppr-full/app/fallback/client/params/layout/[slug]/layout.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/client/params/layout/[slug]/layout.jsx
@@ -1,0 +1,12 @@
+'use client'
+
+import Dynamic from './dynamic'
+
+export default function Layout({ children, params }) {
+  return (
+    <div data-file="app/fallback/client/params/[slug]/layout">
+      {children}
+      <Dynamic params={params} />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/ppr-full/app/fallback/client/params/layout/[slug]/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/client/params/layout/[slug]/page.jsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div data-file="app/fallback/client/params/[slug]/page">my page</div>
+}

--- a/test/e2e/app-dir/ppr-full/app/fallback/client/params/page/[slug]/dynamic.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/client/params/page/[slug]/dynamic.jsx
@@ -1,0 +1,7 @@
+export default function Dynamic({ params }) {
+  return (
+    <div data-file="app/fallback/client/params/[slug]/dynamic">
+      {params.slug}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/ppr-full/app/fallback/client/params/page/[slug]/layout.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/client/params/page/[slug]/layout.jsx
@@ -1,0 +1,7 @@
+'use client'
+
+export default function Layout({ children }) {
+  return (
+    <div data-file="app/fallback/client/params/[slug]/layout">{children}</div>
+  )
+}

--- a/test/e2e/app-dir/ppr-full/app/fallback/client/params/page/[slug]/loading.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/client/params/page/[slug]/loading.jsx
@@ -1,0 +1,5 @@
+export default function Loading() {
+  return (
+    <div data-file="app/fallback/client/params/[slug]/loading">Loading...</div>
+  )
+}

--- a/test/e2e/app-dir/ppr-full/app/fallback/client/params/page/[slug]/page.jsx
+++ b/test/e2e/app-dir/ppr-full/app/fallback/client/params/page/[slug]/page.jsx
@@ -1,0 +1,9 @@
+import Dynamic from './dynamic'
+
+export default function Page({ params }) {
+  return (
+    <div data-file="app/fallback/client/params/[slug]/page">
+      <Dynamic params={params} />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/ppr-full/ppr-full.test.ts
+++ b/test/e2e/app-dir/ppr-full/ppr-full.test.ts
@@ -275,7 +275,7 @@ describe('ppr-full', () => {
         for (const [pattern, client, nested] of patterns) {
           let slug: string
           if (nested) {
-            let slugs: string[] = []
+            const slugs: string[] = []
             for (let j = i + 1; j < i + 2; j++) {
               slugs.push(`slug-${pad(i)}/slug-${pad(j)}`)
             }
@@ -313,7 +313,7 @@ describe('ppr-full', () => {
             expect(streamEnd - start).toBeGreaterThanOrEqual(delay)
 
             if (client) {
-              let browser = await next.browser(pathname)
+              const browser = await next.browser(pathname)
               try {
                 await browser.waitForElementByCss('[data-slug]')
                 expect(
@@ -345,7 +345,7 @@ describe('ppr-full', () => {
       describe('Dynamic Shell', () => {
         it('should render the fallback shell on first visit', async () => {
           const random = Math.random().toString(16).slice(2)
-          const pathname = '/fallback/dynamic/params/on-first-visit-' + random
+          const pathname = `/fallback/dynamic/params/on-first-visit-${random}`
           const $ = await next.render$(pathname)
           expect($('[data-slug]').closest('[hidden]').length).toBe(1)
           expect($('[data-agent]').closest('[hidden]').length).toBe(1)
@@ -353,7 +353,7 @@ describe('ppr-full', () => {
 
         it('should render the dynamic shell on the second visit', async () => {
           const random = Math.random().toString(16).slice(2)
-          const pathname = '/fallback/dynamic/params/on-second-visit-' + random
+          const pathname = `/fallback/dynamic/params/on-second-visit-${random}`
 
           let $ = await next.render$(pathname)
           expect($('[data-slug]').closest('[hidden]').length).toBe(1)
@@ -368,7 +368,7 @@ describe('ppr-full', () => {
 
         it('should render the dynamic shell as static if the page is static', async () => {
           const random = Math.random().toString(16).slice(2)
-          const pathname = '/fallback/params/on-second-visit-' + random
+          const pathname = `/fallback/params/on-second-visit-${random}`
 
           // Expect that the slug had to be resumed.
           let $ = await next.render$(pathname)
@@ -402,7 +402,7 @@ describe('ppr-full', () => {
 
         it('will only revalidate the page', async () => {
           const random = Math.random().toString(16).slice(2)
-          const pathname = '/fallback/dynamic/params/revalidate-' + random
+          const pathname = `/fallback/dynamic/params/revalidate-${random}`
 
           let $ = await next.render$(pathname)
           const fallbackID = $('[data-layout]').data('layout') as string
@@ -418,7 +418,7 @@ describe('ppr-full', () => {
 
           // Now let's revalidate the page.
           await next.fetch(
-            '/api/revalidate?pathname=' + encodeURIComponent(pathname)
+            `/api/revalidate?pathname=${encodeURIComponent(pathname)}`
           )
 
           // We expect to get the fallback shell again.
@@ -437,7 +437,7 @@ describe('ppr-full', () => {
 
         it('will revalidate the page and fallback shell', async () => {
           const random = Math.random().toString(16).slice(2)
-          const pathname = '/fallback/dynamic/params/revalidate-' + random
+          const pathname = `/fallback/dynamic/params/revalidate-${random}`
 
           let $ = await next.render$(pathname)
           const fallbackID = $('[data-layout]').data('layout') as string
@@ -453,19 +453,56 @@ describe('ppr-full', () => {
 
           // Now let's revalidate the page.
           await next.fetch(
-            '/api/revalidate?pathname=/fallback/dynamic/params/[slug]'
+            `/api/revalidate?pathname=${encodeURIComponent(pathname)}`
           )
 
-          // We expect to get a revalidated shell, not the same one as before.
+          // We expect to get the fallback shell.
           $ = await next.render$(pathname)
-          expect($('[data-layout]').data('layout')).not.toBe(fallbackID)
+          expect($('[data-layout]').data('layout')).toBe(fallbackID)
 
           // Let's wait for the page to be revalidated.
+          let revalidatedDynamicID: string
           await retry(async () => {
             $ = await next.render$(pathname)
-            expect($('[data-layout]').data('layout')).not.toBe(dynamicID)
+            revalidatedDynamicID = $('[data-layout]').data('layout') as string
+            expect(revalidatedDynamicID).not.toBe(dynamicID)
+            expect(revalidatedDynamicID).not.toBe(fallbackID)
           })
         })
+      })
+
+      it('should allow client layouts without postponing fallback if params are not accessed', async () => {
+        const $ = await next.render$('/fallback/client/params/page/slug-01')
+
+        let selector = $(
+          '[data-file="app/fallback/client/params/[slug]/loading"]'
+        )
+        expect(selector.length).toBe(1)
+        expect(selector.closest('[hidden]').length).toBe(0)
+
+        selector = $('[data-file="app/fallback/client/params/[slug]/layout"]')
+        expect(selector.length).toBe(1)
+        expect(selector.closest('[hidden]').length).toBe(0)
+
+        selector = $('[data-file="app/fallback/client/params/[slug]/page"]')
+        expect(selector.length).toBe(1)
+        expect(selector.closest('[hidden]').length).toBe(1)
+      })
+
+      it('should postpone in client layout when fallback params are accessed', async () => {
+        const $ = await next.render$('/fallback/client/params/layout/slug-01')
+
+        let selector = $('[data-fallback="true"]')
+        expect(selector.length).toBe(1)
+        expect(selector.closest('[hidden]').length).toBe(0)
+
+        selector = $('[data-file="app/fallback/client/params/[slug]/layout"]')
+        expect(selector.length).toBe(1)
+        expect(selector.closest('[hidden]').length).toBe(1)
+
+        selector = $('[data-file="app/fallback/client/params/[slug]/page"]')
+        expect(selector.length).toBe(1)
+        expect(selector.closest('[hidden]').length).toBe(1)
       })
     })
   }


### PR DESCRIPTION
Stacked on #70328

When fallback params are passed to a layout we need to treat client component layouts special because passing the fallback params to the client component is otherwise enough to make them postpone. This change introduces a similar abstraction that we use for client component Pages where we pass our Page component to a PageRoot component which reifies the dynamically tracked params from the underlying params.