### PR TITLE
Increase retry duration from 3 to 5 seconds in RSC HMR cache tests

### DIFF
--- a/test/development/app-dir/server-components-hmr-cache/server-components-hmr-cache.test.ts
+++ b/test/development/app-dir/server-components-hmr-cache/server-components-hmr-cache.test.ts
@@ -18,27 +18,23 @@ describe('server-components-hmr-cache', () => {
   }
 
   describe.each(['edge', 'node'])('%s runtime', (runtime) => {
-    afterEach(async () => {
-      await next.patchFile('components/shared-page.tsx', (content) =>
-        content.replace('bar', 'foo')
-      )
-    })
-
     it('should use cached fetch calls for fast refresh requests', async () => {
       const browser = await next.browser(`/${runtime}`)
       const valueBeforePatch = await browser.elementById('value').text()
 
-      await next.patchFile('components/shared-page.tsx', (content) =>
-        content.replace('foo', 'bar')
+      await next.patchFile(
+        'components/shared-page.tsx',
+        (content) => content.replace('foo', 'bar'),
+        async () => {
+          await retry(async () => {
+            const updatedContent = await browser.elementById('content').text()
+            expect(updatedContent).toBe('bar')
+          })
+
+          const valueAfterPatch = await browser.elementById('value').text()
+          expect(valueBeforePatch).toEqual(valueAfterPatch)
+        }
       )
-
-      await retry(async () => {
-        const updatedContent = await browser.elementById('content').text()
-        expect(updatedContent).toBe('bar')
-      })
-
-      const valueAfterPatch = await browser.elementById('value').text()
-      expect(valueBeforePatch).toEqual(valueAfterPatch)
     })
 
     it('should not use cached fetch calls for intentional refresh requests', async () => {
@@ -62,17 +58,19 @@ describe('server-components-hmr-cache', () => {
         const valueBeforePatch = getLoggedAfterValue()
         cliOutputLength = next.cliOutput.length
 
-        await next.patchFile('components/shared-page.tsx', (content) =>
-          content.replace('foo', 'bar')
+        await next.patchFile(
+          'components/shared-page.tsx',
+          (content) => content.replace('foo', 'bar'),
+          async () => {
+            await retry(async () => {
+              const updatedContent = await browser.elementById('content').text()
+              expect(updatedContent).toBe('bar')
+            })
+
+            const valueAfterPatch = getLoggedAfterValue()
+            expect(valueBeforePatch).toEqual(valueAfterPatch)
+          }
         )
-
-        await retry(async () => {
-          const updatedContent = await browser.elementById('content').text()
-          expect(updatedContent).toBe('bar')
-        })
-
-        const valueAfterPatch = getLoggedAfterValue()
-        expect(valueBeforePatch).toEqual(valueAfterPatch)
       })
 
       it('should not use cached fetch calls for intentional refresh requests', async () => {
@@ -112,17 +110,19 @@ describe('server-components-hmr-cache', () => {
         const browser = await next.browser(`/${runtime}`)
         const valueBeforePatch = await browser.elementById('value').text()
 
-        await next.patchFile('components/shared-page.tsx', (content) =>
-          content.replace('foo', 'bar')
+        await next.patchFile(
+          'components/shared-page.tsx',
+          (content) => content.replace('foo', 'bar'),
+          async () => {
+            await retry(async () => {
+              const updatedContent = await browser.elementById('content').text()
+              expect(updatedContent).toBe('bar')
+            })
+
+            const valueAfterPatch = await browser.elementById('value').text()
+            expect(valueBeforePatch).not.toEqual(valueAfterPatch)
+          }
         )
-
-        await retry(async () => {
-          const updatedContent = await browser.elementById('content').text()
-          expect(updatedContent).toBe('bar')
-        })
-
-        const valueAfterPatch = await browser.elementById('value').text()
-        expect(valueBeforePatch).not.toEqual(valueAfterPatch)
       })
 
       describe('in after()', () => {
@@ -135,17 +135,21 @@ describe('server-components-hmr-cache', () => {
           const valueBeforePatch = await retry(() => getLoggedAfterValue())
           cliOutputLength = next.cliOutput.length
 
-          await next.patchFile('components/shared-page.tsx', (content) =>
-            content.replace('foo', 'bar')
+          await next.patchFile(
+            'components/shared-page.tsx',
+            (content) => content.replace('foo', 'bar'),
+            async () => {
+              await retry(async () => {
+                const updatedContent = await browser
+                  .elementById('content')
+                  .text()
+                expect(updatedContent).toBe('bar')
+              })
+
+              const valueAfterPatch = await retry(() => getLoggedAfterValue())
+              expect(valueBeforePatch).not.toEqual(valueAfterPatch)
+            }
           )
-
-          await retry(async () => {
-            const updatedContent = await browser.elementById('content').text()
-            expect(updatedContent).toBe('bar')
-          })
-
-          const valueAfterPatch = await retry(() => getLoggedAfterValue())
-          expect(valueBeforePatch).not.toEqual(valueAfterPatch)
         })
       })
     })

--- a/test/development/app-dir/server-components-hmr-cache/server-components-hmr-cache.test.ts
+++ b/test/development/app-dir/server-components-hmr-cache/server-components-hmr-cache.test.ts
@@ -29,7 +29,7 @@ describe('server-components-hmr-cache', () => {
           await retry(async () => {
             const updatedContent = await browser.elementById('content').text()
             expect(updatedContent).toBe('bar')
-          })
+          }, 5000)
 
           const valueAfterPatch = await browser.elementById('value').text()
           expect(valueBeforePatch).toEqual(valueAfterPatch)
@@ -45,7 +45,7 @@ describe('server-components-hmr-cache', () => {
       await retry(async () => {
         const valueAfterRefresh = await browser.elementById('value').text()
         expect(valueBeforeRefresh).not.toEqual(valueAfterRefresh)
-      })
+      }, 5000)
     })
 
     describe('in after()', () => {
@@ -65,7 +65,7 @@ describe('server-components-hmr-cache', () => {
             await retry(async () => {
               const updatedContent = await browser.elementById('content').text()
               expect(updatedContent).toBe('bar')
-            })
+            }, 5000)
 
             const valueAfterPatch = getLoggedAfterValue()
             expect(valueBeforePatch).toEqual(valueAfterPatch)
@@ -83,7 +83,7 @@ describe('server-components-hmr-cache', () => {
         await retry(async () => {
           const valueAfterRefresh = getLoggedAfterValue()
           expect(valueBeforeRefresh).not.toEqual(valueAfterRefresh)
-        })
+        }, 5000)
       })
     })
 
@@ -117,7 +117,7 @@ describe('server-components-hmr-cache', () => {
             await retry(async () => {
               const updatedContent = await browser.elementById('content').text()
               expect(updatedContent).toBe('bar')
-            })
+            }, 5000)
 
             const valueAfterPatch = await browser.elementById('value').text()
             expect(valueBeforePatch).not.toEqual(valueAfterPatch)
@@ -144,7 +144,7 @@ describe('server-components-hmr-cache', () => {
                   .elementById('content')
                   .text()
                 expect(updatedContent).toBe('bar')
-              })
+              }, 5000)
 
               const valueAfterPatch = await retry(() => getLoggedAfterValue())
               expect(valueBeforePatch).not.toEqual(valueAfterPatch)


### PR DESCRIPTION
The compilation for HMR changes often takes around 3 seconds in CI, so we need to increase the duration for the `retry` calls to avoid flakiness.

[This test run](https://github.com/vercel/next.js/actions/runs/11036231635/job/30654233890) shows that it sometimes barely finishes the compilation before the timeout:

<img width="467" alt="Screenshot 2024-10-11 at 19 14 41" src="https://github.com/user-attachments/assets/faae5593-3b03-4085-b3e6-54eff5c514bc">

... and sometimes it doesn't:

<img width="591" alt="Screenshot 2024-10-11 at 19 22 48" src="https://github.com/user-attachments/assets/4441b700-6c79-42dc-bdb6-abf29d7ceeec">
