### PR TITLE
[Turbopack] AutoMap, AutoSet and CountHashSet use FxHasher by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,6 +564,7 @@ dependencies = [
 name = "auto-hash-map"
 version = "0.1.0"
 dependencies = [
+ "rustc-hash",
  "serde",
  "smallvec",
 ]

--- a/turbopack/crates/turbo-tasks-auto-hash-map/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-auto-hash-map/Cargo.toml
@@ -9,5 +9,6 @@ edition = "2021"
 workspace = true
 
 [dependencies]
+rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 smallvec = { workspace = true }

--- a/turbopack/crates/turbo-tasks-auto-hash-map/src/map.rs
+++ b/turbopack/crates/turbo-tasks-auto-hash-map/src/map.rs
@@ -1,11 +1,12 @@
 use std::{
     borrow::Borrow,
-    collections::{hash_map::RandomState, HashMap},
+    collections::HashMap,
     fmt::{Debug, Formatter},
-    hash::{BuildHasher, Hash},
+    hash::{BuildHasher, BuildHasherDefault, Hash},
     marker::PhantomData,
 };
 
+use rustc_hash::FxHasher;
 use serde::{
     de::{MapAccess, Visitor},
     ser::SerializeMap,
@@ -16,7 +17,7 @@ use smallvec::SmallVec;
 use crate::{MAX_LIST_SIZE, MIN_HASH_SIZE};
 
 #[derive(Clone)]
-pub enum AutoMap<K, V, H = RandomState, const I: usize = 0> {
+pub enum AutoMap<K, V, H = BuildHasherDefault<FxHasher>, const I: usize = 0> {
     List(SmallVec<[(K, V); I]>),
     Map(Box<HashMap<K, V, H>>),
 }
@@ -33,7 +34,7 @@ impl<K: Debug, V: Debug, H, const I: usize> Debug for AutoMap<K, V, H, I> {
     }
 }
 
-impl<K, V> AutoMap<K, V, RandomState, 0> {
+impl<K, V> AutoMap<K, V, BuildHasherDefault<FxHasher>, 0> {
     /// see [HashMap::new](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.new)
     pub const fn new() -> Self {
         AutoMap::List(SmallVec::new_const())

--- a/turbopack/crates/turbo-tasks-auto-hash-map/src/set.rs
+++ b/turbopack/crates/turbo-tasks-auto-hash-map/src/set.rs
@@ -1,16 +1,16 @@
 use std::{
-    collections::hash_map::RandomState,
     fmt::Debug,
-    hash::{BuildHasher, Hash},
+    hash::{BuildHasher, BuildHasherDefault, Hash},
     marker::PhantomData,
 };
 
+use rustc_hash::FxHasher;
 use serde::{Deserialize, Serialize};
 
 use crate::AutoMap;
 
 #[derive(Clone)]
-pub struct AutoSet<K, H = RandomState, const I: usize = 0> {
+pub struct AutoSet<K, H = BuildHasherDefault<FxHasher>, const I: usize = 0> {
     map: AutoMap<K, (), H, I>,
 }
 
@@ -28,7 +28,7 @@ impl<K: Debug, H, const I: usize> Debug for AutoSet<K, H, I> {
     }
 }
 
-impl<K> AutoSet<K, RandomState, 0> {
+impl<K> AutoSet<K, BuildHasherDefault<FxHasher>, 0> {
     /// see [HashSet::new](https://doc.rust-lang.org/std/collections/hash_set/struct.HashSet.html#method.new)
     pub const fn new() -> Self {
         Self {

--- a/turbopack/crates/turbo-tasks-memory/src/count_hash_set.rs
+++ b/turbopack/crates/turbo-tasks-memory/src/count_hash_set.rs
@@ -1,8 +1,7 @@
 use std::{
     borrow::Borrow,
-    collections::hash_map::RandomState,
     fmt::{Debug, Formatter},
-    hash::{BuildHasher, Hash},
+    hash::{BuildHasher, BuildHasherDefault, Hash},
     iter::FilterMap,
 };
 
@@ -10,9 +9,10 @@ use auto_hash_map::{
     map::{Entry, Iter, RawEntry},
     AutoMap,
 };
+use rustc_hash::FxHasher;
 
 #[derive(Clone)]
-pub struct CountHashSet<T, H = RandomState> {
+pub struct CountHashSet<T, H = BuildHasherDefault<FxHasher>> {
     inner: AutoMap<T, isize, H>,
     negative_entries: usize,
 }


### PR DESCRIPTION
### What?

Use FxHasher instead of RandomState for better performance and less memory

### Why?

There is no risk of a DoS attacks here