### PR TITLE
feat(turbo-tasks): Ignore fields annotated with `#[turbo_tasks(trace_ignore)]`

### DIFF
--- a/turbopack/crates/turbo-tasks-macros-tests/tests/derive_resolved_value/pass_ignore_field.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/derive_resolved_value/pass_ignore_field.rs
@@ -1,0 +1,17 @@
+use std::marker::PhantomData;
+
+use turbo_tasks::ResolvedValue;
+
+struct UnannotatedValue<T>(PhantomData<T>);
+
+#[derive(ResolvedValue)]
+struct ContainsIgnore<T> {
+    #[turbo_tasks(trace_ignore)]
+    a: UnannotatedValue<T>,
+}
+
+fn main() {
+    let _ = ContainsIgnore {
+        a: UnannotatedValue(PhantomData::<u32>),
+    };
+}

--- a/turbopack/crates/turbo-tasks-macros/src/derive/trace_raw_vcs_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/trace_raw_vcs_macro.rs
@@ -6,7 +6,7 @@ use turbo_tasks_macros_shared::{generate_destructuring, match_expansion};
 
 use super::FieldAttributes;
 
-fn filter_field(field: &Field) -> bool {
+pub fn filter_field(field: &Field) -> bool {
     !FieldAttributes::from(field.attrs.as_slice()).trace_ignore
 }
 


### PR DESCRIPTION
This annotation implies that the field does not contain any `Vc` types, so we can re-use that here. We can skip checking for `ResolvedValue` on these fields.

As we start codemodding stuff, we should consider renaming this annotation to something more generic (e.g. `#[turbo_tasks(does_not_contain_vc)]`), but this is good enough for now.