### PR TITLE
refactor prefetch alias handling

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -154,6 +154,7 @@ function useNavigate(dispatch: React.Dispatch<ReducerActions>): RouterNavigate {
         locationSearch: location.search,
         shouldScroll: shouldScroll ?? true,
         navigateType,
+        allowAliasing: true,
       })
     },
     [dispatch]

--- a/packages/next/src/client/components/router-reducer/aliased-prefetch-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/aliased-prefetch-navigations.ts
@@ -1,0 +1,241 @@
+import type {
+  CacheNodeSeedData,
+  FlightRouterState,
+} from '../../../server/app-render/types'
+import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
+import {
+  addSearchParamsIfPageSegment,
+  PAGE_SEGMENT_KEY,
+} from '../../../shared/lib/segment'
+import type { NormalizedFlightData } from '../../flight-data-helpers'
+import { createEmptyCacheNode } from '../app-router'
+import { applyRouterStatePatchToTree } from './apply-router-state-patch-to-tree'
+import { createHrefFromUrl } from './create-href-from-url'
+import { createRouterCacheKey } from './create-router-cache-key'
+import { fillCacheWithNewSubTreeDataButOnlyLoading } from './fill-cache-with-new-subtree-data'
+import { handleMutable } from './handle-mutable'
+import type { Mutable, ReadonlyReducerState } from './router-reducer-types'
+
+/**
+ * This is a stop-gap until per-segment caching is implemented. It leverages the `aliased` flag that is added
+ * to prefetch entries when it's determined that the loading state from that entry should be used for this navigation.
+ * This function takes the aliased entry and only applies the loading state to the updated cache node.
+ * We should remove this once per-segment fetching is implemented as ideally the prefetch cache will contain a
+ * more granular segment map and so the router will be able to simply re-use the loading segment for the new navigation.
+ */
+export function handleAliasedPrefetchEntry(
+  state: ReadonlyReducerState,
+  flightData: NormalizedFlightData[],
+  url: URL,
+  mutable: Mutable
+) {
+  let currentTree = state.tree
+  let currentCache = state.cache
+  const href = createHrefFromUrl(url)
+  let applied
+
+  for (const normalizedFlightData of flightData) {
+    // If the segment doesn't have a loading component, we don't need to do anything.
+    if (!hasLoadingComponentInSeedData(normalizedFlightData.seedData)) {
+      continue
+    }
+
+    let treePatch = normalizedFlightData.tree
+    // Segments are keyed by searchParams (e.g. __PAGE__?{"foo":"bar"}). We might return a less specific, param-less entry,
+    // so we ensure that the final tree contains the correct searchParams (reflected in the URL) are provided in the updated FlightRouterState tree.
+    // We only do this on the first read, as otherwise we'd be overwriting the searchParams that may have already been set
+    treePatch = addSearchParamsToPageSegments(
+      treePatch,
+      Object.fromEntries(url.searchParams)
+    )
+
+    const { seedData, isRootRender, pathToSegment } = normalizedFlightData
+    // TODO-APP: remove ''
+    const flightSegmentPathWithLeadingEmpty = ['', ...pathToSegment]
+
+    // Segments are keyed by searchParams (e.g. __PAGE__?{"foo":"bar"}). We might return a less specific, param-less entry,
+    // so we ensure that the final tree contains the correct searchParams (reflected in the URL) are provided in the updated FlightRouterState tree.
+    // We only do this on the first read, as otherwise we'd be overwriting the searchParams that may have already been set
+    treePatch = addSearchParamsToPageSegments(
+      treePatch,
+      Object.fromEntries(url.searchParams)
+    )
+
+    let newTree = applyRouterStatePatchToTree(
+      flightSegmentPathWithLeadingEmpty,
+      currentTree,
+      treePatch,
+      href
+    )
+
+    const newCache = createEmptyCacheNode()
+
+    // The prefetch cache entry was aliased -- this signals that we only fill in the cache with the
+    // loading state and not the actual parallel route seed data.
+    if (isRootRender && seedData) {
+      // Fill in the cache with the new loading / rsc data
+      const rsc = seedData[1]
+      const loading = seedData[3]
+      newCache.loading = loading
+      newCache.rsc = rsc
+
+      // Construct a new tree and apply the aliased loading state for each parallel route
+      fillNewTreeWithOnlyLoadingSegments(
+        newCache,
+        currentCache,
+        treePatch,
+        seedData
+      )
+    } else {
+      // Copy rsc for the root node of the cache.
+      newCache.rsc = currentCache.rsc
+      newCache.prefetchRsc = currentCache.prefetchRsc
+      newCache.loading = currentCache.loading
+      newCache.parallelRoutes = new Map(currentCache.parallelRoutes)
+
+      // copy the loading state only into the leaf node (the part that changed)
+      fillCacheWithNewSubTreeDataButOnlyLoading(
+        newCache,
+        currentCache,
+        normalizedFlightData
+      )
+    }
+
+    // If we don't have an updated tree, there's no reason to update the cache, as the tree
+    // dictates what cache nodes to render.
+    if (newTree) {
+      currentTree = newTree
+      currentCache = newCache
+      applied = true
+    }
+  }
+
+  if (!applied) {
+    return false
+  }
+
+  mutable.patchedTree = currentTree
+  mutable.cache = currentCache
+  mutable.canonicalUrl = href
+  mutable.hashFragment = url.hash
+
+  return handleMutable(state, mutable)
+}
+
+function hasLoadingComponentInSeedData(seedData: CacheNodeSeedData | null) {
+  if (!seedData) return false
+
+  const parallelRoutes = seedData[2]
+  const loading = seedData[3]
+
+  if (loading) {
+    return true
+  }
+
+  for (const key in parallelRoutes) {
+    if (hasLoadingComponentInSeedData(parallelRoutes[key])) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function fillNewTreeWithOnlyLoadingSegments(
+  newCache: CacheNode,
+  existingCache: CacheNode,
+  routerState: FlightRouterState,
+  cacheNodeSeedData: CacheNodeSeedData | null
+) {
+  const isLastSegment = Object.keys(routerState[1]).length === 0
+  if (isLastSegment) {
+    return
+  }
+
+  for (const key in routerState[1]) {
+    const parallelRouteState = routerState[1][key]
+    const segmentForParallelRoute = parallelRouteState[0]
+    const cacheKey = createRouterCacheKey(segmentForParallelRoute)
+
+    const parallelSeedData =
+      cacheNodeSeedData !== null && cacheNodeSeedData[2][key] !== undefined
+        ? cacheNodeSeedData[2][key]
+        : null
+
+    let newCacheNode: CacheNode
+    if (parallelSeedData !== null) {
+      // New data was sent from the server.
+      const rsc = parallelSeedData[1]
+      const loading = parallelSeedData[3]
+      newCacheNode = {
+        lazyData: null,
+        // copy the layout but null the page segment as that's not meant to be used
+        rsc: segmentForParallelRoute.includes(PAGE_SEGMENT_KEY) ? null : rsc,
+        prefetchRsc: null,
+        head: null,
+        prefetchHead: null,
+        parallelRoutes: new Map(),
+        loading,
+      }
+    } else {
+      // No data available for this node. This will trigger a lazy fetch
+      // during render.
+      newCacheNode = {
+        lazyData: null,
+        rsc: null,
+        prefetchRsc: null,
+        head: null,
+        prefetchHead: null,
+        parallelRoutes: new Map(),
+        loading: null,
+      }
+    }
+
+    const existingParallelRoutes = newCache.parallelRoutes.get(key)
+    if (existingParallelRoutes) {
+      existingParallelRoutes.set(cacheKey, newCacheNode)
+    } else {
+      newCache.parallelRoutes.set(key, new Map([[cacheKey, newCacheNode]]))
+    }
+
+    fillNewTreeWithOnlyLoadingSegments(
+      newCacheNode,
+      existingCache,
+      parallelRouteState,
+      parallelSeedData
+    )
+  }
+}
+
+/**
+ * Add search params to the page segments in the flight router state
+ * Page segments that are associated with search params have a page segment key
+ * followed by a query string. This function will add those params to the page segment.
+ * This is useful if we return an aliased prefetch entry (ie, won't have search params)
+ * but the canonical router URL has search params.
+ */
+export function addSearchParamsToPageSegments(
+  flightRouterState: FlightRouterState,
+  searchParams: Record<string, string | string[] | undefined>
+): FlightRouterState {
+  const [segment, parallelRoutes, ...rest] = flightRouterState
+
+  // If it's a page segment, modify the segment by adding search params
+  if (segment.includes(PAGE_SEGMENT_KEY)) {
+    const newSegment = addSearchParamsIfPageSegment(segment, searchParams)
+    console.log({ existingSegment: segment, newSegment })
+    return [newSegment, parallelRoutes, ...rest]
+  }
+
+  // Otherwise, recurse through the parallel routes and return a new tree
+  const updatedParallelRoutes: { [key: string]: FlightRouterState } = {}
+
+  for (const [key, parallelRoute] of Object.entries(parallelRoutes)) {
+    updatedParallelRoutes[key] = addSearchParamsToPageSegments(
+      parallelRoute,
+      searchParams
+    )
+  }
+
+  return [segment, updatedParallelRoutes, ...rest]
+}

--- a/packages/next/src/client/components/router-reducer/prefetch-cache-utils.ts
+++ b/packages/next/src/client/components/router-reducer/prefetch-cache-utils.ts
@@ -68,7 +68,8 @@ function getExistingCacheEntry(
   url: URL,
   kind: PrefetchKind = PrefetchKind.TEMPORARY,
   nextUrl: string | null,
-  prefetchCache: Map<string, PrefetchCacheEntry>
+  prefetchCache: Map<string, PrefetchCacheEntry>,
+  allowAliasing: boolean
 ): AliasedPrefetchCacheEntry | undefined {
   // We first check if there's a more specific interception route prefetch entry
   // This is because when we detect a prefetch that corresponds with an interception route, we prefix it with nextUrl (see `createPrefetchCacheKey`)
@@ -91,7 +92,7 @@ function getExistingCacheEntry(
       : cacheKeyWithoutParams
 
     const existingEntry = prefetchCache.get(cacheKeyToUse)
-    if (existingEntry) {
+    if (existingEntry && allowAliasing) {
       // We know we're returning an aliased entry when the pathname matches but the search params don't,
       const isAliased =
         existingEntry.url.pathname === url.pathname &&
@@ -114,6 +115,7 @@ function getExistingCacheEntry(
     const entryWithoutParams = prefetchCache.get(cacheKeyWithoutParams)
     if (
       process.env.NODE_ENV !== 'development' &&
+      allowAliasing &&
       url.search &&
       kind !== PrefetchKind.FULL &&
       entryWithoutParams &&
@@ -130,7 +132,11 @@ function getExistingCacheEntry(
   // We attempt a partial match by checking if there's a cache entry with the same pathname.
   // Regardless of what we find, since it doesn't correspond with the requested URL, we'll mark it "aliased".
   // This will signal to the router that it should only apply the loading state on the prefetched data.
-  if (process.env.NODE_ENV !== 'development' && kind !== PrefetchKind.FULL) {
+  if (
+    process.env.NODE_ENV !== 'development' &&
+    kind !== PrefetchKind.FULL &&
+    allowAliasing
+  ) {
     for (const cacheEntry of prefetchCache.values()) {
       if (
         cacheEntry.url.pathname === url.pathname &&
@@ -157,18 +163,21 @@ export function getOrCreatePrefetchCacheEntry({
   buildId,
   prefetchCache,
   kind,
+  allowAliasing = true,
 }: Pick<
   ReadonlyReducerState,
   'nextUrl' | 'prefetchCache' | 'tree' | 'buildId'
 > & {
   url: URL
   kind?: PrefetchKind
+  allowAliasing: boolean
 }): AliasedPrefetchCacheEntry {
   const existingCacheEntry = getExistingCacheEntry(
     url,
     kind,
     nextUrl,
-    prefetchCache
+    prefetchCache,
+    allowAliasing
   )
 
   if (existingCacheEntry) {

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -20,10 +20,7 @@ import { handleMutable } from '../handle-mutable'
 import { applyFlightData } from '../apply-flight-data'
 import { prefetchQueue } from './prefetch-reducer'
 import { createEmptyCacheNode } from '../../app-router'
-import {
-  addSearchParamsToPageSegments,
-  DEFAULT_SEGMENT_KEY,
-} from '../../../../shared/lib/segment'
+import { DEFAULT_SEGMENT_KEY } from '../../../../shared/lib/segment'
 import {
   listenForDynamicRequest,
   updateCacheNodeOnNavigation,
@@ -33,7 +30,7 @@ import {
   prunePrefetchCache,
 } from '../prefetch-cache-utils'
 import { clearCacheNodeDataForSegmentPath } from '../clear-cache-node-data-for-segment-path'
-import { fillCacheWithNewSubTreeDataButOnlyLoading } from '../fill-cache-with-new-subtree-data'
+import { handleAliasedPrefetchEntry } from '../aliased-prefetch-navigations'
 
 export function handleExternalUrl(
   state: ReadonlyReducerState,
@@ -105,7 +102,8 @@ export function navigateReducer(
   state: ReadonlyReducerState,
   action: NavigateAction
 ): ReducerState {
-  const { url, isExternalUrl, navigateType, shouldScroll } = action
+  const { url, isExternalUrl, navigateType, shouldScroll, allowAliasing } =
+    action
   const mutable: Mutable = {}
   const { hash } = url
   const href = createHrefFromUrl(url)
@@ -114,6 +112,7 @@ export function navigateReducer(
   prunePrefetchCache(state.prefetchCache)
 
   mutable.preserveCustomHistoryState = false
+  mutable.pendingPush = pendingPush
 
   if (isExternalUrl) {
     return handleExternalUrl(state, mutable, url.toString(), pendingPush)
@@ -131,6 +130,7 @@ export function navigateReducer(
     tree: state.tree,
     buildId: state.buildId,
     prefetchCache: state.prefetchCache,
+    allowAliasing,
   })
   const { treeAtTimeOfPrefetch, data } = prefetchValues
 
@@ -151,15 +151,27 @@ export function navigateReducer(
         return handleExternalUrl(state, mutable, flightData, pendingPush)
       }
 
-      // When the server indicates an override for the canonical URL (such as a redirect in middleware)
-      // we only want to use that if we're not using an aliased entry as the redirect will correspond with
-      // the aliased prefetch which might have different search params. Since we're only using the aliased entry
-      // for the loading state, the proper override will happen in the server patch action when the dynamic
-      // data is loaded.
-      const updatedCanonicalUrl =
-        canonicalUrlOverride && !prefetchValues.aliased
-          ? createHrefFromUrl(canonicalUrlOverride)
-          : href
+      if (prefetchValues.aliased) {
+        const result = handleAliasedPrefetchEntry(
+          state,
+          flightData,
+          url,
+          mutable
+        )
+
+        // We didn't return new router state because we didn't apply the aliased entry for some reason.
+        // We'll re-invoke the navigation handler but ensure that we don't attempt to use the aliased entry. This
+        // will create an on-demand prefetch entry.
+        if (result === false) {
+          return navigateReducer(state, { ...action, allowAliasing: false })
+        }
+
+        return result
+      }
+
+      const updatedCanonicalUrl = canonicalUrlOverride
+        ? createHrefFromUrl(canonicalUrlOverride)
+        : href
 
       // Track if the navigation was only an update to the hash fragment
       mutable.onlyHashChange =
@@ -181,16 +193,6 @@ export function navigateReducer(
 
         // TODO-APP: remove ''
         const flightSegmentPathWithLeadingEmpty = ['', ...flightSegmentPath]
-
-        // Segments are keyed by searchParams (e.g. __PAGE__?{"foo":"bar"}). We might return a less specific, param-less entry,
-        // so we ensure that the final tree contains the correct searchParams (reflected in the URL) are provided in the updated FlightRouterState tree.
-        // We only do this on the first read, as otherwise we'd be overwriting the searchParams that may have already been set
-        if (prefetchValues.aliased && isFirstRead) {
-          treePatch = addSearchParamsToPageSegments(
-            treePatch,
-            Object.fromEntries(url.searchParams)
-          )
-        }
 
         // Create new tree based on the flightSegmentPath and router state patch
         let newTree = applyRouterStatePatchToTree(
@@ -301,36 +303,10 @@ export function navigateReducer(
             const cache: CacheNode = createEmptyCacheNode()
             let applied = false
 
-            // The prefetch cache entry was aliased -- this signals that we only fill in the cache with the
-            // loading state and not the actual parallel route seed data.
-            if (prefetchValues.aliased && seedData) {
-              if (isRootRender) {
-                // Fill in the cache with the new loading / rsc data
-                const rsc = seedData[1]
-                const loading = seedData[3]
-                cache.loading = loading
-                cache.rsc = rsc
-              } else {
-                // Copy rsc for the root node of the cache.
-                cache.rsc = currentCache.rsc
-                cache.prefetchRsc = currentCache.prefetchRsc
-                cache.loading = currentCache.loading
-                cache.parallelRoutes = new Map(currentCache.parallelRoutes)
-
-                // recursively fill in `rsc` and `loading` but skip everything else
-                fillCacheWithNewSubTreeDataButOnlyLoading(
-                  cache,
-                  currentCache,
-                  normalizedFlightData,
-                  prefetchValues
-                )
-              }
-
-              applied = true
-            } else if (
+            if (
               prefetchValues.status === PrefetchCacheEntryStatus.stale &&
               !mutable.onlyHashChange &&
-              (!isFirstRead || prefetchValues.aliased)
+              !isFirstRead
             ) {
               // When we have a stale prefetch entry, we only want to re-use the loading state of the route we're navigating to, to support instant loading navigations
               // this will trigger a lazy fetch for the actual page data by nulling the `rsc` and `prefetchRsc` values for page data,
@@ -399,7 +375,6 @@ export function navigateReducer(
 
       mutable.patchedTree = currentTree
       mutable.canonicalUrl = updatedCanonicalUrl
-      mutable.pendingPush = pendingPush
       mutable.scrollableSegments = scrollableSegments
       mutable.hashFragment = hash
       mutable.shouldScroll = shouldScroll

--- a/packages/next/src/client/components/router-reducer/reducers/prefetch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/prefetch-reducer.ts
@@ -29,6 +29,7 @@ export function prefetchReducer(
     kind: action.kind,
     tree: state.tree,
     buildId: state.buildId,
+    allowAliasing: true,
   })
 
   return state

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -112,6 +112,7 @@ export interface NavigateAction {
   locationSearch: Location['search']
   navigateType: 'push' | 'replace'
   shouldScroll: boolean
+  allowAliasing: boolean
 }
 
 /**

--- a/packages/next/src/shared/lib/segment.ts
+++ b/packages/next/src/shared/lib/segment.ts
@@ -1,4 +1,4 @@
-import type { Segment } from '../../server/app-render/types'
+import type { FlightRouterState, Segment } from '../../server/app-render/types'
 
 export function isGroupSegment(segment: string) {
   // Use array[0] for performant purpose
@@ -19,6 +19,38 @@ export function addSearchParamsIfPageSegment(
   }
 
   return segment
+}
+
+/**
+ * Add search params to the page segments in the flight router state
+ * Page segments that are associated with search params have a page segment key
+ * followed by a query string. This function will add those params to the page segment.
+ * This is useful if we return an aliased prefetch entry (ie, won't have search params)
+ * but the canonical router URL has search params.
+ */
+export function addSearchParamsToPageSegments(
+  flightRouterState: FlightRouterState,
+  searchParams: Record<string, string | string[] | undefined>
+): FlightRouterState {
+  const [segment, parallelRoutes, ...rest] = flightRouterState
+
+  // If it's a page segment, modify the segment by adding search params
+  if (segment.includes(PAGE_SEGMENT_KEY)) {
+    const newSegment = addSearchParamsIfPageSegment(segment, searchParams)
+    return [newSegment, parallelRoutes, ...rest]
+  }
+
+  // Otherwise, recurse through the parallel routes and return a new tree
+  const updatedParallelRoutes: { [key: string]: FlightRouterState } = {}
+
+  for (const [key, parallelRoute] of Object.entries(parallelRoutes)) {
+    updatedParallelRoutes[key] = addSearchParamsToPageSegments(
+      parallelRoute,
+      searchParams
+    )
+  }
+
+  return [segment, updatedParallelRoutes, ...rest]
 }
 
 export const PAGE_SEGMENT_KEY = '__PAGE__'

--- a/packages/next/src/shared/lib/segment.ts
+++ b/packages/next/src/shared/lib/segment.ts
@@ -1,4 +1,4 @@
-import type { FlightRouterState, Segment } from '../../server/app-render/types'
+import type { Segment } from '../../server/app-render/types'
 
 export function isGroupSegment(segment: string) {
   // Use array[0] for performant purpose
@@ -19,38 +19,6 @@ export function addSearchParamsIfPageSegment(
   }
 
   return segment
-}
-
-/**
- * Add search params to the page segments in the flight router state
- * Page segments that are associated with search params have a page segment key
- * followed by a query string. This function will add those params to the page segment.
- * This is useful if we return an aliased prefetch entry (ie, won't have search params)
- * but the canonical router URL has search params.
- */
-export function addSearchParamsToPageSegments(
-  flightRouterState: FlightRouterState,
-  searchParams: Record<string, string | string[] | undefined>
-): FlightRouterState {
-  const [segment, parallelRoutes, ...rest] = flightRouterState
-
-  // If it's a page segment, modify the segment by adding search params
-  if (segment.includes(PAGE_SEGMENT_KEY)) {
-    const newSegment = addSearchParamsIfPageSegment(segment, searchParams)
-    return [newSegment, parallelRoutes, ...rest]
-  }
-
-  // Otherwise, recurse through the parallel routes and return a new tree
-  const updatedParallelRoutes: { [key: string]: FlightRouterState } = {}
-
-  for (const [key, parallelRoute] of Object.entries(parallelRoutes)) {
-    updatedParallelRoutes[key] = addSearchParamsToPageSegments(
-      parallelRoute,
-      searchParams
-    )
-  }
-
-  return [segment, updatedParallelRoutes, ...rest]
 }
 
 export const PAGE_SEGMENT_KEY = '__PAGE__'

--- a/test/e2e/app-dir/next-form/default/next-form-prefetch.test.ts
+++ b/test/e2e/app-dir/next-form/default/next-form-prefetch.test.ts
@@ -10,11 +10,7 @@ import { retry } from '../../../../lib/next-test-utils'
 
 const _describe =
   // prefetching is disabled in dev.
-  isNextDev ||
-  // FIXME(form): currently failing in PPR, unflag this when https://github.com/vercel/next.js/pull/70532 is ready
-  process.env.__NEXT_EXPERIMENTAL_PPR
-    ? describe.skip
-    : describe
+  isNextDev ? describe.skip : describe
 
 _describe('app dir - form prefetching', () => {
   const { next } = nextTestSetup({


### PR DESCRIPTION
This adjusts the implementation of prefetched alias handling to be no longer be sprinkled throughout the existing navigation handler. Ultimately the goal will be to delete this handling once we have per-segment fetching, so keeping it in a single place will make that easier to do.

This PR introduces a few changes to the previous behavior:
- If we've determined an alias is to be used, it will recursively copy the canonical search params into the `FlightRouterState`. This is because an aliased entry won't necessarily correspond with the search params for the URL being navigated to, and we encode search params into the `FlightRouterState`.
- Now we check to see if the aliased entry has any loading segments. If not, there's no work to be done, so we return to the regular navigation behavior and kick off a temporary prefetch for the page being navigated to. 
- In the case of constructing a new tree (ie from a navigation corresponding with a static page or something that started rendering from the root), previously we were only copying the root level into the cache. This updates the handling to construct a full tree with only the loading segments. 


Caught by failing test in #68305 when used with PPR, so this re-enables that test. 