### PR TITLE
chore: auto-format generated types with prettier

### DIFF
--- a/packages/next/src/build/swc/generated-wasm.d.ts
+++ b/packages/next/src/build/swc/generated-wasm.d.ts
@@ -4,18 +4,6 @@
 /* tslint:disable */
 /* eslint-disable */
 /**
- * @param {string} value
- * @param {any} opts
- * @returns {any}
- */
-export function mdxCompileSync(value: string, opts: any): any
-/**
- * @param {string} value
- * @param {any} opts
- * @returns {Promise<any>}
- */
-export function mdxCompile(value: string, opts: any): Promise<any>
-/**
  * @param {string} s
  * @param {any} opts
  * @returns {any}
@@ -51,3 +39,15 @@ export function parseSync(s: string, opts: any): any
  * @returns {Promise<any>}
  */
 export function parse(s: string, opts: any): Promise<any>
+/**
+ * @param {string} value
+ * @param {any} opts
+ * @returns {any}
+ */
+export function mdxCompileSync(value: string, opts: any): any
+/**
+ * @param {string} value
+ * @param {any} opts
+ * @returns {Promise<any>}
+ */
+export function mdxCompile(value: string, opts: any): Promise<any>

--- a/scripts/build-native.cjs
+++ b/scripts/build-native.cjs
@@ -5,6 +5,7 @@ const {
   booleanArg,
   execAsyncWithOutput,
   execFn,
+  exec,
   namedValueArg,
 } = require('./pack-util.cjs')
 const fs = require('fs')
@@ -85,4 +86,11 @@ function writeTypes() {
     vendoredTypes + generatedTypesMarker + generatedNotice + generatedTypes
 
   fs.writeFileSync(vendoredTypesPath, vendoredTypes)
+
+  exec('Prettify generated types', [
+    'pnpm',
+    'prettier',
+    '--write',
+    vendoredTypesPath,
+  ])
 }

--- a/scripts/build-wasm.cjs
+++ b/scripts/build-wasm.cjs
@@ -5,6 +5,7 @@ const {
   booleanArg,
   execAsyncWithOutput,
   execFn,
+  exec,
   namedValueArg,
 } = require('./pack-util.cjs')
 const fs = require('fs')
@@ -79,4 +80,11 @@ function writeTypes() {
   const vendoredTypes = generatedNotice + generatedTypes
 
   fs.writeFileSync(vendoredTypesPath, vendoredTypes)
+
+  exec('Prettify generated types', [
+    'pnpm',
+    'prettier',
+    '--write',
+    vendoredTypesPath,
+  ])
 }


### PR DESCRIPTION
### What?

Added a step in both `build-native.cjs` and `build-wasm.cjs` scripts to run Prettier on the generated types file after writing it.

Should have been added with #69680, but I didn't think about it.

Currently, every time you built the native module you have changes in the git repo (which would be fixed on commit, but graphite might not be happy with uncommitted changes).
