### PR TITLE
next-upgrade: Default to release channel that's used

### DIFF
--- a/packages/next-codemod/bin/next-codemod.ts
+++ b/packages/next-codemod/bin/next-codemod.ts
@@ -51,6 +51,7 @@ program
     '[revision]',
     'NPM dist tag or exact version to upgrade to (e.g. "latest" or "15.0.0-canary.167"). Prompts to choose a dist tag if omitted.'
   )
+  .option('-v, --verbose', 'Verbose output', false)
   .action(runUpgrade)
 
 program.parse(process.argv)

--- a/packages/next-codemod/bin/next-codemod.ts
+++ b/packages/next-codemod/bin/next-codemod.ts
@@ -51,7 +51,7 @@ program
     '[revision]',
     'NPM dist tag or exact version to upgrade to (e.g. "latest" or "15.0.0-canary.167"). Prompts to choose a dist tag if omitted.'
   )
-  .option('-v, --verbose', 'Verbose output', false)
+  .option('--verbose', 'Verbose output', false)
   .action(runUpgrade)
 
 program.parse(process.argv)

--- a/packages/next-codemod/bin/next-codemod.ts
+++ b/packages/next-codemod/bin/next-codemod.ts
@@ -49,7 +49,12 @@ program
 
   .argument(
     '[revision]',
-    'NPM dist tag or exact version to upgrade to (e.g. "latest" or "15.0.0-canary.167"). Prompts to choose a dist tag if omitted.'
+    'NPM dist tag or exact version to upgrade to (e.g. "latest" or "15.0.0-canary.167"). Valid dist-tags are "latest", "canary" or "rc".',
+    packageJson.version.includes('-canary.')
+      ? 'canary'
+      : packageJson.version.includes('-rc.')
+        ? 'rc'
+        : 'latest'
   )
   .option('--verbose', 'Verbose output', false)
   .action(runUpgrade)

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -8,14 +8,7 @@ import { availableCodemods } from '../lib/codemods'
 import { getPkgManager, installPackages } from '../lib/handle-package'
 import { runTransform } from './transform'
 
-type StandardVersionSpecifier = 'canary' | 'rc' | 'latest'
-type CustomVersionSpecifier = string
-type VersionSpecifier = StandardVersionSpecifier | CustomVersionSpecifier
 type PackageManager = 'pnpm' | 'npm' | 'yarn' | 'bun'
