### PR TITLE
refactor(next-codemod): migrate to commander and prompts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,6 +57,8 @@
     "RUST_BACKTRACE": "0"
   },
   "cSpell.words": [
+    "codemod",
+    "codemods",
     "Destructuring",
     "Entrypoints",
     "jscodeshift",

--- a/packages/next-codemod/bin/cli.ts
+++ b/packages/next-codemod/bin/cli.ts
@@ -10,46 +10,17 @@
 
 import globby from 'globby'
 import inquirer from 'inquirer'
-import meow from 'meow'
 import path from 'path'
 import execa from 'execa'
-import { yellow } from 'picocolors'
-import isGitClean from 'is-git-clean'
+// import ciInfo from 'ci-info'
+import { Command } from 'commander'
+// import prompts from 'prompts'
 import { installPackage, uninstallPackage } from '../lib/handle-package'
 import { runUpgrade } from './upgrade'
+import { checkGitStatus, TRANSFORMER_INQUIRER_CHOICES } from '../lib/utils'
 
 export const jscodeshiftExecutable = require.resolve('.bin/jscodeshift')
 export const transformerDirectory = path.join(__dirname, '../', 'transforms')
-
-export function checkGitStatus(force) {
-  let clean = false
-  let errorMessage = 'Unable to determine if git directory is clean'
-  try {
-    clean = isGitClean.sync(process.cwd())
-    errorMessage = 'Git directory is not clean'
-  } catch (err) {
-    if (err && err.stderr && err.stderr.includes('Not a git repository')) {
-      clean = true
-    }
-  }
-
-  if (!clean) {
-    if (force) {
-      console.log(`WARNING: ${errorMessage}. Forcibly continuing.`)
-    } else {
-      console.log('Thank you for using @next/codemod!')
-      console.log(
-        yellow(
-          '\nBut before we continue, please stash or commit your git changes.'
-        )
-      )
-      console.log(
-        '\nYou may use the --force flag to override this safety check.'
-      )
-      process.exit(1)
-    }
-  }
-}
 
 export function runTransform({ files, flags, transformer }) {
   const transformerPath = path.join(transformerDirectory, `${transformer}.js`)
@@ -116,65 +87,6 @@ export function runTransform({ files, flags, transformer }) {
   }
 }
 
-const TRANSFORMER_INQUIRER_CHOICES = [
-  {
-    name: 'name-default-component: Transforms anonymous components into named components to make sure they work with Fast Refresh',
-    value: 'name-default-component',
-  },
-  {
-    name: 'add-missing-react-import: Transforms files that do not import `React` to include the import in order for the new React JSX transform',
-    value: 'add-missing-react-import',
-  },
-  {
-    name: 'withamp-to-config: Transforms the withAmp HOC into Next.js 9 page configuration',
-    value: 'withamp-to-config',
-  },
-  {
-    name: 'url-to-withrouter: Transforms the deprecated automatically injected url property on top level pages to using withRouter',
-    value: 'url-to-withrouter',
-  },
-  {
-    name: 'cra-to-next (experimental): automatically migrates a Create React App project to Next.js',
-    value: 'cra-to-next',
-  },
-  {
-    name: 'new-link: Ensures your <Link> usage is backwards compatible.',
-    value: 'new-link',
-  },
-  {
-    name: 'next-og-import: Transforms imports from `next/server` to `next/og` for usage of Dynamic OG Image Generation.',
-    value: 'next-og-import',
-  },
-  {
-    name: 'metadata-to-viewport-export: Migrates certain viewport related metadata from the `metadata` export to a new `viewport` export.',
-    value: 'metadata-to-viewport-export',
-  },
-  {
-    name: 'next-dynamic-access-named-export: Transforms dynamic imports that return the named export itself to a module like object.',
-    value: 'next-dynamic-access-named-export',
-  },
-  {
-    name: 'next-image-to-legacy-image: safely migrate Next.js 10, 11, 12 applications importing `next/image` to the renamed `next/legacy/image` import in Next.js 13',
-    value: 'next-image-to-legacy-image',
-  },
-  {
-    name: 'next-image-experimental (experimental): dangerously migrates from `next/legacy/image` to the new `next/image` by adding inline styles and removing unused props',
-    value: 'next-image-experimental',
-  },
-  {
-    name: 'built-in-next-font: Uninstall `@next/font` and transform imports to `next/font`',
-    value: 'built-in-next-font',
-  },
-  {
-    name: 'next-async-request-api: Transforms usage of Next.js async Request APIs',
-    value: 'next-async-request-api',
-  },
-  {
-    name: 'next-request-geo-ip: Install `@vercel/functions` to replace `geo` and `ip` properties on `NextRequest`',
-    value: 'next-request-geo-ip',
-  },
-]
-
 function expandFilePathsIfNeeded(filesBeforeExpansion) {
   const shouldExpandFiles = filesBeforeExpansion.some((file) =>
     file.includes('*')
@@ -184,42 +96,49 @@ function expandFilePathsIfNeeded(filesBeforeExpansion) {
     : filesBeforeExpansion
 }
 
-export function run() {
-  const cli = meow({
-    description: 'Codemods for updating Next.js apps.',
-    help: `
-    Usage
-      $ npx @next/codemod <transform> <path> <...options>
-        transform    One of the choices from https://github.com/vercel/next.js/tree/canary/packages/next-codemod
-        path         Files or directory to transform. Can be a glob like pages/**.js
-    Options
-      --force            Bypass Git safety checks and forcibly run codemods
-      --dry              Dry run (no changes are made to files)
-      --print            Print transformed files to your terminal
-      --jscodeshift  (Advanced) Pass options directly to jscodeshift
-    `,
-    flags: {
-      boolean: ['force', 'dry', 'print', 'help'],
-      string: ['_'],
-      alias: {
-        h: 'help',
-      },
-    },
-  } as meow.Options<meow.AnyFlags>)
+const packageJson = require('../package.json')
+const program = new Command(packageJson.name)
+  .description('Codemods for updating Next.js apps.')
+  .version(
+    packageJson.version,
+    '-v, --version',
+    'Output the current version of @next/codemod.'
+  )
+  .argument(
+    '[transform]',
+    'One of the choices from https://github.com/vercel/next.js/tree/canary/packages/next-codemod'
+  )
+  .argument(
+    '[path]',
+    'Files or directory to transform. Can be a glob like pages/**.js'
+  )
+  .usage('[transform] [path] [options]')
+  .helpOption('-h, --help', 'Display this help message.')
+  .option('--force', 'Bypass Git safety checks and forcibly run codemods')
+  .option('--dry', 'Dry run (no changes are made to files)')
+  .option('--print', 'Print transformed files to your terminal')
+  .option('--jscodeshift', '(Advanced) Pass options directly to jscodeshift')
+  .action(run)
+  .allowUnknownOption()
+  .parse(process.argv)
 
-  if (!cli.flags.dry) {
-    checkGitStatus(cli.flags.force)
+const opts = program.opts()
+const { args } = program
+
+function run() {
+  if (!opts.dry) {
+    checkGitStatus(opts.force)
   }
 
-  const isUpgrade = cli.input[0] === 'upgrade' || cli.input[0] === 'up'
+  const isUpgrade = args[0] === 'upgrade' || args[0] === 'up'
 
   if (isUpgrade) {
     return runUpgrade().catch(console.error)
   }
 
   if (
-    cli.input[0] &&
-    !TRANSFORMER_INQUIRER_CHOICES.find((x) => x.value === cli.input[0])
+    args[0] &&
+    !TRANSFORMER_INQUIRER_CHOICES.find((x) => x.value === args[0])
   ) {
     console.error('Invalid transform choice, pick one of:')
     console.error(
@@ -234,7 +153,7 @@ export function run() {
         type: 'input',
         name: 'files',
         message: 'On which files or directory should the codemods be applied?',
-        when: !cli.input[1],
+        when: !args[1],
         default: '.',
         // validate: () =>
         filter: (files) => files.trim(),
@@ -243,7 +162,7 @@ export function run() {
         type: 'list',
         name: 'transformer',
         message: 'Which transform would you like to apply?',
-        when: !cli.input[0],
+        when: !args[0],
         pageSize: TRANSFORMER_INQUIRER_CHOICES.length,
         choices: TRANSFORMER_INQUIRER_CHOICES,
       },
@@ -251,10 +170,10 @@ export function run() {
     .then((answers) => {
       const { files, transformer } = answers
 
-      const filesBeforeExpansion = cli.input[1] || files
+      const filesBeforeExpansion = args[1] || files
       const filesExpanded = expandFilePathsIfNeeded([filesBeforeExpansion])
 
-      const selectedTransformer = cli.input[0] || transformer
+      const selectedTransformer = args[0] || transformer
 
       if (!filesExpanded.length) {
         console.log(`No files found matching ${filesBeforeExpansion.join(' ')}`)
@@ -263,7 +182,7 @@ export function run() {
 
       return runTransform({
         files: filesExpanded,
-        flags: cli.flags,
+        flags: opts,
         transformer: selectedTransformer,
       })
     })

--- a/packages/next-codemod/bin/next-codemod.ts
+++ b/packages/next-codemod/bin/next-codemod.ts
@@ -40,6 +40,13 @@ const program = new Command(packageJson.name)
   )
   .action(runTransform)
   .allowUnknownOption()
-  .parse(process.argv)
 
-program.command('upgrade').action(runUpgrade)
+program
+  .command('upgrade')
+  .description(
+    'Upgrade Next.js apps to desired versions with a single command.'
+  )
+  .usage('[options]')
+  .action(runUpgrade)
+
+program.parse(process.argv)

--- a/packages/next-codemod/bin/next-codemod.ts
+++ b/packages/next-codemod/bin/next-codemod.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-
 /**
  * Copyright 2015-present, Facebook, Inc.
  *
@@ -7,7 +6,40 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-// Based on https://github.com/reactjs/react-codemod/blob/dd8671c9a470a2c342b221ec903c574cf31e9f57/bin/react-codemod.js
-// next-codemod optional-name-of-transform optional/path/to/src [...options]
+// Based on https://github.com/reactjs/react-codemod/blob/dd8671c9a470a2c342b221ec903c574cf31e9f57/bin/cli.js
+// @next/codemod optional-name-of-transform optional/path/to/src [...options]
 
-require('./cli').run()
+import { Command } from 'commander'
+import { runUpgrade } from './upgrade'
+import { runTransform } from './transform'
+
+const packageJson = require('../package.json')
+const program = new Command(packageJson.name)
+  .description('Codemods for updating Next.js apps.')
+  .version(
+    packageJson.version,
+    '-v, --version',
+    'Output the current version of @next/codemod.'
+  )
+  .argument(
+    '[codemod]',
+    'Codemod slug to run. See "https://github.com/vercel/next.js/tree/canary/packages/next-codemod".'
+  )
+  .argument(
+    '[source]',
+    'Path to source files or directory to transform including glob patterns.'
+  )
+  .usage('[codemod] [source] [options]')
+  .helpOption('-h, --help', 'Display this help message.')
+  .option('-f, --force', 'Bypass Git safety checks and forcibly run codemods')
+  .option('-d, --dry', 'Dry run (no changes are made to files)')
+  .option('-p, --print', 'Print transformed files to your terminal')
+  .option(
+    '-j, --jscodeshift',
+    '(Advanced) Pass options directly to jscodeshift'
+  )
+  .action(runTransform)
+  .allowUnknownOption()
+  .parse(process.argv)
+
+program.command('upgrade').action(runUpgrade)

--- a/packages/next-codemod/bin/transform.ts
+++ b/packages/next-codemod/bin/transform.ts
@@ -1,25 +1,9 @@
-#!/usr/bin/env node
-/**
- * Copyright 2015-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- */
-// Based on https://github.com/reactjs/react-codemod/blob/dd8671c9a470a2c342b221ec903c574cf31e9f57/bin/cli.js
-// @next/codemod optional-name-of-transform optional/path/to/src [...options]
-
-import globby from 'globby'
 import execa from 'execa'
+import globby from 'globby'
 import prompts from 'prompts'
 import { join } from 'node:path'
-import { Command } from 'commander'
-import { runUpgrade } from './upgrade'
 import { installPackage, uninstallPackage } from '../lib/handle-package'
 import { checkGitStatus, TRANSFORMER_INQUIRER_CHOICES } from '../lib/utils'
-
-export const jscodeshiftExecutable = require.resolve('.bin/jscodeshift')
-export const transformerDirectory = join(__dirname, '../', 'transforms')
 
 function expandFilePathsIfNeeded(filesBeforeExpansion) {
   const shouldExpandFiles = filesBeforeExpansion.some((file) =>
@@ -30,35 +14,14 @@ function expandFilePathsIfNeeded(filesBeforeExpansion) {
     : filesBeforeExpansion
 }
 
-const packageJson = require('../package.json')
-const program = new Command(packageJson.name)
-  .description('Codemods for updating Next.js apps.')
-  .version(
-    packageJson.version,
-    '-v, --version',
-    'Output the current version of @next/codemod.'
-  )
-  .argument(
-    '[transform]',
-    'One of the choices from https://github.com/vercel/next.js/tree/canary/packages/next-codemod'
-  )
-  .argument(
-    '[path]',
-    'Files or directory to transform. Can be a glob like pages/**.js'
-  )
-  .usage('[transform] [path] [options]')
-  .helpOption('-h, --help', 'Display this help message.')
-  .option('--force', 'Bypass Git safety checks and forcibly run codemods')
-  .option('--dry', 'Dry run (no changes are made to files)')
-  .option('--print', 'Print transformed files to your terminal')
-  .option('--jscodeshift', '(Advanced) Pass options directly to jscodeshift')
-  .action(run)
-  .allowUnknownOption()
-  .parse(process.argv)
+export const jscodeshiftExecutable = require.resolve('.bin/jscodeshift')
+export const transformerDirectory = join(__dirname, '../', 'transforms')
 
-program.command('upgrade').action(runUpgrade)
-
-async function run(transform: string, path: string, options: any) {
+export async function runTransform(
+  transform: string,
+  path: string,
+  options: any
+) {
   let transformer = transform
   let directory = path
 

--- a/packages/next-codemod/lib/handle-package.ts
+++ b/packages/next-codemod/lib/handle-package.ts
@@ -71,8 +71,8 @@ export function installPackage(
     execa.sync(pkgManager, ['add', packageToInstall], { stdio: 'inherit' })
   } catch (error) {
     throw new Error(
-      `Failed to install "${packageToInstall}". Please install it manually.`
-      // { cause: error }
+      `Failed to install "${packageToInstall}". Please install it manually.`,
+      { cause: error }
     )
   }
 }

--- a/packages/next-codemod/lib/handle-package.ts
+++ b/packages/next-codemod/lib/handle-package.ts
@@ -71,8 +71,8 @@ export function installPackage(
     execa.sync(pkgManager, ['add', packageToInstall], { stdio: 'inherit' })
   } catch (error) {
     throw new Error(
-      `Failed to install "${packageToInstall}". Please install it manually.`,
-      { cause: error }
+      `Failed to install "${packageToInstall}". Please install it manually.`
+      // { cause: error }
     )
   }
 }

--- a/packages/next-codemod/lib/utils.ts
+++ b/packages/next-codemod/lib/utils.ts
@@ -1,0 +1,91 @@
+import { yellow } from 'picocolors'
+import isGitClean from 'is-git-clean'
+
+export function checkGitStatus(force) {
+  let clean = false
+  let errorMessage = 'Unable to determine if git directory is clean'
+  try {
+    clean = isGitClean.sync(process.cwd())
+    errorMessage = 'Git directory is not clean'
+  } catch (err) {
+    if (err && err.stderr && err.stderr.includes('Not a git repository')) {
+      clean = true
+    }
+  }
+
+  if (!clean) {
+    if (force) {
+      console.log(`WARNING: ${errorMessage}. Forcibly continuing.`)
+    } else {
+      console.log('Thank you for using @next/codemod!')
+      console.log(
+        yellow(
+          '\nBut before we continue, please stash or commit your git changes.'
+        )
+      )
+      console.log(
+        '\nYou may use the --force flag to override this safety check.'
+      )
+      process.exit(1)
+    }
+  }
+}
+
+export const TRANSFORMER_INQUIRER_CHOICES = [
+  {
+    name: 'name-default-component: Transforms anonymous components into named components to make sure they work with Fast Refresh',
+    value: 'name-default-component',
+  },
+  {
+    name: 'add-missing-react-import: Transforms files that do not import `React` to include the import in order for the new React JSX transform',
+    value: 'add-missing-react-import',
+  },
+  {
+    name: 'withamp-to-config: Transforms the withAmp HOC into Next.js 9 page configuration',
+    value: 'withamp-to-config',
+  },
+  {
+    name: 'url-to-withrouter: Transforms the deprecated automatically injected url property on top level pages to using withRouter',
+    value: 'url-to-withrouter',
+  },
+  {
+    name: 'cra-to-next (experimental): automatically migrates a Create React App project to Next.js',
+    value: 'cra-to-next',
+  },
+  {
+    name: 'new-link: Ensures your <Link> usage is backwards compatible.',
+    value: 'new-link',
+  },
+  {
+    name: 'next-og-import: Transforms imports from `next/server` to `next/og` for usage of Dynamic OG Image Generation.',
+    value: 'next-og-import',
+  },
+  {
+    name: 'metadata-to-viewport-export: Migrates certain viewport related metadata from the `metadata` export to a new `viewport` export.',
+    value: 'metadata-to-viewport-export',
+  },
+  {
+    name: 'next-dynamic-access-named-export: Transforms dynamic imports that return the named export itself to a module like object.',
+    value: 'next-dynamic-access-named-export',
+  },
+  {
+    name: 'next-image-to-legacy-image: safely migrate Next.js 10, 11, 12 applications importing `next/image` to the renamed `next/legacy/image` import in Next.js 13',
+    value: 'next-image-to-legacy-image',
+  },
+  {
+    name: 'next-image-experimental (experimental): dangerously migrates from `next/legacy/image` to the new `next/image` by adding inline styles and removing unused props',
+    value: 'next-image-experimental',
+  },
+  {
+    name: 'built-in-next-font: Uninstall `@next/font` and transform imports to `next/font`',
+    value: 'built-in-next-font',
+  },
+  {
+    name: 'next-async-request-api: Transforms usage of Next.js async Request APIs',
+    value: 'next-async-request-api',
+  },
+  {
+    name: 'next-request-geo-ip: Install `@vercel/functions` to replace `geo` and `ip` properties on `NextRequest`',
+    value: 'next-request-geo-ip',
+  },
+]

--- a/packages/next-codemod/lib/utils.ts
+++ b/packages/next-codemod/lib/utils.ts
@@ -33,59 +33,72 @@ export function checkGitStatus(force) {
 
 export const TRANSFORMER_INQUIRER_CHOICES = [
   {
-    name: 'name-default-component: Transforms anonymous components into named components to make sure they work with Fast Refresh',
+    title:
+      'name-default-component: Transforms anonymous components into named components to make sure they work with Fast Refresh',
     value: 'name-default-component',
   },
   {
-    name: 'add-missing-react-import: Transforms files that do not import `React` to include the import in order for the new React JSX transform',
+    title:
+      'add-missing-react-import: Transforms files that do not import `React` to include the import in order for the new React JSX transform',
     value: 'add-missing-react-import',
   },
   {
-    name: 'withamp-to-config: Transforms the withAmp HOC into Next.js 9 page configuration',
+    title:
+      'withamp-to-config: Transforms the withAmp HOC into Next.js 9 page configuration',
     value: 'withamp-to-config',
   },
   {
-    name: 'url-to-withrouter: Transforms the deprecated automatically injected url property on top level pages to using withRouter',
+    title:
+      'url-to-withrouter: Transforms the deprecated automatically injected url property on top level pages to using withRouter',
     value: 'url-to-withrouter',
   },
   {
-    name: 'cra-to-next (experimental): automatically migrates a Create React App project to Next.js',
+    title:
+      'cra-to-next (experimental): automatically migrates a Create React App project to Next.js',
     value: 'cra-to-next',
   },
   {
-    name: 'new-link: Ensures your <Link> usage is backwards compatible.',
+    title: 'new-link: Ensures your <Link> usage is backwards compatible.',
     value: 'new-link',
   },
   {
-    name: 'next-og-import: Transforms imports from `next/server` to `next/og` for usage of Dynamic OG Image Generation.',
+    title:
+      'next-og-import: Transforms imports from `next/server` to `next/og` for usage of Dynamic OG Image Generation.',
     value: 'next-og-import',
   },
   {
-    name: 'metadata-to-viewport-export: Migrates certain viewport related metadata from the `metadata` export to a new `viewport` export.',
+    title:
+      'metadata-to-viewport-export: Migrates certain viewport related metadata from the `metadata` export to a new `viewport` export.',
     value: 'metadata-to-viewport-export',
   },
   {
-    name: 'next-dynamic-access-named-export: Transforms dynamic imports that return the named export itself to a module like object.',
+    title:
+      'next-dynamic-access-named-export: Transforms dynamic imports that return the named export itself to a module like object.',
     value: 'next-dynamic-access-named-export',
   },
   {
-    name: 'next-image-to-legacy-image: safely migrate Next.js 10, 11, 12 applications importing `next/image` to the renamed `next/legacy/image` import in Next.js 13',
+    title:
+      'next-image-to-legacy-image: safely migrate Next.js 10, 11, 12 applications importing `next/image` to the renamed `next/legacy/image` import in Next.js 13',
     value: 'next-image-to-legacy-image',
   },
   {
-    name: 'next-image-experimental (experimental): dangerously migrates from `next/legacy/image` to the new `next/image` by adding inline styles and removing unused props',
+    title:
+      'next-image-experimental (experimental): dangerously migrates from `next/legacy/image` to the new `next/image` by adding inline styles and removing unused props',
     value: 'next-image-experimental',
   },
   {
-    name: 'built-in-next-font: Uninstall `@next/font` and transform imports to `next/font`',
+    title:
+      'built-in-next-font: Uninstall `@next/font` and transform imports to `next/font`',
     value: 'built-in-next-font',
   },
   {
-    name: 'next-async-request-api: Transforms usage of Next.js async Request APIs',
+    title:
+      'next-async-request-api: Transforms usage of Next.js async Request APIs',
     value: 'next-async-request-api',
   },
   {
-    name: 'next-request-geo-ip: Install `@vercel/functions` to replace `geo` and `ip` properties on `NextRequest`',
+    title:
+      'next-request-geo-ip: Install `@vercel/functions` to replace `geo` and `ip` properties on `NextRequest`',
     value: 'next-request-geo-ip',
   },
 ]

--- a/packages/next-codemod/package.json
+++ b/packages/next-codemod/package.json
@@ -10,13 +10,14 @@
   "dependencies": {
     "chalk": "4.1.2",
     "cheerio": "1.0.0-rc.9",
+    "ci-info": "4.0.0",
+    "commander": "12.1.0",
     "compare-versions": "6.1.1",
     "execa": "4.0.3",
     "globby": "11.0.1",
     "inquirer": "7.3.3",
     "is-git-clean": "1.1.0",
     "jscodeshift": "17.0.0",
-    "meow": "7.0.1",
     "picocolors": "1.0.0",
     "prompts": "2.4.2"
   },

--- a/packages/next-codemod/package.json
+++ b/packages/next-codemod/package.json
@@ -10,12 +10,10 @@
   "dependencies": {
     "chalk": "4.1.2",
     "cheerio": "1.0.0-rc.9",
-    "ci-info": "4.0.0",
     "commander": "12.1.0",
     "compare-versions": "6.1.1",
     "execa": "4.0.3",
     "globby": "11.0.1",
-    "inquirer": "7.3.3",
     "is-git-clean": "1.1.0",
     "jscodeshift": "17.0.0",
     "picocolors": "1.0.0",

--- a/packages/next-codemod/tsconfig.json
+++ b/packages/next-codemod/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "sourceMap": true,
     "esModuleInterop": true,
-    "target": "es2015",
+    "target": "ES2022",
     "downlevelIteration": true,
     "preserveWatchOutput": true
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1502,9 +1502,6 @@ importers:
       cheerio:
         specifier: 1.0.0-rc.9
         version: 1.0.0-rc.9
-      ci-info:
-        specifier: 4.0.0
-        version: 4.0.0
       commander:
         specifier: 12.1.0
         version: 12.1.0
@@ -1517,9 +1514,6 @@ importers:
       globby:
         specifier: 11.0.1
         version: 11.0.1
-      inquirer:
-        specifier: 7.3.3
-        version: 7.3.3
       is-git-clean:
         specifier: 1.1.0
         version: 1.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -857,7 +857,7 @@ importers:
         version: 0.5.13
       babel-plugin-react-compiler:
         specifier: '*'
-        version: 0.0.0-experimental-6067d4e-20240923
+        version: 0.0.0-experimental-6067d4e-20240924
       busboy:
         specifier: 1.6.0
         version: 1.6.0
@@ -1502,6 +1502,12 @@ importers:
       cheerio:
         specifier: 1.0.0-rc.9
         version: 1.0.0-rc.9
+      ci-info:
+        specifier: 4.0.0
+        version: 4.0.0
+      commander:
+        specifier: 12.1.0
+        version: 12.1.0
       compare-versions:
         specifier: 6.1.1
         version: 6.1.1
@@ -1520,9 +1526,6 @@ importers:
       jscodeshift:
         specifier: 17.0.0
         version: 17.0.0(@babel/preset-env@7.24.8(@babel/core@7.22.5))
-      meow:
-        specifier: 7.0.1
-        version: 7.0.1
       picocolors:
         specifier: 1.0.0
         version: 1.0.0
@@ -5117,9 +5120,6 @@ packages:
   '@types/minimatch@3.0.3':
     resolution: {integrity: sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==}
 
-  '@types/minimist@1.2.0':
-    resolution: {integrity: sha512-BsF2gEVEIOcbQCSwXR6V14fGD6QLLT0yQBK6RpblkxVYP9x8ANNThpxMUxV7h4KKjqMDR8qELlcnqrEoyvsohw==}
-
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
 
@@ -5953,8 +5953,8 @@ packages:
     peerDependencies:
       '@babel/core': 7.22.5
 
-  babel-plugin-react-compiler@0.0.0-experimental-6067d4e-20240923:
-    resolution: {integrity: sha512-0vYsWhC8W4BUIS5cLiGBJkOpj8bINpbATo9O9scZ7vxL6/+jMIomUkX+k+R0lpG0ztu0x8QVMENwoFCawdZEbQ==}
+  babel-plugin-react-compiler@0.0.0-experimental-6067d4e-20240924:
+    resolution: {integrity: sha512-Xprt5PqHZKqF2H8Di7y+o9j1RTFsNGJ6ntBcRFu8kcChy5sVSVVIKXq+FBezcBhVChzaRrUb+OV/nWZlJH1aJA==}
 
   babel-plugin-react-compiler@0.0.0-experimental-c23de8d-20240515:
     resolution: {integrity: sha512-0XN2gmpT55QtAz5n7d5g91y1AuO9tRhWBaLgCRyc4ExHrlr7+LfxW+YTb3mOwxngkkiggwM8HyYsaEK9MqhnlQ==}
@@ -10487,10 +10487,6 @@ packages:
   meow@3.7.0:
     resolution: {integrity: sha512-TNdwZs0skRlpPpCUK25StC4VH+tP5GgeY1HQOOGP+lQ2xtdkN2VtT/5tiX9k3IWpkBPV9b3LsAWXn4GGi/PrSA==}
     engines: {node: '>=0.10.0'}
-
-  meow@7.0.1:
-    resolution: {integrity: sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==}
-    engines: {node: '>=10'}
 
   meow@7.1.1:
     resolution: {integrity: sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==}
@@ -19702,8 +19698,6 @@ snapshots:
 
   '@types/minimatch@3.0.3': {}
 
-  '@types/minimist@1.2.0': {}
-
   '@types/minimist@1.2.5': {}
 
   '@types/mute-stream@0.0.4':
@@ -20696,7 +20690,7 @@ snapshots:
       - supports-color
     optional: true
 
-  babel-plugin-react-compiler@0.0.0-experimental-6067d4e-20240923:
+  babel-plugin-react-compiler@0.0.0-experimental-6067d4e-20240924:
     dependencies:
       '@babel/generator': 7.2.0
       '@babel/types': 7.22.5
@@ -26575,22 +26569,6 @@ snapshots:
       read-pkg-up: 1.0.1
       redent: 1.0.0
       trim-newlines: 1.0.0
-
-  meow@7.0.1:
-    dependencies:
-      '@types/minimist': 1.2.0
-      arrify: 2.0.1
-      camelcase: 6.2.0
-      camelcase-keys: 6.2.2
-      decamelize-keys: 1.1.0
-      hard-rejection: 2.1.0
-      minimist-options: 4.1.0
-      normalize-package-data: 2.5.0
-      read-pkg-up: 7.0.1
-      redent: 3.0.0
-      trim-newlines: 3.0.0
-      type-fest: 0.13.1
-      yargs-parser: 18.1.3
 
   meow@7.1.1:
     dependencies:


### PR DESCRIPTION
### Why?

Prerequisite of `@next/codemod upgrade`.

Current status of next-codemod is difficult to extend another commands as it relies on [meow](https://www.npmjs.com/package/meow) which requires to handle args and flags manually. For consistency with `next` and `create-next-app`, migrated to `commander` and `prompts`.

https://github.com/user-attachments/assets/8d2e53be-4b7d-4755-9a3f-c73df1f9ef7e

No behavioral changes **except the help message**.