### PR TITLE
Include buildId in the cache breaker until we have hashed Action IDs

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1904,6 +1904,7 @@ export default async function build(
               nextConfigOutput: config.output,
               pprConfig: config.experimental.ppr,
               isAppPPRFallbacksEnabled: config.experimental.pprFallbacks,
+              buildId,
             })
         )
 
@@ -2123,6 +2124,7 @@ export default async function build(
                             pprConfig: config.experimental.ppr,
                             isAppPPRFallbacksEnabled:
                               config.experimental.pprFallbacks,
+                            buildId,
                           })
                         }
                       )

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1360,6 +1360,7 @@ export async function buildAppStaticPaths({
   ComponentMod,
   isRoutePPREnabled,
   isAppPPRFallbacksEnabled,
+  buildId,
 }: {
   dir: string
   page: string
@@ -1376,6 +1377,7 @@ export async function buildAppStaticPaths({
   ComponentMod: AppPageModule
   isRoutePPREnabled: boolean | undefined
   isAppPPRFallbacksEnabled: boolean | undefined
+  buildId: string
 }): Promise<PartialStaticPathsResult> {
   ComponentMod.patchFetch()
 
@@ -1424,6 +1426,7 @@ export async function buildAppStaticPaths({
           after: false,
           dynamicIO: false,
         },
+        buildId,
       },
     },
     async (): Promise<PartialStaticPathsResult> => {
@@ -1592,6 +1595,7 @@ export async function isPageStatic({
   cacheHandler,
   pprConfig,
   isAppPPRFallbacksEnabled,
+  buildId,
 }: {
   dir: string
   page: string
@@ -1613,6 +1617,7 @@ export async function isPageStatic({
   nextConfigOutput: 'standalone' | 'export' | undefined
   pprConfig: ExperimentalPPRConfig | undefined
   isAppPPRFallbacksEnabled: boolean | undefined
+  buildId: string
 }): Promise<PageIsStaticResult> {
   const isPageStaticSpan = trace('is-page-static-utils', parentId)
   return isPageStaticSpan
@@ -1739,6 +1744,7 @@ export async function isPageStatic({
               nextConfigOutput,
               isRoutePPREnabled,
               isAppPPRFallbacksEnabled,
+              buildId,
             }))
         }
       } else {

--- a/packages/next/src/client/components/static-generation-async-storage.external.ts
+++ b/packages/next/src/client/components/static-generation-async-storage.external.ts
@@ -66,6 +66,8 @@ export interface StaticGenerationStore {
   isPrefetchRequest?: boolean
 
   requestEndedState?: { ended?: boolean }
+
+  buildId: string
 }
 
 export type StaticGenerationAsyncStorage =

--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -43,7 +43,8 @@ export async function exportAppRoute(
   distDir: string,
   htmlFilepath: string,
   fileWriter: FileWriter,
-  experimental: Required<Pick<ExperimentalConfig, 'after' | 'dynamicIO'>>
+  experimental: Required<Pick<ExperimentalConfig, 'after' | 'dynamicIO'>>,
+  buildId: string
 ): Promise<ExportRouteResult> {
   // Ensure that the URL is absolute.
   req.url = `http://localhost:3000${req.url}`
@@ -76,6 +77,7 @@ export async function exportAppRoute(
       incrementalCache,
       waitUntil: undefined,
       onClose: undefined,
+      buildId,
     },
   }
 

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -246,7 +246,8 @@ async function exportPageImpl(
         distDir,
         htmlFilepath,
         fileWriter,
-        input.renderOpts.experimental
+        input.renderOpts.experimental,
+        input.renderOpts.buildId
       )
     }
 

--- a/packages/next/src/server/async-storage/with-static-generation-store.ts
+++ b/packages/next/src/server/async-storage/with-static-generation-store.ts
@@ -56,6 +56,7 @@ export type StaticGenerationContext = {
     | 'nextExport'
     | 'isDraftMode'
     | 'isDebugDynamicAccesses'
+    | 'buildId'
   > &
     Partial<RequestLifecycleOpts>
 }
@@ -114,6 +115,7 @@ export const withStaticGenerationStore: WithStore<
 
     requestEndedState,
     isPrefetchRequest,
+    buildId: renderOpts.buildId,
   }
 
   // TODO: remove this when we resolve accessing the store outside the execution context

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2506,6 +2506,7 @@ export default abstract class Server<
               onClose: res.onClose.bind(res),
               onInstrumentationRequestError:
                 this.renderOpts.onInstrumentationRequestError,
+              buildId: this.renderOpts.buildId,
             },
           }
 

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -776,6 +776,7 @@ export default class DevServer extends Server {
           maxMemoryCacheSize: this.nextConfig.cacheMaxMemorySize,
           nextConfigOutput: this.nextConfig.output,
           isAppPPRFallbacksEnabled: this.nextConfig.experimental.pprFallbacks,
+          buildId: this.renderOpts.buildId,
         })
         return pathsResult
       } finally {

--- a/packages/next/src/server/dev/static-paths-worker.ts
+++ b/packages/next/src/server/dev/static-paths-worker.ts
@@ -53,6 +53,7 @@ export async function loadStaticPaths({
   cacheHandler,
   nextConfigOutput,
   isAppPPRFallbacksEnabled,
+  buildId,
 }: {
   dir: string
   distDir: string
@@ -70,6 +71,7 @@ export async function loadStaticPaths({
   cacheHandler?: string
   nextConfigOutput: 'standalone' | 'export' | undefined
   isAppPPRFallbacksEnabled: boolean | undefined
+  buildId: string
 }): Promise<PartialStaticPathsResult> {
   // update work memory runtime-config
   require('../../shared/lib/runtime-config.external').setConfig(config)
@@ -129,6 +131,7 @@ export async function loadStaticPaths({
       nextConfigOutput,
       isRoutePPREnabled,
       isAppPPRFallbacksEnabled,
+      buildId,
     })
   }
 

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -1,3 +1,4 @@
+import type { DeepReadonly } from '../../shared/lib/deep-readonly'
 import { createSnapshot } from '../../client/components/async-local-storage'
 /* eslint-disable import/no-extraneous-dependencies */
 import {
@@ -14,6 +15,8 @@ import {
 
 import type { StaticGenerationStore } from '../../client/components/static-generation-async-storage.external'
 import { staticGenerationAsyncStorage } from '../../client/components/static-generation-async-storage.external'
+
+import type { ClientReferenceManifest } from '../../build/webpack/plugins/flight-manifest-plugin'
 
 import {
   getClientReferenceManifestSingleton,
@@ -75,6 +78,7 @@ const runInCleanSnapshot = createSnapshot()
 
 async function generateCacheEntry(
   staticGenerationStore: StaticGenerationStore,
+  clientReferenceManifest: DeepReadonly<ClientReferenceManifest>,
   cacheHandler: CacheHandler,
   serializedCacheKey: string | ArrayBuffer,
   encodedArguments: FormData | string,
@@ -96,11 +100,9 @@ async function generateCacheEntry(
   let didError = false
   let firstError: any = null
 
-  const clientReferenceManifestSingleton = getClientReferenceManifestSingleton()
-
   const stream = renderToReadableStream(
     result,
-    clientReferenceManifestSingleton.clientModules,
+    clientReferenceManifest.clientModules,
     {
       environmentName: 'Cache',
       temporaryReferences,
@@ -216,9 +218,16 @@ export function cache(kind: string, id: string, fn: any) {
         // might include request specific things like cookies() inside a React.cache().
         // Note: It is important that we await at least once before this because it lets us
         // pop out of any stack specific contexts as well - aka "Sync" Local Storage.
+
+        // Get the clientReferenceManifestSingleton while we're still in the outer Context.
+        // In case getClientReferenceManifestSingleton is implemented using AsyncLocalStorage.
+        const clientReferenceManifestSingleton =
+          getClientReferenceManifestSingleton()
+
         stream = await runInCleanSnapshot(
           generateCacheEntry,
           staticGenerationStore,
+          clientReferenceManifestSingleton,
           cacheHandler,
           serializedCacheKey,
           encodedArguments,
@@ -229,9 +238,12 @@ export function cache(kind: string, id: string, fn: any) {
         if (entry.stale) {
           // If this is stale, and we're not in a prerender (i.e. this is dynamic render),
           // then we should warm up the cache with a fresh revalidated entry.
+          const clientReferenceManifestSingleton =
+            getClientReferenceManifestSingleton()
           const ignoredStream = await runInCleanSnapshot(
             generateCacheEntry,
             staticGenerationStore,
+            clientReferenceManifestSingleton,
             cacheHandler,
             serializedCacheKey,
             encodedArguments,

--- a/packages/next/src/server/web/edge-route-module-wrapper.ts
+++ b/packages/next/src/server/web/edge-route-module-wrapper.ts
@@ -117,6 +117,7 @@ export class EdgeRouteModuleWrapper {
           after: isAfterEnabled,
           dynamicIO: false,
         },
+        buildId: '', // TODO: Populate this properly.
       },
     }
 

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -362,6 +362,7 @@ export function unstable_cache<T extends Callback>(
             page: '/',
             isStaticGeneration: false,
             fallbackRouteParams: null,
+            buildId: '', // Since this is a fake one it can't "use cache" anyway.
           },
           cb,
           ...args


### PR DESCRIPTION
Currently our Action IDs don't include hashing of the implementation which they ideally should, or at least have a separate ID for that. This means it is not safe to reuse cache entries across deployments since the Action ID can remain unchanged.

For now we include the build ID as part of the cache key to ensure we don't use cache entries. We should remove this or replace it with the hash of the Action later.

