### PR TITLE
[Turbopack] fix rsc chunking optimization

### DIFF
--- a/crates/next-core/src/base_loader_tree.rs
+++ b/crates/next-core/src/base_loader_tree.rs
@@ -8,6 +8,7 @@ use turbopack_core::{
     file_source::FileSource,
     module::Module,
     reference_type::{EcmaScriptModulesReferenceSubType, ReferenceType},
+    source::Source,
 };
 use turbopack_ecmascript::{magic_identifier, utils::StringifyJs};
 
@@ -64,9 +65,7 @@ impl BaseLoaderTreeBuilder {
         i
     }
 
-    pub fn process_module(&self, path: Vc<FileSystemPath>) -> Vc<Box<dyn Module>> {
-        let source = Vc::upcast(FileSource::new(path));
-
+    pub fn process_source(&self, source: Vc<Box<dyn Source>>) -> Vc<Box<dyn Module>> {
         let reference_type = Value::new(ReferenceType::EcmaScriptModules(
             EcmaScriptModulesReferenceSubType::Undefined,
         ));
@@ -74,6 +73,11 @@ impl BaseLoaderTreeBuilder {
         self.server_component_transition
             .process(source, self.module_asset_context, reference_type)
             .module()
+    }
+
+    pub fn process_module(&self, module: Vc<Box<dyn Module>>) -> Vc<Box<dyn Module>> {
+        self.server_component_transition
+            .process_module(module, self.module_asset_context)
     }
 
     pub async fn create_module_tuple_code(
@@ -96,7 +100,7 @@ impl BaseLoaderTreeBuilder {
             .into(),
         );
 
-        let module = self.process_module(path);
+        let module = self.process_source(Vc::upcast(FileSource::new(path)));
 
         self.inner_assets
             .insert(format!("MODULE_{i}").into(), module);

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -107,7 +107,7 @@ pub async fn get_app_page_entry(
     let source = VirtualSource::new_with_ident(
         source
             .ident()
-            .with_query(Vc::cell(query.to_string().into())),
+            .with_query(Vc::cell(format!("?{}", query.to_string()).into())),
         AssetContent::file(file.into()),
     );
 

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -107,7 +107,7 @@ pub async fn get_app_page_entry(
     let source = VirtualSource::new_with_ident(
         source
             .ident()
-            .with_query(Vc::cell(format!("?{}", query.to_string()).into())),
+            .with_query(Vc::cell(format!("?{}", query).into())),
         AssetContent::file(file.into()),
     );
 

--- a/test/e2e/app-dir/app-edge-root-layout/index.test.ts
+++ b/test/e2e/app-dir/app-edge-root-layout/index.test.ts
@@ -25,7 +25,7 @@ describe('app-dir edge runtime root layout', () => {
       const middlewareManifest = await next.readFile(
         '.next/server/middleware-manifest.json'
       )
-      expect(middlewareManifest).not.toContain('favicon')
+      expect(middlewareManifest).not.toContain('/favicon')
     })
   }
 })

--- a/turbopack/crates/turbopack-core/src/server_fs.rs
+++ b/turbopack/crates/turbopack-core/src/server_fs.rs
@@ -52,12 +52,12 @@ impl FileSystem for ServerFileSystem {
         _fs_path: Vc<FileSystemPath>,
         _target: Vc<LinkContent>,
     ) -> Result<Vc<Completion>> {
-        bail!("Writing is not possible to the marker filesystem for the  server")
+        bail!("Writing is not possible to the marker filesystem for the server")
     }
 
     #[turbo_tasks::function]
     fn metadata(&self, _fs_path: Vc<FileSystemPath>) -> Result<Vc<FileMeta>> {
-        bail!("Reading is not possible from the marker filesystem for the  server")
+        bail!("Reading is not possible from the marker filesystem for the server")
     }
 }
 


### PR DESCRIPTION
### What?

* While looking for server component entries and client components, look for server utils too
* Create a separate chunk group for server utils
* Mark all user imports in the rsc entrypoint has server component entries
* Fix order of imports to allow proper caching
