### PR TITLE
Ensure that client reference module export names are not mangled

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -88,6 +88,7 @@ import {
   getBabelLoader,
   getReactCompilerLoader,
 } from './get-babel-loader-config'
+import type { NextFlightLoaderOptions } from './webpack/loaders/next-flight-loader'
 
 type ExcludesFalse = <T>(x: T | false) => x is T
 type ClientEntries = {
@@ -525,7 +526,7 @@ export default async function getBaseWebpackConfig(
     loader: 'next-flight-loader',
     options: {
       isEdgeServer,
-    },
+    } satisfies NextFlightLoaderOptions,
   }
 
   const appServerLayerLoaders = hasAppDir

--- a/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
@@ -2,19 +2,30 @@ import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import { RSC_MOD_REF_PROXY_ALIAS } from '../../../../lib/constants'
 import {
   BARREL_OPTIMIZATION_PREFIX,
+  DEFAULT_RUNTIME_WEBPACK,
+  EDGE_RUNTIME_WEBPACK,
   RSC_MODULE_TYPES,
 } from '../../../../shared/lib/constants'
 import { warnOnce } from '../../../../shared/lib/utils/warn-once'
 import { getRSCModuleInformation } from '../../../analysis/get-page-static-info'
 import { formatBarrelOptimizedResource } from '../../utils'
 import { getModuleBuildInfo } from '../get-module-build-info'
+import type {
+  javascript,
+  LoaderContext,
+} from 'next/dist/compiled/webpack/webpack'
+
+export interface NextFlightLoaderOptions {
+  isEdgeServer: boolean
+}
+
+type SourceType = javascript.JavascriptParser['sourceType'] | 'commonjs'
 
 const noopHeadPath = require.resolve('next/dist/client/components/noop-head')
 // For edge runtime it will be aliased to esm version by webpack
 const MODULE_PROXY_PATH =
   'next/dist/build/webpack/loaders/next-flight-loader/module-proxy'
 
-type SourceType = 'auto' | 'commonjs' | 'module'
 export function getAssumedSourceType(
   mod: webpack.Module,
   sourceType: SourceType
@@ -45,7 +56,7 @@ export function getAssumedSourceType(
 }
 
 export default function transformSource(
-  this: any,
+  this: LoaderContext<NextFlightLoaderOptions>,
   source: string,
   sourceMap: any
 ) {
@@ -56,10 +67,11 @@ export default function transformSource(
 
   const options = this.getOptions()
   const { isEdgeServer } = options
+  const module = this._module!
 
   // Assign the RSC meta information to buildInfo.
   // Exclude next internal files which are not marked as client files
-  const buildInfo = getModuleBuildInfo(this._module)
+  const buildInfo = getModuleBuildInfo(module)
   buildInfo.rsc = getRSCModuleInformation(source, true)
 
   // Resource key is the unique identifier for the resource. When RSC renders
@@ -75,19 +87,20 @@ export default function transformSource(
   // Because of that, we must add another query param to the resource key to
   // differentiate them.
   let resourceKey: string = this.resourcePath
-  if (this._module?.matchResource?.startsWith(BARREL_OPTIMIZATION_PREFIX)) {
+  if (module.matchResource?.startsWith(BARREL_OPTIMIZATION_PREFIX)) {
     resourceKey = formatBarrelOptimizedResource(
       resourceKey,
-      this._module.matchResource
+      module.matchResource
     )
   }
 
   // A client boundary.
   if (buildInfo.rsc?.type === RSC_MODULE_TYPES.client) {
     const assumedSourceType = getAssumedSourceType(
-      this._module,
-      this._module?.parser?.sourceType
+      module,
+      (module.parser as javascript.JavascriptParser).sourceType
     )
+
     const clientRefs = buildInfo.rsc.clientRefs!
 
     if (assumedSourceType === 'module') {
@@ -99,6 +112,17 @@ export default function transformSource(
         )
         return
       }
+
+      const runtime = isEdgeServer
+        ? EDGE_RUNTIME_WEBPACK
+        : DEFAULT_RUNTIME_WEBPACK
+
+      // Prevent module concatenation, and prevent export names from being mangled,
+      // in production builds, so that exports of client reference modules can be
+      // resolved by React using the metadata from the client manifest.
+      this._compilation!.moduleGraph.getExportsInfo(module).setUsedInUnknownWay(
+        runtime
+      )
 
       // `proxy` is the module proxy that we treat the module as a client boundary.
       // For ESM, we access the property of the module proxy directly for each export.

--- a/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
@@ -26,7 +26,10 @@ const noopHeadPath = require.resolve('next/dist/client/components/noop-head')
 // For edge runtime it will be aliased to esm version by webpack
 const MODULE_PROXY_PATH =
   'next/dist/build/webpack/loaders/next-flight-loader/module-proxy'
-const isSharedRuntime = picomatch('**/next/dist/**/*.shared-runtime.js')
+
+const isSharedRuntime = picomatch('**/next/dist/**/*.shared-runtime.js', {
+  dot: true, // required for .pnpm paths
+})
 
 export function getAssumedSourceType(
   mod: webpack.Module,
@@ -120,6 +123,7 @@ export default function transformSource(
         // mangled, in production builds, so that exports of client reference
         // modules can be resolved by React using the metadata from the client
         // manifest.
+        console.log('XXX', resourceKey)
         this._compilation!.moduleGraph.getExportsInfo(
           module
         ).setUsedInUnknownWay(

--- a/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
@@ -123,7 +123,6 @@ export default function transformSource(
         // mangled, in production builds, so that exports of client reference
         // modules can be resolved by React using the metadata from the client
         // manifest.
-        console.log('XXX', resourceKey)
         this._compilation!.moduleGraph.getExportsInfo(
           module
         ).setUsedInUnknownWay(

--- a/packages/next/types/$$compiled.internal.d.ts
+++ b/packages/next/types/$$compiled.internal.d.ts
@@ -561,6 +561,7 @@ declare module 'next/dist/compiled/webpack/webpack' {
     ModuleFilenameHelpers,
   } from 'webpack'
   export type {
+    javascript,
     LoaderDefinitionFunction,
     LoaderContext,
     ModuleGraph,


### PR DESCRIPTION
This is required for client reference modules in the RSC layer to be resolvable by React using the metadata from the client manifest.

Using `setUsedInUnknownWay` to tell Webpack that exports are used in an unknown way is preferable over injecting runtime code that accesses the exports dynamically.

The change is covered by the test `use-cache > should cache results` (`pnpm test-start test/e2e/app-dir/use-cache/use-cache.test.ts`), which currently fails in #70524.

As a follow-up, we need to do something similar in Turbopack as well.