### PR TITLE
perf(turbopack): Optimize turbopack tree shaking using `pure`

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -584,7 +584,7 @@ impl DepGraph {
         let mut new_graph = InternedGraph::default();
         let mut done = FxHashSet::default();
 
-        let mapped = condensed.map(
+        let mapped = condensed.filter_map(
             |_, node| {
                 if node.iter().all(|&ix| {
                     let id = &self.g.graph_ix[ix as usize];
@@ -605,9 +605,9 @@ impl DepGraph {
                     .collect::<Vec<_>>();
                 item_ids.sort();
 
-                new_graph.node(&item_ids)
+                Some(new_graph.node(&item_ids))
             },
-            |_, edge| *edge,
+            |_, edge| Some(*edge),
         );
 
         let map = GraphMap::from_graph(mapped);

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -575,7 +575,7 @@ impl DepGraph {
     /// performance.
     pub(super) fn finalize(
         &self,
-        _data: &FxHashMap<ItemId, ItemData>,
+        data: &FxHashMap<ItemId, ItemData>,
     ) -> InternedGraph<Vec<ItemId>> {
         let graph = self.g.idx_graph.clone().into_graph::<u32>();
 
@@ -586,6 +586,15 @@ impl DepGraph {
 
         let mapped = condensed.map(
             |_, node| {
+                if node.iter().all(|&ix| {
+                    let id = &self.g.graph_ix[ix as usize];
+
+                    data[id].pure
+                }) {
+                    done.extend(node.iter().copied());
+                    return None;
+                }
+
                 let mut item_ids = node
                     .iter()
                     .map(|&ix| {

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -586,15 +586,6 @@ impl DepGraph {
 
         let mapped = condensed.filter_map(
             |_, node| {
-                if node.iter().all(|&ix| {
-                    let id = &self.g.graph_ix[ix as usize];
-
-                    data[id].pure
-                }) {
-                    done.extend(node.iter().copied());
-                    return None;
-                }
-
                 let mut item_ids = node
                     .iter()
                     .map(|&ix| {
@@ -616,7 +607,12 @@ impl DepGraph {
 
         for node in self.g.graph_ix.iter() {
             let ix = self.g.get_node(node);
+
             if !done.contains(&ix) {
+                if data[node].pure {
+                    continue;
+                }
+
                 let item_ids = vec![node.clone()];
                 new_graph.node(&item_ids);
             }


### PR DESCRIPTION
### What?

Use `pure` property to check if we need a group

### Why?

To reduce the number of internal parts.

### How?

