### PR TITLE
next-upgrade: Allow choosing same codemods that are available in the currently used version

### DIFF
--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -6,6 +6,7 @@ import { compareVersions } from 'compare-versions'
 import chalk from 'chalk'
 import { availableCodemods } from '../lib/codemods'
 import { getPkgManager, installPackages } from '../lib/handle-package'
+import { runTransform } from './transform'
 
 type StandardVersionSpecifier = 'canary' | 'rc' | 'latest'
 type CustomVersionSpecifier = string
@@ -358,11 +359,6 @@ async function suggestCodemods(
   )
 
   for (const codemod of codemods) {
-    execSync(
-      `npx --yes @next/codemod@latest ${codemod} ${process.cwd()} --force`,
-      {
-        stdio: 'inherit',
-      }
-    )
+    await runTransform(codemod, process.cwd(), { force: true })
   }
 }


### PR DESCRIPTION
Using `npx next-codemod@latest <codemod>` means you can't actually use the codemods we suggest when you run `npx next-codemod` at a different version.

It's also unnecessary indirection and overhead at this point.