### PR TITLE
filter x-middleware-set-cookie from response

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -2404,10 +2404,6 @@ export function collectMeta({
     // normalize header values as initialHeaders
     // must be Record<string, string>
     for (const key in headers) {
-      // set-cookie is already handled - the middleware cookie setting case
-      // isn't needed for the prerender manifest since it can't read cookies
-      if (key === 'x-middleware-set-cookie') continue
-
       let value = headers[key]
 
       if (Array.isArray(value)) {

--- a/packages/next/src/server/async-storage/with-request-store.ts
+++ b/packages/next/src/server/async-storage/with-request-store.ts
@@ -83,7 +83,7 @@ type RequestResponsePair =
   | { req: NextRequest; res: undefined } // in an api route or middleware
 
 /**
- * If middleware set cookies in this request (indicated by `x-middleware-set-cookie`),
+ * If middleware set cookies in this request (indicated by `middleware-set-cookie`),
  * then merge those into the existing cookie object, so that when `cookies()` is accessed
  * it's able to read the newly set cookies.
  */
@@ -92,10 +92,10 @@ function mergeMiddlewareCookies(
   existingCookies: RequestCookies | ResponseCookies
 ) {
   if (
-    'x-middleware-set-cookie' in req.headers &&
-    typeof req.headers['x-middleware-set-cookie'] === 'string'
+    'middleware-set-cookie' in req.headers &&
+    typeof req.headers['middleware-set-cookie'] === 'string'
   ) {
-    const setCookieValue = req.headers['x-middleware-set-cookie']
+    const setCookieValue = req.headers['middleware-set-cookie']
     const responseHeaders = new Headers()
 
     for (const cookie of splitCookiesString(setCookieValue)) {


### PR DESCRIPTION
This header is only needed internally and can be omitted from the final response to the client. This refactors the implementation to use `x-middleware-request-*` and `x-middleware-override-headers` which were designed for a similar purpose ([implementation ref)](https://github.com/vercel/next.js/pull/41380). Headers prefixed with this value are automatically stripped from the client response. 