### PR TITLE
Change default SWR delta value to 1 year

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/swrDelta.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/swrDelta.mdx
@@ -16,4 +16,4 @@ module.exports = {
 }
 ```
 
-Now instead of an empty `stale-while-revalidate` period being provided in the `Cache-Control` header, the custom period will be included.
+Now instead of the default of 1 year `stale-while-revalidate` period being provided in the `Cache-Control` header, the custom period will be included.

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1001,7 +1001,7 @@ export const defaultConfig: NextConfig = {
     keepAlive: true,
   },
   logging: {},
-  swrDelta: undefined,
+  swrDelta: process.env.__NEXT_TEST_MODE ? undefined : 31536000,
   staticPageGenerationTimeout: 60,
   output: !!process.env.NEXT_PRIVATE_STANDALONE ? 'standalone' : undefined,
   modularizeImports: undefined,


### PR DESCRIPTION
As previously discussed we've talked about ensuring this `stale-while-revalidate` can be consumed by CDNs by default which means we need to have a default SWR delta so this defaults to one year although it can still be customized via the `swrDelta` config. 

One gotcha with this is users when testing locally with `next start` or there is no CDN consuming the header browsers will consume the header. This gotcha is worth the change as it can be configured and most proper setups should be behind a CDN to consume this header. 