### PR TITLE
add missing node modules to externals

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -833,6 +833,8 @@ export default async function getBaseWebpackConfig(
 
   const aliasCodeConditionTest = [codeCondition.test, pageExtensionsRegex]
 
+  const builtinModules = require('module').builtinModules
+
   let webpackConfig: webpack.Configuration = {
     parallelism: Number(process.env.NEXT_WEBPACK_PARALLELISM) || undefined,
     ...(isNodeServer ? { externalsPresets: { node: true } } : {}),
@@ -856,6 +858,7 @@ export default async function getBaseWebpackConfig(
               : []),
           ]
         : [
+            ...builtinModules,
             ({
               context,
               request,

--- a/test/development/basic/node-builtins/app/server-component/page.js
+++ b/test/development/basic/node-builtins/app/server-component/page.js
@@ -18,6 +18,8 @@ import timers from 'timers'
 import tty from 'tty'
 import util from 'util'
 import zlib from 'zlib'
+
+import '_http_common'
 import 'setimmediate'
 
 async function getData() {

--- a/turbopack/crates/turbopack-resolve/src/resolve.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve.rs
@@ -15,7 +15,7 @@ use crate::{
     typescript::{apply_tsconfig_resolve_options, tsconfig, tsconfig_resolve_options},
 };
 
-const NODE_EXTERNALS: [&str; 51] = [
+const NODE_EXTERNALS: [&str; 63] = [
     "assert",
     "async_hooks",
     "buffer",
@@ -67,6 +67,18 @@ const NODE_EXTERNALS: [&str; 51] = [
     "worker_threads",
     "zlib",
     "pnpapi",
+    "_http_agent",
+    "_http_client",
+    "_http_common",
+    "_http_incoming",
+    "_http_outgoing",
+    "_http_server",
+    "_stream_duplex",
+    "_stream_passthrough",
+    "_stream_readable",
+    "_stream_transform",
+    "_stream_wrap",
+    "_stream_writable",
 ];
 
 const EDGE_NODE_EXTERNALS: [&str; 5] = ["buffer", "events", "assert", "util", "async_hooks"];


### PR DESCRIPTION
We should not attempt to bundle builtin node modules on the server. This adds modules provided by Node.js to our externals list (along with some missing internal ones in Turbopack. These were copied from [here](https://github.com/vercel/next.js/blob/a675bde6c738318264573144663e38819aeb2661/crates/next-custom-transforms/src/transforms/warn_for_edge_runtime.rs#L77-L89)).

Fixes #70262
Closes NDX-314