### PR TITLE
Fix `waitUntil` usage in `generateDynamicFlightRenderResult`

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -517,24 +517,29 @@ async function generateDynamicFlightRenderResult(
   )
   await waitAtLeastOneReactRenderTask()
 
+  let waitUntil: Promise<any> | undefined = undefined
+
   if (
     ctx.staticGenerationStore.pendingRevalidates ||
     ctx.staticGenerationStore.revalidatedTags ||
     ctx.staticGenerationStore.pendingRevalidateWrites
   ) {
-    const promises = Promise.all([
+    waitUntil = Promise.all([
       ctx.staticGenerationStore.incrementalCache?.revalidateTag(
         ctx.staticGenerationStore.revalidatedTags || []
       ),
       ...Object.values(ctx.staticGenerationStore.pendingRevalidates || {}),
       ...(ctx.staticGenerationStore.pendingRevalidateWrites || []),
     ])
-    ctx.renderOpts.waitUntil = (p) => promises.then(() => p)
   }
 
-  return new FlightRenderResult(flightReadableStream, {
-    fetchMetrics: ctx.staticGenerationStore.fetchMetrics,
-  })
+  return new FlightRenderResult(
+    flightReadableStream,
+    {
+      fetchMetrics: ctx.staticGenerationStore.fetchMetrics,
+    },
+    waitUntil
+  )
 }
 
 /**

--- a/packages/next/src/server/app-render/flight-render-result.ts
+++ b/packages/next/src/server/app-render/flight-render-result.ts
@@ -7,8 +7,13 @@ import RenderResult, { type RenderResultMetadata } from '../render-result'
 export class FlightRenderResult extends RenderResult {
   constructor(
     response: string | ReadableStream<Uint8Array>,
-    metadata: RenderResultMetadata = {}
+    metadata: RenderResultMetadata = {},
+    waitUntil?: Promise<unknown>
   ) {
-    super(response, { contentType: RSC_CONTENT_TYPE_HEADER, metadata })
+    super(response, {
+      contentType: RSC_CONTENT_TYPE_HEADER,
+      metadata,
+      waitUntil,
+    })
   }
 }


### PR DESCRIPTION
@lubieowoce This is meant as a fix for the issue you addressed in PR #70446
I pass the `waitUntil` argument to `FlightRenderResult`, which passes it down to `RenderResult`.
This falls in line with the usage of `options.waitUntil` in `app-render.tsx`.