### PR TITLE
Separate the rendering of viewport from metadata

### DIFF
--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -1,12 +1,9 @@
 import type { ParsedUrlQuery } from 'querystring'
-import type {
-  AppRenderContext,
-  GetDynamicParamFromSegment,
-} from '../../server/app-render/app-render'
+import type { GetDynamicParamFromSegment } from '../../server/app-render/app-render'
 import type { LoaderTree } from '../../server/lib/app-dir-module'
 import type { CreateServerParamsForMetadata } from '../../server/request/params'
 
-import React from 'react'
+import { cache, cloneElement } from 'react'
 import {
   AppleWebAppMeta,
   FormatDetectionMeta,
@@ -23,7 +20,11 @@ import {
   AppLinksMeta,
 } from './generate/opengraph'
 import { IconsMetadata } from './generate/icons'
-import { resolveMetadata } from './resolve-metadata'
+import {
+  resolveMetadataItems,
+  accumulateMetadata,
+  accumulateViewport,
+} from './resolve-metadata'
 import { MetaFilter } from './generate/meta'
 import type {
   ResolvedMetadata,
@@ -32,49 +33,6 @@ import type {
 import { isNotFoundError } from '../../client/components/not-found'
 import type { MetadataContext } from './types/resolvers'
 import type { StaticGenerationStore } from '../../client/components/static-generation-async-storage.external'
-import { trackFallbackParamAccessed } from '../../server/app-render/dynamic-rendering'
-
-export function createMetadataContext(
-  pathname: string,
-  renderOpts: AppRenderContext['renderOpts']
-): MetadataContext {
-  return {
-    pathname,
-    trailingSlash: renderOpts.trailingSlash,
-    isStandaloneMode: renderOpts.nextConfigOutput === 'standalone',
-  }
-}
-
-export function createTrackedMetadataContext(
-  pathname: string,
-  renderOpts: AppRenderContext['renderOpts'],
-  staticGenerationStore: StaticGenerationStore | null
-): MetadataContext {
-  return {
-    // Use the regular metadata context, but we trap the pathname access.
-    ...createMetadataContext(pathname, renderOpts),
-
-    // Setup the trap around the pathname access so we can track when the
-    // pathname is accessed while resolving metadata which would indicate it's
-    // being used to resolve a relative URL. If that's the case, we don't want
-    // to provide it, and instead we should error.
-    get pathname() {
-      if (
-        staticGenerationStore &&
-        staticGenerationStore.isStaticGeneration &&
-        staticGenerationStore.fallbackRouteParams &&
-        staticGenerationStore.fallbackRouteParams.size > 0
-      ) {
-        trackFallbackParamAccessed(
-          staticGenerationStore,
-          'metadata relative url resolving'
-        )
-      }
-
-      return pathname
-    },
-  }
-}
 
 // Use a promise to share the status of the metadata resolving,
 // returning two components `MetadataTree` and `MetadataOutlet`
@@ -101,15 +59,52 @@ export function createMetadataComponents({
   createServerParamsForMetadata: CreateServerParamsForMetadata
   staticGenerationStore: StaticGenerationStore
 }): [React.ComponentType, () => Promise<void>] {
-  let currentMetadataReady:
-    | null
-    | (Promise<void> & {
-        status?: string
-        value?: unknown
-      }) = null
+  function MetadataRoot() {
+    return (
+      <>
+        <Metadata />
+        <Viewport />
+        {appUsingSizeAdjustment ? <meta name="next-size-adjust" /> : null}
+      </>
+    )
+  }
 
-  async function MetadataTree() {
-    const pendingMetadata = getResolvedMetadata(
+  async function viewport() {
+    return getResolvedViewport(
+      tree,
+      searchParams,
+      getDynamicParamFromSegment,
+      createServerParamsForMetadata,
+      staticGenerationStore,
+      errorType
+    )
+  }
+
+  async function Viewport() {
+    try {
+      return await viewport()
+    } catch (error) {
+      if (!errorType && isNotFoundError(error)) {
+        try {
+          return await getNotFoundViewport(
+            tree,
+            searchParams,
+            getDynamicParamFromSegment,
+            createServerParamsForMetadata,
+            staticGenerationStore
+          )
+        } catch {}
+      }
+      // We don't actually want to error in this component. We will
+      // also error in the MetadataOutlet which causes the error to
+      // bubble from the right position in the page to be caught by the
+      // appropriate boundaries
+      return null
+    }
+  }
+
+  async function metadata() {
+    return getResolvedMetadata(
       tree,
       searchParams,
       getDynamicParamFromSegment,
@@ -118,62 +113,43 @@ export function createMetadataComponents({
       staticGenerationStore,
       errorType
     )
-
-    // We instrument the promise compatible with React. This isn't necessary but we can
-    // perform a similar trick in synchronously unwrapping in the outlet component to avoid
-    // ticking a new microtask unecessarily
-    const metadataReady: Promise<void> & { status: string; value: unknown } =
-      pendingMetadata.then(
-        ([error]) => {
-          if (error) {
-            metadataReady.status = 'rejected'
-            metadataReady.value = error
-            throw error
-          }
-          metadataReady.status = 'fulfilled'
-          metadataReady.value = undefined
-        },
-        (error) => {
-          metadataReady.status = 'rejected'
-          metadataReady.value = error
-          throw error
-        }
-      ) as Promise<void> & { status: string; value: unknown }
-    metadataReady.status = 'pending'
-    currentMetadataReady = metadataReady
-    // We aren't going to await this promise immediately but if it rejects early we don't
-    // want unhandled rejection errors so we attach a throwaway catch handler.
-    metadataReady.catch(() => {})
-
-    // We ignore any error from metadata here because it needs to be thrown from within the Page
-    // not where the metadata itself is actually rendered
-    const [, elements] = await pendingMetadata
-
-    return (
-      <>
-        {elements.map((el, index) => {
-          return React.cloneElement(el as React.ReactElement, { key: index })
-        })}
-        {appUsingSizeAdjustment ? <meta name="next-size-adjust" /> : null}
-      </>
-    )
   }
 
-  function getMetadataReady() {
-    return Promise.resolve().then(() => {
-      if (currentMetadataReady) {
-        return currentMetadataReady
+  async function Metadata() {
+    try {
+      return await metadata()
+    } catch (error) {
+      if (!errorType && isNotFoundError(error)) {
+        try {
+          return await getNotFoundMetadata(
+            tree,
+            searchParams,
+            getDynamicParamFromSegment,
+            metadataContext,
+            createServerParamsForMetadata,
+            staticGenerationStore
+          )
+        } catch {}
       }
-      throw new Error(
-        'getMetadataReady was called before MetadataTree rendered'
-      )
-    })
+      // We don't actually want to error in this component. We will
+      // also error in the MetadataOutlet which causes the error to
+      // bubble from the right position in the page to be caught by the
+      // appropriate boundaries
+      return null
+    }
   }
 
-  return [MetadataTree, getMetadataReady]
+  async function getMetadataAndViewportReady(): Promise<void> {
+    await viewport()
+    await metadata()
+    return undefined
+  }
+
+  return [MetadataRoot, getMetadataAndViewportReady]
 }
 
-async function getResolvedMetadata(
+const getResolvedMetadata = cache(getResolvedMetadataImpl)
+async function getResolvedMetadataImpl(
   tree: LoaderTree,
   searchParams: Promise<ParsedUrlQuery>,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
@@ -181,58 +157,123 @@ async function getResolvedMetadata(
   createServerParamsForMetadata: CreateServerParamsForMetadata,
   staticGenerationStore: StaticGenerationStore,
   errorType?: 'not-found' | 'redirect'
-): Promise<[any, Array<React.ReactNode>]> {
-  const errorMetadataItem: [null, null, null] = [null, null, null]
+): Promise<React.ReactNode> {
   const errorConvention = errorType === 'redirect' ? undefined : errorType
 
-  const [error, metadata, viewport] = await resolveMetadata({
+  const metadataItems = await resolveMetadataItems(
     tree,
-    parentParams: {},
-    metadataItems: [],
-    errorMetadataItem,
     searchParams,
-    getDynamicParamFromSegment,
     errorConvention,
-    metadataContext,
+    getDynamicParamFromSegment,
     createServerParamsForMetadata,
-    staticGenerationStore,
-  })
-  if (!error) {
-    return [null, createMetadataElements(metadata, viewport)]
-  } else {
-    // If a not-found error is triggered during metadata resolution, we want to capture the metadata
-    // for the not-found route instead of whatever triggered the error. For all error types, we resolve an
-    // error, which will cause the outlet to throw it so it'll be handled by an error boundary
-    // (either an actual error, or an internal error that renders UI such as the NotFoundBoundary).
-    if (!errorType && isNotFoundError(error)) {
-      const [notFoundMetadataError, notFoundMetadata, notFoundViewport] =
-        await resolveMetadata({
-          tree,
-          parentParams: {},
-          metadataItems: [],
-          errorMetadataItem,
-          searchParams,
-          getDynamicParamFromSegment,
-          errorConvention: 'not-found',
-          metadataContext,
-          createServerParamsForMetadata,
-          staticGenerationStore,
-        })
-      return [
-        notFoundMetadataError || error,
-        createMetadataElements(notFoundMetadata, notFoundViewport),
-      ]
-    }
-    return [error, []]
-  }
+    staticGenerationStore
+  )
+  const elements: Array<React.ReactNode> = createMetadataElements(
+    await accumulateMetadata(metadataItems, metadataContext)
+  )
+  return (
+    <>
+      {elements.map((el, index) => {
+        return cloneElement(el as React.ReactElement, { key: index })
+      })}
+    </>
+  )
 }
 
-function createMetadataElements(
-  metadata: ResolvedMetadata,
-  viewport: ResolvedViewport
-) {
+const getNotFoundMetadata = cache(getNotFoundMetadataImpl)
+async function getNotFoundMetadataImpl(
+  tree: LoaderTree,
+  searchParams: Promise<ParsedUrlQuery>,
+  getDynamicParamFromSegment: GetDynamicParamFromSegment,
+  metadataContext: MetadataContext,
+  createServerParamsForMetadata: CreateServerParamsForMetadata,
+  staticGenerationStore: StaticGenerationStore
+): Promise<React.ReactNode> {
+  const notFoundErrorConvention = 'not-found'
+  const notFoundMetadataItems = await resolveMetadataItems(
+    tree,
+    searchParams,
+    notFoundErrorConvention,
+    getDynamicParamFromSegment,
+    createServerParamsForMetadata,
+    staticGenerationStore
+  )
+
+  const elements: Array<React.ReactNode> = createMetadataElements(
+    await accumulateMetadata(notFoundMetadataItems, metadataContext)
+  )
+  return (
+    <>
+      {elements.map((el, index) => {
+        return cloneElement(el as React.ReactElement, { key: index })
+      })}
+    </>
+  )
+}
+
+const getResolvedViewport = cache(getResolvedViewportImpl)
+async function getResolvedViewportImpl(
+  tree: LoaderTree,
+  searchParams: Promise<ParsedUrlQuery>,
+  getDynamicParamFromSegment: GetDynamicParamFromSegment,
+  createServerParamsForMetadata: CreateServerParamsForMetadata,
+  staticGenerationStore: StaticGenerationStore,
+  errorType?: 'not-found' | 'redirect'
+): Promise<React.ReactNode> {
+  const errorConvention = errorType === 'redirect' ? undefined : errorType
+
+  const metadataItems = await resolveMetadataItems(
+    tree,
+    searchParams,
+    errorConvention,
+    getDynamicParamFromSegment,
+    createServerParamsForMetadata,
+    staticGenerationStore
+  )
+  const elements: Array<React.ReactNode> = createViewportElements(
+    await accumulateViewport(metadataItems)
+  )
+  return (
+    <>
+      {elements.map((el, index) => {
+        return cloneElement(el as React.ReactElement, { key: index })
+      })}
+    </>
+  )
+}
+
+const getNotFoundViewport = cache(getNotFoundViewportImpl)
+async function getNotFoundViewportImpl(
+  tree: LoaderTree,
+  searchParams: Promise<ParsedUrlQuery>,
+  getDynamicParamFromSegment: GetDynamicParamFromSegment,
+  createServerParamsForMetadata: CreateServerParamsForMetadata,
+  staticGenerationStore: StaticGenerationStore
+): Promise<React.ReactNode> {
+  const notFoundErrorConvention = 'not-found'
+  const notFoundMetadataItems = await resolveMetadataItems(
+    tree,
+    searchParams,
+    notFoundErrorConvention,
+    getDynamicParamFromSegment,
+    createServerParamsForMetadata,
+    staticGenerationStore
+  )
+
+  const elements: Array<React.ReactNode> = createViewportElements(
+    await accumulateViewport(notFoundMetadataItems)
+  )
+  return (
+    <>
+      {elements.map((el, index) => {
+        return cloneElement(el as React.ReactElement, { key: index })
+      })}
+    </>
+  )
+}
+
+function createMetadataElements(metadata: ResolvedMetadata) {
   return MetaFilter([
-    ViewportMeta({ viewport: viewport }),
     BasicMeta({ metadata }),
     AlternatesMetadata({ alternates: metadata.alternates }),
     ItunesMeta({ itunes: metadata.itunes }),
@@ -245,4 +286,8 @@ function createMetadataElements(
     AppLinksMeta({ appLinks: metadata.appLinks }),
     IconsMetadata({ icons: metadata.icons }),
   ])
+}
+
+function createViewportElements(viewport: ResolvedViewport) {
+  return MetaFilter([ViewportMeta({ viewport: viewport })])
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -48,10 +48,9 @@ import {
   RSC_HEADER,
 } from '../../client/components/app-router-headers'
 import {
-  createMetadataComponents,
   createTrackedMetadataContext,
   createMetadataContext,
-} from '../../lib/metadata/metadata'
+} from '../../lib/metadata/metadata-context'
 import { withRequestStore } from '../async-storage/with-request-store'
 import { withStaticGenerationStore } from '../async-storage/with-static-generation-store'
 import { isNotFoundError } from '../../client/components/not-found'
@@ -389,6 +388,7 @@ async function generateDynamicRSCPayload(
       tree: loaderTree,
       createServerSearchParamsForMetadata,
       createServerParamsForMetadata,
+      createMetadataComponents,
     },
     getDynamicParamFromSegment,
     appUsingSizeAdjustment,
@@ -571,6 +571,7 @@ async function getRSCPayload(
       GlobalError,
       createServerSearchParamsForMetadata,
       createServerParamsForMetadata,
+      createMetadataComponents,
     },
     requestStore: { url },
     staticGenerationStore,
@@ -672,6 +673,7 @@ async function getErrorRSCPayload(
       GlobalError,
       createServerSearchParamsForMetadata,
       createServerParamsForMetadata,
+      createMetadataComponents,
     },
     requestStore: { url },
     requestId,

--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -29,6 +29,7 @@ import {
 } from '../request/params'
 import * as serverHooks from '../../client/components/hooks-server-context'
 import { NotFoundBoundary } from '../../client/components/not-found-boundary'
+import { createMetadataComponents } from '../../lib/metadata/metadata'
 import { patchFetch as _patchFetch } from '../lib/patch-fetch'
 // not being used but needs to be included in the client manifest for /_not-found
 import '../../client/components/error-boundary'
@@ -69,4 +70,5 @@ export {
   ClientSegmentRoot,
   NotFoundBoundary,
   patchFetch,
+  createMetadataComponents,
 }


### PR DESCRIPTION
viewport will never be streaming because is necessarily blocks important shell time rendering with things like themeColor and viewport size. Most other metadata can be streamed in if we're not serving an agent which doesn't construct a DOM. This change doesn't actually make metadata streaming but it does further separate the two so we can more easily alter the rendering characteristics of metadata without affecting viewport.

The approach is to ensure the metadata component creation is in the react-server layer in the server module graph so it can access `React.cache`. then we construct a pair of functions that can produce the resolved metadata and viewport values, throwing if there is an encountered error. We suppress these errors in our top level metadata component (MetadataRoot) and and simultaneously expose a ready function which calls these (`React.cache()`'d) functions in the Metadata outlet where any errors will throw.

This cleans up the layering quite a bit and makes some runtime error checks unecessary such as ensuring you rendered the MetadataRoot before attempting to determine if the metadata was resolved.

The key thing achieved here though is that Metadata and Viewport now resolve in parallel but separately. We avoid double walking the module graph by again making use of `React.cache()`. In the future we can render each of these components differently without affecting each other.

This work is motivated more immediately by some error tracking work I will land after this that needs to determine whether viewport or metadata were dynamic independently.

There is one semantic difference worth calling out. Previously if you called `notFound()` in `generateMetadata()` or `generateViewport()` both would render the appropriate not found metadata/viewport. In this latest update only the one that called notFound will update to reflect the notFound metadata/viewport. I think fundamentally the approach to handling notFound needs to change here. Really we should be abandoning the render and starting over. This will be doubly important once metadata is streaming. I'm ok with the edge case as is given customizing viewport is not very common and calling notFound from within generateViewport is expected to be an edge case of an edge case. The workaround for now is to call notFound simultaneously from both generateViewport and generateMetadata