### PR TITLE
codemod: improve dynamic API cases

### DIFF
--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-15.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-15.output.js
@@ -2,7 +2,7 @@ import { cookies } from "next/headers";
 
 async function MyComponent() {
   function asyncFunction() {
-    callSomething(/* TODO: please manually await this call, codemod cannot transform due to undetermined async scope */
+    callSomething(/* TODO: please manually await this call, if it's a server component, you can turn it to async function */
     cookies());
   }
 }

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-16.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-16.output.js
@@ -1,6 +1,6 @@
 import { cookies } from "next/headers";
 
 function MyComponent() {
-  callSomething(/* TODO: please manually await this call, codemod cannot transform due to undetermined async scope */
+  callSomething(/* TODO: please manually await this call, if it's a server component, you can turn it to async function */
   cookies());
 }

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-19.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-19.input.tsx
@@ -1,0 +1,13 @@
+import { cookies, headers } from 'next/headers'
+
+export function myFun() {
+  return async function () {
+    cookies().get('name')
+  }
+}
+
+export function myFun2() {
+  return function () {
+    headers()
+  }
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-19.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-19.output.tsx
@@ -1,0 +1,13 @@
+import { cookies, headers, type UnsafeUnwrappedHeaders } from 'next/headers';
+
+export function myFun() {
+  return async function () {
+    (await cookies()).get('name')
+  };
+}
+
+export function myFun2() {
+  return function () {
+    (headers() as unknown as UnsafeUnwrappedHeaders)
+  };
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-20.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-20.input.tsx
@@ -1,0 +1,8 @@
+import { cookies, draftMode } from 'cookies'
+
+export async function myFun() {
+  const isDraft = (await draftMode()).isEnabled
+  return async function () {
+    return (await cookies()).get('token')
+  }
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-20.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-20.input.tsx
@@ -1,8 +1,7 @@
-import { cookies, draftMode } from 'cookies'
+import { cookies } from 'cookies'
 
-export async function myFun() {
-  const isDraft = (await draftMode()).isEnabled
-  return async function () {
+export function MyCls() {
+  return async function Page() {
     return (await cookies()).get('token')
   }
 }

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-20.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-20.output.tsx
@@ -1,0 +1,8 @@
+import { cookies, draftMode } from 'cookies'
+
+export async function myFun() {
+  const isDraft = (await draftMode()).isEnabled
+  return async function () {
+    return (await cookies()).get('token')
+  }
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-20.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-20.output.tsx
@@ -1,8 +1,7 @@
-import { cookies, draftMode } from 'cookies'
+import { cookies } from 'cookies'
 
-export async function myFun() {
-  const isDraft = (await draftMode()).isEnabled
-  return async function () {
+export function MyCls() {
+  return async function Page() {
     return (await cookies()).get('token')
   }
 }

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-21.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-21.input.tsx
@@ -1,0 +1,7 @@
+const nextHeaders = import('next/headers')
+
+function myFunc() {
+  nextHeaders.cookies()
+}
+
+const nextHeaders2 = /* The APIs under 'next/headers' are async now, need to be manually awaited. */ import('next/headers')

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-21.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-21.output.tsx
@@ -1,0 +1,8 @@
+const nextHeaders = /* The APIs under 'next/headers' are async now, need to be manually awaited. */
+import('next/headers')
+
+function myFunc() {
+  nextHeaders.cookies()
+}
+
+const nextHeaders2 = /* The APIs under 'next/headers' are async now, need to be manually awaited. */ import('next/headers')

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-type-cast-02.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-type-cast-02.output.js
@@ -6,7 +6,7 @@ import {
 } from 'next/headers'
 
 export function MyDraftComponent() {
-if (/* TODO: please manually await this call, codemod cannot transform due to undetermined async scope */
+if (/* TODO: please manually await this call, if it's a server component, you can turn it to async function */
 draftMode().isEnabled) {
     return null
   }
@@ -15,13 +15,13 @@ draftMode().isEnabled) {
 }
 
 export function MyCookiesComponent() {
-  const c = /* TODO: please manually await this call, codemod cannot transform due to undetermined async scope */
+  const c = /* TODO: please manually await this call, if it's a server component, you can turn it to async function */
   cookies()
   return c.get('name')
 }
 
 export function MyHeadersComponent() {
-  const h = /* TODO: please manually await this call, codemod cannot transform due to undetermined async scope */
+  const h = /* TODO: please manually await this call, if it's a server component, you can turn it to async function */
   headers()
   return (
     <p>{h.get('x-foo')}</p>

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-11.input.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-11.input.js
@@ -1,0 +1,6 @@
+// This is not matched param, don't transform
+export default async function Page({
+  nothing
+}) {
+  f1(nothing)
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-11.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-11.output.js
@@ -1,0 +1,6 @@
+// This is not matched param, don't transform
+export default async function Page({
+  nothing
+}) {
+  f1(nothing)
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-12.input.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-12.input.js
@@ -1,0 +1,9 @@
+// Parallel route case, having multiple props
+export default async function Layout({
+  params,
+  modal,
+  sidebar: Sidebar,
+  ...rest
+}) {
+  f1(params.foo)
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-12.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-12.output.js
@@ -1,0 +1,12 @@
+// Parallel route case, having multiple props
+export default async function Layout(props) {
+  const params = await props.params;
+
+  const {
+    modal,
+    sidebar: Sidebar,
+    ...rest
+  } = props;
+
+  f1(params.foo)
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-13.input.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-13.input.js
@@ -1,0 +1,6 @@
+// props should not be touched
+export default async function Page({
+  ...props
+}) {
+  f1(props.params)
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-13.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-13.output.js
@@ -1,0 +1,6 @@
+// props should not be touched
+export default async function Page({
+  ...props
+}) {
+  f1(props.params)
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-14.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-14.input.tsx
@@ -1,0 +1,6 @@
+export default async function Page({
+  params: usedParams,
+  searchParams: _,
+}: any) {
+  console.log(usedParams)
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-14.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-14.output.tsx
@@ -1,0 +1,4 @@
+export default async function Page(props: any) {
+  const usedParams = await props.params;
+  console.log(usedParams)
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-15.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-15.input.tsx
@@ -10,5 +10,3 @@ async function generateMetadata({ params }) {
 
 export default Page
 export { generateMetadata }
-
-

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-15.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-15.input.tsx
@@ -1,0 +1,14 @@
+async function Page({
+  params: usedParams
+}: any) {
+  console.log(usedParams)
+}
+
+async function generateMetadata({ params }) {
+  console.log(params)
+}
+
+export default Page
+export { generateMetadata }
+
+

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-15.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-15.output.tsx
@@ -1,0 +1,12 @@
+async function Page(props: any) {
+  const usedParams = await props.params;
+  console.log(usedParams)
+}
+
+async function generateMetadata(props) {
+  const params = await props.params;
+  console.log(params)
+}
+
+export default Page
+export { generateMetadata }

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-16.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-16.input.tsx
@@ -1,0 +1,10 @@
+async function Page(props: any) {
+  console.log(props.params.foo)
+}
+
+function generateMetadata(props): Metadata {
+  console.log(props.params)
+}
+
+export default Page
+export { generateMetadata }

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-16.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-16.output.tsx
@@ -1,0 +1,10 @@
+async function Page(props: any) {
+  console.log((await props.params).foo)
+}
+
+async function generateMetadata(props): Promise<Metadata> {
+  console.log((await props.params))
+}
+
+export default Page
+export { generateMetadata }

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-17.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-17.input.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+function Page(props: any) {
+  console.log(props.params.foo)
+  if (typeof window === 'undefined') {
+    console.log(props.params.bar)
+  }
+}
+
+export default Page

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-17.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-17.output.tsx
@@ -1,0 +1,12 @@
+'use client';
+import { use } from "react";
+
+function Page(props: any) {
+  const params = use(props.params);
+  console.log(params.foo)
+  if (typeof window === 'undefined') {
+    console.log(params.bar)
+  }
+}
+
+export default Page

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-18.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-18.input.tsx
@@ -1,0 +1,8 @@
+export default function Page(props: any) {
+  callback(props, 1)
+}
+
+export function generateMetadata(props) {
+  callback2(props)
+}
+

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-18.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-18.output.tsx
@@ -1,0 +1,10 @@
+export default function Page(props: any) {
+  callback(/* 'props' is passed as an argument. Any asynchronous properties of 'props' must be awaited when accessed. */
+  props, 1)
+}
+
+export function generateMetadata(props) {
+  callback2(/* 'props' is passed as an argument. Any asynchronous properties of 'props' must be awaited when accessed. */
+  props)
+}
+

--- a/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
@@ -7,15 +7,8 @@ import {
   insertReactUseImport,
   isFunctionScope,
   findClosetParentFunctionScope,
+  wrapParentheseIfNeeded,
 } from './utils'
-
-function wrapParathnessIfNeeded(
-  hasChainAccess: boolean,
-  j: API['jscodeshift'],
-  expression
-) {
-  return hasChainAccess ? j.parenthesizedExpression(expression) : expression
-}
 
 export function transformDynamicAPI(
   source: string,
@@ -92,7 +85,7 @@ export function transformDynamicAPI(
               // add parentheses to wrap the function call
               j.callExpression(j.identifier(asyncRequestApiName), [])
             )
-            j(path).replaceWith(wrapParathnessIfNeeded(hasChainAccess, j, expr))
+            j(path).replaceWith(wrapParentheseIfNeeded(hasChainAccess, j, expr))
             modified = true
           }
         } else {
@@ -140,7 +133,7 @@ export function transformDynamicAPI(
                   j.callExpression(j.identifier(asyncRequestApiName), [])
                 )
                 j(path).replaceWith(
-                  wrapParathnessIfNeeded(hasChainAccess, j, expr)
+                  wrapParentheseIfNeeded(hasChainAccess, j, expr)
                 )
 
                 turnFunctionReturnTypeToAsync(closetScopePath.node, j)

--- a/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
@@ -222,7 +222,7 @@ const API_CAST_TYPE_MAP = {
 
 function castTypesOrAddComment(
   j: API['jscodeshift'],
-  path: ASTPath<any>,
+  path: ASTPath<CallExpression>,
   originRequestApiName: string,
   root: Collection<any>,
   filePath: string,
@@ -231,6 +231,9 @@ function castTypesOrAddComment(
 ) {
   const isTsFile = filePath.endsWith('.ts') || filePath.endsWith('.tsx')
   if (isTsFile) {
+    // if the path of call expression is already being awaited, no need to cast
+    if (path.parentPath?.node?.type === 'AwaitExpression') return
+
     /* Do type cast for headers, cookies, draftMode
       import {
         type UnsafeUnwrappedHeaders,

--- a/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
@@ -152,7 +152,7 @@ export function transformDynamicAPI(
             // if parent is function and it's a hook, which starts with 'use', wrap the api call with 'use()'
             const parentFunction = findClosetParentFunctionScope(path, j)
 
-            if (parentFunction.size() > 0) {
+            if (parentFunction) {
               const parentFunctionName = parentFunction.get().node.id?.name
               const isParentFunctionHook = parentFunctionName?.startsWith('use')
               if (isParentFunctionHook) {
@@ -169,7 +169,8 @@ export function transformDynamicAPI(
                   originRequestApiName,
                   root,
                   filePath,
-                  insertedTypes
+                  insertedTypes,
+                  ` TODO: please manually await this call, if it's a server component, you can turn it to async function `
                 )
               }
             } else {
@@ -179,7 +180,8 @@ export function transformDynamicAPI(
                 originRequestApiName,
                 root,
                 filePath,
-                insertedTypes
+                insertedTypes,
+                ' TODO: please manually await this call, codemod cannot transform due to undetermined async scope '
               )
             }
             modified = true
@@ -224,7 +226,8 @@ function castTypesOrAddComment(
   originRequestApiName: string,
   root: Collection<any>,
   filePath: string,
-  insertedTypes: Set<string>
+  insertedTypes: Set<string>,
+  customMessage: string
 ) {
   const isTsFile = filePath.endsWith('.ts') || filePath.endsWith('.tsx')
   if (isTsFile) {
@@ -281,9 +284,7 @@ function castTypesOrAddComment(
   } else {
     // Otherwise for JS file, leave a message to the user to manually handle the transformation
     path.node.comments = [
-      j.commentBlock(
-        ' TODO: please manually await this call, codemod cannot transform due to undetermined async scope '
-      ),
+      j.commentBlock(customMessage),
       ...(path.node.comments || []),
     ]
   }

--- a/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
@@ -207,19 +207,21 @@ export function transformDynamicAPI(
   const isClientComponent = determineClientDirective(root, j, source)
 
   // Only transform the valid calls in server or shared components
-  if (!isClientComponent) {
-    // Import declaration case, e.g. import { cookies } from 'next/headers'
-    const importedNextAsyncRequestApisMapping =
-      findImportMappingFromNextHeaders(root, j)
-    for (const originName in importedNextAsyncRequestApisMapping) {
-      const aliasName = importedNextAsyncRequestApisMapping[originName]
-      processAsyncApiCalls(aliasName, originName)
-    }
+  if (isClientComponent) return null
 
-    // Add import { use } from 'react' if needed and not already imported
-    if (needsReactUseImport) {
-      insertReactUseImport(root, j)
-    }
+  // Import declaration case, e.g. import { cookies } from 'next/headers'
+  const importedNextAsyncRequestApisMapping = findImportMappingFromNextHeaders(
+    root,
+    j
+  )
+  for (const originName in importedNextAsyncRequestApisMapping) {
+    const aliasName = importedNextAsyncRequestApisMapping[originName]
+    processAsyncApiCalls(aliasName, originName)
+  }
+
+  // Add import { use } from 'react' if needed and not already imported
+  if (needsReactUseImport) {
+    insertReactUseImport(root, j)
   }
 
   return modified ? root.toSource() : null

--- a/packages/next-codemod/transforms/lib/async-request-api/utils.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/utils.ts
@@ -443,3 +443,11 @@ export function getFunctionPathFromExportPath(
 
   return undefined
 }
+
+export function wrapParentheseIfNeeded(
+  hasChainAccess: boolean,
+  j: API['jscodeshift'],
+  expression
+) {
+  return hasChainAccess ? j.parenthesizedExpression(expression) : expression
+}

--- a/packages/next-codemod/transforms/lib/async-request-api/utils.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/utils.ts
@@ -265,3 +265,26 @@ export function generateUniqueIdentifier(
   const propsIdentifier = j.identifier(idName)
   return propsIdentifier
 }
+
+export function isFunctionScope(path: ASTPath, j: API['jscodeshift']) {
+  const node = path.node
+
+  // Check if the node is a function (declaration, expression, or arrow function)
+  return (
+    j.FunctionDeclaration.check(node) ||
+    j.FunctionExpression.check(node) ||
+    j.ArrowFunctionExpression.check(node)
+  )
+}
+
+export function findClosetParentFunctionScope(
+  path: ASTPath,
+  j: API['jscodeshift']
+) {
+  let parentFunctionPath = path.scope.path
+  while (parentFunctionPath && !isFunctionScope(parentFunctionPath, j)) {
+    parentFunctionPath = parentFunctionPath.parent
+  }
+
+  return parentFunctionPath
+}

--- a/packages/next-codemod/transforms/lib/async-request-api/utils.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/utils.ts
@@ -451,3 +451,19 @@ export function wrapParentheseIfNeeded(
 ) {
   return hasChainAccess ? j.parenthesizedExpression(expression) : expression
 }
+
+export function insertCommentOnce(
+  path: ASTPath<any>,
+  j: API['j'],
+  comment: string
+) {
+  if (path.node.comments) {
+    const hasComment = path.node.comments.some(
+      (commentNode) => commentNode.value === comment
+    )
+    if (hasComment) {
+      return
+    }
+  }
+  path.node.comments = [j.commentBlock(comment), ...(path.node.comments || [])]
+}

--- a/packages/next-codemod/transforms/next-dynamic-access-named-export.ts
+++ b/packages/next-codemod/transforms/next-dynamic-access-named-export.ts
@@ -15,7 +15,7 @@ export default function transformer(file: FileInfo, api: API) {
     const dynamicImportName = importDecl.specifiers?.[0]?.local?.name
 
     if (!dynamicImportName) {
-      return root.toSource()
+      return file.source
     }
     // Find call expressions where the callee is the imported 'dynamic'
     root


### PR DESCRIPTION
Deal with more cases of codemod dynamic API transform

1. Parent is a return statement but it's function

```js
return async function () {
  // dynamic usage should also be handled
  await cookies()
}
```

2. Fix handling of destruction, keep the rest properties in a destruction statement


```js
export default async function Layout(props) {
+  const params = await props.params;
  // rest properties were destructed in the function argument, after we rename, we do a destruction again  
  const {
    modal,
    sidebar: Sidebar,
    ...rest
  } = props;

  f1(params.foo)
}
```

3. `Page(...props) {}` should not be transformed or renamed

4. The identifier should be picked the renamed one

```js
export default async function Page({
  params: usedParams,
  searchParams: _,
}: any) {
  console.log(usedParams)
}
```
we need to correctly insert the renamed prop
```js
const usedParams = await props.params
```

5. handle `export default <identifier>`

6. handle properties access of `props`

- If `Page` is client component, need to hoist `params`, return the value from `use(params)`
- If `Page` is server component, awaited the `params` access everywhere

```js
async function Page(props: any) {
  console.log(props.params.foo)
}
```

7. leave a comment if the entry `props` is being passed down to somewhere else
```js
export function generateMetadata(props) {
  callback2(/* 'props' is passed as an argument. Any asynchronous properties of 'props' must be awaited when accessed. */
  props)
}
```

