### PR TITLE
Fix comment numbering in middleware example in docs

### DIFF
--- a/docs/02-app/01-building-your-application/09-authentication/index.mdx
+++ b/docs/02-app/01-building-your-application/09-authentication/index.mdx
@@ -1059,12 +1059,12 @@ export default async function middleware(req: NextRequest) {
   const cookie = cookies().get('session')?.value
   const session = await decrypt(cookie)
 
-  // 5. Redirect to /login if the user is not authenticated
+  // 4. Redirect to /login if the user is not authenticated
   if (isProtectedRoute && !session?.userId) {
     return NextResponse.redirect(new URL('/login', req.nextUrl))
   }
 
-  // 6. Redirect to /dashboard if the user is authenticated
+  // 5. Redirect to /dashboard if the user is authenticated
   if (
     isPublicRoute &&
     session?.userId &&


### PR DESCRIPTION
### What?
This PR fixes a numbering issue in the example code of the documentation. The comments in the code jumped from step 3 to step 5, so I renumbered them to maintain the correct sequence.

### Why?
Correcting the comment numbering improves the clarity and readability of the code, ensuring that readers can follow the steps in the right order.

### How?
I changed step 5 to step 4 and step 6 to step 5, adjusting the comment sequence without altering the logic or functionality of the code.

### Evidence

![image](https://github.com/user-attachments/assets/12b15de3-2cc3-4dca-9185-cde5a97cd0c3)