### PR TITLE
codemod(turbopack): Rewrite `self: Vc<Self>` as `&self` in trivial cases

### DIFF
--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -255,8 +255,8 @@ impl MiddlewareEndpoint {
     }
 
     #[turbo_tasks::function]
-    async fn userland_module(self: Vc<Self>) -> Result<Vc<Box<dyn Module>>> {
-        let this = self.await?;
+    async fn userland_module(&self) -> Result<Vc<Box<dyn Module>>> {
+        let this = self;
 
         Ok(this
             .asset_context

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -640,8 +640,8 @@ impl PageEndpoint {
     }
 
     #[turbo_tasks::function]
-    async fn source(self: Vc<Self>) -> Result<Vc<Box<dyn Source>>> {
-        let this = self.await?;
+    async fn source(&self) -> Result<Vc<Box<dyn Source>>> {
+        let this = self;
         Ok(Vc::upcast(FileSource::new(this.page.project_path())))
     }
 
@@ -946,10 +946,10 @@ impl PageEndpoint {
 
     #[turbo_tasks::function]
     async fn pages_manifest(
-        self: Vc<Self>,
+        &self,
         entry_chunk: Vc<Box<dyn OutputAsset>>,
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
-        let this = self.await?;
+        let this = self;
         let node_root = this.pages_project.project().node_root();
         let chunk_path = entry_chunk.ident().path().await?;
 
@@ -991,10 +991,10 @@ impl PageEndpoint {
 
     #[turbo_tasks::function]
     async fn build_manifest(
-        self: Vc<Self>,
+        &self,
         client_chunks: Vc<OutputAssets>,
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
-        let this = self.await?;
+        let this = self;
         let node_root = this.pages_project.project().node_root();
         let client_relative_path = this.pages_project.project().client_relative_path();
         let client_relative_path_ref = client_relative_path.await?;

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -301,8 +301,8 @@ impl ProjectContainer {
 #[turbo_tasks::value_impl]
 impl ProjectContainer {
     #[turbo_tasks::function]
-    pub async fn project(self: Vc<Self>) -> Result<Vc<Project>> {
-        let this = self.await?;
+    pub async fn project(&self) -> Result<Vc<Project>> {
+        let this = self;
 
         let env_map: Vc<EnvMap>;
         let next_config;
@@ -385,11 +385,11 @@ impl ProjectContainer {
     /// disabled, this will always return [`OptionSourceMap::none`].
     #[turbo_tasks::function]
     pub async fn get_source_map(
-        self: Vc<Self>,
+        &self,
         file_path: Vc<FileSystemPath>,
         section: Option<RcStr>,
     ) -> Result<Vc<OptionSourceMap>> {
-        Ok(if let Some(map) = self.await?.versioned_content_map {
+        Ok(if let Some(map) = self.versioned_content_map {
             map.get_source_map(file_path, section)
         } else {
             OptionSourceMap::none()
@@ -517,8 +517,8 @@ impl Project {
     }
 
     #[turbo_tasks::function]
-    async fn project_fs(self: Vc<Self>) -> Result<Vc<DiskFileSystem>> {
-        let this = self.await?;
+    async fn project_fs(&self) -> Result<Vc<DiskFileSystem>> {
+        let this = self;
         let disk_fs = DiskFileSystem::new(
             PROJECT_FILESYSTEM_NAME.into(),
             this.root_path.clone(),
@@ -537,15 +537,15 @@ impl Project {
     }
 
     #[turbo_tasks::function]
-    pub async fn output_fs(self: Vc<Self>) -> Result<Vc<DiskFileSystem>> {
-        let this = self.await?;
+    pub async fn output_fs(&self) -> Result<Vc<DiskFileSystem>> {
+        let this = self;
         let disk_fs = DiskFileSystem::new("output".into(), this.project_path.clone(), vec![]);
         Ok(disk_fs)
     }
 
     #[turbo_tasks::function]
-    pub async fn dist_dir(self: Vc<Self>) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(self.await?.dist_dir.clone()))
+    pub async fn dist_dir(&self) -> Result<Vc<RcStr>> {
+        Ok(Vc::cell(self.dist_dir.clone()))
     }
 
     #[turbo_tasks::function]
@@ -589,23 +589,23 @@ impl Project {
     }
 
     #[turbo_tasks::function]
-    pub(super) async fn env(self: Vc<Self>) -> Result<Vc<Box<dyn ProcessEnv>>> {
-        Ok(self.await?.env)
+    pub(super) async fn env(&self) -> Result<Vc<Box<dyn ProcessEnv>>> {
+        Ok(self.env)
     }
 
     #[turbo_tasks::function]
-    pub(super) async fn next_config(self: Vc<Self>) -> Result<Vc<NextConfig>> {
-        Ok(self.await?.next_config)
+    pub(super) async fn next_config(&self) -> Result<Vc<NextConfig>> {
+        Ok(self.next_config)
     }
 
     #[turbo_tasks::function]
-    pub(super) async fn next_mode(self: Vc<Self>) -> Result<Vc<NextMode>> {
-        Ok(self.await?.mode)
+    pub(super) async fn next_mode(&self) -> Result<Vc<NextMode>> {
+        Ok(self.mode)
     }
 
     #[turbo_tasks::function]
-    pub(super) async fn js_config(self: Vc<Self>) -> Result<Vc<JsConfig>> {
-        Ok(self.await?.js_config)
+    pub(super) async fn js_config(&self) -> Result<Vc<JsConfig>> {
+        Ok(self.js_config)
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -95,7 +95,7 @@ impl VersionedContentMap {
     /// operation. When assets change, map_path_to_op is updated.
     #[turbo_tasks::function]
     async fn compute_entry(
-        self: Vc<Self>,
+        &self,
         assets_operation: Vc<OutputAssetsOperation>,
         node_root: Vc<FileSystemPath>,
         client_relative_path: Vc<FileSystemPath>,
@@ -118,7 +118,7 @@ impl VersionedContentMap {
         }
         let entries = get_entries(assets).await.unwrap_or_default();
 
-        self.await?.map_path_to_op.update_conditionally(|map| {
+        self.map_path_to_op.update_conditionally(|map| {
             let mut changed = false;
 
             // get current map's keys, subtract keys that don't exist in operation

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -732,8 +732,8 @@ struct DuplicateParallelRouteIssue {
 #[turbo_tasks::value_impl]
 impl Issue for DuplicateParallelRouteIssue {
     #[turbo_tasks::function]
-    async fn file_path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
-        let this = self.await?;
+    async fn file_path(&self) -> Result<Vc<FileSystemPath>> {
+        let this = self;
         Ok(this.app_dir.join(this.page.to_string().into()))
     }
 

--- a/crates/next-core/src/next_client/runtime_entry.rs
+++ b/crates/next-core/src/next_client/runtime_entry.rs
@@ -69,12 +69,12 @@ pub struct RuntimeEntries(Vec<Vc<RuntimeEntry>>);
 impl RuntimeEntries {
     #[turbo_tasks::function]
     pub async fn resolve_entries(
-        self: Vc<Self>,
+        &self,
         asset_context: Vc<Box<dyn AssetContext>>,
     ) -> Result<Vc<EvaluatableAssets>> {
         let mut runtime_entries = Vec::new();
 
-        for reference in &self.await? {
+        for reference in &self.0 {
             let resolved_entries = reference.resolve_entry(asset_context).await?;
             runtime_entries.extend(&resolved_entries);
         }

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -792,10 +792,9 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn server_external_packages(self: Vc<Self>) -> Result<Vc<Vec<RcStr>>> {
+    pub async fn server_external_packages(&self) -> Result<Vc<Vec<RcStr>>> {
         Ok(Vc::cell(
-            self.await?
-                .server_external_packages
+            self.server_external_packages
                 .as_ref()
                 .cloned()
                 .unwrap_or_default(),
@@ -803,12 +802,11 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn env(self: Vc<Self>) -> Result<Vc<EnvMap>> {
+    pub async fn env(&self) -> Result<Vc<EnvMap>> {
         // The value expected for env is Record<String, String>, but config itself
         // allows arbitrary object (https://github.com/vercel/next.js/blob/25ba8a74b7544dfb6b30d1b67c47b9cb5360cb4e/packages/next/src/server/config-schema.ts#L203)
         // then stringifies it. We do the interop here as well.
         let env = self
-            .await?
             .env
             .iter()
             .map(|(k, v)| {
@@ -828,28 +826,28 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn image_config(self: Vc<Self>) -> Result<Vc<ImageConfig>> {
-        Ok(self.await?.images.clone().cell())
+    pub async fn image_config(&self) -> Result<Vc<ImageConfig>> {
+        Ok(self.images.clone().cell())
     }
 
     #[turbo_tasks::function]
-    pub async fn page_extensions(self: Vc<Self>) -> Result<Vc<Vec<RcStr>>> {
-        Ok(Vc::cell(self.await?.page_extensions.clone()))
+    pub async fn page_extensions(&self) -> Result<Vc<Vec<RcStr>>> {
+        Ok(Vc::cell(self.page_extensions.clone()))
     }
 
     #[turbo_tasks::function]
-    pub async fn transpile_packages(self: Vc<Self>) -> Result<Vc<Vec<RcStr>>> {
+    pub async fn transpile_packages(&self) -> Result<Vc<Vec<RcStr>>> {
         Ok(Vc::cell(
-            self.await?.transpile_packages.clone().unwrap_or_default(),
+            self.transpile_packages.clone().unwrap_or_default(),
         ))
     }
 
     #[turbo_tasks::function]
     pub async fn webpack_rules(
-        self: Vc<Self>,
+        &self,
         active_conditions: Vec<RcStr>,
     ) -> Result<Vc<OptionWebpackRules>> {
-        let this = self.await?;
+        let this = self;
         let Some(turbo_rules) = this
             .experimental
             .turbo
@@ -937,8 +935,8 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn resolve_alias_options(self: Vc<Self>) -> Result<Vc<ResolveAliasMap>> {
-        let this = self.await?;
+    pub async fn resolve_alias_options(&self) -> Result<Vc<ResolveAliasMap>> {
+        let this = self;
         let Some(resolve_alias) = this
             .experimental
             .turbo
@@ -952,8 +950,8 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn resolve_extension(self: Vc<Self>) -> Result<Vc<ResolveExtensions>> {
-        let this = self.await?;
+    pub async fn resolve_extension(&self) -> Result<Vc<ResolveExtensions>> {
+        let this = self;
         let Some(resolve_extensions) = this
             .experimental
             .turbo
@@ -966,8 +964,8 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn import_externals(self: Vc<Self>) -> Result<Vc<bool>> {
-        Ok(Vc::cell(match self.await?.experimental.esm_externals {
+    pub async fn import_externals(&self) -> Result<Vc<bool>> {
+        Ok(Vc::cell(match self.experimental.esm_externals {
             Some(EsmExternals::Bool(b)) => b,
             Some(EsmExternals::Loose(_)) => bail!("esmExternals = \"loose\" is not supported"),
             None => true,
@@ -975,8 +973,8 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn mdx_rs(self: Vc<Self>) -> Result<Vc<OptionalMdxTransformOptions>> {
-        let options = &self.await?.experimental.mdx_rs;
+    pub async fn mdx_rs(&self) -> Result<Vc<OptionalMdxTransformOptions>> {
+        let options = &self.experimental.mdx_rs;
 
         let options = match options {
             Some(MdxRsOptions::Boolean(true)) => OptionalMdxTransformOptions(Some(
@@ -1005,8 +1003,8 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn react_compiler(self: Vc<Self>) -> Result<Vc<OptionalReactCompilerOptions>> {
-        let options = &self.await?.experimental.react_compiler;
+    pub async fn react_compiler(&self) -> Result<Vc<OptionalReactCompilerOptions>> {
+        let options = &self.experimental.react_compiler;
 
         let options = match options {
             Some(ReactCompilerOptionsOrBoolean::Boolean(true)) => {
@@ -1028,24 +1026,20 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn sass_config(self: Vc<Self>) -> Result<Vc<JsonValue>> {
+    pub async fn sass_config(&self) -> Result<Vc<JsonValue>> {
+        Ok(Vc::cell(self.sass_options.clone().unwrap_or_default()))
+    }
+
+    #[turbo_tasks::function]
+    pub async fn skip_middleware_url_normalize(&self) -> Result<Vc<bool>> {
         Ok(Vc::cell(
-            self.await?.sass_options.clone().unwrap_or_default(),
+            self.skip_middleware_url_normalize.unwrap_or(false),
         ))
     }
 
     #[turbo_tasks::function]
-    pub async fn skip_middleware_url_normalize(self: Vc<Self>) -> Result<Vc<bool>> {
-        Ok(Vc::cell(
-            self.await?.skip_middleware_url_normalize.unwrap_or(false),
-        ))
-    }
-
-    #[turbo_tasks::function]
-    pub async fn skip_trailing_slash_redirect(self: Vc<Self>) -> Result<Vc<bool>> {
-        Ok(Vc::cell(
-            self.await?.skip_trailing_slash_redirect.unwrap_or(false),
-        ))
+    pub async fn skip_trailing_slash_redirect(&self) -> Result<Vc<bool>> {
+        Ok(Vc::cell(self.skip_trailing_slash_redirect.unwrap_or(false)))
     }
 
     /// Returns the final asset prefix. If an assetPrefix is set, it's used.
@@ -1069,10 +1063,9 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn enable_ppr(self: Vc<Self>) -> Result<Vc<bool>> {
+    pub async fn enable_ppr(&self) -> Result<Vc<bool>> {
         Ok(Vc::cell(
-            self.await?
-                .experimental
+            self.experimental
                 .ppr
                 .as_ref()
                 .map(|ppr| match ppr {
@@ -1086,22 +1079,19 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn enable_taint(self: Vc<Self>) -> Result<Vc<bool>> {
-        Ok(Vc::cell(self.await?.experimental.taint.unwrap_or(false)))
+    pub async fn enable_taint(&self) -> Result<Vc<bool>> {
+        Ok(Vc::cell(self.experimental.taint.unwrap_or(false)))
     }
 
     #[turbo_tasks::function]
-    pub async fn enable_dynamic_io(self: Vc<Self>) -> Result<Vc<bool>> {
-        Ok(Vc::cell(
-            self.await?.experimental.dynamic_io.unwrap_or(false),
-        ))
+    pub async fn enable_dynamic_io(&self) -> Result<Vc<bool>> {
+        Ok(Vc::cell(self.experimental.dynamic_io.unwrap_or(false)))
     }
 
     #[turbo_tasks::function]
-    pub async fn use_swc_css(self: Vc<Self>) -> Result<Vc<bool>> {
+    pub async fn use_swc_css(&self) -> Result<Vc<bool>> {
         Ok(Vc::cell(
-            self.await?
-                .experimental
+            self.experimental
                 .turbo
                 .as_ref()
                 .and_then(|turbo| turbo.use_swc_css)
@@ -1110,10 +1100,9 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn optimize_package_imports(self: Vc<Self>) -> Result<Vc<Vec<RcStr>>> {
+    pub async fn optimize_package_imports(&self) -> Result<Vc<Vec<RcStr>>> {
         Ok(Vc::cell(
-            self.await?
-                .experimental
+            self.experimental
                 .optimize_package_imports
                 .clone()
                 .unwrap_or_default(),
@@ -1122,11 +1111,10 @@ impl NextConfig {
 
     #[turbo_tasks::function]
     pub async fn tree_shaking_mode_for_foreign_code(
-        self: Vc<Self>,
+        &self,
         is_development: bool,
     ) -> Result<Vc<OptionTreeShaking>> {
         let tree_shaking = self
-            .await?
             .experimental
             .turbo
             .as_ref()
@@ -1159,8 +1147,8 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn module_id_strategy_config(self: Vc<Self>) -> Result<Vc<OptionModuleIdStrategy>> {
-        let this = self.await?;
+    pub async fn module_id_strategy_config(&self) -> Result<Vc<OptionModuleIdStrategy>> {
+        let this = self;
         let Some(module_id_strategy) = this
             .experimental
             .turbo
@@ -1194,10 +1182,8 @@ impl JsConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn compiler_options(self: Vc<Self>) -> Result<Vc<serde_json::Value>> {
-        Ok(Vc::cell(
-            self.await?.compiler_options.clone().unwrap_or_default(),
-        ))
+    pub async fn compiler_options(&self) -> Result<Vc<serde_json::Value>> {
+        Ok(Vc::cell(self.compiler_options.clone().unwrap_or_default()))
     }
 }
 

--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -30,10 +30,10 @@ impl NextDynamicEntryModule {
 
     #[turbo_tasks::function]
     pub async fn client_chunks(
-        self: Vc<Self>,
+        &self,
         client_chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<OutputAssets>> {
-        let this = self.await?;
+        let this = self;
 
         let Some(client_entry_module) =
             Vc::try_resolve_sidecast::<Box<dyn ChunkableModule>>(this.client_entry_module).await?

--- a/crates/next-core/src/next_font/google/options.rs
+++ b/crates/next-core/src/next_font/google/options.rs
@@ -35,8 +35,8 @@ impl NextFontGoogleOptions {
     }
 
     #[turbo_tasks::function]
-    pub async fn font_family(self: Vc<Self>) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell((*self.await?.font_family).into()))
+    pub async fn font_family(&self) -> Result<Vc<RcStr>> {
+        Ok(Vc::cell((*self.font_family).into()))
     }
 }
 

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -321,8 +321,8 @@ impl Issue for FontResolvingIssue {
     }
 
     #[turbo_tasks::function]
-    async fn file_path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
-        Ok(self.await?.origin_path)
+    async fn file_path(&self) -> Result<Vc<FileSystemPath>> {
+        Ok(self.origin_path)
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_font/local/options.rs
+++ b/crates/next-core/src/next_font/local/options.rs
@@ -41,8 +41,8 @@ impl NextFontLocalOptions {
     }
 
     #[turbo_tasks::function]
-    pub async fn font_family(self: Vc<Self>) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(self.await?.variable_name.clone()))
+    pub async fn font_family(&self) -> Result<Vc<RcStr>> {
+        Ok(Vc::cell(self.variable_name.clone()))
     }
 }
 

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -46,8 +46,8 @@ impl NextServerComponentModule {
     }
 
     #[turbo_tasks::function]
-    pub async fn server_path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
-        let this = self.await?;
+    pub async fn server_path(&self) -> Result<Vc<FileSystemPath>> {
+        let this = self;
         Ok(this.module.ident().path())
     }
 }
@@ -143,8 +143,8 @@ impl EcmascriptChunkItem for NextServerComponentChunkItem {
     }
 
     #[turbo_tasks::function]
-    async fn content(self: Vc<Self>) -> Result<Vc<EcmascriptChunkItemContent>> {
-        let this = self.await?;
+    async fn content(&self) -> Result<Vc<EcmascriptChunkItemContent>> {
+        let this = self;
         let inner = this.inner.await?;
 
         let module_id = inner

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -96,10 +96,10 @@ impl PageLoaderAsset {
 
     #[turbo_tasks::function]
     async fn chunks_data(
-        self: Vc<Self>,
+        &self,
         rebase_prefix_path: Vc<FileSystemPathOption>,
     ) -> Result<Vc<ChunksData>> {
-        let this = self.await?;
+        let this = self;
         let mut chunks = this.page_chunks;
 
         // If we are provided a prefix path, we need to rewrite our chunk paths to

--- a/crates/next-core/src/pages_structure.rs
+++ b/crates/next-core/src/pages_structure.rs
@@ -102,8 +102,8 @@ impl PagesDirectoryStructure {
     /// Returns the path to the directory of this structure in the project file
     /// system.
     #[turbo_tasks::function]
-    pub async fn project_path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
-        Ok(self.await?.project_path)
+    pub async fn project_path(&self) -> Result<Vc<FileSystemPath>> {
+        Ok(self.project_path)
     }
 }
 

--- a/turbopack/crates/turbo-tasks-env/src/dotenv.rs
+++ b/turbopack/crates/turbo-tasks-env/src/dotenv.rs
@@ -24,8 +24,8 @@ impl DotenvProcessEnv {
     }
 
     #[turbo_tasks::function]
-    pub async fn read_prior(self: Vc<Self>) -> Result<Vc<EnvMap>> {
-        let this = self.await?;
+    pub async fn read_prior(&self) -> Result<Vc<EnvMap>> {
+        let this = self;
         match this.prior {
             None => Ok(EnvMap::empty()),
             Some(p) => Ok(p.read_all()),

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1170,8 +1170,8 @@ impl FileSystemPath {
     /// Similar to [FileSystemPath::join], but returns an Option that will be
     /// None when the joined path would leave the filesystem root.
     #[turbo_tasks::function]
-    pub async fn try_join(self: Vc<Self>, path: RcStr) -> Result<Vc<FileSystemPathOption>> {
-        let this = self.await?;
+    pub async fn try_join(&self, path: RcStr) -> Result<Vc<FileSystemPathOption>> {
+        let this = self;
         if let Some(path) = join_path(&this.path, &path) {
             Ok(Vc::cell(Some(
                 Self::new_normalized(this.fs, path.into()).resolve().await?,
@@ -1184,8 +1184,8 @@ impl FileSystemPath {
     /// Similar to [FileSystemPath::join], but returns an Option that will be
     /// None when the joined path would leave the current path.
     #[turbo_tasks::function]
-    pub async fn try_join_inside(self: Vc<Self>, path: RcStr) -> Result<Vc<FileSystemPathOption>> {
-        let this = self.await?;
+    pub async fn try_join_inside(&self, path: RcStr) -> Result<Vc<FileSystemPathOption>> {
+        let this = self;
         if let Some(path) = join_path(&this.path, &path) {
             if path.starts_with(&*this.path) {
                 return Ok(Vc::cell(Some(
@@ -1211,31 +1211,31 @@ impl FileSystemPath {
     }
 
     #[turbo_tasks::function]
-    pub async fn fs(self: Vc<Self>) -> Result<Vc<Box<dyn FileSystem>>> {
-        Ok(self.await?.fs)
+    pub async fn fs(&self) -> Result<Vc<Box<dyn FileSystem>>> {
+        Ok(self.fs)
     }
 
     #[turbo_tasks::function]
-    pub async fn extension(self: Vc<Self>) -> Result<Vc<RcStr>> {
-        let this = self.await?;
+    pub async fn extension(&self) -> Result<Vc<RcStr>> {
+        let this = self;
         Ok(Vc::cell(this.extension_ref().unwrap_or("").into()))
     }
 
     #[turbo_tasks::function]
-    pub async fn is_inside(self: Vc<Self>, other: Vc<FileSystemPath>) -> Result<Vc<bool>> {
-        Ok(Vc::cell(self.await?.is_inside_ref(&*other.await?)))
+    pub async fn is_inside(&self, other: Vc<FileSystemPath>) -> Result<Vc<bool>> {
+        Ok(Vc::cell(self.is_inside_ref(&*other.await?)))
     }
 
     #[turbo_tasks::function]
-    pub async fn is_inside_or_equal(self: Vc<Self>, other: Vc<FileSystemPath>) -> Result<Vc<bool>> {
-        Ok(Vc::cell(self.await?.is_inside_or_equal_ref(&*other.await?)))
+    pub async fn is_inside_or_equal(&self, other: Vc<FileSystemPath>) -> Result<Vc<bool>> {
+        Ok(Vc::cell(self.is_inside_or_equal_ref(&*other.await?)))
     }
 
     /// Creates a new [`Vc<FileSystemPath>`] like `self` but with the given
     /// extension.
     #[turbo_tasks::function]
-    pub async fn with_extension(self: Vc<Self>, extension: RcStr) -> Result<Vc<FileSystemPath>> {
-        let this = self.await?;
+    pub async fn with_extension(&self, extension: RcStr) -> Result<Vc<FileSystemPath>> {
+        let this = self;
         let (path_without_extension, _) = this.split_extension();
         Ok(Self::new_normalized(
             this.fs,
@@ -1257,8 +1257,8 @@ impl FileSystemPath {
     /// * The entire file name if the file name begins with `.` and has no other `.`s within;
     /// * Otherwise, the portion of the file name before the final `.`
     #[turbo_tasks::function]
-    pub async fn file_stem(self: Vc<Self>) -> Result<Vc<Option<RcStr>>> {
-        let this = self.await?;
+    pub async fn file_stem(&self) -> Result<Vc<Option<RcStr>>> {
+        let this = self;
         let (_, file_stem, _) = this.split_file_stem_extension();
         if file_stem.is_empty() {
             return Ok(Vc::cell(None));
@@ -1483,8 +1483,8 @@ pub struct RealPathResult {
 #[turbo_tasks::value_impl]
 impl RealPathResult {
     #[turbo_tasks::function]
-    pub async fn path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
-        Ok(self.await?.path)
+    pub async fn path(&self) -> Result<Vc<FileSystemPath>> {
+        Ok(self.path)
     }
 }
 

--- a/turbopack/crates/turbo-tasks-memory/tests/task_statistics.rs
+++ b/turbopack/crates/turbo-tasks-memory/tests/task_statistics.rs
@@ -224,8 +224,8 @@ impl Doublable for WrappedU64 {
     }
 
     #[turbo_tasks::function]
-    async fn double_vc(self: Vc<Self>) -> Result<Vc<Self>> {
-        let val = self.await?.0;
+    async fn double_vc(&self) -> Result<Vc<Self>> {
+        let val = self.0;
         Ok(WrappedU64(val * 2).cell())
     }
 }

--- a/turbopack/crates/turbo-tasks-testing/tests/call_types.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/call_types.rs
@@ -99,8 +99,8 @@ impl Value {
     }
 
     #[turbo_tasks::function]
-    async fn async_vc_method(self: Vc<Self>) -> Result<Vc<u32>> {
-        Ok(Vc::cell(self.await?.0))
+    async fn async_vc_method(&self) -> Result<Vc<u32>> {
+        Ok(Vc::cell(self.0))
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/completion.rs
+++ b/turbopack/crates/turbo-tasks/src/completion.rs
@@ -59,8 +59,8 @@ impl Completions {
 
     /// Merges the list of completions into one.
     #[turbo_tasks::function]
-    pub async fn completed(self: Vc<Self>) -> anyhow::Result<Vc<Completion>> {
-        self.await?
+    pub async fn completed(&self) -> anyhow::Result<Vc<Completion>> {
+        self.0
             .iter()
             .map(|&c| async move {
                 c.await?;

--- a/turbopack/crates/turbo-tasks/src/primitives.rs
+++ b/turbopack/crates/turbo-tasks/src/primitives.rs
@@ -86,8 +86,8 @@ impl Bools {
     }
 
     #[turbo_tasks::function]
-    async fn into_bools(self: Vc<Bools>) -> Result<Vc<Vec<bool>>> {
-        let this = self.await?;
+    async fn into_bools(&self) -> Result<Vc<Vec<bool>>> {
+        let this = &self.0;
 
         let bools = this
             .iter()

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -485,11 +485,8 @@ impl ChunkingContext for BrowserChunkingContext {
     }
 
     #[turbo_tasks::function]
-    async fn chunk_item_id_from_ident(
-        self: Vc<Self>,
-        ident: Vc<AssetIdent>,
-    ) -> Result<Vc<ModuleId>> {
-        Ok(self.await?.module_id_strategy.get_module_id(ident))
+    async fn chunk_item_id_from_ident(&self, ident: Vc<AssetIdent>) -> Result<Vc<ModuleId>> {
+        Ok(self.module_id_strategy.get_module_id(ident))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -47,18 +47,16 @@ impl EcmascriptDevChunkContent {
     }
 
     #[turbo_tasks::function]
-    pub async fn entries(
-        self: Vc<EcmascriptDevChunkContent>,
-    ) -> Result<Vc<EcmascriptDevChunkContentEntries>> {
-        Ok(self.await?.entries)
+    pub async fn entries(&self) -> Result<Vc<EcmascriptDevChunkContentEntries>> {
+        Ok(self.entries)
     }
 }
 
 #[turbo_tasks::value_impl]
 impl EcmascriptDevChunkContent {
     #[turbo_tasks::function]
-    pub(crate) async fn own_version(self: Vc<Self>) -> Result<Vc<EcmascriptDevChunkVersion>> {
-        let this = self.await?;
+    pub(crate) async fn own_version(&self) -> Result<Vc<EcmascriptDevChunkVersion>> {
+        let this = self;
         Ok(EcmascriptDevChunkVersion::new(
             this.chunking_context.output_root(),
             this.chunk.ident().path(),

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -57,8 +57,8 @@ impl EcmascriptDevEvaluateChunk {
     }
 
     #[turbo_tasks::function]
-    async fn chunks_data(self: Vc<Self>) -> Result<Vc<ChunksData>> {
-        let this = self.await?;
+    async fn chunks_data(&self) -> Result<Vc<ChunksData>> {
+        let this = self;
         Ok(ChunkData::from_assets(
             this.chunking_context.output_root(),
             this.other_chunks,

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
@@ -70,8 +70,8 @@ impl EcmascriptDevChunkListContent {
 
     /// Computes the version of this content.
     #[turbo_tasks::function]
-    pub async fn version(self: Vc<Self>) -> Result<Vc<EcmascriptDevChunkListVersion>> {
-        let this = self.await?;
+    pub async fn version(&self) -> Result<Vc<EcmascriptDevChunkListVersion>> {
+        let this = self;
 
         let mut by_merger = IndexMap::<_, Vec<_>>::new();
         let mut by_path = IndexMap::<_, _>::new();

--- a/turbopack/crates/turbopack-browser/src/ecmascript/merged/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/merged/content.rs
@@ -23,10 +23,9 @@ pub(super) struct EcmascriptDevMergedChunkContent {
 #[turbo_tasks::value_impl]
 impl EcmascriptDevMergedChunkContent {
     #[turbo_tasks::function]
-    pub async fn version(self: Vc<Self>) -> Result<Vc<EcmascriptDevMergedChunkVersion>> {
+    pub async fn version(&self) -> Result<Vc<EcmascriptDevMergedChunkVersion>> {
         Ok(EcmascriptDevMergedChunkVersion {
             versions: self
-                .await?
                 .contents
                 .iter()
                 .map(|content| async move { content.own_version().await })

--- a/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
@@ -69,12 +69,12 @@ pub struct RuntimeEntries(Vec<Vc<RuntimeEntry>>);
 impl RuntimeEntries {
     #[turbo_tasks::function]
     pub async fn resolve_entries(
-        self: Vc<Self>,
+        &self,
         asset_context: Vc<Box<dyn AssetContext>>,
     ) -> Result<Vc<EvaluatableAssets>> {
         let mut runtime_entries = Vec::new();
 
-        for reference in &self.await? {
+        for reference in &self.0 {
             let resolved_entries = reference.resolve_entry(asset_context).await?;
             runtime_entries.extend(&resolved_entries);
         }

--- a/turbopack/crates/turbopack-core/src/chunk/available_chunk_items.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/available_chunk_items.rs
@@ -65,8 +65,8 @@ impl AvailableChunkItems {
     }
 
     #[turbo_tasks::function]
-    pub async fn hash(self: Vc<Self>) -> Result<Vc<u64>> {
-        let this = self.await?;
+    pub async fn hash(&self) -> Result<Vc<u64>> {
+        let this = self;
         let mut hasher = Xxh3Hash64Hasher::new();
         if let Some(parent) = this.parent {
             hasher.write_value(parent.hash().await?);
@@ -88,10 +88,10 @@ impl AvailableChunkItems {
 
     #[turbo_tasks::function]
     pub async fn get(
-        self: Vc<Self>,
+        &self,
         chunk_item: Vc<Box<dyn ChunkItem>>,
     ) -> Result<Vc<OptionAvailableChunkItemInfo>> {
-        let this = self.await?;
+        let this = self;
         if let Some(&info) = this.chunk_items.await?.get(&chunk_item) {
             return Ok(Vc::cell(Some(info)));
         };

--- a/turbopack/crates/turbopack-core/src/chunk/data.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/data.rs
@@ -137,7 +137,7 @@ impl ChunkData {
 
     /// Returns [`OutputAsset`]s that this chunk data references.
     #[turbo_tasks::function]
-    pub async fn references(self: Vc<Self>) -> Result<Vc<OutputAssets>> {
-        Ok(self.await?.references)
+    pub async fn references(&self) -> Result<Vc<OutputAssets>> {
+        Ok(self.references)
     }
 }

--- a/turbopack/crates/turbopack-core/src/chunk/module_id_strategies.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/module_id_strategies.rs
@@ -43,9 +43,9 @@ impl GlobalModuleIdStrategy {
 #[turbo_tasks::value_impl]
 impl ModuleIdStrategy for GlobalModuleIdStrategy {
     #[turbo_tasks::function]
-    async fn get_module_id(self: Vc<Self>, ident: Vc<AssetIdent>) -> Result<Vc<ModuleId>> {
+    async fn get_module_id(&self, ident: Vc<AssetIdent>) -> Result<Vc<ModuleId>> {
         let ident_string = ident.to_string().await?.clone_value();
-        if let Some(module_id) = self.await?.module_id_map.get(&ident_string) {
+        if let Some(module_id) = self.module_id_map.get(&ident_string) {
             // dbg!(format!("Hit {}", ident.to_string().await?));
             return Ok(*module_id);
         }

--- a/turbopack/crates/turbopack-core/src/code_builder.rs
+++ b/turbopack/crates/turbopack-core/src/code_builder.rs
@@ -191,8 +191,8 @@ impl GenerateSourceMap for Code {
 impl Code {
     /// Returns the hash of the source code of this Code.
     #[turbo_tasks::function]
-    pub async fn source_code_hash(self: Vc<Self>) -> Result<Vc<u64>> {
-        let code = self.await?;
+    pub async fn source_code_hash(&self) -> Result<Vc<u64>> {
+        let code = self;
         let hash = hash_xxh3_hash64(code.source_code());
         Ok(Vc::cell(hash))
     }

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -263,8 +263,8 @@ impl CompileTimeInfo {
     }
 
     #[turbo_tasks::function]
-    pub async fn environment(self: Vc<Self>) -> Result<Vc<Environment>> {
-        Ok(self.await?.environment)
+    pub async fn environment(&self) -> Result<Vc<Environment>> {
+        Ok(self.environment)
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -66,8 +66,8 @@ pub enum ExecutionEnvironment {
 #[turbo_tasks::value_impl]
 impl Environment {
     #[turbo_tasks::function]
-    pub async fn compile_target(self: Vc<Self>) -> Result<Vc<CompileTarget>> {
-        let this = self.await?;
+    pub async fn compile_target(&self) -> Result<Vc<CompileTarget>> {
+        let this = self;
         Ok(match this.execution {
             ExecutionEnvironment::NodeJsBuildTime(node_env, ..)
             | ExecutionEnvironment::NodeJsLambda(node_env) => node_env.await?.compile_target,
@@ -78,8 +78,8 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
-    pub async fn runtime_versions(self: Vc<Self>) -> Result<Vc<RuntimeVersions>> {
-        let this = self.await?;
+    pub async fn runtime_versions(&self) -> Result<Vc<RuntimeVersions>> {
+        let this = self;
         Ok(match this.execution {
             ExecutionEnvironment::NodeJsBuildTime(node_env, ..)
             | ExecutionEnvironment::NodeJsLambda(node_env) => node_env.runtime_versions(),
@@ -95,8 +95,8 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
-    pub async fn node_externals(self: Vc<Self>) -> Result<Vc<bool>> {
-        let this = self.await?;
+    pub async fn node_externals(&self) -> Result<Vc<bool>> {
+        let this = self;
         Ok(match this.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Vc::cell(true)
@@ -108,8 +108,8 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
-    pub async fn supports_esm_externals(self: Vc<Self>) -> Result<Vc<bool>> {
-        let this = self.await?;
+    pub async fn supports_esm_externals(&self) -> Result<Vc<bool>> {
+        let this = self;
         Ok(match this.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Vc::cell(true)
@@ -121,8 +121,8 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
-    pub async fn supports_commonjs_externals(self: Vc<Self>) -> Result<Vc<bool>> {
-        let this = self.await?;
+    pub async fn supports_commonjs_externals(&self) -> Result<Vc<bool>> {
+        let this = self;
         Ok(match this.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Vc::cell(true)
@@ -134,8 +134,8 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
-    pub async fn supports_wasm(self: Vc<Self>) -> Result<Vc<bool>> {
-        let this = self.await?;
+    pub async fn supports_wasm(&self) -> Result<Vc<bool>> {
+        let this = self;
         Ok(match this.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Vc::cell(true)
@@ -147,8 +147,8 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
-    pub async fn resolve_extensions(self: Vc<Self>) -> Result<Vc<Vec<RcStr>>> {
-        let env = self.await?;
+    pub async fn resolve_extensions(&self) -> Result<Vc<Vec<RcStr>>> {
+        let env = self;
         Ok(match env.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Vc::cell(vec![".js".into(), ".node".into(), ".json".into()])
@@ -161,8 +161,8 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
-    pub async fn resolve_node_modules(self: Vc<Self>) -> Result<Vc<bool>> {
-        let env = self.await?;
+    pub async fn resolve_node_modules(&self) -> Result<Vc<bool>> {
+        let env = self;
         Ok(match env.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Vc::cell(true)
@@ -175,8 +175,8 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
-    pub async fn resolve_conditions(self: Vc<Self>) -> Result<Vc<Vec<RcStr>>> {
-        let env = self.await?;
+    pub async fn resolve_conditions(&self) -> Result<Vc<Vec<RcStr>>> {
+        let env = self;
         Ok(match env.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Vc::cell(vec!["node".into()])
@@ -190,8 +190,8 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
-    pub async fn cwd(self: Vc<Self>) -> Result<Vc<Option<RcStr>>> {
-        let env = self.await?;
+    pub async fn cwd(&self) -> Result<Vc<Option<RcStr>>> {
+        let env = self;
         Ok(match env.execution {
             ExecutionEnvironment::NodeJsBuildTime(env)
             | ExecutionEnvironment::NodeJsLambda(env) => env.await?.cwd,
@@ -200,8 +200,8 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
-    pub async fn rendering(self: Vc<Self>) -> Result<Vc<Rendering>> {
-        let env = self.await?;
+    pub async fn rendering(&self) -> Result<Vc<Rendering>> {
+        let env = self;
         Ok(match env.execution {
             ExecutionEnvironment::NodeJsBuildTime(_) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Rendering::Server.cell()
@@ -213,8 +213,8 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
-    pub async fn chunk_loading(self: Vc<Self>) -> Result<Vc<ChunkLoading>> {
-        let env = self.await?;
+    pub async fn chunk_loading(&self) -> Result<Vc<ChunkLoading>> {
+        let env = self;
         Ok(match env.execution {
             ExecutionEnvironment::NodeJsBuildTime(_) | ExecutionEnvironment::NodeJsLambda(_) => {
                 ChunkLoading::NodeJs.cell()
@@ -251,8 +251,8 @@ impl Default for NodeJsEnvironment {
 #[turbo_tasks::value_impl]
 impl NodeJsEnvironment {
     #[turbo_tasks::function]
-    pub async fn runtime_versions(self: Vc<Self>) -> Result<Vc<RuntimeVersions>> {
-        let str = match *self.await?.node_version.await? {
+    pub async fn runtime_versions(&self) -> Result<Vc<RuntimeVersions>> {
+        let str = match *self.node_version.await? {
             NodeJsVersion::Current(process_env) => get_current_nodejs_version(process_env),
             NodeJsVersion::Static(version) => version,
         }

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -223,8 +223,8 @@ impl ValueToString for IssueProcessingPathItem {
 #[turbo_tasks::value_impl]
 impl IssueProcessingPathItem {
     #[turbo_tasks::function]
-    pub async fn into_plain(self: Vc<Self>) -> Result<Vc<PlainIssueProcessingPathItem>> {
-        let this = self.await?;
+    pub async fn into_plain(&self) -> Result<Vc<PlainIssueProcessingPathItem>> {
+        let this = self;
         Ok(PlainIssueProcessingPathItem {
             file_path: if let Some(context) = this.file_path {
                 Some(context.to_string().await?)
@@ -369,8 +369,8 @@ pub struct CapturedIssues {
 #[turbo_tasks::value_impl]
 impl CapturedIssues {
     #[turbo_tasks::function]
-    pub async fn is_empty(self: Vc<Self>) -> Result<Vc<bool>> {
-        Ok(Vc::cell(self.await?.is_empty_ref()))
+    pub async fn is_empty(&self) -> Result<Vc<bool>> {
+        Ok(Vc::cell(self.is_empty_ref()))
     }
 }
 
@@ -762,8 +762,8 @@ impl PlainIssue {
     /// same issue to pass from multiple processing paths, making for overly
     /// verbose logging.
     #[turbo_tasks::function]
-    pub async fn internal_hash(self: Vc<Self>, full: bool) -> Result<Vc<u64>> {
-        Ok(Vc::cell(self.await?.internal_hash_ref(full)))
+    pub async fn internal_hash(&self, full: bool) -> Result<Vc<u64>> {
+        Ok(Vc::cell(self.internal_hash_ref(full)))
     }
 }
 
@@ -777,8 +777,8 @@ pub struct PlainIssueSource {
 #[turbo_tasks::value_impl]
 impl IssueSource {
     #[turbo_tasks::function]
-    pub async fn into_plain(self: Vc<Self>) -> Result<Vc<PlainIssueSource>> {
-        let this = self.await?;
+    pub async fn into_plain(&self) -> Result<Vc<PlainIssueSource>> {
+        let this = self;
         Ok(PlainIssueSource {
             asset: PlainSource::from_source(this.source).await?,
             range: match this.range {

--- a/turbopack/crates/turbopack-core/src/output.rs
+++ b/turbopack/crates/turbopack-core/src/output.rs
@@ -33,8 +33,8 @@ impl OutputAssets {
     }
 
     #[turbo_tasks::function]
-    pub async fn concatenate(self: Vc<Self>, other: Vc<Self>) -> Result<Vc<Self>> {
-        let mut assets: IndexSet<_> = self.await?.iter().copied().collect();
+    pub async fn concatenate(&self, other: Vc<Self>) -> Result<Vc<Self>> {
+        let mut assets: IndexSet<_> = self.0.iter().copied().collect();
         assets.extend(other.await?.iter().copied());
         Ok(Vc::cell(assets.into_iter().collect()))
     }

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -86,8 +86,8 @@ impl SingleModuleReference {
 
     /// The [Vc<Box<dyn Asset>>] that this reference resolves to.
     #[turbo_tasks::function]
-    pub async fn asset(self: Vc<Self>) -> Result<Vc<Box<dyn Module>>> {
-        Ok(self.await?.asset)
+    pub async fn asset(&self) -> Result<Vc<Box<dyn Module>>> {
+        Ok(self.asset)
     }
 }
 
@@ -132,8 +132,8 @@ impl SingleOutputAssetReference {
 
     /// The [Vc<Box<dyn Asset>>] that this reference resolves to.
     #[turbo_tasks::function]
-    pub async fn asset(self: Vc<Self>) -> Result<Vc<Box<dyn OutputAsset>>> {
-        Ok(self.await?.asset)
+    pub async fn asset(&self) -> Result<Vc<Box<dyn OutputAsset>>> {
+        Ok(self.asset)
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -319,14 +319,14 @@ impl ModuleResolveResult {
     }
 
     #[turbo_tasks::function]
-    pub async fn is_unresolveable(self: Vc<Self>) -> Result<Vc<bool>> {
-        let this = self.await?;
+    pub async fn is_unresolveable(&self) -> Result<Vc<bool>> {
+        let this = self;
         Ok(Vc::cell(this.is_unresolveable_ref()))
     }
 
     #[turbo_tasks::function]
-    pub async fn first_module(self: Vc<Self>) -> Result<Vc<OptionModule>> {
-        let this = self.await?;
+    pub async fn first_module(&self) -> Result<Vc<OptionModule>> {
+        let this = self;
         Ok(Vc::cell(this.primary.iter().find_map(
             |(_, item)| match item {
                 &ModuleResolveResultItem::Module(a) => Some(a),
@@ -338,8 +338,8 @@ impl ModuleResolveResult {
     /// Returns a set (no duplicates) of primary modules in the result. All
     /// modules are already resolved Vc.
     #[turbo_tasks::function]
-    pub async fn primary_modules(self: Vc<Self>) -> Result<Vc<Modules>> {
-        let this = self.await?;
+    pub async fn primary_modules(&self) -> Result<Vc<Modules>> {
+        let this = self;
         let mut iter = this.primary_modules_iter();
         let Some(first) = iter.next() else {
             return Ok(Vc::cell(vec![]));
@@ -360,8 +360,8 @@ impl ModuleResolveResult {
     }
 
     #[turbo_tasks::function]
-    pub async fn primary_output_assets(self: Vc<Self>) -> Result<Vc<OutputAssets>> {
-        let this = self.await?;
+    pub async fn primary_output_assets(&self) -> Result<Vc<OutputAssets>> {
+        let this = self;
         Ok(Vc::cell(
             this.primary
                 .iter()
@@ -746,9 +746,8 @@ impl ResolveResult {
 #[turbo_tasks::value_impl]
 impl ResolveResult {
     #[turbo_tasks::function]
-    pub async fn as_raw_module_result(self: Vc<Self>) -> Result<Vc<ModuleResolveResult>> {
+    pub async fn as_raw_module_result(&self) -> Result<Vc<ModuleResolveResult>> {
         Ok(self
-            .await?
             .map_module(|asset| async move {
                 Ok(ModuleResolveResultItem::Module(Vc::upcast(RawModule::new(
                     asset,
@@ -852,14 +851,14 @@ impl ResolveResult {
     }
 
     #[turbo_tasks::function]
-    pub async fn is_unresolveable(self: Vc<Self>) -> Result<Vc<bool>> {
-        let this = self.await?;
+    pub async fn is_unresolveable(&self) -> Result<Vc<bool>> {
+        let this = self;
         Ok(Vc::cell(this.is_unresolveable_ref()))
     }
 
     #[turbo_tasks::function]
-    pub async fn first_source(self: Vc<Self>) -> Result<Vc<OptionSource>> {
-        let this = self.await?;
+    pub async fn first_source(&self) -> Result<Vc<OptionSource>> {
+        let this = self;
         Ok(Vc::cell(this.primary.iter().find_map(|(_, item)| {
             if let &ResolveResultItem::Source(a) = item {
                 Some(a)
@@ -870,8 +869,8 @@ impl ResolveResult {
     }
 
     #[turbo_tasks::function]
-    pub async fn primary_sources(self: Vc<Self>) -> Result<Vc<Sources>> {
-        let this = self.await?;
+    pub async fn primary_sources(&self) -> Result<Vc<Sources>> {
+        let this = self;
         Ok(Vc::cell(
             this.primary
                 .iter()
@@ -892,11 +891,11 @@ impl ResolveResult {
     /// some, they are discarded.
     #[turbo_tasks::function]
     pub async fn with_replaced_request_key(
-        self: Vc<Self>,
+        &self,
         old_request_key: RcStr,
         request_key: Value<RequestKey>,
     ) -> Result<Vc<Self>> {
-        let this = self.await?;
+        let this = self;
         let request_key = request_key.into_value();
         let new_primary = this
             .primary
@@ -928,13 +927,13 @@ impl ResolveResult {
     /// if there are still some, they are discarded.
     #[turbo_tasks::function]
     pub async fn with_replaced_request_key_pattern(
-        self: Vc<Self>,
+        &self,
         old_request_key: Vc<Pattern>,
         request_key: Vc<Pattern>,
     ) -> Result<Vc<Self>> {
         let old_request_key = &*old_request_key.await?;
         let request_key = &*request_key.await?;
-        let this = self.await?;
+        let this = self;
         let new_primary = this
             .primary
             .iter()
@@ -962,8 +961,8 @@ impl ResolveResult {
     /// Returns a new [ResolveResult] where all [RequestKey]s are set to the
     /// passed `request`.
     #[turbo_tasks::function]
-    pub async fn with_request(self: Vc<Self>, request: RcStr) -> Result<Vc<Self>> {
-        let this = self.await?;
+    pub async fn with_request(&self, request: RcStr) -> Result<Vc<Self>> {
+        let this = self;
         let new_primary = this
             .primary
             .iter()

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -444,12 +444,12 @@ impl ImportMap {
 impl ResolvedMap {
     #[turbo_tasks::function]
     pub async fn lookup(
-        self: Vc<Self>,
+        &self,
         resolved: Vc<FileSystemPath>,
         lookup_path: Vc<FileSystemPath>,
         request: Vc<Request>,
     ) -> Result<Vc<ImportMapResult>> {
-        let this = self.await?;
+        let this = self;
         let resolved = resolved.await?;
         for (root, glob, mapping) in this.by_glob.iter() {
             let root = root.await?;

--- a/turbopack/crates/turbopack-core/src/resolve/plugin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/plugin.rs
@@ -22,8 +22,8 @@ impl AfterResolvePluginCondition {
     }
 
     #[turbo_tasks::function]
-    pub async fn matches(self: Vc<Self>, fs_path: Vc<FileSystemPath>) -> Result<Vc<bool>> {
-        let this = self.await?;
+    pub async fn matches(&self, fs_path: Vc<FileSystemPath>) -> Result<Vc<bool>> {
+        let this = self;
         let root = this.root.await?;
         let glob = this.glob.await?;
 

--- a/turbopack/crates/turbopack-core/src/source_transform.rs
+++ b/turbopack/crates/turbopack-core/src/source_transform.rs
@@ -14,12 +14,9 @@ pub struct SourceTransforms(Vec<Vc<Box<dyn SourceTransform>>>);
 #[turbo_tasks::value_impl]
 impl SourceTransforms {
     #[turbo_tasks::function]
-    pub async fn transform(
-        self: Vc<Self>,
-        source: Vc<Box<dyn Source>>,
-    ) -> Result<Vc<Box<dyn Source>>> {
+    pub async fn transform(&self, source: Vc<Box<dyn Source>>) -> Result<Vc<Box<dyn Source>>> {
         Ok(self
-            .await?
+            .0
             .iter()
             .fold(source, |source, transform| transform.transform(source)))
     }

--- a/turbopack/crates/turbopack-core/src/version.rs
+++ b/turbopack/crates/turbopack-core/src/version.rs
@@ -250,8 +250,8 @@ pub struct VersionState {
 #[turbo_tasks::value_impl]
 impl VersionState {
     #[turbo_tasks::function]
-    pub async fn get(self: Vc<Self>) -> Result<Vc<Box<dyn Version>>> {
-        let this = self.await?;
+    pub async fn get(&self) -> Result<Vc<Box<dyn Version>>> {
+        let this = self;
         let version = TraitRef::cell(this.version.get().clone());
         Ok(version)
     }

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -65,8 +65,8 @@ impl CssModuleAsset {
 
     /// Retrns the asset ident of the source without the "css" modifier
     #[turbo_tasks::function]
-    pub async fn source_ident(self: Vc<Self>) -> Result<Vc<AssetIdent>> {
-        Ok(self.await?.source.ident())
+    pub async fn source_ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self.source.ident())
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -232,8 +232,8 @@ fn chunk_item_key() -> Vc<RcStr> {
 #[turbo_tasks::value_impl]
 impl OutputAsset for CssChunk {
     #[turbo_tasks::function]
-    async fn ident(self: Vc<Self>) -> Result<Vc<AssetIdent>> {
-        let this = self.await?;
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        let this = self;
 
         let mut assets = Vec::new();
 

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -152,8 +152,8 @@ struct ModuleCssClasses(IndexMap<String, Vec<ModuleCssClass>>);
 #[turbo_tasks::value_impl]
 impl ModuleCssAsset {
     #[turbo_tasks::function]
-    async fn inner(self: Vc<Self>) -> Result<Vc<ProcessResult>> {
-        let this = self.await?;
+    async fn inner(&self) -> Result<Vc<ProcessResult>> {
+        let this = self;
         Ok(this.asset_context.process(
             this.source,
             Value::new(ReferenceType::Css(CssReferenceSubType::Internal)),

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -126,8 +126,8 @@ impl DevHtmlAsset {
     }
 
     #[turbo_tasks::function]
-    async fn chunks(self: Vc<Self>) -> Result<Vc<OutputAssets>> {
-        let this = self.await?;
+    async fn chunks(&self) -> Result<Vc<OutputAssets>> {
+        let this = self;
 
         let all_assets = this
             .entries
@@ -180,8 +180,8 @@ impl DevHtmlAssetContent {
 #[turbo_tasks::value_impl]
 impl DevHtmlAssetContent {
     #[turbo_tasks::function]
-    async fn content(self: Vc<Self>) -> Result<Vc<AssetContent>> {
-        let this = self.await?;
+    async fn content(&self) -> Result<Vc<AssetContent>> {
+        let this = self;
 
         let mut scripts = Vec::new();
         let mut stylesheets = Vec::new();

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -88,8 +88,8 @@ impl AssetGraphContentSource {
     }
 
     #[turbo_tasks::function]
-    async fn all_assets_map(self: Vc<Self>) -> Result<Vc<OutputAssetsMap>> {
-        let this = self.await?;
+    async fn all_assets_map(&self) -> Result<Vc<OutputAssetsMap>> {
+        let this = self;
         Ok(Vc::cell(
             expand(
                 &*this.root_assets.await?,

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
@@ -30,8 +30,8 @@ pub struct AsyncLoaderChunkItem {
 #[turbo_tasks::value_impl]
 impl AsyncLoaderChunkItem {
     #[turbo_tasks::function]
-    pub(super) async fn chunks(self: Vc<Self>) -> Result<Vc<OutputAssets>> {
-        let this = self.await?;
+    pub(super) async fn chunks(&self) -> Result<Vc<OutputAssets>> {
+        let this = self;
         let module = this.module.await?;
         if let Some(chunk_items) = module.availability_info.available_chunk_items() {
             if chunk_items

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -78,8 +78,8 @@ impl EcmascriptChunkItemContent {
     }
 
     #[turbo_tasks::function]
-    pub async fn module_factory(self: Vc<Self>) -> Result<Vc<Code>> {
-        let this = self.await?;
+    pub async fn module_factory(&self) -> Result<Vc<Code>> {
+        let this = self;
         let mut args = vec![
             "r: __turbopack_require__",
             "f: __turbopack_module_context__",

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -76,8 +76,8 @@ fn availability_root_key() -> Vc<RcStr> {
 #[turbo_tasks::value_impl]
 impl Chunk for EcmascriptChunk {
     #[turbo_tasks::function]
-    async fn ident(self: Vc<Self>) -> Result<Vc<AssetIdent>> {
-        let this = self.await?;
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        let this = self;
 
         let mut assets = Vec::new();
 
@@ -135,8 +135,8 @@ impl Chunk for EcmascriptChunk {
     }
 
     #[turbo_tasks::function]
-    async fn references(self: Vc<Self>) -> Result<Vc<OutputAssets>> {
-        let this = self.await?;
+    async fn references(&self) -> Result<Vc<OutputAssets>> {
+        let this = self;
         let content = this.content.await?;
         Ok(Vc::cell(content.referenced_output_assets.clone()))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
@@ -124,8 +124,8 @@ struct ChunkGroupFilesChunkItem {
 #[turbo_tasks::value_impl]
 impl ChunkGroupFilesChunkItem {
     #[turbo_tasks::function]
-    async fn chunks(self: Vc<Self>) -> Result<Vc<OutputAssets>> {
-        let this = self.await?;
+    async fn chunks(&self) -> Result<Vc<OutputAssets>> {
+        let this = self;
         let inner = this.inner.await?;
         let chunks = if let Some(ecma) =
             Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(inner.module).await?
@@ -250,11 +250,11 @@ impl Introspectable for ChunkGroupFilesAsset {
     }
 
     #[turbo_tasks::function]
-    async fn children(self: Vc<Self>) -> Result<Vc<IntrospectableChildren>> {
+    async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         let mut children = IndexSet::new();
         children.insert((
             Vc::cell("inner asset".into()),
-            IntrospectableModule::new(Vc::upcast(self.await?.module)),
+            IntrospectableModule::new(Vc::upcast(self.module)),
         ));
         Ok(Vc::cell(children))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -357,8 +357,8 @@ impl EcmascriptParsable for EcmascriptModuleAsset {
     }
 
     #[turbo_tasks::function]
-    async fn ty(self: Vc<Self>) -> Result<Vc<EcmascriptModuleAssetType>> {
-        Ok(self.await?.ty.cell())
+    async fn ty(&self) -> Result<Vc<EcmascriptModuleAssetType>> {
+        Ok(self.ty.cell())
     }
 }
 
@@ -461,8 +461,8 @@ impl EcmascriptModuleAsset {
     }
 
     #[turbo_tasks::function]
-    pub async fn source(self: Vc<Self>) -> Result<Vc<Box<dyn Source>>> {
-        Ok(self.await?.source)
+    pub async fn source(&self) -> Result<Vc<Box<dyn Source>>> {
+        Ok(self.source)
     }
 
     #[turbo_tasks::function]
@@ -471,8 +471,8 @@ impl EcmascriptModuleAsset {
     }
 
     #[turbo_tasks::function]
-    pub async fn options(self: Vc<Self>) -> Result<Vc<EcmascriptOptions>> {
-        Ok(self.await?.options)
+    pub async fn options(&self) -> Result<Vc<EcmascriptOptions>> {
+        Ok(self.options)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -52,8 +52,8 @@ impl ManifestAsyncModule {
     }
 
     #[turbo_tasks::function]
-    pub(super) async fn chunks(self: Vc<Self>) -> Result<Vc<OutputAssets>> {
-        let this = self.await?;
+    pub(super) async fn chunks(&self) -> Result<Vc<OutputAssets>> {
+        let this = self;
         Ok(this
             .chunking_context
             .chunk_group_assets(Vc::upcast(this.inner), Value::new(this.availability_info)))

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
@@ -29,8 +29,8 @@ pub(super) struct ManifestChunkItem {
 #[turbo_tasks::value_impl]
 impl ManifestChunkItem {
     #[turbo_tasks::function]
-    async fn chunks_data(self: Vc<Self>) -> Result<Vc<ChunksData>> {
-        let this = self.await?;
+    async fn chunks_data(&self) -> Result<Vc<ChunksData>> {
+        let this = self;
         Ok(ChunkData::from_assets(
             this.chunking_context.output_root(),
             this.manifest.chunks(),

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
@@ -58,8 +58,8 @@ impl ManifestLoaderChunkItem {
     }
 
     #[turbo_tasks::function]
-    pub async fn chunks_data(self: Vc<Self>) -> Result<Vc<ChunksData>> {
-        let this = self.await?;
+    pub async fn chunks_data(&self) -> Result<Vc<ChunksData>> {
+        let this = self;
         let chunks = this.manifest.manifest_chunks();
         Ok(ChunkData::from_assets(
             this.chunking_context.output_root(),

--- a/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
@@ -174,7 +174,7 @@ impl AsyncModule {
     /// Returns
     #[turbo_tasks::function]
     pub async fn module_options(
-        self: Vc<Self>,
+        &self,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Vc<OptionAsyncModuleOptions>> {
         if async_module_info.is_none() {
@@ -182,7 +182,7 @@ impl AsyncModule {
         }
 
         Ok(Vc::cell(Some(AsyncModuleOptions {
-            has_top_level_await: self.await?.has_top_level_await,
+            has_top_level_await: self.has_top_level_await,
         })))
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/binding.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/binding.rs
@@ -151,10 +151,10 @@ impl EsmBinding {
 impl CodeGenerateable for EsmBindings {
     #[turbo_tasks::function]
     async fn code_generation(
-        self: Vc<Self>,
+        &self,
         _context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
-        let this = self.await?;
+        let this = self;
         let mut visitors = Vec::new();
         let bindings = this.bindings.clone();
 

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -40,9 +40,9 @@ impl EcmascriptModuleFacadeModule {
     }
 
     #[turbo_tasks::function]
-    pub async fn async_module(self: Vc<Self>) -> Result<Vc<AsyncModule>> {
+    pub async fn async_module(&self) -> Result<Vc<AsyncModule>> {
         let (import_externals, has_top_level_await) =
-            if let Some(async_module) = *self.await?.module.get_async_module().await? {
+            if let Some(async_module) = *self.module.get_async_module().await? {
                 (
                     async_module.await?.import_externals,
                     async_module.await?.has_top_level_await,

--- a/turbopack/crates/turbopack-ecmascript/src/static_code.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/static_code.rs
@@ -47,8 +47,8 @@ impl StaticEcmascriptCode {
     /// Computes the contents of the asset and pushes it to
     /// the code builder, including the source map if available.
     #[turbo_tasks::function]
-    pub async fn code(self: Vc<Self>) -> Result<Vc<Code>> {
-        let this = self.await?;
+    pub async fn code(&self) -> Result<Vc<Code>> {
+        let this = self;
         let runtime_base_content = this.asset.module_content_without_analysis().await?;
         let mut code = CodeBuilder::default();
         code.push_source(

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -33,8 +33,8 @@ pub struct EcmascriptModulePartAsset {
 #[turbo_tasks::value_impl]
 impl EcmascriptParsable for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
-    async fn failsafe_parse(self: Vc<Self>) -> Result<Vc<ParseResult>> {
-        let this = self.await?;
+    async fn failsafe_parse(&self) -> Result<Vc<ParseResult>> {
+        let this = self;
 
         let parsed = this.full_module.failsafe_parse();
         let split_data = split(
@@ -59,27 +59,24 @@ impl EcmascriptParsable for EcmascriptModulePartAsset {
 #[turbo_tasks::value_impl]
 impl EcmascriptAnalyzable for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
-    async fn analyze(self: Vc<Self>) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
-        let this = self.await?;
+    async fn analyze(&self) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
+        let this = self;
         let part = this.part;
         Ok(analyse_ecmascript_module(this.full_module, Some(part)))
     }
 
     #[turbo_tasks::function]
-    async fn module_content_without_analysis(
-        self: Vc<Self>,
-    ) -> Result<Vc<EcmascriptModuleContent>> {
-        Ok(self.await?.full_module.module_content_without_analysis())
+    async fn module_content_without_analysis(&self) -> Result<Vc<EcmascriptModuleContent>> {
+        Ok(self.full_module.module_content_without_analysis())
     }
 
     #[turbo_tasks::function]
     async fn module_content(
-        self: Vc<Self>,
+        &self,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Vc<EcmascriptModuleContent>> {
         Ok(self
-            .await?
             .full_module
             .module_content(chunking_context, async_module_info))
     }
@@ -275,8 +272,8 @@ impl ChunkableModule for EcmascriptModulePartAsset {
 #[turbo_tasks::value_impl]
 impl EcmascriptModulePartAsset {
     #[turbo_tasks::function]
-    pub(super) async fn analyze(self: Vc<Self>) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
-        let this = self.await?;
+    pub(super) async fn analyze(&self) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
+        let this = self;
 
         Ok(analyze(this.full_module, this.part))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
@@ -32,10 +32,10 @@ impl EcmascriptChunkItem for EcmascriptModulePartChunkItem {
 
     #[turbo_tasks::function]
     async fn content_with_async_module_info(
-        self: Vc<Self>,
+        &self,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Vc<EcmascriptChunkItemContent>> {
-        let this = self.await?;
+        let this = self;
         let module = this.module.await?;
 
         let split_data = split_module(module.full_module);

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -35,8 +35,8 @@ pub fn worker_modifier() -> Vc<RcStr> {
 #[turbo_tasks::value_impl]
 impl WorkerLoaderChunkItem {
     #[turbo_tasks::function]
-    async fn chunks(self: Vc<Self>) -> Result<Vc<OutputAssets>> {
-        let this = self.await?;
+    async fn chunks(&self) -> Result<Vc<OutputAssets>> {
+        let this = self;
         let module = this.module.await?;
 
         let Some(evaluatable) =

--- a/turbopack/crates/turbopack-mdx/src/lib.rs
+++ b/turbopack/crates/turbopack-mdx/src/lib.rs
@@ -134,8 +134,8 @@ impl Asset for MdxTransformedAsset {
 #[turbo_tasks::value_impl]
 impl MdxTransformedAsset {
     #[turbo_tasks::function]
-    async fn process(self: Vc<Self>) -> Result<Vc<MdxTransformResult>> {
-        let this = self.await?;
+    async fn process(&self) -> Result<Vc<MdxTransformResult>> {
+        let this = self;
         let content = this.source.content().await?;
         let transform_options = this.options.await?;
 

--- a/turbopack/crates/turbopack-node/src/execution_context.rs
+++ b/turbopack/crates/turbopack-node/src/execution_context.rs
@@ -28,17 +28,17 @@ impl ExecutionContext {
     }
 
     #[turbo_tasks::function]
-    pub async fn project_path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
-        Ok(self.await?.project_path)
+    pub async fn project_path(&self) -> Result<Vc<FileSystemPath>> {
+        Ok(self.project_path)
     }
 
     #[turbo_tasks::function]
-    pub async fn chunking_context(self: Vc<Self>) -> Result<Vc<Box<dyn ChunkingContext>>> {
-        Ok(self.await?.chunking_context)
+    pub async fn chunking_context(&self) -> Result<Vc<Box<dyn ChunkingContext>>> {
+        Ok(self.chunking_context)
     }
 
     #[turbo_tasks::function]
-    pub async fn env(self: Vc<Self>) -> Result<Vc<Box<dyn ProcessEnv>>> {
-        Ok(self.await?.env)
+    pub async fn env(&self) -> Result<Vc<Box<dyn ProcessEnv>>> {
+        Ok(self.env)
     }
 }

--- a/turbopack/crates/turbopack-node/src/render/node_api_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/node_api_source.rs
@@ -71,8 +71,8 @@ pub struct NodeApiContentSource {
 #[turbo_tasks::value_impl]
 impl NodeApiContentSource {
     #[turbo_tasks::function]
-    pub async fn get_pathname(self: Vc<Self>) -> Result<Vc<RcStr>> {
-        Ok(self.await?.pathname)
+    pub async fn get_pathname(&self) -> Result<Vc<RcStr>> {
+        Ok(self.pathname)
     }
 }
 

--- a/turbopack/crates/turbopack-node/src/render/rendered_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/rendered_source.rs
@@ -99,8 +99,8 @@ pub struct NodeRenderContentSource {
 #[turbo_tasks::value_impl]
 impl NodeRenderContentSource {
     #[turbo_tasks::function]
-    pub async fn get_pathname(self: Vc<Self>) -> Result<Vc<RcStr>> {
-        Ok(self.await?.pathname)
+    pub async fn get_pathname(&self) -> Result<Vc<RcStr>> {
+        Ok(self.pathname)
     }
 }
 

--- a/turbopack/crates/turbopack-node/src/source_map/trace.rs
+++ b/turbopack/crates/turbopack-node/src/source_map/trace.rs
@@ -128,8 +128,8 @@ impl SourceMapTrace {
     /// the individual sections of the JS file's map without the
     /// serialization.
     #[turbo_tasks::function]
-    pub async fn trace(self: Vc<Self>) -> Result<Vc<TraceResult>> {
-        let this = self.await?;
+    pub async fn trace(&self) -> Result<Vc<TraceResult>> {
+        let this = self;
 
         let token = this
             .map

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -424,8 +424,8 @@ impl GenerateSourceMap for PostCssTransformedAsset {
 #[turbo_tasks::value_impl]
 impl PostCssTransformedAsset {
     #[turbo_tasks::function]
-    async fn process(self: Vc<Self>) -> Result<Vc<ProcessPostCssResult>> {
-        let this = self.await?;
+    async fn process(&self) -> Result<Vc<ProcessPostCssResult>> {
+        let this = self;
         let ExecutionContext {
             project_path,
             chunking_context,

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -363,11 +363,8 @@ impl ChunkingContext for NodeJsChunkingContext {
     }
 
     #[turbo_tasks::function]
-    async fn chunk_item_id_from_ident(
-        self: Vc<Self>,
-        ident: Vc<AssetIdent>,
-    ) -> Result<Vc<ModuleId>> {
-        Ok(self.await?.module_id_strategy.get_module_id(ident))
+    async fn chunk_item_id_from_ident(&self, ident: Vc<AssetIdent>) -> Result<Vc<ModuleId>> {
+        Ok(self.module_id_strategy.get_module_id(ident))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -109,8 +109,8 @@ impl EcmascriptBuildNodeChunkContent {
     }
 
     #[turbo_tasks::function]
-    pub(crate) async fn own_version(self: Vc<Self>) -> Result<Vc<EcmascriptBuildNodeChunkVersion>> {
-        let this = self.await?;
+    pub(crate) async fn own_version(&self) -> Result<Vc<EcmascriptBuildNodeChunkVersion>> {
+        let this = self;
         Ok(EcmascriptBuildNodeChunkVersion::new(
             this.chunking_context.output_root(),
             this.chunk.ident().path(),

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -144,8 +144,8 @@ impl EcmascriptBuildNodeEntryChunk {
     }
 
     #[turbo_tasks::function]
-    async fn runtime_chunk(self: Vc<Self>) -> Result<Vc<EcmascriptBuildNodeRuntimeChunk>> {
-        let this = self.await?;
+    async fn runtime_chunk(&self) -> Result<Vc<EcmascriptBuildNodeRuntimeChunk>> {
+        let this = self;
         Ok(EcmascriptBuildNodeRuntimeChunk::new(this.chunking_context))
     }
 }

--- a/turbopack/crates/turbopack-static/src/lib.rs
+++ b/turbopack/crates/turbopack-static/src/lib.rs
@@ -61,10 +61,10 @@ impl StaticModuleAsset {
 
     #[turbo_tasks::function]
     async fn static_asset(
-        self: Vc<Self>,
+        &self,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<StaticAsset>> {
-        Ok(StaticAsset::new(chunking_context, self.await?.source))
+        Ok(StaticAsset::new(chunking_context, self.source))
     }
 }
 

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -368,18 +368,18 @@ impl ModuleAssetContext {
     }
 
     #[turbo_tasks::function]
-    pub async fn module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
-        Ok(self.await?.module_options_context)
+    pub async fn module_options_context(&self) -> Result<Vc<ModuleOptionsContext>> {
+        Ok(self.module_options_context)
     }
 
     #[turbo_tasks::function]
-    pub async fn resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
-        Ok(self.await?.resolve_options_context)
+    pub async fn resolve_options_context(&self) -> Result<Vc<ResolveOptionsContext>> {
+        Ok(self.resolve_options_context)
     }
 
     #[turbo_tasks::function]
-    pub async fn is_types_resolving_enabled(self: Vc<Self>) -> Result<Vc<bool>> {
-        let resolve_options_context = self.await?.resolve_options_context.await?;
+    pub async fn is_types_resolving_enabled(&self) -> Result<Vc<bool>> {
+        let resolve_options_context = self.resolve_options_context.await?;
         Ok(Vc::cell(
             resolve_options_context.enable_types && resolve_options_context.enable_typescript,
         ))
@@ -769,12 +769,8 @@ impl AssetContext for ModuleAssetContext {
     }
 
     #[turbo_tasks::function]
-    async fn side_effect_free_packages(self: Vc<Self>) -> Result<Vc<Glob>> {
-        let pkgs = &*self
-            .await?
-            .module_options_context
-            .await?
-            .side_effect_free_packages;
+    async fn side_effect_free_packages(&self) -> Result<Vc<Glob>> {
+        let pkgs = &*self.module_options_context.await?.side_effect_free_packages;
 
         let mut globs = Vec::with_capacity(pkgs.len());
 


### PR DESCRIPTION
Noticed this pattern while touching `turbo-tasks-fs`.

Functions that take `self: Vc<Self>` and immediately await it without ever using the `Vc` version of the argument should just take `&self` as an argument.

Follow-ups:

- [x] If we have a trivial `let this = self` or `let this = &self.0`, we should rewrite references to `this` to use `self`. *Done in #70431*
- [x] If we can be sure that a function never returns anything other than `Ok(...)`, we should remove `Result` from the return type. *Done in #70492*
- [x] If a function is `async`, but has no `.await`, remove the `async` keyword. *Done in #70474*

Those changes need to be performed as a separate codemod pass due to limitations with `ast-grep`.

## How?

ast-grep: https://ast-grep.github.io/

Using the ast-grep config: https://gist.github.com/bgw/b7bc0a921cf3e3447acaf8feda60b518

Ran it with:

```
sg scan -U -r ../codemod_rewrite_vc_self.yml .
```

## Should this be a lint?

**Maybe.** I've managed to get the false-positive rate down to zero on our existing codebase (at the cost of missing some opportunities for cleanup).

ast-grep supports running as a lint rule, and this can be autofixed. However, if we fix the `let this = ...` and `Result<...>` cases as well with additional lint rules, **this might be a bit annoying as it'll trigger cascading lint rules**. You *might* need to run the linter multiple times for it to eventually settle.

It does not appear to be possible to do all these changes in a single lint rule, as we require modifying overlapping ranges of code (which ast-grep sadly doesn't seem to support with the `rewriters` rules).

We should also consider `dynlint` before heavily investing into `ast-grep` as a linter: https://github.com/trailofbits/dylint