### PR TITLE
refactor(turbo-tasks-fs): Use ResolvedVc instead of Vc in structs

### DIFF
--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1180,8 +1180,14 @@ impl PageEndpoint {
     }
 
     #[turbo_tasks::function]
-    fn client_relative_path(&self) -> Vc<FileSystemPathOption> {
-        Vc::cell(Some(self.pages_project.project().client_relative_path()))
+    async fn client_relative_path(&self) -> Result<Vc<FileSystemPathOption>> {
+        Ok(Vc::cell(Some(
+            self.pages_project
+                .project()
+                .client_relative_path()
+                .to_resolved()
+                .await?,
+        )))
     }
 }
 

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1330,9 +1330,9 @@ pub async fn get_global_metadata(
         };
 
         if dynamic {
-            *entry = Some(MetadataItem::Dynamic { path: file });
+            *entry = Some(MetadataItem::Dynamic { path: *file });
         } else {
-            *entry = Some(MetadataItem::Static { path: file });
+            *entry = Some(MetadataItem::Static { path: *file });
         }
         // TODO(WEB-952) handle symlinks in app dir
     }

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -111,7 +111,7 @@ impl PageLoaderAsset {
                 .map(|chunk| {
                     Vc::upcast(ProxiedAsset::new(
                         *chunk,
-                        FileSystemPath::rebase(chunk.ident().path(), *rebase_path, root_path),
+                        FileSystemPath::rebase(chunk.ident().path(), **rebase_path, root_path),
                     ))
                 })
                 .collect();
@@ -131,7 +131,10 @@ fn page_loader_chunk_reference_description() -> Vc<RcStr> {
 impl OutputAsset for PageLoaderAsset {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
-        let root = self.rebase_prefix_path.await?.unwrap_or(self.server_root);
+        let root = self
+            .rebase_prefix_path
+            .await?
+            .map_or(self.server_root, |path| *path);
         Ok(AssetIdent::from_path(
             root.join(
                 format!(

--- a/turbopack/crates/node-file-trace/src/lib.rs
+++ b/turbopack/crates/node-file-trace/src/lib.rs
@@ -205,7 +205,7 @@ async fn add_glob_results(
     let result = result.await?;
     for entry in result.results.values() {
         if let DirectoryEntry::File(path) = entry {
-            let source = Vc::upcast(FileSource::new(*path));
+            let source = Vc::upcast(FileSource::new(**path));
             let module = asset_context
                 .process(
                     source,
@@ -224,7 +224,7 @@ async fn add_glob_results(
             Box::pin(add_glob_results(asset_context, result, list))
         }
         // Boxing for async recursion
-        recurse(asset_context, *result, list).await?;
+        recurse(asset_context, **result, list).await?;
     }
     Ok(())
 }

--- a/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
+++ b/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
@@ -76,12 +76,12 @@ async fn hash_directory(directory: Vc<FileSystemPath>) -> Result<Vc<RcStr>> {
             for entry in entries.values() {
                 match entry {
                     DirectoryEntry::File(path) => {
-                        let name = filename(*path).await?;
-                        hashes.insert(name, hash_file(*path).await?.clone_value());
+                        let name = filename(**path).await?;
+                        hashes.insert(name, hash_file(**path).await?.clone_value());
                     }
                     DirectoryEntry::Directory(path) => {
-                        let name = filename(*path).await?;
-                        hashes.insert(name, hash_directory(*path).await?.clone_value());
+                        let name = filename(**path).await?;
+                        hashes.insert(name, hash_directory(**path).await?.clone_value());
                     }
                     _ => {}
                 }

--- a/turbopack/crates/turbo-tasks-fs/examples/hash_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/examples/hash_glob.rs
@@ -72,11 +72,11 @@ async fn hash_glob_result(result: Vc<ReadGlobResult>) -> Result<Vc<RcStr>> {
     let mut hashes = BTreeMap::new();
     for (name, entry) in result.results.iter() {
         if let DirectoryEntry::File(path) = entry {
-            hashes.insert(name, hash_file(*path).await?.clone_value());
+            hashes.insert(name, hash_file(**path).await?.clone_value());
         }
     }
     for (name, result) in result.inner.iter() {
-        let hash = hash_glob_result(*result).await?;
+        let hash = hash_glob_result(**result).await?;
         if !hash.is_empty() {
             hashes.insert(name, hash.clone_value());
         }

--- a/turbopack/crates/turbo-tasks-fs/src/attach.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/attach.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use auto_hash_map::AutoMap;
-use turbo_tasks::{Completion, RcStr, ValueToString, Vc};
+use turbo_tasks::{Completion, RcStr, ResolvedVc, ValueToString, Vc};
 
 use crate::{
     DirectoryContent, DirectoryEntry, FileContent, FileMeta, FileSystem, FileSystemPath,
@@ -13,11 +13,11 @@ use crate::{
 /// Caveat: The `child_path` itself is not visible as a directory entry.
 #[turbo_tasks::value]
 pub struct AttachedFileSystem {
-    root_fs: Vc<Box<dyn FileSystem>>,
+    root_fs: ResolvedVc<Box<dyn FileSystem>>,
     // we turn this into a string because creating a FileSystemPath requires the filesystem which
     // we are creating (circular reference)
     child_path: RcStr,
-    child_fs: Vc<Box<dyn FileSystem>>,
+    child_fs: ResolvedVc<Box<dyn FileSystem>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -27,7 +27,7 @@ impl AttachedFileSystem {
     #[turbo_tasks::function]
     pub async fn new(
         child_path: Vc<FileSystemPath>,
-        child_fs: Vc<Box<dyn FileSystem>>,
+        child_fs: ResolvedVc<Box<dyn FileSystem>>,
     ) -> Result<Vc<Self>> {
         let child_path = child_path.await?;
 
@@ -45,11 +45,11 @@ impl AttachedFileSystem {
     /// [FileSystem] or this [AttachedFileSystem].
     #[turbo_tasks::function]
     pub async fn convert_path(
-        self: Vc<Self>,
+        self: ResolvedVc<Self>,
         contained_path_vc: Vc<FileSystemPath>,
     ) -> Result<Vc<FileSystemPath>> {
         let contained_path = contained_path_vc.await?;
-        let self_fs: Vc<Box<dyn FileSystem>> = Vc::upcast(self);
+        let self_fs: ResolvedVc<Box<dyn FileSystem>> = ResolvedVc::upcast(self);
         let this = self.await?;
 
         match contained_path.fs {
@@ -89,12 +89,12 @@ impl AttachedFileSystem {
     /// on the [AttachedFileSystem]
     #[turbo_tasks::function]
     pub async fn get_inner_fs_path(
-        self: Vc<Self>,
+        self: ResolvedVc<Self>,
         path: Vc<FileSystemPath>,
     ) -> Result<Vc<FileSystemPath>> {
         let this = self.await?;
         let path = path.await?;
-        let self_fs: Vc<Box<dyn FileSystem>> = Vc::upcast(self);
+        let self_fs: ResolvedVc<Box<dyn FileSystem>> = ResolvedVc::upcast(self);
 
         if path.fs != self_fs {
             let self_fs_str = self_fs.to_string().await?;
@@ -144,10 +144,10 @@ impl FileSystem for AttachedFileSystem {
             use DirectoryEntry::*;
 
             let entry = match *entry {
-                File(path) => File(self.convert_path(path)),
-                Directory(path) => Directory(self.convert_path(path)),
-                Symlink(path) => Symlink(self.convert_path(path)),
-                Other(path) => Other(self.convert_path(path)),
+                File(path) => File(self.convert_path(*path).to_resolved().await?),
+                Directory(path) => Directory(self.convert_path(*path).to_resolved().await?),
+                Symlink(path) => Symlink(self.convert_path(*path).to_resolved().await?),
+                Other(path) => Other(self.convert_path(*path).to_resolved().await?),
                 Error => Error,
             };
 

--- a/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, Result};
+use auto_hash_map::AutoMap;
 use include_dir::{Dir, DirEntry};
 use turbo_tasks::{Completion, RcStr, ValueToString, Vc};
 
@@ -46,29 +47,26 @@ impl FileSystem for EmbeddedFileSystem {
             (_, None) => return Ok(DirectoryContent::NotFound.cell()),
         };
 
-        let entries = dir
-            .entries()
-            .iter()
-            .map(|e| {
-                let entry_name: RcStr = e
-                    .path()
-                    .file_name()
-                    .unwrap_or_default()
-                    .to_string_lossy()
-                    .into();
-                let entry_path = path.join(entry_name.clone());
+        let mut converted_entries = AutoMap::new();
+        for e in dir.entries() {
+            let entry_name: RcStr = e
+                .path()
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .into();
+            let entry_path = path.join(entry_name.clone()).to_resolved().await?;
 
-                (
-                    entry_name,
-                    match e {
-                        DirEntry::Dir(_) => DirectoryEntry::Directory(entry_path),
-                        DirEntry::File(_) => DirectoryEntry::File(entry_path),
-                    },
-                )
-            })
-            .collect();
+            converted_entries.insert(
+                entry_name,
+                match e {
+                    DirEntry::Dir(_) => DirectoryEntry::Directory(entry_path),
+                    DirEntry::File(_) => DirectoryEntry::File(entry_path),
+                },
+            );
+        }
 
-        Ok(DirectoryContent::new(entries))
+        Ok(DirectoryContent::new(converted_entries))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use anyhow::Result;
-use turbo_tasks::{RcStr, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, Vc};
 
 use crate::{glob::Glob, DirectoryContent, DirectoryEntry, FileSystemPath};
 
@@ -9,7 +9,7 @@ use crate::{glob::Glob, DirectoryContent, DirectoryEntry, FileSystemPath};
 #[derive(Default, Debug)]
 pub struct ReadGlobResult {
     pub results: HashMap<String, DirectoryEntry>,
-    pub inner: HashMap<String, Vc<ReadGlobResult>>,
+    pub inner: HashMap<String, ResolvedVc<ReadGlobResult>>,
 }
 
 /// Reads matches of a glob pattern.
@@ -22,7 +22,7 @@ pub async fn read_glob(
     glob: Vc<Glob>,
     include_dot_files: bool,
 ) -> Result<Vc<ReadGlobResult>> {
-    read_glob_internal("", directory, glob, include_dot_files).await
+    Ok(*read_glob_internal("", directory, glob, include_dot_files).await?)
 }
 
 #[turbo_tasks::function(fs)]
@@ -32,7 +32,7 @@ async fn read_glob_inner(
     glob: Vc<Glob>,
     include_dot_files: bool,
 ) -> Result<Vc<ReadGlobResult>> {
-    read_glob_internal(&prefix, directory, glob, include_dot_files).await
+    Ok(*read_glob_internal(&prefix, directory, glob, include_dot_files).await?)
 }
 
 async fn read_glob_internal(
@@ -40,7 +40,7 @@ async fn read_glob_internal(
     directory: Vc<FileSystemPath>,
     glob: Vc<Glob>,
     include_dot_files: bool,
-) -> Result<Vc<ReadGlobResult>> {
+) -> Result<ResolvedVc<ReadGlobResult>> {
     let dir = directory.read_dir().await?;
     let mut result = ReadGlobResult::default();
     let glob_value = glob.await?;
@@ -63,7 +63,9 @@ async fn read_glob_internal(
                         if glob_value.execute(&full_path_prefix) {
                             result.inner.insert(
                                 full_path,
-                                read_glob_inner(full_path_prefix, path, glob, include_dot_files),
+                                read_glob_inner(full_path_prefix, *path, glob, include_dot_files)
+                                    .to_resolved()
+                                    .await?,
                             );
                         }
                     }
@@ -78,5 +80,5 @@ async fn read_glob_internal(
         }
         DirectoryContent::NotFound => {}
     }
-    Ok(ReadGlobResult::cell(result))
+    Ok(ReadGlobResult::resolved_cell(result))
 }

--- a/turbopack/crates/turbopack-core/src/chunk/optimize.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/optimize.rs
@@ -45,7 +45,7 @@ where
 
                     Ok((
                         if let Some(common_parent) = &*common_parent {
-                            Some(FileSystemPathKey::new(*common_parent).await?)
+                            Some(FileSystemPathKey::new(**common_parent).await?)
                         } else {
                             None
                         },

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1010,7 +1010,7 @@ async fn type_exists(
 ) -> Result<Option<Vc<FileSystemPath>>> {
     let result = fs_path.resolve().await?.realpath_with_links().await?;
     for path in result.symlinks.iter() {
-        refs.push(Vc::upcast(FileSource::new(*path)));
+        refs.push(Vc::upcast(FileSource::new(**path)));
     }
     let path = result.path.resolve().await?;
     Ok(if *path.get_type().await? == ty {
@@ -1026,7 +1026,7 @@ async fn any_exists(
 ) -> Result<Option<(FileSystemEntryType, Vc<FileSystemPath>)>> {
     let result = fs_path.resolve().await?.realpath_with_links().await?;
     for path in result.symlinks.iter() {
-        refs.push(Vc::upcast(FileSource::new(*path)));
+        refs.push(Vc::upcast(FileSource::new(**path)));
     }
     let path = result.path.resolve().await?;
     let ty = *path.get_type().await?;
@@ -1334,10 +1334,10 @@ pub async fn resolve_raw(
         let RealPathResult { path, symlinks } = &*path.realpath_with_links().await?;
         Ok(ResolveResult::source_with_affecting_sources(
             RequestKey::new(request.into()),
-            Vc::upcast(FileSource::new(*path)),
+            Vc::upcast(FileSource::new(**path)),
             symlinks
                 .iter()
-                .copied()
+                .map(|symlink| **symlink)
                 .map(FileSource::new)
                 .map(Vc::upcast)
                 .collect(),
@@ -2583,7 +2583,7 @@ async fn resolved(
 
     if let Some(resolved_map) = options_value.resolved_map {
         let result = resolved_map
-            .lookup(*path, original_context, original_request)
+            .lookup(**path, original_context, original_request)
             .await?;
 
         let resolved_result = resolve_import_map_result(
@@ -2603,10 +2603,10 @@ async fn resolved(
 
     Ok(ResolveResult::source_with_affecting_sources(
         request_key,
-        Vc::upcast(FileSource::new_with_query(*path, query)),
+        Vc::upcast(FileSource::new_with_query(**path, query)),
         symlinks
             .iter()
-            .copied()
+            .map(|symlink| **symlink)
             .map(FileSource::new)
             .map(Vc::upcast)
             .collect(),

--- a/turbopack/crates/turbopack-core/src/resolve/pattern.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/pattern.rs
@@ -1512,7 +1512,7 @@ pub async fn read_matches(
                                 if let Some(pos) = pat.match_position(&prefix) {
                                     results.push((
                                         pos,
-                                        PatternMatch::File(prefix.clone().into(), *path),
+                                        PatternMatch::File(prefix.clone().into(), **path),
                                     ));
                                 }
                                 prefix.truncate(len)
@@ -1527,7 +1527,7 @@ pub async fn read_matches(
                                 if let Some(pos) = pat.match_position(&prefix) {
                                     results.push((
                                         pos,
-                                        PatternMatch::Directory(prefix.clone().into(), *path),
+                                        PatternMatch::Directory(prefix.clone().into(), **path),
                                     ));
                                 }
                                 prefix.push('/');
@@ -1535,13 +1535,13 @@ pub async fn read_matches(
                                 if let Some(pos) = pat.match_position(&prefix) {
                                     results.push((
                                         pos,
-                                        PatternMatch::Directory(prefix.clone().into(), *path),
+                                        PatternMatch::Directory(prefix.clone().into(), **path),
                                     ));
                                 }
                                 if let Some(pos) = pat.could_match_position(&prefix) {
                                     nested.push((
                                         pos,
-                                        read_matches(*path, prefix.clone().into(), true, pattern),
+                                        read_matches(**path, prefix.clone().into(), true, pattern),
                                     ));
                                 }
                                 prefix.truncate(len)
@@ -1562,13 +1562,16 @@ pub async fn read_matches(
                                                 pos,
                                                 PatternMatch::Directory(
                                                     prefix.clone().into(),
-                                                    *fs_path,
+                                                    **fs_path,
                                                 ),
                                             ));
                                         } else {
                                             results.push((
                                                 pos,
-                                                PatternMatch::File(prefix.clone().into(), *fs_path),
+                                                PatternMatch::File(
+                                                    prefix.clone().into(),
+                                                    **fs_path,
+                                                ),
                                             ));
                                         }
                                     }
@@ -1583,7 +1586,7 @@ pub async fn read_matches(
                                                 pos,
                                                 PatternMatch::Directory(
                                                     prefix.clone().into(),
-                                                    *fs_path,
+                                                    **fs_path,
                                                 ),
                                             ));
                                         }
@@ -1598,7 +1601,7 @@ pub async fn read_matches(
                                                 pos,
                                                 PatternMatch::Directory(
                                                     prefix.clone().into(),
-                                                    *fs_path,
+                                                    **fs_path,
                                                 ),
                                             ));
                                         }

--- a/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
@@ -56,11 +56,11 @@ async fn get_routes_from_directory(dir: Vc<FileSystemPath>) -> Result<Vc<RouteTr
                 Some(RouteTree::new_route(
                     vec![BaseSegment::Static(name.clone())],
                     RouteType::Exact,
-                    Vc::upcast(StaticAssetsContentSourceItem::new(*path)),
+                    Vc::upcast(StaticAssetsContentSourceItem::new(**path)),
                 ))
             }
             DirectoryEntry::Directory(path) => Some(
-                get_routes_from_directory(*path)
+                get_routes_from_directory(**path)
                     .with_prepended_base(vec![BaseSegment::Static(name.clone())]),
             ),
             _ => None,
@@ -121,12 +121,12 @@ impl Introspectable for StaticAssetsContentSource {
             .map(|(name, entry)| {
                 let child = match entry {
                     DirectoryEntry::File(path) | DirectoryEntry::Symlink(path) => {
-                        IntrospectableSource::new(Vc::upcast(FileSource::new(*path)))
+                        IntrospectableSource::new(Vc::upcast(FileSource::new(**path)))
                     }
                     DirectoryEntry::Directory(path) => {
                         Vc::upcast(StaticAssetsContentSource::with_prefix(
                             Vc::cell(format!("{}{name}/", &*prefix).into()),
-                            *path,
+                            **path,
                         ))
                     }
                     DirectoryEntry::Other(_) => todo!("what's DirectoryContent::Other?"),

--- a/turbopack/crates/turbopack-ecmascript/src/references/node.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/node.rs
@@ -122,11 +122,11 @@ async fn resolve_reference_from_dir(
             PatternMatch::File(matched_path, file) => {
                 let realpath = file.realpath_with_links().await?;
                 for &symlink in &realpath.symlinks {
-                    affecting_sources.push(Vc::upcast(FileSource::new(symlink)));
+                    affecting_sources.push(Vc::upcast(FileSource::new(*symlink)));
                 }
                 results.push((
                     RequestKey::new(matched_path.clone()),
-                    Vc::upcast(RawModule::new(Vc::upcast(FileSource::new(realpath.path)))),
+                    Vc::upcast(RawModule::new(Vc::upcast(FileSource::new(*realpath.path)))),
                 ));
             }
             PatternMatch::Directory(..) => {}

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -84,7 +84,7 @@ impl DirList {
                 DirectoryEntry::File(path) => {
                     if let Some(relative_path) = root_val.get_relative_path_to(&*path.await?) {
                         if regex.is_match(&relative_path) {
-                            list.insert(relative_path, DirListEntry::File(*path));
+                            list.insert(relative_path, DirListEntry::File(**path));
                         }
                     }
                 }
@@ -93,7 +93,7 @@ impl DirList {
                         list.insert(
                             relative_path,
                             DirListEntry::Dir(DirList::read_internal(
-                                root, *path, recursive, filter,
+                                root, **path, recursive, filter,
                             )),
                         );
                     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
@@ -80,7 +80,7 @@ impl ModuleReference for TsReferencePathAssetReference {
                     .origin
                     .asset_context()
                     .process(
-                        Vc::upcast(FileSource::new(*path)),
+                        Vc::upcast(FileSource::new(**path)),
                         Value::new(ReferenceType::TypeScript(
                             TypeScriptReferenceSubType::Undefined,
                         )),

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -704,7 +704,7 @@ async fn dir_dependency(glob: Vc<ReadGlobResult>) -> Result<Vc<Completion>> {
     let glob = glob.await?;
     glob.inner
         .values()
-        .map(|&inner| dir_dependency(inner))
+        .map(|&inner| dir_dependency(*inner))
         .try_join()
         .await?;
     shallow.await?;

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -150,7 +150,7 @@ pub async fn resolve_node_pre_gyp_files(
                         {
                             sources.insert(
                                 format!("{native_binding_path}/{key}").into(),
-                                Vc::upcast(FileSource::new(dylib)),
+                                Vc::upcast(FileSource::new(*dylib)),
                             );
                         }
                     }
@@ -179,17 +179,17 @@ pub async fn resolve_node_pre_gyp_files(
                         DirectoryEntry::File(dylib) => {
                             sources.insert(
                                 format!("deps/lib/{key}").into(),
-                                Vc::upcast(FileSource::new(dylib)),
+                                Vc::upcast(FileSource::new(*dylib)),
                             );
                         }
                         DirectoryEntry::Symlink(dylib) => {
                             let realpath_with_links = dylib.realpath_with_links().await?;
                             for &symlink in realpath_with_links.symlinks.iter() {
-                                affecting_paths.push(symlink);
+                                affecting_paths.push(*symlink);
                             }
                             sources.insert(
                                 format!("deps/lib/{key}").into(),
-                                Vc::upcast(FileSource::new(realpath_with_links.path)),
+                                Vc::upcast(FileSource::new(*realpath_with_links.path)),
                             );
                         }
                         _ => {}

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -269,7 +269,7 @@ pub async fn tsconfig_resolve_options(
                 let mut context_dir = source.ident().path().parent();
                 if let Some(base_url) = json["compilerOptions"]["baseUrl"].as_str() {
                     if let Some(new_context) = *context_dir.try_join(base_url.into()).await? {
-                        context_dir = new_context;
+                        context_dir = *new_context;
                     }
                 };
                 for (key, value) in paths.iter() {
@@ -336,7 +336,7 @@ pub async fn tsconfig_resolve_options(
     .unwrap_or_default();
 
     Ok(TsConfigResolveOptions {
-        base_url,
+        base_url: base_url.as_deref().copied(),
         import_map,
         is_module_resolution_nodenext,
     }

--- a/turbopack/crates/turbopack-test-utils/src/snapshot.rs
+++ b/turbopack/crates/turbopack-test-utils/src/snapshot.rs
@@ -91,7 +91,7 @@ pub async fn expected(dir: Vc<FileSystemPath>) -> Result<HashSet<Vc<FileSystemPa
         for (file, entry) in entries {
             match entry {
                 DirectoryEntry::File(file) => {
-                    expected.insert(*file);
+                    expected.insert(**file);
                 }
                 _ => bail!(
                     "expected file at {}, found {:?}",


### PR DESCRIPTION
This is a handmade refactor of `turbo-tasks-fs` to switch every struct's field from `Vc<T>` to `ResolvedVc<T>`.

I chose `turbo-tasks-fs` because it's reasonably small, but very widely used, and it has a representative mix of code patterns.

In the process of creating this PR, I wrote up a guide of the steps required to refactor this, in the hope that we can automate most of these steps for most code: https://vercel.notion.site/Codemod-Notes-for-Vc-T-ResolvedVc-T-10ee06b059c480688ebffe5eb983db25