### PR TITLE
Enable more MDX Turbopack tests

### DIFF
--- a/test/development/acceptance-app/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance-app/ReactRefreshRegression.test.ts
@@ -11,7 +11,8 @@ describe('ReactRefreshRegression app', () => {
     dependencies: {
       'styled-components': '5.1.0',
       '@next/mdx': 'canary',
-      '@mdx-js/loader': '0.18.0',
+      '@mdx-js/loader': '2.2.1',
+      '@mdx-js/react': '2.2.1',
     },
     skipStart: true,
   })
@@ -333,15 +334,11 @@ describe('ReactRefreshRegression app', () => {
   })
 
   // https://github.com/vercel/next.js/issues/13574
-  // Test is skipped with Turbopack as the package uses webpack loaders
-  ;(process.env.TURBOPACK ? describe.skip : describe)(
-    'Turbopack skipped tests',
-    () => {
-      test('custom loader mdx should have Fast Refresh enabled', async () => {
-        const files = new Map()
-        files.set(
-          'next.config.js',
-          outdent`
+  test('custom loader mdx should have Fast Refresh enabled', async () => {
+    const files = new Map()
+    files.set(
+      'next.config.js',
+      outdent`
         const withMDX = require("@next/mdx")({
           extension: /\\.mdx?$/,
         });
@@ -349,46 +346,44 @@ describe('ReactRefreshRegression app', () => {
           pageExtensions: ["js", "mdx"],
         });
       `
-        )
-        files.set('app/content.mdx', `Hello World!`)
-        files.set(
-          'app/page.js',
-          outdent`
+    )
+    files.set('app/content.mdx', `Hello World!`)
+    files.set(
+      'app/page.js',
+      outdent`
         'use client'
         import MDX from './content.mdx'
         export default function Page() {
           return <div id="content"><MDX /></div>
         }
       `
-        )
+    )
 
-        const { session, cleanup } = await sandbox(next, files)
-        expect(
-          await session.evaluate(
-            () => document.querySelector('#content').textContent
-          )
-        ).toBe('Hello World!')
+    const { session, cleanup } = await sandbox(next, files)
+    expect(
+      await session.evaluate(
+        () => document.querySelector('#content').textContent
+      )
+    ).toBe('Hello World!')
 
-        let didNotReload = await session.patch('app/content.mdx', `Hello Foo!`)
-        expect(didNotReload).toBe(true)
-        await session.assertNoRedbox()
-        expect(
-          await session.evaluate(
-            () => document.querySelector('#content').textContent
-          )
-        ).toBe('Hello Foo!')
+    let didNotReload = await session.patch('app/content.mdx', `Hello Foo!`)
+    expect(didNotReload).toBe(true)
+    await session.assertNoRedbox()
+    expect(
+      await session.evaluate(
+        () => document.querySelector('#content').textContent
+      )
+    ).toBe('Hello Foo!')
 
-        didNotReload = await session.patch('app/content.mdx', `Hello Bar!`)
-        expect(didNotReload).toBe(true)
-        await session.assertNoRedbox()
-        expect(
-          await session.evaluate(
-            () => document.querySelector('#content').textContent
-          )
-        ).toBe('Hello Bar!')
+    didNotReload = await session.patch('app/content.mdx', `Hello Bar!`)
+    expect(didNotReload).toBe(true)
+    await session.assertNoRedbox()
+    expect(
+      await session.evaluate(
+        () => document.querySelector('#content').textContent
+      )
+    ).toBe('Hello Bar!')
 
-        await cleanup()
-      })
-    }
-  )
+    await cleanup()
+  })
 })

--- a/test/development/acceptance/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance/ReactRefreshRegression.test.ts
@@ -12,7 +12,8 @@ describe('ReactRefreshRegression', () => {
     dependencies: {
       'styled-components': '5.1.0',
       '@next/mdx': 'canary',
-      '@mdx-js/loader': '0.18.0',
+      '@mdx-js/loader': '2.2.1',
+      '@mdx-js/react': '2.2.1',
     },
   })
 
@@ -295,17 +296,13 @@ describe('ReactRefreshRegression', () => {
   })
 
   // https://github.com/vercel/next.js/issues/13574
