### PR TITLE
next-upgrade: Allow custom selection of codemods

### DIFF
--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -337,20 +337,18 @@ async function suggestCodemods(
     return
   }
 
-  let codemodsString = `\nThe following ${chalk.blue('codemods')} are available for your upgrade:`
-  relevantCodemods.forEach((codemod) => {
-    codemodsString += `\n- ${codemod.title} ${chalk.gray(`(${codemod.value})`)}`
-  })
-  codemodsString += '\n'
-
-  console.log(codemodsString)
-
-  const responseCodemods = await prompts(
+  const { codemods } = await prompts(
     {
-      type: 'confirm',
-      name: 'apply',
-      message: `Do you want to apply these codemods?`,
-      initial: true,
+      type: 'multiselect',
+      name: 'codemods',
+      message: `\nThe following ${chalk.blue('codemods')} are recommended for your upgrade. Would you like to apply them?`,
+      choices: relevantCodemods.map((codemod) => {
+        return {
+          title: `${codemod.title} ${chalk.grey(`(${codemod.value})`)}`,
+          value: codemod.value,
+          selected: true,
+        }
+      }),
     },
     {
       onCancel: () => {
@@ -359,13 +357,9 @@ async function suggestCodemods(
     }
   )
 
-  if (!responseCodemods.apply) {
-    return
-  }
-
-  for (const codemod of relevantCodemods) {
+  for (const codemod of codemods) {
     execSync(
-      `npx @next/codemod@latest ${codemod.value} ${process.cwd()} --force`,
+      `npx --yes @next/codemod@latest ${codemod} ${process.cwd()} --force`,
       {
         stdio: 'inherit',
       }


### PR DESCRIPTION
Instead of having to choose between all or none of the codemods, each application
can now be select up front.
We select all by default so that you still have just one keypress
for the happy path.
But sometimes codemods are added later.
Or we have codemods that may not be suitable depending on how code is structured.
Or we have optional codemods.

For me specifically it was just motivated by not being able to select a specific version yet
and skipping the async API codemod while it's under development.

https://github.com/user-attachments/assets/cab5187e-1f4f-454c-9785-73a9b29273fe

