### PR TITLE
docs(link): add mention about how App Router prefetches on hover

### DIFF
--- a/docs/02-app/02-api-reference/01-components/link.mdx
+++ b/docs/02-app/02-api-reference/01-components/link.mdx
@@ -291,7 +291,7 @@ export default function Home() {
 
 <AppOnly>
 
-Prefetching happens when a `<Link />` component enters the user's viewport (initially or through scroll). Next.js prefetches and loads the linked route (denoted by the `href`) and its data in the background to improve the performance of client-side navigation's. **Prefetching is only enabled in production**.
+Prefetching happens when a `<Link />` component enters the user's viewport (initially or through scroll). Next.js prefetches and loads the linked route (denoted by the `href`) and its data in the background to improve the performance of client-side navigation's. If the prefetched data has expired by the time the `<Link />` is clicked, Next.js will attempt to prefetch again on hover. **Prefetching is only enabled in production**.
 
 The following values can be passed to the `prefetch` prop:
 

--- a/docs/02-app/02-api-reference/01-components/link.mdx
+++ b/docs/02-app/02-api-reference/01-components/link.mdx
@@ -291,7 +291,7 @@ export default function Home() {
 
 <AppOnly>
 
-Prefetching happens when a `<Link />` component enters the user's viewport (initially or through scroll). Next.js prefetches and loads the linked route (denoted by the `href`) and its data in the background to improve the performance of client-side navigations. If the prefetched data has expired by the time the user hovers over `<Link />`, Next.js will attempt to prefetch it again. **Prefetching is only enabled in production**.
+Prefetching happens when a `<Link />` component enters the user's viewport (initially or through scroll). Next.js prefetches and loads the linked route (denoted by the `href`) and its data in the background to improve the performance of client-side navigations. If the prefetched data has expired by the time the user hovers over a `<Link />`, Next.js will attempt to prefetch it again. **Prefetching is only enabled in production**.
 
 The following values can be passed to the `prefetch` prop:
 

--- a/docs/02-app/02-api-reference/01-components/link.mdx
+++ b/docs/02-app/02-api-reference/01-components/link.mdx
@@ -291,7 +291,7 @@ export default function Home() {
 
 <AppOnly>
 
-Prefetching happens when a `<Link />` component enters the user's viewport (initially or through scroll). Next.js prefetches and loads the linked route (denoted by the `href`) and its data in the background to improve the performance of client-side navigation's. If the prefetched data has expired by the time the `<Link />` is clicked, Next.js will attempt to prefetch again on hover. **Prefetching is only enabled in production**.
+Prefetching happens when a `<Link />` component enters the user's viewport (initially or through scroll). Next.js prefetches and loads the linked route (denoted by the `href`) and its data in the background to improve the performance of client-side navigations. If the prefetched data has expired by the time the user hovers over the link, Next.js will attempt to prefetch it again. **Prefetching is only enabled in production**.
 
 The following values can be passed to the `prefetch` prop:
 

--- a/docs/02-app/02-api-reference/01-components/link.mdx
+++ b/docs/02-app/02-api-reference/01-components/link.mdx
@@ -291,7 +291,7 @@ export default function Home() {
 
 <AppOnly>
 
-Prefetching happens when a `<Link />` component enters the user's viewport (initially or through scroll). Next.js prefetches and loads the linked route (denoted by the `href`) and its data in the background to improve the performance of client-side navigations. If the prefetched data has expired by the time the user hovers over the link, Next.js will attempt to prefetch it again. **Prefetching is only enabled in production**.
+Prefetching happens when a `<Link />` component enters the user's viewport (initially or through scroll). Next.js prefetches and loads the linked route (denoted by the `href`) and its data in the background to improve the performance of client-side navigations. If the prefetched data has expired by the time the user hovers over `<Link />`, Next.js will attempt to prefetch it again. **Prefetching is only enabled in production**.
 
 The following values can be passed to the `prefetch` prop:
 


### PR DESCRIPTION
## Why?

There is no mention of how App Router uses hover for prefetching (`null`, and `true`). There is only a mention of hover for the `false` state.

- Fixes https://github.com/vercel/next.js/issues/70473