### PR TITLE
ppr navigations: patch router state tree with existing full tree

### DIFF
--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -269,7 +269,7 @@ export function updateCacheNodeOnNavigation(
   return {
     // Return a cloned copy of the router state with updated children.
     route: patchRouterStateWithNewChildren(
-      newRouterState,
+      oldRouterState,
       patchedRouterStateChildren
     ),
     // Only return the new cache node if there are pending tasks that need to be resolved


### PR DESCRIPTION
When constructing the new `FlightRouterStateTree`, we currently pass in the "treePatch" data from the prefetch response, which for the purposes of PPR is a full tree rendered from the root. But as we move to unfork the router implementation, where the server might start rendering at a place other than the root, we need to make sure that when we construct the new tree it still starts from the root and doesn't return a partial tree.

This passes the existing `FlightRouterState` tree into the `patchRouterStateWIthNewChildren` function which effectively clones the existing tree and only updates the changed data. 