### PR TITLE
Fix missing `await` of `params` when metadata is used

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
@@ -88,7 +88,7 @@ async function nextMetadataImageLoader(
     }
 
     export default async function (props) {
-      const { __metadata_id__: _, ...params } = props.params
+      const { __metadata_id__: _, ...params } = await props.params
       const imageUrl = fillMetadataSegment(${JSON.stringify(
         pathnamePrefix
       )}, params, ${JSON.stringify(pageSegment)})


### PR DESCRIPTION
## test plan

- [x] No more warnings when visiting `/` while running `pnpm next dev test/e2e/app-dir/metadata-dynamic-routes`