### PR TITLE
chore(gitattributes): Mark more __snapshots__ directories as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,4 +8,4 @@ turbopack/crates/turbo-tasks-macros-tests/tests/**/*.stderr linguist-generated=t
 turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/**/output.md linguist-generated=true
 turbopack/crates/turbopack-tests/tests/snapshot/**/output/** linguist-generated=true
 
-.config/ast-grep/rule-tests/__snapshots__/** linguist-generated=true
+**/__snapshots__/** linguist-generated=true


### PR DESCRIPTION
Noticed these files while reviewing https://github.com/vercel/next.js/pull/70242

Mark them as generated so that github & graphite collapse them when reviewing code.

```
$ git ls-files | git check-attr -a --stdin | grep __snapshots__
```

```
.config/ast-grep/rule-tests/__snapshots__/no-context-snapshot.yml: linguist-generated: true
examples/with-jest-babel/__tests__/__snapshots__/snapshot.tsx.snap: linguist-generated: true
examples/with-jest/__tests__/__snapshots__/snapshot.tsx.snap: linguist-generated: true
examples/with-typescript-graphql/test/__snapshots__/index.test.tsx.snap: linguist-generated: true
test/development/acceptance-app/__snapshots__/ReactRefreshLogBox.test.ts.snap: linguist-generated: true
test/development/acceptance/__snapshots__/ReactRefreshLogBox.test.ts.snap: linguist-generated: true
test/development/acceptance/__snapshots__/ReactRefreshLogBoxMisc.test.ts.snap: linguist-generated: true
test/development/acceptance/__snapshots__/error-recovery.test.ts.snap: linguist-generated: true
test/development/basic/__snapshots__/next-rs-api.test.ts.snap: linguist-generated: true
test/production/eslint/test/__snapshots__/next-build-and-lint.test.ts.snap: linguist-generated: true
```