### PR TITLE
fix: clone response in first handler to prevent race (#70082)

### DIFF
--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -735,7 +735,14 @@ function createPatchedFetcher(
 
           if (pendingRevalidate) {
             const res: Response = await pendingRevalidate
-            return res.clone()
+            const clonedResponse = res.clone()
+
+            return {
+              body: await clonedResponse.arrayBuffer(),
+              headers: clonedResponse.headers,
+              status: clonedResponse.status,
+              statusText: clonedResponse.statusText,
+            }
           }
           return (staticGenerationStore.pendingRevalidates[cacheKey] =
             doOriginalFetch(true, cacheReasonOverride).finally(async () => {
@@ -757,7 +764,7 @@ function createPatchedFetcher(
   patched.__nextGetStaticStore = () => staticGenerationAsyncStorage
   patched._nextOriginalFetch = originFetch
 
-  return patched
+  return patched as PatchedFetcher
 }
 
 // we patch fetch to collect cache information used for

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -735,21 +735,18 @@ function createPatchedFetcher(
 
           if (pendingRevalidate) {
             const res: Response = await pendingRevalidate
-            const clonedResponse = res.clone()
-
-            return {
-              body: await clonedResponse.arrayBuffer(),
-              headers: clonedResponse.headers,
-              status: clonedResponse.status,
-              statusText: clonedResponse.statusText,
-            }
+            return res.clone()
           }
           return (staticGenerationStore.pendingRevalidates[cacheKey] =
-            doOriginalFetch(true, cacheReasonOverride).finally(async () => {
-              staticGenerationStore.pendingRevalidates ??= {}
-              delete staticGenerationStore.pendingRevalidates[cacheKey || '']
-              await handleUnlock()
-            }))
+            doOriginalFetch(true, cacheReasonOverride)
+              .then((res) => {
+                return res.clone()
+              })
+              .finally(async () => {
+                staticGenerationStore.pendingRevalidates ??= {}
+                delete staticGenerationStore.pendingRevalidates[cacheKey || '']
+                await handleUnlock()
+              }))
         } else {
           return doOriginalFetch(false, cacheReasonOverride).finally(
             handleUnlock


### PR DESCRIPTION
This fixes a race where if the body was resolved before the clone operation, it would clone later, resulting in an error being thrown due to the body already being consumed.

backports #70082