### PR TITLE
Fix legacy env case with experimental tracing

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -772,6 +772,15 @@ export default async function build(
         await fs.mkdir(shuttleDir, {
           recursive: true,
         })
+
+        // since inlining comes after static generation we need
+        // to ensure this value is assigned to process env so it
+        // can still be accessed
+        for (const key in config.env) {
+          if (!process.env[key]) {
+            process.env[key] = config.env[key]
+          }
+        }
       }
 
       const customRoutes: CustomRoutes = await nextBuildSpan

--- a/test/e2e/app-dir/app/app/legacy-env/page.js
+++ b/test/e2e/app-dir/app/app/legacy-env/page.js
@@ -1,3 +1,6 @@
 export default function Page() {
+  if (!process.env.LEGACY_ENV_KEY) {
+    throw new Error('missing env key LEGACY_ENV_KEY!!')
+  }
   return <p id="legacy-env">{process.env.LEGACY_ENV_KEY}</p>
 }

--- a/test/e2e/app-dir/app/pages/ssg.js
+++ b/test/e2e/app-dir/app/pages/ssg.js
@@ -10,6 +10,9 @@ export default function Page(props) {
 }
 
 export function getStaticProps() {
+  if (!process.env.LEGACY_ENV_KEY) {
+    throw new Error('missing env key LEGACY_ENV_KEY!!')
+  }
   return {
     props: {},
   }


### PR DESCRIPTION
This ensures `env` keys in `next.config` are properly exposed during page collecting step during build since the inlining step comes after. 

x-ref: https://github.com/vercel/next.js/pull/70380
x-ref: https://vercel.com/vercel/vercel-site/9WqUX9vu15oVEy1acDqoXddcH27K?filter=errors