### PR TITLE
codemod(turbopack): Remove unused `Result<...>` return types from `#[turbo_task::function]`s

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -152,26 +152,26 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    fn client_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
-        Ok(get_client_module_options_context(
+    fn client_module_options_context(self: Vc<Self>) -> Vc<ModuleOptionsContext> {
+        get_client_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
             self.project().client_compile_time_info().environment(),
             Value::new(self.client_ty()),
             self.project().next_mode(),
             self.project().next_config(),
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    fn client_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
-        Ok(get_client_resolve_options_context(
+    fn client_resolve_options_context(self: Vc<Self>) -> Vc<ResolveOptionsContext> {
+        get_client_resolve_options_context(
             self.project().project_path(),
             Value::new(self.client_ty()),
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
-        ))
+        )
     }
 
     #[turbo_tasks::function]
@@ -180,101 +180,101 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    fn client_transition(self: Vc<Self>) -> Result<Vc<FullContextTransition>> {
+    fn client_transition(self: Vc<Self>) -> Vc<FullContextTransition> {
         let module_context = self.client_module_context();
-        Ok(FullContextTransition::new(module_context))
+        FullContextTransition::new(module_context)
     }
 
     #[turbo_tasks::function]
-    fn rsc_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
-        Ok(get_server_module_options_context(
+    fn rsc_module_options_context(self: Vc<Self>) -> Vc<ModuleOptionsContext> {
+        get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
             Value::new(self.rsc_ty()),
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::NodeJs,
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    fn edge_rsc_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
-        Ok(get_server_module_options_context(
+    fn edge_rsc_module_options_context(self: Vc<Self>) -> Vc<ModuleOptionsContext> {
+        get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
             Value::new(self.rsc_ty()),
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::Edge,
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    fn route_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
-        Ok(get_server_module_options_context(
+    fn route_module_options_context(self: Vc<Self>) -> Vc<ModuleOptionsContext> {
+        get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
             Value::new(self.route_ty()),
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::NodeJs,
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    fn edge_route_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
-        Ok(get_server_module_options_context(
+    fn edge_route_module_options_context(self: Vc<Self>) -> Vc<ModuleOptionsContext> {
+        get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
             Value::new(self.route_ty()),
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::Edge,
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    fn rsc_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
-        Ok(get_server_resolve_options_context(
+    fn rsc_resolve_options_context(self: Vc<Self>) -> Vc<ResolveOptionsContext> {
+        get_server_resolve_options_context(
             self.project().project_path(),
             Value::new(self.rsc_ty()),
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    fn edge_rsc_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
-        Ok(get_edge_resolve_options_context(
+    fn edge_rsc_resolve_options_context(self: Vc<Self>) -> Vc<ResolveOptionsContext> {
+        get_edge_resolve_options_context(
             self.project().project_path(),
             Value::new(self.rsc_ty()),
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    fn route_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
-        Ok(get_server_resolve_options_context(
+    fn route_resolve_options_context(self: Vc<Self>) -> Vc<ResolveOptionsContext> {
+        get_server_resolve_options_context(
             self.project().project_path(),
             Value::new(self.route_ty()),
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    fn edge_route_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
-        Ok(get_edge_resolve_options_context(
+    fn edge_route_resolve_options_context(self: Vc<Self>) -> Vc<ResolveOptionsContext> {
+        get_edge_resolve_options_context(
             self.project().project_path(),
             Value::new(self.route_ty()),
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
-        ))
+        )
     }
 
     #[turbo_tasks::function]
@@ -444,49 +444,49 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    fn ssr_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
-        Ok(get_server_module_options_context(
+    fn ssr_module_options_context(self: Vc<Self>) -> Vc<ModuleOptionsContext> {
+        get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
             Value::new(self.ssr_ty()),
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::NodeJs,
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    fn edge_ssr_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
-        Ok(get_server_module_options_context(
+    fn edge_ssr_module_options_context(self: Vc<Self>) -> Vc<ModuleOptionsContext> {
+        get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
             Value::new(self.ssr_ty()),
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::Edge,
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    fn ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
-        Ok(get_server_resolve_options_context(
+    fn ssr_resolve_options_context(self: Vc<Self>) -> Vc<ResolveOptionsContext> {
+        get_server_resolve_options_context(
             self.project().project_path(),
             Value::new(self.ssr_ty()),
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    fn edge_ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
-        Ok(get_edge_resolve_options_context(
+    fn edge_ssr_resolve_options_context(self: Vc<Self>) -> Vc<ResolveOptionsContext> {
+        get_edge_resolve_options_context(
             self.project().project_path(),
             Value::new(self.ssr_ty()),
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
-        ))
+        )
     }
 
     #[turbo_tasks::function]
@@ -530,11 +530,8 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    fn runtime_entries(self: Vc<Self>) -> Result<Vc<RuntimeEntries>> {
-        Ok(get_server_runtime_entries(
-            Value::new(self.rsc_ty()),
-            self.project().next_mode(),
-        ))
+    fn runtime_entries(self: Vc<Self>) -> Vc<RuntimeEntries> {
+        get_server_runtime_entries(Value::new(self.rsc_ty()), self.project().next_mode())
     }
 
     #[turbo_tasks::function]
@@ -558,15 +555,15 @@ impl AppProject {
     }
 
     #[turbo_tasks::function]
-    fn client_runtime_entries(self: Vc<Self>) -> Result<Vc<EvaluatableAssets>> {
-        Ok(get_client_runtime_entries(
+    fn client_runtime_entries(self: Vc<Self>) -> Vc<EvaluatableAssets> {
+        get_client_runtime_entries(
             self.project().project_path(),
             Value::new(self.client_ty()),
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
         )
-        .resolve_entries(Vc::upcast(self.client_module_context())))
+        .resolve_entries(Vc::upcast(self.client_module_context()))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/global_module_id_strategy.rs
+++ b/crates/next-api/src/global_module_id_strategy.rs
@@ -84,9 +84,7 @@ impl GlobalModuleIdStrategyBuilder {
 // NOTE(LichuAcu) We can't move this function to `turbopack-core` because we need access to
 // `Endpoint`, which is not available there.
 #[turbo_tasks::function]
-fn preprocess_module_ids(
-    endpoint: Vc<Box<dyn Endpoint>>,
-) -> Result<Vc<PreprocessedChildrenIdents>> {
+fn preprocess_module_ids(endpoint: Vc<Box<dyn Endpoint>>) -> Vc<PreprocessedChildrenIdents> {
     let root_modules = endpoint.root_modules();
-    Ok(children_modules_idents(root_modules))
+    children_modules_idents(root_modules)
 }

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -65,7 +65,7 @@ impl InstrumentationEndpoint {
     }
 
     #[turbo_tasks::function]
-    fn core_modules(&self) -> Result<Vc<InstrumentationCoreModules>> {
+    fn core_modules(&self) -> Vc<InstrumentationCoreModules> {
         let userland_module = self
             .asset_context
             .process(
@@ -81,11 +81,11 @@ impl InstrumentationEndpoint {
             "instrumentation".into(),
         );
 
-        Ok(InstrumentationCoreModules {
+        InstrumentationCoreModules {
             userland_module,
             edge_entry_module,
         }
-        .cell())
+        .cell()
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -255,14 +255,13 @@ impl MiddlewareEndpoint {
     }
 
     #[turbo_tasks::function]
-    fn userland_module(&self) -> Result<Vc<Box<dyn Module>>> {
-        Ok(self
-            .asset_context
+    fn userland_module(&self) -> Vc<Box<dyn Module>> {
+        self.asset_context
             .process(
                 self.source,
                 Value::new(ReferenceType::Entry(EntryReferenceSubType::Middleware)),
             )
-            .module())
+            .module()
     }
 }
 
@@ -311,7 +310,7 @@ impl Endpoint for MiddlewareEndpoint {
     }
 
     #[turbo_tasks::function]
-    fn root_modules(self: Vc<Self>) -> Result<Vc<Modules>> {
-        Ok(Vc::cell(vec![self.userland_module()]))
+    fn root_modules(self: Vc<Self>) -> Vc<Modules> {
+        Vc::cell(vec![self.userland_module()])
     }
 }

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -81,8 +81,8 @@ pub struct PagesProject {
 #[turbo_tasks::value_impl]
 impl PagesProject {
     #[turbo_tasks::function]
-    pub fn new(project: Vc<Project>) -> Result<Vc<Self>> {
-        Ok(PagesProject { project }.cell())
+    pub fn new(project: Vc<Project>) -> Vc<Self> {
+        PagesProject { project }.cell()
     }
 
     #[turbo_tasks::function]
@@ -279,8 +279,8 @@ impl PagesProject {
     }
 
     #[turbo_tasks::function]
-    fn client_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
-        Ok(get_client_module_options_context(
+    fn client_module_options_context(self: Vc<Self>) -> Vc<ModuleOptionsContext> {
+        get_client_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
             self.project().client_compile_time_info().environment(),
@@ -289,12 +289,12 @@ impl PagesProject {
             }),
             self.project().next_mode(),
             self.project().next_config(),
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    fn client_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
-        Ok(get_client_resolve_options_context(
+    fn client_resolve_options_context(self: Vc<Self>) -> Vc<ResolveOptionsContext> {
+        get_client_resolve_options_context(
             self.project().project_path(),
             Value::new(ClientContextType::Pages {
                 pages_dir: self.pages_dir(),
@@ -302,7 +302,7 @@ impl PagesProject {
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
-        ))
+        )
     }
 
     #[turbo_tasks::function]
@@ -385,8 +385,8 @@ impl PagesProject {
     }
 
     #[turbo_tasks::function]
-    fn ssr_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
-        Ok(get_server_module_options_context(
+    fn ssr_module_options_context(self: Vc<Self>) -> Vc<ModuleOptionsContext> {
+        get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
             Value::new(ServerContextType::Pages {
@@ -395,12 +395,12 @@ impl PagesProject {
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::NodeJs,
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    fn edge_ssr_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
-        Ok(get_server_module_options_context(
+    fn edge_ssr_module_options_context(self: Vc<Self>) -> Vc<ModuleOptionsContext> {
+        get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
             Value::new(ServerContextType::Pages {
@@ -409,12 +409,12 @@ impl PagesProject {
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::Edge,
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    fn api_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
-        Ok(get_server_module_options_context(
+    fn api_module_options_context(self: Vc<Self>) -> Vc<ModuleOptionsContext> {
+        get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
             Value::new(ServerContextType::PagesApi {
@@ -423,12 +423,12 @@ impl PagesProject {
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::NodeJs,
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    fn edge_api_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
-        Ok(get_server_module_options_context(
+    fn edge_api_module_options_context(self: Vc<Self>) -> Vc<ModuleOptionsContext> {
+        get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
             Value::new(ServerContextType::PagesApi {
@@ -437,12 +437,12 @@ impl PagesProject {
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::Edge,
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    fn ssr_data_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
-        Ok(get_server_module_options_context(
+    fn ssr_data_module_options_context(self: Vc<Self>) -> Vc<ModuleOptionsContext> {
+        get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
             Value::new(ServerContextType::PagesData {
@@ -451,12 +451,12 @@ impl PagesProject {
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::NodeJs,
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    fn edge_ssr_data_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
-        Ok(get_server_module_options_context(
+    fn edge_ssr_data_module_options_context(self: Vc<Self>) -> Vc<ModuleOptionsContext> {
+        get_server_module_options_context(
             self.project().project_path(),
             self.project().execution_context(),
             Value::new(ServerContextType::PagesData {
@@ -465,12 +465,12 @@ impl PagesProject {
             self.project().next_mode(),
             self.project().next_config(),
             NextRuntime::Edge,
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    fn ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
-        Ok(get_server_resolve_options_context(
+    fn ssr_resolve_options_context(self: Vc<Self>) -> Vc<ResolveOptionsContext> {
+        get_server_resolve_options_context(
             self.project().project_path(),
             // NOTE(alexkirsz) This could be `PagesData` for the data endpoint, but it doesn't
             // matter (for now at least) because `get_server_resolve_options_context` doesn't
@@ -481,12 +481,12 @@ impl PagesProject {
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    fn edge_ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
-        Ok(get_edge_resolve_options_context(
+    fn edge_ssr_resolve_options_context(self: Vc<Self>) -> Vc<ResolveOptionsContext> {
+        get_edge_resolve_options_context(
             self.project().project_path(),
             // NOTE(alexkirsz) This could be `PagesData` for the data endpoint, but it doesn't
             // matter (for now at least) because `get_server_resolve_options_context` doesn't
@@ -497,11 +497,11 @@ impl PagesProject {
             self.project().next_mode(),
             self.project().next_config(),
             self.project().execution_context(),
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    fn client_runtime_entries(self: Vc<Self>) -> Result<Vc<EvaluatableAssets>> {
+    fn client_runtime_entries(self: Vc<Self>) -> Vc<EvaluatableAssets> {
         let client_runtime_entries = get_client_runtime_entries(
             self.project().project_path(),
             Value::new(ClientContextType::Pages {
@@ -511,27 +511,27 @@ impl PagesProject {
             self.project().next_config(),
             self.project().execution_context(),
         );
-        Ok(client_runtime_entries.resolve_entries(self.client_module_context()))
+        client_runtime_entries.resolve_entries(self.client_module_context())
     }
 
     #[turbo_tasks::function]
-    fn runtime_entries(self: Vc<Self>) -> Result<Vc<RuntimeEntries>> {
-        Ok(get_server_runtime_entries(
+    fn runtime_entries(self: Vc<Self>) -> Vc<RuntimeEntries> {
+        get_server_runtime_entries(
             Value::new(ServerContextType::Pages {
                 pages_dir: self.pages_dir(),
             }),
             self.project().next_mode(),
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    fn data_runtime_entries(self: Vc<Self>) -> Result<Vc<RuntimeEntries>> {
-        Ok(get_server_runtime_entries(
+    fn data_runtime_entries(self: Vc<Self>) -> Vc<RuntimeEntries> {
+        get_server_runtime_entries(
             Value::new(ServerContextType::PagesData {
                 pages_dir: self.pages_dir(),
             }),
             self.project().next_mode(),
-        ))
+        )
     }
 
     #[turbo_tasks::function]
@@ -638,8 +638,8 @@ impl PageEndpoint {
     }
 
     #[turbo_tasks::function]
-    fn source(&self) -> Result<Vc<Box<dyn Source>>> {
-        Ok(Vc::upcast(FileSource::new(self.page.project_path())))
+    fn source(&self) -> Vc<Box<dyn Source>> {
+        Vc::upcast(FileSource::new(self.page.project_path()))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -386,12 +386,12 @@ impl ProjectContainer {
         &self,
         file_path: Vc<FileSystemPath>,
         section: Option<RcStr>,
-    ) -> Result<Vc<OptionSourceMap>> {
-        Ok(if let Some(map) = self.versioned_content_map {
+    ) -> Vc<OptionSourceMap> {
+        if let Some(map) = self.versioned_content_map {
             map.get_source_map(file_path, section)
         } else {
             OptionSourceMap::none()
-        })
+        }
     }
 }
 
@@ -510,8 +510,8 @@ impl Project {
     }
 
     #[turbo_tasks::function]
-    pub fn pages_project(self: Vc<Self>) -> Result<Vc<PagesProject>> {
-        Ok(PagesProject::new(self))
+    pub fn pages_project(self: Vc<Self>) -> Vc<PagesProject> {
+        PagesProject::new(self)
     }
 
     #[turbo_tasks::function]
@@ -528,20 +528,20 @@ impl Project {
     }
 
     #[turbo_tasks::function]
-    fn client_fs(self: Vc<Self>) -> Result<Vc<Box<dyn FileSystem>>> {
+    fn client_fs(self: Vc<Self>) -> Vc<Box<dyn FileSystem>> {
         let virtual_fs = VirtualFileSystem::new();
-        Ok(Vc::upcast(virtual_fs))
+        Vc::upcast(virtual_fs)
     }
 
     #[turbo_tasks::function]
-    pub fn output_fs(&self) -> Result<Vc<DiskFileSystem>> {
+    pub fn output_fs(&self) -> Vc<DiskFileSystem> {
         let disk_fs = DiskFileSystem::new("output".into(), self.project_path.clone(), vec![]);
-        Ok(disk_fs)
+        disk_fs
     }
 
     #[turbo_tasks::function]
-    pub fn dist_dir(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(self.dist_dir.clone()))
+    pub fn dist_dir(&self) -> Vc<RcStr> {
+        Vc::cell(self.dist_dir.clone())
     }
 
     #[turbo_tasks::function]
@@ -585,23 +585,23 @@ impl Project {
     }
 
     #[turbo_tasks::function]
-    pub(super) fn env(&self) -> Result<Vc<Box<dyn ProcessEnv>>> {
-        Ok(self.env)
+    pub(super) fn env(&self) -> Vc<Box<dyn ProcessEnv>> {
+        self.env
     }
 
     #[turbo_tasks::function]
-    pub(super) fn next_config(&self) -> Result<Vc<NextConfig>> {
-        Ok(self.next_config)
+    pub(super) fn next_config(&self) -> Vc<NextConfig> {
+        self.next_config
     }
 
     #[turbo_tasks::function]
-    pub(super) fn next_mode(&self) -> Result<Vc<NextMode>> {
-        Ok(self.mode)
+    pub(super) fn next_mode(&self) -> Vc<NextMode> {
+        self.mode
     }
 
     #[turbo_tasks::function]
-    pub(super) fn js_config(&self) -> Result<Vc<JsConfig>> {
-        Ok(self.js_config)
+    pub(super) fn js_config(&self) -> Vc<JsConfig> {
+        self.js_config
     }
 
     #[turbo_tasks::function]
@@ -630,11 +630,8 @@ impl Project {
     }
 
     #[turbo_tasks::function]
-    pub(super) fn client_compile_time_info(&self) -> Result<Vc<CompileTimeInfo>> {
-        Ok(get_client_compile_time_info(
-            self.browserslist_query.clone(),
-            self.define_env.client(),
-        ))
+    pub(super) fn client_compile_time_info(&self) -> Vc<CompileTimeInfo> {
+        get_client_compile_time_info(self.browserslist_query.clone(), self.define_env.client())
     }
 
     #[turbo_tasks::function]
@@ -668,15 +665,15 @@ impl Project {
     }
 
     #[turbo_tasks::function]
-    pub(super) fn client_chunking_context(self: Vc<Self>) -> Result<Vc<Box<dyn ChunkingContext>>> {
-        Ok(get_client_chunking_context(
+    pub(super) fn client_chunking_context(self: Vc<Self>) -> Vc<Box<dyn ChunkingContext>> {
+        get_client_chunking_context(
             self.project_path(),
             self.client_relative_path(),
             self.next_config().computed_asset_prefix(),
             self.client_compile_time_info().environment(),
             self.next_mode(),
             self.module_id_strategy(),
-        ))
+        )
     }
 
     #[turbo_tasks::function]
@@ -1322,6 +1319,6 @@ fn all_assets_from_entries_operation(
 }
 
 #[turbo_tasks::function]
-fn stable_endpoint(endpoint: Vc<Box<dyn Endpoint>>) -> Result<Vc<Box<dyn Endpoint>>> {
-    Ok(endpoint)
+fn stable_endpoint(endpoint: Vc<Box<dyn Endpoint>>) -> Vc<Box<dyn Endpoint>> {
+    endpoint
 }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -535,8 +535,7 @@ impl Project {
 
     #[turbo_tasks::function]
     pub fn output_fs(&self) -> Vc<DiskFileSystem> {
-        let disk_fs = DiskFileSystem::new("output".into(), self.project_path.clone(), vec![]);
-        disk_fs
+        DiskFileSystem::new("output".into(), self.project_path.clone(), vec![])
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -230,13 +230,13 @@ impl VersionedContentMap {
     }
 
     #[turbo_tasks::function]
-    fn raw_get(&self, path: Vc<FileSystemPath>) -> Result<Vc<OptionMapEntry>> {
+    fn raw_get(&self, path: Vc<FileSystemPath>) -> Vc<OptionMapEntry> {
         let assets = {
             let map = self.map_path_to_op.get();
             map.get(&path).and_then(|m| m.iter().last().copied())
         };
         let Some(assets) = assets else {
-            return Ok(Vc::cell(None));
+            return Vc::cell(None);
         };
         // Need to reconnect the operation to the map
         Vc::connect(assets);
@@ -246,11 +246,11 @@ impl VersionedContentMap {
             map.get(&assets).copied()
         };
         let Some(compute_entry) = compute_entry else {
-            return Ok(Vc::cell(None));
+            return Vc::cell(None);
         };
         // Need to reconnect the operation to the map
         Vc::connect(compute_entry);
 
-        Ok(compute_entry)
+        compute_entry
     }
 }

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -732,8 +732,8 @@ struct DuplicateParallelRouteIssue {
 #[turbo_tasks::value_impl]
 impl Issue for DuplicateParallelRouteIssue {
     #[turbo_tasks::function]
-    fn file_path(&self) -> Result<Vc<FileSystemPath>> {
-        Ok(self.app_dir.join(self.page.to_string().into()))
+    fn file_path(&self) -> Vc<FileSystemPath> {
+        self.app_dir.join(self.page.to_string().into())
     }
 
     #[turbo_tasks::function]
@@ -1355,8 +1355,8 @@ impl Issue for DirectoryTreeIssue {
     }
 
     #[turbo_tasks::function]
-    fn title(&self) -> Result<Vc<StyledString>> {
-        Ok(StyledString::Text("An issue occurred while preparing your Next.js app".into()).cell())
+    fn title(&self) -> Vc<StyledString> {
+        StyledString::Text("An issue occurred while preparing your Next.js app".into()).cell()
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/bootstrap.rs
+++ b/crates/next-core/src/bootstrap.rs
@@ -20,15 +20,15 @@ pub fn route_bootstrap(
     base_path: Vc<FileSystemPath>,
     bootstrap_asset: Vc<Box<dyn Source>>,
     config: Vc<BootstrapConfig>,
-) -> Result<Vc<Box<dyn EvaluatableAsset>>> {
-    Ok(bootstrap(
+) -> Vc<Box<dyn EvaluatableAsset>> {
+    bootstrap(
         asset,
         asset_context,
         base_path,
         bootstrap_asset,
         Vc::cell(IndexMap::new()),
         config,
-    ))
+    )
 }
 
 #[turbo_tasks::value(transparent)]

--- a/crates/next-core/src/hmr_entry.rs
+++ b/crates/next-core/src/hmr_entry.rs
@@ -121,8 +121,8 @@ impl ValueToString for HmrEntryModuleReference {
 #[turbo_tasks::value_impl]
 impl ModuleReference for HmrEntryModuleReference {
     #[turbo_tasks::function]
-    fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
-        Ok(ModuleResolveResult::module(self.module).cell())
+    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
+        ModuleResolveResult::module(self.module).cell()
     }
 }
 

--- a/crates/next-core/src/next_app/include_modules_module.rs
+++ b/crates/next-core/src/next_app/include_modules_module.rs
@@ -78,14 +78,14 @@ impl ChunkableModule for IncludeModulesModule {
     fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<Box<dyn ChunkItem>>> {
-        Ok(Vc::upcast(
+    ) -> Vc<Box<dyn ChunkItem>> {
+        Vc::upcast(
             IncludeModulesChunkItem {
                 module: self,
                 chunking_context,
             }
             .cell(),
-        ))
+        )
     }
 }
 
@@ -165,8 +165,8 @@ impl ValueToString for IncludedModuleReference {
 #[turbo_tasks::value_impl]
 impl ModuleReference for IncludedModuleReference {
     #[turbo_tasks::function]
-    fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
-        Ok(ModuleResolveResult::module(self.module).cell())
+    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
+        ModuleResolveResult::module(self.module).cell()
     }
 }
 

--- a/crates/next-core/src/next_build.rs
+++ b/crates/next-core/src/next_build.rs
@@ -6,16 +6,14 @@ use turbopack_core::resolve::{options::ImportMapping, ExternalType};
 use crate::next_import_map::get_next_package;
 
 #[turbo_tasks::function]
-pub async fn get_postcss_package_mapping(
-    project_path: Vc<FileSystemPath>,
-) -> Result<Vc<ImportMapping>> {
-    Ok(ImportMapping::Alternatives(vec![
+pub async fn get_postcss_package_mapping(project_path: Vc<FileSystemPath>) -> Vc<ImportMapping> {
+    ImportMapping::Alternatives(vec![
         // Prefer the local installed version over the next.js version
         ImportMapping::PrimaryAlternative("postcss".into(), Some(project_path)).cell(),
         ImportMapping::PrimaryAlternative("postcss".into(), Some(get_next_package(project_path)))
             .cell(),
     ])
-    .cell())
+    .cell()
 }
 
 #[turbo_tasks::function]

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -57,10 +57,10 @@ impl Module for EcmascriptClientReferenceModule {
     }
 
     #[turbo_tasks::function]
-    fn additional_layers_modules(&self) -> Result<Vc<Modules>> {
+    fn additional_layers_modules(&self) -> Vc<Modules> {
         let client_module = Vc::upcast(self.client_module);
         let ssr_module = Vc::upcast(self.ssr_module);
-        Ok(Vc::cell(vec![client_module, ssr_module]))
+        Vc::cell(vec![client_module, ssr_module])
     }
 }
 

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -792,17 +792,17 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub fn server_external_packages(&self) -> Result<Vc<Vec<RcStr>>> {
-        Ok(Vc::cell(
+    pub fn server_external_packages(&self) -> Vc<Vec<RcStr>> {
+        Vc::cell(
             self.server_external_packages
                 .as_ref()
                 .cloned()
                 .unwrap_or_default(),
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    pub fn env(&self) -> Result<Vc<EnvMap>> {
+    pub fn env(&self) -> Vc<EnvMap> {
         // The value expected for env is Record<String, String>, but config itself
         // allows arbitrary object (https://github.com/vercel/next.js/blob/25ba8a74b7544dfb6b30d1b67c47b9cb5360cb4e/packages/next/src/server/config-schema.ts#L203)
         // then stringifies it. We do the interop here as well.
@@ -822,38 +822,36 @@ impl NextConfig {
             })
             .collect();
 
-        Ok(Vc::cell(env))
+        Vc::cell(env)
     }
 
     #[turbo_tasks::function]
-    pub fn image_config(&self) -> Result<Vc<ImageConfig>> {
-        Ok(self.images.clone().cell())
+    pub fn image_config(&self) -> Vc<ImageConfig> {
+        self.images.clone().cell()
     }
 
     #[turbo_tasks::function]
-    pub fn page_extensions(&self) -> Result<Vc<Vec<RcStr>>> {
-        Ok(Vc::cell(self.page_extensions.clone()))
+    pub fn page_extensions(&self) -> Vc<Vec<RcStr>> {
+        Vc::cell(self.page_extensions.clone())
     }
 
     #[turbo_tasks::function]
-    pub fn transpile_packages(&self) -> Result<Vc<Vec<RcStr>>> {
-        Ok(Vc::cell(
-            self.transpile_packages.clone().unwrap_or_default(),
-        ))
+    pub fn transpile_packages(&self) -> Vc<Vec<RcStr>> {
+        Vc::cell(self.transpile_packages.clone().unwrap_or_default())
     }
 
     #[turbo_tasks::function]
-    pub fn webpack_rules(&self, active_conditions: Vec<RcStr>) -> Result<Vc<OptionWebpackRules>> {
+    pub fn webpack_rules(&self, active_conditions: Vec<RcStr>) -> Vc<OptionWebpackRules> {
         let Some(turbo_rules) = self
             .experimental
             .turbo
             .as_ref()
             .and_then(|t| t.rules.as_ref())
         else {
-            return Ok(Vc::cell(None));
+            return Vc::cell(None);
         };
         if turbo_rules.is_empty() {
-            return Ok(Vc::cell(None));
+            return Vc::cell(None);
         }
         let active_conditions = active_conditions.into_iter().collect::<HashSet<_>>();
         let mut rules = IndexMap::new();
@@ -927,7 +925,7 @@ impl NextConfig {
                 }
             }
         }
-        Ok(Vc::cell(Some(Vc::cell(rules))))
+        Vc::cell(Some(Vc::cell(rules)))
     }
 
     #[turbo_tasks::function]
@@ -945,16 +943,16 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub fn resolve_extension(&self) -> Result<Vc<ResolveExtensions>> {
+    pub fn resolve_extension(&self) -> Vc<ResolveExtensions> {
         let Some(resolve_extensions) = self
             .experimental
             .turbo
             .as_ref()
             .and_then(|t| t.resolve_extensions.as_ref())
         else {
-            return Ok(Vc::cell(None));
+            return Vc::cell(None);
         };
-        Ok(Vc::cell(Some(resolve_extensions.clone())))
+        Vc::cell(Some(resolve_extensions.clone()))
     }
 
     #[turbo_tasks::function]
@@ -967,7 +965,7 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub fn mdx_rs(&self) -> Result<Vc<OptionalMdxTransformOptions>> {
+    pub fn mdx_rs(&self) -> Vc<OptionalMdxTransformOptions> {
         let options = &self.experimental.mdx_rs;
 
         let options = match options {
@@ -993,11 +991,11 @@ impl NextConfig {
             _ => OptionalMdxTransformOptions(None),
         };
 
-        Ok(options.cell())
+        options.cell()
     }
 
     #[turbo_tasks::function]
-    pub fn react_compiler(&self) -> Result<Vc<OptionalReactCompilerOptions>> {
+    pub fn react_compiler(&self) -> Vc<OptionalReactCompilerOptions> {
         let options = &self.experimental.react_compiler;
 
         let options = match options {
@@ -1016,24 +1014,22 @@ impl NextConfig {
             _ => OptionalReactCompilerOptions(None),
         };
 
-        Ok(options.cell())
+        options.cell()
     }
 
     #[turbo_tasks::function]
-    pub fn sass_config(&self) -> Result<Vc<JsonValue>> {
-        Ok(Vc::cell(self.sass_options.clone().unwrap_or_default()))
+    pub fn sass_config(&self) -> Vc<JsonValue> {
+        Vc::cell(self.sass_options.clone().unwrap_or_default())
     }
 
     #[turbo_tasks::function]
-    pub fn skip_middleware_url_normalize(&self) -> Result<Vc<bool>> {
-        Ok(Vc::cell(
-            self.skip_middleware_url_normalize.unwrap_or(false),
-        ))
+    pub fn skip_middleware_url_normalize(&self) -> Vc<bool> {
+        Vc::cell(self.skip_middleware_url_normalize.unwrap_or(false))
     }
 
     #[turbo_tasks::function]
-    pub fn skip_trailing_slash_redirect(&self) -> Result<Vc<bool>> {
-        Ok(Vc::cell(self.skip_trailing_slash_redirect.unwrap_or(false)))
+    pub fn skip_trailing_slash_redirect(&self) -> Vc<bool> {
+        Vc::cell(self.skip_trailing_slash_redirect.unwrap_or(false))
     }
 
     /// Returns the final asset prefix. If an assetPrefix is set, it's used.
@@ -1057,8 +1053,8 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub fn enable_ppr(&self) -> Result<Vc<bool>> {
-        Ok(Vc::cell(
+    pub fn enable_ppr(&self) -> Vc<bool> {
+        Vc::cell(
             self.experimental
                 .ppr
                 .as_ref()
@@ -1069,52 +1065,52 @@ impl NextConfig {
                     ExperimentalPartialPrerendering::Boolean(b) => *b,
                 })
                 .unwrap_or(false),
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    pub fn enable_taint(&self) -> Result<Vc<bool>> {
-        Ok(Vc::cell(self.experimental.taint.unwrap_or(false)))
+    pub fn enable_taint(&self) -> Vc<bool> {
+        Vc::cell(self.experimental.taint.unwrap_or(false))
     }
 
     #[turbo_tasks::function]
-    pub fn enable_dynamic_io(&self) -> Result<Vc<bool>> {
-        Ok(Vc::cell(self.experimental.dynamic_io.unwrap_or(false)))
+    pub fn enable_dynamic_io(&self) -> Vc<bool> {
+        Vc::cell(self.experimental.dynamic_io.unwrap_or(false))
     }
 
     #[turbo_tasks::function]
-    pub fn use_swc_css(&self) -> Result<Vc<bool>> {
-        Ok(Vc::cell(
+    pub fn use_swc_css(&self) -> Vc<bool> {
+        Vc::cell(
             self.experimental
                 .turbo
                 .as_ref()
                 .and_then(|turbo| turbo.use_swc_css)
                 .unwrap_or(false),
-        ))
+        )
     }
 
     #[turbo_tasks::function]
-    pub fn optimize_package_imports(&self) -> Result<Vc<Vec<RcStr>>> {
-        Ok(Vc::cell(
+    pub fn optimize_package_imports(&self) -> Vc<Vec<RcStr>> {
+        Vc::cell(
             self.experimental
                 .optimize_package_imports
                 .clone()
                 .unwrap_or_default(),
-        ))
+        )
     }
 
     #[turbo_tasks::function]
     pub fn tree_shaking_mode_for_foreign_code(
         &self,
         is_development: bool,
-    ) -> Result<Vc<OptionTreeShaking>> {
+    ) -> Vc<OptionTreeShaking> {
         let tree_shaking = self
             .experimental
             .turbo
             .as_ref()
             .and_then(|v| v.tree_shaking);
 
-        Ok(OptionTreeShaking(match tree_shaking {
+        OptionTreeShaking(match tree_shaking {
             Some(false) => Some(TreeShakingMode::ReexportsOnly),
             Some(true) => Some(TreeShakingMode::ModuleFragments),
             None => {
@@ -1125,32 +1121,32 @@ impl NextConfig {
                 }
             }
         })
-        .cell())
+        .cell()
     }
 
     #[turbo_tasks::function]
     pub fn tree_shaking_mode_for_user_code(
         self: Vc<Self>,
         is_development: bool,
-    ) -> Result<Vc<OptionTreeShaking>> {
-        Ok(Vc::cell(Some(if is_development {
+    ) -> Vc<OptionTreeShaking> {
+        Vc::cell(Some(if is_development {
             TreeShakingMode::ReexportsOnly
         } else {
             TreeShakingMode::ModuleFragments
-        })))
+        }))
     }
 
     #[turbo_tasks::function]
-    pub fn module_id_strategy_config(&self) -> Result<Vc<OptionModuleIdStrategy>> {
+    pub fn module_id_strategy_config(&self) -> Vc<OptionModuleIdStrategy> {
         let Some(module_id_strategy) = self
             .experimental
             .turbo
             .as_ref()
             .and_then(|t| t.module_id_strategy.as_ref())
         else {
-            return Ok(Vc::cell(None));
+            return Vc::cell(None);
         };
-        Ok(Vc::cell(Some(module_id_strategy.clone())))
+        Vc::cell(Some(module_id_strategy.clone()))
     }
 }
 
@@ -1175,8 +1171,8 @@ impl JsConfig {
     }
 
     #[turbo_tasks::function]
-    pub fn compiler_options(&self) -> Result<Vc<serde_json::Value>> {
-        Ok(Vc::cell(self.compiler_options.clone().unwrap_or_default()))
+    pub fn compiler_options(&self) -> Vc<serde_json::Value> {
+        Vc::cell(self.compiler_options.clone().unwrap_or_default())
     }
 }
 

--- a/crates/next-core/src/next_edge/entry.rs
+++ b/crates/next-core/src/next_edge/entry.rs
@@ -37,11 +37,10 @@ pub async fn wrap_edge_entry(
         "MODULE".into() => entry
     };
 
-    let module = asset_context
+    asset_context
         .process(
             Vc::upcast(virtual_source),
             Value::new(ReferenceType::Internal(Vc::cell(inner_assets))),
         )
-        .module();
-    module
+        .module()
 }

--- a/crates/next-core/src/next_edge/entry.rs
+++ b/crates/next-core/src/next_edge/entry.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use indexmap::indexmap;
 use indoc::formatdoc;
 use turbo_tasks::{RcStr, Value, Vc};
@@ -15,7 +14,7 @@ pub async fn wrap_edge_entry(
     project_root: Vc<FileSystemPath>,
     entry: Vc<Box<dyn Module>>,
     pathname: RcStr,
-) -> Result<Vc<Box<dyn Module>>> {
+) -> Vc<Box<dyn Module>> {
     // The wrapped module could be an async module, we handle that with the proxy
     // here. The comma expression makes sure we don't call the function with the
     // module as the "this" arg.
@@ -44,5 +43,5 @@ pub async fn wrap_edge_entry(
             Value::new(ReferenceType::Internal(Vc::cell(inner_assets))),
         )
         .module();
-    Ok(module)
+    module
 }

--- a/crates/next-core/src/next_font/google/options.rs
+++ b/crates/next-core/src/next_font/google/options.rs
@@ -35,8 +35,8 @@ impl NextFontGoogleOptions {
     }
 
     #[turbo_tasks::function]
-    pub fn font_family(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell((*self.font_family).into()))
+    pub fn font_family(&self) -> Vc<RcStr> {
+        Vc::cell((*self.font_family).into())
     }
 }
 

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -321,8 +321,8 @@ impl Issue for FontResolvingIssue {
     }
 
     #[turbo_tasks::function]
-    fn file_path(&self) -> Result<Vc<FileSystemPath>> {
-        Ok(self.origin_path)
+    fn file_path(&self) -> Vc<FileSystemPath> {
+        self.origin_path
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_font/local/options.rs
+++ b/crates/next-core/src/next_font/local/options.rs
@@ -41,8 +41,8 @@ impl NextFontLocalOptions {
     }
 
     #[turbo_tasks::function]
-    pub fn font_family(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(self.variable_name.clone()))
+    pub fn font_family(&self) -> Vc<RcStr> {
+        Vc::cell(self.variable_name.clone())
     }
 }
 

--- a/crates/next-core/src/next_image/module.rs
+++ b/crates/next-core/src/next_image/module.rs
@@ -41,7 +41,7 @@ impl StructuredImageModuleType {
         module_asset_context: Vc<ModuleAssetContext>,
     ) -> Vc<Box<dyn Module>> {
         let static_asset = StaticModuleAsset::new(source, Vc::upcast(module_asset_context));
-        let module = module_asset_context
+        module_asset_context
             .process(
                 Vc::upcast(
                     StructuredImageFileSource {
@@ -54,8 +54,7 @@ impl StructuredImageModuleType {
                     "IMAGE".into() => Vc::upcast(static_asset)
                 )))),
             )
-            .module();
-        module
+            .module()
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_image/module.rs
+++ b/crates/next-core/src/next_image/module.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use indexmap::indexmap;
 use turbo_tasks::{TaskInput, Value, Vc};
 use turbopack::{module_options::CustomModuleType, ModuleAssetContext};
@@ -40,7 +39,7 @@ impl StructuredImageModuleType {
         source: Vc<Box<dyn Source>>,
         blur_placeholder_mode: BlurPlaceholderMode,
         module_asset_context: Vc<ModuleAssetContext>,
-    ) -> Result<Vc<Box<dyn Module>>> {
+    ) -> Vc<Box<dyn Module>> {
         let static_asset = StaticModuleAsset::new(source, Vc::upcast(module_asset_context));
         let module = module_asset_context
             .process(
@@ -56,7 +55,7 @@ impl StructuredImageModuleType {
                 )))),
             )
             .module();
-        Ok(module)
+        module
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -172,10 +172,7 @@ fn process_global_item(
     module_context: Vc<Box<dyn AssetContext>>,
 ) -> Vc<Box<dyn Module>> {
     let source = Vc::upcast(FileSource::new(item.project_path()));
-
-    let module = module_context.process(source, reference_type).module();
-
-    module
+    module_context.process(source, reference_type).module()
 }
 
 #[turbo_tasks::function]

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -170,12 +170,12 @@ fn process_global_item(
     item: Vc<PagesStructureItem>,
     reference_type: Value<ReferenceType>,
     module_context: Vc<Box<dyn AssetContext>>,
-) -> Result<Vc<Box<dyn Module>>> {
+) -> Vc<Box<dyn Module>> {
     let source = Vc::upcast(FileSource::new(item.project_path()));
 
     let module = module_context.process(source, reference_type).module();
 
-    Ok(module)
+    module
 }
 
 #[turbo_tasks::function]

--- a/crates/next-core/src/next_route_matcher/mod.rs
+++ b/crates/next-core/src/next_route_matcher/mod.rs
@@ -21,8 +21,8 @@ pub(crate) struct NextExactMatcher {
 #[turbo_tasks::value_impl]
 impl NextExactMatcher {
     #[turbo_tasks::function]
-    pub fn new(path: Vc<RcStr>) -> Result<Vc<Self>> {
-        Ok(Self::cell(NextExactMatcher { path }))
+    pub fn new(path: Vc<RcStr>) -> Vc<Self> {
+        Self::cell(NextExactMatcher { path })
     }
 }
 

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -476,7 +476,7 @@ impl Issue for UnableToExternalize {
     }
 
     #[turbo_tasks::function]
-    async fn title(&self) -> Result<Vc<StyledString>> {
+    async fn title(&self) -> Vc<StyledString> {
         let request = &self.request;
         let package = if request.starts_with('@') {
             request
@@ -490,14 +490,14 @@ impl Issue for UnableToExternalize {
         } else {
             request.clone()
         };
-        Ok(StyledString::Line(vec![
+        StyledString::Line(vec![
             StyledString::Text("Package ".into()),
             StyledString::Code(package),
             StyledString::Text(" (".into()),
             StyledString::Code("serverExternalPackages".into()),
             StyledString::Text(" or default list) can't be external".into()),
         ])
-        .cell())
+        .cell()
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -46,8 +46,8 @@ impl NextServerComponentModule {
     }
 
     #[turbo_tasks::function]
-    pub fn server_path(&self) -> Result<Vc<FileSystemPath>> {
-        Ok(self.module.ident().path())
+    pub fn server_path(&self) -> Vc<FileSystemPath> {
+        self.module.ident().path()
     }
 }
 
@@ -92,14 +92,14 @@ impl ChunkableModule for NextServerComponentModule {
     fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
-        Ok(Vc::upcast(
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        Vc::upcast(
             NextServerComponentChunkItem {
                 chunking_context,
                 inner: self,
             }
             .cell(),
-        ))
+        )
     }
 }
 

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -130,7 +130,7 @@ impl BeforeResolvePlugin for InvalidImportResolvePlugin {
         lookup_path: Vc<FileSystemPath>,
         _reference_type: Value<ReferenceType>,
         _request: Vc<Request>,
-    ) -> Result<Vc<ResolveResultOption>> {
+    ) -> Vc<ResolveResultOption> {
         InvalidImportModuleIssue {
             file_path: lookup_path,
             messages: self.message.clone(),
@@ -140,12 +140,12 @@ impl BeforeResolvePlugin for InvalidImportResolvePlugin {
         .cell()
         .emit();
 
-        Ok(ResolveResultOption::some(
+        ResolveResultOption::some(
             ResolveResult::primary(ResolveResultItem::Error(Vc::cell(
                 self.message.join("\n").into(),
             )))
             .cell(),
-        ))
+        )
     }
 }
 

--- a/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
+++ b/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
@@ -157,8 +157,8 @@ impl Issue for PageStaticInfoIssue {
     }
 
     #[turbo_tasks::function]
-    fn description(&self) -> Result<Vc<OptionStyledString>> {
-        Ok(Vc::cell(Some(
+    fn description(&self) -> Vc<OptionStyledString> {
+        Vc::cell(Some(
             StyledString::Line(
                 self.messages
                     .iter()
@@ -166,6 +166,6 @@ impl Issue for PageStaticInfoIssue {
                     .collect::<Vec<StyledString>>(),
             )
             .cell(),
-        )))
+        ))
     }
 }

--- a/crates/next-core/src/pages_structure.rs
+++ b/crates/next-core/src/pages_structure.rs
@@ -32,15 +32,15 @@ impl PagesStructureItem {
         fallback_path: Option<Vc<FileSystemPath>>,
         next_router_path: Vc<FileSystemPath>,
         original_path: Vc<FileSystemPath>,
-    ) -> Result<Vc<Self>> {
-        Ok(PagesStructureItem {
+    ) -> Vc<Self> {
+        PagesStructureItem {
             base_path,
             extensions,
             fallback_path,
             next_router_path,
             original_path,
         }
-        .cell())
+        .cell()
     }
 
     #[turbo_tasks::function]
@@ -102,8 +102,8 @@ impl PagesDirectoryStructure {
     /// Returns the path to the directory of this structure in the project file
     /// system.
     #[turbo_tasks::function]
-    pub fn project_path(&self) -> Result<Vc<FileSystemPath>> {
-        Ok(self.project_path)
+    pub fn project_path(&self) -> Vc<FileSystemPath> {
+        self.project_path
     }
 }
 

--- a/turbopack/crates/node-file-trace/src/lib.rs
+++ b/turbopack/crates/node-file-trace/src/lib.rs
@@ -632,7 +632,7 @@ async fn create_module_asset(
     process_cwd: Option<RcStr>,
     module_options: TransientInstance<ModuleOptionsContext>,
     resolve_options: TransientInstance<ResolveOptionsContext>,
-) -> Result<Vc<ModuleAssetContext>> {
+) -> Vc<ModuleAssetContext> {
     let env = Environment::new(Value::new(ExecutionEnvironment::NodeJsLambda(
         NodeJsEnvironment {
             cwd: Vc::cell(process_cwd),
@@ -666,13 +666,13 @@ async fn create_module_asset(
         );
     }
 
-    Ok(ModuleAssetContext::new(
+    ModuleAssetContext::new(
         Default::default(),
         compile_time_info,
         ModuleOptionsContext::clone(&*module_options).cell(),
         resolve_options.cell(),
         Vc::cell("node_file_trace".into()),
-    ))
+    )
 }
 
 fn register() {

--- a/turbopack/crates/turbo-tasks-env/src/dotenv.rs
+++ b/turbopack/crates/turbo-tasks-env/src/dotenv.rs
@@ -24,10 +24,10 @@ impl DotenvProcessEnv {
     }
 
     #[turbo_tasks::function]
-    pub fn read_prior(&self) -> Result<Vc<EnvMap>> {
+    pub fn read_prior(&self) -> Vc<EnvMap> {
         match self.prior {
-            None => Ok(EnvMap::empty()),
-            Some(p) => Ok(p.read_all()),
+            None => EnvMap::empty(),
+            Some(p) => p.read_all(),
         }
     }
 
@@ -76,9 +76,9 @@ impl DotenvProcessEnv {
 #[turbo_tasks::value_impl]
 impl ProcessEnv for DotenvProcessEnv {
     #[turbo_tasks::function]
-    fn read_all(self: Vc<Self>) -> Result<Vc<EnvMap>> {
+    fn read_all(self: Vc<Self>) -> Vc<EnvMap> {
         let prior = self.read_prior();
-        Ok(self.read_all_with_prior(prior))
+        self.read_all_with_prior(prior)
     }
 }
 

--- a/turbopack/crates/turbo-tasks-env/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-env/src/lib.rs
@@ -30,8 +30,8 @@ impl EnvMap {
 #[turbo_tasks::value_impl]
 impl ProcessEnv for EnvMap {
     #[turbo_tasks::function]
-    fn read_all(self: Vc<Self>) -> Result<Vc<EnvMap>> {
-        Ok(self)
+    fn read_all(self: Vc<Self>) -> Vc<EnvMap> {
+        self
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks-fs/src/embed/file.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/file.rs
@@ -30,8 +30,8 @@ pub async fn content_from_relative_path(
 }
 
 #[turbo_tasks::function]
-pub fn content_from_str(string: RcStr) -> Result<Vc<FileContent>> {
-    Ok(File::from(string).into())
+pub fn content_from_str(string: RcStr) -> Vc<FileContent> {
+    File::from(string).into()
 }
 
 /// Loads a file's content from disk and invalidates on change (debug builds).

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1209,13 +1209,13 @@ impl FileSystemPath {
     }
 
     #[turbo_tasks::function]
-    pub fn fs(&self) -> Result<Vc<Box<dyn FileSystem>>> {
-        Ok(self.fs)
+    pub fn fs(&self) -> Vc<Box<dyn FileSystem>> {
+        self.fs
     }
 
     #[turbo_tasks::function]
-    pub fn extension(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(self.extension_ref().unwrap_or("").into()))
+    pub fn extension(&self) -> Vc<RcStr> {
+        Vc::cell(self.extension_ref().unwrap_or("").into())
     }
 
     #[turbo_tasks::function]
@@ -1231,9 +1231,9 @@ impl FileSystemPath {
     /// Creates a new [`Vc<FileSystemPath>`] like `self` but with the given
     /// extension.
     #[turbo_tasks::function]
-    pub async fn with_extension(&self, extension: RcStr) -> Result<Vc<FileSystemPath>> {
+    pub async fn with_extension(&self, extension: RcStr) -> Vc<FileSystemPath> {
         let (path_without_extension, _) = self.split_extension();
-        Ok(Self::new_normalized(
+        Self::new_normalized(
             self.fs,
             // Like `Path::with_extension` and `PathBuf::set_extension`, if the extension is empty,
             // we remove the extension altogether.
@@ -1241,7 +1241,7 @@ impl FileSystemPath {
                 true => path_without_extension.into(),
                 false => format!("{path_without_extension}.{extension}").into(),
             },
-        ))
+        )
     }
 
     /// Extracts the stem (non-extension) portion of self.file_name.
@@ -1253,12 +1253,12 @@ impl FileSystemPath {
     /// * The entire file name if the file name begins with `.` and has no other `.`s within;
     /// * Otherwise, the portion of the file name before the final `.`
     #[turbo_tasks::function]
-    pub fn file_stem(&self) -> Result<Vc<Option<RcStr>>> {
+    pub fn file_stem(&self) -> Vc<Option<RcStr>> {
         let (_, file_stem, _) = self.split_file_stem_extension();
         if file_stem.is_empty() {
-            return Ok(Vc::cell(None));
+            return Vc::cell(None);
         }
-        Ok(Vc::cell(Some(file_stem.into())))
+        Vc::cell(Some(file_stem.into()))
     }
 
     /// See [`truncate_file_name_with_hash`]. Preserves the input [`Vc`] if no truncation was
@@ -1478,8 +1478,8 @@ pub struct RealPathResult {
 #[turbo_tasks::value_impl]
 impl RealPathResult {
     #[turbo_tasks::function]
-    pub fn path(&self) -> Result<Vc<FileSystemPath>> {
-        Ok(self.path)
+    pub fn path(&self) -> Vc<FileSystemPath> {
+        self.path
     }
 }
 

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -485,8 +485,8 @@ impl ChunkingContext for BrowserChunkingContext {
     }
 
     #[turbo_tasks::function]
-    fn chunk_item_id_from_ident(&self, ident: Vc<AssetIdent>) -> Result<Vc<ModuleId>> {
-        Ok(self.module_id_strategy.get_module_id(ident))
+    fn chunk_item_id_from_ident(&self, ident: Vc<AssetIdent>) -> Vc<ModuleId> {
+        self.module_id_strategy.get_module_id(ident)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
@@ -40,8 +40,8 @@ impl EcmascriptDevChunk {
 #[turbo_tasks::value_impl]
 impl ValueToString for EcmascriptDevChunk {
     #[turbo_tasks::function]
-    fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell("Ecmascript Dev Chunk".into()))
+    fn to_string(&self) -> Vc<RcStr> {
+        Vc::cell("Ecmascript Dev Chunk".into())
     }
 }
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -47,20 +47,20 @@ impl EcmascriptDevChunkContent {
     }
 
     #[turbo_tasks::function]
-    pub fn entries(&self) -> Result<Vc<EcmascriptDevChunkContentEntries>> {
-        Ok(self.entries)
+    pub fn entries(&self) -> Vc<EcmascriptDevChunkContentEntries> {
+        self.entries
     }
 }
 
 #[turbo_tasks::value_impl]
 impl EcmascriptDevChunkContent {
     #[turbo_tasks::function]
-    pub(crate) fn own_version(&self) -> Result<Vc<EcmascriptDevChunkVersion>> {
-        Ok(EcmascriptDevChunkVersion::new(
+    pub(crate) fn own_version(&self) -> Vc<EcmascriptDevChunkVersion> {
+        EcmascriptDevChunkVersion::new(
             self.chunking_context.output_root(),
             self.chunk.ident().path(),
             self.entries,
-        ))
+        )
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -57,11 +57,8 @@ impl EcmascriptDevEvaluateChunk {
     }
 
     #[turbo_tasks::function]
-    fn chunks_data(&self) -> Result<Vc<ChunksData>> {
-        Ok(ChunkData::from_assets(
-            self.chunking_context.output_root(),
-            self.other_chunks,
-        ))
+    fn chunks_data(&self) -> Vc<ChunksData> {
+        ChunkData::from_assets(self.chunking_context.output_root(), self.other_chunks)
     }
 
     #[turbo_tasks::function]
@@ -191,8 +188,8 @@ impl EcmascriptDevEvaluateChunk {
 #[turbo_tasks::value_impl]
 impl ValueToString for EcmascriptDevEvaluateChunk {
     #[turbo_tasks::function]
-    fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell("Ecmascript Dev Evaluate Chunk".into()))
+    fn to_string(&self) -> Vc<RcStr> {
+        Vc::cell("Ecmascript Dev Evaluate Chunk".into())
     }
 }
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
@@ -61,8 +61,8 @@ impl EcmascriptDevChunkList {
 #[turbo_tasks::value_impl]
 impl ValueToString for EcmascriptDevChunkList {
     #[turbo_tasks::function]
-    fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell("Ecmascript Dev Chunk List".into()))
+    fn to_string(&self) -> Vc<RcStr> {
+        Vc::cell("Ecmascript Dev Chunk List".into())
     }
 }
 
@@ -111,8 +111,8 @@ impl OutputAsset for EcmascriptDevChunkList {
     }
 
     #[turbo_tasks::function]
-    fn references(&self) -> Result<Vc<OutputAssets>> {
-        Ok(self.chunks)
+    fn references(&self) -> Vc<OutputAssets> {
+        self.chunks
     }
 }
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/runtime.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/runtime.rs
@@ -46,8 +46,8 @@ impl EcmascriptDevChunkRuntime {
 #[turbo_tasks::value_impl]
 impl ValueToString for EcmascriptDevChunkRuntime {
     #[turbo_tasks::function]
-    fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell("Ecmascript Dev Runtime".to_string()))
+    fn to_string(&self) -> Vc<RcStr> {
+        Vc::cell("Ecmascript Dev Runtime".to_string())
     }
 }
 

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -50,7 +50,7 @@ async fn foreign_code_context_condition() -> Result<ContextCondition> {
 }
 
 #[turbo_tasks::function]
-pub fn get_client_import_map(project_path: Vc<FileSystemPath>) -> Result<Vc<ImportMap>> {
+pub fn get_client_import_map(project_path: Vc<FileSystemPath>) -> Vc<ImportMap> {
     let mut import_map = ImportMap::empty();
 
     import_map.insert_singleton_alias("@swc/helpers", project_path);
@@ -67,7 +67,7 @@ pub fn get_client_import_map(project_path: Vc<FileSystemPath>) -> Result<Vc<Impo
         .cell(),
     );
 
-    Ok(import_map.cell())
+    import_map.cell()
 }
 
 #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-cli/src/dev/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/mod.rs
@@ -232,7 +232,7 @@ async fn source(
     entry_requests: TransientInstance<Vec<EntryRequest>>,
     eager_compile: bool,
     browserslist_query: RcStr,
-) -> Result<Vc<Box<dyn ContentSource>>> {
+) -> Vc<Box<dyn ContentSource>> {
     let project_relative = project_dir.strip_prefix(&*root_dir).unwrap();
     let project_relative: RcStr = project_relative
         .strip_prefix(MAIN_SEPARATOR)
@@ -309,7 +309,7 @@ async fn source(
         main_source,
     ));
 
-    Ok(source)
+    source
 }
 
 pub fn register() {

--- a/turbopack/crates/turbopack-cli/src/dev/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/mod.rs
@@ -303,13 +303,11 @@ async fn source(
         .cell(),
     );
     let main_source = Vc::upcast(main_source);
-    let source = Vc::upcast(PrefixedRouterContentSource::new(
+    Vc::upcast(PrefixedRouterContentSource::new(
         Default::default(),
         vec![("__turbopack__".into(), introspect)],
         main_source,
-    ));
-
-    source
+    ))
 }
 
 pub fn register() {

--- a/turbopack/crates/turbopack-core/src/chunk/data.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/data.rs
@@ -137,7 +137,7 @@ impl ChunkData {
 
     /// Returns [`OutputAsset`]s that this chunk data references.
     #[turbo_tasks::function]
-    pub fn references(&self) -> Result<Vc<OutputAssets>> {
-        Ok(self.references)
+    pub fn references(&self) -> Vc<OutputAssets> {
+        self.references
     }
 }

--- a/turbopack/crates/turbopack-core/src/code_builder.rs
+++ b/turbopack/crates/turbopack-core/src/code_builder.rs
@@ -191,9 +191,9 @@ impl GenerateSourceMap for Code {
 impl Code {
     /// Returns the hash of the source code of this Code.
     #[turbo_tasks::function]
-    pub fn source_code_hash(&self) -> Result<Vc<u64>> {
+    pub fn source_code_hash(&self) -> Vc<u64> {
         let code = self;
         let hash = hash_xxh3_hash64(code.source_code());
-        Ok(Vc::cell(hash))
+        Vc::cell(hash)
     }
 }

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use indexmap::IndexMap;
 use turbo_tasks::{RcStr, Vc};
 use turbo_tasks_fs::FileSystemPath;
@@ -263,8 +262,8 @@ impl CompileTimeInfo {
     }
 
     #[turbo_tasks::function]
-    pub fn environment(&self) -> Result<Vc<Environment>> {
-        Ok(self.environment)
+    pub fn environment(&self) -> Vc<Environment> {
+        self.environment
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -93,57 +93,57 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
-    pub fn node_externals(&self) -> Result<Vc<bool>> {
-        Ok(match self.execution {
+    pub fn node_externals(&self) -> Vc<bool> {
+        match self.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Vc::cell(true)
             }
             ExecutionEnvironment::Browser(_) => Vc::cell(false),
             ExecutionEnvironment::EdgeWorker(_) => Vc::cell(false),
             ExecutionEnvironment::Custom(_) => todo!(),
-        })
+        }
     }
 
     #[turbo_tasks::function]
-    pub fn supports_esm_externals(&self) -> Result<Vc<bool>> {
-        Ok(match self.execution {
+    pub fn supports_esm_externals(&self) -> Vc<bool> {
+        match self.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Vc::cell(true)
             }
             ExecutionEnvironment::Browser(_) => Vc::cell(false),
             ExecutionEnvironment::EdgeWorker(_) => Vc::cell(false),
             ExecutionEnvironment::Custom(_) => todo!(),
-        })
+        }
     }
 
     #[turbo_tasks::function]
-    pub fn supports_commonjs_externals(&self) -> Result<Vc<bool>> {
-        Ok(match self.execution {
+    pub fn supports_commonjs_externals(&self) -> Vc<bool> {
+        match self.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Vc::cell(true)
             }
             ExecutionEnvironment::Browser(_) => Vc::cell(false),
             ExecutionEnvironment::EdgeWorker(_) => Vc::cell(true),
             ExecutionEnvironment::Custom(_) => todo!(),
-        })
+        }
     }
 
     #[turbo_tasks::function]
-    pub fn supports_wasm(&self) -> Result<Vc<bool>> {
-        Ok(match self.execution {
+    pub fn supports_wasm(&self) -> Vc<bool> {
+        match self.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Vc::cell(true)
             }
             ExecutionEnvironment::Browser(_) => Vc::cell(false),
             ExecutionEnvironment::EdgeWorker(_) => Vc::cell(false),
             ExecutionEnvironment::Custom(_) => todo!(),
-        })
+        }
     }
 
     #[turbo_tasks::function]
-    pub fn resolve_extensions(&self) -> Result<Vc<Vec<RcStr>>> {
+    pub fn resolve_extensions(&self) -> Vc<Vec<RcStr>> {
         let env = self;
-        Ok(match env.execution {
+        match env.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Vc::cell(vec![".js".into(), ".node".into(), ".json".into()])
             }
@@ -151,13 +151,13 @@ impl Environment {
                 Vc::<Vec<RcStr>>::default()
             }
             ExecutionEnvironment::Custom(_) => todo!(),
-        })
+        }
     }
 
     #[turbo_tasks::function]
-    pub fn resolve_node_modules(&self) -> Result<Vc<bool>> {
+    pub fn resolve_node_modules(&self) -> Vc<bool> {
         let env = self;
-        Ok(match env.execution {
+        match env.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Vc::cell(true)
             }
@@ -165,13 +165,13 @@ impl Environment {
                 Vc::cell(false)
             }
             ExecutionEnvironment::Custom(_) => todo!(),
-        })
+        }
     }
 
     #[turbo_tasks::function]
-    pub fn resolve_conditions(&self) -> Result<Vc<Vec<RcStr>>> {
+    pub fn resolve_conditions(&self) -> Vc<Vec<RcStr>> {
         let env = self;
-        Ok(match env.execution {
+        match env.execution {
             ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Vc::cell(vec!["node".into()])
             }
@@ -180,7 +180,7 @@ impl Environment {
                 Vc::cell(vec!["edge-light".into(), "worker".into()])
             }
             ExecutionEnvironment::Custom(_) => todo!(),
-        })
+        }
     }
 
     #[turbo_tasks::function]
@@ -194,29 +194,29 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
-    pub fn rendering(&self) -> Result<Vc<Rendering>> {
+    pub fn rendering(&self) -> Vc<Rendering> {
         let env = self;
-        Ok(match env.execution {
+        match env.execution {
             ExecutionEnvironment::NodeJsBuildTime(_) | ExecutionEnvironment::NodeJsLambda(_) => {
                 Rendering::Server.cell()
             }
             ExecutionEnvironment::EdgeWorker(_) => Rendering::Server.cell(),
             ExecutionEnvironment::Browser(_) => Rendering::Client.cell(),
             _ => Rendering::None.cell(),
-        })
+        }
     }
 
     #[turbo_tasks::function]
-    pub fn chunk_loading(&self) -> Result<Vc<ChunkLoading>> {
+    pub fn chunk_loading(&self) -> Vc<ChunkLoading> {
         let env = self;
-        Ok(match env.execution {
+        match env.execution {
             ExecutionEnvironment::NodeJsBuildTime(_) | ExecutionEnvironment::NodeJsLambda(_) => {
                 ChunkLoading::NodeJs.cell()
             }
             ExecutionEnvironment::EdgeWorker(_) => ChunkLoading::Edge.cell(),
             ExecutionEnvironment::Browser(_) => ChunkLoading::Dom.cell(),
             ExecutionEnvironment::Custom(_) => todo!(),
-        })
+        }
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -368,8 +368,8 @@ pub struct CapturedIssues {
 #[turbo_tasks::value_impl]
 impl CapturedIssues {
     #[turbo_tasks::function]
-    pub fn is_empty(&self) -> Result<Vc<bool>> {
-        Ok(Vc::cell(self.is_empty_ref()))
+    pub fn is_empty(&self) -> Vc<bool> {
+        Vc::cell(self.is_empty_ref())
     }
 }
 
@@ -761,8 +761,8 @@ impl PlainIssue {
     /// same issue to pass from multiple processing paths, making for overly
     /// verbose logging.
     #[turbo_tasks::function]
-    pub fn internal_hash(&self, full: bool) -> Result<Vc<u64>> {
-        Ok(Vc::cell(self.internal_hash_ref(full)))
+    pub fn internal_hash(&self, full: bool) -> Vc<u64> {
+        Vc::cell(self.internal_hash_ref(full))
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -86,8 +86,8 @@ impl SingleModuleReference {
 
     /// The [Vc<Box<dyn Asset>>] that this reference resolves to.
     #[turbo_tasks::function]
-    pub fn asset(&self) -> Result<Vc<Box<dyn Module>>> {
-        Ok(self.asset)
+    pub fn asset(&self) -> Vc<Box<dyn Module>> {
+        self.asset
     }
 }
 
@@ -132,8 +132,8 @@ impl SingleOutputAssetReference {
 
     /// The [Vc<Box<dyn Asset>>] that this reference resolves to.
     #[turbo_tasks::function]
-    pub fn asset(&self) -> Result<Vc<Box<dyn OutputAsset>>> {
-        Ok(self.asset)
+    pub fn asset(&self) -> Vc<Box<dyn OutputAsset>> {
+        self.asset
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -319,18 +319,16 @@ impl ModuleResolveResult {
     }
 
     #[turbo_tasks::function]
-    pub fn is_unresolveable(&self) -> Result<Vc<bool>> {
-        Ok(Vc::cell(self.is_unresolveable_ref()))
+    pub fn is_unresolveable(&self) -> Vc<bool> {
+        Vc::cell(self.is_unresolveable_ref())
     }
 
     #[turbo_tasks::function]
-    pub fn first_module(&self) -> Result<Vc<OptionModule>> {
-        Ok(Vc::cell(self.primary.iter().find_map(
-            |(_, item)| match item {
-                &ModuleResolveResultItem::Module(a) => Some(a),
-                _ => None,
-            },
-        )))
+    pub fn first_module(&self) -> Vc<OptionModule> {
+        Vc::cell(self.primary.iter().find_map(|(_, item)| match item {
+            &ModuleResolveResultItem::Module(a) => Some(a),
+            _ => None,
+        }))
     }
 
     /// Returns a set (no duplicates) of primary modules in the result. All
@@ -357,8 +355,8 @@ impl ModuleResolveResult {
     }
 
     #[turbo_tasks::function]
-    pub fn primary_output_assets(&self) -> Result<Vc<OutputAssets>> {
-        Ok(Vc::cell(
+    pub fn primary_output_assets(&self) -> Vc<OutputAssets> {
+        Vc::cell(
             self.primary
                 .iter()
                 .filter_map(|(_, item)| match item {
@@ -366,7 +364,7 @@ impl ModuleResolveResult {
                     _ => None,
                 })
                 .collect(),
-        ))
+        )
     }
 }
 
@@ -847,24 +845,24 @@ impl ResolveResult {
     }
 
     #[turbo_tasks::function]
-    pub fn is_unresolveable(&self) -> Result<Vc<bool>> {
-        Ok(Vc::cell(self.is_unresolveable_ref()))
+    pub fn is_unresolveable(&self) -> Vc<bool> {
+        Vc::cell(self.is_unresolveable_ref())
     }
 
     #[turbo_tasks::function]
-    pub fn first_source(&self) -> Result<Vc<OptionSource>> {
-        Ok(Vc::cell(self.primary.iter().find_map(|(_, item)| {
+    pub fn first_source(&self) -> Vc<OptionSource> {
+        Vc::cell(self.primary.iter().find_map(|(_, item)| {
             if let &ResolveResultItem::Source(a) = item {
                 Some(a)
             } else {
                 None
             }
-        })))
+        }))
     }
 
     #[turbo_tasks::function]
-    pub fn primary_sources(&self) -> Result<Vc<Sources>> {
-        Ok(Vc::cell(
+    pub fn primary_sources(&self) -> Vc<Sources> {
+        Vc::cell(
             self.primary
                 .iter()
                 .filter_map(|(_, item)| {
@@ -875,7 +873,7 @@ impl ResolveResult {
                     }
                 })
                 .collect(),
-        ))
+        )
     }
 
     /// Returns a new [ResolveResult] where all [RequestKey]s are updated. The `old_request_key`
@@ -953,7 +951,7 @@ impl ResolveResult {
     /// Returns a new [ResolveResult] where all [RequestKey]s are set to the
     /// passed `request`.
     #[turbo_tasks::function]
-    pub fn with_request(&self, request: RcStr) -> Result<Vc<Self>> {
+    pub fn with_request(&self, request: RcStr) -> Vc<Self> {
         let new_primary = self
             .primary
             .iter()
@@ -967,11 +965,11 @@ impl ResolveResult {
                 )
             })
             .collect();
-        Ok(ResolveResult {
+        ResolveResult {
             primary: new_primary,
             affecting_sources: self.affecting_sources.clone(),
         }
-        .into())
+        .into()
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -28,12 +28,10 @@ impl SourceMapAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for SourceMapAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Result<Vc<AssetIdent>> {
+    fn ident(&self) -> Vc<AssetIdent> {
         // NOTE(alexkirsz) We used to include the asset's version id in the path,
         // but this caused `all_assets_map` to be recomputed on every change.
-        Ok(AssetIdent::from_path(
-            self.asset.ident().path().append(".map".into()),
-        ))
+        AssetIdent::from_path(self.asset.ident().path().append(".map".into()))
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/source_transform.rs
+++ b/turbopack/crates/turbopack-core/src/source_transform.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use turbo_tasks::Vc;
 
 use crate::source::Source;
@@ -14,10 +13,9 @@ pub struct SourceTransforms(Vec<Vc<Box<dyn SourceTransform>>>);
 #[turbo_tasks::value_impl]
 impl SourceTransforms {
     #[turbo_tasks::function]
-    pub fn transform(&self, source: Vc<Box<dyn Source>>) -> Result<Vc<Box<dyn Source>>> {
-        Ok(self
-            .0
+    pub fn transform(&self, source: Vc<Box<dyn Source>>) -> Vc<Box<dyn Source>> {
+        self.0
             .iter()
-            .fold(source, |source, transform| transform.transform(source)))
+            .fold(source, |source, transform| transform.transform(source))
     }
 }

--- a/turbopack/crates/turbopack-core/src/version.rs
+++ b/turbopack/crates/turbopack-core/src/version.rs
@@ -236,8 +236,8 @@ impl FileHashVersion {
 #[turbo_tasks::value_impl]
 impl Version for FileHashVersion {
     #[turbo_tasks::function]
-    fn id(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(self.hash.clone()))
+    fn id(&self) -> Vc<RcStr> {
+        Vc::cell(self.hash.clone())
     }
 }
 
@@ -250,9 +250,9 @@ pub struct VersionState {
 #[turbo_tasks::value_impl]
 impl VersionState {
     #[turbo_tasks::function]
-    pub fn get(&self) -> Result<Vc<Box<dyn Version>>> {
+    pub fn get(&self) -> Vc<Box<dyn Version>> {
         let version = TraitRef::cell(self.version.get().clone());
-        Ok(version)
+        version
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -65,8 +65,8 @@ impl CssModuleAsset {
 
     /// Retrns the asset ident of the source without the "css" modifier
     #[turbo_tasks::function]
-    pub fn source_ident(&self) -> Result<Vc<AssetIdent>> {
-        Ok(self.source.ident())
+    pub fn source_ident(&self) -> Vc<AssetIdent> {
+        self.source.ident()
     }
 }
 
@@ -90,20 +90,20 @@ impl ParseCss for CssModuleAsset {
 #[turbo_tasks::value_impl]
 impl ProcessCss for CssModuleAsset {
     #[turbo_tasks::function]
-    fn get_css_with_placeholder(self: Vc<Self>) -> Result<Vc<CssWithPlaceholderResult>> {
+    fn get_css_with_placeholder(self: Vc<Self>) -> Vc<CssWithPlaceholderResult> {
         let parse_result = self.parse_css();
 
-        Ok(process_css_with_placeholder(parse_result))
+        process_css_with_placeholder(parse_result)
     }
 
     #[turbo_tasks::function]
     fn finalize_css(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<FinalCssResult>> {
+    ) -> Vc<FinalCssResult> {
         let process_result = self.get_css_with_placeholder();
 
-        Ok(finalize_css(process_result, chunking_context))
+        finalize_css(process_result, chunking_context)
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -100,15 +100,15 @@ fn single_item_modifier() -> Vc<RcStr> {
 #[turbo_tasks::value_impl]
 impl OutputAsset for SingleItemCssChunk {
     #[turbo_tasks::function]
-    fn ident(&self) -> Result<Vc<AssetIdent>> {
-        Ok(AssetIdent::from_path(
+    fn ident(&self) -> Vc<AssetIdent> {
+        AssetIdent::from_path(
             self.chunking_context.chunk_path(
                 self.item
                     .asset_ident()
                     .with_modifier(single_item_modifier()),
                 ".css".into(),
             ),
-        ))
+        )
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
@@ -28,10 +28,8 @@ impl SingleItemCssChunkSourceMapAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for SingleItemCssChunkSourceMapAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Result<Vc<AssetIdent>> {
-        Ok(AssetIdent::from_path(
-            self.chunk.path().append(".map".into()),
-        ))
+    fn ident(&self) -> Vc<AssetIdent> {
+        AssetIdent::from_path(self.chunk.path().append(".map".into()))
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/source_map.rs
@@ -28,10 +28,8 @@ impl CssChunkSourceMapAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for CssChunkSourceMapAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Result<Vc<AssetIdent>> {
-        Ok(AssetIdent::from_path(
-            self.chunk.path().append(".map".into()),
-        ))
+    fn ident(&self) -> Vc<AssetIdent> {
+        AssetIdent::from_path(self.chunk.path().append(".map".into()))
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -49,14 +49,11 @@ pub struct ModuleCssAsset {
 #[turbo_tasks::value_impl]
 impl ModuleCssAsset {
     #[turbo_tasks::function]
-    pub fn new(
-        source: Vc<Box<dyn Source>>,
-        asset_context: Vc<Box<dyn AssetContext>>,
-    ) -> Result<Vc<Self>> {
-        Ok(Self::cell(ModuleCssAsset {
+    pub fn new(source: Vc<Box<dyn Source>>, asset_context: Vc<Box<dyn AssetContext>>) -> Vc<Self> {
+        Self::cell(ModuleCssAsset {
             source,
             asset_context,
-        }))
+        })
     }
 }
 
@@ -152,11 +149,11 @@ struct ModuleCssClasses(IndexMap<String, Vec<ModuleCssClass>>);
 #[turbo_tasks::value_impl]
 impl ModuleCssAsset {
     #[turbo_tasks::function]
-    fn inner(&self) -> Result<Vc<ProcessResult>> {
-        Ok(self.asset_context.process(
+    fn inner(&self) -> Vc<ProcessResult> {
+        self.asset_context.process(
             self.source,
             Value::new(ReferenceType::Css(CssReferenceSubType::Internal)),
-        ))
+        )
     }
 
     #[turbo_tasks::function]
@@ -237,14 +234,14 @@ impl ChunkableModule for ModuleCssAsset {
     fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
-        Ok(Vc::upcast(
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        Vc::upcast(
             ModuleChunkItem {
                 chunking_context,
                 module: self,
             }
             .cell(),
-        ))
+        )
     }
 }
 
@@ -439,11 +436,9 @@ impl Issue for CssModuleComposesIssue {
     }
 
     #[turbo_tasks::function]
-    fn title(&self) -> Result<Vc<StyledString>> {
-        Ok(StyledString::Text(
-            "An issue occurred while resolving a CSS module `composes:` rule".into(),
-        )
-        .cell())
+    fn title(&self) -> Vc<StyledString> {
+        StyledString::Text("An issue occurred while resolving a CSS module `composes:` rule".into())
+            .cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -241,7 +241,7 @@ struct DevHtmlAssetVersion {
 #[turbo_tasks::value_impl]
 impl Version for DevHtmlAssetVersion {
     #[turbo_tasks::function]
-    fn id(&self) -> Result<Vc<RcStr>> {
+    fn id(&self) -> Vc<RcStr> {
         let mut hasher = Xxh3Hash64Hasher::new();
         for relative_path in &*self.content.chunk_paths {
             hasher.write_ref(relative_path);
@@ -251,6 +251,6 @@ impl Version for DevHtmlAssetVersion {
         }
         let hash = hasher.finish();
         let hex_hash = encode_hex(hash);
-        Ok(Vc::cell(hex_hash.into()))
+        Vc::cell(hex_hash.into())
     }
 }

--- a/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/conditional.rs
@@ -108,15 +108,15 @@ impl Introspectable for ConditionalContentSource {
     }
 
     #[turbo_tasks::function]
-    fn details(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
+    fn details(&self) -> Vc<RcStr> {
+        Vc::cell(
             if *self.activated.get() {
                 "activated"
             } else {
                 "not activated"
             }
             .into(),
-        ))
+        )
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-dev-server/src/source/router.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/router.rs
@@ -29,13 +29,13 @@ impl PrefixedRouterContentSource {
         prefix: Vc<RcStr>,
         routes: Vec<(RcStr, Vc<Box<dyn ContentSource>>)>,
         fallback: Vc<Box<dyn ContentSource>>,
-    ) -> Result<Vc<Self>> {
-        Ok(PrefixedRouterContentSource {
+    ) -> Vc<Self> {
+        PrefixedRouterContentSource {
             prefix,
             routes,
             fallback,
         }
-        .cell())
+        .cell()
     }
 }
 

--- a/turbopack/crates/turbopack-dev-server/src/update/stream.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/stream.rs
@@ -164,7 +164,7 @@ async fn compute_update_stream(
     from: Vc<VersionState>,
     get_content: TransientInstance<GetContentFn>,
     sender: TransientInstance<Sender<Result<ReadRef<UpdateStreamItem>>>>,
-) -> Result<Vc<()>> {
+) -> Vc<()> {
     let item = get_update_stream_item(resource, from, get_content)
         .strongly_consistent()
         .await;
@@ -172,7 +172,7 @@ async fn compute_update_stream(
     // Send update. Ignore channel closed error.
     let _ = sender.send(item).await;
 
-    Ok(Default::default())
+    Default::default()
 }
 
 pub(super) struct UpdateStream(

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
@@ -64,11 +64,9 @@ impl Issue for UnsupportedSwcEcmaTransformPluginsIssue {
     }
 
     #[turbo_tasks::function]
-    fn title(&self) -> Result<Vc<StyledString>> {
-        Ok(StyledString::Text(
-            "Unsupported SWC EcmaScript transform plugins on this platform.".into(),
-        )
-        .cell())
+    fn title(&self) -> Vc<StyledString> {
+        StyledString::Text("Unsupported SWC EcmaScript transform plugins on this platform.".into())
+            .cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
@@ -80,13 +80,13 @@ impl ChunkableModule for AsyncLoaderModule {
     fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
-        Ok(Vc::upcast(
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        Vc::upcast(
             AsyncLoaderChunkItem {
                 chunking_context,
                 module: self,
             }
             .cell(),
-        ))
+        )
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -48,18 +48,18 @@ impl EcmascriptChunk {
     pub fn new(
         chunking_context: Vc<Box<dyn ChunkingContext>>,
         content: Vc<EcmascriptChunkContent>,
-    ) -> Result<Vc<Self>> {
-        Ok(EcmascriptChunk {
+    ) -> Vc<Self> {
+        EcmascriptChunk {
             chunking_context,
             content,
         }
-        .cell())
+        .cell()
     }
 
     #[turbo_tasks::function]
-    pub fn entry_ids(self: Vc<Self>) -> Result<Vc<ModuleIds>> {
+    pub fn entry_ids(self: Vc<Self>) -> Vc<ModuleIds> {
         // TODO return something usefull
-        Ok(Vc::cell(Default::default()))
+        Vc::cell(Default::default())
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
@@ -249,12 +249,12 @@ impl Introspectable for ChunkGroupFilesAsset {
     }
 
     #[turbo_tasks::function]
-    fn children(&self) -> Result<Vc<IntrospectableChildren>> {
+    fn children(&self) -> Vc<IntrospectableChildren> {
         let mut children = IndexSet::new();
         children.insert((
             Vc::cell("inner asset".into()),
             IntrospectableModule::new(Vc::upcast(self.module)),
         ));
-        Ok(Vc::cell(children))
+        Vc::cell(children)
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -352,13 +352,13 @@ impl EcmascriptParsable for EcmascriptModuleAsset {
     }
 
     #[turbo_tasks::function]
-    fn parse_original(self: Vc<Self>) -> Result<Vc<ParseResult>> {
-        Ok(self.failsafe_parse())
+    fn parse_original(self: Vc<Self>) -> Vc<ParseResult> {
+        self.failsafe_parse()
     }
 
     #[turbo_tasks::function]
-    fn ty(&self) -> Result<Vc<EcmascriptModuleAssetType>> {
-        Ok(self.ty.cell())
+    fn ty(&self) -> Vc<EcmascriptModuleAssetType> {
+        self.ty.cell()
     }
 }
 
@@ -461,8 +461,8 @@ impl EcmascriptModuleAsset {
     }
 
     #[turbo_tasks::function]
-    pub fn source(&self) -> Result<Vc<Box<dyn Source>>> {
-        Ok(self.source)
+    pub fn source(&self) -> Vc<Box<dyn Source>> {
+        self.source
     }
 
     #[turbo_tasks::function]
@@ -471,8 +471,8 @@ impl EcmascriptModuleAsset {
     }
 
     #[turbo_tasks::function]
-    pub fn options(&self) -> Result<Vc<EcmascriptOptions>> {
-        Ok(self.options)
+    pub fn options(&self) -> Vc<EcmascriptOptions> {
+        self.options
     }
 
     #[turbo_tasks::function]
@@ -572,11 +572,11 @@ impl ChunkableModule for EcmascriptModuleAsset {
     fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<Box<dyn ChunkItem>>> {
-        Ok(Vc::upcast(ModuleChunkItem::cell(ModuleChunkItem {
+    ) -> Vc<Box<dyn ChunkItem>> {
+        Vc::upcast(ModuleChunkItem::cell(ModuleChunkItem {
             module: self,
             chunking_context,
-        })))
+        }))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -52,10 +52,9 @@ impl ManifestAsyncModule {
     }
 
     #[turbo_tasks::function]
-    pub(super) fn chunks(&self) -> Result<Vc<OutputAssets>> {
-        Ok(self
-            .chunking_context
-            .chunk_group_assets(Vc::upcast(self.inner), Value::new(self.availability_info)))
+    pub(super) fn chunks(&self) -> Vc<OutputAssets> {
+        self.chunking_context
+            .chunk_group_assets(Vc::upcast(self.inner), Value::new(self.availability_info))
     }
 
     #[turbo_tasks::function]
@@ -142,14 +141,14 @@ impl ChunkableModule for ManifestAsyncModule {
     fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
-        Ok(Vc::upcast(
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        Vc::upcast(
             ManifestChunkItem {
                 chunking_context,
                 manifest: self,
             }
             .cell(),
-        ))
+        )
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
@@ -29,11 +29,8 @@ pub(super) struct ManifestChunkItem {
 #[turbo_tasks::value_impl]
 impl ManifestChunkItem {
     #[turbo_tasks::function]
-    fn chunks_data(&self) -> Result<Vc<ChunksData>> {
-        Ok(ChunkData::from_assets(
-            self.chunking_context.output_root(),
-            self.manifest.chunks(),
-        ))
+    fn chunks_data(&self) -> Vc<ChunksData> {
+        ChunkData::from_assets(self.chunking_context.output_root(), self.manifest.chunks())
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
@@ -58,12 +58,9 @@ impl ManifestLoaderChunkItem {
     }
 
     #[turbo_tasks::function]
-    pub fn chunks_data(&self) -> Result<Vc<ChunksData>> {
+    pub fn chunks_data(&self) -> Vc<ChunksData> {
         let chunks = self.manifest.manifest_chunks();
-        Ok(ChunkData::from_assets(
-            self.chunking_context.output_root(),
-            chunks,
-        ))
+        ChunkData::from_assets(self.chunking_context.output_root(), chunks)
     }
 
     #[turbo_tasks::function]
@@ -124,8 +121,8 @@ impl ChunkItem for ManifestLoaderChunkItem {
     }
 
     #[turbo_tasks::function]
-    fn chunking_context(&self) -> Result<Vc<Box<dyn ChunkingContext>>> {
-        Ok(Vc::upcast(self.chunking_context))
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+        Vc::upcast(self.chunking_context)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
@@ -176,14 +176,14 @@ impl AsyncModule {
     pub fn module_options(
         &self,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
-    ) -> Result<Vc<OptionAsyncModuleOptions>> {
+    ) -> Vc<OptionAsyncModuleOptions> {
         if async_module_info.is_none() {
-            return Ok(Vc::cell(None));
+            return Vc::cell(None);
         }
 
-        Ok(Vc::cell(Some(AsyncModuleOptions {
+        Vc::cell(Some(AsyncModuleOptions {
             has_top_level_await: self.has_top_level_await,
-        })))
+        }))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -125,14 +125,14 @@ impl ChunkableModule for CachedExternalModule {
     fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<Box<dyn ChunkItem>>> {
-        Ok(Vc::upcast(
+    ) -> Vc<Box<dyn ChunkItem>> {
+        Vc::upcast(
             CachedExternalModuleChunkItem {
                 module: self,
                 chunking_context,
             }
             .cell(),
-        ))
+        )
     }
 }
 
@@ -230,18 +230,18 @@ impl EcmascriptChunkItem for CachedExternalModuleChunkItem {
     fn content_with_async_module_info(
         &self,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
-    ) -> Result<Vc<EcmascriptChunkItemContent>> {
+    ) -> Vc<EcmascriptChunkItemContent> {
         let async_module_options = self
             .module
             .get_async_module()
             .module_options(async_module_info);
 
-        Ok(EcmascriptChunkItemContent::new(
+        EcmascriptChunkItemContent::new(
             self.module.content(),
             self.chunking_context,
             EcmascriptOptions::default().cell(),
             async_module_options,
-        ))
+        )
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -262,15 +262,15 @@ impl ModuleReference for RequireContextAssetReference {
 #[turbo_tasks::value_impl]
 impl ValueToString for RequireContextAssetReference {
     #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
+    async fn to_string(&self) -> Vc<RcStr> {
+        Vc::cell(
             format!(
                 "require.context {}/{}",
                 self.dir,
                 if self.include_subdirs { "**" } else { "*" },
             )
             .into(),
-        ))
+        )
     }
 }
 
@@ -317,8 +317,8 @@ impl ModuleReference for ResolvedModuleReference {
 #[turbo_tasks::value_impl]
 impl ValueToString for ResolvedModuleReference {
     #[turbo_tasks::function]
-    fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell("resolved reference".into()))
+    fn to_string(&self) -> Vc<RcStr> {
+        Vc::cell("resolved reference".into())
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
@@ -97,10 +97,8 @@ impl ModuleReference for TsReferencePathAssetReference {
 #[turbo_tasks::value_impl]
 impl ValueToString for TsReferencePathAssetReference {
     #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("typescript reference path comment {}", self.path,).into(),
-        ))
+    async fn to_string(&self) -> Vc<RcStr> {
+        Vc::cell(format!("typescript reference path comment {}", self.path,).into())
     }
 }
 
@@ -138,9 +136,7 @@ impl ModuleReference for TsReferenceTypeAssetReference {
 #[turbo_tasks::value_impl]
 impl ValueToString for TsReferenceTypeAssetReference {
     #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("typescript reference type comment {}", self.module,).into(),
-        ))
+    async fn to_string(&self) -> Vc<RcStr> {
+        Vc::cell(format!("typescript reference type comment {}", self.module,).into())
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
@@ -162,8 +162,8 @@ impl ChunkItem for EcmascriptModuleFacadeChunkItem {
     }
 
     #[turbo_tasks::function]
-    fn asset_ident(&self) -> Result<Vc<AssetIdent>> {
-        Ok(self.module.ident())
+    fn asset_ident(&self) -> Vc<AssetIdent> {
+        self.module.ident()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -61,10 +61,10 @@ impl EcmascriptModuleFacadeModule {
 #[turbo_tasks::value_impl]
 impl Module for EcmascriptModuleFacadeModule {
     #[turbo_tasks::function]
-    fn ident(&self) -> Result<Vc<AssetIdent>> {
+    fn ident(&self) -> Vc<AssetIdent> {
         let inner = self.module.ident();
 
-        Ok(inner.with_part(self.ty))
+        inner.with_part(self.ty)
     }
 
     #[turbo_tasks::function]
@@ -135,10 +135,10 @@ impl Module for EcmascriptModuleFacadeModule {
 #[turbo_tasks::value_impl]
 impl Asset for EcmascriptModuleFacadeModule {
     #[turbo_tasks::function]
-    fn content(&self) -> Result<Vc<AssetContent>> {
+    fn content(&self) -> Vc<AssetContent> {
         let f = File::from("");
 
-        Ok(AssetContent::file(FileContent::Content(f).cell()))
+        AssetContent::file(FileContent::Content(f).cell())
     }
 }
 
@@ -286,14 +286,14 @@ impl ChunkableModule for EcmascriptModuleFacadeModule {
     fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
-        Ok(Vc::upcast(
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        Vc::upcast(
             EcmascriptModuleFacadeChunkItem {
                 module: self,
                 chunking_context,
             }
             .cell(),
-        ))
+        )
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
@@ -83,8 +83,8 @@ impl ChunkItem for EcmascriptModuleLocalsChunkItem {
     }
 
     #[turbo_tasks::function]
-    fn asset_ident(&self) -> Result<Vc<AssetIdent>> {
-        Ok(self.module.ident())
+    fn asset_ident(&self) -> Vc<AssetIdent> {
+        self.module.ident()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -41,10 +41,10 @@ impl EcmascriptModuleLocalsModule {
 #[turbo_tasks::value_impl]
 impl Module for EcmascriptModuleLocalsModule {
     #[turbo_tasks::function]
-    fn ident(&self) -> Result<Vc<AssetIdent>> {
+    fn ident(&self) -> Vc<AssetIdent> {
         let inner = self.module.ident();
 
-        Ok(inner.with_part(ModulePart::locals()))
+        inner.with_part(ModulePart::locals())
     }
 
     #[turbo_tasks::function]
@@ -115,13 +115,13 @@ impl ChunkableModule for EcmascriptModuleLocalsModule {
     fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
-        Ok(Vc::upcast(
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        Vc::upcast(
             EcmascriptModuleLocalsChunkItem {
                 module: self,
                 chunking_context,
             }
             .cell(),
-        ))
+        )
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -44,27 +44,27 @@ impl EcmascriptParsable for EcmascriptModulePartAsset {
         Ok(part_of_module(split_data, self.part))
     }
     #[turbo_tasks::function]
-    fn parse_original(&self) -> Result<Vc<ParseResult>> {
-        Ok(self.full_module.parse_original())
+    fn parse_original(&self) -> Vc<ParseResult> {
+        self.full_module.parse_original()
     }
 
     #[turbo_tasks::function]
-    fn ty(&self) -> Result<Vc<EcmascriptModuleAssetType>> {
-        Ok(self.full_module.ty())
+    fn ty(&self) -> Vc<EcmascriptModuleAssetType> {
+        self.full_module.ty()
     }
 }
 
 #[turbo_tasks::value_impl]
 impl EcmascriptAnalyzable for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
-    fn analyze(&self) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
+    fn analyze(&self) -> Vc<AnalyzeEcmascriptModuleResult> {
         let part = self.part;
-        Ok(analyse_ecmascript_module(self.full_module, Some(part)))
+        analyse_ecmascript_module(self.full_module, Some(part))
     }
 
     #[turbo_tasks::function]
-    fn module_content_without_analysis(&self) -> Result<Vc<EcmascriptModuleContent>> {
-        Ok(self.full_module.module_content_without_analysis())
+    fn module_content_without_analysis(&self) -> Vc<EcmascriptModuleContent> {
+        self.full_module.module_content_without_analysis()
     }
 
     #[turbo_tasks::function]
@@ -72,10 +72,9 @@ impl EcmascriptAnalyzable for EcmascriptModulePartAsset {
         &self,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
-    ) -> Result<Vc<EcmascriptModuleContent>> {
-        Ok(self
-            .full_module
-            .module_content(chunking_context, async_module_info))
+    ) -> Vc<EcmascriptModuleContent> {
+        self.full_module
+            .module_content(chunking_context, async_module_info)
     }
 }
 
@@ -207,22 +206,22 @@ impl ChunkableModule for EcmascriptModulePartAsset {
     fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
-        Ok(Vc::upcast(
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        Vc::upcast(
             EcmascriptModulePartChunkItem {
                 module: self,
                 chunking_context,
             }
             .cell(),
-        ))
+        )
     }
 }
 
 #[turbo_tasks::value_impl]
 impl EcmascriptModulePartAsset {
     #[turbo_tasks::function]
-    pub(super) fn analyze(&self) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
-        Ok(analyze(self.full_module, self.part))
+    pub(super) fn analyze(&self) -> Vc<AnalyzeEcmascriptModuleResult> {
+        analyze(self.full_module, self.part)
     }
 }
 
@@ -230,8 +229,8 @@ impl EcmascriptModulePartAsset {
 fn analyze(
     module: Vc<EcmascriptModuleAsset>,
     part: Vc<ModulePart>,
-) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
-    Ok(analyse_ecmascript_module(module, Some(part)))
+) -> Vc<AnalyzeEcmascriptModuleResult> {
+    analyse_ecmascript_module(module, Some(part))
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
@@ -80,8 +80,8 @@ impl ChunkItem for EcmascriptModulePartChunkItem {
     }
 
     #[turbo_tasks::function]
-    fn asset_ident(&self) -> Result<Vc<AssetIdent>> {
-        Ok(self.module.ident())
+    fn asset_ident(&self) -> Vc<AssetIdent> {
+        self.module.ident()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -114,13 +114,13 @@ impl ModuleReference for WebpackChunkAssetReference {
 #[turbo_tasks::value_impl]
 impl ValueToString for WebpackChunkAssetReference {
     #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
+    async fn to_string(&self) -> Vc<RcStr> {
         let chunk_id = match &self.chunk_id {
             Lit::Str(str) => str.value.to_string(),
             Lit::Num(num) => format!("{num}"),
             _ => todo!(),
         };
-        Ok(Vc::cell(format!("webpack chunk {}", chunk_id).into()))
+        Vc::cell(format!("webpack chunk {}", chunk_id).into())
     }
 }
 
@@ -147,8 +147,8 @@ impl ModuleReference for WebpackEntryAssetReference {
 #[turbo_tasks::value_impl]
 impl ValueToString for WebpackEntryAssetReference {
     #[turbo_tasks::function]
-    fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell("webpack entry".into()))
+    fn to_string(&self) -> Vc<RcStr> {
+        Vc::cell("webpack entry".into())
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -112,8 +112,8 @@ impl ChunkItem for WorkerLoaderChunkItem {
     }
 
     #[turbo_tasks::function]
-    fn content_ident(&self) -> Result<Vc<AssetIdent>> {
-        Ok(self.module.ident())
+    fn content_ident(&self) -> Vc<AssetIdent> {
+        self.module.ident()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -70,13 +70,13 @@ impl ChunkableModule for WorkerLoaderModule {
     fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
-        Ok(Vc::upcast(
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        Vc::upcast(
             WorkerLoaderChunkItem {
                 chunking_context,
                 module: self,
             }
             .cell(),
-        ))
+        )
     }
 }

--- a/turbopack/crates/turbopack-json/src/lib.rs
+++ b/turbopack/crates/turbopack-json/src/lib.rs
@@ -66,11 +66,11 @@ impl ChunkableModule for JsonModuleAsset {
     fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
-        Ok(Vc::upcast(JsonChunkItem::cell(JsonChunkItem {
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        Vc::upcast(JsonChunkItem::cell(JsonChunkItem {
             module: self,
             chunking_context,
-        })))
+        }))
     }
 }
 

--- a/turbopack/crates/turbopack-node/src/execution_context.rs
+++ b/turbopack/crates/turbopack-node/src/execution_context.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use turbo_tasks::Vc;
 use turbo_tasks_env::ProcessEnv;
 use turbo_tasks_fs::FileSystemPath;
@@ -28,17 +27,17 @@ impl ExecutionContext {
     }
 
     #[turbo_tasks::function]
-    pub fn project_path(&self) -> Result<Vc<FileSystemPath>> {
-        Ok(self.project_path)
+    pub fn project_path(&self) -> Vc<FileSystemPath> {
+        self.project_path
     }
 
     #[turbo_tasks::function]
-    pub fn chunking_context(&self) -> Result<Vc<Box<dyn ChunkingContext>>> {
-        Ok(self.chunking_context)
+    pub fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+        self.chunking_context
     }
 
     #[turbo_tasks::function]
-    pub fn env(&self) -> Result<Vc<Box<dyn ProcessEnv>>> {
-        Ok(self.env)
+    pub fn env(&self) -> Vc<Box<dyn ProcessEnv>> {
+        self.env
     }
 }

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -261,13 +261,13 @@ pub fn get_intermediate_asset(
     chunking_context: Vc<Box<dyn ChunkingContext>>,
     main_entry: Vc<Box<dyn Module>>,
     other_entries: Vc<EvaluatableAssets>,
-) -> Result<Vc<Box<dyn OutputAsset>>> {
-    Ok(Vc::upcast(chunking_context.root_entry_chunk_group_asset(
+) -> Vc<Box<dyn OutputAsset>> {
+    Vc::upcast(chunking_context.root_entry_chunk_group_asset(
         chunking_context.chunk_path(main_entry.ident(), ".js".into()),
         main_entry,
         OutputAssets::empty(),
         other_entries,
-    )))
+    ))
 }
 
 #[derive(Clone, Debug)]

--- a/turbopack/crates/turbopack-node/src/render/issue.rs
+++ b/turbopack/crates/turbopack-node/src/render/issue.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::issue::{Issue, IssueStage, OptionStyledString, StyledString};
@@ -34,7 +33,7 @@ impl Issue for RenderingIssue {
     }
 
     #[turbo_tasks::function]
-    async fn detail(&self) -> Result<Vc<OptionStyledString>> {
+    async fn detail(&self) -> Vc<OptionStyledString> {
         let mut details = vec![];
 
         if let Some(status) = self.status {
@@ -45,7 +44,7 @@ impl Issue for RenderingIssue {
             }
         }
 
-        Ok(Vc::cell(Some(StyledString::Stack(details).cell())))
+        Vc::cell(Some(StyledString::Stack(details).cell()))
     }
 
     // TODO parse stack trace into source location

--- a/turbopack/crates/turbopack-node/src/render/node_api_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/node_api_source.rs
@@ -71,8 +71,8 @@ pub struct NodeApiContentSource {
 #[turbo_tasks::value_impl]
 impl NodeApiContentSource {
     #[turbo_tasks::function]
-    pub fn get_pathname(&self) -> Result<Vc<RcStr>> {
-        Ok(self.pathname)
+    pub fn get_pathname(&self) -> Vc<RcStr> {
+        self.pathname
     }
 }
 
@@ -174,14 +174,14 @@ impl Introspectable for NodeApiContentSource {
     }
 
     #[turbo_tasks::function]
-    async fn details(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
+    async fn details(&self) -> Vc<RcStr> {
+        Vc::cell(
             format!(
                 "base: {:?}\ntype: {:?}",
                 self.base_segments, self.route_type
             )
             .into(),
-        ))
+        )
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-node/src/render/rendered_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/rendered_source.rs
@@ -99,8 +99,8 @@ pub struct NodeRenderContentSource {
 #[turbo_tasks::value_impl]
 impl NodeRenderContentSource {
     #[turbo_tasks::function]
-    pub fn get_pathname(&self) -> Result<Vc<RcStr>> {
-        Ok(self.pathname)
+    pub fn get_pathname(&self) -> Vc<RcStr> {
+        self.pathname
     }
 }
 
@@ -263,14 +263,14 @@ impl Introspectable for NodeRenderContentSource {
     }
 
     #[turbo_tasks::function]
-    async fn details(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
+    async fn details(&self) -> Vc<RcStr> {
+        Vc::cell(
             format!(
                 "base: {:?}\ntype: {:?}",
                 self.base_segments, self.route_type
             )
             .into(),
-        ))
+        )
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -171,7 +171,7 @@ struct ProcessPostCssResult {
 async fn config_changed(
     asset_context: Vc<Box<dyn AssetContext>>,
     postcss_config_path: Vc<FileSystemPath>,
-) -> Result<Vc<Completion>> {
+) -> Vc<Completion> {
     let config_asset = asset_context
         .process(
             Vc::upcast(FileSource::new(postcss_config_path)),
@@ -179,11 +179,11 @@ async fn config_changed(
         )
         .module();
 
-    Ok(Vc::<Completions>::cell(vec![
+    Vc::<Completions>::cell(vec![
         any_content_changed_of_module(config_asset),
         extra_configs_changed(asset_context, postcss_config_path),
     ])
-    .completed())
+    .completed()
 }
 
 #[turbo_tasks::function]
@@ -360,7 +360,7 @@ fn postcss_executor(
     asset_context: Vc<Box<dyn AssetContext>>,
     project_path: Vc<FileSystemPath>,
     postcss_config_path: Vc<FileSystemPath>,
-) -> Result<Vc<ProcessResult>> {
+) -> Vc<ProcessResult> {
     let config_asset = asset_context
         .process(
             config_loader_source(project_path, postcss_config_path),
@@ -368,7 +368,7 @@ fn postcss_executor(
         )
         .module();
 
-    Ok(asset_context.process(
+    asset_context.process(
         Vc::upcast(VirtualSource::new(
             postcss_config_path.join("transform.ts".into()),
             AssetContent::File(embed_file("transforms/postcss.ts".into())).cell(),
@@ -376,7 +376,7 @@ fn postcss_executor(
         Value::new(ReferenceType::Internal(Vc::cell(indexmap! {
             "CONFIG".into() => config_asset
         }))),
-    ))
+    )
 }
 
 async fn find_config_in_location(

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -820,7 +820,7 @@ impl Issue for EvaluateErrorLoggingIssue {
     }
 
     #[turbo_tasks::function]
-    fn description(&self) -> Result<Vc<OptionStyledString>> {
+    fn description(&self) -> Vc<OptionStyledString> {
         fn fmt_args(prefix: String, args: &[JsonValue]) -> String {
             let mut iter = args.iter();
             let Some(first) = iter.next() else {
@@ -854,6 +854,6 @@ impl Issue for EvaluateErrorLoggingIssue {
                 }
             })
             .collect::<Vec<_>>();
-        Ok(Vc::cell(Some(StyledString::Stack(lines).cell())))
+        Vc::cell(Some(StyledString::Stack(lines).cell()))
     }
 }

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -363,8 +363,8 @@ impl ChunkingContext for NodeJsChunkingContext {
     }
 
     #[turbo_tasks::function]
-    fn chunk_item_id_from_ident(&self, ident: Vc<AssetIdent>) -> Result<Vc<ModuleId>> {
-        Ok(self.module_id_strategy.get_module_id(ident))
+    fn chunk_item_id_from_ident(&self, ident: Vc<AssetIdent>) -> Vc<ModuleId> {
+        self.module_id_strategy.get_module_id(ident)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
@@ -41,8 +41,8 @@ impl EcmascriptBuildNodeChunk {
 #[turbo_tasks::value_impl]
 impl ValueToString for EcmascriptBuildNodeChunk {
     #[turbo_tasks::function]
-    fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell("Ecmascript Build Node Chunk".into()))
+    fn to_string(&self) -> Vc<RcStr> {
+        Vc::cell("Ecmascript Build Node Chunk".into())
     }
 }
 

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -35,13 +35,13 @@ impl EcmascriptBuildNodeChunkContent {
         chunking_context: Vc<NodeJsChunkingContext>,
         chunk: Vc<EcmascriptBuildNodeChunk>,
         content: Vc<EcmascriptChunkContent>,
-    ) -> Result<Vc<Self>> {
-        Ok(EcmascriptBuildNodeChunkContent {
+    ) -> Vc<Self> {
+        EcmascriptBuildNodeChunkContent {
             content,
             chunking_context,
             chunk,
         }
-        .cell())
+        .cell()
     }
 }
 

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -144,16 +144,16 @@ impl EcmascriptBuildNodeEntryChunk {
     }
 
     #[turbo_tasks::function]
-    fn runtime_chunk(&self) -> Result<Vc<EcmascriptBuildNodeRuntimeChunk>> {
-        Ok(EcmascriptBuildNodeRuntimeChunk::new(self.chunking_context))
+    fn runtime_chunk(&self) -> Vc<EcmascriptBuildNodeRuntimeChunk> {
+        EcmascriptBuildNodeRuntimeChunk::new(self.chunking_context)
     }
 }
 
 #[turbo_tasks::value_impl]
 impl ValueToString for EcmascriptBuildNodeEntryChunk {
     #[turbo_tasks::function]
-    fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell("Ecmascript Build Node Evaluate Chunk".into()))
+    fn to_string(&self) -> Vc<RcStr> {
+        Vc::cell("Ecmascript Build Node Evaluate Chunk".into())
     }
 }
 

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -91,8 +91,8 @@ impl EcmascriptBuildNodeRuntimeChunk {
 #[turbo_tasks::value_impl]
 impl ValueToString for EcmascriptBuildNodeRuntimeChunk {
     #[turbo_tasks::function]
-    fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell("Ecmascript Build Node Runtime Chunk".into()))
+    fn to_string(&self) -> Vc<RcStr> {
+        Vc::cell("Ecmascript Build Node Runtime Chunk".into())
     }
 }
 

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -519,11 +519,8 @@ impl Issue for TsConfigIssue {
     }
 
     #[turbo_tasks::function]
-    fn title(&self) -> Result<Vc<StyledString>> {
-        Ok(
-            StyledString::Text("An issue occurred while parsing a tsconfig.json file.".into())
-                .cell(),
-        )
+    fn title(&self) -> Vc<StyledString> {
+        StyledString::Text("An issue occurred while parsing a tsconfig.json file.".into()).cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-static/src/fixed.rs
+++ b/turbopack/crates/turbopack-static/src/fixed.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -31,8 +30,8 @@ impl FixedStaticAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for FixedStaticAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Result<Vc<AssetIdent>> {
-        Ok(AssetIdent::from_path(self.output_path))
+    fn ident(&self) -> Vc<AssetIdent> {
+        AssetIdent::from_path(self.output_path)
     }
 }
 

--- a/turbopack/crates/turbopack-static/src/lib.rs
+++ b/turbopack/crates/turbopack-static/src/lib.rs
@@ -60,11 +60,8 @@ impl StaticModuleAsset {
     }
 
     #[turbo_tasks::function]
-    fn static_asset(
-        &self,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<StaticAsset>> {
-        Ok(StaticAsset::new(chunking_context, self.source))
+    fn static_asset(&self, chunking_context: Vc<Box<dyn ChunkingContext>>) -> Vc<StaticAsset> {
+        StaticAsset::new(chunking_context, self.source)
     }
 }
 
@@ -93,12 +90,12 @@ impl ChunkableModule for StaticModuleAsset {
     fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
-        Ok(Vc::upcast(ModuleChunkItem::cell(ModuleChunkItem {
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        Vc::upcast(ModuleChunkItem::cell(ModuleChunkItem {
             module: self,
             chunking_context,
             static_asset: self.static_asset(Vc::upcast(chunking_context)),
-        })))
+        }))
     }
 }
 

--- a/turbopack/crates/turbopack-wasm/src/loader.rs
+++ b/turbopack/crates/turbopack-wasm/src/loader.rs
@@ -62,9 +62,7 @@ pub(crate) async fn instantiating_loader_source(
 /// Create a javascript loader to compile the WebAssembly module and export it
 /// without instantiating.
 #[turbo_tasks::function]
-pub(crate) fn compiling_loader_source(
-    source: Vc<WebAssemblySource>,
-) -> Result<Vc<Box<dyn Source>>> {
+pub(crate) fn compiling_loader_source(source: Vc<WebAssemblySource>) -> Vc<Box<dyn Source>> {
     let code: RcStr = formatdoc! {
         r#"
             import wasmPath from "WASM_PATH";
@@ -76,8 +74,8 @@ pub(crate) fn compiling_loader_source(
     }
     .into();
 
-    Ok(Vc::upcast(VirtualSource::new(
+    Vc::upcast(VirtualSource::new(
         source.ident().path().append("_.loader.mjs".into()),
         AssetContent::file(File::from(code).into()),
-    )))
+    ))
 }

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -136,14 +136,14 @@ impl ChunkableModule for WebAssemblyModuleAsset {
     fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
-        Ok(Vc::upcast(
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        Vc::upcast(
             ModuleChunkItem {
                 module: self,
                 chunking_context,
             }
             .cell(),
-        ))
+        )
     }
 }
 
@@ -192,13 +192,13 @@ impl ChunkItem for ModuleChunkItem {
     }
 
     #[turbo_tasks::function]
-    fn references(&self) -> Result<Vc<ModuleReferences>> {
+    fn references(&self) -> Vc<ModuleReferences> {
         let loader = self
             .module
             .loader()
             .as_chunk_item(Vc::upcast(self.chunking_context));
 
-        Ok(loader.references())
+        loader.references()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-wasm/src/output_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/output_asset.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use turbo_tasks::{RcStr, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -40,12 +39,12 @@ impl WebAssemblyAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for WebAssemblyAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Result<Vc<AssetIdent>> {
+    fn ident(&self) -> Vc<AssetIdent> {
         let ident = self.source.ident().with_modifier(modifier());
 
         let asset_path = self.chunking_context.chunk_path(ident, ".wasm".into());
 
-        Ok(AssetIdent::from_path(asset_path))
+        AssetIdent::from_path(asset_path)
     }
 }
 

--- a/turbopack/crates/turbopack-wasm/src/raw.rs
+++ b/turbopack/crates/turbopack-wasm/src/raw.rs
@@ -77,15 +77,15 @@ impl ChunkableModule for RawWebAssemblyModuleAsset {
     fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
-        Ok(Vc::upcast(
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        Vc::upcast(
             RawModuleChunkItem {
                 module: self,
                 chunking_context,
                 wasm_asset: self.wasm_asset(Vc::upcast(chunking_context)),
             }
             .cell(),
-        ))
+        )
     }
 }
 

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -368,13 +368,13 @@ impl ModuleAssetContext {
     }
 
     #[turbo_tasks::function]
-    pub fn module_options_context(&self) -> Result<Vc<ModuleOptionsContext>> {
-        Ok(self.module_options_context)
+    pub fn module_options_context(&self) -> Vc<ModuleOptionsContext> {
+        self.module_options_context
     }
 
     #[turbo_tasks::function]
-    pub fn resolve_options_context(&self) -> Result<Vc<ResolveOptionsContext>> {
-        Ok(self.resolve_options_context)
+    pub fn resolve_options_context(&self) -> Vc<ResolveOptionsContext> {
+        self.resolve_options_context
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -30,26 +30,26 @@ use crate::{
 async fn package_import_map_from_import_mapping(
     package_name: RcStr,
     package_mapping: Vc<ImportMapping>,
-) -> Result<Vc<ImportMap>> {
+) -> Vc<ImportMap> {
     let mut import_map = ImportMap::default();
     import_map.insert_exact_alias(
         format!("@vercel/turbopack/{}", package_name),
         package_mapping,
     );
-    Ok(import_map.cell())
+    import_map.cell()
 }
 
 #[turbo_tasks::function]
 async fn package_import_map_from_context(
     package_name: RcStr,
     context_path: Vc<FileSystemPath>,
-) -> Result<Vc<ImportMap>> {
+) -> Vc<ImportMap> {
     let mut import_map = ImportMap::default();
     import_map.insert_exact_alias(
         format!("@vercel/turbopack/{}", package_name),
         ImportMapping::PrimaryAlternative(package_name, Some(context_path)).cell(),
     );
-    Ok(import_map.cell())
+    import_map.cell()
 }
 
 #[turbo_tasks::value(cell = "new", eq = "manual")]

--- a/turbopack/crates/turbopack/src/transition/context_transition.rs
+++ b/turbopack/crates/turbopack/src/transition/context_transition.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use turbo_tasks::{RcStr, Vc};
 use turbopack_core::compile_time_info::CompileTimeInfo;
 use turbopack_resolve::resolve_options_context::ResolveOptionsContext;
@@ -22,14 +21,14 @@ impl ContextTransition {
         module_options_context: Vc<ModuleOptionsContext>,
         resolve_options_context: Vc<ResolveOptionsContext>,
         layer: Vc<RcStr>,
-    ) -> Result<Vc<ContextTransition>> {
-        Ok(ContextTransition {
+    ) -> Vc<ContextTransition> {
+        ContextTransition {
             module_options_context,
             resolve_options_context,
             compile_time_info,
             layer,
         }
-        .cell())
+        .cell()
     }
 }
 

--- a/turbopack/crates/turbopack/src/transition/full_context_transition.rs
+++ b/turbopack/crates/turbopack/src/transition/full_context_transition.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use turbo_tasks::Vc;
 
 use crate::{transition::Transition, ModuleAssetContext};
@@ -12,8 +11,8 @@ pub struct FullContextTransition {
 #[turbo_tasks::value_impl]
 impl FullContextTransition {
     #[turbo_tasks::function]
-    pub fn new(module_context: Vc<ModuleAssetContext>) -> Result<Vc<FullContextTransition>> {
-        Ok(FullContextTransition { module_context }.cell())
+    pub fn new(module_context: Vc<ModuleAssetContext>) -> Vc<FullContextTransition> {
+        FullContextTransition { module_context }.cell()
     }
 }
 


### PR DESCRIPTION
The `#[turbo_tasks::function]` macro always exposes a `impl Future<Output = Result<ReadRef<T>>>`, regardless of the function's actual return type.

We only need to use a `Result<...>` return type when the function can fail. If it's infallible, this just adds noise.

I left a bunch of these behind in #70412, plus I think we had a lot of these independent of that PR. This cleans them up.

```yaml
language: rust
id: remove_unused_result_return_type

utils:
  last-expression-inside-block:
    any:
      - inside: # single-line blocks just have the expression as the only child
          kind: block
        nthChild:
          position: 1
          reverse: true
      - inside: # multi-line blocks wrap their final expression in an expression_statement
          kind: expression_statement
          inside:
            kind: block
          nthChild:
            position: 1
            reverse: true
  ok-expression:
    kind: call_expression
    any:
      - pattern: Ok($_ARG)
      - pattern: $$$::Ok($_ARG)
  ok-expression-capturing:
    kind: call_expression
    any:
      - pattern: Ok($ARG)
      - pattern: $$$::Ok($ARG)
  # ast-grep does not appear to allow utils to be recursive, split out "simple blocks", and limit supported nesting
  simple-block-with-implicit-ok-return:
    kind: block
    has:
      nthChild:
        position: 1
        reverse: true
      matches: ok-expression
  simple-expression-ok-value:
    any:
      - matches: simple-block-with-implicit-ok-return
      - kind: if_expression
        all:
          - has:
              field: consequence
              matches: simple-block-with-implicit-ok-return
          - has:
              field: alternative
              has:
                matches: simple-block-with-implicit-ok-return
      - kind: match_expression
        has:
          field: body
          not:
            has:
              kind: match_arm
              has:
                field: value
                not:
                  any:
                    - matches: ok-expression
                    - matches: simple-block-with-implicit-ok-return
  block-with-implicit-ok-return:
    any:
      - matches: simple-block-with-implicit-ok-return
      - kind: block
        has:
          nthChild:
            position: 1
            reverse: true
          any:
            - kind: expression_statement 
              has:
                matches: simple-expression-ok-value
            - matches: simple-expression-ok-value # single-line blocks don't
  result-return-type:
    pattern:
      context: fn func() -> Result<$INNER_RET_TY> {}
      selector: generic_type
  infallible-fn:  # this function only appears to return `Ok(...)`, it does not use try_expression (`?`) or `anyhow::bail!(...)`
    kind: function_item
    not:
      has:
        field: body
        any:
          - not:
              matches: block-with-implicit-ok-return
          - has:
              stopBy:
                kind: function_item
              any:
                - kind: try_expression
                - pattern: "?"
                  inside:
                    kind: macro_invocation
                    stopBy: end
                - pattern: bail!($$$)
                - pattern: $$$::bail!($$$)
                - kind: return_expression
                  not:
                    has:
                      matches: ok-expression

rule:
  all:
    - pattern: $FUNC
    - kind: function_item
      has:
        field: return_type
        matches: result-return-type
      follows:
        pattern:
          context: |
            #[turbo_tasks::function]
          selector: attribute_item
        stopBy:
          not:
            kind: attribute_item
    - matches: infallible-fn

rewriters:  # this rewriter is far from perfect, and might rewrite too much
  - id: rewrite-return-type
    rule:
      matches: result-return-type
      inside:
        kind: function_item
        field: return_type
    fix: $INNER_RET_TY
  - id: unwrap-ok-values
    rule:
      all:
        - matches: ok-expression-capturing
        - any:
          - matches: last-expression-inside-block
          - inside:
              kind: return_expression
          - inside:
              kind: match_arm
    fix: $ARG

transform:
  NEW_FUNC:
    rewrite:
      rewriters:
        - rewrite-return-type
        - unwrap-ok-values
      source: $FUNC

fix: $NEW_FUNC

ignores:
  - "**/turbo-tasks-testing/**"
  - "**/turbo-tasks-memory/tests/**"
```

```
sg scan -U -r ../codemod_remove_unused_result_return_type.yml && cargo fix --lib --allow-dirty && cargo fmt
```

I used `cargo fix` in this case to auto-remove the now-unused `anyhow::Result` imports.

I manually fixed clippy lints that now violated the `let_and_return` lint rule (using a separate commit inside this PR), as `cargo clippy --fix` seemed to hang when processing our `build.rs` files?