### PR TITLE
Fix legacy env config with experimental tracing

### DIFF
--- a/packages/next/src/build/flying-shuttle/store-shuttle.ts
+++ b/packages/next/src/build/flying-shuttle/store-shuttle.ts
@@ -30,7 +30,6 @@ export function generateShuttleManifest(config: NextConfigComplete) {
     gitSha,
     nextVersion,
     config: {
-      env: config.env,
       i18n: config.i18n,
       basePath: config.basePath,
       sassOptions: config.sassOptions,

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2670,7 +2670,7 @@ export default async function build(
           await nextBuildSpan
             .traceChild('inline-static-env')
             .traceAsyncFn(async () => {
-              await inlineStaticEnv({ distDir })
+              await inlineStaticEnv({ config, distDir })
             })
         }
       }

--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -74,7 +74,7 @@ export function getNextPublicEnvironmentVariables(): DefineEnv {
 /**
  * Collects the `env` config value from the Next.js config.
  */
-function getNextConfigEnv(config: NextConfigComplete): DefineEnv {
+export function getNextConfigEnv(config: NextConfigComplete): DefineEnv {
   // Refactored code below to use for-of
   const defineEnv: DefineEnv = {}
   const env = config.env
@@ -286,9 +286,10 @@ export function getDefineEnv({
     // with flying shuttle enabled so we can update them
     // without invalidating entries
     for (const key in nextPublicEnv) {
-      if (key in nextConfigEnv) {
-        continue
-      }
+      serializedDefineEnv[key] = key
+    }
+
+    for (const key in nextConfigEnv) {
       serializedDefineEnv[key] = key
     }
   }

--- a/test/e2e/app-dir/app/app/legacy-env/page.js
+++ b/test/e2e/app-dir/app/app/legacy-env/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="legacy-env">{process.env.LEGACY_ENV_KEY}</p>
+}

--- a/test/e2e/app-dir/app/next.config.js
+++ b/test/e2e/app-dir/app/next.config.js
@@ -2,6 +2,9 @@
  * @type import('next').NextConfig
  */
 module.exports = {
+  env: {
+    LEGACY_ENV_KEY: '1',
+  },
   experimental: {
     clientRouterFilterRedirects: true,
     parallelServerCompiles: true,


### PR DESCRIPTION
Ensure legacy env keys don't need to invalidate the whole build the same way we do for `NEXT_PUBLIC_`