### PR TITLE
Add cause to turbopack-node error

### DIFF
--- a/turbopack/crates/turbopack-node/js/src/ipc/index.ts
+++ b/turbopack/crates/turbopack-node/js/src/ipc/index.ts
@@ -7,6 +7,7 @@ export type StructuredError = {
   name: string;
   message: string;
   stack: StackFrame[];
+  cause: StructuredError | undefined
 };
 
 export function structuredError(e: Error): StructuredError {
@@ -16,6 +17,7 @@ export function structuredError(e: Error): StructuredError {
     name: e.name,
     message: e.message,
     stack: typeof e.stack === "string" ? parseStackTrace(e.stack!) : [],
+    cause: e.cause ? structuredError(getProperError(e.cause)) : undefined,
   };
 }
 

--- a/turbopack/crates/turbopack-node/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-node/src/source_map/mod.rs
@@ -267,6 +267,7 @@ pub struct StructuredError {
     pub message: String,
     #[turbo_tasks(trace_ignore)]
     stack: Vec<StackFrame<'static>>,
+    cause: Option<Box<StructuredError>>,
 }
 
 impl StructuredError {
@@ -305,6 +306,20 @@ impl StructuredError {
                 formatting_mode,
             )?;
         }
+
+        if let Some(cause) = &self.cause {
+            message.write_str("\nCaused by: ")?;
+            message.write_str(
+                &Box::pin(cause.print(
+                    assets_for_source_mapping,
+                    root,
+                    project_dir,
+                    formatting_mode,
+                ))
+                .await?,
+            )?;
+        }
+
         Ok(message)
     }
 }


### PR DESCRIPTION
Occurs for example in
```
Failed to load chunk server/chunks/08b5e__pnpm_560cbe._.js
	....
Caused by SyntaxError: Identifier 'require' has already been declared
	....
```