### PR TITLE
next-upgrade: select codemods by canary version

### DIFF
--- a/packages/next-codemod/lib/codemods.ts
+++ b/packages/next-codemod/lib/codemods.ts
@@ -94,15 +94,20 @@ export const availableCodemods: VersionCodemods[] = [
     ],
   },
   {
-    version: '15.0',
+    version: '15.0.0-canary.153',
+    codemods: [
+      {
+        title: 'Migrate `geo` and `ip` properties on `NextRequest`',
+        value: 'next-request-geo-ip',
+      },
+    ],
+  },
+  {
+    version: '15.0.0-canary.171',
     codemods: [
       {
         title: 'Transforms usage of Next.js async Request APIs',
         value: 'next-async-request-api',
-      },
-      {
-        title: 'Migrate `geo` and `ip` properties on `NextRequest`',
-        value: 'next-request-geo-ip',
       },
     ],
   },


### PR DESCRIPTION
Otherwise new codemods will not be selected until a stable release is out. Without this change, none of the new codemods was currently suggested.

## test plan

```bash
$ node ~/packages/next-codemod/bin/next-codemod.js upgrade
You are currently using Next.js 14.2.13
✔ What Next.js version do you want to upgrade to? › Canary
✔ Turbopack is now the stable default for dev mode. Enable it? … no
Upgrading your project to Next.js canary...

The following codemods are available for your upgrade:
- Migrate `geo` and `ip` properties on `NextRequest` (next-request-geo-ip)
- Transforms usage of Next.js async Request APIs (next-async-request-api)

```