### PR TITLE
fix: fix warnings from invalid api's called from edge runtime

### DIFF
--- a/packages/next/src/lib/scheduler.ts
+++ b/packages/next/src/lib/scheduler.ts
@@ -15,7 +15,11 @@ export const scheduleOnNextTick = <T = void>(cb: ScheduledFn<T>): void => {
   // This was inspired by the implementation of the DataLoader interface: https://github.com/graphql/dataloader/blob/d336bd15282664e0be4b4a657cb796f09bafbc6b/src/index.js#L213-L255
   //
   Promise.resolve().then(() => {
-    process.nextTick(cb)
+    if (process.env.NEXT_RUNTIME === 'edge') {
+      setTimeout(cb, 0)
+    } else {
+      process.nextTick(cb)
+    }
   })
 }
 

--- a/packages/next/src/server/async-storage/cache-scope.ts
+++ b/packages/next/src/server/async-storage/cache-scope.ts
@@ -1,11 +1,11 @@
-import { AsyncLocalStorage } from 'async_hooks'
+import { createAsyncLocalStorage } from '../../client/components/async-local-storage'
 
 export interface CacheScopeStore {
   cache?: Map<string, any>
 }
 
 export const cacheScopeAsyncLocalStorage =
-  new AsyncLocalStorage<CacheScopeStore>()
+  createAsyncLocalStorage<CacheScopeStore>()
 
 /**
  * For dynamic IO handling we want to have a scoped memory


### PR DESCRIPTION
Updates some API's so that they aren't calling unsupported Node.js API's while in the Edge runtime.