### PR TITLE
next-upgrade: Hide install output by default

### DIFF
--- a/packages/next-codemod/bin/next-codemod.ts
+++ b/packages/next-codemod/bin/next-codemod.ts
@@ -51,6 +51,7 @@ program
     '[revision]',
     'NPM dist tag or exact version to upgrade to (e.g. "latest" or "15.0.0-canary.167"). Prompts to choose a dist tag if omitted.'
   )
+  .option('-v, --verbose', 'Verbose output', false)
   .action(runUpgrade)
 
 program.parse(process.argv)

--- a/packages/next-codemod/bin/next-codemod.ts
+++ b/packages/next-codemod/bin/next-codemod.ts
@@ -51,7 +51,7 @@ program
     '[revision]',
     'NPM dist tag or exact version to upgrade to (e.g. "latest" or "15.0.0-canary.167"). Prompts to choose a dist tag if omitted.'
   )
-  .option('-v, --verbose', 'Verbose output', false)
+  .option('--verbose', 'Verbose output', false)
   .action(runUpgrade)
 
 program.parse(process.argv)

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -35,7 +35,11 @@ async function loadHighestNPMVersionMatching(query: string) {
   return versions[versions.length - 1]
 }
 
-export async function runUpgrade(revision: string | undefined): Promise<void> {
+export async function runUpgrade(
+  revision: string | undefined,
+  options: { verbose: boolean }
+): Promise<void> {
+  const { verbose } = options
   const appPackageJsonPath = path.resolve(process.cwd(), 'package.json')
   let appPackageJson = JSON.parse(fs.readFileSync(appPackageJsonPath, 'utf8'))
 
@@ -183,7 +187,10 @@ export async function runUpgrade(revision: string | undefined): Promise<void> {
     `Upgrading your project to ${chalk.blue('Next.js ' + targetVersionSpecifier)}...\n`
   )
 
-  installPackages([nextDependency, ...reactDependencies], packageManager)
+  installPackages([nextDependency, ...reactDependencies], {
+    packageManager,
+    silent: !verbose,
+  })
 
   await suggestCodemods(installedNextVersion, targetNextVersion)
 

--- a/packages/next-codemod/lib/handle-package.ts
+++ b/packages/next-codemod/lib/handle-package.ts
@@ -58,13 +58,18 @@ export function uninstallPackage(
 
 export function installPackages(
   packageToInstall: string[],
-  pkgManager?: PackageManager
+  options: { packageManager?: PackageManager; silent?: boolean } = {}
 ) {
-  pkgManager ??= getPkgManager(process.cwd())
-  if (!pkgManager) throw new Error('Failed to find package manager')
+  const { packageManager = getPkgManager(process.cwd()), silent = false } =
+    options
+
+  if (!packageManager) throw new Error('Failed to find package manager')
 
   try {
-    execa.sync(pkgManager, ['add', ...packageToInstall], { stdio: 'inherit' })
+    execa.sync(packageManager, ['add', ...packageToInstall], {
+      // Keeping stderr since it'll likely be relevant later when it fails.
+      stdio: silent ? ['ignore', 'ignore', 'inherit'] : 'inherit',
+    })
   } catch (error) {
     throw new Error(
       `Failed to install "${packageToInstall}". Please install it manually.`,


### PR DESCRIPTION
Takes up 80% of terminal output when the user is given the choice to apply codemods.
That's a lot of noise to parse out even though it's not interesting since the install succeeded.
In the error case, we still print stderr to the user.

## test plan

- [x] `upgrade --verbose` includes all install output
- [x] `upgrade --no-verbose` still includes e.g. `npm error code ERESOLVE` if the install fails