### PR TITLE
Unwrap `registerServerReference` function

### DIFF
--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -1626,7 +1626,6 @@ impl<C: Comments> VisitMut for ServerActions<C> {
         if (self.has_action || self.has_cache) && self.config.is_react_server_layer {
             // Inlined actions are only allowed on the server layer.
             // import { registerServerReference } from 'private-next-rsc-server-reference'
-            // registerServerReference("action_id")
             new.push(ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
                 span: DUMMY_SP,
                 specifiers: vec![ImportSpecifier::Named(ImportNamedSpecifier {
@@ -1825,21 +1824,22 @@ fn annotate_ident_as_server_reference(
     bound: Vec<Option<ExprOrSpread>>,
     action_id: String,
 ) -> Expr {
-    // Add the proxy wrapper call `registerServerReference($$id, $$bound, myAction,
-    // maybe_orig_action)`.
-
+    // registerServerReference(reference, id, null)
     let proxy_expr = Expr::Call(CallExpr {
         span: DUMMY_SP,
         callee: quote_ident!("registerServerReference").as_callee(),
         args: vec![
-            // $$id
+            ExprOrSpread {
+                spread: None,
+                expr: Box::new(Expr::Ident(ident)),
+            },
             ExprOrSpread {
                 spread: None,
                 expr: Box::new(action_id.clone().into()),
             },
             ExprOrSpread {
                 spread: None,
-                expr: Box::new(Expr::Ident(ident)),
+                expr: Box::new(Expr::Lit(Lit::Null(Null { span: DUMMY_SP }))),
             },
         ],
         ..Default::default()

--- a/crates/next-custom-transforms/tests/errors/server-actions/client-graph/1/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/client-graph/1/output.js
@@ -1,5 +1,5 @@
 /* __next_internal_client_entry_do_not_use__ default auto */ /* __next_internal_action_entry_do_not_use__ {"6a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0"} */ export default function App() {
-    var fn = registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0);
+    var fn = registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null);
     return <div>App</div>;
 }
 export async function $$RSC_SERVER_ACTION_0() {}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/1/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/1/output.js
@@ -5,4 +5,4 @@ import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     foo
 ]);
-registerServerReference("ab21efdafbe611287bc25c0462b1e0510d13e48b", foo);
+registerServerReference(foo, "ab21efdafbe611287bc25c0462b1e0510d13e48b", null);

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/2/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/2/output.js
@@ -6,4 +6,4 @@ import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     bar
 ]);
-registerServerReference("ac840dcaf5e8197cb02b7f3a43c119b7a770b272", bar);
+registerServerReference(bar, "ac840dcaf5e8197cb02b7f3a43c119b7a770b272", null);

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/3/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/3/output.js
@@ -5,4 +5,4 @@ import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     x
 ]);
-registerServerReference("b78c261f135a7a852508c2920bd7228020ff4bd7", x);
+registerServerReference(x, "b78c261f135a7a852508c2920bd7228020ff4bd7", null);

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/6/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/6/output.js
@@ -1,6 +1,6 @@
 /* __next_internal_action_entry_do_not_use__ {"6a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-export default registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0);
+export default registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null);
 export async function $$RSC_SERVER_ACTION_0() {}
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([]);

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/7/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/7/output.js
@@ -1,4 +1,4 @@
 /* __next_internal_action_entry_do_not_use__ {"6a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-const foo = registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0);
+const foo = registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null);
 export async function $$RSC_SERVER_ACTION_0() {}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/8/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/8/output.js
@@ -1,6 +1,6 @@
 /* __next_internal_action_entry_do_not_use__ {"6a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-const foo = registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0);
+const foo = registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null);
 export async function $$RSC_SERVER_ACTION_0() {
     'use strict';
 }

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/1/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/1/output.js
@@ -2,7 +2,7 @@
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import deleteFromDb from 'db';
 export function Item({ id1, id2 }) {
-    var deleteItem = registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
+    var deleteItem = registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
         id1,
         id2
     ]));
@@ -18,7 +18,7 @@ export default function Home() {
         name: 'John',
         test: 'test'
     };
-    const action = registerServerReference("90b5db271335765a4b0eab01f044b381b5ebd5cd", $$RSC_SERVER_ACTION_1).bind(null, encryptActionBoundArgs("90b5db271335765a4b0eab01f044b381b5ebd5cd", [
+    const action = registerServerReference($$RSC_SERVER_ACTION_1, "90b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("90b5db271335765a4b0eab01f044b381b5ebd5cd", [
         info.name,
         info.test
     ]));

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/10/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/10/output.js
@@ -5,4 +5,4 @@ import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     foo
 ]);
-registerServerReference("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", foo);
+registerServerReference(foo, "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/11/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/11/output.js
@@ -5,4 +5,4 @@ import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     $$RSC_SERVER_ACTION_0
 ]);
-registerServerReference("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", $$RSC_SERVER_ACTION_0);
+registerServerReference($$RSC_SERVER_ACTION_0, "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/12/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/12/output.js
@@ -6,4 +6,4 @@ import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     foo
 ]);
-registerServerReference("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", foo);
+registerServerReference(foo, "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/13/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/13/output.js
@@ -9,5 +9,5 @@ ensureServerEntryExports([
     foo,
     bar
 ]);
-registerServerReference("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", foo);
-registerServerReference("ac840dcaf5e8197cb02b7f3a43c119b7a770b272", bar);
+registerServerReference(foo, "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", null);
+registerServerReference(bar, "ac840dcaf5e8197cb02b7f3a43c119b7a770b272", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/14/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/14/output.js
@@ -7,4 +7,4 @@ import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     foo
 ]);
-registerServerReference("ab21efdafbe611287bc25c0462b1e0510d13e48b", foo);
+registerServerReference(foo, "ab21efdafbe611287bc25c0462b1e0510d13e48b", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/15/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/15/output.js
@@ -1,6 +1,6 @@
 /* __next_internal_action_entry_do_not_use__ {"90b5db271335765a4b0eab01f044b381b5ebd5cd":"$$RSC_SERVER_ACTION_1","c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-export default $$RSC_SERVER_ACTION_0 = registerServerReference("90b5db271335765a4b0eab01f044b381b5ebd5cd", $$RSC_SERVER_ACTION_1);
+export default $$RSC_SERVER_ACTION_0 = registerServerReference($$RSC_SERVER_ACTION_1, "90b5db271335765a4b0eab01f044b381b5ebd5cd", null);
 var $$RSC_SERVER_ACTION_0;
 export async function $$RSC_SERVER_ACTION_1(a, b) {
     console.log(a, b);
@@ -9,4 +9,4 @@ import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     $$RSC_SERVER_ACTION_0
 ]);
-registerServerReference("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", $$RSC_SERVER_ACTION_0);
+registerServerReference($$RSC_SERVER_ACTION_0, "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/16/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/16/output.js
@@ -4,7 +4,7 @@ import deleteFromDb from 'db';
 const v1 = 'v1';
 export function Item({ id1, id2 }) {
     const v2 = id2;
-    const deleteItem = registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
+    const deleteItem = registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
         id1,
         v2
     ]));
@@ -17,7 +17,7 @@ export async function $$RSC_SERVER_ACTION_0($$ACTION_CLOSURE_BOUND) {
     await deleteFromDb($$ACTION_ARG_1);
 }
 const f = (x)=>{
-    var g = registerServerReference("90b5db271335765a4b0eab01f044b381b5ebd5cd", $$RSC_SERVER_ACTION_1).bind(null, encryptActionBoundArgs("90b5db271335765a4b0eab01f044b381b5ebd5cd", [
+    var g = registerServerReference($$RSC_SERVER_ACTION_1, "90b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("90b5db271335765a4b0eab01f044b381b5ebd5cd", [
         x
     ]));
 };
@@ -26,7 +26,7 @@ export async function $$RSC_SERVER_ACTION_1($$ACTION_CLOSURE_BOUND, y, ...z) {
     return $$ACTION_ARG_0 + y + z[0];
 }
 const g = (x)=>{
-    f = registerServerReference("1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", $$RSC_SERVER_ACTION_2).bind(null, encryptActionBoundArgs("1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", [
+    f = registerServerReference($$RSC_SERVER_ACTION_2, "1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", null).bind(null, encryptActionBoundArgs("1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", [
         x
     ]));
 };

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/17/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/17/output.js
@@ -1,6 +1,6 @@
 /* __next_internal_action_entry_do_not_use__ {"6a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0","ab21efdafbe611287bc25c0462b1e0510d13e48b":"foo","ac840dcaf5e8197cb02b7f3a43c119b7a770b272":"bar"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-export const foo = registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0);
+export const foo = registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null);
 export async function $$RSC_SERVER_ACTION_0() {}
 const bar = async ()=>{};
 export { bar };
@@ -9,5 +9,5 @@ ensureServerEntryExports([
     foo,
     bar
 ]);
-registerServerReference("ab21efdafbe611287bc25c0462b1e0510d13e48b", foo);
-registerServerReference("ac840dcaf5e8197cb02b7f3a43c119b7a770b272", bar);
+registerServerReference(foo, "ab21efdafbe611287bc25c0462b1e0510d13e48b", null);
+registerServerReference(bar, "ac840dcaf5e8197cb02b7f3a43c119b7a770b272", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/18/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/18/output.js
@@ -5,13 +5,13 @@ const v1 = 'v1';
 export function Item({ id1, id2 }) {
     const v2 = id2;
     return <>
-      <Button action={registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
+      <Button action={registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
         id1,
         v2
     ]))}>
         Delete
       </Button>
-      <Button action={registerServerReference("1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", $$RSC_SERVER_ACTION_2).bind(null, encryptActionBoundArgs("1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", [
+      <Button action={registerServerReference($$RSC_SERVER_ACTION_2, "1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", null).bind(null, encryptActionBoundArgs("1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", [
         id1,
         v2
     ]))}>

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/19/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/19/output.js
@@ -2,7 +2,7 @@
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export function Item({ value }) {
     return <>
-      <Button action={registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
+      <Button action={registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
         value
     ]))}>
         Multiple

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/2/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/2/output.js
@@ -1,11 +1,11 @@
 /* __next_internal_action_entry_do_not_use__ {"6a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0","90b5db271335765a4b0eab01f044b381b5ebd5cd":"$$RSC_SERVER_ACTION_1"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-var myAction = registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0);
+var myAction = registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null);
 export async function $$RSC_SERVER_ACTION_0(a, b, c) {
     console.log('a');
 }
 export default function Page() {
     return <Button action={myAction}>Delete</Button>;
 }
-export const action = withValidate(registerServerReference("90b5db271335765a4b0eab01f044b381b5ebd5cd", $$RSC_SERVER_ACTION_1));
+export const action = withValidate(registerServerReference($$RSC_SERVER_ACTION_1, "90b5db271335765a4b0eab01f044b381b5ebd5cd", null));
 export async function $$RSC_SERVER_ACTION_1() {}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/20/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/20/output.js
@@ -8,4 +8,4 @@ import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     foo
 ]);
-registerServerReference("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", foo);
+registerServerReference(foo, "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/21/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/21/output.js
@@ -4,7 +4,7 @@ import { validator, another } from 'auth';
 const x = 1;
 export default function Page() {
     const y = 1;
-    return <Foo action={validator(registerServerReference("90b5db271335765a4b0eab01f044b381b5ebd5cd", $$RSC_SERVER_ACTION_1).bind(null, encryptActionBoundArgs("90b5db271335765a4b0eab01f044b381b5ebd5cd", [
+    return <Foo action={validator(registerServerReference($$RSC_SERVER_ACTION_1, "90b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("90b5db271335765a4b0eab01f044b381b5ebd5cd", [
         y
     ])))}/>;
 }
@@ -12,7 +12,7 @@ export async function $$RSC_SERVER_ACTION_1($$ACTION_CLOSURE_BOUND, z) {
     var [$$ACTION_ARG_0] = await decryptActionBoundArgs("90b5db271335765a4b0eab01f044b381b5ebd5cd", $$ACTION_CLOSURE_BOUND);
     return x + $$ACTION_ARG_0 + z;
 }
-validator(registerServerReference("1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", $$RSC_SERVER_ACTION_2));
+validator(registerServerReference($$RSC_SERVER_ACTION_2, "1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", null));
 export async function $$RSC_SERVER_ACTION_2() {}
-another(validator(registerServerReference("9ed0cc47abc4e1c64320cf42b74ae60b58c40f00", $$RSC_SERVER_ACTION_3)));
+another(validator(registerServerReference($$RSC_SERVER_ACTION_3, "9ed0cc47abc4e1c64320cf42b74ae60b58c40f00", null)));
 export async function $$RSC_SERVER_ACTION_3() {}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/22/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/22/output.js
@@ -1,9 +1,9 @@
 /* __next_internal_action_entry_do_not_use__ {"1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91":"$$RSC_SERVER_ACTION_2","6a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0","c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default","f14702b5a021dd117f7ec7a3c838f397c2046d3b":"action"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { validator } from 'auth';
-export const action = validator(registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0));
+export const action = validator(registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null));
 export async function $$RSC_SERVER_ACTION_0() {}
-export default $$RSC_SERVER_ACTION_1 = validator(registerServerReference("1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", $$RSC_SERVER_ACTION_2));
+export default $$RSC_SERVER_ACTION_1 = validator(registerServerReference($$RSC_SERVER_ACTION_2, "1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", null));
 var $$RSC_SERVER_ACTION_1;
 export async function $$RSC_SERVER_ACTION_2() {}
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
@@ -11,5 +11,5 @@ ensureServerEntryExports([
     action,
     $$RSC_SERVER_ACTION_1
 ]);
-registerServerReference("f14702b5a021dd117f7ec7a3c838f397c2046d3b", action);
-registerServerReference("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", $$RSC_SERVER_ACTION_1);
+registerServerReference(action, "f14702b5a021dd117f7ec7a3c838f397c2046d3b", null);
+registerServerReference($$RSC_SERVER_ACTION_1, "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/23/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/23/output.js
@@ -1,11 +1,11 @@
 /* __next_internal_action_entry_do_not_use__ {"6a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0","90b5db271335765a4b0eab01f044b381b5ebd5cd":"$$RSC_SERVER_ACTION_1"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export default function Page({ foo, x, y }) {
-    var action = registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
+    var action = registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
         x
     ]));
     action.bind(null, foo[0], foo[1], foo.x, foo[y]);
-    const action2 = registerServerReference("90b5db271335765a4b0eab01f044b381b5ebd5cd", $$RSC_SERVER_ACTION_1).bind(null, encryptActionBoundArgs("90b5db271335765a4b0eab01f044b381b5ebd5cd", [
+    const action2 = registerServerReference($$RSC_SERVER_ACTION_1,"90b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("90b5db271335765a4b0eab01f044b381b5ebd5cd", [
         x
     ]));
     action2.bind(null, foo[0], foo[1], foo.x, foo[y]);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/24/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/24/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"6a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 export default function Page({ foo, x, y }) {
-    var action = registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
+    var action = registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
         foo
     ]));
 }

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/25/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/25/output.js
@@ -7,7 +7,7 @@ export function Item({ id1, id2 }) {
         id1++;
         return <Button action={deleteItem}>Delete</Button>;
     })();
-    var deleteItem = registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
+    var deleteItem = registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
         id1,
         id2
     ]));
@@ -26,7 +26,7 @@ export function Item2({ id1, id2 }) {
     id1++;
     temp.push(<Button action={deleteItem}>Delete</Button>);
     return temp;
-    var deleteItem = registerServerReference("90b5db271335765a4b0eab01f044b381b5ebd5cd", $$RSC_SERVER_ACTION_1).bind(null, encryptActionBoundArgs("90b5db271335765a4b0eab01f044b381b5ebd5cd", [
+    var deleteItem = registerServerReference($$RSC_SERVER_ACTION_1, "90b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("90b5db271335765a4b0eab01f044b381b5ebd5cd", [
         id1,
         id2
     ]));

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/26/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/26/output.js
@@ -1,7 +1,7 @@
 /* __next_internal_action_entry_do_not_use__ {"6a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 const noop = (action)=>action;
-export const log = noop(registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0));
+export const log = noop(registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null));
 export async function $$RSC_SERVER_ACTION_0(data) {
     console.log(data);
 }

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/27/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/27/output.js
@@ -3,24 +3,24 @@
 // 2. Actual action functions should be renamed to `$$ACTION_...` and got exported.
 /* __next_internal_action_entry_do_not_use__ {"1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91":"$$RSC_SERVER_ACTION_2","6a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0","90b5db271335765a4b0eab01f044b381b5ebd5cd":"$$RSC_SERVER_ACTION_1","9ed0cc47abc4e1c64320cf42b74ae60b58c40f00":"$$RSC_SERVER_ACTION_3","a9b2939c1f39073a6bed227fd20233064c8b7869":"$$RSC_SERVER_ACTION_4"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-var foo = registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0);
+var foo = registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null);
 export async function $$RSC_SERVER_ACTION_0() {
     console.log(1);
 }
 export { foo };
-export var bar = registerServerReference("90b5db271335765a4b0eab01f044b381b5ebd5cd", $$RSC_SERVER_ACTION_1);
+export var bar = registerServerReference($$RSC_SERVER_ACTION_1, "90b5db271335765a4b0eab01f044b381b5ebd5cd", null);
 export async function $$RSC_SERVER_ACTION_1() {
     console.log(2);
 }
-export default registerServerReference("1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", $$RSC_SERVER_ACTION_2);
+export default registerServerReference($$RSC_SERVER_ACTION_2, "1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", null);
 export async function $$RSC_SERVER_ACTION_2() {
     console.log(3);
 }
-export const qux = registerServerReference("9ed0cc47abc4e1c64320cf42b74ae60b58c40f00", $$RSC_SERVER_ACTION_3);
+export const qux = registerServerReference($$RSC_SERVER_ACTION_3, "9ed0cc47abc4e1c64320cf42b74ae60b58c40f00", null);
 export async function $$RSC_SERVER_ACTION_3() {
     console.log(4);
 }
-export const quux = registerServerReference("a9b2939c1f39073a6bed227fd20233064c8b7869", $$RSC_SERVER_ACTION_4);
+export const quux = registerServerReference($$RSC_SERVER_ACTION_4, "a9b2939c1f39073a6bed227fd20233064c8b7869", null);
 export async function $$RSC_SERVER_ACTION_4() {
     console.log(5);
 }

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/28/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/28/output.js
@@ -2,7 +2,7 @@
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 let a, f;
 function Comp(b, c, ...g) {
-    return registerServerReference("1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", $$RSC_SERVER_ACTION_2).bind(null, encryptActionBoundArgs("1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", [
+    return registerServerReference($$RSC_SERVER_ACTION_2, "1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", null).bind(null, encryptActionBoundArgs("1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", [
         b,
         c,
         g
@@ -24,7 +24,7 @@ export async function $$RSC_SERVER_ACTION_2($$ACTION_CLOSURE_BOUND, d) {
         window
     });
     console.log(a, $$ACTION_ARG_0, action2);
-    var action2 = registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
+    var action2 = registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
         $$ACTION_ARG_1,
         d,
         f,
@@ -32,7 +32,7 @@ export async function $$RSC_SERVER_ACTION_2($$ACTION_CLOSURE_BOUND, d) {
     ]));
     return [
         action2,
-        registerServerReference("90b5db271335765a4b0eab01f044b381b5ebd5cd", $$RSC_SERVER_ACTION_1).bind(null, encryptActionBoundArgs("90b5db271335765a4b0eab01f044b381b5ebd5cd", [
+        registerServerReference($$RSC_SERVER_ACTION_1, "90b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("90b5db271335765a4b0eab01f044b381b5ebd5cd", [
             action2,
             $$ACTION_ARG_1,
             d

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/29/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/29/output.js
@@ -1,6 +1,6 @@
 /* __next_internal_action_entry_do_not_use__ {"28baf972d345b86b747ad0df73d75a0088a42214":"dec","6a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0","c18c215a6b7cdc64bf709f3a714ffdef1bf9651d":"default"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-export const dec = registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0);
+export const dec = registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null);
 export async function $$RSC_SERVER_ACTION_0(value) {
     return value - 1;
 }
@@ -11,5 +11,5 @@ ensureServerEntryExports([
     dec,
     dec
 ]);
-registerServerReference("28baf972d345b86b747ad0df73d75a0088a42214", dec);
-registerServerReference("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", dec);
+registerServerReference(dec, "28baf972d345b86b747ad0df73d75a0088a42214", null);
+registerServerReference(dec, "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/3/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/3/output.js
@@ -8,4 +8,4 @@ import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     myAction
 ]);
-registerServerReference("e10665baac148856374b2789aceb970f66fec33e", myAction);
+registerServerReference(myAction, "e10665baac148856374b2789aceb970f66fec33e", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/30/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/30/output.js
@@ -2,7 +2,7 @@
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 let a, f;
 export async function action0(b, c, ...g) {
-    return registerServerReference("1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", $$RSC_SERVER_ACTION_2).bind(null, encryptActionBoundArgs("1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", [
+    return registerServerReference($$RSC_SERVER_ACTION_2, "1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", null).bind(null, encryptActionBoundArgs("1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", [
         b,
         c,
         g
@@ -24,7 +24,7 @@ export async function $$RSC_SERVER_ACTION_2($$ACTION_CLOSURE_BOUND, d) {
         window
     });
     console.log(a, $$ACTION_ARG_0, action2);
-    var action2 = registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
+    var action2 = registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
         $$ACTION_ARG_1,
         d,
         f,
@@ -32,7 +32,7 @@ export async function $$RSC_SERVER_ACTION_2($$ACTION_CLOSURE_BOUND, d) {
     ]));
     return [
         action2,
-        registerServerReference("90b5db271335765a4b0eab01f044b381b5ebd5cd", $$RSC_SERVER_ACTION_1).bind(null, encryptActionBoundArgs("90b5db271335765a4b0eab01f044b381b5ebd5cd", [
+        registerServerReference($$RSC_SERVER_ACTION_1, "90b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("90b5db271335765a4b0eab01f044b381b5ebd5cd", [
             action2,
             $$ACTION_ARG_1,
             d
@@ -43,4 +43,4 @@ import { ensureServerEntryExports } from "private-next-rsc-action-validate";
 ensureServerEntryExports([
     action0
 ]);
-registerServerReference("0090eaf4e1f08a2d94f6be401e54a2ded399b87c", action0);
+registerServerReference(action0, "0090eaf4e1f08a2d94f6be401e54a2ded399b87c", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/31/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/31/output.js
@@ -21,5 +21,5 @@ ensureServerEntryExports([
     action,
     action2
 ]);
-registerServerReference("f14702b5a021dd117f7ec7a3c838f397c2046d3b", action);
-registerServerReference("abf760c735ba66c4c26a2913864dd7e28fb88a91", action2);
+registerServerReference(action, "f14702b5a021dd117f7ec7a3c838f397c2046d3b", null);
+registerServerReference(action2, "abf760c735ba66c4c26a2913864dd7e28fb88a91", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/32/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/32/output.js
@@ -16,7 +16,7 @@ export function Component() {
             current: 1
         }
     };
-    var action = registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
+    var action = registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
         data,
         baz.value,
         foo

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/33/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/33/output.js
@@ -5,7 +5,7 @@ const v = 'world';
 export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "3128060c414d59f8552e4788b846c0d2b7f74743", async function fn() {
     return 'hello, ' + v;
 });
-var fn = registerServerReference("3128060c414d59f8552e4788b846c0d2b7f74743", $$RSC_SERVER_CACHE_0);
+var fn = registerServerReference($$RSC_SERVER_CACHE_0, "3128060c414d59f8552e4788b846c0d2b7f74743", null);
 export async function Component() {
     const data = await fn();
     return <div>{data}</div>;

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/34/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/34/output.js
@@ -4,4 +4,4 @@ import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "3128060c414d59f8552e4788b846c0d2b7f74743", async function foo() {
     return 'data';
 });
-export var foo = registerServerReference("3128060c414d59f8552e4788b846c0d2b7f74743", $$RSC_SERVER_CACHE_0);
+export var foo = registerServerReference($$RSC_SERVER_CACHE_0, "3128060c414d59f8552e4788b846c0d2b7f74743", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/35/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/35/output.js
@@ -4,4 +4,4 @@ import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "3128060c414d59f8552e4788b846c0d2b7f74743", async function() {
     return 'data';
 });
-export const my_fn = registerServerReference("3128060c414d59f8552e4788b846c0d2b7f74743", $$RSC_SERVER_CACHE_0);
+export const my_fn = registerServerReference($$RSC_SERVER_CACHE_0, "3128060c414d59f8552e4788b846c0d2b7f74743", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/36/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/36/output.js
@@ -4,8 +4,8 @@ import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "3128060c414d59f8552e4788b846c0d2b7f74743", async function foo() {
     return 'data A';
 });
-export var foo = registerServerReference("3128060c414d59f8552e4788b846c0d2b7f74743", $$RSC_SERVER_CACHE_0);
+export var foo = registerServerReference($$RSC_SERVER_CACHE_0, "3128060c414d59f8552e4788b846c0d2b7f74743", null);
 export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "951c375b4a6a6e89d67b743ec5808127cfde405d", async function bar() {
     return 'data B';
 });
-export var bar = registerServerReference("951c375b4a6a6e89d67b743ec5808127cfde405d", $$RSC_SERVER_CACHE_1);
+export var bar = registerServerReference($$RSC_SERVER_CACHE_1, "951c375b4a6a6e89d67b743ec5808127cfde405d", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/37/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/37/output.js
@@ -4,7 +4,7 @@ import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "3128060c414d59f8552e4788b846c0d2b7f74743", async function fn() {
     return 'foo';
 });
-var fn = registerServerReference("3128060c414d59f8552e4788b846c0d2b7f74743", $$RSC_SERVER_CACHE_0);
+var fn = registerServerReference($$RSC_SERVER_CACHE_0, "3128060c414d59f8552e4788b846c0d2b7f74743", null);
 async function Component() {
     const data = await fn();
     return <div>{data}</div>;

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/38/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/38/output.js
@@ -4,4 +4,4 @@ import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export var $$RSC_SERVER_CACHE_0 = $$cache__("x", "3128060c414d59f8552e4788b846c0d2b7f74743", async function foo() {
     return 'data';
 });
-export var foo = registerServerReference("3128060c414d59f8552e4788b846c0d2b7f74743", $$RSC_SERVER_CACHE_0);
+export var foo = registerServerReference($$RSC_SERVER_CACHE_0, "3128060c414d59f8552e4788b846c0d2b7f74743", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/4/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/4/output.js
@@ -5,7 +5,7 @@ export async function b() {}
 export async function c() {}
 function d() {}
 function Foo() {
-    var e = registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0);
+    var e = registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null);
 }
 export async function $$RSC_SERVER_ACTION_0() {}
 import { ensureServerEntryExports } from "private-next-rsc-action-validate";
@@ -14,6 +14,6 @@ ensureServerEntryExports([
     b,
     c
 ]);
-registerServerReference("6e7bc104e4d6e7fda190c4a51be969cfd0be6d6d", a);
-registerServerReference("d1f7eb64271d7c601dfef7d4d7053de1c2ca4338", b);
-registerServerReference("1ab723c80dcca470e0410b4b2a2fc2bf21f41476", c);
+registerServerReference(a, "6e7bc104e4d6e7fda190c4a51be969cfd0be6d6d", null);
+registerServerReference(b, "d1f7eb64271d7c601dfef7d4d7053de1c2ca4338", null);
+registerServerReference(c, "1ab723c80dcca470e0410b4b2a2fc2bf21f41476", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/5/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/5/output.js
@@ -4,7 +4,7 @@ import deleteFromDb from 'db';
 const v1 = 'v1';
 export function Item({ id1, id2, id3, id4 }) {
     const v2 = id2;
-    var deleteItem = registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
+    var deleteItem = registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
         id1,
         v2,
         id3,

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/6/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/6/output.js
@@ -19,7 +19,7 @@ export function y(p, [p1, { p2 }], ...p3) {
     if (true) {
         const f8 = 1;
     }
-    var action = registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
+    var action = registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
         f2,
         f11,
         p,

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/7/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/7/output.js
@@ -2,7 +2,7 @@
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import deleteFromDb from 'db';
 export function Item1(product, foo, bar) {
-    const a = registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
+    const a = registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null).bind(null, encryptActionBoundArgs("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", [
         product,
         foo,
         bar
@@ -14,7 +14,7 @@ export async function $$RSC_SERVER_ACTION_0($$ACTION_CLOSURE_BOUND) {
     await deleteFromDb($$ACTION_ARG_0.id, $$ACTION_ARG_0?.foo, $$ACTION_ARG_0.bar.baz, $$ACTION_ARG_0[$$ACTION_ARG_1, $$ACTION_ARG_2]);
 }
 export function Item2(product, foo, bar) {
-    var deleteItem2 = registerServerReference("90b5db271335765a4b0eab01f044b381b5ebd5cd", $$RSC_SERVER_ACTION_1).bind(null, encryptActionBoundArgs("90b5db271335765a4b0eab01f044b381b5ebd5cd", [
+    var deleteItem2 = registerServerReference($$RSC_SERVER_ACTION_1, "90b5db271335765a4b0eab01f044b381b5ebd5cd", null).bind(null, encryptActionBoundArgs("90b5db271335765a4b0eab01f044b381b5ebd5cd", [
         product,
         foo,
         bar
@@ -26,7 +26,7 @@ export async function $$RSC_SERVER_ACTION_1($$ACTION_CLOSURE_BOUND) {
     await deleteFromDb($$ACTION_ARG_0.id, $$ACTION_ARG_0?.foo, $$ACTION_ARG_0.bar.baz, $$ACTION_ARG_0[$$ACTION_ARG_1, $$ACTION_ARG_2]);
 }
 export function Item3(product, foo, bar) {
-    const deleteItem3 = registerServerReference("9ed0cc47abc4e1c64320cf42b74ae60b58c40f00", $$RSC_SERVER_ACTION_3).bind(null, encryptActionBoundArgs("9ed0cc47abc4e1c64320cf42b74ae60b58c40f00", [
+    const deleteItem3 = registerServerReference($$RSC_SERVER_ACTION_3, "9ed0cc47abc4e1c64320cf42b74ae60b58c40f00", null).bind(null, encryptActionBoundArgs("9ed0cc47abc4e1c64320cf42b74ae60b58c40f00", [
         product,
         foo,
         bar
@@ -38,7 +38,7 @@ export async function $$RSC_SERVER_ACTION_3($$ACTION_CLOSURE_BOUND) {
     await deleteFromDb($$ACTION_ARG_0.id, $$ACTION_ARG_0?.foo, $$ACTION_ARG_0.bar.baz, $$ACTION_ARG_0[$$ACTION_ARG_1, $$ACTION_ARG_2]);
 }
 export function Item4(product, foo, bar) {
-    const deleteItem4 = registerServerReference("a9b2939c1f39073a6bed227fd20233064c8b7869", $$RSC_SERVER_ACTION_4).bind(null, encryptActionBoundArgs("a9b2939c1f39073a6bed227fd20233064c8b7869", [
+    const deleteItem4 = registerServerReference($$RSC_SERVER_ACTION_4, "a9b2939c1f39073a6bed227fd20233064c8b7869", null).bind(null, encryptActionBoundArgs("a9b2939c1f39073a6bed227fd20233064c8b7869", [
         product,
         foo,
         bar

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/8/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/8/output.js
@@ -1,6 +1,6 @@
 /* __next_internal_action_entry_do_not_use__ {"6a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
-var myAction = registerServerReference("6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$RSC_SERVER_ACTION_0);
+var myAction = registerServerReference($$RSC_SERVER_ACTION_0, "6a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null);
 export async function $$RSC_SERVER_ACTION_0(a, b, c) {
     // comment
     'use strict';

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/9/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/9/output.js
@@ -13,6 +13,6 @@ ensureServerEntryExports([
     bar,
     qux
 ]);
-registerServerReference("ab21efdafbe611287bc25c0462b1e0510d13e48b", foo);
-registerServerReference("050e3854b72b19e3c7e3966a67535543a90bf7e0", bar);
-registerServerReference("c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", qux);
+registerServerReference(foo, "ab21efdafbe611287bc25c0462b1e0510d13e48b", null);
+registerServerReference(bar, "050e3854b72b19e3c7e3966a67535543a90bf7e0", null);
+registerServerReference(qux, "c18c215a6b7cdc64bf709f3a714ffdef1bf9651d", null);

--- a/packages/next/src/build/webpack/loaders/next-flight-loader/server-reference.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/server-reference.ts
@@ -1,6 +1,2 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { registerServerReference as flightRegisterServerReference } from 'react-server-dom-webpack/server.edge'
-
-export function registerServerReference(id: string, action: any) {
-  return flightRegisterServerReference(action, id, null)
-}
+export { registerServerReference } from 'react-server-dom-webpack/server.edge'


### PR DESCRIPTION
In the same vein as #69190, where we already unwrapped `createServerReference`, we now also unwrap `registerServerReference`, which is required for React to select the right call stack frame when generating source locations for server actions (see facebook/react#30741).

Whereas unwrapping of `createServerReference` was required for server actions that are imported into client components, unwrapping `registerServerReference` is needed for server actions that are passed from server components to client components.

This does not fully enable the source mapping just yet. For this to work end-to-end, the next step is to generate proper spans in the SWC transform, which will be done in the next PR.