### PR TITLE
test: disable next/test tests

### DIFF
--- a/test/e2e/next-test/next-test.test.ts
+++ b/test/e2e/next-test/next-test.test.ts
@@ -25,7 +25,7 @@ function createTemporaryFixture(fixtureName: string) {
   return dir
 }
 
-describe('next test', () => {
+describe.skip('next test', () => {
   const { next: basicExample, skipped } = nextTestSetup({
     files: new FileRef(join(__dirname, 'basic-example')),
     dependencies: {


### PR DESCRIPTION
Disable `next/test` tests to unblock CI. Looks flaky, it's not awalys passed

x-ref: https://github.com/vercel/next.js/actions/runs/11031668188/job/30638985367?pr=70378
x-ref: https://github.com/vercel/next.js/actions/runs/11024513436/job/30619652282?pr=70431