### PR TITLE
Add additional fixes for experimental tracing

### DIFF
--- a/packages/next/src/build/flying-shuttle/stitch-builds.ts
+++ b/packages/next/src/build/flying-shuttle/stitch-builds.ts
@@ -85,15 +85,23 @@ export async function stitchBuilds(
     { overwrite: true }
   )
 
-  async function copyPageChunk(entry: string, type: 'app' | 'pages') {
-    // copy entry chunk and flight manifest stuff
-    // TODO: copy .map files?
-    const entryFile = path.join('server', type, `${entry}.js`)
+  async function copyIfNoDestFile(srcFile: string, destFile: string) {
+    const content = await fs.promises.readFile(srcFile)
+    await fs.promises
+      .writeFile(destFile, content, { flag: 'wx' })
+      .catch((err) => {
+        if (err.code !== 'EEXIST') {
+          throw err
+        }
+      })
+  }
 
+  async function copyPageChunk(entry: string, type: 'app' | 'pages') {
+    const entryFile = path.join('server', type, `${entry}.js`)
     await fs.promises.mkdir(path.join(distDir, path.dirname(entryFile)), {
       recursive: true,
     })
-    await fs.promises.copyFile(
+    await copyIfNoDestFile(
       path.join(shuttleDir, entryFile + '.nft.json'),
       path.join(distDir, entryFile + '.nft.json')
     )
@@ -104,26 +112,24 @@ export async function stitchBuilds(
         type,
         `${entry}_${CLIENT_REFERENCE_MANIFEST}.js`
       )
-      await fs.promises.copyFile(
+      await copyIfNoDestFile(
         path.join(shuttleDir, clientRefManifestFile),
         path.join(distDir, clientRefManifestFile)
       )
     }
-    await fs.promises.copyFile(
+    await copyIfNoDestFile(
       path.join(shuttleDir, entryFile),
       path.join(distDir, entryFile)
     )
     // copy map file as well if it exists
-    await fs.promises
-      .copyFile(
-        path.join(shuttleDir, `${entryFile}.map`),
-        path.join(distDir, `${entryFile}.map`)
-      )
-      .catch((err) => {
-        if (err.code !== 'ENOENT') {
-          throw err
-        }
-      })
+    await copyIfNoDestFile(
+      path.join(shuttleDir, `${entryFile}.map`),
+      path.join(distDir, `${entryFile}.map`)
+    ).catch((err) => {
+      if (err.code !== 'ENOENT') {
+        throw err
+      }
+    })
   }
   const copySema = new Sema(8)
 
@@ -161,21 +167,22 @@ export async function stitchBuilds(
   )
   const dynamicRouteMap: Record<string, any> = {}
   const combinedDynamicRoutes: Record<string, any>[] = [
-    ...currentRoutesManifest.dynamicRoutes,
     ...restoreRoutesManifest.dynamicRoutes,
+    ...currentRoutesManifest.dynamicRoutes,
   ]
   for (const route of combinedDynamicRoutes) {
     dynamicRouteMap[route.page] = route
   }
 
   const mergedRoutesManifest = {
+    ...restoreRoutesManifest,
     ...currentRoutesManifest,
     dynamicRoutes: getSortedRoutes(
       combinedDynamicRoutes.map((item) => item.page)
     ).map((page) => dynamicRouteMap[page]),
     staticRoutes: [
-      ...currentRoutesManifest.staticRoutes,
       ...restoreRoutesManifest.staticRoutes,
+      ...currentRoutesManifest.staticRoutes,
     ],
   }
   await fs.promises.writeFile(
@@ -311,6 +318,7 @@ export async function stitchBuilds(
       )
     )
   const mergedMiddlewareManifest = {
+    ...restoreMiddlewareManifest,
     ...currentMiddlewareManifest,
     functions: {
       ...restoreMiddlewareManifest.functions,
@@ -344,6 +352,7 @@ export async function stitchBuilds(
     ].map(async (file) => JSON.parse(await fs.promises.readFile(file, 'utf8')))
   )
   const mergedNextFontManifest = {
+    ...restoreNextFontManifest,
     ...currentNextFontManifest,
     pages: {
       ...restoreNextFontManifest.pages,
@@ -378,6 +387,7 @@ export async function stitchBuilds(
       )
     )
   const mergedFunctionsConfigManifest = {
+    ...restoreFunctionsConfigManifest,
     ...currentFunctionsConfigManifest,
     functions: {
       ...restoreFunctionsConfigManifest.functions,
@@ -446,6 +456,7 @@ export async function stitchBuilds(
       )
     )
   const mergedServerRefManifest = {
+    ...restoreServerRefManifest,
     ...currentServerRefManifest,
     node: {
       ...restoreServerRefManifest.node,
@@ -466,9 +477,6 @@ export async function stitchBuilds(
       JSON.stringify(mergedServerRefManifest)
     )}`
   )
-
-  // TODO: inline env variables post build by find/replace
-  // in all the chunks for NEXT_PUBLIC_?
 
   return updatedManifests
 }

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2277,6 +2277,10 @@ export default async function getBaseWebpackConfig(
     }
   }
 
+  if (isFullFlyingShuttle && !dev) {
+    webpack5Config.cache = false
+  }
+
   const rules = webpackConfig.module?.rules || []
 
   const customSvgRule = rules.find(


### PR DESCRIPTION
Ensures we don't overwrite freshly built assets over restored assets and ensures restore references in manifest are overwritten but not fully omitted. Also ensures we don't have conflicting cache enabled with this feature. 