### PR TITLE
Recommend `React.use()` to unwrap async APIs in the browser

### DIFF
--- a/packages/next/src/server/request/params.browser.ts
+++ b/packages/next/src/server/request/params.browser.ts
@@ -121,7 +121,7 @@ function makeDynamicallyTrackedExoticParamsWithDevWarnings(
 
 function warnForSyncAccess(expression: string) {
   console.error(
-    `A param property was accessed directly with ${expression}. \`params\` is now a Promise and should be awaited before accessing properties of the underlying params object. In this version of Next.js direct access to param properties is still supported to facilitate migration but in a future version you will be required to await \`params\`. If this use is inside an async function await it. If this use is inside a synchronous function then convert the function to async or await it from outside this function and pass the result in.`
+    `A param property was accessed directly with ${expression}. \`params\` is now a Promise and should be unwrapped with \`React.use()\` before accessing properties of the underlying params object. In this version of Next.js direct access to param properties is still supported to facilitate migration but in a future version you will be required to unwrap \`params\` with \`React.use()\`.`
   )
 }
 
@@ -130,11 +130,11 @@ function warnForEnumeration(missingProperties: Array<string>) {
     const describedMissingProperties =
       describeListOfPropertyNames(missingProperties)
     console.error(
-      `params are being enumerated incompletely with \`{...params}\`, \`Object.keys(params)\`, or similar. The following properties were not copied: ${describedMissingProperties}. \`params\` is now a Promise, however in the current version of Next.js direct access to the underlying params object is still supported to facilitate migration to the new type. param names that conflict with Promise properties cannot be accessed directly and must be accessed by first awaiting the \`params\` promise.`
+      `params are being enumerated incompletely with \`{...params}\`, \`Object.keys(params)\`, or similar. The following properties were not copied: ${describedMissingProperties}. \`params\` is now a Promise, however in the current version of Next.js direct access to the underlying params object is still supported to facilitate migration to the new type. param names that conflict with Promise properties cannot be accessed directly and must be accessed by first unwrapping the \`params\` promise with \`React.use()\`.`
     )
   } else {
     console.error(
-      `params are being enumerated with \`{...params}\`, \`Object.keys(params)\`, or similar. \`params\` is now a Promise, however in the current version of Next.js direct access to the underlying params object is still supported to facilitate migration to the new type. You should update your code to await \`params\` before accessing its properties.`
+      `params are being enumerated with \`{...params}\`, \`Object.keys(params)\`, or similar. \`params\` is now a Promise, however in the current version of Next.js direct access to the underlying params object is still supported to facilitate migration to the new type. You should update your code to unwrap \`params\` with \`React.use()\` before accessing its properties.`
     )
   }
 }

--- a/packages/next/src/server/request/search-params.browser.ts
+++ b/packages/next/src/server/request/search-params.browser.ts
@@ -121,12 +121,12 @@ function makeUntrackedExoticSearchParams(
 
 function warnForSyncAccess(expression: string) {
   console.error(
-    `A searchParam property was accessed directly with ${expression}. \`searchParams\` is now a Promise and should be awaited before accessing properties of the underlying searchParams object. In this version of Next.js direct access to searchParam properties is still supported to facilitate migration but in a future version you will be required to await \`searchParams\`. If this use is inside an async function await it. If this use is inside a synchronous function then convert the function to async or await it from outside this function and pass the result in.`
+    `A searchParam property was accessed directly with ${expression}. \`searchParams\` is now a Promise and should be unwrapped with \`React.use()\` before accessing properties of the underlying searchParams object. In this version of Next.js direct access to searchParam properties is still supported to facilitate migration but in a future version you will be required to unwrap \`searchParams\` with \`React.use()\`.`
   )
 }
 
 function warnForSyncSpread() {
   console.error(
-    `the keys of \`searchParams\` were accessed through something like \`Object.keys(searchParams)\` or \`{...searchParams}\`. \`searchParams\` is now a Promise and should be awaited before accessing properties of the underlying searchParams object. In this version of Next.js direct access to searchParam properties is still supported to facilitate migration but in a future version you will be required to await \`searchParams\`. If this use is inside an async function await it. If this use is inside a synchronous function then convert the function to async or await it from outside this function and pass the result in.`
+    `the keys of \`searchParams\` were accessed through something like \`Object.keys(searchParams)\` or \`{...searchParams}\`. \`searchParams\` is now a Promise and should be unwrapped with \`React.use()\` in Client Components before accessing properties of the underlying searchParams object. In this version of Next.js direct access to searchParam properties is still supported to facilitate migration but in a future version you will be required to unwrap \`searchParams\` with \`React.use()\`.`
   )
 }


### PR DESCRIPTION
We were recommending `await` which isn't available in Client components.

We also need to fork the message for the Node.js build because `await` is
not available in any Client render e.g. during SSR.