### PR TITLE
codemod(turbopack): Inline trivial uses of `let this = self`

### DIFF
--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -256,12 +256,10 @@ impl MiddlewareEndpoint {
 
     #[turbo_tasks::function]
     async fn userland_module(&self) -> Result<Vc<Box<dyn Module>>> {
-        let this = self;
-
-        Ok(this
+        Ok(self
             .asset_context
             .process(
-                this.source,
+                self.source,
                 Value::new(ReferenceType::Entry(EntryReferenceSubType::Middleware)),
             )
             .module())

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -641,8 +641,7 @@ impl PageEndpoint {
 
     #[turbo_tasks::function]
     async fn source(&self) -> Result<Vc<Box<dyn Source>>> {
-        let this = self;
-        Ok(Vc::upcast(FileSource::new(this.page.project_path())))
+        Ok(Vc::upcast(FileSource::new(self.page.project_path())))
     }
 
     #[turbo_tasks::function]
@@ -949,8 +948,7 @@ impl PageEndpoint {
         &self,
         entry_chunk: Vc<Box<dyn OutputAsset>>,
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
-        let this = self;
-        let node_root = this.pages_project.project().node_root();
+        let node_root = self.pages_project.project().node_root();
         let chunk_path = entry_chunk.ident().path().await?;
 
         let asset_path = node_root
@@ -960,11 +958,11 @@ impl PageEndpoint {
             .context("ssr chunk entry path must be inside the node root")?;
 
         let pages_manifest = PagesManifest {
-            pages: [(this.pathname.await?.clone_value(), asset_path.into())]
+            pages: [(self.pathname.await?.clone_value(), asset_path.into())]
                 .into_iter()
                 .collect(),
         };
-        let manifest_path_prefix = get_asset_prefix_from_pathname(&this.pathname.await?);
+        let manifest_path_prefix = get_asset_prefix_from_pathname(&self.pathname.await?);
         Ok(Vc::upcast(VirtualOutputAsset::new(
             node_root
                 .join(format!("server/pages{manifest_path_prefix}/pages-manifest.json",).into()),
@@ -994,13 +992,12 @@ impl PageEndpoint {
         &self,
         client_chunks: Vc<OutputAssets>,
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
-        let this = self;
-        let node_root = this.pages_project.project().node_root();
-        let client_relative_path = this.pages_project.project().client_relative_path();
+        let node_root = self.pages_project.project().node_root();
+        let client_relative_path = self.pages_project.project().client_relative_path();
         let client_relative_path_ref = client_relative_path.await?;
         let build_manifest = BuildManifest {
             pages: [(
-                this.pathname.await?.clone_value(),
+                self.pathname.await?.clone_value(),
                 client_chunks
                     .await?
                     .iter()
@@ -1022,7 +1019,7 @@ impl PageEndpoint {
             .collect(),
             ..Default::default()
         };
-        let manifest_path_prefix = get_asset_prefix_from_pathname(&this.pathname.await?);
+        let manifest_path_prefix = get_asset_prefix_from_pathname(&self.pathname.await?);
         Ok(Vc::upcast(VirtualOutputAsset::new(
             node_root
                 .join(format!("server/pages{manifest_path_prefix}/build-manifest.json",).into()),

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -302,8 +302,6 @@ impl ProjectContainer {
 impl ProjectContainer {
     #[turbo_tasks::function]
     pub async fn project(&self) -> Result<Vc<Project>> {
-        let this = self;
-
         let env_map: Vc<EnvMap>;
         let next_config;
         let define_env;
@@ -317,7 +315,7 @@ impl ProjectContainer {
         let preview_props;
         let browserslist_query;
         {
-            let options = this.options_state.get();
+            let options = self.options_state.get();
             let options = options
                 .as_ref()
                 .context("ProjectContainer need to be initialized with initialize()")?;
@@ -361,7 +359,7 @@ impl ProjectContainer {
             } else {
                 NextMode::Build.cell()
             },
-            versioned_content_map: this.versioned_content_map,
+            versioned_content_map: self.versioned_content_map,
             build_id,
             encryption_key,
             preview_props,
@@ -518,13 +516,12 @@ impl Project {
 
     #[turbo_tasks::function]
     async fn project_fs(&self) -> Result<Vc<DiskFileSystem>> {
-        let this = self;
         let disk_fs = DiskFileSystem::new(
             PROJECT_FILESYSTEM_NAME.into(),
-            this.root_path.clone(),
+            self.root_path.clone(),
             vec![],
         );
-        if this.watch {
+        if self.watch {
             disk_fs.await?.start_watching_with_invalidation_reason()?;
         }
         Ok(disk_fs)
@@ -538,8 +535,7 @@ impl Project {
 
     #[turbo_tasks::function]
     pub async fn output_fs(&self) -> Result<Vc<DiskFileSystem>> {
-        let this = self;
-        let disk_fs = DiskFileSystem::new("output".into(), this.project_path.clone(), vec![]);
+        let disk_fs = DiskFileSystem::new("output".into(), self.project_path.clone(), vec![]);
         Ok(disk_fs)
     }
 

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -733,8 +733,7 @@ struct DuplicateParallelRouteIssue {
 impl Issue for DuplicateParallelRouteIssue {
     #[turbo_tasks::function]
     async fn file_path(&self) -> Result<Vc<FileSystemPath>> {
-        let this = self;
-        Ok(this.app_dir.join(this.page.to_string().into()))
+        Ok(self.app_dir.join(self.page.to_string().into()))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -847,8 +847,7 @@ impl NextConfig {
         &self,
         active_conditions: Vec<RcStr>,
     ) -> Result<Vc<OptionWebpackRules>> {
-        let this = self;
-        let Some(turbo_rules) = this
+        let Some(turbo_rules) = self
             .experimental
             .turbo
             .as_ref()
@@ -936,8 +935,7 @@ impl NextConfig {
 
     #[turbo_tasks::function]
     pub async fn resolve_alias_options(&self) -> Result<Vc<ResolveAliasMap>> {
-        let this = self;
-        let Some(resolve_alias) = this
+        let Some(resolve_alias) = self
             .experimental
             .turbo
             .as_ref()
@@ -951,8 +949,7 @@ impl NextConfig {
 
     #[turbo_tasks::function]
     pub async fn resolve_extension(&self) -> Result<Vc<ResolveExtensions>> {
-        let this = self;
-        let Some(resolve_extensions) = this
+        let Some(resolve_extensions) = self
             .experimental
             .turbo
             .as_ref()
@@ -1148,8 +1145,7 @@ impl NextConfig {
 
     #[turbo_tasks::function]
     pub async fn module_id_strategy_config(&self) -> Result<Vc<OptionModuleIdStrategy>> {
-        let this = self;
-        let Some(module_id_strategy) = this
+        let Some(module_id_strategy) = self
             .experimental
             .turbo
             .as_ref()

--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -33,10 +33,8 @@ impl NextDynamicEntryModule {
         &self,
         client_chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<OutputAssets>> {
-        let this = self;
-
         let Some(client_entry_module) =
-            Vc::try_resolve_sidecast::<Box<dyn ChunkableModule>>(this.client_entry_module).await?
+            Vc::try_resolve_sidecast::<Box<dyn ChunkableModule>>(self.client_entry_module).await?
         else {
             bail!("dynamic client asset must be chunkable");
         };

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -47,8 +47,7 @@ impl NextServerComponentModule {
 
     #[turbo_tasks::function]
     pub async fn server_path(&self) -> Result<Vc<FileSystemPath>> {
-        let this = self;
-        Ok(this.module.ident().path())
+        Ok(self.module.ident().path())
     }
 }
 
@@ -144,12 +143,11 @@ impl EcmascriptChunkItem for NextServerComponentChunkItem {
 
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<EcmascriptChunkItemContent>> {
-        let this = self;
-        let inner = this.inner.await?;
+        let inner = self.inner.await?;
 
         let module_id = inner
             .module
-            .as_chunk_item(Vc::upcast(this.chunking_context))
+            .as_chunk_item(Vc::upcast(self.chunking_context))
             .id()
             .await?;
         Ok(EcmascriptChunkItemContent {

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -99,8 +99,7 @@ impl PageLoaderAsset {
         &self,
         rebase_prefix_path: Vc<FileSystemPathOption>,
     ) -> Result<Vc<ChunksData>> {
-        let this = self;
-        let mut chunks = this.page_chunks;
+        let mut chunks = self.page_chunks;
 
         // If we are provided a prefix path, we need to rewrite our chunk paths to
         // remove that prefix.
@@ -119,7 +118,7 @@ impl PageLoaderAsset {
             chunks = Vc::cell(rebased);
         };
 
-        Ok(ChunkData::from_assets(this.server_root, chunks))
+        Ok(ChunkData::from_assets(self.server_root, chunks))
     }
 }
 

--- a/turbopack/crates/turbo-tasks-env/src/dotenv.rs
+++ b/turbopack/crates/turbo-tasks-env/src/dotenv.rs
@@ -25,8 +25,7 @@ impl DotenvProcessEnv {
 
     #[turbo_tasks::function]
     pub async fn read_prior(&self) -> Result<Vc<EnvMap>> {
-        let this = self;
-        match this.prior {
+        match self.prior {
             None => Ok(EnvMap::empty()),
             Some(p) => Ok(p.read_all()),
         }

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1171,10 +1171,9 @@ impl FileSystemPath {
     /// None when the joined path would leave the filesystem root.
     #[turbo_tasks::function]
     pub async fn try_join(&self, path: RcStr) -> Result<Vc<FileSystemPathOption>> {
-        let this = self;
-        if let Some(path) = join_path(&this.path, &path) {
+        if let Some(path) = join_path(&self.path, &path) {
             Ok(Vc::cell(Some(
-                Self::new_normalized(this.fs, path.into()).resolve().await?,
+                Self::new_normalized(self.fs, path.into()).resolve().await?,
             )))
         } else {
             Ok(FileSystemPathOption::none())
@@ -1185,11 +1184,10 @@ impl FileSystemPath {
     /// None when the joined path would leave the current path.
     #[turbo_tasks::function]
     pub async fn try_join_inside(&self, path: RcStr) -> Result<Vc<FileSystemPathOption>> {
-        let this = self;
-        if let Some(path) = join_path(&this.path, &path) {
-            if path.starts_with(&*this.path) {
+        if let Some(path) = join_path(&self.path, &path) {
+            if path.starts_with(&*self.path) {
                 return Ok(Vc::cell(Some(
-                    Self::new_normalized(this.fs, path.into()).resolve().await?,
+                    Self::new_normalized(self.fs, path.into()).resolve().await?,
                 )));
             }
         }
@@ -1217,8 +1215,7 @@ impl FileSystemPath {
 
     #[turbo_tasks::function]
     pub async fn extension(&self) -> Result<Vc<RcStr>> {
-        let this = self;
-        Ok(Vc::cell(this.extension_ref().unwrap_or("").into()))
+        Ok(Vc::cell(self.extension_ref().unwrap_or("").into()))
     }
 
     #[turbo_tasks::function]
@@ -1235,10 +1232,9 @@ impl FileSystemPath {
     /// extension.
     #[turbo_tasks::function]
     pub async fn with_extension(&self, extension: RcStr) -> Result<Vc<FileSystemPath>> {
-        let this = self;
-        let (path_without_extension, _) = this.split_extension();
+        let (path_without_extension, _) = self.split_extension();
         Ok(Self::new_normalized(
-            this.fs,
+            self.fs,
             // Like `Path::with_extension` and `PathBuf::set_extension`, if the extension is empty,
             // we remove the extension altogether.
             match extension.is_empty() {
@@ -1258,8 +1254,7 @@ impl FileSystemPath {
     /// * Otherwise, the portion of the file name before the final `.`
     #[turbo_tasks::function]
     pub async fn file_stem(&self) -> Result<Vc<Option<RcStr>>> {
-        let this = self;
-        let (_, file_stem, _) = this.split_file_stem_extension();
+        let (_, file_stem, _) = self.split_file_stem_extension();
         if file_stem.is_empty() {
             return Ok(Vc::cell(None));
         }

--- a/turbopack/crates/turbo-tasks/src/primitives.rs
+++ b/turbopack/crates/turbo-tasks/src/primitives.rs
@@ -87,9 +87,8 @@ impl Bools {
 
     #[turbo_tasks::function]
     async fn into_bools(&self) -> Result<Vc<Vec<bool>>> {
-        let this = &self.0;
-
-        let bools = this
+        let bools = self
+            .0
             .iter()
             .map(|b| b.into_future().map_ok(|b| *b))
             .try_join()

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -56,11 +56,10 @@ impl EcmascriptDevChunkContent {
 impl EcmascriptDevChunkContent {
     #[turbo_tasks::function]
     pub(crate) async fn own_version(&self) -> Result<Vc<EcmascriptDevChunkVersion>> {
-        let this = self;
         Ok(EcmascriptDevChunkVersion::new(
-            this.chunking_context.output_root(),
-            this.chunk.ident().path(),
-            this.entries,
+            self.chunking_context.output_root(),
+            self.chunk.ident().path(),
+            self.entries,
         ))
     }
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -58,10 +58,9 @@ impl EcmascriptDevEvaluateChunk {
 
     #[turbo_tasks::function]
     async fn chunks_data(&self) -> Result<Vc<ChunksData>> {
-        let this = self;
         Ok(ChunkData::from_assets(
-            this.chunking_context.output_root(),
-            this.other_chunks,
+            self.chunking_context.output_root(),
+            self.other_chunks,
         ))
     }
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
@@ -71,12 +71,10 @@ impl EcmascriptDevChunkListContent {
     /// Computes the version of this content.
     #[turbo_tasks::function]
     pub async fn version(&self) -> Result<Vc<EcmascriptDevChunkListVersion>> {
-        let this = self;
-
         let mut by_merger = IndexMap::<_, Vec<_>>::new();
         let mut by_path = IndexMap::<_, _>::new();
 
-        for (chunk_path, chunk_content) in &this.chunks_contents {
+        for (chunk_path, chunk_content) in &self.chunks_contents {
             if let Some(mergeable) =
                 Vc::try_resolve_sidecast::<Box<dyn MergeableVersionedContent>>(*chunk_content)
                     .await?

--- a/turbopack/crates/turbopack-core/src/chunk/available_chunk_items.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/available_chunk_items.rs
@@ -66,14 +66,13 @@ impl AvailableChunkItems {
 
     #[turbo_tasks::function]
     pub async fn hash(&self) -> Result<Vc<u64>> {
-        let this = self;
         let mut hasher = Xxh3Hash64Hasher::new();
-        if let Some(parent) = this.parent {
+        if let Some(parent) = self.parent {
             hasher.write_value(parent.hash().await?);
         } else {
             hasher.write_value(0u64);
         }
-        let item_idents = this
+        let item_idents = self
             .chunk_items
             .await?
             .iter()
@@ -91,11 +90,10 @@ impl AvailableChunkItems {
         &self,
         chunk_item: Vc<Box<dyn ChunkItem>>,
     ) -> Result<Vc<OptionAvailableChunkItemInfo>> {
-        let this = self;
-        if let Some(&info) = this.chunk_items.await?.get(&chunk_item) {
+        if let Some(&info) = self.chunk_items.await?.get(&chunk_item) {
             return Ok(Vc::cell(Some(info)));
         };
-        if let Some(parent) = this.parent {
+        if let Some(parent) = self.parent {
             return Ok(parent.get(chunk_item));
         }
         Ok(Vc::cell(None))

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -67,8 +67,7 @@ pub enum ExecutionEnvironment {
 impl Environment {
     #[turbo_tasks::function]
     pub async fn compile_target(&self) -> Result<Vc<CompileTarget>> {
-        let this = self;
-        Ok(match this.execution {
+        Ok(match self.execution {
             ExecutionEnvironment::NodeJsBuildTime(node_env, ..)
             | ExecutionEnvironment::NodeJsLambda(node_env) => node_env.await?.compile_target,
             ExecutionEnvironment::Browser(_) => CompileTarget::unknown(),
@@ -79,8 +78,7 @@ impl Environment {
 
     #[turbo_tasks::function]
     pub async fn runtime_versions(&self) -> Result<Vc<RuntimeVersions>> {
-        let this = self;
-        Ok(match this.execution {
+        Ok(match self.execution {
             ExecutionEnvironment::NodeJsBuildTime(node_env, ..)
             | ExecutionEnvironment::NodeJsLambda(node_env) => node_env.runtime_versions(),
             ExecutionEnvironment::Browser(browser_env) => {
@@ -96,8 +94,7 @@ impl Environment {
 
     #[turbo_tasks::function]
     pub async fn node_externals(&self) -> Result<Vc<bool>> {
-        let this = self;
-        Ok(match this.execution {
+        Ok(match self.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Vc::cell(true)
             }
@@ -109,8 +106,7 @@ impl Environment {
 
     #[turbo_tasks::function]
     pub async fn supports_esm_externals(&self) -> Result<Vc<bool>> {
-        let this = self;
-        Ok(match this.execution {
+        Ok(match self.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Vc::cell(true)
             }
@@ -122,8 +118,7 @@ impl Environment {
 
     #[turbo_tasks::function]
     pub async fn supports_commonjs_externals(&self) -> Result<Vc<bool>> {
-        let this = self;
-        Ok(match this.execution {
+        Ok(match self.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Vc::cell(true)
             }
@@ -135,8 +130,7 @@ impl Environment {
 
     #[turbo_tasks::function]
     pub async fn supports_wasm(&self) -> Result<Vc<bool>> {
-        let this = self;
-        Ok(match this.execution {
+        Ok(match self.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Vc::cell(true)
             }

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -224,14 +224,13 @@ impl ValueToString for IssueProcessingPathItem {
 impl IssueProcessingPathItem {
     #[turbo_tasks::function]
     pub async fn into_plain(&self) -> Result<Vc<PlainIssueProcessingPathItem>> {
-        let this = self;
         Ok(PlainIssueProcessingPathItem {
-            file_path: if let Some(context) = this.file_path {
+            file_path: if let Some(context) = self.file_path {
                 Some(context.to_string().await?)
             } else {
                 None
             },
-            description: this.description.await?,
+            description: self.description.await?,
         }
         .cell())
     }
@@ -778,15 +777,14 @@ pub struct PlainIssueSource {
 impl IssueSource {
     #[turbo_tasks::function]
     pub async fn into_plain(&self) -> Result<Vc<PlainIssueSource>> {
-        let this = self;
         Ok(PlainIssueSource {
-            asset: PlainSource::from_source(this.source).await?,
-            range: match this.range {
+            asset: PlainSource::from_source(self.source).await?,
+            range: match self.range {
                 Some(range) => match &*range.await? {
                     SourceRange::LineColumn(start, end) => Some((*start, *end)),
                     SourceRange::ByteOffset(start, end) => {
                         if let FileLinesContent::Lines(lines) =
-                            &*this.source.content().lines().await?
+                            &*self.source.content().lines().await?
                         {
                             let start = find_line_and_column(lines.as_ref(), *start);
                             let end = find_line_and_column(lines.as_ref(), *end);

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -320,14 +320,12 @@ impl ModuleResolveResult {
 
     #[turbo_tasks::function]
     pub async fn is_unresolveable(&self) -> Result<Vc<bool>> {
-        let this = self;
-        Ok(Vc::cell(this.is_unresolveable_ref()))
+        Ok(Vc::cell(self.is_unresolveable_ref()))
     }
 
     #[turbo_tasks::function]
     pub async fn first_module(&self) -> Result<Vc<OptionModule>> {
-        let this = self;
-        Ok(Vc::cell(this.primary.iter().find_map(
+        Ok(Vc::cell(self.primary.iter().find_map(
             |(_, item)| match item {
                 &ModuleResolveResultItem::Module(a) => Some(a),
                 _ => None,
@@ -339,8 +337,7 @@ impl ModuleResolveResult {
     /// modules are already resolved Vc.
     #[turbo_tasks::function]
     pub async fn primary_modules(&self) -> Result<Vc<Modules>> {
-        let this = self;
-        let mut iter = this.primary_modules_iter();
+        let mut iter = self.primary_modules_iter();
         let Some(first) = iter.next() else {
             return Ok(Vc::cell(vec![]));
         };
@@ -353,7 +350,7 @@ impl ModuleResolveResult {
 
         // We have at least two items, so we need to deduplicate them
         let mut set = IndexSet::from([first, second]);
-        for module in this.primary_modules_iter() {
+        for module in self.primary_modules_iter() {
             set.insert(module.resolve().await?);
         }
         Ok(Vc::cell(set.into_iter().collect()))
@@ -361,9 +358,8 @@ impl ModuleResolveResult {
 
     #[turbo_tasks::function]
     pub async fn primary_output_assets(&self) -> Result<Vc<OutputAssets>> {
-        let this = self;
         Ok(Vc::cell(
-            this.primary
+            self.primary
                 .iter()
                 .filter_map(|(_, item)| match item {
                     &ModuleResolveResultItem::OutputAsset(a) => Some(a),
@@ -852,14 +848,12 @@ impl ResolveResult {
 
     #[turbo_tasks::function]
     pub async fn is_unresolveable(&self) -> Result<Vc<bool>> {
-        let this = self;
-        Ok(Vc::cell(this.is_unresolveable_ref()))
+        Ok(Vc::cell(self.is_unresolveable_ref()))
     }
 
     #[turbo_tasks::function]
     pub async fn first_source(&self) -> Result<Vc<OptionSource>> {
-        let this = self;
-        Ok(Vc::cell(this.primary.iter().find_map(|(_, item)| {
+        Ok(Vc::cell(self.primary.iter().find_map(|(_, item)| {
             if let &ResolveResultItem::Source(a) = item {
                 Some(a)
             } else {
@@ -870,9 +864,8 @@ impl ResolveResult {
 
     #[turbo_tasks::function]
     pub async fn primary_sources(&self) -> Result<Vc<Sources>> {
-        let this = self;
         Ok(Vc::cell(
-            this.primary
+            self.primary
                 .iter()
                 .filter_map(|(_, item)| {
                     if let &ResolveResultItem::Source(a) = item {
@@ -895,9 +888,8 @@ impl ResolveResult {
         old_request_key: RcStr,
         request_key: Value<RequestKey>,
     ) -> Result<Vc<Self>> {
-        let this = self;
         let request_key = request_key.into_value();
-        let new_primary = this
+        let new_primary = self
             .primary
             .iter()
             .filter_map(|(k, v)| {
@@ -916,7 +908,7 @@ impl ResolveResult {
             .collect();
         Ok(ResolveResult {
             primary: new_primary,
-            affecting_sources: this.affecting_sources.clone(),
+            affecting_sources: self.affecting_sources.clone(),
         }
         .into())
     }
@@ -933,8 +925,8 @@ impl ResolveResult {
     ) -> Result<Vc<Self>> {
         let old_request_key = &*old_request_key.await?;
         let request_key = &*request_key.await?;
-        let this = self;
-        let new_primary = this
+
+        let new_primary = self
             .primary
             .iter()
             .map(|(k, v)| {
@@ -953,7 +945,7 @@ impl ResolveResult {
             .collect();
         Ok(ResolveResult {
             primary: new_primary,
-            affecting_sources: this.affecting_sources.clone(),
+            affecting_sources: self.affecting_sources.clone(),
         }
         .into())
     }
@@ -962,8 +954,7 @@ impl ResolveResult {
     /// passed `request`.
     #[turbo_tasks::function]
     pub async fn with_request(&self, request: RcStr) -> Result<Vc<Self>> {
-        let this = self;
-        let new_primary = this
+        let new_primary = self
             .primary
             .iter()
             .map(|(k, v)| {
@@ -978,7 +969,7 @@ impl ResolveResult {
             .collect();
         Ok(ResolveResult {
             primary: new_primary,
-            affecting_sources: this.affecting_sources.clone(),
+            affecting_sources: self.affecting_sources.clone(),
         }
         .into())
     }

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -449,9 +449,8 @@ impl ResolvedMap {
         lookup_path: Vc<FileSystemPath>,
         request: Vc<Request>,
     ) -> Result<Vc<ImportMapResult>> {
-        let this = self;
         let resolved = resolved.await?;
-        for (root, glob, mapping) in this.by_glob.iter() {
+        for (root, glob, mapping) in self.by_glob.iter() {
             let root = root.await?;
             if let Some(path) = root.get_path_to(&resolved) {
                 if glob.await?.execute(path) {

--- a/turbopack/crates/turbopack-core/src/resolve/plugin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/plugin.rs
@@ -23,9 +23,8 @@ impl AfterResolvePluginCondition {
 
     #[turbo_tasks::function]
     pub async fn matches(&self, fs_path: Vc<FileSystemPath>) -> Result<Vc<bool>> {
-        let this = self;
-        let root = this.root.await?;
-        let glob = this.glob.await?;
+        let root = self.root.await?;
+        let glob = self.glob.await?;
 
         let path = fs_path.await?;
 

--- a/turbopack/crates/turbopack-core/src/version.rs
+++ b/turbopack/crates/turbopack-core/src/version.rs
@@ -251,8 +251,7 @@ pub struct VersionState {
 impl VersionState {
     #[turbo_tasks::function]
     pub async fn get(&self) -> Result<Vc<Box<dyn Version>>> {
-        let this = self;
-        let version = TraitRef::cell(this.version.get().clone());
+        let version = TraitRef::cell(self.version.get().clone());
         Ok(version)
     }
 }

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -233,11 +233,9 @@ fn chunk_item_key() -> Vc<RcStr> {
 impl OutputAsset for CssChunk {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
-        let this = self;
-
         let mut assets = Vec::new();
 
-        let CssChunkContent { chunk_items, .. } = &*this.content.await?;
+        let CssChunkContent { chunk_items, .. } = &*self.content.await?;
         let mut common_path = if let Some(chunk_item) = chunk_items.first() {
             let path = chunk_item.asset_ident().path().resolve().await?;
             Some((path, path.await?))
@@ -283,7 +281,7 @@ impl OutputAsset for CssChunk {
             layer: None,
         };
 
-        Ok(AssetIdent::from_path(this.chunking_context.chunk_path(
+        Ok(AssetIdent::from_path(self.chunking_context.chunk_path(
             AssetIdent::new(Value::new(ident)),
             ".css".into(),
         )))

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -153,9 +153,8 @@ struct ModuleCssClasses(IndexMap<String, Vec<ModuleCssClass>>);
 impl ModuleCssAsset {
     #[turbo_tasks::function]
     async fn inner(&self) -> Result<Vc<ProcessResult>> {
-        let this = self;
-        Ok(this.asset_context.process(
-            this.source,
+        Ok(self.asset_context.process(
+            self.source,
             Value::new(ReferenceType::Css(CssReferenceSubType::Internal)),
         ))
     }

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -127,9 +127,7 @@ impl DevHtmlAsset {
 
     #[turbo_tasks::function]
     async fn chunks(&self) -> Result<Vc<OutputAssets>> {
-        let this = self;
-
-        let all_assets = this
+        let all_assets = self
             .entries
             .iter()
             .map(|entry| async move {
@@ -181,12 +179,10 @@ impl DevHtmlAssetContent {
 impl DevHtmlAssetContent {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<AssetContent>> {
-        let this = self;
-
         let mut scripts = Vec::new();
         let mut stylesheets = Vec::new();
 
-        for relative_path in &*this.chunk_paths {
+        for relative_path in &*self.chunk_paths {
             if relative_path.ends_with(".js") {
                 scripts.push(format!("<script src=\"{}\"></script>", relative_path));
             } else if relative_path.ends_with(".css") {
@@ -199,7 +195,7 @@ impl DevHtmlAssetContent {
             }
         }
 
-        let body = match &this.body {
+        let body = match &self.body {
             Some(body) => body.as_str(),
             None => "",
         };

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -89,12 +89,11 @@ impl AssetGraphContentSource {
 
     #[turbo_tasks::function]
     async fn all_assets_map(&self) -> Result<Vc<OutputAssetsMap>> {
-        let this = self;
         Ok(Vc::cell(
             expand(
-                &*this.root_assets.await?,
-                &*this.root_path.await?,
-                this.expanded.as_ref(),
+                &*self.root_assets.await?,
+                &*self.root_path.await?,
+                self.expanded.as_ref(),
             )
             .await?,
         ))

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
@@ -31,14 +31,13 @@ pub struct AsyncLoaderChunkItem {
 impl AsyncLoaderChunkItem {
     #[turbo_tasks::function]
     pub(super) async fn chunks(&self) -> Result<Vc<OutputAssets>> {
-        let this = self;
-        let module = this.module.await?;
+        let module = self.module.await?;
         if let Some(chunk_items) = module.availability_info.available_chunk_items() {
             if chunk_items
                 .get(
                     module
                         .inner
-                        .as_chunk_item(Vc::upcast(this.chunking_context))
+                        .as_chunk_item(Vc::upcast(self.chunking_context))
                         .resolve()
                         .await?,
                 )
@@ -48,7 +47,7 @@ impl AsyncLoaderChunkItem {
                 return Ok(Vc::cell(vec![]));
             }
         }
-        Ok(this.chunking_context.chunk_group_assets(
+        Ok(self.chunking_context.chunk_group_assets(
             Vc::upcast(module.inner),
             Value::new(module.availability_info),
         ))

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -79,7 +79,6 @@ impl EcmascriptChunkItemContent {
 
     #[turbo_tasks::function]
     pub async fn module_factory(&self) -> Result<Vc<Code>> {
-        let this = self;
         let mut args = vec![
             "r: __turbopack_require__",
             "f: __turbopack_module_context__",
@@ -99,53 +98,53 @@ impl EcmascriptChunkItemContent {
             // HACK
             "__dirname",
         ];
-        if this.options.async_module.is_some() {
+        if self.options.async_module.is_some() {
             args.push("a: __turbopack_async_module__");
         }
-        if this.options.externals {
+        if self.options.externals {
             args.push("x: __turbopack_external_require__");
             args.push("y: __turbopack_external_import__");
         }
-        if this.options.refresh {
+        if self.options.refresh {
             args.push("k: __turbopack_refresh__");
         }
-        if this.options.module || this.options.refresh {
+        if self.options.module || self.options.refresh {
             args.push("m: module");
         }
-        if this.options.exports {
+        if self.options.exports {
             args.push("e: exports");
         }
-        if this.options.stub_require {
+        if self.options.stub_require {
             args.push("z: require");
         } else {
             args.push("t: require");
         }
-        if this.options.wasm {
+        if self.options.wasm {
             args.push("w: __turbopack_wasm__");
             args.push("u: __turbopack_wasm_module__");
         }
         let mut code = CodeBuilder::default();
         let args = FormatIter(|| args.iter().copied().intersperse(", "));
-        if this.options.this {
+        if self.options.this {
             code += "(function(__turbopack_context__) {\n";
         } else {
             code += "((__turbopack_context__) => {\n";
         }
-        if this.options.strict {
+        if self.options.strict {
             code += "\"use strict\";\n\n";
         } else {
             code += "\n";
         }
         writeln!(code, "var {{ {} }} = __turbopack_context__;", args)?;
 
-        if this.options.async_module.is_some() {
+        if self.options.async_module.is_some() {
             code += "__turbopack_async_module__(async (__turbopack_handle_async_dependencies__, \
                      __turbopack_async_result__) => { try {\n";
         }
 
-        code.push_source(&this.inner_code, this.source_map);
+        code.push_source(&self.inner_code, self.source_map);
 
-        if let Some(opts) = &this.options.async_module {
+        if let Some(opts) = &self.options.async_module {
             write!(
                 code,
                 "__turbopack_async_result__();\n}} catch(e) {{ __turbopack_async_result__(e); }} \

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -77,11 +77,9 @@ fn availability_root_key() -> Vc<RcStr> {
 impl Chunk for EcmascriptChunk {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
-        let this = self;
-
         let mut assets = Vec::new();
 
-        let EcmascriptChunkContent { chunk_items, .. } = &*this.content.await?;
+        let EcmascriptChunkContent { chunk_items, .. } = &*self.content.await?;
         let mut common_path = if let Some((chunk_item, _)) = chunk_items.first() {
             let path = chunk_item.asset_ident().path().resolve().await?;
             Some((path, path.await?))
@@ -136,8 +134,7 @@ impl Chunk for EcmascriptChunk {
 
     #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<OutputAssets>> {
-        let this = self;
-        let content = this.content.await?;
+        let content = self.content.await?;
         Ok(Vc::cell(content.referenced_output_assets.clone()))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
@@ -125,8 +125,7 @@ struct ChunkGroupFilesChunkItem {
 impl ChunkGroupFilesChunkItem {
     #[turbo_tasks::function]
     async fn chunks(&self) -> Result<Vc<OutputAssets>> {
-        let this = self;
-        let inner = this.inner.await?;
+        let inner = self.inner.await?;
         let chunks = if let Some(ecma) =
             Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(inner.module).await?
         {

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -53,10 +53,9 @@ impl ManifestAsyncModule {
 
     #[turbo_tasks::function]
     pub(super) async fn chunks(&self) -> Result<Vc<OutputAssets>> {
-        let this = self;
-        Ok(this
+        Ok(self
             .chunking_context
-            .chunk_group_assets(Vc::upcast(this.inner), Value::new(this.availability_info)))
+            .chunk_group_assets(Vc::upcast(self.inner), Value::new(self.availability_info)))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
@@ -30,10 +30,9 @@ pub(super) struct ManifestChunkItem {
 impl ManifestChunkItem {
     #[turbo_tasks::function]
     async fn chunks_data(&self) -> Result<Vc<ChunksData>> {
-        let this = self;
         Ok(ChunkData::from_assets(
-            this.chunking_context.output_root(),
-            this.manifest.chunks(),
+            self.chunking_context.output_root(),
+            self.manifest.chunks(),
         ))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
@@ -59,10 +59,9 @@ impl ManifestLoaderChunkItem {
 
     #[turbo_tasks::function]
     pub async fn chunks_data(&self) -> Result<Vc<ChunksData>> {
-        let this = self;
-        let chunks = this.manifest.manifest_chunks();
+        let chunks = self.manifest.manifest_chunks();
         Ok(ChunkData::from_assets(
-            this.chunking_context.output_root(),
+            self.chunking_context.output_root(),
             chunks,
         ))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/binding.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/binding.rs
@@ -154,9 +154,8 @@ impl CodeGenerateable for EsmBindings {
         &self,
         _context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
-        let this = self;
         let mut visitors = Vec::new();
-        let bindings = this.bindings.clone();
+        let bindings = self.bindings.clone();
 
         for item in bindings.into_iter() {
             item.to_visitors(&mut visitors).await?;

--- a/turbopack/crates/turbopack-ecmascript/src/static_code.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/static_code.rs
@@ -48,8 +48,7 @@ impl StaticEcmascriptCode {
     /// the code builder, including the source map if available.
     #[turbo_tasks::function]
     pub async fn code(&self) -> Result<Vc<Code>> {
-        let this = self;
-        let runtime_base_content = this.asset.module_content_without_analysis().await?;
+        let runtime_base_content = self.asset.module_content_without_analysis().await?;
         let mut code = CodeBuilder::default();
         code.push_source(
             &runtime_base_content.inner_code,

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -34,16 +34,14 @@ pub struct EcmascriptModulePartAsset {
 impl EcmascriptParsable for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     async fn failsafe_parse(&self) -> Result<Vc<ParseResult>> {
-        let this = self;
-
-        let parsed = this.full_module.failsafe_parse();
+        let parsed = self.full_module.failsafe_parse();
         let split_data = split(
-            this.full_module.ident(),
-            this.full_module.source(),
+            self.full_module.ident(),
+            self.full_module.source(),
             parsed,
-            this.full_module.options().await?.special_exports,
+            self.full_module.options().await?.special_exports,
         );
-        Ok(part_of_module(split_data, this.part))
+        Ok(part_of_module(split_data, self.part))
     }
     #[turbo_tasks::function]
     fn parse_original(&self) -> Result<Vc<ParseResult>> {
@@ -60,9 +58,8 @@ impl EcmascriptParsable for EcmascriptModulePartAsset {
 impl EcmascriptAnalyzable for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     async fn analyze(&self) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
-        let this = self;
-        let part = this.part;
-        Ok(analyse_ecmascript_module(this.full_module, Some(part)))
+        let part = self.part;
+        Ok(analyse_ecmascript_module(self.full_module, Some(part)))
     }
 
     #[turbo_tasks::function]
@@ -225,9 +222,7 @@ impl ChunkableModule for EcmascriptModulePartAsset {
 impl EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     pub(super) async fn analyze(&self) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
-        let this = self;
-
-        Ok(analyze(this.full_module, this.part))
+        Ok(analyze(self.full_module, self.part))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
@@ -35,13 +35,12 @@ impl EcmascriptChunkItem for EcmascriptModulePartChunkItem {
         &self,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Vc<EcmascriptChunkItemContent>> {
-        let this = self;
-        let module = this.module.await?;
+        let module = self.module.await?;
 
         let split_data = split_module(module.full_module);
         let parsed = part_of_module(split_data, module.part);
 
-        let analyze = this.module.analyze().await?;
+        let analyze = self.module.analyze().await?;
         let async_module_options = analyze.async_module.module_options(async_module_info);
 
         let module_type_result = *module.full_module.determine_module_type().await?;
@@ -50,7 +49,7 @@ impl EcmascriptChunkItem for EcmascriptModulePartChunkItem {
             parsed,
             module.full_module.ident(),
             module_type_result.module_type,
-            this.chunking_context,
+            self.chunking_context,
             analyze.references,
             analyze.code_generation,
             analyze.async_module,
@@ -61,7 +60,7 @@ impl EcmascriptChunkItem for EcmascriptModulePartChunkItem {
 
         Ok(EcmascriptChunkItemContent::new(
             content,
-            this.chunking_context,
+            self.chunking_context,
             module.full_module.await?.options,
             async_module_options,
         ))

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -36,8 +36,7 @@ pub fn worker_modifier() -> Vc<RcStr> {
 impl WorkerLoaderChunkItem {
     #[turbo_tasks::function]
     async fn chunks(&self) -> Result<Vc<OutputAssets>> {
-        let this = self;
-        let module = this.module.await?;
+        let module = self.module.await?;
 
         let Some(evaluatable) =
             Vc::try_resolve_downcast::<Box<dyn EvaluatableAsset>>(module.inner).await?
@@ -48,9 +47,9 @@ impl WorkerLoaderChunkItem {
             );
         };
 
-        Ok(this.chunking_context.evaluated_chunk_group_assets(
+        Ok(self.chunking_context.evaluated_chunk_group_assets(
             AssetIdent::from_path(
-                this.chunking_context
+                self.chunking_context
                     .chunk_path(module.inner.ident(), ".js".into()),
             )
             .with_modifier(worker_modifier()),

--- a/turbopack/crates/turbopack-mdx/src/lib.rs
+++ b/turbopack/crates/turbopack-mdx/src/lib.rs
@@ -135,9 +135,8 @@ impl Asset for MdxTransformedAsset {
 impl MdxTransformedAsset {
     #[turbo_tasks::function]
     async fn process(&self) -> Result<Vc<MdxTransformResult>> {
-        let this = self;
-        let content = this.source.content().await?;
-        let transform_options = this.options.await?;
+        let content = self.source.content().await?;
+        let transform_options = self.options.await?;
 
         let AssetContent::File(file) = &*content else {
             anyhow::bail!("Unexpected mdx asset content");
@@ -175,7 +174,7 @@ impl MdxTransformedAsset {
                 .jsx_import_source
                 .clone()
                 .map(RcStr::into_owned),
-            filepath: Some(this.source.ident().path().await?.to_string()),
+            filepath: Some(self.source.ident().path().await?.to_string()),
             ..Default::default()
         };
 
@@ -210,11 +209,11 @@ impl MdxTransformedAsset {
                         }
                     };
 
-                    IssueSource::from_line_col(this.source, start, end)
+                    IssueSource::from_line_col(self.source, start, end)
                 });
 
                 MdxIssue {
-                    path: this.source.ident().path(),
+                    path: self.source.ident().path(),
                     loc,
                     reason: err.reason,
                     mdx_rule_id: *err.rule_id,

--- a/turbopack/crates/turbopack-node/src/source_map/trace.rs
+++ b/turbopack/crates/turbopack-node/src/source_map/trace.rs
@@ -129,11 +129,9 @@ impl SourceMapTrace {
     /// serialization.
     #[turbo_tasks::function]
     pub async fn trace(&self) -> Result<Vc<TraceResult>> {
-        let this = self;
-
-        let token = this
+        let token = self
             .map
-            .lookup_token(this.line.saturating_sub(1), this.column.saturating_sub(1))
+            .lookup_token(self.line.saturating_sub(1), self.column.saturating_sub(1))
             .await?;
         let result = match &*token {
             Token::Original(t) => TraceResult::Found(StackFrame {
@@ -143,7 +141,7 @@ impl SourceMapTrace {
                 name: t
                     .name
                     .clone()
-                    .or_else(|| this.name.clone())
+                    .or_else(|| self.name.clone())
                     .map(|v| v.into_owned())
                     .map(Cow::Owned),
             }),

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -110,12 +110,11 @@ impl EcmascriptBuildNodeChunkContent {
 
     #[turbo_tasks::function]
     pub(crate) async fn own_version(&self) -> Result<Vc<EcmascriptBuildNodeChunkVersion>> {
-        let this = self;
         Ok(EcmascriptBuildNodeChunkVersion::new(
-            this.chunking_context.output_root(),
-            this.chunk.ident().path(),
-            this.content,
-            this.chunking_context.await?.minify_type(),
+            self.chunking_context.output_root(),
+            self.chunk.ident().path(),
+            self.content,
+            self.chunking_context.await?.minify_type(),
         ))
     }
 }

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -145,8 +145,7 @@ impl EcmascriptBuildNodeEntryChunk {
 
     #[turbo_tasks::function]
     async fn runtime_chunk(&self) -> Result<Vc<EcmascriptBuildNodeRuntimeChunk>> {
-        let this = self;
-        Ok(EcmascriptBuildNodeRuntimeChunk::new(this.chunking_context))
+        Ok(EcmascriptBuildNodeRuntimeChunk::new(self.chunking_context))
     }
 }
 


### PR DESCRIPTION
A follow-up to the #70431 codemod diff, which leave behind a lot of trivial `let this = self;` statements.

Using the following ast-grep rule config:

```yaml
language: rust
id: inline_trivial_this

utils:
  block-with-this:
    all:
    - pattern: $BLOCK
    - kind: block
    - has:
        all:
          - pattern: let this = $SELF;
          - any:
            - pattern: let this = self;
            - pattern: let this = &self.0;

rule:
  matches: block-with-this

rewriters:
  - id: remove-let-this
    rule:
      pattern: let this = $SELF;
    fix: ""
  - id: inline-this-auto-deref
    rule:
      pattern: this
      inside:
        kind: field_expression
    transform:
      SELF_AUTO_DEREF:
        replace:
          source: $SELF
          replace: "&?(?<INNER>.*)"
          by: "$INNER"
    fix: $SELF_AUTO_DEREF
  - id: inline-this
    rule:
      pattern: this
    fix: $SELF

transform:
  NEW_BLOCK:
    rewrite:
      source: $BLOCK
      rewriters:
        - remove-let-this
        - inline-this-auto-deref
        - inline-this

fix:
  $NEW_BLOCK
```

Applied with

```
sg scan -U -r ../codemod_inline_trivial_this.yml .
```