### PR TITLE
Turbopack build: Skip styled-jsx babel plugin test

### DIFF
--- a/test/integration/styled-jsx-plugin/test/index.test.js
+++ b/test/integration/styled-jsx-plugin/test/index.test.js
@@ -20,25 +20,29 @@ function runTests() {
   })
 }
 
-describe('styled-jsx using in node_modules', () => {
-  ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
-    'production mode',
-    () => {
-      beforeAll(async () => {
-        const output = await nextBuild(appDir, undefined, {
-          stdout: true,
-          stderr: true,
-          cwd: appDir,
+// This test is skipped in Turbopack because it uses a custom babelrc.
+;(process.env.TURBOPACK ? describe.skip : describe)(
+  'styled-jsx using in node_modules',
+  () => {
+    ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
+      'production mode',
+      () => {
+        beforeAll(async () => {
+          const output = await nextBuild(appDir, undefined, {
+            stdout: true,
+            stderr: true,
+            cwd: appDir,
+          })
+
+          console.log(output.stdout, output.stderr)
+
+          appPort = await findPort()
+          app = await nextStart(appDir, appPort)
         })
+        afterAll(() => killApp(app))
 
-        console.log(output.stdout, output.stderr)
-
-        appPort = await findPort()
-        app = await nextStart(appDir, appPort)
-      })
-      afterAll(() => killApp(app))
-
-      runTests()
-    }
-  )
-})
+        runTests()
+      }
+    )
+  }
+)

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -14958,10 +14958,10 @@
     },
     "test/integration/styled-jsx-plugin/test/index.test.js": {
       "passed": [],
-      "failed": [
+      "failed": [],
+      "pending": [
         "styled-jsx using in node_modules production mode should serve a page correctly"
       ],
-      "pending": [],
       "flakey": [],
       "runtimeError": false
     },


### PR DESCRIPTION
## What?

Skips a test that checks `.babelrc` with Turbopack.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
