### PR TITLE
Update no duplicate headers case

### DIFF
--- a/test/e2e/app-dir/no-duplicate-headers-middleware/middleware.ts
+++ b/test/e2e/app-dir/no-duplicate-headers-middleware/middleware.ts
@@ -6,7 +6,6 @@ export function middleware(request: NextRequest) {
     return NextResponse.next({
       headers: {
         'Cache-Control': 'max-age=1234',
-        'Content-Type': 'image/vnd.microsoft.icon',
       },
     })
   }

--- a/test/e2e/app-dir/no-duplicate-headers-middleware/no-duplicate-headers-middleware.test.ts
+++ b/test/e2e/app-dir/no-duplicate-headers-middleware/no-duplicate-headers-middleware.test.ts
@@ -9,6 +9,5 @@ describe('no-duplicate-headers-next-config', () => {
     const res = await next.fetch('favicon.ico')
     expect(res.status).toBe(200)
     expect(res.headers.get('cache-control')).toBe('max-age=1234')
-    expect(res.headers.get('content-type')).toBe('image/vnd.microsoft.icon')
   })
 })

--- a/test/e2e/app-dir/no-duplicate-headers-next-config/next.config.js
+++ b/test/e2e/app-dir/no-duplicate-headers-next-config/next.config.js
@@ -11,10 +11,6 @@ const nextConfig = {
             key: 'cache-control',
             value: 'max-age=1234',
           },
-          {
-            key: 'content-type',
-            value: 'image/vnd.microsoft.icon',
-          },
         ],
       },
     ]

--- a/test/e2e/app-dir/no-duplicate-headers-next-config/no-duplicate-headers-next-config.test.ts
+++ b/test/e2e/app-dir/no-duplicate-headers-next-config/no-duplicate-headers-next-config.test.ts
@@ -9,6 +9,5 @@ describe('no-duplicate-headers-next-config', () => {
     const res = await next.fetch('favicon.ico')
     expect(res.status).toBe(200)
     expect(res.headers.get('cache-control')).toBe('max-age=1234')
-    expect(res.headers.get('content-type')).toBe('image/vnd.microsoft.icon')
   })
 })


### PR DESCRIPTION
This header isn't always able to be overridden so we shouldn't be asserting it specifically in our tests. 

x-ref: [slack thread](https://vercel.slack.com/archives/C04KC8A53T7/p1727138501597279?thread_ts=1727137032.335159&cid=C04KC8A53T7)