### PR TITLE
Fix the typo in the example comment for the fetch options.cache section.

### DIFF
--- a/docs/02-app/01-building-your-application/04-caching/index.mdx
+++ b/docs/02-app/01-building-your-application/04-caching/index.mdx
@@ -430,7 +430,7 @@ See the [`fetch` API Reference](/docs/app/api-reference/functions/fetch) for mor
 You can opt individual `fetch` into caching by setting the `cache` option to `force-cache`:
 
 ```jsx
-// Opt out of caching
+// Opt into caching
 fetch(`https://...`, { cache: 'force-cache' })
 ```
 


### PR DESCRIPTION
### What?
Fixed a typo in the example comment for the [fetch options.cache](https://nextjs.org/docs/app/building-your-application/caching#fetch-optionscache) section.
### Why?
The typo could lead to confusion, and correcting it ensures that the example is clear and professional.
### How?
Updated the comment with the correct wording to reflect the intended message without changing the functionality of the example.