### PR TITLE
Turbopack: next/dynamic layout segment optimization

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -884,7 +884,7 @@ impl AppEndpoint {
 
                     for refs in client_references
                         .await?
-                        .client_references_ecma_by_server_component
+                        .client_references_by_server_component
                         .values()
                     {
                         let result = collect_next_dynamic_imports(
@@ -893,7 +893,12 @@ impl AppEndpoint {
                             visited_modules,
                         )
                         .await?;
-                        client_dynamic_imports.extend(result.client_dynamic_imports.clone());
+                        client_dynamic_imports.extend(
+                            result
+                                .client_dynamic_imports
+                                .iter()
+                                .map(|(k, v)| (*k, v.clone())),
+                        );
                         visited_modules = result.visited_modules;
                     }
 

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -890,22 +890,6 @@ impl AppEndpoint {
                     }
                 }
 
-                // let mut x = vec![];
-                // for (comp, r) in &client_references_by_server_comp {
-                //     if let Some(server) = comp {
-                //         x.push((
-                //             server.ident().to_string().await?.to_string(),
-                //             r.iter().map(|v| v.ident().to_string()).try_join().await?,
-                //         ));
-                //     } else {
-                //         x.push((
-                //             "None".to_string(),
-                //             r.iter().map(|v| v.ident().to_string()).try_join().await?,
-                //         ));
-                //     }
-                // }
-                // println!("{:#?}", x);
-
                 let client_dynamic_imports = {
                     let mut client_dynamic_imports = IndexMap::new();
                     let mut visited_modules = VisitedDynamicImportModules::empty();

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -888,7 +888,8 @@ impl AppEndpoint {
                         .values()
                     {
                         let result = collect_next_dynamic_imports(
-                            *refs,
+                            // TODO get rid of this clone without breaking memoization
+                            refs.await?.clone_value(),
                             Vc::upcast(this.app_project.client_module_context()),
                             visited_modules,
                         )
@@ -1203,7 +1204,7 @@ impl AppEndpoint {
 
                 // create react-loadable-manifest for next/dynamic
                 let mut dynamic_import_modules = collect_next_dynamic_imports(
-                    Vc::cell(vec![Vc::upcast(app_entry.rsc_entry)]),
+                    vec![Vc::upcast(app_entry.rsc_entry)],
                     Vc::upcast(this.app_project.client_module_context()),
                     VisitedDynamicImportModules::empty(),
                 )
@@ -1358,7 +1359,7 @@ impl AppEndpoint {
                 // create react-loadable-manifest for next/dynamic
                 let availability_info = Value::new(AvailabilityInfo::Root);
                 let mut dynamic_import_modules = collect_next_dynamic_imports(
-                    Vc::cell(vec![Vc::upcast(app_entry.rsc_entry)]),
+                    vec![Vc::upcast(app_entry.rsc_entry)],
                     Vc::upcast(this.app_project.client_module_context()),
                     VisitedDynamicImportModules::empty(),
                 )

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -888,8 +888,7 @@ impl AppEndpoint {
                         .values()
                     {
                         let result = collect_next_dynamic_imports(
-                            // TODO get rid of this clone without breaking memoization
-                            refs.await?.clone_value(),
+                            refs.clone(),
                             Vc::upcast(this.app_project.client_module_context()),
                             visited_modules,
                         )

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -891,17 +891,17 @@ impl AppEndpoint {
                 }
 
                 // let mut x = vec![];
-                // for y in &client_references.await?.client_references {
-                //     let t = match y.ty() {
-                //         ClientReferenceType::EcmascriptClientReference(t) => {
-                //             t.ident().to_string().await?
-                //         }
-                //         ClientReferenceType::CssClientReference(t) =>
-                // t.ident().to_string().await?,     };
-                //     if let Some(server) = y.server_component() {
-                //         x.push((server.ident().to_string().await?.to_string(), t));
+                // for (comp, r) in &client_references_by_server_comp {
+                //     if let Some(server) = comp {
+                //         x.push((
+                //             server.ident().to_string().await?.to_string(),
+                //             r.iter().map(|v| v.ident().to_string()).try_join().await?,
+                //         ));
                 //     } else {
-                //         x.push(("None".to_string(), t));
+                //         x.push((
+                //             "None".to_string(),
+                //             r.iter().map(|v| v.ident().to_string()).try_join().await?,
+                //         ));
                 //     }
                 // }
                 // println!("{:#?}", x);

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -187,7 +187,7 @@ pub(crate) async fn collect_next_dynamic_imports(
             }
         });
 
-        // Consolifate import mappings into a single indexmap
+        // Consolidate import mappings into a single indexmap
         let mut import_mappings: IndexMap<Vc<Box<dyn Module>>, DynamicImportedModules> =
             IndexMap::new();
 

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -165,7 +165,6 @@ pub(crate) async fn collect_next_dynamic_imports(
         // (Module<A>, Vec<(B, Module<B>)>) (where B is the raw import source string,
         // and Module<B> is the actual resolved Module)
         let (result, visited_modules) = NonDeterministic::new()
-            // TODO: use param
             .skip_duplicates_with_visited_nodes(VisitedNodes(visited_modules.await?.0.clone()))
             .visit(
                 server_entries

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -144,6 +144,8 @@ impl VisitedDynamicImportModules {
 ///      won't occur
 #[turbo_tasks::function]
 pub(crate) async fn collect_next_dynamic_imports(
+    // `server_entries` cannot be a `Vc<Vec<_>>` because that would compare by cell identity and
+    // not by value, breaking memoization.
     server_entries: Vec<Vc<Box<dyn Module>>>,
     client_asset_context: Vc<Box<dyn AssetContext>>,
     visited_modules: Vc<VisitedDynamicImportModules>,

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -144,7 +144,7 @@ impl VisitedDynamicImportModules {
 ///      won't occur
 #[turbo_tasks::function]
 pub(crate) async fn collect_next_dynamic_imports(
-    server_entries: Vec<Vc<Box<dyn Module>>>,
+    server_entries: Vc<Vec<Vc<Box<dyn Module>>>>,
     client_asset_context: Vc<Box<dyn AssetContext>>,
     visited_modules: Vc<VisitedDynamicImportModules>,
 ) -> Result<Vc<NextDynamicImportsResult>> {
@@ -159,7 +159,8 @@ pub(crate) async fn collect_next_dynamic_imports(
             .skip_duplicates_with_visited_nodes(VisitedNodes(visited_modules.await?.0.clone()))
             .visit(
                 server_entries
-                    .into_iter()
+                    .await?
+                    .iter()
                     .map(|module| async move {
                         Ok(NextDynamicVisitEntry::Module(
                             module.resolve().await?,

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -144,7 +144,7 @@ impl VisitedDynamicImportModules {
 ///      won't occur
 #[turbo_tasks::function]
 pub(crate) async fn collect_next_dynamic_imports(
-    server_entries: Vc<Vec<Vc<Box<dyn Module>>>>,
+    server_entries: Vec<Vc<Box<dyn Module>>>,
     client_asset_context: Vc<Box<dyn AssetContext>>,
     visited_modules: Vc<VisitedDynamicImportModules>,
 ) -> Result<Vc<NextDynamicImportsResult>> {
@@ -159,7 +159,6 @@ pub(crate) async fn collect_next_dynamic_imports(
             .skip_duplicates_with_visited_nodes(VisitedNodes(visited_modules.await?.0.clone()))
             .visit(
                 server_entries
-                    .await?
                     .iter()
                     .map(|module| async move {
                         Ok(NextDynamicVisitEntry::Module(

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -149,15 +149,6 @@ pub(crate) async fn collect_next_dynamic_imports(
     visited_modules: Vc<VisitedDynamicImportModules>,
 ) -> Result<Vc<NextDynamicImportsResult>> {
     async move {
-        let server_entries = server_entries.into_iter().collect::<Vec<_>>();
-        println!(
-            "collect_next_dynamic_imports {:?}",
-            server_entries
-                .iter()
-                .map(|module| module.ident().to_string())
-                .try_join()
-                .await?
-        );
         // Traverse referenced modules graph, collect all of the dynamic imports:
         // - Read the Program AST of the Module, this is the origin (A)
         //  - If there's `dynamic(import(B))`, then B is the module that is being imported

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use anyhow::{bail, Context, Result};
 use indexmap::IndexMap;
 use next_core::{

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -61,7 +61,7 @@ use turbopack_nodejs::NodeJsChunkingContext;
 use crate::{
     dynamic_imports::{
         collect_chunk_group, collect_evaluated_chunk_group, collect_next_dynamic_imports,
-        DynamicImportedChunks,
+        DynamicImportedChunks, VisitedDynamicImportModules,
     },
     font::create_font_manifest,
     loadable_manifest::create_react_loadable_manifest,
@@ -825,9 +825,10 @@ impl PageEndpoint {
                     Value::new(AvailabilityInfo::Root),
                 );
 
-                let dynamic_import_modules = collect_next_dynamic_imports(
+                let (dynamic_import_modules, visited_modules) = collect_next_dynamic_imports(
                     [Vc::upcast(ssr_module)],
                     this.pages_project.client_module_context(),
+                    VisitedDynamicImportModules::default(),
                 )
                 .await?;
                 let client_chunking_context =
@@ -864,9 +865,10 @@ impl PageEndpoint {
                     .await?;
 
                 let availability_info = Value::new(AvailabilityInfo::Root);
-                let dynamic_import_modules = collect_next_dynamic_imports(
+                let (dynamic_import_modules, visited_modules) = collect_next_dynamic_imports(
                     [Vc::upcast(ssr_module)],
                     this.pages_project.client_module_context(),
+                    VisitedDynamicImportModules::default(),
                 )
                 .await?;
                 let client_chunking_context =

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -826,7 +826,7 @@ impl PageEndpoint {
                 );
 
                 let dynamic_import_modules = collect_next_dynamic_imports(
-                    Vc::cell(vec![Vc::upcast(ssr_module)]),
+                    vec![Vc::upcast(ssr_module)],
                     this.pages_project.client_module_context(),
                     VisitedDynamicImportModules::empty(),
                 )
@@ -868,7 +868,7 @@ impl PageEndpoint {
 
                 let availability_info = Value::new(AvailabilityInfo::Root);
                 let dynamic_import_modules = collect_next_dynamic_imports(
-                    Vc::cell(vec![Vc::upcast(ssr_module)]),
+                    vec![Vc::upcast(ssr_module)],
                     this.pages_project.client_module_context(),
                     VisitedDynamicImportModules::empty(),
                 )

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use anyhow::{bail, Context, Result};
 use indexmap::IndexMap;
 use next_core::{
@@ -827,12 +825,14 @@ impl PageEndpoint {
                     Value::new(AvailabilityInfo::Root),
                 );
 
-                let (dynamic_import_modules, visited_modules) = collect_next_dynamic_imports(
-                    [Vc::upcast(ssr_module)],
+                let dynamic_import_modules = collect_next_dynamic_imports(
+                    vec![Vc::upcast(ssr_module)],
                     this.pages_project.client_module_context(),
-                    VisitedDynamicImportModules::default(),
+                    VisitedDynamicImportModules::empty(),
                 )
-                .await?;
+                .await?
+                .client_dynamic_imports
+                .clone();
                 let client_chunking_context =
                     this.pages_project.project().client_chunking_context();
                 let dynamic_import_entries = collect_evaluated_chunk_group(
@@ -867,17 +867,19 @@ impl PageEndpoint {
                     .await?;
 
                 let availability_info = Value::new(AvailabilityInfo::Root);
-                let (dynamic_import_modules, visited_modules) = collect_next_dynamic_imports(
-                    [Vc::upcast(ssr_module)],
+                let dynamic_import_modules = collect_next_dynamic_imports(
+                    vec![Vc::upcast(ssr_module)],
                     this.pages_project.client_module_context(),
-                    VisitedDynamicImportModules::default(),
+                    VisitedDynamicImportModules::empty(),
                 )
-                .await?;
+                .await?
+                .client_dynamic_imports
+                .clone();
                 let client_chunking_context =
                     this.pages_project.project().client_chunking_context();
                 let dynamic_import_entries = collect_chunk_group(
                     Vc::upcast(client_chunking_context),
-                    dynamic_import_modules,
+                    dynamic_import_modules.clone(),
                     availability_info,
                 )
                 .await?;

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -826,7 +826,7 @@ impl PageEndpoint {
                 );
 
                 let dynamic_import_modules = collect_next_dynamic_imports(
-                    vec![Vc::upcast(ssr_module)],
+                    Vc::cell(vec![Vc::upcast(ssr_module)]),
                     this.pages_project.client_module_context(),
                     VisitedDynamicImportModules::empty(),
                 )
@@ -868,7 +868,7 @@ impl PageEndpoint {
 
                 let availability_info = Value::new(AvailabilityInfo::Root);
                 let dynamic_import_modules = collect_next_dynamic_imports(
-                    vec![Vc::upcast(ssr_module)],
+                    Vc::cell(vec![Vc::upcast(ssr_module)]),
                     this.pages_project.client_module_context(),
                     VisitedDynamicImportModules::empty(),
                 )

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -52,7 +52,7 @@ pub struct ClientReferenceGraphResult {
     pub client_references: Vec<ClientReference>,
     #[allow(clippy::type_complexity)]
     pub client_references_ecma_by_server_component:
-        IndexMap<Option<Vc<NextServerComponentModule>>, Vc<Vec<Vc<Box<dyn Module>>>>>,
+        IndexMap<Option<Vc<NextServerComponentModule>>, Vec<Vc<Box<dyn Module>>>>,
     pub server_component_entries: Vec<Vc<NextServerComponentModule>>,
     pub server_utils: Vec<Vc<Box<dyn Module>>>,
 }
@@ -144,10 +144,7 @@ pub async fn client_reference_graph(
 
         Ok(ClientReferenceGraphResult {
             client_references,
-            client_references_ecma_by_server_component: client_references_ecma_by_server_component
-                .into_iter()
-                .map(|(k, v)| (k, Vc::cell(v)))
-                .collect(),
+            client_references_ecma_by_server_component,
             server_component_entries,
             server_utils,
         }

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -1,7 +1,7 @@
 use std::future::Future;
 
 use anyhow::Result;
-use indexmap::IndexSet;
+use indexmap::{IndexMap, IndexSet};
 use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use turbo_tasks::{
@@ -50,6 +50,9 @@ pub enum ClientReferenceType {
 #[derive(Debug)]
 pub struct ClientReferenceGraphResult {
     pub client_references: Vec<ClientReference>,
+    #[allow(clippy::type_complexity)]
+    pub client_references_ecma_by_server_component:
+        IndexMap<Option<Vc<NextServerComponentModule>>, Vc<Vec<Vc<Box<dyn Module>>>>>,
     pub server_component_entries: Vec<Vc<NextServerComponentModule>>,
     pub server_utils: Vec<Vc<Box<dyn Module>>>,
 }
@@ -80,6 +83,11 @@ pub async fn client_reference_graph(
         let mut client_references = vec![];
         let mut server_component_entries = vec![];
         let mut server_utils = vec![];
+
+        let mut client_references_ecma_by_server_component = IndexMap::new();
+        // Make sure None (for the various internal next/dist/esm/client/components/*) is listed
+        // first
+        client_references_ecma_by_server_component.insert(None, Vec::new());
 
         let graph = AdjacencyMap::new()
             .skip_duplicates()
@@ -115,6 +123,15 @@ pub async fn client_reference_graph(
                 }
                 VisitClientReferenceNodeType::ClientReference(client_reference, _) => {
                     client_references.push(*client_reference);
+
+                    if let ClientReferenceType::EcmascriptClientReference(entry) =
+                        client_reference.ty()
+                    {
+                        client_references_ecma_by_server_component
+                            .entry(client_reference.server_component)
+                            .or_insert_with(Vec::new)
+                            .push(Vc::upcast::<Box<dyn Module>>(entry.await?.ssr_module));
+                    }
                 }
                 VisitClientReferenceNodeType::ServerUtilEntry(server_util, _) => {
                     server_utils.push(*server_util);
@@ -127,6 +144,10 @@ pub async fn client_reference_graph(
 
         Ok(ClientReferenceGraphResult {
             client_references,
+            client_references_ecma_by_server_component: client_references_ecma_by_server_component
+                .into_iter()
+                .map(|(k, v)| (k, Vc::cell(v)))
+                .collect(),
             server_component_entries,
             server_utils,
         }

--- a/turbopack/crates/turbo-tasks/src/graph/graph_store.rs
+++ b/turbopack/crates/turbo-tasks/src/graph/graph_store.rs
@@ -5,7 +5,7 @@ use super::VisitedNodes;
 /// A graph store is a data structure that will be built up during a graph
 /// traversal. It is used to store the results of the traversal.
 pub trait GraphStore {
-    type Node: Clone + Hash + Eq;
+    type Node;
     type Handle: Clone;
 
     // TODO(alexkirsz) An `entry(from_handle) -> Entry` API would be more

--- a/turbopack/crates/turbo-tasks/src/graph/graph_store.rs
+++ b/turbopack/crates/turbo-tasks/src/graph/graph_store.rs
@@ -1,5 +1,7 @@
 use std::collections::HashSet;
 
+use super::VisitedNodes;
+
 /// A graph store is a data structure that will be built up during a graph
 /// traversal. It is used to store the results of the traversal.
 pub trait GraphStore {
@@ -62,6 +64,10 @@ where
             visited: Default::default(),
         }
     }
+
+    pub fn new_with_visited_nodes(store: StoreImpl, visited: HashSet<StoreImpl::Node>) -> Self {
+        Self { store, visited }
+    }
 }
 
 impl<StoreImpl> GraphStore for SkipDuplicates<StoreImpl>
@@ -97,5 +103,10 @@ where
     /// Consumes the wrapper and returns the underlying store.
     pub fn into_inner(self) -> StoreImpl {
         self.store
+    }
+
+    /// Consumes the wrapper and returns the underlying store along with the visited nodes.
+    pub fn into_inner_with_visited(self) -> (StoreImpl, VisitedNodes<StoreImpl::Node>) {
+        (self.store, VisitedNodes(self.visited))
     }
 }

--- a/turbopack/crates/turbo-tasks/src/graph/graph_store.rs
+++ b/turbopack/crates/turbo-tasks/src/graph/graph_store.rs
@@ -1,11 +1,11 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, hash::Hash};
 
 use super::VisitedNodes;
 
 /// A graph store is a data structure that will be built up during a graph
 /// traversal. It is used to store the results of the traversal.
 pub trait GraphStore {
-    type Node;
+    type Node: Clone + Hash + Eq;
     type Handle: Clone;
 
     // TODO(alexkirsz) An `entry(from_handle) -> Entry` API would be more

--- a/turbopack/crates/turbo-tasks/src/graph/graph_traversal.rs
+++ b/turbopack/crates/turbo-tasks/src/graph/graph_traversal.rs
@@ -2,6 +2,7 @@ use std::{collections::HashSet, future::Future, pin::Pin};
 
 use anyhow::Result;
 use futures::{stream::FuturesUnordered, Stream};
+use turbo_tasks_macros::TaskInput;
 
 use super::{
     graph_store::{GraphNode, GraphStore},
@@ -10,7 +11,7 @@ use super::{
 };
 
 /// A list of modules that were already visited and should be skipped (including their subgraphs).
-#[derive(Default)]
+#[derive(Clone, Default, Debug)]
 pub struct VisitedNodes<T>(pub HashSet<T>);
 
 /// [`GraphTraversal`] is a utility type that can be used to traverse a graph of

--- a/turbopack/crates/turbo-tasks/src/graph/graph_traversal.rs
+++ b/turbopack/crates/turbo-tasks/src/graph/graph_traversal.rs
@@ -2,7 +2,6 @@ use std::{collections::HashSet, future::Future, pin::Pin};
 
 use anyhow::Result;
 use futures::{stream::FuturesUnordered, Stream};
-use turbo_tasks_macros::TaskInput;
 
 use super::{
     graph_store::{GraphNode, GraphStore},

--- a/turbopack/crates/turbo-tasks/src/graph/graph_traversal.rs
+++ b/turbopack/crates/turbo-tasks/src/graph/graph_traversal.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, pin::Pin};
+use std::{collections::HashSet, future::Future, pin::Pin};
 
 use anyhow::Result;
 use futures::{stream::FuturesUnordered, Stream};
@@ -8,6 +8,10 @@ use super::{
     with_future::With,
     SkipDuplicates, Visit, VisitControlFlow,
 };
+
+/// A list of modules that were already visited and should be skipped (including their subgraphs).
+#[derive(Default)]
+pub struct VisitedNodes<T>(pub HashSet<T>);
 
 /// [`GraphTraversal`] is a utility type that can be used to traverse a graph of
 /// nodes, where each node can have a variable number of outgoing edges. The
@@ -24,6 +28,10 @@ pub trait GraphTraversal: GraphStore + Sized {
         RootEdgesIt: IntoIterator<Item = VisitImpl::Edge>;
 
     fn skip_duplicates(self) -> SkipDuplicates<Self>;
+    fn skip_duplicates_with_visited_nodes(
+        self,
+        visited: VisitedNodes<Self::Node>,
+    ) -> SkipDuplicates<Self>;
 }
 
 impl<Store> GraphTraversal for Store
@@ -72,6 +80,13 @@ where
 
     fn skip_duplicates(self) -> SkipDuplicates<Self> {
         SkipDuplicates::new(self)
+    }
+
+    fn skip_duplicates_with_visited_nodes(
+        self,
+        visited: VisitedNodes<Store::Node>,
+    ) -> SkipDuplicates<Self> {
+        SkipDuplicates::new_with_visited_nodes(self, visited.0)
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/graph/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/graph/mod.rs
@@ -9,6 +9,6 @@ mod with_future;
 pub use adjacency_map::AdjacencyMap;
 pub use control_flow::VisitControlFlow;
 pub use graph_store::{GraphStore, SkipDuplicates};
-pub use graph_traversal::{GraphTraversal, GraphTraversalResult};
+pub use graph_traversal::{GraphTraversal, GraphTraversalResult, VisitedNodes};
 pub use non_deterministic::NonDeterministic;
 pub use visit::Visit;

--- a/turbopack/crates/turbo-tasks/src/graph/non_deterministic.rs
+++ b/turbopack/crates/turbo-tasks/src/graph/non_deterministic.rs
@@ -1,5 +1,3 @@
-use std::hash::Hash;
-
 use super::graph_store::{GraphNode, GraphStore};
 
 /// A graph traversal that does not guarantee any particular order, and may not
@@ -20,7 +18,7 @@ impl<T> NonDeterministic<T> {
     }
 }
 
-impl<T: Clone + Hash + Eq> GraphStore for NonDeterministic<T> {
+impl<T> GraphStore for NonDeterministic<T> {
     type Node = T;
     type Handle = ();
 

--- a/turbopack/crates/turbo-tasks/src/graph/non_deterministic.rs
+++ b/turbopack/crates/turbo-tasks/src/graph/non_deterministic.rs
@@ -1,3 +1,5 @@
+use std::hash::Hash;
+
 use super::graph_store::{GraphNode, GraphStore};
 
 /// A graph traversal that does not guarantee any particular order, and may not
@@ -18,7 +20,7 @@ impl<T> NonDeterministic<T> {
     }
 }
 
-impl<T> GraphStore for NonDeterministic<T> {
+impl<T: Clone + Hash + Eq> GraphStore for NonDeterministic<T> {
     type Node = T;
     type Handle = ();
 


### PR DESCRIPTION
Closes PACK-3274

This deduplicates work by only searching for `next/dynamic` once per layout segment.

- `collect_next_dynamic_imports` is a turbotask now, executed once per layout segment 
- `collect_next_dynamic_imports` also takes a list of visited modules, to prevent revisiting 

Before
<img width="1722" alt="Bildschirmfoto 2024-10-01 um 15 28 34" src="https://github.com/user-attachments/assets/0db86796-289e-4d8a-95b9-4164bcaabc71">

After
<img width="1728" alt="Bildschirmfoto 2024-10-02 um 15 17 10" src="https://github.com/user-attachments/assets/bfb99b03-26d8-4c0f-b97e-f9e437f7fc4c">
