### PR TITLE
next-upgrade: Remove extraneous if no channel is specified

### DIFF
--- a/packages/next-codemod/bin/next-codemod.ts
+++ b/packages/next-codemod/bin/next-codemod.ts
@@ -46,7 +46,11 @@ program
   .description(
     'Upgrade Next.js apps to desired versions with a single command.'
   )
-  .usage('[options]')
+
+  .argument(
+    '[revision]',
+    'NPM dist tag or exact version to upgrade to (e.g. "latest" or "15.0.0-canary.167"). Prompts to choose a dist tag if omitted.'
+  )
   .action(runUpgrade)
 
 program.parse(process.argv)


### PR DESCRIPTION
You'd always get `Next.js upgrade does not exist.` even though no (faulty) version was specified.

Before:

```bash
$ node ~/packages/next-codemod/bin/next-codemod.js upgrade
Next.js upgrade does not exist. Check available versions at https://www.npmjs.com/package/next?activeTab=versions, or choose one from below
```

After:
```bash
$ node ~/packages/next-codemod/bin/next-codemod.js upgrade  
You are currently using Next.js 15.0.0-canary.173
✔ What Next.js version do you want to upgrade to? › Canary
✔ Turbopack is now the stable default for dev mode. Enable it? … no
Upgrading your project to Next.js canary...
$  node ~/packages/next-codemod/bin/next-codemod.js upgrade rc
✔ Turbopack is now the stable default for dev mode. Enable it? … no
Upgrading your project to Next.js 15.0.0-rc.0...
```