### PR TITLE
next-upgrade: Ensure install packages works on exotic package revisions

### DIFF
--- a/packages/next-codemod/bin/transform.ts
+++ b/packages/next-codemod/bin/transform.ts
@@ -2,7 +2,7 @@ import execa from 'execa'
 import globby from 'globby'
 import prompts from 'prompts'
 import { join } from 'node:path'
-import { installPackage, uninstallPackage } from '../lib/handle-package'
+import { installPackages, uninstallPackage } from '../lib/handle-package'
 import { checkGitStatus, TRANSFORMER_INQUIRER_CHOICES } from '../lib/utils'
 
 function expandFilePathsIfNeeded(filesBeforeExpansion) {
@@ -128,6 +128,6 @@ export async function runTransform(
 
   if (!dry && transformer === 'next-request-geo-ip') {
     console.log('Installing `@vercel/functions`...')
-    installPackage('@vercel/functions')
+    installPackages(['@vercel/functions'])
   }
 }

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -5,7 +5,7 @@ import path from 'path'
 import { compareVersions } from 'compare-versions'
 import chalk from 'chalk'
 import { availableCodemods } from '../lib/codemods'
-import { getPkgManager, installPackage } from '../lib/handle-package'
+import { getPkgManager, installPackages } from '../lib/handle-package'
 
 type StandardVersionSpecifier = 'canary' | 'rc' | 'latest'
 type CustomVersionSpecifier = string
@@ -133,7 +133,7 @@ export async function runUpgrade(): Promise<void> {
     `@types/react-dom@${targetNextPackageJson.devDependencies['@types/react-dom']}`,
   ]
 
-  installPackage([nextDependency, ...reactDependencies], packageManager)
+  installPackages([nextDependency, ...reactDependencies], packageManager)
 
   console.log(
     `Upgrading your project to ${chalk.blue('Next.js ' + targetVersionSpecifier)}...\n`

--- a/packages/next-codemod/lib/handle-package.ts
+++ b/packages/next-codemod/lib/handle-package.ts
@@ -56,19 +56,15 @@ export function uninstallPackage(
   execa.sync(pkgManager, [command, packageToUninstall], { stdio: 'inherit' })
 }
 
-export function installPackage(
-  packageToInstall: string | string[],
+export function installPackages(
+  packageToInstall: string[],
   pkgManager?: PackageManager
 ) {
   pkgManager ??= getPkgManager(process.cwd())
   if (!pkgManager) throw new Error('Failed to find package manager')
 
-  if (Array.isArray(packageToInstall)) {
-    packageToInstall = packageToInstall.join(' ')
-  }
-
   try {
-    execa.sync(pkgManager, ['add', packageToInstall], { stdio: 'inherit' })
+    execa.sync(pkgManager, ['add', ...packageToInstall], { stdio: 'inherit' })
   } catch (error) {
     throw new Error(
       `Failed to install "${packageToInstall}". Please install it manually.`,


### PR DESCRIPTION
Spawning a process with multiple args is not the same as spawning it with
a single arg that was created from `args.join(' ')`.
This works most of the time but broke when I tried to use specific protocols e.g. `@types/react@npm:types-react@rc`.
This is a valid revision but not parsed properly if passed as a single arg to the dependencies.


## test plan

- `node ~/packages/next-codemod/ upgrade` in https://github.com/eps1lon/supabase installs