### PR TITLE
chore: throw error when trying to use next.config.mts/.cjs/.cts (not supported yet)

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/index.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/index.mdx
@@ -37,6 +37,8 @@ const nextConfig = {
 export default nextConfig
 ```
 
+> **Good to know**: `next.config` with the `.mts` ([Module TypeScript](https://www.typescriptlang.org/docs/handbook/modules/reference.html)) extension is currently **not** supported.
+
 ## Configuration as a Function
 
 You can also use a function:

--- a/docs/02-app/02-api-reference/05-next-config-js/index.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/index.mdx
@@ -37,7 +37,7 @@ const nextConfig = {
 export default nextConfig
 ```
 
-> **Good to know**: `next.config` with the `.cjs`, `.cts`, or `.mts`  extensions are currently **not** supported.
+> **Good to know**: `next.config` with the `.cjs`, `.cts`, or `.mts` extensions are currently **not** supported.
 
 ## Configuration as a Function
 

--- a/docs/02-app/02-api-reference/05-next-config-js/index.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/index.mdx
@@ -37,7 +37,7 @@ const nextConfig = {
 export default nextConfig
 ```
 
-> **Good to know**: `next.config` with the `.mts` ([Module TypeScript](https://www.typescriptlang.org/docs/handbook/modules/reference.html)) extension is currently **not** supported.
+> **Good to know**: `next.config` with the `.cjs`, `.cts`, or `.mts`  extensions are currently **not** supported.
 
 ## Configuration as a Function
 

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1178,6 +1178,7 @@ export default async function loadConfig(
     const configBaseName = basename(CONFIG_FILES[0], extname(CONFIG_FILES[0]))
     const unsupportedConfig = findUp.sync(
       [
+        `${configBaseName}.mts`,
         `${configBaseName}.jsx`,
         `${configBaseName}.tsx`,
         `${configBaseName}.json`,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1178,10 +1178,12 @@ export default async function loadConfig(
     const configBaseName = basename(CONFIG_FILES[0], extname(CONFIG_FILES[0]))
     const unsupportedConfig = findUp.sync(
       [
+        `${configBaseName}.cjs`,
+        `${configBaseName}.cts`,
         `${configBaseName}.mts`,
+        `${configBaseName}.json`,
         `${configBaseName}.jsx`,
         `${configBaseName}.tsx`,
-        `${configBaseName}.json`,
       ],
       { cwd: dir }
     )


### PR DESCRIPTION
## Why?

We should update our documentation and also throw an error if somebody tries to use the `.mts` ( ES Module TypeScript) extension with `next.config`. We currently don't support this extension.

- Fixes: https://github.com/vercel/next.js/issues/70201