### PR TITLE
Add Iframely to bot list

### DIFF
--- a/packages/next/src/server/web/spec-extension/user-agent.ts
+++ b/packages/next/src/server/web/spec-extension/user-agent.ts
@@ -27,7 +27,7 @@ interface UserAgent {
 }
 
 export function isBot(input: string): boolean {
-  return /Googlebot|Mediapartners-Google|AdsBot-Google|googleweblight|Storebot-Google|Google-PageRenderer|Google-InspectionTool|Bingbot|BingPreview|Slurp|DuckDuckBot|baiduspider|yandex|sogou|LinkedInBot|bitlybot|tumblr|vkShare|quora link preview|facebookexternalhit|facebookcatalog|Twitterbot|applebot|redditbot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|ia_archiver/i.test(
+  return /Googlebot|Mediapartners-Google|AdsBot-Google|googleweblight|Storebot-Google|Google-PageRenderer|Google-InspectionTool|Bingbot|BingPreview|Slurp|DuckDuckBot|baiduspider|yandex|sogou|LinkedInBot|bitlybot|tumblr|vkShare|quora link preview|facebookexternalhit|facebookcatalog|Twitterbot|applebot|redditbot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|ia_archiver|Iframely/i.test(
     input
   )
 }

--- a/packages/next/src/shared/lib/router/utils/is-bot.ts
+++ b/packages/next/src/shared/lib/router/utils/is-bot.ts
@@ -1,5 +1,5 @@
 const BOT_UA_RE =
-  /Googlebot|Mediapartners-Google|AdsBot-Google|googleweblight|Storebot-Google|Google-PageRenderer|Bingbot|BingPreview|Slurp|DuckDuckBot|baiduspider|yandex|sogou|LinkedInBot|bitlybot|tumblr|vkShare|quora link preview|facebookexternalhit|facebookcatalog|Twitterbot|applebot|redditbot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|ia_archiver/i
+  /Googlebot|Mediapartners-Google|AdsBot-Google|googleweblight|Storebot-Google|Google-PageRenderer|Bingbot|BingPreview|Slurp|DuckDuckBot|baiduspider|yandex|sogou|LinkedInBot|bitlybot|tumblr|vkShare|quora link preview|facebookexternalhit|facebookcatalog|Twitterbot|applebot|redditbot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|ia_archiver|Iframely/i
 
 export function isBot(userAgent: string): boolean {
   return BOT_UA_RE.test(userAgent)


### PR DESCRIPTION
This PR adds Iframely to the list of bot user agents.  Iframely is used in the backend by Atlassian Jira as an example with the following user agent when previewing URLs in the UI:
```
Iframely/1.3.1 (+https://iframely.com/docs/about) Atlassian
```

More info about Iframely here:
https://iframely.com/docs/about