### PR TITLE
codemod(turbopack): Remove unused async function modifier keywords

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -152,7 +152,7 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    async fn client_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
+    fn client_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_client_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
@@ -164,7 +164,7 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    async fn client_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
+    fn client_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_client_resolve_options_context(
             self.project().project_path(),
             Value::new(self.client_ty()),
@@ -180,13 +180,13 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    async fn client_transition(self: Vc<Self>) -> Result<Vc<FullContextTransition>> {
+    fn client_transition(self: Vc<Self>) -> Result<Vc<FullContextTransition>> {
         let module_context = self.client_module_context();
         Ok(FullContextTransition::new(module_context))
     }
 
     #[turbo_tasks::function]
-    async fn rsc_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
+    fn rsc_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
@@ -198,7 +198,7 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    async fn edge_rsc_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
+    fn edge_rsc_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
@@ -210,7 +210,7 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    async fn route_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
+    fn route_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
@@ -222,7 +222,7 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    async fn edge_route_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
+    fn edge_route_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
@@ -234,7 +234,7 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    async fn rsc_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
+    fn rsc_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_server_resolve_options_context(
             self.project().project_path(),
             Value::new(self.rsc_ty()),
@@ -245,7 +245,7 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    async fn edge_rsc_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
+    fn edge_rsc_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_edge_resolve_options_context(
             self.project().project_path(),
             Value::new(self.rsc_ty()),
@@ -256,7 +256,7 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    async fn route_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
+    fn route_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_server_resolve_options_context(
             self.project().project_path(),
             Value::new(self.route_ty()),
@@ -267,9 +267,7 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    async fn edge_route_resolve_options_context(
-        self: Vc<Self>,
-    ) -> Result<Vc<ResolveOptionsContext>> {
+    fn edge_route_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_edge_resolve_options_context(
             self.project().project_path(),
             Value::new(self.route_ty()),
@@ -446,7 +444,7 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    async fn ssr_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
+    fn ssr_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
@@ -458,7 +456,7 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    async fn edge_ssr_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
+    fn edge_ssr_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
@@ -470,7 +468,7 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    async fn ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
+    fn ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_server_resolve_options_context(
             self.project().project_path(),
             Value::new(self.ssr_ty()),
@@ -481,7 +479,7 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    async fn edge_ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
+    fn edge_ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_edge_resolve_options_context(
             self.project().project_path(),
             Value::new(self.ssr_ty()),
@@ -532,7 +530,7 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    async fn runtime_entries(self: Vc<Self>) -> Result<Vc<RuntimeEntries>> {
+    fn runtime_entries(self: Vc<Self>) -> Result<Vc<RuntimeEntries>> {
         Ok(get_server_runtime_entries(
             Value::new(self.rsc_ty()),
             self.project().next_mode(),
@@ -560,7 +558,7 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    async fn client_runtime_entries(self: Vc<Self>) -> Result<Vc<EvaluatableAssets>> {
+    fn client_runtime_entries(self: Vc<Self>) -> Result<Vc<EvaluatableAssets>> {
         Ok(get_client_runtime_entries(
             self.project().project_path(),
             Value::new(self.client_ty()),

--- a/crates/next-api/src/global_module_id_strategy.rs
+++ b/crates/next-api/src/global_module_id_strategy.rs
@@ -84,7 +84,7 @@ impl GlobalModuleIdStrategyBuilder {
 // NOTE(LichuAcu) We can't move this function to `turbopack-core` because we need access to
 // `Endpoint`, which is not available there.
 #[turbo_tasks::function]
-async fn preprocess_module_ids(
+fn preprocess_module_ids(
     endpoint: Vc<Box<dyn Endpoint>>,
 ) -> Result<Vc<PreprocessedChildrenIdents>> {
     let root_modules = endpoint.root_modules();

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -65,7 +65,7 @@ impl InstrumentationEndpoint {
     }
 
     #[turbo_tasks::function]
-    async fn core_modules(&self) -> Result<Vc<InstrumentationCoreModules>> {
+    fn core_modules(&self) -> Result<Vc<InstrumentationCoreModules>> {
         let userland_module = self
             .asset_context
             .process(

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -255,7 +255,7 @@ impl MiddlewareEndpoint {
     }
 
     #[turbo_tasks::function]
-    async fn userland_module(&self) -> Result<Vc<Box<dyn Module>>> {
+    fn userland_module(&self) -> Result<Vc<Box<dyn Module>>> {
         Ok(self
             .asset_context
             .process(

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -81,7 +81,7 @@ pub struct PagesProject {
 #[turbo_tasks::value_impl]
 impl PagesProject {
     #[turbo_tasks::function]
-    pub async fn new(project: Vc<Project>) -> Result<Vc<Self>> {
+    pub fn new(project: Vc<Project>) -> Result<Vc<Self>> {
         Ok(PagesProject { project }.cell())
     }
 
@@ -279,7 +279,7 @@ impl PagesProject {
     }
 
     #[turbo_tasks::function]
-    async fn client_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
+    fn client_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_client_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
@@ -293,7 +293,7 @@ impl PagesProject {
     }
 
     #[turbo_tasks::function]
-    async fn client_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
+    fn client_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_client_resolve_options_context(
             self.project().project_path(),
             Value::new(ClientContextType::Pages {
@@ -385,7 +385,7 @@ impl PagesProject {
     }
 
     #[turbo_tasks::function]
-    async fn ssr_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
+    fn ssr_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
@@ -399,7 +399,7 @@ impl PagesProject {
     }
 
     #[turbo_tasks::function]
-    async fn edge_ssr_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
+    fn edge_ssr_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
@@ -413,7 +413,7 @@ impl PagesProject {
     }
 
     #[turbo_tasks::function]
-    async fn api_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
+    fn api_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
@@ -427,7 +427,7 @@ impl PagesProject {
     }
 
     #[turbo_tasks::function]
-    async fn edge_api_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
+    fn edge_api_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
@@ -441,7 +441,7 @@ impl PagesProject {
     }
 
     #[turbo_tasks::function]
-    async fn ssr_data_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
+    fn ssr_data_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
@@ -455,9 +455,7 @@ impl PagesProject {
     }
 
     #[turbo_tasks::function]
-    async fn edge_ssr_data_module_options_context(
-        self: Vc<Self>,
-    ) -> Result<Vc<ModuleOptionsContext>> {
+    fn edge_ssr_data_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
         Ok(get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
@@ -471,7 +469,7 @@ impl PagesProject {
     }
 
     #[turbo_tasks::function]
-    async fn ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
+    fn ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_server_resolve_options_context(
             self.project().project_path(),
             // NOTE(alexkirsz) This could be `PagesData` for the data endpoint, but it doesn't
@@ -487,7 +485,7 @@ impl PagesProject {
     }
 
     #[turbo_tasks::function]
-    async fn edge_ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
+    fn edge_ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_edge_resolve_options_context(
             self.project().project_path(),
             // NOTE(alexkirsz) This could be `PagesData` for the data endpoint, but it doesn't
@@ -503,7 +501,7 @@ impl PagesProject {
     }
 
     #[turbo_tasks::function]
-    async fn client_runtime_entries(self: Vc<Self>) -> Result<Vc<EvaluatableAssets>> {
+    fn client_runtime_entries(self: Vc<Self>) -> Result<Vc<EvaluatableAssets>> {
         let client_runtime_entries = get_client_runtime_entries(
             self.project().project_path(),
             Value::new(ClientContextType::Pages {
@@ -517,7 +515,7 @@ impl PagesProject {
     }
 
     #[turbo_tasks::function]
-    async fn runtime_entries(self: Vc<Self>) -> Result<Vc<RuntimeEntries>> {
+    fn runtime_entries(self: Vc<Self>) -> Result<Vc<RuntimeEntries>> {
         Ok(get_server_runtime_entries(
             Value::new(ServerContextType::Pages {
                 pages_dir: self.pages_dir(),
@@ -527,7 +525,7 @@ impl PagesProject {
     }
 
     #[turbo_tasks::function]
-    async fn data_runtime_entries(self: Vc<Self>) -> Result<Vc<RuntimeEntries>> {
+    fn data_runtime_entries(self: Vc<Self>) -> Result<Vc<RuntimeEntries>> {
         Ok(get_server_runtime_entries(
             Value::new(ServerContextType::PagesData {
                 pages_dir: self.pages_dir(),
@@ -640,7 +638,7 @@ impl PageEndpoint {
     }
 
     #[turbo_tasks::function]
-    async fn source(&self) -> Result<Vc<Box<dyn Source>>> {
+    fn source(&self) -> Result<Vc<Box<dyn Source>>> {
         Ok(Vc::upcast(FileSource::new(self.page.project_path())))
     }
 

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -382,7 +382,7 @@ impl ProjectContainer {
     /// Gets a source map for a particular `file_path`. If `dev` mode is
     /// disabled, this will always return [`OptionSourceMap::none`].
     #[turbo_tasks::function]
-    pub async fn get_source_map(
+    pub fn get_source_map(
         &self,
         file_path: Vc<FileSystemPath>,
         section: Option<RcStr>,
@@ -510,7 +510,7 @@ impl Project {
     }
 
     #[turbo_tasks::function]
-    pub async fn pages_project(self: Vc<Self>) -> Result<Vc<PagesProject>> {
+    pub fn pages_project(self: Vc<Self>) -> Result<Vc<PagesProject>> {
         Ok(PagesProject::new(self))
     }
 
@@ -528,19 +528,19 @@ impl Project {
     }
 
     #[turbo_tasks::function]
-    async fn client_fs(self: Vc<Self>) -> Result<Vc<Box<dyn FileSystem>>> {
+    fn client_fs(self: Vc<Self>) -> Result<Vc<Box<dyn FileSystem>>> {
         let virtual_fs = VirtualFileSystem::new();
         Ok(Vc::upcast(virtual_fs))
     }
 
     #[turbo_tasks::function]
-    pub async fn output_fs(&self) -> Result<Vc<DiskFileSystem>> {
+    pub fn output_fs(&self) -> Result<Vc<DiskFileSystem>> {
         let disk_fs = DiskFileSystem::new("output".into(), self.project_path.clone(), vec![]);
         Ok(disk_fs)
     }
 
     #[turbo_tasks::function]
-    pub async fn dist_dir(&self) -> Result<Vc<RcStr>> {
+    pub fn dist_dir(&self) -> Result<Vc<RcStr>> {
         Ok(Vc::cell(self.dist_dir.clone()))
     }
 
@@ -585,22 +585,22 @@ impl Project {
     }
 
     #[turbo_tasks::function]
-    pub(super) async fn env(&self) -> Result<Vc<Box<dyn ProcessEnv>>> {
+    pub(super) fn env(&self) -> Result<Vc<Box<dyn ProcessEnv>>> {
         Ok(self.env)
     }
 
     #[turbo_tasks::function]
-    pub(super) async fn next_config(&self) -> Result<Vc<NextConfig>> {
+    pub(super) fn next_config(&self) -> Result<Vc<NextConfig>> {
         Ok(self.next_config)
     }
 
     #[turbo_tasks::function]
-    pub(super) async fn next_mode(&self) -> Result<Vc<NextMode>> {
+    pub(super) fn next_mode(&self) -> Result<Vc<NextMode>> {
         Ok(self.mode)
     }
 
     #[turbo_tasks::function]
-    pub(super) async fn js_config(&self) -> Result<Vc<JsConfig>> {
+    pub(super) fn js_config(&self) -> Result<Vc<JsConfig>> {
         Ok(self.js_config)
     }
 
@@ -630,7 +630,7 @@ impl Project {
     }
 
     #[turbo_tasks::function]
-    pub(super) async fn client_compile_time_info(&self) -> Result<Vc<CompileTimeInfo>> {
+    pub(super) fn client_compile_time_info(&self) -> Result<Vc<CompileTimeInfo>> {
         Ok(get_client_compile_time_info(
             self.browserslist_query.clone(),
             self.define_env.client(),
@@ -668,9 +668,7 @@ impl Project {
     }
 
     #[turbo_tasks::function]
-    pub(super) async fn client_chunking_context(
-        self: Vc<Self>,
-    ) -> Result<Vc<Box<dyn ChunkingContext>>> {
+    pub(super) fn client_chunking_context(self: Vc<Self>) -> Result<Vc<Box<dyn ChunkingContext>>> {
         Ok(get_client_chunking_context(
             self.project_path(),
             self.client_relative_path(),
@@ -1324,6 +1322,6 @@ fn all_assets_from_entries_operation(
 }
 
 #[turbo_tasks::function]
-async fn stable_endpoint(endpoint: Vc<Box<dyn Endpoint>>) -> Result<Vc<Box<dyn Endpoint>>> {
+fn stable_endpoint(endpoint: Vc<Box<dyn Endpoint>>) -> Result<Vc<Box<dyn Endpoint>>> {
     Ok(endpoint)
 }

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -230,7 +230,7 @@ impl VersionedContentMap {
     }
 
     #[turbo_tasks::function]
-    async fn raw_get(&self, path: Vc<FileSystemPath>) -> Result<Vc<OptionMapEntry>> {
+    fn raw_get(&self, path: Vc<FileSystemPath>) -> Result<Vc<OptionMapEntry>> {
         let assets = {
             let map = self.map_path_to_op.get();
             map.get(&path).and_then(|m| m.iter().last().copied())

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -732,7 +732,7 @@ struct DuplicateParallelRouteIssue {
 #[turbo_tasks::value_impl]
 impl Issue for DuplicateParallelRouteIssue {
     #[turbo_tasks::function]
-    async fn file_path(&self) -> Result<Vc<FileSystemPath>> {
+    fn file_path(&self) -> Result<Vc<FileSystemPath>> {
         Ok(self.app_dir.join(self.page.to_string().into()))
     }
 
@@ -1355,7 +1355,7 @@ impl Issue for DirectoryTreeIssue {
     }
 
     #[turbo_tasks::function]
-    async fn title(&self) -> Result<Vc<StyledString>> {
+    fn title(&self) -> Result<Vc<StyledString>> {
         Ok(StyledString::Text("An issue occurred while preparing your Next.js app".into()).cell())
     }
 

--- a/crates/next-core/src/bootstrap.rs
+++ b/crates/next-core/src/bootstrap.rs
@@ -14,7 +14,7 @@ use turbopack_core::{
 use turbopack_ecmascript::utils::StringifyJs;
 
 #[turbo_tasks::function]
-pub async fn route_bootstrap(
+pub fn route_bootstrap(
     asset: Vc<Box<dyn Module>>,
     asset_context: Vc<Box<dyn AssetContext>>,
     base_path: Vc<FileSystemPath>,

--- a/crates/next-core/src/hmr_entry.rs
+++ b/crates/next-core/src/hmr_entry.rs
@@ -121,7 +121,7 @@ impl ValueToString for HmrEntryModuleReference {
 #[turbo_tasks::value_impl]
 impl ModuleReference for HmrEntryModuleReference {
     #[turbo_tasks::function]
-    async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
+    fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
         Ok(ModuleResolveResult::module(self.module).cell())
     }
 }

--- a/crates/next-core/src/next_app/include_modules_module.rs
+++ b/crates/next-core/src/next_app/include_modules_module.rs
@@ -75,7 +75,7 @@ impl EcmascriptChunkPlaceable for IncludeModulesModule {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for IncludeModulesModule {
     #[turbo_tasks::function]
-    async fn as_chunk_item(
+    fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn ChunkItem>>> {
@@ -165,7 +165,7 @@ impl ValueToString for IncludedModuleReference {
 #[turbo_tasks::value_impl]
 impl ModuleReference for IncludedModuleReference {
     #[turbo_tasks::function]
-    async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
+    fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
         Ok(ModuleResolveResult::module(self.module).cell())
     }
 }

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -57,7 +57,7 @@ impl Module for EcmascriptClientReferenceModule {
     }
 
     #[turbo_tasks::function]
-    async fn additional_layers_modules(&self) -> Result<Vc<Modules>> {
+    fn additional_layers_modules(&self) -> Result<Vc<Modules>> {
         let client_module = Vc::upcast(self.client_module);
         let ssr_module = Vc::upcast(self.ssr_module);
         Ok(Vc::cell(vec![client_module, ssr_module]))

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_proxy_module.rs
@@ -262,7 +262,7 @@ fn client_reference_description() -> Vc<RcStr> {
 #[turbo_tasks::value_impl]
 impl ChunkItem for ProxyModuleChunkItem {
     #[turbo_tasks::function]
-    async fn asset_ident(&self) -> Vc<AssetIdent> {
+    fn asset_ident(&self) -> Vc<AssetIdent> {
         self.client_proxy_asset.ident()
     }
 
@@ -272,7 +272,7 @@ impl ChunkItem for ProxyModuleChunkItem {
     }
 
     #[turbo_tasks::function]
-    async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
     }
 

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -792,7 +792,7 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn server_external_packages(&self) -> Result<Vc<Vec<RcStr>>> {
+    pub fn server_external_packages(&self) -> Result<Vc<Vec<RcStr>>> {
         Ok(Vc::cell(
             self.server_external_packages
                 .as_ref()
@@ -802,7 +802,7 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn env(&self) -> Result<Vc<EnvMap>> {
+    pub fn env(&self) -> Result<Vc<EnvMap>> {
         // The value expected for env is Record<String, String>, but config itself
         // allows arbitrary object (https://github.com/vercel/next.js/blob/25ba8a74b7544dfb6b30d1b67c47b9cb5360cb4e/packages/next/src/server/config-schema.ts#L203)
         // then stringifies it. We do the interop here as well.
@@ -826,27 +826,24 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn image_config(&self) -> Result<Vc<ImageConfig>> {
+    pub fn image_config(&self) -> Result<Vc<ImageConfig>> {
         Ok(self.images.clone().cell())
     }
 
     #[turbo_tasks::function]
-    pub async fn page_extensions(&self) -> Result<Vc<Vec<RcStr>>> {
+    pub fn page_extensions(&self) -> Result<Vc<Vec<RcStr>>> {
         Ok(Vc::cell(self.page_extensions.clone()))
     }
 
     #[turbo_tasks::function]
-    pub async fn transpile_packages(&self) -> Result<Vc<Vec<RcStr>>> {
+    pub fn transpile_packages(&self) -> Result<Vc<Vec<RcStr>>> {
         Ok(Vc::cell(
             self.transpile_packages.clone().unwrap_or_default(),
         ))
     }
 
     #[turbo_tasks::function]
-    pub async fn webpack_rules(
-        &self,
-        active_conditions: Vec<RcStr>,
-    ) -> Result<Vc<OptionWebpackRules>> {
+    pub fn webpack_rules(&self, active_conditions: Vec<RcStr>) -> Result<Vc<OptionWebpackRules>> {
         let Some(turbo_rules) = self
             .experimental
             .turbo
@@ -934,7 +931,7 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn resolve_alias_options(&self) -> Result<Vc<ResolveAliasMap>> {
+    pub fn resolve_alias_options(&self) -> Result<Vc<ResolveAliasMap>> {
         let Some(resolve_alias) = self
             .experimental
             .turbo
@@ -948,7 +945,7 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn resolve_extension(&self) -> Result<Vc<ResolveExtensions>> {
+    pub fn resolve_extension(&self) -> Result<Vc<ResolveExtensions>> {
         let Some(resolve_extensions) = self
             .experimental
             .turbo
@@ -970,7 +967,7 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn mdx_rs(&self) -> Result<Vc<OptionalMdxTransformOptions>> {
+    pub fn mdx_rs(&self) -> Result<Vc<OptionalMdxTransformOptions>> {
         let options = &self.experimental.mdx_rs;
 
         let options = match options {
@@ -1000,7 +997,7 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn react_compiler(&self) -> Result<Vc<OptionalReactCompilerOptions>> {
+    pub fn react_compiler(&self) -> Result<Vc<OptionalReactCompilerOptions>> {
         let options = &self.experimental.react_compiler;
 
         let options = match options {
@@ -1023,19 +1020,19 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn sass_config(&self) -> Result<Vc<JsonValue>> {
+    pub fn sass_config(&self) -> Result<Vc<JsonValue>> {
         Ok(Vc::cell(self.sass_options.clone().unwrap_or_default()))
     }
 
     #[turbo_tasks::function]
-    pub async fn skip_middleware_url_normalize(&self) -> Result<Vc<bool>> {
+    pub fn skip_middleware_url_normalize(&self) -> Result<Vc<bool>> {
         Ok(Vc::cell(
             self.skip_middleware_url_normalize.unwrap_or(false),
         ))
     }
 
     #[turbo_tasks::function]
-    pub async fn skip_trailing_slash_redirect(&self) -> Result<Vc<bool>> {
+    pub fn skip_trailing_slash_redirect(&self) -> Result<Vc<bool>> {
         Ok(Vc::cell(self.skip_trailing_slash_redirect.unwrap_or(false)))
     }
 
@@ -1060,7 +1057,7 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn enable_ppr(&self) -> Result<Vc<bool>> {
+    pub fn enable_ppr(&self) -> Result<Vc<bool>> {
         Ok(Vc::cell(
             self.experimental
                 .ppr
@@ -1076,17 +1073,17 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn enable_taint(&self) -> Result<Vc<bool>> {
+    pub fn enable_taint(&self) -> Result<Vc<bool>> {
         Ok(Vc::cell(self.experimental.taint.unwrap_or(false)))
     }
 
     #[turbo_tasks::function]
-    pub async fn enable_dynamic_io(&self) -> Result<Vc<bool>> {
+    pub fn enable_dynamic_io(&self) -> Result<Vc<bool>> {
         Ok(Vc::cell(self.experimental.dynamic_io.unwrap_or(false)))
     }
 
     #[turbo_tasks::function]
-    pub async fn use_swc_css(&self) -> Result<Vc<bool>> {
+    pub fn use_swc_css(&self) -> Result<Vc<bool>> {
         Ok(Vc::cell(
             self.experimental
                 .turbo
@@ -1097,7 +1094,7 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn optimize_package_imports(&self) -> Result<Vc<Vec<RcStr>>> {
+    pub fn optimize_package_imports(&self) -> Result<Vc<Vec<RcStr>>> {
         Ok(Vc::cell(
             self.experimental
                 .optimize_package_imports
@@ -1107,7 +1104,7 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn tree_shaking_mode_for_foreign_code(
+    pub fn tree_shaking_mode_for_foreign_code(
         &self,
         is_development: bool,
     ) -> Result<Vc<OptionTreeShaking>> {
@@ -1132,7 +1129,7 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn tree_shaking_mode_for_user_code(
+    pub fn tree_shaking_mode_for_user_code(
         self: Vc<Self>,
         is_development: bool,
     ) -> Result<Vc<OptionTreeShaking>> {
@@ -1144,7 +1141,7 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn module_id_strategy_config(&self) -> Result<Vc<OptionModuleIdStrategy>> {
+    pub fn module_id_strategy_config(&self) -> Result<Vc<OptionModuleIdStrategy>> {
         let Some(module_id_strategy) = self
             .experimental
             .turbo
@@ -1178,7 +1175,7 @@ impl JsConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn compiler_options(&self) -> Result<Vc<serde_json::Value>> {
+    pub fn compiler_options(&self) -> Result<Vc<serde_json::Value>> {
         Ok(Vc::cell(self.compiler_options.clone().unwrap_or_default()))
     }
 }

--- a/crates/next-core/src/next_font/google/options.rs
+++ b/crates/next-core/src/next_font/google/options.rs
@@ -35,7 +35,7 @@ impl NextFontGoogleOptions {
     }
 
     #[turbo_tasks::function]
-    pub async fn font_family(&self) -> Result<Vc<RcStr>> {
+    pub fn font_family(&self) -> Result<Vc<RcStr>> {
         Ok(Vc::cell((*self.font_family).into()))
     }
 }

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -65,7 +65,7 @@ impl NextFontLocalResolvePlugin {
 #[turbo_tasks::value_impl]
 impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
     #[turbo_tasks::function]
-    async fn before_resolve_condition(&self) -> Vc<BeforeResolvePluginCondition> {
+    fn before_resolve_condition(&self) -> Vc<BeforeResolvePluginCondition> {
         BeforeResolvePluginCondition::from_request_glob(Glob::new(
             "{next,@vercel/turbopack-next/internal}/font/local/*".into(),
         ))
@@ -321,7 +321,7 @@ impl Issue for FontResolvingIssue {
     }
 
     #[turbo_tasks::function]
-    async fn file_path(&self) -> Result<Vc<FileSystemPath>> {
+    fn file_path(&self) -> Result<Vc<FileSystemPath>> {
         Ok(self.origin_path)
     }
 

--- a/crates/next-core/src/next_font/local/options.rs
+++ b/crates/next-core/src/next_font/local/options.rs
@@ -41,7 +41,7 @@ impl NextFontLocalOptions {
     }
 
     #[turbo_tasks::function]
-    pub async fn font_family(&self) -> Result<Vc<RcStr>> {
+    pub fn font_family(&self) -> Result<Vc<RcStr>> {
         Ok(Vc::cell(self.variable_name.clone()))
     }
 }

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -166,7 +166,7 @@ pub async fn create_page_ssr_entry_module(
 }
 
 #[turbo_tasks::function]
-async fn process_global_item(
+fn process_global_item(
     item: Vc<PagesStructureItem>,
     reference_type: Value<ReferenceType>,
     module_context: Vc<Box<dyn AssetContext>>,

--- a/crates/next-core/src/next_route_matcher/mod.rs
+++ b/crates/next-core/src/next_route_matcher/mod.rs
@@ -21,7 +21,7 @@ pub(crate) struct NextExactMatcher {
 #[turbo_tasks::value_impl]
 impl NextExactMatcher {
     #[turbo_tasks::function]
-    pub async fn new(path: Vc<RcStr>) -> Result<Vc<Self>> {
+    pub fn new(path: Vc<RcStr>) -> Result<Vc<Self>> {
         Ok(Self::cell(NextExactMatcher { path }))
     }
 }

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -348,7 +348,7 @@ async fn next_server_free_vars(define_env: Vc<EnvMap>) -> Result<Vc<FreeVarRefer
 }
 
 #[turbo_tasks::function]
-pub async fn get_server_compile_time_info(
+pub fn get_server_compile_time_info(
     process_env: Vc<Box<dyn ProcessEnv>>,
     define_env: Vc<EnvMap>,
 ) -> Vc<CompileTimeInfo> {

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -46,7 +46,7 @@ impl NextServerComponentModule {
     }
 
     #[turbo_tasks::function]
-    pub async fn server_path(&self) -> Result<Vc<FileSystemPath>> {
+    pub fn server_path(&self) -> Result<Vc<FileSystemPath>> {
         Ok(self.module.ident().path())
     }
 }
@@ -89,7 +89,7 @@ impl Asset for NextServerComponentModule {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for NextServerComponentModule {
     #[turbo_tasks::function]
-    async fn as_chunk_item(
+    fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
@@ -177,7 +177,7 @@ impl ChunkItem for NextServerComponentChunkItem {
     }
 
     #[turbo_tasks::function]
-    async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         self.chunking_context
     }
 

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -125,7 +125,7 @@ impl BeforeResolvePlugin for InvalidImportResolvePlugin {
     }
 
     #[turbo_tasks::function]
-    async fn before_resolve(
+    fn before_resolve(
         &self,
         lookup_path: Vc<FileSystemPath>,
         _reference_type: Value<ReferenceType>,

--- a/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
+++ b/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
@@ -157,7 +157,7 @@ impl Issue for PageStaticInfoIssue {
     }
 
     #[turbo_tasks::function]
-    async fn description(&self) -> Result<Vc<OptionStyledString>> {
+    fn description(&self) -> Result<Vc<OptionStyledString>> {
         Ok(Vc::cell(Some(
             StyledString::Line(
                 self.messages

--- a/crates/next-core/src/pages_structure.rs
+++ b/crates/next-core/src/pages_structure.rs
@@ -26,7 +26,7 @@ pub struct PagesStructureItem {
 #[turbo_tasks::value_impl]
 impl PagesStructureItem {
     #[turbo_tasks::function]
-    async fn new(
+    fn new(
         base_path: Vc<FileSystemPath>,
         extensions: Vc<Vec<RcStr>>,
         fallback_path: Option<Vc<FileSystemPath>>,
@@ -102,7 +102,7 @@ impl PagesDirectoryStructure {
     /// Returns the path to the directory of this structure in the project file
     /// system.
     #[turbo_tasks::function]
-    pub async fn project_path(&self) -> Result<Vc<FileSystemPath>> {
+    pub fn project_path(&self) -> Result<Vc<FileSystemPath>> {
         Ok(self.project_path)
     }
 }

--- a/turbopack/crates/turbo-tasks-env/src/dotenv.rs
+++ b/turbopack/crates/turbo-tasks-env/src/dotenv.rs
@@ -24,7 +24,7 @@ impl DotenvProcessEnv {
     }
 
     #[turbo_tasks::function]
-    pub async fn read_prior(&self) -> Result<Vc<EnvMap>> {
+    pub fn read_prior(&self) -> Result<Vc<EnvMap>> {
         match self.prior {
             None => Ok(EnvMap::empty()),
             Some(p) => Ok(p.read_all()),
@@ -76,7 +76,7 @@ impl DotenvProcessEnv {
 #[turbo_tasks::value_impl]
 impl ProcessEnv for DotenvProcessEnv {
     #[turbo_tasks::function]
-    async fn read_all(self: Vc<Self>) -> Result<Vc<EnvMap>> {
+    fn read_all(self: Vc<Self>) -> Result<Vc<EnvMap>> {
         let prior = self.read_prior();
         Ok(self.read_all_with_prior(prior))
     }

--- a/turbopack/crates/turbo-tasks-env/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-env/src/lib.rs
@@ -30,12 +30,12 @@ impl EnvMap {
 #[turbo_tasks::value_impl]
 impl ProcessEnv for EnvMap {
     #[turbo_tasks::function]
-    async fn read_all(self: Vc<Self>) -> Result<Vc<EnvMap>> {
+    fn read_all(self: Vc<Self>) -> Result<Vc<EnvMap>> {
         Ok(self)
     }
 
     #[turbo_tasks::function]
-    async fn read(self: Vc<Self>, name: RcStr) -> Vc<Option<RcStr>> {
+    fn read(self: Vc<Self>, name: RcStr) -> Vc<Option<RcStr>> {
         case_insensitive_read(self, name)
     }
 }

--- a/turbopack/crates/turbo-tasks-fs/src/embed/file.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/file.rs
@@ -30,7 +30,7 @@ pub async fn content_from_relative_path(
 }
 
 #[turbo_tasks::function]
-pub async fn content_from_str(string: RcStr) -> Result<Vc<FileContent>> {
+pub fn content_from_str(string: RcStr) -> Result<Vc<FileContent>> {
     Ok(File::from(string).into())
 }
 

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1195,7 +1195,7 @@ impl FileSystemPath {
     }
 
     #[turbo_tasks::function]
-    pub async fn read_glob(
+    pub fn read_glob(
         self: Vc<Self>,
         glob: Vc<Glob>,
         include_dot_files: bool,
@@ -1209,12 +1209,12 @@ impl FileSystemPath {
     }
 
     #[turbo_tasks::function]
-    pub async fn fs(&self) -> Result<Vc<Box<dyn FileSystem>>> {
+    pub fn fs(&self) -> Result<Vc<Box<dyn FileSystem>>> {
         Ok(self.fs)
     }
 
     #[turbo_tasks::function]
-    pub async fn extension(&self) -> Result<Vc<RcStr>> {
+    pub fn extension(&self) -> Result<Vc<RcStr>> {
         Ok(Vc::cell(self.extension_ref().unwrap_or("").into()))
     }
 
@@ -1253,7 +1253,7 @@ impl FileSystemPath {
     /// * The entire file name if the file name begins with `.` and has no other `.`s within;
     /// * Otherwise, the portion of the file name before the final `.`
     #[turbo_tasks::function]
-    pub async fn file_stem(&self) -> Result<Vc<Option<RcStr>>> {
+    pub fn file_stem(&self) -> Result<Vc<Option<RcStr>>> {
         let (_, file_stem, _) = self.split_file_stem_extension();
         if file_stem.is_empty() {
             return Ok(Vc::cell(None));
@@ -1478,7 +1478,7 @@ pub struct RealPathResult {
 #[turbo_tasks::value_impl]
 impl RealPathResult {
     #[turbo_tasks::function]
-    pub async fn path(&self) -> Result<Vc<FileSystemPath>> {
+    pub fn path(&self) -> Result<Vc<FileSystemPath>> {
         Ok(self.path)
     }
 }

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -485,7 +485,7 @@ impl ChunkingContext for BrowserChunkingContext {
     }
 
     #[turbo_tasks::function]
-    async fn chunk_item_id_from_ident(&self, ident: Vc<AssetIdent>) -> Result<Vc<ModuleId>> {
+    fn chunk_item_id_from_ident(&self, ident: Vc<AssetIdent>) -> Result<Vc<ModuleId>> {
         Ok(self.module_id_strategy.get_module_id(ident))
     }
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
@@ -40,7 +40,7 @@ impl EcmascriptDevChunk {
 #[turbo_tasks::value_impl]
 impl ValueToString for EcmascriptDevChunk {
     #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
+    fn to_string(&self) -> Result<Vc<RcStr>> {
         Ok(Vc::cell("Ecmascript Dev Chunk".into()))
     }
 }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -47,7 +47,7 @@ impl EcmascriptDevChunkContent {
     }
 
     #[turbo_tasks::function]
-    pub async fn entries(&self) -> Result<Vc<EcmascriptDevChunkContentEntries>> {
+    pub fn entries(&self) -> Result<Vc<EcmascriptDevChunkContentEntries>> {
         Ok(self.entries)
     }
 }
@@ -55,7 +55,7 @@ impl EcmascriptDevChunkContent {
 #[turbo_tasks::value_impl]
 impl EcmascriptDevChunkContent {
     #[turbo_tasks::function]
-    pub(crate) async fn own_version(&self) -> Result<Vc<EcmascriptDevChunkVersion>> {
+    pub(crate) fn own_version(&self) -> Result<Vc<EcmascriptDevChunkVersion>> {
         Ok(EcmascriptDevChunkVersion::new(
             self.chunking_context.output_root(),
             self.chunk.ident().path(),

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -57,7 +57,7 @@ impl EcmascriptDevEvaluateChunk {
     }
 
     #[turbo_tasks::function]
-    async fn chunks_data(&self) -> Result<Vc<ChunksData>> {
+    fn chunks_data(&self) -> Result<Vc<ChunksData>> {
         Ok(ChunkData::from_assets(
             self.chunking_context.output_root(),
             self.other_chunks,
@@ -189,7 +189,7 @@ impl EcmascriptDevEvaluateChunk {
 #[turbo_tasks::value_impl]
 impl ValueToString for EcmascriptDevEvaluateChunk {
     #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
+    fn to_string(&self) -> Result<Vc<RcStr>> {
         Ok(Vc::cell("Ecmascript Dev Evaluate Chunk".into()))
     }
 }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
@@ -61,7 +61,7 @@ impl EcmascriptDevChunkList {
 #[turbo_tasks::value_impl]
 impl ValueToString for EcmascriptDevChunkList {
     #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
+    fn to_string(&self) -> Result<Vc<RcStr>> {
         Ok(Vc::cell("Ecmascript Dev Chunk List".into()))
     }
 }
@@ -111,7 +111,7 @@ impl OutputAsset for EcmascriptDevChunkList {
     }
 
     #[turbo_tasks::function]
-    async fn references(&self) -> Result<Vc<OutputAssets>> {
+    fn references(&self) -> Result<Vc<OutputAssets>> {
         Ok(self.chunks)
     }
 }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/runtime.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/runtime.rs
@@ -46,7 +46,7 @@ impl EcmascriptDevChunkRuntime {
 #[turbo_tasks::value_impl]
 impl ValueToString for EcmascriptDevChunkRuntime {
     #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
+    fn to_string(&self) -> Result<Vc<RcStr>> {
         Ok(Vc::cell("Ecmascript Dev Runtime".to_string()))
     }
 }

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -50,7 +50,7 @@ async fn foreign_code_context_condition() -> Result<ContextCondition> {
 }
 
 #[turbo_tasks::function]
-pub async fn get_client_import_map(project_path: Vc<FileSystemPath>) -> Result<Vc<ImportMap>> {
+pub fn get_client_import_map(project_path: Vc<FileSystemPath>) -> Result<Vc<ImportMap>> {
     let mut import_map = ImportMap::empty();
 
     import_map.insert_singleton_alias("@swc/helpers", project_path);

--- a/turbopack/crates/turbopack-core/src/chunk/data.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/data.rs
@@ -137,7 +137,7 @@ impl ChunkData {
 
     /// Returns [`OutputAsset`]s that this chunk data references.
     #[turbo_tasks::function]
-    pub async fn references(&self) -> Result<Vc<OutputAssets>> {
+    pub fn references(&self) -> Result<Vc<OutputAssets>> {
         Ok(self.references)
     }
 }

--- a/turbopack/crates/turbopack-core/src/code_builder.rs
+++ b/turbopack/crates/turbopack-core/src/code_builder.rs
@@ -191,7 +191,7 @@ impl GenerateSourceMap for Code {
 impl Code {
     /// Returns the hash of the source code of this Code.
     #[turbo_tasks::function]
-    pub async fn source_code_hash(&self) -> Result<Vc<u64>> {
+    pub fn source_code_hash(&self) -> Result<Vc<u64>> {
         let code = self;
         let hash = hash_xxh3_hash64(code.source_code());
         Ok(Vc::cell(hash))

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -263,7 +263,7 @@ impl CompileTimeInfo {
     }
 
     #[turbo_tasks::function]
-    pub async fn environment(&self) -> Result<Vc<Environment>> {
+    pub fn environment(&self) -> Result<Vc<Environment>> {
         Ok(self.environment)
     }
 }

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -93,7 +93,7 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
-    pub async fn node_externals(&self) -> Result<Vc<bool>> {
+    pub fn node_externals(&self) -> Result<Vc<bool>> {
         Ok(match self.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Vc::cell(true)
@@ -105,7 +105,7 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
-    pub async fn supports_esm_externals(&self) -> Result<Vc<bool>> {
+    pub fn supports_esm_externals(&self) -> Result<Vc<bool>> {
         Ok(match self.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Vc::cell(true)
@@ -117,7 +117,7 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
-    pub async fn supports_commonjs_externals(&self) -> Result<Vc<bool>> {
+    pub fn supports_commonjs_externals(&self) -> Result<Vc<bool>> {
         Ok(match self.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Vc::cell(true)
@@ -129,7 +129,7 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
-    pub async fn supports_wasm(&self) -> Result<Vc<bool>> {
+    pub fn supports_wasm(&self) -> Result<Vc<bool>> {
         Ok(match self.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Vc::cell(true)
@@ -141,7 +141,7 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
-    pub async fn resolve_extensions(&self) -> Result<Vc<Vec<RcStr>>> {
+    pub fn resolve_extensions(&self) -> Result<Vc<Vec<RcStr>>> {
         let env = self;
         Ok(match env.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
@@ -155,7 +155,7 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
-    pub async fn resolve_node_modules(&self) -> Result<Vc<bool>> {
+    pub fn resolve_node_modules(&self) -> Result<Vc<bool>> {
         let env = self;
         Ok(match env.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
@@ -169,7 +169,7 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
-    pub async fn resolve_conditions(&self) -> Result<Vc<Vec<RcStr>>> {
+    pub fn resolve_conditions(&self) -> Result<Vc<Vec<RcStr>>> {
         let env = self;
         Ok(match env.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
@@ -194,7 +194,7 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
-    pub async fn rendering(&self) -> Result<Vc<Rendering>> {
+    pub fn rendering(&self) -> Result<Vc<Rendering>> {
         let env = self;
         Ok(match env.execution {
             ExecutionEnvironment::NodeJsBuildTime(_) | ExecutionEnvironment::NodeJsLambda(_) => {
@@ -207,7 +207,7 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
-    pub async fn chunk_loading(&self) -> Result<Vc<ChunkLoading>> {
+    pub fn chunk_loading(&self) -> Result<Vc<ChunkLoading>> {
         let env = self;
         Ok(match env.execution {
             ExecutionEnvironment::NodeJsBuildTime(_) | ExecutionEnvironment::NodeJsLambda(_) => {

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -368,7 +368,7 @@ pub struct CapturedIssues {
 #[turbo_tasks::value_impl]
 impl CapturedIssues {
     #[turbo_tasks::function]
-    pub async fn is_empty(&self) -> Result<Vc<bool>> {
+    pub fn is_empty(&self) -> Result<Vc<bool>> {
         Ok(Vc::cell(self.is_empty_ref()))
     }
 }
@@ -761,7 +761,7 @@ impl PlainIssue {
     /// same issue to pass from multiple processing paths, making for overly
     /// verbose logging.
     #[turbo_tasks::function]
-    pub async fn internal_hash(&self, full: bool) -> Result<Vc<u64>> {
+    pub fn internal_hash(&self, full: bool) -> Result<Vc<u64>> {
         Ok(Vc::cell(self.internal_hash_ref(full)))
     }
 }

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -86,7 +86,7 @@ impl SingleModuleReference {
 
     /// The [Vc<Box<dyn Asset>>] that this reference resolves to.
     #[turbo_tasks::function]
-    pub async fn asset(&self) -> Result<Vc<Box<dyn Module>>> {
+    pub fn asset(&self) -> Result<Vc<Box<dyn Module>>> {
         Ok(self.asset)
     }
 }
@@ -132,7 +132,7 @@ impl SingleOutputAssetReference {
 
     /// The [Vc<Box<dyn Asset>>] that this reference resolves to.
     #[turbo_tasks::function]
-    pub async fn asset(&self) -> Result<Vc<Box<dyn OutputAsset>>> {
+    pub fn asset(&self) -> Result<Vc<Box<dyn OutputAsset>>> {
         Ok(self.asset)
     }
 }

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -319,12 +319,12 @@ impl ModuleResolveResult {
     }
 
     #[turbo_tasks::function]
-    pub async fn is_unresolveable(&self) -> Result<Vc<bool>> {
+    pub fn is_unresolveable(&self) -> Result<Vc<bool>> {
         Ok(Vc::cell(self.is_unresolveable_ref()))
     }
 
     #[turbo_tasks::function]
-    pub async fn first_module(&self) -> Result<Vc<OptionModule>> {
+    pub fn first_module(&self) -> Result<Vc<OptionModule>> {
         Ok(Vc::cell(self.primary.iter().find_map(
             |(_, item)| match item {
                 &ModuleResolveResultItem::Module(a) => Some(a),
@@ -357,7 +357,7 @@ impl ModuleResolveResult {
     }
 
     #[turbo_tasks::function]
-    pub async fn primary_output_assets(&self) -> Result<Vc<OutputAssets>> {
+    pub fn primary_output_assets(&self) -> Result<Vc<OutputAssets>> {
         Ok(Vc::cell(
             self.primary
                 .iter()
@@ -847,12 +847,12 @@ impl ResolveResult {
     }
 
     #[turbo_tasks::function]
-    pub async fn is_unresolveable(&self) -> Result<Vc<bool>> {
+    pub fn is_unresolveable(&self) -> Result<Vc<bool>> {
         Ok(Vc::cell(self.is_unresolveable_ref()))
     }
 
     #[turbo_tasks::function]
-    pub async fn first_source(&self) -> Result<Vc<OptionSource>> {
+    pub fn first_source(&self) -> Result<Vc<OptionSource>> {
         Ok(Vc::cell(self.primary.iter().find_map(|(_, item)| {
             if let &ResolveResultItem::Source(a) = item {
                 Some(a)
@@ -863,7 +863,7 @@ impl ResolveResult {
     }
 
     #[turbo_tasks::function]
-    pub async fn primary_sources(&self) -> Result<Vc<Sources>> {
+    pub fn primary_sources(&self) -> Result<Vc<Sources>> {
         Ok(Vc::cell(
             self.primary
                 .iter()
@@ -883,7 +883,7 @@ impl ResolveResult {
     /// contains [RequestKey]s that don't have the `old_request_key` prefix, but if there are still
     /// some, they are discarded.
     #[turbo_tasks::function]
-    pub async fn with_replaced_request_key(
+    pub fn with_replaced_request_key(
         &self,
         old_request_key: RcStr,
         request_key: Value<RequestKey>,
@@ -953,7 +953,7 @@ impl ResolveResult {
     /// Returns a new [ResolveResult] where all [RequestKey]s are set to the
     /// passed `request`.
     #[turbo_tasks::function]
-    pub async fn with_request(&self, request: RcStr) -> Result<Vc<Self>> {
+    pub fn with_request(&self, request: RcStr) -> Result<Vc<Self>> {
         let new_primary = self
             .primary
             .iter()

--- a/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -28,7 +28,7 @@ impl SourceMapAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for SourceMapAsset {
     #[turbo_tasks::function]
-    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+    fn ident(&self) -> Result<Vc<AssetIdent>> {
         // NOTE(alexkirsz) We used to include the asset's version id in the path,
         // but this caused `all_assets_map` to be recomputed on every change.
         Ok(AssetIdent::from_path(

--- a/turbopack/crates/turbopack-core/src/source_transform.rs
+++ b/turbopack/crates/turbopack-core/src/source_transform.rs
@@ -14,7 +14,7 @@ pub struct SourceTransforms(Vec<Vc<Box<dyn SourceTransform>>>);
 #[turbo_tasks::value_impl]
 impl SourceTransforms {
     #[turbo_tasks::function]
-    pub async fn transform(&self, source: Vc<Box<dyn Source>>) -> Result<Vc<Box<dyn Source>>> {
+    pub fn transform(&self, source: Vc<Box<dyn Source>>) -> Result<Vc<Box<dyn Source>>> {
         Ok(self
             .0
             .iter()

--- a/turbopack/crates/turbopack-core/src/version.rs
+++ b/turbopack/crates/turbopack-core/src/version.rs
@@ -236,7 +236,7 @@ impl FileHashVersion {
 #[turbo_tasks::value_impl]
 impl Version for FileHashVersion {
     #[turbo_tasks::function]
-    async fn id(&self) -> Result<Vc<RcStr>> {
+    fn id(&self) -> Result<Vc<RcStr>> {
         Ok(Vc::cell(self.hash.clone()))
     }
 }
@@ -250,7 +250,7 @@ pub struct VersionState {
 #[turbo_tasks::value_impl]
 impl VersionState {
     #[turbo_tasks::function]
-    pub async fn get(&self) -> Result<Vc<Box<dyn Version>>> {
+    pub fn get(&self) -> Result<Vc<Box<dyn Version>>> {
         let version = TraitRef::cell(self.version.get().clone());
         Ok(version)
     }

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -65,7 +65,7 @@ impl CssModuleAsset {
 
     /// Retrns the asset ident of the source without the "css" modifier
     #[turbo_tasks::function]
-    pub async fn source_ident(&self) -> Result<Vc<AssetIdent>> {
+    pub fn source_ident(&self) -> Result<Vc<AssetIdent>> {
         Ok(self.source.ident())
     }
 }
@@ -90,14 +90,14 @@ impl ParseCss for CssModuleAsset {
 #[turbo_tasks::value_impl]
 impl ProcessCss for CssModuleAsset {
     #[turbo_tasks::function]
-    async fn get_css_with_placeholder(self: Vc<Self>) -> Result<Vc<CssWithPlaceholderResult>> {
+    fn get_css_with_placeholder(self: Vc<Self>) -> Result<Vc<CssWithPlaceholderResult>> {
         let parse_result = self.parse_css();
 
         Ok(process_css_with_placeholder(parse_result))
     }
 
     #[turbo_tasks::function]
-    async fn finalize_css(
+    fn finalize_css(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<FinalCssResult>> {
@@ -192,7 +192,7 @@ impl ChunkItem for CssModuleChunkItem {
     }
 
     #[turbo_tasks::function]
-    async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
     }
 

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -100,7 +100,7 @@ fn single_item_modifier() -> Vc<RcStr> {
 #[turbo_tasks::value_impl]
 impl OutputAsset for SingleItemCssChunk {
     #[turbo_tasks::function]
-    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+    fn ident(&self) -> Result<Vc<AssetIdent>> {
         Ok(AssetIdent::from_path(
             self.chunking_context.chunk_path(
                 self.item

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
@@ -28,7 +28,7 @@ impl SingleItemCssChunkSourceMapAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for SingleItemCssChunkSourceMapAsset {
     #[turbo_tasks::function]
-    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+    fn ident(&self) -> Result<Vc<AssetIdent>> {
         Ok(AssetIdent::from_path(
             self.chunk.path().append(".map".into()),
         ))

--- a/turbopack/crates/turbopack-css/src/chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/source_map.rs
@@ -28,7 +28,7 @@ impl CssChunkSourceMapAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for CssChunkSourceMapAsset {
     #[turbo_tasks::function]
-    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+    fn ident(&self) -> Result<Vc<AssetIdent>> {
         Ok(AssetIdent::from_path(
             self.chunk.path().append(".map".into()),
         ))

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -49,7 +49,7 @@ pub struct ModuleCssAsset {
 #[turbo_tasks::value_impl]
 impl ModuleCssAsset {
     #[turbo_tasks::function]
-    pub async fn new(
+    pub fn new(
         source: Vc<Box<dyn Source>>,
         asset_context: Vc<Box<dyn AssetContext>>,
     ) -> Result<Vc<Self>> {
@@ -152,7 +152,7 @@ struct ModuleCssClasses(IndexMap<String, Vec<ModuleCssClass>>);
 #[turbo_tasks::value_impl]
 impl ModuleCssAsset {
     #[turbo_tasks::function]
-    async fn inner(&self) -> Result<Vc<ProcessResult>> {
+    fn inner(&self) -> Result<Vc<ProcessResult>> {
         Ok(self.asset_context.process(
             self.source,
             Value::new(ReferenceType::Css(CssReferenceSubType::Internal)),
@@ -234,7 +234,7 @@ impl ModuleCssAsset {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for ModuleCssAsset {
     #[turbo_tasks::function]
-    async fn as_chunk_item(
+    fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
@@ -288,7 +288,7 @@ impl ChunkItem for ModuleChunkItem {
     }
 
     #[turbo_tasks::function]
-    async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
     }
 
@@ -439,7 +439,7 @@ impl Issue for CssModuleComposesIssue {
     }
 
     #[turbo_tasks::function]
-    async fn title(&self) -> Result<Vc<StyledString>> {
+    fn title(&self) -> Result<Vc<StyledString>> {
         Ok(StyledString::Text(
             "An issue occurred while resolving a CSS module `composes:` rule".into(),
         )

--- a/turbopack/crates/turbopack-css/src/references/mod.rs
+++ b/turbopack/crates/turbopack-css/src/references/mod.rs
@@ -239,7 +239,7 @@ impl<'a> Visitor<'_> for ModuleReferencesVisitor<'a> {
 }
 
 #[turbo_tasks::function]
-pub async fn css_resolve(
+pub fn css_resolve(
     origin: Vc<Box<dyn ResolveOrigin>>,
     request: Vc<Request>,
     ty: Value<CssReferenceSubType>,

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -241,7 +241,7 @@ struct DevHtmlAssetVersion {
 #[turbo_tasks::value_impl]
 impl Version for DevHtmlAssetVersion {
     #[turbo_tasks::function]
-    async fn id(&self) -> Result<Vc<RcStr>> {
+    fn id(&self) -> Result<Vc<RcStr>> {
         let mut hasher = Xxh3Hash64Hasher::new();
         for relative_path in &*self.content.chunk_paths {
             hasher.write_ref(relative_path);

--- a/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
@@ -108,7 +108,7 @@ impl Introspectable for ConditionalContentSource {
     }
 
     #[turbo_tasks::function]
-    async fn details(&self) -> Result<Vc<RcStr>> {
+    fn details(&self) -> Result<Vc<RcStr>> {
         Ok(Vc::cell(
             if *self.activated.get() {
                 "activated"

--- a/turbopack/crates/turbopack-dev-server/src/source/router.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/router.rs
@@ -25,7 +25,7 @@ pub struct PrefixedRouterContentSource {
 #[turbo_tasks::value_impl]
 impl PrefixedRouterContentSource {
     #[turbo_tasks::function]
-    pub async fn new(
+    pub fn new(
         prefix: Vc<RcStr>,
         routes: Vec<(RcStr, Vc<Box<dyn ContentSource>>)>,
         fallback: Vc<Box<dyn ContentSource>>,

--- a/turbopack/crates/turbopack-dev-server/src/source/wrapping_source.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/wrapping_source.rs
@@ -31,7 +31,7 @@ pub struct WrappedGetContentSourceContent {
 #[turbo_tasks::value_impl]
 impl WrappedGetContentSourceContent {
     #[turbo_tasks::function]
-    pub async fn new(
+    pub fn new(
         inner: Vc<Box<dyn GetContentSourceContent>>,
         processor: Vc<Box<dyn ContentSourceProcessor>>,
     ) -> Vc<Self> {

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
@@ -64,7 +64,7 @@ impl Issue for UnsupportedSwcEcmaTransformPluginsIssue {
     }
 
     #[turbo_tasks::function]
-    async fn title(&self) -> Result<Vc<StyledString>> {
+    fn title(&self) -> Result<Vc<StyledString>> {
         Ok(StyledString::Text(
             "Unsupported SWC EcmaScript transform plugins on this platform.".into(),
         )

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
@@ -196,7 +196,7 @@ impl ChunkItem for AsyncLoaderChunkItem {
     }
 
     #[turbo_tasks::function]
-    async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
@@ -77,7 +77,7 @@ impl Asset for AsyncLoaderModule {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for AsyncLoaderModule {
     #[turbo_tasks::function]
-    async fn as_chunk_item(
+    fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -45,7 +45,7 @@ pub struct EcmascriptChunks(Vec<Vc<EcmascriptChunk>>);
 #[turbo_tasks::value_impl]
 impl EcmascriptChunk {
     #[turbo_tasks::function]
-    pub async fn new(
+    pub fn new(
         chunking_context: Vc<Box<dyn ChunkingContext>>,
         content: Vc<EcmascriptChunkContent>,
     ) -> Result<Vc<Self>> {
@@ -57,7 +57,7 @@ impl EcmascriptChunk {
     }
 
     #[turbo_tasks::function]
-    pub async fn entry_ids(self: Vc<Self>) -> Result<Vc<ModuleIds>> {
+    pub fn entry_ids(self: Vc<Self>) -> Result<Vc<ModuleIds>> {
         // TODO return something usefull
         Ok(Vc::cell(Default::default()))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
@@ -214,7 +214,7 @@ impl ChunkItem for ChunkGroupFilesChunkItem {
     }
 
     #[turbo_tasks::function]
-    async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
     }
 
@@ -249,7 +249,7 @@ impl Introspectable for ChunkGroupFilesAsset {
     }
 
     #[turbo_tasks::function]
-    async fn children(&self) -> Result<Vc<IntrospectableChildren>> {
+    fn children(&self) -> Result<Vc<IntrospectableChildren>> {
         let mut children = IndexSet::new();
         children.insert((
             Vc::cell("inner asset".into()),

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -352,12 +352,12 @@ impl EcmascriptParsable for EcmascriptModuleAsset {
     }
 
     #[turbo_tasks::function]
-    async fn parse_original(self: Vc<Self>) -> Result<Vc<ParseResult>> {
+    fn parse_original(self: Vc<Self>) -> Result<Vc<ParseResult>> {
         Ok(self.failsafe_parse())
     }
 
     #[turbo_tasks::function]
-    async fn ty(&self) -> Result<Vc<EcmascriptModuleAssetType>> {
+    fn ty(&self) -> Result<Vc<EcmascriptModuleAssetType>> {
         Ok(self.ty.cell())
     }
 }
@@ -461,7 +461,7 @@ impl EcmascriptModuleAsset {
     }
 
     #[turbo_tasks::function]
-    pub async fn source(&self) -> Result<Vc<Box<dyn Source>>> {
+    pub fn source(&self) -> Result<Vc<Box<dyn Source>>> {
         Ok(self.source)
     }
 
@@ -471,7 +471,7 @@ impl EcmascriptModuleAsset {
     }
 
     #[turbo_tasks::function]
-    pub async fn options(&self) -> Result<Vc<EcmascriptOptions>> {
+    pub fn options(&self) -> Result<Vc<EcmascriptOptions>> {
         Ok(self.options)
     }
 
@@ -569,7 +569,7 @@ impl Asset for EcmascriptModuleAsset {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for EcmascriptModuleAsset {
     #[turbo_tasks::function]
-    async fn as_chunk_item(
+    fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn ChunkItem>>> {
@@ -641,7 +641,7 @@ impl ChunkItem for ModuleChunkItem {
     }
 
     #[turbo_tasks::function]
-    async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -52,7 +52,7 @@ impl ManifestAsyncModule {
     }
 
     #[turbo_tasks::function]
-    pub(super) async fn chunks(&self) -> Result<Vc<OutputAssets>> {
+    pub(super) fn chunks(&self) -> Result<Vc<OutputAssets>> {
         Ok(self
             .chunking_context
             .chunk_group_assets(Vc::upcast(self.inner), Value::new(self.availability_info)))
@@ -139,7 +139,7 @@ impl Asset for ManifestAsyncModule {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for ManifestAsyncModule {
     #[turbo_tasks::function]
-    async fn as_chunk_item(
+    fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
@@ -29,7 +29,7 @@ pub(super) struct ManifestChunkItem {
 #[turbo_tasks::value_impl]
 impl ManifestChunkItem {
     #[turbo_tasks::function]
-    async fn chunks_data(&self) -> Result<Vc<ChunksData>> {
+    fn chunks_data(&self) -> Result<Vc<ChunksData>> {
         Ok(ChunkData::from_assets(
             self.chunking_context.output_root(),
             self.manifest.chunks(),
@@ -97,7 +97,7 @@ impl ChunkItem for ManifestChunkItem {
     }
 
     #[turbo_tasks::function]
-    async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
@@ -58,7 +58,7 @@ impl ManifestLoaderChunkItem {
     }
 
     #[turbo_tasks::function]
-    pub async fn chunks_data(&self) -> Result<Vc<ChunksData>> {
+    pub fn chunks_data(&self) -> Result<Vc<ChunksData>> {
         let chunks = self.manifest.manifest_chunks();
         Ok(ChunkData::from_assets(
             self.chunking_context.output_root(),
@@ -124,7 +124,7 @@ impl ChunkItem for ManifestLoaderChunkItem {
     }
 
     #[turbo_tasks::function]
-    async fn chunking_context(&self) -> Result<Vc<Box<dyn ChunkingContext>>> {
+    fn chunking_context(&self) -> Result<Vc<Box<dyn ChunkingContext>>> {
         Ok(Vc::upcast(self.chunking_context))
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
@@ -173,7 +173,7 @@ impl AsyncModule {
 
     /// Returns
     #[turbo_tasks::function]
-    pub async fn module_options(
+    pub fn module_options(
         &self,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Vc<OptionAsyncModuleOptions>> {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -90,7 +90,7 @@ impl UrlAssetReference {
 #[turbo_tasks::value_impl]
 impl ModuleReference for UrlAssetReference {
     #[turbo_tasks::function]
-    async fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
+    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         url_resolve(
             self.origin,
             self.request,

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -122,7 +122,7 @@ impl Asset for CachedExternalModule {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for CachedExternalModule {
     #[turbo_tasks::function]
-    async fn as_chunk_item(
+    fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn ChunkItem>>> {
@@ -227,7 +227,7 @@ impl EcmascriptChunkItem for CachedExternalModuleChunkItem {
     }
 
     #[turbo_tasks::function]
-    async fn content_with_async_module_info(
+    fn content_with_async_module_info(
         &self,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Vc<EcmascriptChunkItemContent>> {

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -317,7 +317,7 @@ impl ModuleReference for ResolvedModuleReference {
 #[turbo_tasks::value_impl]
 impl ValueToString for ResolvedModuleReference {
     #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
+    fn to_string(&self) -> Result<Vc<RcStr>> {
         Ok(Vc::cell("resolved reference".into()))
     }
 }
@@ -509,7 +509,7 @@ impl ChunkItem for RequireContextChunkItem {
     }
 
     #[turbo_tasks::function]
-    async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -61,7 +61,7 @@ impl EcmascriptModuleFacadeModule {
 #[turbo_tasks::value_impl]
 impl Module for EcmascriptModuleFacadeModule {
     #[turbo_tasks::function]
-    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+    fn ident(&self) -> Result<Vc<AssetIdent>> {
         let inner = self.module.ident();
 
         Ok(inner.with_part(self.ty))
@@ -135,7 +135,7 @@ impl Module for EcmascriptModuleFacadeModule {
 #[turbo_tasks::value_impl]
 impl Asset for EcmascriptModuleFacadeModule {
     #[turbo_tasks::function]
-    async fn content(&self) -> Result<Vc<AssetContent>> {
+    fn content(&self) -> Result<Vc<AssetContent>> {
         let f = File::from("");
 
         Ok(AssetContent::file(FileContent::Content(f).cell()))
@@ -283,7 +283,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for EcmascriptModuleFacadeModule {
     #[turbo_tasks::function]
-    async fn as_chunk_item(
+    fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -41,7 +41,7 @@ impl EcmascriptModuleLocalsModule {
 #[turbo_tasks::value_impl]
 impl Module for EcmascriptModuleLocalsModule {
     #[turbo_tasks::function]
-    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+    fn ident(&self) -> Result<Vc<AssetIdent>> {
         let inner = self.module.ident();
 
         Ok(inner.with_part(ModulePart::locals()))
@@ -112,7 +112,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleLocalsModule {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for EcmascriptModuleLocalsModule {
     #[turbo_tasks::function]
-    async fn as_chunk_item(
+    fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -49,7 +49,7 @@ impl EcmascriptParsable for EcmascriptModulePartAsset {
     }
 
     #[turbo_tasks::function]
-    async fn ty(&self) -> Result<Vc<EcmascriptModuleAssetType>> {
+    fn ty(&self) -> Result<Vc<EcmascriptModuleAssetType>> {
         Ok(self.full_module.ty())
     }
 }
@@ -57,18 +57,18 @@ impl EcmascriptParsable for EcmascriptModulePartAsset {
 #[turbo_tasks::value_impl]
 impl EcmascriptAnalyzable for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
-    async fn analyze(&self) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
+    fn analyze(&self) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
         let part = self.part;
         Ok(analyse_ecmascript_module(self.full_module, Some(part)))
     }
 
     #[turbo_tasks::function]
-    async fn module_content_without_analysis(&self) -> Result<Vc<EcmascriptModuleContent>> {
+    fn module_content_without_analysis(&self) -> Result<Vc<EcmascriptModuleContent>> {
         Ok(self.full_module.module_content_without_analysis())
     }
 
     #[turbo_tasks::function]
-    async fn module_content(
+    fn module_content(
         &self,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
@@ -204,7 +204,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModulePartAsset {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
-    async fn as_chunk_item(
+    fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
@@ -221,7 +221,7 @@ impl ChunkableModule for EcmascriptModulePartAsset {
 #[turbo_tasks::value_impl]
 impl EcmascriptModulePartAsset {
     #[turbo_tasks::function]
-    pub(super) async fn analyze(&self) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
+    pub(super) fn analyze(&self) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
         Ok(analyze(self.full_module, self.part))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
@@ -75,17 +75,17 @@ impl EcmascriptChunkItem for EcmascriptModulePartChunkItem {
 #[turbo_tasks::value_impl]
 impl ChunkItem for EcmascriptModulePartChunkItem {
     #[turbo_tasks::function]
-    async fn references(&self) -> Vc<ModuleReferences> {
+    fn references(&self) -> Vc<ModuleReferences> {
         self.module.references()
     }
 
     #[turbo_tasks::function]
-    async fn asset_ident(&self) -> Result<Vc<AssetIdent>> {
+    fn asset_ident(&self) -> Result<Vc<AssetIdent>> {
         Ok(self.module.ident())
     }
 
     #[turbo_tasks::function]
-    async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -147,7 +147,7 @@ impl ModuleReference for WebpackEntryAssetReference {
 #[turbo_tasks::value_impl]
 impl ValueToString for WebpackEntryAssetReference {
     #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
+    fn to_string(&self) -> Result<Vc<RcStr>> {
         Ok(Vc::cell("webpack entry".into()))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -112,7 +112,7 @@ impl ChunkItem for WorkerLoaderChunkItem {
     }
 
     #[turbo_tasks::function]
-    async fn content_ident(&self) -> Result<Vc<AssetIdent>> {
+    fn content_ident(&self) -> Result<Vc<AssetIdent>> {
         Ok(self.module.ident())
     }
 
@@ -136,7 +136,7 @@ impl ChunkItem for WorkerLoaderChunkItem {
     }
 
     #[turbo_tasks::function]
-    async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -67,7 +67,7 @@ impl Asset for WorkerLoaderModule {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for WorkerLoaderModule {
     #[turbo_tasks::function]
-    async fn as_chunk_item(
+    fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {

--- a/turbopack/crates/turbopack-json/src/lib.rs
+++ b/turbopack/crates/turbopack-json/src/lib.rs
@@ -63,7 +63,7 @@ impl Asset for JsonModuleAsset {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for JsonModuleAsset {
     #[turbo_tasks::function]
-    async fn as_chunk_item(
+    fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
@@ -101,7 +101,7 @@ impl ChunkItem for JsonChunkItem {
     }
 
     #[turbo_tasks::function]
-    async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
     }
 

--- a/turbopack/crates/turbopack-node/src/execution_context.rs
+++ b/turbopack/crates/turbopack-node/src/execution_context.rs
@@ -28,17 +28,17 @@ impl ExecutionContext {
     }
 
     #[turbo_tasks::function]
-    pub async fn project_path(&self) -> Result<Vc<FileSystemPath>> {
+    pub fn project_path(&self) -> Result<Vc<FileSystemPath>> {
         Ok(self.project_path)
     }
 
     #[turbo_tasks::function]
-    pub async fn chunking_context(&self) -> Result<Vc<Box<dyn ChunkingContext>>> {
+    pub fn chunking_context(&self) -> Result<Vc<Box<dyn ChunkingContext>>> {
         Ok(self.chunking_context)
     }
 
     #[turbo_tasks::function]
-    pub async fn env(&self) -> Result<Vc<Box<dyn ProcessEnv>>> {
+    pub fn env(&self) -> Result<Vc<Box<dyn ProcessEnv>>> {
         Ok(self.env)
     }
 }

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -257,7 +257,7 @@ pub async fn get_renderer_pool(
 
 /// Converts a module graph into node.js executable assets
 #[turbo_tasks::function]
-pub async fn get_intermediate_asset(
+pub fn get_intermediate_asset(
     chunking_context: Vc<Box<dyn ChunkingContext>>,
     main_entry: Vc<Box<dyn Module>>,
     other_entries: Vc<EvaluatableAssets>,

--- a/turbopack/crates/turbopack-node/src/render/node_api_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/node_api_source.rs
@@ -71,7 +71,7 @@ pub struct NodeApiContentSource {
 #[turbo_tasks::value_impl]
 impl NodeApiContentSource {
     #[turbo_tasks::function]
-    pub async fn get_pathname(&self) -> Result<Vc<RcStr>> {
+    pub fn get_pathname(&self) -> Result<Vc<RcStr>> {
         Ok(self.pathname)
     }
 }

--- a/turbopack/crates/turbopack-node/src/render/rendered_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/rendered_source.rs
@@ -99,7 +99,7 @@ pub struct NodeRenderContentSource {
 #[turbo_tasks::value_impl]
 impl NodeRenderContentSource {
     #[turbo_tasks::function]
-    pub async fn get_pathname(&self) -> Result<Vc<RcStr>> {
+    pub fn get_pathname(&self) -> Result<Vc<RcStr>> {
         Ok(self.pathname)
     }
 }

--- a/turbopack/crates/turbopack-node/src/source_map/trace.rs
+++ b/turbopack/crates/turbopack-node/src/source_map/trace.rs
@@ -102,12 +102,7 @@ pub enum TraceResult {
 #[turbo_tasks::value_impl]
 impl SourceMapTrace {
     #[turbo_tasks::function]
-    pub async fn new(
-        map: Vc<SourceMap>,
-        line: usize,
-        column: usize,
-        name: Option<RcStr>,
-    ) -> Vc<Self> {
+    pub fn new(map: Vc<SourceMap>, line: usize, column: usize, name: Option<RcStr>) -> Vc<Self> {
         SourceMapTrace {
             map,
             line,

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -356,7 +356,7 @@ pub(crate) async fn config_loader_source(
 }
 
 #[turbo_tasks::function]
-async fn postcss_executor(
+fn postcss_executor(
     asset_context: Vc<Box<dyn AssetContext>>,
     project_path: Vc<FileSystemPath>,
     postcss_config_path: Vc<FileSystemPath>,

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -820,7 +820,7 @@ impl Issue for EvaluateErrorLoggingIssue {
     }
 
     #[turbo_tasks::function]
-    async fn description(&self) -> Result<Vc<OptionStyledString>> {
+    fn description(&self) -> Result<Vc<OptionStyledString>> {
         fn fmt_args(prefix: String, args: &[JsonValue]) -> String {
             let mut iter = args.iter();
             let Some(first) = iter.next() else {

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -363,7 +363,7 @@ impl ChunkingContext for NodeJsChunkingContext {
     }
 
     #[turbo_tasks::function]
-    async fn chunk_item_id_from_ident(&self, ident: Vc<AssetIdent>) -> Result<Vc<ModuleId>> {
+    fn chunk_item_id_from_ident(&self, ident: Vc<AssetIdent>) -> Result<Vc<ModuleId>> {
         Ok(self.module_id_strategy.get_module_id(ident))
     }
 

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
@@ -41,7 +41,7 @@ impl EcmascriptBuildNodeChunk {
 #[turbo_tasks::value_impl]
 impl ValueToString for EcmascriptBuildNodeChunk {
     #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
+    fn to_string(&self) -> Result<Vc<RcStr>> {
         Ok(Vc::cell("Ecmascript Build Node Chunk".into()))
     }
 }

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -31,7 +31,7 @@ pub(super) struct EcmascriptBuildNodeChunkContent {
 #[turbo_tasks::value_impl]
 impl EcmascriptBuildNodeChunkContent {
     #[turbo_tasks::function]
-    pub(crate) async fn new(
+    pub(crate) fn new(
         chunking_context: Vc<NodeJsChunkingContext>,
         chunk: Vc<EcmascriptBuildNodeChunk>,
         content: Vc<EcmascriptChunkContent>,

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -144,7 +144,7 @@ impl EcmascriptBuildNodeEntryChunk {
     }
 
     #[turbo_tasks::function]
-    async fn runtime_chunk(&self) -> Result<Vc<EcmascriptBuildNodeRuntimeChunk>> {
+    fn runtime_chunk(&self) -> Result<Vc<EcmascriptBuildNodeRuntimeChunk>> {
         Ok(EcmascriptBuildNodeRuntimeChunk::new(self.chunking_context))
     }
 }
@@ -152,7 +152,7 @@ impl EcmascriptBuildNodeEntryChunk {
 #[turbo_tasks::value_impl]
 impl ValueToString for EcmascriptBuildNodeEntryChunk {
     #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
+    fn to_string(&self) -> Result<Vc<RcStr>> {
         Ok(Vc::cell("Ecmascript Build Node Evaluate Chunk".into()))
     }
 }

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -91,7 +91,7 @@ impl EcmascriptBuildNodeRuntimeChunk {
 #[turbo_tasks::value_impl]
 impl ValueToString for EcmascriptBuildNodeRuntimeChunk {
     #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
+    fn to_string(&self) -> Result<Vc<RcStr>> {
         Ok(Vc::cell("Ecmascript Build Node Runtime Chunk".into()))
     }
 }

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -519,7 +519,7 @@ impl Issue for TsConfigIssue {
     }
 
     #[turbo_tasks::function]
-    async fn title(&self) -> Result<Vc<StyledString>> {
+    fn title(&self) -> Result<Vc<StyledString>> {
         Ok(
             StyledString::Text("An issue occurred while parsing a tsconfig.json file.".into())
                 .cell(),

--- a/turbopack/crates/turbopack-static/src/fixed.rs
+++ b/turbopack/crates/turbopack-static/src/fixed.rs
@@ -31,7 +31,7 @@ impl FixedStaticAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for FixedStaticAsset {
     #[turbo_tasks::function]
-    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+    fn ident(&self) -> Result<Vc<AssetIdent>> {
         Ok(AssetIdent::from_path(self.output_path))
     }
 }

--- a/turbopack/crates/turbopack-static/src/lib.rs
+++ b/turbopack/crates/turbopack-static/src/lib.rs
@@ -60,7 +60,7 @@ impl StaticModuleAsset {
     }
 
     #[turbo_tasks::function]
-    async fn static_asset(
+    fn static_asset(
         &self,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<StaticAsset>> {
@@ -90,7 +90,7 @@ impl Asset for StaticModuleAsset {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for StaticModuleAsset {
     #[turbo_tasks::function]
-    async fn as_chunk_item(
+    fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
@@ -139,7 +139,7 @@ impl ChunkItem for ModuleChunkItem {
     }
 
     #[turbo_tasks::function]
-    async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
     }
 

--- a/turbopack/crates/turbopack-wasm/src/loader.rs
+++ b/turbopack/crates/turbopack-wasm/src/loader.rs
@@ -62,7 +62,7 @@ pub(crate) async fn instantiating_loader_source(
 /// Create a javascript loader to compile the WebAssembly module and export it
 /// without instantiating.
 #[turbo_tasks::function]
-pub(crate) async fn compiling_loader_source(
+pub(crate) fn compiling_loader_source(
     source: Vc<WebAssemblySource>,
 ) -> Result<Vc<Box<dyn Source>>> {
     let code: RcStr = formatdoc! {

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -117,7 +117,7 @@ impl Module for WebAssemblyModuleAsset {
     }
 
     #[turbo_tasks::function]
-    async fn references(self: Vc<Self>) -> Vc<ModuleReferences> {
+    fn references(self: Vc<Self>) -> Vc<ModuleReferences> {
         self.loader().references()
     }
 }
@@ -133,7 +133,7 @@ impl Asset for WebAssemblyModuleAsset {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for WebAssemblyModuleAsset {
     #[turbo_tasks::function]
-    async fn as_chunk_item(
+    fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
@@ -192,7 +192,7 @@ impl ChunkItem for ModuleChunkItem {
     }
 
     #[turbo_tasks::function]
-    async fn references(&self) -> Result<Vc<ModuleReferences>> {
+    fn references(&self) -> Result<Vc<ModuleReferences>> {
         let loader = self
             .module
             .loader()
@@ -202,7 +202,7 @@ impl ChunkItem for ModuleChunkItem {
     }
 
     #[turbo_tasks::function]
-    async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
     }
 

--- a/turbopack/crates/turbopack-wasm/src/output_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/output_asset.rs
@@ -40,7 +40,7 @@ impl WebAssemblyAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for WebAssemblyAsset {
     #[turbo_tasks::function]
-    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+    fn ident(&self) -> Result<Vc<AssetIdent>> {
         let ident = self.source.ident().with_modifier(modifier());
 
         let asset_path = self.chunking_context.chunk_path(ident, ".wasm".into());

--- a/turbopack/crates/turbopack-wasm/src/raw.rs
+++ b/turbopack/crates/turbopack-wasm/src/raw.rs
@@ -74,7 +74,7 @@ impl Asset for RawWebAssemblyModuleAsset {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for RawWebAssemblyModuleAsset {
     #[turbo_tasks::function]
-    async fn as_chunk_item(
+    fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
@@ -120,7 +120,7 @@ impl ChunkItem for RawModuleChunkItem {
     }
 
     #[turbo_tasks::function]
-    async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
     }
 

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -368,12 +368,12 @@ impl ModuleAssetContext {
     }
 
     #[turbo_tasks::function]
-    pub async fn module_options_context(&self) -> Result<Vc<ModuleOptionsContext>> {
+    pub fn module_options_context(&self) -> Result<Vc<ModuleOptionsContext>> {
         Ok(self.module_options_context)
     }
 
     #[turbo_tasks::function]
-    pub async fn resolve_options_context(&self) -> Result<Vc<ResolveOptionsContext>> {
+    pub fn resolve_options_context(&self) -> Result<Vc<ResolveOptionsContext>> {
         Ok(self.resolve_options_context)
     }
 
@@ -783,7 +783,7 @@ impl AssetContext for ModuleAssetContext {
 }
 
 #[turbo_tasks::function]
-pub async fn emit_with_completion(
+pub fn emit_with_completion(
     asset: Vc<Box<dyn OutputAsset>>,
     output_dir: Vc<FileSystemPath>,
 ) -> Vc<Completion> {
@@ -791,7 +791,7 @@ pub async fn emit_with_completion(
 }
 
 #[turbo_tasks::function]
-async fn emit_assets_aggregated(
+fn emit_assets_aggregated(
     asset: Vc<Box<dyn OutputAsset>>,
     output_dir: Vc<FileSystemPath>,
 ) -> Vc<Completion> {
@@ -816,7 +816,7 @@ async fn emit_aggregated_assets(
 }
 
 #[turbo_tasks::function]
-pub async fn emit_asset(asset: Vc<Box<dyn OutputAsset>>) -> Vc<Completion> {
+pub fn emit_asset(asset: Vc<Box<dyn OutputAsset>>) -> Vc<Completion> {
     asset.content().write(asset.ident().path())
 }
 

--- a/turbopack/crates/turbopack/src/transition/context_transition.rs
+++ b/turbopack/crates/turbopack/src/transition/context_transition.rs
@@ -17,7 +17,7 @@ pub struct ContextTransition {
 #[turbo_tasks::value_impl]
 impl ContextTransition {
     #[turbo_tasks::function]
-    pub async fn new(
+    pub fn new(
         compile_time_info: Vc<CompileTimeInfo>,
         module_options_context: Vc<ModuleOptionsContext>,
         resolve_options_context: Vc<ResolveOptionsContext>,

--- a/turbopack/crates/turbopack/src/transition/full_context_transition.rs
+++ b/turbopack/crates/turbopack/src/transition/full_context_transition.rs
@@ -12,7 +12,7 @@ pub struct FullContextTransition {
 #[turbo_tasks::value_impl]
 impl FullContextTransition {
     #[turbo_tasks::function]
-    pub async fn new(module_context: Vc<ModuleAssetContext>) -> Result<Vc<FullContextTransition>> {
+    pub fn new(module_context: Vc<ModuleAssetContext>) -> Result<Vc<FullContextTransition>> {
         Ok(FullContextTransition { module_context }.cell())
     }
 }


### PR DESCRIPTION
I left a bunch of these behind in #70412 . This cleans them up.

The only remaining work after this is removing unused `Result<...>`s from return types.

ast-grep config:

```yaml
language: rust
id: remove_unused_async_keyword

rule:
  pattern: async
  inside:
    kind: function_modifiers
    inside:
      kind: function_item
      follows:
        pattern:
          context: |
            #[turbo_tasks::function]
          selector: attribute_item
        stopBy:
          not:
            kind: attribute_item
      has:
        field: body
        not:
          has:
            any:
              - kind: await_expression
              - pattern:
                  context: foo!($$$ await $$$)
                  selector: token_tree
                inside:
                  kind: macro_invocation
                  stopBy: end
            stopBy:
              any:
                - kind: function_item
                - kind: async_block
                - kind: closure_expression

fix: ""

# these files have intentionally async functions
ignores:
  - "**/turbo-tasks-testing/**"
  - "**/turbo-tasks-memory/tests/**"
```

Applied with:

```
sg scan -U -r ../codemod_remove_unused_async_keyword.yml . && cargo fmt
```