### PR TITLE
Error consistently during prospective prerender

### DIFF
--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -300,7 +300,7 @@ export function abortAndThrowOnSynchronousDynamicDataAccess(
   prerenderStore: PrerenderStore
 ): never {
   abortOnSynchronousDynamicDataAccess(route, expression, prerenderStore)
-  throw new Error(
+  throw createPrerenderInterruptedError(
     `Route ${route} needs to bail out of prerendering at this point because it used ${expression}.`
   )
 }

--- a/packages/next/src/server/request/utils.ts
+++ b/packages/next/src/server/request/utils.ts
@@ -33,7 +33,7 @@ export function describeHasCheckingStringProperty(
   prop: string
 ) {
   const stringifiedProp = JSON.stringify(prop)
-  return `\`Reflect.has(${target}, ${stringifiedProp}\`, \`${stringifiedProp} in ${target}\`, or similar`
+  return `\`Reflect.has(${target}, ${stringifiedProp})\`, \`${stringifiedProp} in ${target}\`, or similar`
 }
 
 export function throwWithStaticGenerationBailoutError(

--- a/test/e2e/app-dir/dynamic-io/app/params/semantics/[lowcard]/[highcard]/sync/layout-access/client/layout.tsx
+++ b/test/e2e/app-dir/dynamic-io/app/params/semantics/[lowcard]/[highcard]/sync/layout-access/client/layout.tsx
@@ -11,6 +11,10 @@ export default async function Page({
   params: Promise<{ lowcard: string; highcard: string }>
   children: React.ReactNode
 }) {
+  // We wait an extra microtask to avoid erroring before some sibling branches have completed.
+  // In a future update we will make this a build error and explicitly test it but to keep the spirit of
+  // this test in tact we contrive a slightly delayed sync access
+  await 1
   const syncParams = params as unknown as UnsafeUnwrappedParams<typeof params>
   return (
     <section>

--- a/test/e2e/app-dir/dynamic-io/app/params/semantics/[lowcard]/[highcard]/sync/layout-has/client/layout.tsx
+++ b/test/e2e/app-dir/dynamic-io/app/params/semantics/[lowcard]/[highcard]/sync/layout-has/client/layout.tsx
@@ -11,6 +11,10 @@ export default async function Page({
   params: Promise<{ lowcard: string; highcard: string }>
   children: React.ReactNode
 }) {
+  // We wait an extra microtask to avoid erroring before some sibling branches have completed.
+  // In a future update we will make this a build error and explicitly test it but to keep the spirit of
+  // this test in tact we contrive a slightly delayed sync access
+  await 1
   const syncParams = params as unknown as UnsafeUnwrappedParams<typeof params>
   return (
     <section>

--- a/test/e2e/app-dir/dynamic-io/app/params/semantics/[lowcard]/[highcard]/sync/layout-spread/client/layout.tsx
+++ b/test/e2e/app-dir/dynamic-io/app/params/semantics/[lowcard]/[highcard]/sync/layout-spread/client/layout.tsx
@@ -11,6 +11,10 @@ export default async function Page({
   params: Promise<{ lowcard: string; highcard: string }>
   children: React.ReactNode
 }) {
+  // We wait an extra microtask to avoid erroring before some sibling branches have completed.
+  // In a future update we will make this a build error and explicitly test it but to keep the spirit of
+  // this test in tact we contrive a slightly delayed sync access
+  await 1
   const syncParams = params as unknown as UnsafeUnwrappedParams<typeof params>
   const copied = { ...syncParams }
   return (

--- a/test/e2e/app-dir/dynamic-io/app/params/semantics/[lowcard]/[highcard]/sync/page-access/client/page.tsx
+++ b/test/e2e/app-dir/dynamic-io/app/params/semantics/[lowcard]/[highcard]/sync/page-access/client/page.tsx
@@ -9,6 +9,10 @@ export default async function Page({
 }: {
   params: Promise<{ lowcard: string; highcard: string }>
 }) {
+  // We wait an extra microtask to avoid erroring before some sibling branches have completed.
+  // In a future update we will make this a build error and explicitly test it but to keep the spirit of
+  // this test in tact we contrive a slightly delayed sync access
+  await 1
   const syncParams = params as unknown as UnsafeUnwrappedParams<typeof params>
   return (
     <section>

--- a/test/e2e/app-dir/dynamic-io/app/params/semantics/[lowcard]/[highcard]/sync/page-has/client/page.tsx
+++ b/test/e2e/app-dir/dynamic-io/app/params/semantics/[lowcard]/[highcard]/sync/page-has/client/page.tsx
@@ -9,6 +9,10 @@ export default async function Page({
 }: {
   params: Promise<{ lowcard: string; highcard: string }>
 }) {
+  // We wait an extra microtask to avoid erroring before some sibling branches have completed.
+  // In a future update we will make this a build error and explicitly test it but to keep the spirit of
+  // this test in tact we contrive a slightly delayed sync access
+  await 1
   const syncParams = params as unknown as UnsafeUnwrappedParams<typeof params>
   return (
     <section>

--- a/test/e2e/app-dir/dynamic-io/app/params/semantics/[lowcard]/[highcard]/sync/page-spread/client/page.tsx
+++ b/test/e2e/app-dir/dynamic-io/app/params/semantics/[lowcard]/[highcard]/sync/page-spread/client/page.tsx
@@ -9,6 +9,10 @@ export default async function Page({
 }: {
   params: Promise<{ lowcard: string; highcard: string }>
 }) {
+  // We wait an extra microtask to avoid erroring before some sibling branches have completed.
+  // In a future update we will make this a build error and explicitly test it but to keep the spirit of
+  // this test in tact we contrive a slightly delayed sync access
+  await 1
   const syncParams = params as unknown as UnsafeUnwrappedParams<typeof params>
   const copied = { ...syncParams }
   return (

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.search.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.search.test.ts
@@ -287,10 +287,10 @@ describe('dynamic-io', () => {
         expect($('#page').text()).toBe('at runtime')
         expect(searchWarnings).toEqual([
           expect.stringContaining(
-            '`Reflect.has(searchParams, "sentinel"`, `"sentinel" in searchParams`, or similar'
+            '`Reflect.has(searchParams, "sentinel")`, `"sentinel" in searchParams`, or similar'
           ),
           expect.stringContaining(
-            '`Reflect.has(searchParams, "foo"`, `"foo" in searchParams`, or similar'
+            '`Reflect.has(searchParams, "foo")`, `"foo" in searchParams`, or similar'
           ),
         ])
       } else {
@@ -314,10 +314,10 @@ describe('dynamic-io', () => {
         expect($('#page').text()).toBe('at runtime')
         expect(searchWarnings).toEqual([
           expect.stringContaining(
-            '`Reflect.has(searchParams, "sentinel"`, `"sentinel" in searchParams`, or similar'
+            '`Reflect.has(searchParams, "sentinel")`, `"sentinel" in searchParams`, or similar'
           ),
           expect.stringContaining(
-            '`Reflect.has(searchParams, "foo"`, `"foo" in searchParams`, or similar'
+            '`Reflect.has(searchParams, "foo")`, `"foo" in searchParams`, or similar'
           ),
         ])
       } else {
@@ -341,10 +341,10 @@ describe('dynamic-io', () => {
         expect($('#page').text()).toBe('at runtime')
         expect(searchWarnings).toEqual([
           expect.stringContaining(
-            '`Reflect.has(searchParams, "sentinel"`, `"sentinel" in searchParams`, or similar'
+            '`Reflect.has(searchParams, "sentinel")`, `"sentinel" in searchParams`, or similar'
           ),
           expect.stringContaining(
-            '`Reflect.has(searchParams, "foo"`, `"foo" in searchParams`, or similar'
+            '`Reflect.has(searchParams, "foo")`, `"foo" in searchParams`, or similar'
           ),
         ])
       } else {
@@ -366,10 +366,10 @@ describe('dynamic-io', () => {
         expect($('#page').text()).toBe('at runtime')
         expect(searchWarnings).toEqual([
           expect.stringContaining(
-            '`Reflect.has(searchParams, "sentinel"`, `"sentinel" in searchParams`, or similar'
+            '`Reflect.has(searchParams, "sentinel")`, `"sentinel" in searchParams`, or similar'
           ),
           expect.stringContaining(
-            '`Reflect.has(searchParams, "foo"`, `"foo" in searchParams`, or similar'
+            '`Reflect.has(searchParams, "foo")`, `"foo" in searchParams`, or similar'
           ),
         ])
       } else {
@@ -605,10 +605,10 @@ describe('dynamic-io', () => {
         expect($('#page').text()).toBe('at runtime')
         expect(searchWarnings).toEqual([
           expect.stringContaining(
-            '`Reflect.has(searchParams, "sentinel"`, `"sentinel" in searchParams`, or similar.'
+            '`Reflect.has(searchParams, "sentinel")`, `"sentinel" in searchParams`, or similar.'
           ),
           expect.stringContaining(
-            'Reflect.has(searchParams, "foo"`, `"foo" in searchParams`, or similar.'
+            'Reflect.has(searchParams, "foo")`, `"foo" in searchParams`, or similar.'
           ),
         ])
       } else {
@@ -628,10 +628,10 @@ describe('dynamic-io', () => {
         expect($('#page').text()).toBe('at runtime')
         expect(searchWarnings).toEqual([
           expect.stringContaining(
-            '`Reflect.has(searchParams, "sentinel"`, `"sentinel" in searchParams`, or similar.'
+            '`Reflect.has(searchParams, "sentinel")`, `"sentinel" in searchParams`, or similar.'
           ),
           expect.stringContaining(
-            'Reflect.has(searchParams, "foo"`, `"foo" in searchParams`, or similar.'
+            'Reflect.has(searchParams, "foo")`, `"foo" in searchParams`, or similar.'
           ),
         ])
       } else {
@@ -655,10 +655,10 @@ describe('dynamic-io', () => {
         expect($('#page').text()).toBe('at runtime')
         expect(searchWarnings).toEqual([
           expect.stringContaining(
-            '`Reflect.has(searchParams, "sentinel"`, `"sentinel" in searchParams`, or similar.'
+            '`Reflect.has(searchParams, "sentinel")`, `"sentinel" in searchParams`, or similar.'
           ),
           expect.stringContaining(
-            'Reflect.has(searchParams, "foo"`, `"foo" in searchParams`, or similar.'
+            'Reflect.has(searchParams, "foo")`, `"foo" in searchParams`, or similar.'
           ),
         ])
       } else {
@@ -678,10 +678,10 @@ describe('dynamic-io', () => {
         expect($('#page').text()).toBe('at runtime')
         expect(searchWarnings).toEqual([
           expect.stringContaining(
-            '`Reflect.has(searchParams, "sentinel"`, `"sentinel" in searchParams`, or similar.'
+            '`Reflect.has(searchParams, "sentinel")`, `"sentinel" in searchParams`, or similar.'
           ),
           expect.stringContaining(
-            'Reflect.has(searchParams, "foo"`, `"foo" in searchParams`, or similar.'
+            'Reflect.has(searchParams, "foo")`, `"foo" in searchParams`, or similar.'
           ),
         ])
       } else {

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.test.ts
@@ -12,6 +12,11 @@ describe('dynamic-io', () => {
     return
   }
 
+  it('should not have route specific errors', async () => {
+    expect(next.cliOutput).not.toMatch('Error: Route /')
+    expect(next.cliOutput).not.toMatch('Error occurred prerendering page')
+  })
+
   it('should prerender fully static pages', async () => {
     let $ = await next.render$('/cases/static', {})
     if (isNextDev) {


### PR DESCRIPTION
When `dynamicIO` is enabled there is a prospective render used to fill caches. Previously we ignored errors during this phase. However this might mask user errors that are flakey. With this change we consider errors during the prospective render valid and throw them to the same handling logic that handles errors for the final render. We exclude control errors like prerender complete and prerender interrupted.