### PR TITLE
Avoid prefetch request before meta-tag-based redirect

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -119,6 +119,12 @@ export function navigateReducer(
     return handleExternalUrl(state, mutable, url.toString(), pendingPush)
   }
 
+  // Handles case where `<meta http-equiv="refresh">` tag is present,
+  // which will trigger an MPA navigation.
+  if (document.getElementById('__next-page-redirect')) {
+    return handleExternalUrl(state, mutable, href, pendingPush)
+  }
+
   const prefetchValues = getOrCreatePrefetchCacheEntry({
     url,
     nextUrl: state.nextUrl,
@@ -143,12 +149,6 @@ export function navigateReducer(
       // Handle case when navigating to page in `pages` from `app`
       if (typeof flightData === 'string') {
         return handleExternalUrl(state, mutable, flightData, pendingPush)
-      }
-
-      // Handles case where `<meta http-equiv="refresh">` tag is present,
-      // which will trigger an MPA navigation.
-      if (document.getElementById('__next-page-redirect')) {
-        return handleExternalUrl(state, mutable, href, pendingPush)
       }
 
       // When the server indicates an override for the canonical URL (such as a redirect in middleware)


### PR DESCRIPTION
When calling `redirect('/some-path')` in a server component after the shell has already been served to the browser, we can no longer return a response with a 307 status code. Instead, a meta tag is streamed into the HTML document to trigger the navigation (e.g., `<meta http-equiv="refresh" content="1;url=/some-path" />`).

Since #63786, an additional client-side redirect in the client router is suppressed when this meta tag is discovered. However, the fix did not account for the ("temporary") prefetch request that may be triggered right before the MPA navigation is executed.

With this PR, we now check for the meta tag before creating the prefetch entry and return early if the tag is detected.