### PR TITLE
fix(turbopack): Remove wrong check for `__turbopack_refresh__`

### DIFF
--- a/test/integration/telemetry/pages/warning.skip
+++ b/test/integration/telemetry/pages/warning.skip
@@ -1,8 +1,8 @@
 function a(v) {
   return v
 }
-;['index.js'].forEach(f => {
-  require(a('./dynamic-file-imports/' + f))
+;['index.js'].forEach(async f => {
+  await import(a('./dynamic-file-imports/' + f))
 })
 
 export default () => 'Warn'

--- a/test/production/app-dir/actions-tree-shaking/reexport/reexport.test.ts
+++ b/test/production/app-dir/actions-tree-shaking/reexport/reexport.test.ts
@@ -36,7 +36,8 @@ import { retry } from 'next-test-utils'
           rsc: process.env.TURBOPACK ? 1 : 3,
         },
         'app/named-reexport/client/page': {
-          'action-browser': 3,
+          // Turbopack supports tree-shaking these re-exports
+          'action-browser': process.env.TURBOPACK ? 1 : 3,
         },
       })
     })

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/util.rs
@@ -519,13 +519,6 @@ impl Visit for ShouldSkip {
             return;
         }
 
-        // This is needed to pass some tests even if we enable tree shaking only for production
-        // builds.
-        if n.is_ident_ref_to("__turbopack_refresh__") {
-            self.skip = true;
-            return;
-        }
-
         n.visit_children_with(self);
     }
 


### PR DESCRIPTION
### What?

Remove a wrong check for turbopack tree shaking

### Why?

It's not necessary anymore

### How?

