### PR TITLE
fix(turbopack): Fix span of import statements while tree shaking

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -953,6 +953,7 @@ impl DepGraph {
                                 var_decls: [local].into_iter().collect(),
                                 pure: true,
                                 content: ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
+                                    span: item.span,
                                     specifiers: vec![s.clone()],
                                     ..item.clone()
                                 })),


### PR DESCRIPTION
### What?

Use the span of the import statement instead of `DUMMY_SP`.

### Why?

It's required to generate a correct sourcemap.

### How?

Closes PACK-3270