-  // Test is skipped with Turbopack as the package uses webpack loaders
-  ;(process.env.TURBOPACK ? describe.skip : describe)(
-    'Turbopack skipped tests',
-    () => {
-      test('custom loader (mdx) should have Fast Refresh enabled', async () => {
-        const { session, cleanup } = await sandbox(
-          next,
-          new Map([
-            [
-              'next.config.js',
-              outdent`
+  test('custom loader mdx should have Fast Refresh enabled', async () => {
+    const { session, cleanup } = await sandbox(
+      next,
+      new Map([
+        [
+          'next.config.js',
+          outdent`
               const withMDX = require("@next/mdx")({
                 extension: /\\.mdx?$/,
               });
@@ -313,37 +310,35 @@ describe('ReactRefreshRegression', () => {
                 pageExtensions: ["js", "mdx"],
               });
             `,
-            ],
-            ['pages/mdx.mdx', `Hello World!`],
-          ]),
-          '/mdx'
-        )
-        expect(
-          await session.evaluate(
-            () => document.querySelector('#__next').textContent
-          )
-        ).toBe('Hello World!')
+        ],
+        ['pages/mdx.mdx', `Hello World!`],
+      ]),
+      '/mdx'
+    )
+    expect(
+      await session.evaluate(
+        () => document.querySelector('#__next').textContent
+      )
+    ).toBe('Hello World!')
 
-        let didNotReload = await session.patch('pages/mdx.mdx', `Hello Foo!`)
-        expect(didNotReload).toBe(true)
-        await session.assertNoRedbox()
-        expect(
-          await session.evaluate(
-            () => document.querySelector('#__next').textContent
-          )
-        ).toBe('Hello Foo!')
+    let didNotReload = await session.patch('pages/mdx.mdx', `Hello Foo!`)
+    expect(didNotReload).toBe(true)
+    await session.assertNoRedbox()
+    expect(
+      await session.evaluate(
+        () => document.querySelector('#__next').textContent
+      )
+    ).toBe('Hello Foo!')
 
-        didNotReload = await session.patch('pages/mdx.mdx', `Hello Bar!`)
-        expect(didNotReload).toBe(true)
-        await session.assertNoRedbox()
-        expect(
-          await session.evaluate(
-            () => document.querySelector('#__next').textContent
-          )
-        ).toBe('Hello Bar!')
+    didNotReload = await session.patch('pages/mdx.mdx', `Hello Bar!`)
+    expect(didNotReload).toBe(true)
+    await session.assertNoRedbox()
+    expect(
+      await session.evaluate(
+        () => document.querySelector('#__next').textContent
+      )
+    ).toBe('Hello Bar!')
 
-        await cleanup()
-      })
-    }
-  )
+    await cleanup()
+  })
 })

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -1369,11 +1369,11 @@
       "ReactRefreshRegression app can fast refresh a page with static generation",
       "ReactRefreshRegression app shows an overlay for anonymous function server-side error",
       "ReactRefreshRegression app shows an overlay for server-side error in client component",
-      "ReactRefreshRegression app shows an overlay for server-side error in server component"
+      "ReactRefreshRegression app shows an overlay for server-side error in server component",
+      "ReactRefreshRegression app custom loader mdx should have Fast Refresh enabled"
     ],
     "failed": [],
     "pending": [
-      "ReactRefreshRegression app Turbopack skipped tests custom loader mdx should have Fast Refresh enabled",
       "ReactRefreshRegression app styled-components hydration mismatch"
     ],
     "flakey": [],
@@ -1732,12 +1732,11 @@
       "ReactRefreshRegression can fast refresh a page with getServerSideProps",
       "ReactRefreshRegression can fast refresh a page with getStaticProps",
       "ReactRefreshRegression shows an overlay for a server-side error",
-      "ReactRefreshRegression styled-components hydration mismatch"
+      "ReactRefreshRegression styled-components hydration mismatch",
+      "ReactRefreshRegression custom loader mdx should have Fast Refresh enabled"
     ],
     "failed": [],
-    "pending": [
-      "ReactRefreshRegression Turbopack skipped tests custom loader (mdx) should have Fast Refresh enabled"
-    ],
+    "pending": [],
     "flakey": [],
     "runtimeError": false
   },


### PR DESCRIPTION
We just forgot enabling them when implementing `@next/mdx` for Turbopack.