-
-interface Response {
-  version: StandardVersionSpecifier
-}
 
 /**
  * @param query
@@ -50,92 +43,17 @@ export async function runUpgrade(
     version: string
     peerDependencies: Record<string, string>
   }
-  let targetVersionSpecifier: VersionSpecifier = ''
 
-  if (revision !== undefined) {
-    const res = await fetch(`https://registry.npmjs.org/next/${revision}`)
-    if (res.status === 200) {
-      targetNextPackageJson = await res.json()
-      targetVersionSpecifier = targetNextPackageJson.version
-    } else {
-      console.error(
-        `${chalk.yellow(`next@${revision}`)} does not exist. Check available versions at ${chalk.underline('https://www.npmjs.com/package/next?activeTab=versions')}, or choose one from below\n`
-      )
-    }
+  const res = await fetch(`https://registry.npmjs.org/next/${revision}`)
+  if (res.status === 200) {
+    targetNextPackageJson = await res.json()
+  } else {
+    throw new Error(
+      `${chalk.yellow(`next@${revision}`)} does not exist. Check available versions at ${chalk.underline('https://www.npmjs.com/package/next?activeTab=versions')}.`
+    )
   }
 
   const installedNextVersion = await getInstalledNextVersion()
-
-  if (!targetNextPackageJson) {
-    let nextPackageJson: { [key: string]: any } = {}
-    try {
-      const resCanary = await fetch(`https://registry.npmjs.org/next/canary`)
-      nextPackageJson['canary'] = await resCanary.json()
-
-      const resRc = await fetch(`https://registry.npmjs.org/next/rc`)
-      nextPackageJson['rc'] = await resRc.json()
-
-      const resLatest = await fetch(`https://registry.npmjs.org/next/latest`)
-      nextPackageJson['latest'] = await resLatest.json()
-    } catch (error) {
-      console.error('Failed to fetch versions from npm registry.')
-      return
-    }
-
-    let showRc = true
-    if (nextPackageJson['latest'].version && nextPackageJson['rc'].version) {
-      showRc =
-        compareVersions(
-          nextPackageJson['rc'].version,
-          nextPackageJson['latest'].version
-        ) === 1
-    }
-
-    const choices = [
-      {
-        title: 'Canary',
-        value: 'canary',
-        description: `Experimental version with latest features (${nextPackageJson['canary'].version})`,
-      },
-    ]
-    if (showRc) {
-      choices.push({
-        title: 'Release Candidate',
-        value: 'rc',
-        description: `Pre-release version for final testing (${nextPackageJson['rc'].version})`,
-      })
-    }
-    choices.push({
-      title: 'Stable',
-      value: 'latest',
-      description: `Production-ready release (${nextPackageJson['latest'].version})`,
-    })
-
-    if (installedNextVersion) {
-      console.log(
-        `You are currently using ${chalk.blue('Next.js ' + installedNextVersion)}`
-      )
-    }
-
-    const initialVersionSpecifierIdx = await getVersionSpecifierIdx(
-      installedNextVersion,
-      showRc
-    )
-
-    const response: Response = await prompts(
-      {
-        type: 'select',
-        name: 'version',
-        message: 'What Next.js version do you want to upgrade to?',
-        choices: choices,
-        initial: initialVersionSpecifierIdx,
-      },
-      { onCancel: () => process.exit(0) }
-    )
-
-    targetNextPackageJson = nextPackageJson[response.version]
-    targetVersionSpecifier = response.version
-  }
 
   const targetNextVersion = targetNextPackageJson.version
 
@@ -190,7 +108,7 @@ export async function runUpgrade(
   }
 
   console.log(
-    `Upgrading your project to ${chalk.blue('Next.js ' + targetVersionSpecifier)}...\n`
+    `Upgrading your project to ${chalk.blue('Next.js ' + targetNextVersion)}...\n`
   )
 
   installPackages([nextDependency, ...reactDependencies], {
@@ -242,27 +160,6 @@ async function getInstalledNextVersion(): Promise<string> {
   )
 
   return installedNextPackageJson.version
-}
-
-/*
- * Returns the index of the current version's specifier in the
- * array ['canary', 'rc', 'latest'] or ['canary', 'latest']
- */
-async function getVersionSpecifierIdx(
-  installedNextVersion: string,
-  showRc: boolean
-): Promise<number> {
-  if (installedNextVersion == null) {
-    return 0
-  }
-
-  if (installedNextVersion.includes('canary')) {
-    return 0
-  }
-  if (installedNextVersion.includes('rc')) {
-    return 1
-  }
-  return showRc ? 2 : 1
 }
 
 /*

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -6,6 +6,7 @@ import { compareVersions } from 'compare-versions'
 import chalk from 'chalk'
 import { availableCodemods } from '../lib/codemods'
 import { getPkgManager, installPackages } from '../lib/handle-package'
+import { runTransform } from './transform'
 
 type StandardVersionSpecifier = 'canary' | 'rc' | 'latest'
 type CustomVersionSpecifier = string
@@ -358,11 +359,6 @@ async function suggestCodemods(
   )
 
   for (const codemod of codemods) {
-    execSync(
-      `npx --yes @next/codemod@latest ${codemod} ${process.cwd()} --force`,
-      {
-        stdio: 'inherit',
-      }
-    )
+    await runTransform(codemod, process.cwd(), { force: true })
   }
 }

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -337,20 +337,18 @@ async function suggestCodemods(
     return
   }
 
-  let codemodsString = `\nThe following ${chalk.blue('codemods')} are available for your upgrade:`
-  relevantCodemods.forEach((codemod) => {
-    codemodsString += `\n- ${codemod.title} ${chalk.gray(`(${codemod.value})`)}`
-  })
-  codemodsString += '\n'
-
-  console.log(codemodsString)
-
-  const responseCodemods = await prompts(
+  const { codemods } = await prompts(
     {
-      type: 'confirm',
-      name: 'apply',
-      message: `Do you want to apply these codemods?`,
-      initial: true,
+      type: 'multiselect',
+      name: 'codemods',
+      message: `\nThe following ${chalk.blue('codemods')} are recommended for your upgrade. Would you like to apply them?`,
+      choices: relevantCodemods.map((codemod) => {
+        return {
+          title: `${codemod.title} ${chalk.grey(`(${codemod.value})`)}`,
+          value: codemod.value,
+          selected: true,
+        }
+      }),
     },
     {
       onCancel: () => {
@@ -359,13 +357,9 @@ async function suggestCodemods(
     }
   )
 
-  if (!responseCodemods.apply) {
-    return
-  }
-
-  for (const codemod of relevantCodemods) {
+  for (const codemod of codemods) {
     execSync(
-      `npx @next/codemod@latest ${codemod.value} ${process.cwd()} --force`,
+      `npx --yes @next/codemod@latest ${codemod} ${process.cwd()} --force`,
       {
         stdio: 'inherit',
       }

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -35,7 +35,11 @@ async function loadHighestNPMVersionMatching(query: string) {
   return versions[versions.length - 1]
 }
 
-export async function runUpgrade(revision: string | undefined): Promise<void> {
+export async function runUpgrade(
+  revision: string | undefined,
+  options: { verbose: boolean }
+): Promise<void> {
+  const { verbose } = options
   const appPackageJsonPath = path.resolve(process.cwd(), 'package.json')
   let appPackageJson = JSON.parse(fs.readFileSync(appPackageJsonPath, 'utf8'))
 
@@ -183,7 +187,10 @@ export async function runUpgrade(revision: string | undefined): Promise<void> {
     `Upgrading your project to ${chalk.blue('Next.js ' + targetVersionSpecifier)}...\n`
   )
 
-  installPackages([nextDependency, ...reactDependencies], packageManager)
+  installPackages([nextDependency, ...reactDependencies], {
+    packageManager,
+    silent: !verbose,
+  })
 
   await suggestCodemods(installedNextVersion, targetNextVersion)
 

--- a/packages/next-codemod/lib/codemods.ts
+++ b/packages/next-codemod/lib/codemods.ts
@@ -94,15 +94,20 @@ export const availableCodemods: VersionCodemods[] = [
     ],
   },
   {
-    version: '15.0',
+    version: '15.0.0-canary.153',
+    codemods: [
+      {
+        title: 'Migrate `geo` and `ip` properties on `NextRequest`',
+        value: 'next-request-geo-ip',
+      },
+    ],
+  },
+  {
+    version: '15.0.0-canary.171',
     codemods: [
       {
         title: 'Transforms usage of Next.js async Request APIs',
         value: 'next-async-request-api',
-      },
-      {
-        title: 'Migrate `geo` and `ip` properties on `NextRequest`',
-        value: 'next-request-geo-ip',
       },
     ],
   },

--- a/packages/next-codemod/lib/handle-package.ts
+++ b/packages/next-codemod/lib/handle-package.ts
@@ -58,13 +58,18 @@ export function uninstallPackage(
 
 export function installPackages(
   packageToInstall: string[],
-  pkgManager?: PackageManager
+  options: { packageManager?: PackageManager; silent?: boolean } = {}
 ) {
-  pkgManager ??= getPkgManager(process.cwd())
-  if (!pkgManager) throw new Error('Failed to find package manager')
+  const { packageManager = getPkgManager(process.cwd()), silent = false } =
+    options
+
+  if (!packageManager) throw new Error('Failed to find package manager')
 
   try {
-    execa.sync(pkgManager, ['add', ...packageToInstall], { stdio: 'inherit' })
+    execa.sync(packageManager, ['add', ...packageToInstall], {
+      // Keeping stderr since it'll likely be relevant later when it fails.
+      stdio: silent ? ['ignore', 'ignore', 'inherit'] : 'inherit',
+    })
   } catch (error) {
     throw new Error(
       `Failed to install "${packageToInstall}". Please install it manually.`,


### PR DESCRIPTION
For example, `npx @next/codemod@canary` will default to the Canary release channel.
`npx @next/codemod@latest` will use the Stable release channel.

This works by reading the `version` field in the `package.json`.
If `canary` is in the version, it will default to the Canary release channel.
If `rc` is in the version, it will default to the RC release channel.
Otherwise we use `latest`.