### PR TITLE
chore(workflow): typo `popular-prs.ts` path

### DIFF
--- a/.github/actions/next-repo-actions/src/popular-prs.ts
+++ b/.github/actions/next-repo-actions/src/popular-prs.ts
@@ -39,7 +39,7 @@ async function run() {
 
       const blocks = BlockCollection([
         Section({
-          text: `*A list of the top ${count} PRs sorted by the most reactions (> 1) over the last 90 days.*\n_Note: This :github2: <https://github.com/vercel/next.js/blob/canary/.github/workflows/popular.yml|workflow> → <https://github.com/vercel/next.js/blob/canary/.github/actions/next-repo-info/src/popular-prs.mjs|action> will run every Monday at 10AM UTC (6AM EST)._`,
+          text: `*A list of the top ${count} PRs sorted by the most reactions (> 1) over the last 90 days.*\n_Note: This :github2: <https://github.com/vercel/next.js/blob/canary/.github/workflows/popular.yml|workflow> → <https://github.com/vercel/next.js/blob/canary/.github/actions/next-repo-actions/src/popular-prs.ts|action> will run every Monday at 10AM UTC (6AM EST)._`,
         }),
         Divider(),
         Section({


### PR DESCRIPTION
# Summary
Update `popular-prs.ts` action path

## Description
At #66383, `popular-prs.mjs` file was moved to `next-repo-actions` folder.
In addition, it updated `.ts` extension at #70414.

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide