### PR TITLE
feat(turbo-tasks): Accept ResolvedVc as a `self` argument

### DIFF
--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_resolved_vc_input.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_resolved_vc_input.rs
@@ -21,6 +21,23 @@ impl ExampleStruct {
     fn constructor_vec(items: Vec<turbo_tasks::ResolvedVc<u32>>) -> Vc<Self> {
         ExampleStruct { items }.cell()
     }
+
+    #[turbo_tasks::function]
+    fn method_with_resolved_vc_self(self: ResolvedVc<Self>) {
+        // inner methods using `self` are unaffected
+        struct InnerImpl;
+        impl InnerImpl {
+            fn inner_method(&self) {
+                let _: &InnerImpl = self;
+            }
+        }
+
+        let _: ResolvedVc<Self> = self;
+    }
+}
+
+impl ExampleStruct {
+    fn non_turbo_method_with_resolved_vc_self(self: ResolvedVc<Self>) {}
 }
 
 #[turbo_tasks::value(resolved, transparent)]


### PR DESCRIPTION
#70269 adds support for `#[turbo_tasks::function]` to accept arguments of type `ResolvedVc<...>`, while still exposing a signature that uses `Vc<...>`.

This PR allows them to also accept `ResolvedVc<...>` for `self`, using the nightly `arbitrary_self_types` feature.

This re-uses the same mechanisms used for other arguments, with the added wrinkle that we can't shadow `self`, so we must rewrite the function body to replace references to `self` with `turbo_tasks_self`.