### PR TITLE
refactor: remove unnecessary page segment check in ppr-navigations

### DIFF
--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -9,10 +9,7 @@ import type {
   ChildSegmentMap,
   ReadyCacheNode,
 } from '../../../shared/lib/app-router-context.shared-runtime'
-import {
-  DEFAULT_SEGMENT_KEY,
-  PAGE_SEGMENT_KEY,
-} from '../../../shared/lib/segment'
+import { DEFAULT_SEGMENT_KEY } from '../../../shared/lib/segment'
 import { matchSegment } from '../match-segments'
 import { createRouterCacheKey } from './create-router-cache-key'
 import type { FetchServerResponseResult } from './fetch-server-response'
@@ -124,27 +121,13 @@ export function updateCacheNodeOnNavigation(
     const oldSegmentChild =
       oldRouterStateChild !== undefined ? oldRouterStateChild[0] : undefined
 
-    // A dynamic segment will be an array, and doesn't correspond with a page segment.
-    const isPageSegment = Array.isArray(newSegmentChild)
-      ? false
-      : // A page segment might contain search parameters, so we verify that it starts with the page segment key.
-        newSegmentChild.startsWith(PAGE_SEGMENT_KEY)
-
     const oldCacheNodeChild =
       oldSegmentMapChild !== undefined
         ? oldSegmentMapChild.get(newSegmentKeyChild)
         : undefined
 
     let taskChild: Task | null
-    if (isPageSegment) {
-      // This is a leaf segment — a page, not a shared layout. We always apply
-      // its data.
-      taskChild = spawnPendingTask(
-        newRouterStateChild,
-        prefetchDataChild !== undefined ? prefetchDataChild : null,
-        prefetchHead
-      )
-    } else if (newSegmentChild === DEFAULT_SEGMENT_KEY) {
+    if (newSegmentChild === DEFAULT_SEGMENT_KEY) {
       // This is another kind of leaf segment — a default route.
       //
       // Default routes have special behavior. When there's no matching segment


### PR DESCRIPTION
In the PPR navigations flow, we were always spawning a pending task for page segments, which seemed to be related to search params not updating. (x-ref: #60242) 

However this case doesn't seem to be necessary: the static prefetch shouldn't contain any data related to search params, as accessing search params will postpone and trigger suspense fallbacks. And when the dynamic request sends down segment key information for page segments search params, the params will be encoded in the segment key (e.g. `__PAGE__{'foo': 'bar'}`, as opposed to just `__PAGE__`. 

I can't think of another case where this handling would be necessary as if we are in a new tree, we'll already spawn a pending task. And if we're in the same tree, I expect the static data should be the same, while the dynamic request will contain the different data. 