### PR TITLE
docs(cli): add mention of default port with experimental-https

### DIFF
--- a/docs/02-app/02-api-reference/06-cli/next.mdx
+++ b/docs/02-app/02-api-reference/06-cli/next.mdx
@@ -207,7 +207,7 @@ For certain use cases like webhooks or authentication, you can use [HTTPS](https
 next dev --experimental-https
 ```
 
-With the generated certificate, the Next.js development server will exist at `https://localhost:3000`. A default port of `3000` is used unless a port option is additionally specified with `-p`, `--port`, or `PORT`.
+With the generated certificate, the Next.js development server will exist at `https://localhost:3000`. The default port `3000` is used unless a port is specified with `-p`, `--port`, or `PORT`.
 
 You can also provide a custom certificate and key with `--experimental-https-key` and `--experimental-https-cert`. Optionally, you can provide a custom CA certificate with `--experimental-https-ca` as well.
 

--- a/docs/02-app/02-api-reference/06-cli/next.mdx
+++ b/docs/02-app/02-api-reference/06-cli/next.mdx
@@ -207,6 +207,8 @@ For certain use cases like webhooks or authentication, you can use [HTTPS](https
 next dev --experimental-https
 ```
 
+With the generated certificate, the Next.js development server will exist at `https://localhost:3000`. A default port of `3000` is used unless a port option is additionally specified with `-p`, `--port`, or `PORT`.
+
 You can also provide a custom certificate and key with `--experimental-https-key` and `--experimental-https-cert`. Optionally, you can provide a custom CA certificate with `--experimental-https-ca` as well.
 
 ```bash filename="Terminal"


### PR DESCRIPTION
## Why?

There is no mention of what the default port is when you `next dev --experimental-https`.

x-ref: https://x.com/rauchg/status/1839092783392632867