### PR TITLE
Rename StaticGenerationStore to WorkStore

### DIFF
--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -34,14 +34,14 @@ const routeModule = new AppRouteRouteModule({
 // are used to hook into the route.
 const {
   requestAsyncStorage,
-  staticGenerationAsyncStorage,
+  workAsyncStorage,
   prerenderAsyncStorage,
   serverHooks,
 } = routeModule
 
 function patchFetch() {
   return _patchFetch({
-    staticGenerationAsyncStorage,
+    workAsyncStorage,
     requestAsyncStorage,
     prerenderAsyncStorage,
   })
@@ -50,7 +50,7 @@ function patchFetch() {
 export {
   routeModule,
   requestAsyncStorage,
-  staticGenerationAsyncStorage,
+  workAsyncStorage,
   serverHooks,
   patchFetch,
 }

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -75,7 +75,7 @@ import { denormalizePagePath } from '../shared/lib/page-path/denormalize-page-pa
 import { normalizePagePath } from '../shared/lib/page-path/normalize-page-path'
 import { getRuntimeContext } from '../server/web/sandbox'
 import { isClientReference } from '../lib/client-reference'
-import { withStaticGenerationStore } from '../server/async-storage/with-static-generation-store'
+import { withStaticGenerationStore } from '../server/async-storage/with-work-store'
 import type { CacheHandler } from '../server/lib/incremental-cache'
 import { IncrementalCache } from '../server/lib/incremental-cache'
 import { nodeFs } from '../server/lib/node-fs-methods'

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1295,7 +1295,7 @@ export async function buildAppStaticPaths({
   }
 
   const routeParams = await withWorkStore(
-    ComponentMod.staticGenerationAsyncStorage,
+    ComponentMod.workAsyncStorage,
     {
       page,
       // We're discovering the parameters here, so we don't have any unknown

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -75,7 +75,7 @@ import { denormalizePagePath } from '../shared/lib/page-path/denormalize-page-pa
 import { normalizePagePath } from '../shared/lib/page-path/normalize-page-path'
 import { getRuntimeContext } from '../server/web/sandbox'
 import { isClientReference } from '../lib/client-reference'
-import { withStaticGenerationStore } from '../server/async-storage/with-work-store'
+import { withWorkStore } from '../server/async-storage/with-work-store'
 import type { CacheHandler } from '../server/lib/incremental-cache'
 import { IncrementalCache } from '../server/lib/incremental-cache'
 import { nodeFs } from '../server/lib/node-fs-methods'
@@ -1294,7 +1294,7 @@ export async function buildAppStaticPaths({
     }
   }
 
-  const routeParams = await withStaticGenerationStore(
+  const routeParams = await withWorkStore(
     ComponentMod.staticGenerationAsyncStorage,
     {
       page,

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -130,7 +130,7 @@ const browserNonTranspileModules = [
 const precompileRegex = /[\\/]next[\\/]dist[\\/]compiled[\\/]/
 
 const asyncStoragesRegex =
-  /next[\\/]dist[\\/](esm[\\/])?client[\\/]components[\\/](static-generation-async-storage|action-async-storage|request-async-storage)/
+  /next[\\/]dist[\\/](esm[\\/])?client[\\/]components[\\/](work-async-storage|action-async-storage|request-async-storage)/
 
 // Support for NODE_PATH
 const nodePathList = (process.env.NODE_PATH || '')

--- a/packages/next/src/client/components/bailout-to-client-rendering.ts
+++ b/packages/next/src/client/components/bailout-to-client-rendering.ts
@@ -1,5 +1,5 @@
 import { BailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
-import { staticGenerationAsyncStorage } from './static-generation-async-storage.external'
+import { staticGenerationAsyncStorage } from './work-async-storage.external'
 
 export function bailoutToClientRendering(reason: string): void | never {
   const staticGenerationStore = staticGenerationAsyncStorage.getStore()

--- a/packages/next/src/client/components/bailout-to-client-rendering.ts
+++ b/packages/next/src/client/components/bailout-to-client-rendering.ts
@@ -2,10 +2,9 @@ import { BailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
 import { staticGenerationAsyncStorage } from './work-async-storage.external'
 
 export function bailoutToClientRendering(reason: string): void | never {
-  const staticGenerationStore = staticGenerationAsyncStorage.getStore()
+  const workStore = staticGenerationAsyncStorage.getStore()
 
-  if (staticGenerationStore?.forceStatic) return
+  if (workStore?.forceStatic) return
 
-  if (staticGenerationStore?.isStaticGeneration)
-    throw new BailoutToCSRError(reason)
+  if (workStore?.isStaticGeneration) throw new BailoutToCSRError(reason)
 }

--- a/packages/next/src/client/components/bailout-to-client-rendering.ts
+++ b/packages/next/src/client/components/bailout-to-client-rendering.ts
@@ -1,8 +1,8 @@
 import { BailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
-import { staticGenerationAsyncStorage } from './work-async-storage.external'
+import { workAsyncStorage } from './work-async-storage.external'
 
 export function bailoutToClientRendering(reason: string): void | never {
-  const workStore = staticGenerationAsyncStorage.getStore()
+  const workStore = workAsyncStorage.getStore()
 
   if (workStore?.forceStatic) return
 

--- a/packages/next/src/client/components/client-page.tsx
+++ b/packages/next/src/client/components/client-page.tsx
@@ -36,7 +36,7 @@ export function ClientPageRoot({
     const store = staticGenerationAsyncStorage.getStore()
     if (!store) {
       throw new InvariantError(
-        'Expected staticGenerationStore to exist when handling searchParams in a client Page.'
+        'Expected workStore to exist when handling searchParams in a client Page.'
       )
     }
 

--- a/packages/next/src/client/components/client-page.tsx
+++ b/packages/next/src/client/components/client-page.tsx
@@ -26,14 +26,14 @@ export function ClientPageRoot({
   promises?: Array<Promise<any>>
 }) {
   if (typeof window === 'undefined') {
-    const { staticGenerationAsyncStorage } =
+    const { workAsyncStorage } =
       require('./work-async-storage.external') as typeof import('./work-async-storage.external')
 
     let clientSearchParams: Promise<ParsedUrlQuery>
     let clientParams: Promise<Params>
     // We are going to instrument the searchParams prop with tracking for the
     // appropriate context. We wrap differently in prerendering vs rendering
-    const store = staticGenerationAsyncStorage.getStore()
+    const store = workAsyncStorage.getStore()
     if (!store) {
       throw new InvariantError(
         'Expected workStore to exist when handling searchParams in a client Page.'

--- a/packages/next/src/client/components/client-page.tsx
+++ b/packages/next/src/client/components/client-page.tsx
@@ -27,7 +27,7 @@ export function ClientPageRoot({
 }) {
   if (typeof window === 'undefined') {
     const { staticGenerationAsyncStorage } =
-      require('./static-generation-async-storage.external') as typeof import('./static-generation-async-storage.external')
+      require('./work-async-storage.external') as typeof import('./work-async-storage.external')
 
     let clientSearchParams: Promise<ParsedUrlQuery>
     let clientParams: Promise<Params>

--- a/packages/next/src/client/components/client-segment.tsx
+++ b/packages/next/src/client/components/client-segment.tsx
@@ -25,13 +25,13 @@ export function ClientSegmentRoot({
   promise?: Promise<any>
 }) {
   if (typeof window === 'undefined') {
-    const { staticGenerationAsyncStorage } =
+    const { workAsyncStorage } =
       require('./work-async-storage.external') as typeof import('./work-async-storage.external')
 
     let clientParams: Promise<Params>
     // We are going to instrument the searchParams prop with tracking for the
     // appropriate context. We wrap differently in prerendering vs rendering
-    const store = staticGenerationAsyncStorage.getStore()
+    const store = workAsyncStorage.getStore()
     if (!store) {
       throw new InvariantError(
         'Expected workStore to exist when handling params in a client segment such as a Layout or Template.'

--- a/packages/next/src/client/components/client-segment.tsx
+++ b/packages/next/src/client/components/client-segment.tsx
@@ -34,7 +34,7 @@ export function ClientSegmentRoot({
     const store = staticGenerationAsyncStorage.getStore()
     if (!store) {
       throw new InvariantError(
-        'Expected staticGenerationStore to exist when handling params in a client segment such as a Layout or Template.'
+        'Expected workStore to exist when handling params in a client segment such as a Layout or Template.'
       )
     }
 

--- a/packages/next/src/client/components/client-segment.tsx
+++ b/packages/next/src/client/components/client-segment.tsx
@@ -26,7 +26,7 @@ export function ClientSegmentRoot({
 }) {
   if (typeof window === 'undefined') {
     const { staticGenerationAsyncStorage } =
-      require('./static-generation-async-storage.external') as typeof import('./static-generation-async-storage.external')
+      require('./work-async-storage.external') as typeof import('./work-async-storage.external')
 
     let clientParams: Promise<Params>
     // We are going to instrument the searchParams prop with tracking for the

--- a/packages/next/src/client/components/error-boundary.tsx
+++ b/packages/next/src/client/components/error-boundary.tsx
@@ -4,7 +4,7 @@ import React, { type JSX } from 'react'
 import { useUntrackedPathname } from './navigation-untracked'
 import { isNextRouterError } from './is-next-router-error'
 import { handleHardNavError } from './nav-failure-handler'
-import { staticGenerationAsyncStorage } from './work-async-storage.external'
+import { workAsyncStorage } from './work-async-storage.external'
 
 const styles = {
   error: {
@@ -52,7 +52,7 @@ interface ErrorBoundaryHandlerState {
 // function crashes so we can maintain our previous cache
 // instead of caching the error page
 function HandleISRError({ error }: { error: any }) {
-  const store = staticGenerationAsyncStorage.getStore()
+  const store = workAsyncStorage.getStore()
   if (store?.isRevalidate || store?.isStaticGeneration) {
     console.error(error)
     throw error

--- a/packages/next/src/client/components/error-boundary.tsx
+++ b/packages/next/src/client/components/error-boundary.tsx
@@ -4,7 +4,7 @@ import React, { type JSX } from 'react'
 import { useUntrackedPathname } from './navigation-untracked'
 import { isNextRouterError } from './is-next-router-error'
 import { handleHardNavError } from './nav-failure-handler'
-import { staticGenerationAsyncStorage } from './static-generation-async-storage.external'
+import { staticGenerationAsyncStorage } from './work-async-storage.external'
 
 const styles = {
   error: {

--- a/packages/next/src/client/components/navigation-untracked.ts
+++ b/packages/next/src/client/components/navigation-untracked.ts
@@ -10,10 +10,10 @@ import { PathnameContext } from '../../shared/lib/hooks-client-context.shared-ru
 function hasFallbackRouteParams() {
   if (typeof window === 'undefined') {
     // AsyncLocalStorage should not be included in the client bundle.
-    const { staticGenerationAsyncStorage } =
+    const { workAsyncStorage } =
       require('./work-async-storage.external') as typeof import('./work-async-storage.external')
 
-    const workStore = staticGenerationAsyncStorage.getStore()
+    const workStore = workAsyncStorage.getStore()
     if (!workStore) return false
 
     const { fallbackRouteParams } = workStore

--- a/packages/next/src/client/components/navigation-untracked.ts
+++ b/packages/next/src/client/components/navigation-untracked.ts
@@ -11,7 +11,7 @@ function hasFallbackRouteParams() {
   if (typeof window === 'undefined') {
     // AsyncLocalStorage should not be included in the client bundle.
     const { staticGenerationAsyncStorage } =
-      require('./static-generation-async-storage.external') as typeof import('./static-generation-async-storage.external')
+      require('./work-async-storage.external') as typeof import('./work-async-storage.external')
 
     const staticGenerationStore = staticGenerationAsyncStorage.getStore()
     if (!staticGenerationStore) return false

--- a/packages/next/src/client/components/navigation-untracked.ts
+++ b/packages/next/src/client/components/navigation-untracked.ts
@@ -13,10 +13,10 @@ function hasFallbackRouteParams() {
     const { staticGenerationAsyncStorage } =
       require('./work-async-storage.external') as typeof import('./work-async-storage.external')
 
-    const staticGenerationStore = staticGenerationAsyncStorage.getStore()
-    if (!staticGenerationStore) return false
+    const workStore = staticGenerationAsyncStorage.getStore()
+    if (!workStore) return false
 
-    const { fallbackRouteParams } = staticGenerationStore
+    const { fallbackRouteParams } = workStore
     if (!fallbackRouteParams || fallbackRouteParams.size === 0) return false
 
     return true

--- a/packages/next/src/client/components/work-async-storage-instance.ts
+++ b/packages/next/src/client/components/work-async-storage-instance.ts
@@ -1,5 +1,4 @@
-import type { StaticGenerationAsyncStorage } from './work-async-storage.external'
+import type { WorkAsyncStorage } from './work-async-storage.external'
 import { createAsyncLocalStorage } from './async-local-storage'
 
-export const workAsyncStorage: StaticGenerationAsyncStorage =
-  createAsyncLocalStorage()
+export const workAsyncStorage: WorkAsyncStorage = createAsyncLocalStorage()

--- a/packages/next/src/client/components/work-async-storage-instance.ts
+++ b/packages/next/src/client/components/work-async-storage-instance.ts
@@ -1,5 +1,5 @@
 import type { StaticGenerationAsyncStorage } from './work-async-storage.external'
 import { createAsyncLocalStorage } from './async-local-storage'
 
-export const staticGenerationAsyncStorage: StaticGenerationAsyncStorage =
+export const workAsyncStorage: StaticGenerationAsyncStorage =
   createAsyncLocalStorage()

--- a/packages/next/src/client/components/work-async-storage-instance.ts
+++ b/packages/next/src/client/components/work-async-storage-instance.ts
@@ -1,4 +1,4 @@
-import type { StaticGenerationAsyncStorage } from './static-generation-async-storage.external'
+import type { StaticGenerationAsyncStorage } from './work-async-storage.external'
 import { createAsyncLocalStorage } from './async-local-storage'
 
 export const staticGenerationAsyncStorage: StaticGenerationAsyncStorage =

--- a/packages/next/src/client/components/work-async-storage.external.ts
+++ b/packages/next/src/client/components/work-async-storage.external.ts
@@ -6,7 +6,7 @@ import type { Revalidate } from '../../server/lib/revalidate'
 import type { FallbackRouteParams } from '../../server/request/fallback-params'
 
 // Share the instance module in the next-shared layer
-import { staticGenerationAsyncStorage } from './static-generation-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
+import { staticGenerationAsyncStorage } from './work-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
 import type { AppSegmentConfig } from '../../build/app-segments/app-segment-config'
 
 export interface StaticGenerationStore {

--- a/packages/next/src/client/components/work-async-storage.external.ts
+++ b/packages/next/src/client/components/work-async-storage.external.ts
@@ -9,7 +9,7 @@ import type { FallbackRouteParams } from '../../server/request/fallback-params'
 import { staticGenerationAsyncStorage } from './work-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
 import type { AppSegmentConfig } from '../../build/app-segments/app-segment-config'
 
-export interface StaticGenerationStore {
+export interface WorkStore {
   readonly isStaticGeneration: boolean
 
   /**
@@ -65,7 +65,6 @@ export interface StaticGenerationStore {
   buildId: string
 }
 
-export type StaticGenerationAsyncStorage =
-  AsyncLocalStorage<StaticGenerationStore>
+export type StaticGenerationAsyncStorage = AsyncLocalStorage<WorkStore>
 
 export { staticGenerationAsyncStorage }

--- a/packages/next/src/client/components/work-async-storage.external.ts
+++ b/packages/next/src/client/components/work-async-storage.external.ts
@@ -65,6 +65,6 @@ export interface WorkStore {
   buildId: string
 }
 
-export type StaticGenerationAsyncStorage = AsyncLocalStorage<WorkStore>
+export type WorkAsyncStorage = AsyncLocalStorage<WorkStore>
 
 export { workAsyncStorage }

--- a/packages/next/src/client/components/work-async-storage.external.ts
+++ b/packages/next/src/client/components/work-async-storage.external.ts
@@ -6,7 +6,7 @@ import type { Revalidate } from '../../server/lib/revalidate'
 import type { FallbackRouteParams } from '../../server/request/fallback-params'
 
 // Share the instance module in the next-shared layer
-import { staticGenerationAsyncStorage } from './work-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
+import { workAsyncStorage } from './work-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
 import type { AppSegmentConfig } from '../../build/app-segments/app-segment-config'
 
 export interface WorkStore {
@@ -67,4 +67,4 @@ export interface WorkStore {
 
 export type StaticGenerationAsyncStorage = AsyncLocalStorage<WorkStore>
 
-export { staticGenerationAsyncStorage }
+export { workAsyncStorage }

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -21,7 +21,7 @@ import { isBailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-cs
 import { NodeNextRequest, NodeNextResponse } from '../../server/base-http/node'
 import { NEXT_IS_PRERENDER_HEADER } from '../../client/components/app-router-headers'
 import type { FetchMetrics } from '../../server/base-http'
-import type { StaticGenerationStore } from '../../client/components/static-generation-async-storage.external'
+import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
 import type { FallbackRouteParams } from '../../server/request/fallback-params'
 
 export const enum ExportedAppPageFiles {

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -21,7 +21,7 @@ import { isBailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-cs
 import { NodeNextRequest, NodeNextResponse } from '../../server/base-http/node'
 import { NEXT_IS_PRERENDER_HEADER } from '../../client/components/app-router-headers'
 import type { FetchMetrics } from '../../server/base-http'
-import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
+import type { WorkStore } from '../../client/components/work-async-storage.external'
 import type { FallbackRouteParams } from '../../server/request/fallback-params'
 
 export const enum ExportedAppPageFiles {
@@ -205,7 +205,7 @@ export async function exportAppPage(
     let fetchMetrics: FetchMetrics | undefined
 
     if (debugOutput) {
-      const store = (renderOpts as any).store as StaticGenerationStore
+      const store = (renderOpts as any).store as WorkStore
       const { dynamicUsageDescription, dynamicUsageStack } = store
       fetchMetrics = store.fetchMetrics
 

--- a/packages/next/src/lib/metadata/metadata-context.tsx
+++ b/packages/next/src/lib/metadata/metadata-context.tsx
@@ -1,6 +1,6 @@
 import type { AppRenderContext } from '../../server/app-render/app-render'
 import type { MetadataContext } from './types/resolvers'
-import type { StaticGenerationStore } from '../../client/components/static-generation-async-storage.external'
+import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
 import { trackFallbackParamAccessed } from '../../server/app-render/dynamic-rendering'
 
 export function createMetadataContext(

--- a/packages/next/src/lib/metadata/metadata-context.tsx
+++ b/packages/next/src/lib/metadata/metadata-context.tsx
@@ -17,7 +17,7 @@ export function createMetadataContext(
 export function createTrackedMetadataContext(
   pathname: string,
   renderOpts: AppRenderContext['renderOpts'],
-  staticGenerationStore: WorkStore | null
+  workStore: WorkStore | null
 ): MetadataContext {
   return {
     // Use the regular metadata context, but we trap the pathname access.
@@ -29,15 +29,12 @@ export function createTrackedMetadataContext(
     // to provide it, and instead we should error.
     get pathname() {
       if (
-        staticGenerationStore &&
-        staticGenerationStore.isStaticGeneration &&
-        staticGenerationStore.fallbackRouteParams &&
-        staticGenerationStore.fallbackRouteParams.size > 0
+        workStore &&
+        workStore.isStaticGeneration &&
+        workStore.fallbackRouteParams &&
+        workStore.fallbackRouteParams.size > 0
       ) {
-        trackFallbackParamAccessed(
-          staticGenerationStore,
-          'metadata relative url resolving'
-        )
+        trackFallbackParamAccessed(workStore, 'metadata relative url resolving')
       }
 
       return pathname

--- a/packages/next/src/lib/metadata/metadata-context.tsx
+++ b/packages/next/src/lib/metadata/metadata-context.tsx
@@ -1,6 +1,6 @@
 import type { AppRenderContext } from '../../server/app-render/app-render'
 import type { MetadataContext } from './types/resolvers'
-import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
+import type { WorkStore } from '../../client/components/work-async-storage.external'
 import { trackFallbackParamAccessed } from '../../server/app-render/dynamic-rendering'
 
 export function createMetadataContext(
@@ -17,7 +17,7 @@ export function createMetadataContext(
 export function createTrackedMetadataContext(
   pathname: string,
   renderOpts: AppRenderContext['renderOpts'],
-  staticGenerationStore: StaticGenerationStore | null
+  staticGenerationStore: WorkStore | null
 ): MetadataContext {
   return {
     // Use the regular metadata context, but we trap the pathname access.

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -32,7 +32,7 @@ import type {
 } from './types/metadata-interface'
 import { isNotFoundError } from '../../client/components/not-found'
 import type { MetadataContext } from './types/resolvers'
-import type { StaticGenerationStore } from '../../client/components/static-generation-async-storage.external'
+import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
 
 // Use a promise to share the status of the metadata resolving,
 // returning two components `MetadataTree` and `MetadataOutlet`

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -32,7 +32,7 @@ import type {
 } from './types/metadata-interface'
 import { isNotFoundError } from '../../client/components/not-found'
 import type { MetadataContext } from './types/resolvers'
-import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
+import type { WorkStore } from '../../client/components/work-async-storage.external'
 
 // Use a promise to share the status of the metadata resolving,
 // returning two components `MetadataTree` and `MetadataOutlet`
@@ -57,7 +57,7 @@ export function createMetadataComponents({
   appUsingSizeAdjustment: boolean
   errorType?: 'not-found' | 'redirect'
   createServerParamsForMetadata: CreateServerParamsForMetadata
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
 }): [React.ComponentType, () => Promise<void>] {
   function MetadataRoot() {
     return (
@@ -155,7 +155,7 @@ async function getResolvedMetadataImpl(
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   metadataContext: MetadataContext,
   createServerParamsForMetadata: CreateServerParamsForMetadata,
-  staticGenerationStore: StaticGenerationStore,
+  staticGenerationStore: WorkStore,
   errorType?: 'not-found' | 'redirect'
 ): Promise<React.ReactNode> {
   const errorConvention = errorType === 'redirect' ? undefined : errorType
@@ -187,7 +187,7 @@ async function getNotFoundMetadataImpl(
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   metadataContext: MetadataContext,
   createServerParamsForMetadata: CreateServerParamsForMetadata,
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
 ): Promise<React.ReactNode> {
   const notFoundErrorConvention = 'not-found'
   const notFoundMetadataItems = await resolveMetadataItems(
@@ -217,7 +217,7 @@ async function getResolvedViewportImpl(
   searchParams: Promise<ParsedUrlQuery>,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   createServerParamsForMetadata: CreateServerParamsForMetadata,
-  staticGenerationStore: StaticGenerationStore,
+  staticGenerationStore: WorkStore,
   errorType?: 'not-found' | 'redirect'
 ): Promise<React.ReactNode> {
   const errorConvention = errorType === 'redirect' ? undefined : errorType
@@ -248,7 +248,7 @@ async function getNotFoundViewportImpl(
   searchParams: Promise<ParsedUrlQuery>,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   createServerParamsForMetadata: CreateServerParamsForMetadata,
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
 ): Promise<React.ReactNode> {
   const notFoundErrorConvention = 'not-found'
   const notFoundMetadataItems = await resolveMetadataItems(

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -48,7 +48,7 @@ export function createMetadataComponents({
   appUsingSizeAdjustment,
   errorType,
   createServerParamsForMetadata,
-  staticGenerationStore,
+  workStore,
 }: {
   tree: LoaderTree
   searchParams: Promise<ParsedUrlQuery>
@@ -57,7 +57,7 @@ export function createMetadataComponents({
   appUsingSizeAdjustment: boolean
   errorType?: 'not-found' | 'redirect'
   createServerParamsForMetadata: CreateServerParamsForMetadata
-  staticGenerationStore: WorkStore
+  workStore: WorkStore
 }): [React.ComponentType, () => Promise<void>] {
   function MetadataRoot() {
     return (
@@ -75,7 +75,7 @@ export function createMetadataComponents({
       searchParams,
       getDynamicParamFromSegment,
       createServerParamsForMetadata,
-      staticGenerationStore,
+      workStore,
       errorType
     )
   }
@@ -91,7 +91,7 @@ export function createMetadataComponents({
             searchParams,
             getDynamicParamFromSegment,
             createServerParamsForMetadata,
-            staticGenerationStore
+            workStore
           )
         } catch {}
       }
@@ -110,7 +110,7 @@ export function createMetadataComponents({
       getDynamicParamFromSegment,
       metadataContext,
       createServerParamsForMetadata,
-      staticGenerationStore,
+      workStore,
       errorType
     )
   }
@@ -127,7 +127,7 @@ export function createMetadataComponents({
             getDynamicParamFromSegment,
             metadataContext,
             createServerParamsForMetadata,
-            staticGenerationStore
+            workStore
           )
         } catch {}
       }
@@ -155,7 +155,7 @@ async function getResolvedMetadataImpl(
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   metadataContext: MetadataContext,
   createServerParamsForMetadata: CreateServerParamsForMetadata,
-  staticGenerationStore: WorkStore,
+  workStore: WorkStore,
   errorType?: 'not-found' | 'redirect'
 ): Promise<React.ReactNode> {
   const errorConvention = errorType === 'redirect' ? undefined : errorType
@@ -166,7 +166,7 @@ async function getResolvedMetadataImpl(
     errorConvention,
     getDynamicParamFromSegment,
     createServerParamsForMetadata,
-    staticGenerationStore
+    workStore
   )
   const elements: Array<React.ReactNode> = createMetadataElements(
     await accumulateMetadata(metadataItems, metadataContext)
@@ -187,7 +187,7 @@ async function getNotFoundMetadataImpl(
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   metadataContext: MetadataContext,
   createServerParamsForMetadata: CreateServerParamsForMetadata,
-  staticGenerationStore: WorkStore
+  workStore: WorkStore
 ): Promise<React.ReactNode> {
   const notFoundErrorConvention = 'not-found'
   const notFoundMetadataItems = await resolveMetadataItems(
@@ -196,7 +196,7 @@ async function getNotFoundMetadataImpl(
     notFoundErrorConvention,
     getDynamicParamFromSegment,
     createServerParamsForMetadata,
-    staticGenerationStore
+    workStore
   )
 
   const elements: Array<React.ReactNode> = createMetadataElements(
@@ -217,7 +217,7 @@ async function getResolvedViewportImpl(
   searchParams: Promise<ParsedUrlQuery>,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   createServerParamsForMetadata: CreateServerParamsForMetadata,
-  staticGenerationStore: WorkStore,
+  workStore: WorkStore,
   errorType?: 'not-found' | 'redirect'
 ): Promise<React.ReactNode> {
   const errorConvention = errorType === 'redirect' ? undefined : errorType
@@ -228,7 +228,7 @@ async function getResolvedViewportImpl(
     errorConvention,
     getDynamicParamFromSegment,
     createServerParamsForMetadata,
-    staticGenerationStore
+    workStore
   )
   const elements: Array<React.ReactNode> = createViewportElements(
     await accumulateViewport(metadataItems)
@@ -248,7 +248,7 @@ async function getNotFoundViewportImpl(
   searchParams: Promise<ParsedUrlQuery>,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   createServerParamsForMetadata: CreateServerParamsForMetadata,
-  staticGenerationStore: WorkStore
+  workStore: WorkStore
 ): Promise<React.ReactNode> {
   const notFoundErrorConvention = 'not-found'
   const notFoundMetadataItems = await resolveMetadataItems(
@@ -257,7 +257,7 @@ async function getNotFoundViewportImpl(
     notFoundErrorConvention,
     getDynamicParamFromSegment,
     createServerParamsForMetadata,
-    staticGenerationStore
+    workStore
   )
 
   const elements: Array<React.ReactNode> = createViewportElements(

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -53,7 +53,7 @@ import { getTracer } from '../../server/lib/trace/tracer'
 import { ResolveMetadataSpan } from '../../server/lib/trace/constants'
 import { PAGE_SEGMENT_KEY } from '../../shared/lib/segment'
 import * as Log from '../../build/output/log'
-import type { StaticGenerationStore } from '../../client/components/static-generation-async-storage.external'
+import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
 import type {
   Params,
   CreateServerParamsForMetadata,

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -489,7 +489,7 @@ async function resolveMetadataItems(
   errorConvention: 'not-found' | undefined,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   createServerParamsForMetadata: CreateServerParamsForMetadata,
-  staticGenerationStore: WorkStore
+  workStore: WorkStore
 ) {
   const parentParams = {}
   const metadataItems: MetadataItems = []
@@ -505,7 +505,7 @@ async function resolveMetadataItems(
     errorMetadataItem,
     getDynamicParamFromSegment,
     createServerParamsForMetadata,
-    staticGenerationStore
+    workStore
   )
 }
 
@@ -520,7 +520,7 @@ async function resolveMetadataItemsImpl(
   errorMetadataItem: MetadataItems[number],
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   createServerParamsForMetadata: CreateServerParamsForMetadata,
-  staticGenerationStore: WorkStore
+  workStore: WorkStore
 ): Promise<MetadataItems> {
   const [segment, parallelRoutes, { page }] = tree
   const currentTreePrefix =
@@ -540,10 +540,7 @@ async function resolveMetadataItemsImpl(
     }
   }
 
-  const params = createServerParamsForMetadata(
-    currentParams,
-    staticGenerationStore
-  )
+  const params = createServerParamsForMetadata(currentParams, workStore)
 
   let layerProps: LayoutProps | PageProps
   if (isPage) {
@@ -581,7 +578,7 @@ async function resolveMetadataItemsImpl(
       errorMetadataItem,
       getDynamicParamFromSegment,
       createServerParamsForMetadata,
-      staticGenerationStore
+      workStore
     )
   }
 

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -53,7 +53,7 @@ import { getTracer } from '../../server/lib/trace/tracer'
 import { ResolveMetadataSpan } from '../../server/lib/trace/constants'
 import { PAGE_SEGMENT_KEY } from '../../shared/lib/segment'
 import * as Log from '../../build/output/log'
-import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
+import type { WorkStore } from '../../client/components/work-async-storage.external'
 import type {
   Params,
   CreateServerParamsForMetadata,
@@ -489,7 +489,7 @@ async function resolveMetadataItems(
   errorConvention: 'not-found' | undefined,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   createServerParamsForMetadata: CreateServerParamsForMetadata,
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
 ) {
   const parentParams = {}
   const metadataItems: MetadataItems = []
@@ -520,7 +520,7 @@ async function resolveMetadataItemsImpl(
   errorMetadataItem: MetadataItems[number],
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   createServerParamsForMetadata: CreateServerParamsForMetadata,
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
 ): Promise<MetadataItems> {
   const [segment, parallelRoutes, { page }] = tree
   const currentTreePrefix =

--- a/packages/next/src/server/after/after-context.ts
+++ b/packages/next/src/server/after/after-context.ts
@@ -8,7 +8,7 @@ import type { RequestLifecycleOpts } from '../base-server'
 import type { AfterCallback, AfterTask } from './after'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { isThenable } from '../../shared/lib/is-thenable'
-import { staticGenerationAsyncStorage } from '../../client/components/work-async-storage.external'
+import { workAsyncStorage } from '../../client/components/work-async-storage.external'
 import { withExecuteRevalidates } from './revalidation-utils'
 
 export type AfterContextOpts = {
@@ -107,7 +107,7 @@ export class AfterContext {
     const readonlyRequestStore: RequestStore =
       wrapRequestStoreForAfterCallbacks(requestStore)
 
-    const workStore = staticGenerationAsyncStorage.getStore()
+    const workStore = workAsyncStorage.getStore()
 
     return withExecuteRevalidates(workStore, () =>
       requestAsyncStorage.run(readonlyRequestStore, async () => {

--- a/packages/next/src/server/after/after-context.ts
+++ b/packages/next/src/server/after/after-context.ts
@@ -8,7 +8,7 @@ import type { RequestLifecycleOpts } from '../base-server'
 import type { AfterCallback, AfterTask } from './after'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { isThenable } from '../../shared/lib/is-thenable'
-import { staticGenerationAsyncStorage } from '../../client/components/static-generation-async-storage.external'
+import { staticGenerationAsyncStorage } from '../../client/components/work-async-storage.external'
 import { withExecuteRevalidates } from './revalidation-utils'
 
 export type AfterContextOpts = {

--- a/packages/next/src/server/after/after-context.ts
+++ b/packages/next/src/server/after/after-context.ts
@@ -107,9 +107,9 @@ export class AfterContext {
     const readonlyRequestStore: RequestStore =
       wrapRequestStoreForAfterCallbacks(requestStore)
 
-    const staticGenerationStore = staticGenerationAsyncStorage.getStore()
+    const workStore = staticGenerationAsyncStorage.getStore()
 
-    return withExecuteRevalidates(staticGenerationStore, () =>
+    return withExecuteRevalidates(workStore, () =>
       requestAsyncStorage.run(readonlyRequestStore, async () => {
         this.callbackQueue.start()
         await this.callbackQueue.onIdle()

--- a/packages/next/src/server/after/after.ts
+++ b/packages/next/src/server/after/after.ts
@@ -1,5 +1,5 @@
 import { getExpectedRequestStore } from '../../client/components/request-async-storage.external'
-import { staticGenerationAsyncStorage } from '../../client/components/work-async-storage.external'
+import { workAsyncStorage } from '../../client/components/work-async-storage.external'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 
 import { markCurrentScopeAsDynamic } from '../app-render/dynamic-rendering'
@@ -22,7 +22,7 @@ export function unstable_after<T>(task: AfterTask<T>) {
     )
   }
 
-  const workStore = staticGenerationAsyncStorage.getStore()
+  const workStore = workAsyncStorage.getStore()
 
   if (workStore) {
     if (workStore.forceStatic) {

--- a/packages/next/src/server/after/after.ts
+++ b/packages/next/src/server/after/after.ts
@@ -1,5 +1,5 @@
 import { getExpectedRequestStore } from '../../client/components/request-async-storage.external'
-import { staticGenerationAsyncStorage } from '../../client/components/static-generation-async-storage.external'
+import { staticGenerationAsyncStorage } from '../../client/components/work-async-storage.external'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 
 import { markCurrentScopeAsDynamic } from '../app-render/dynamic-rendering'

--- a/packages/next/src/server/after/after.ts
+++ b/packages/next/src/server/after/after.ts
@@ -22,15 +22,15 @@ export function unstable_after<T>(task: AfterTask<T>) {
     )
   }
 
-  const staticGenerationStore = staticGenerationAsyncStorage.getStore()
+  const workStore = staticGenerationAsyncStorage.getStore()
 
-  if (staticGenerationStore) {
-    if (staticGenerationStore.forceStatic) {
+  if (workStore) {
+    if (workStore.forceStatic) {
       throw new StaticGenBailoutError(
-        `Route ${staticGenerationStore.route} with \`dynamic = "force-static"\` couldn't be rendered statically because it used \`${callingExpression}\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`
+        `Route ${workStore.route} with \`dynamic = "force-static"\` couldn't be rendered statically because it used \`${callingExpression}\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`
       )
     } else {
-      markCurrentScopeAsDynamic(staticGenerationStore, callingExpression)
+      markCurrentScopeAsDynamic(workStore, callingExpression)
     }
   }
 

--- a/packages/next/src/server/after/revalidation-utils.ts
+++ b/packages/next/src/server/after/revalidation-utils.ts
@@ -1,4 +1,4 @@
-import type { StaticGenerationStore } from '../../client/components/static-generation-async-storage.external'
+import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
 
 /** Run a callback, and execute any *new* revalidations added during its runtime. */
 export async function withExecuteRevalidates<T>(

--- a/packages/next/src/server/after/revalidation-utils.ts
+++ b/packages/next/src/server/after/revalidation-utils.ts
@@ -1,8 +1,8 @@
-import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
+import type { WorkStore } from '../../client/components/work-async-storage.external'
 
 /** Run a callback, and execute any *new* revalidations added during its runtime. */
 export async function withExecuteRevalidates<T>(
-  store: StaticGenerationStore | undefined,
+  store: WorkStore | undefined,
   callback: () => Promise<T>
 ): Promise<T> {
   if (!store) {
@@ -25,14 +25,12 @@ export async function withExecuteRevalidates<T>(
 
 type RevalidationState = Required<
   Pick<
-    StaticGenerationStore,
+    WorkStore,
     'revalidatedTags' | 'pendingRevalidates' | 'pendingRevalidateWrites'
   >
 >
 
-function cloneRevalidationState(
-  store: StaticGenerationStore
-): RevalidationState {
+function cloneRevalidationState(store: WorkStore): RevalidationState {
   return {
     revalidatedTags: store.revalidatedTags ? [...store.revalidatedTags] : [],
     pendingRevalidates: { ...store.pendingRevalidates },
@@ -62,7 +60,7 @@ function diffRevalidationState(
 }
 
 async function executeRevalidates(
-  staticGenerationStore: StaticGenerationStore,
+  staticGenerationStore: WorkStore,
   {
     revalidatedTags,
     pendingRevalidates,

--- a/packages/next/src/server/after/revalidation-utils.ts
+++ b/packages/next/src/server/after/revalidation-utils.ts
@@ -60,7 +60,7 @@ function diffRevalidationState(
 }
 
 async function executeRevalidates(
-  staticGenerationStore: WorkStore,
+  workStore: WorkStore,
   {
     revalidatedTags,
     pendingRevalidates,
@@ -68,7 +68,7 @@ async function executeRevalidates(
   }: RevalidationState
 ) {
   return Promise.all([
-    staticGenerationStore.incrementalCache?.revalidateTag(revalidatedTags),
+    workStore.incrementalCache?.revalidateTag(revalidatedTags),
     ...Object.values(pendingRevalidates),
     ...pendingRevalidateWrites,
   ])

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -20,7 +20,7 @@ import {
   type RedirectType,
 } from '../../client/components/redirect'
 import RenderResult from '../render-result'
-import type { StaticGenerationStore } from '../../client/components/static-generation-async-storage.external'
+import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
 import { FlightRenderResult } from './flight-render-result'
 import {
   filterReqHeaders,

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -110,19 +110,17 @@ function getForwardedHeaders(
 async function addRevalidationHeader(
   res: BaseNextResponse,
   {
-    staticGenerationStore,
+    workStore,
     requestStore,
   }: {
-    staticGenerationStore: WorkStore
+    workStore: WorkStore
     requestStore: RequestStore
   }
 ) {
   await Promise.all([
-    staticGenerationStore.incrementalCache?.revalidateTag(
-      staticGenerationStore.revalidatedTags || []
-    ),
-    ...Object.values(staticGenerationStore.pendingRevalidates || {}),
-    ...(staticGenerationStore.pendingRevalidateWrites || []),
+    workStore.incrementalCache?.revalidateTag(workStore.revalidatedTags || []),
+    ...Object.values(workStore.pendingRevalidates || {}),
+    ...(workStore.pendingRevalidateWrites || []),
   ])
 
   // If a tag was revalidated, the client router needs to invalidate all the
@@ -138,7 +136,7 @@ async function addRevalidationHeader(
   // TODO-APP: Currently paths are treated as tags, so the second element of the tuple
   // is always empty.
 
-  const isTagRevalidated = staticGenerationStore.revalidatedTags?.length ? 1 : 0
+  const isTagRevalidated = workStore.revalidatedTags?.length ? 1 : 0
   const isCookieRevalidated = getModifiedCookieValues(
     requestStore.mutableCookies
   ).length
@@ -160,7 +158,7 @@ async function createForwardedActionResponse(
   host: Host,
   workerPathname: string,
   basePath: string,
-  staticGenerationStore: WorkStore
+  workStore: WorkStore
 ) {
   if (!host) {
     throw new Error(
@@ -175,8 +173,7 @@ async function createForwardedActionResponse(
   // with the response from the forwarded worker
   forwardedHeaders.set('x-action-forwarded', '1')
 
-  const proto =
-    staticGenerationStore.incrementalCache?.requestProtocol || 'https'
+  const proto = workStore.incrementalCache?.requestProtocol || 'https'
 
   // For standalone or the serverful mode, use the internal origin directly
   // other than the host headers from the request.
@@ -281,7 +278,7 @@ async function createRedirectRenderResult(
   redirectUrl: string,
   redirectType: RedirectType,
   basePath: string,
-  staticGenerationStore: WorkStore
+  workStore: WorkStore
 ) {
   res.setHeader('x-action-redirect', `${redirectUrl};${redirectType}`)
 
@@ -306,8 +303,7 @@ async function createRedirectRenderResult(
     const forwardedHeaders = getForwardedHeaders(req, res)
     forwardedHeaders.set(RSC_HEADER, '1')
 
-    const proto =
-      staticGenerationStore.incrementalCache?.requestProtocol || 'https'
+    const proto = workStore.incrementalCache?.requestProtocol || 'https'
 
     // For standalone or the serverful mode, use the internal origin directly
     // other than the host headers from the request.
@@ -318,15 +314,15 @@ async function createRedirectRenderResult(
       `${origin}${appRelativeRedirectUrl.pathname}${appRelativeRedirectUrl.search}`
     )
 
-    if (staticGenerationStore.revalidatedTags) {
+    if (workStore.revalidatedTags) {
       forwardedHeaders.set(
         NEXT_CACHE_REVALIDATED_TAGS_HEADER,
-        staticGenerationStore.revalidatedTags.join(',')
+        workStore.revalidatedTags.join(',')
       )
       forwardedHeaders.set(
         NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER,
-        staticGenerationStore.incrementalCache?.prerenderManifest?.preview
-          ?.previewModeId || ''
+        workStore.incrementalCache?.prerenderManifest?.preview?.previewModeId ||
+          ''
       )
     }
 
@@ -416,7 +412,7 @@ export async function handleAction({
   ComponentMod,
   serverModuleMap,
   generateFlight,
-  staticGenerationStore,
+  workStore,
   requestStore,
   serverActions,
   ctx,
@@ -426,7 +422,7 @@ export async function handleAction({
   ComponentMod: AppPageModule
   serverModuleMap: ServerModuleMap
   generateFlight: GenerateFlight
-  staticGenerationStore: WorkStore
+  workStore: WorkStore
   requestStore: RequestStore
   serverActions?: ServerActionsConfig
   ctx: AppRenderContext
@@ -457,14 +453,14 @@ export async function handleAction({
     return
   }
 
-  if (staticGenerationStore.isStaticGeneration) {
+  if (workStore.isStaticGeneration) {
     throw new Error(
       "Invariant: server actions can't be handled during static rendering"
     )
   }
 
   // When running actions the default is no-store, you can still `cache: 'force-cache'`
-  staticGenerationStore.fetchCache = 'default-no-store'
+  workStore.fetchCache = 'default-no-store'
 
   const originDomain =
     typeof req.headers['origin'] === 'string'
@@ -530,11 +526,11 @@ export async function handleAction({
       if (isFetchAction) {
         res.statusCode = 500
         await Promise.all([
-          staticGenerationStore.incrementalCache?.revalidateTag(
-            staticGenerationStore.revalidatedTags || []
+          workStore.incrementalCache?.revalidateTag(
+            workStore.revalidatedTags || []
           ),
-          ...Object.values(staticGenerationStore.pendingRevalidates || {}),
-          ...(staticGenerationStore.pendingRevalidateWrites || []),
+          ...Object.values(workStore.pendingRevalidates || {}),
+          ...(workStore.pendingRevalidateWrites || []),
         ])
 
         const promise = Promise.reject(error)
@@ -553,7 +549,7 @@ export async function handleAction({
           result: await generateFlight(req, ctx, {
             actionResult: promise,
             // if the page was not revalidated, we can skip the rendering the flight tree
-            skipFlight: !staticGenerationStore.pathWasRevalidated,
+            skipFlight: !workStore.pathWasRevalidated,
           }),
         }
       }
@@ -595,7 +591,7 @@ export async function handleAction({
           host,
           forwardedWorker,
           ctx.renderOpts.basePath,
-          staticGenerationStore
+          workStore
         ),
       }
     }
@@ -839,15 +835,14 @@ export async function handleAction({
       // For form actions, we need to continue rendering the page.
       if (isFetchAction) {
         await addRevalidationHeader(res, {
-          staticGenerationStore,
+          workStore,
           requestStore,
         })
 
         actionResult = await generateFlight(req, ctx, {
           actionResult: Promise.resolve(returnVal),
           // if the page was not revalidated, or if the action was forwarded from another worker, we can skip the rendering the flight tree
-          skipFlight:
-            !staticGenerationStore.pathWasRevalidated || actionWasForwarded,
+          skipFlight: !workStore.pathWasRevalidated || actionWasForwarded,
         })
       }
     })
@@ -864,7 +859,7 @@ export async function handleAction({
       const redirectType = getRedirectTypeFromError(err)
 
       await addRevalidationHeader(res, {
-        staticGenerationStore,
+        workStore,
         requestStore,
       })
 
@@ -882,7 +877,7 @@ export async function handleAction({
             redirectUrl,
             redirectType,
             ctx.renderOpts.basePath,
-            staticGenerationStore
+            workStore
           ),
         }
       }
@@ -906,7 +901,7 @@ export async function handleAction({
       res.statusCode = 404
 
       await addRevalidationHeader(res, {
-        staticGenerationStore,
+        workStore,
         requestStore,
       })
 
@@ -937,11 +932,11 @@ export async function handleAction({
     if (isFetchAction) {
       res.statusCode = 500
       await Promise.all([
-        staticGenerationStore.incrementalCache?.revalidateTag(
-          staticGenerationStore.revalidatedTags || []
+        workStore.incrementalCache?.revalidateTag(
+          workStore.revalidatedTags || []
         ),
-        ...Object.values(staticGenerationStore.pendingRevalidates || {}),
-        ...(staticGenerationStore.pendingRevalidateWrites || []),
+        ...Object.values(workStore.pendingRevalidates || {}),
+        ...(workStore.pendingRevalidateWrites || []),
       ])
       const promise = Promise.reject(err)
       try {
@@ -959,8 +954,7 @@ export async function handleAction({
         result: await generateFlight(req, ctx, {
           actionResult: promise,
           // if the page was not revalidated, or if the action was forwarded from another worker, we can skip the rendering the flight tree
-          skipFlight:
-            !staticGenerationStore.pathWasRevalidated || actionWasForwarded,
+          skipFlight: !workStore.pathWasRevalidated || actionWasForwarded,
         }),
       }
     }

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -20,7 +20,7 @@ import {
   type RedirectType,
 } from '../../client/components/redirect'
 import RenderResult from '../render-result'
-import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
+import type { WorkStore } from '../../client/components/work-async-storage.external'
 import { FlightRenderResult } from './flight-render-result'
 import {
   filterReqHeaders,
@@ -113,7 +113,7 @@ async function addRevalidationHeader(
     staticGenerationStore,
     requestStore,
   }: {
-    staticGenerationStore: StaticGenerationStore
+    staticGenerationStore: WorkStore
     requestStore: RequestStore
   }
 ) {
@@ -160,7 +160,7 @@ async function createForwardedActionResponse(
   host: Host,
   workerPathname: string,
   basePath: string,
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
 ) {
   if (!host) {
     throw new Error(
@@ -281,7 +281,7 @@ async function createRedirectRenderResult(
   redirectUrl: string,
   redirectType: RedirectType,
   basePath: string,
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
 ) {
   res.setHeader('x-action-redirect', `${redirectUrl};${redirectType}`)
 
@@ -426,7 +426,7 @@ export async function handleAction({
   ComponentMod: AppPageModule
   serverModuleMap: ServerModuleMap
   generateFlight: GenerateFlight
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
   requestStore: RequestStore
   serverActions?: ServerActionsConfig
   ctx: AppRenderContext

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -169,7 +169,7 @@ export type GetDynamicParamFromSegment = (
 export type GenerateFlight = typeof generateDynamicFlightRenderResult
 
 export type AppRenderContext = {
-  staticGenerationStore: WorkStore
+  workStore: WorkStore
   requestStore: RequestStore
   componentMod: AppPageModule
   renderOpts: RenderOpts
@@ -396,28 +396,25 @@ async function generateDynamicRSCPayload(
     query,
     requestId,
     flightRouterState,
-    staticGenerationStore,
+    workStore,
   } = ctx
 
   if (!options?.skipFlight) {
     const preloadCallbacks: PreloadCallbacks = []
 
-    const searchParams = createServerSearchParamsForMetadata(
-      query,
-      staticGenerationStore
-    )
+    const searchParams = createServerSearchParamsForMetadata(query, workStore)
     const [MetadataTree, getMetadataReady] = createMetadataComponents({
       tree: loaderTree,
       searchParams,
       metadataContext: createTrackedMetadataContext(
         url.pathname,
         ctx.renderOpts,
-        staticGenerationStore
+        workStore
       ),
       getDynamicParamFromSegment,
       appUsingSizeAdjustment,
       createServerParamsForMetadata,
-      staticGenerationStore,
+      workStore,
     })
     flightData = (
       await walkTreeWithFlightRouterState({
@@ -460,7 +457,7 @@ async function generateDynamicRSCPayload(
   return {
     b: ctx.renderOpts.buildId,
     f: flightData,
-    S: staticGenerationStore.isStaticGeneration,
+    S: workStore.isStaticGeneration,
   }
 }
 
@@ -473,7 +470,7 @@ function createErrorContext(
     routePath: ctx.pagePath,
     routeType: ctx.isAction ? 'action' : 'render',
     renderSource,
-    revalidateReason: getRevalidateReason(ctx.staticGenerationStore),
+    revalidateReason: getRevalidateReason(ctx.workStore),
   }
 }
 /**
@@ -518,22 +515,22 @@ async function generateDynamicFlightRenderResult(
   await waitAtLeastOneReactRenderTask()
 
   if (
-    ctx.staticGenerationStore.pendingRevalidates ||
-    ctx.staticGenerationStore.revalidatedTags ||
-    ctx.staticGenerationStore.pendingRevalidateWrites
+    ctx.workStore.pendingRevalidates ||
+    ctx.workStore.revalidatedTags ||
+    ctx.workStore.pendingRevalidateWrites
   ) {
     const promises = Promise.all([
-      ctx.staticGenerationStore.incrementalCache?.revalidateTag(
-        ctx.staticGenerationStore.revalidatedTags || []
+      ctx.workStore.incrementalCache?.revalidateTag(
+        ctx.workStore.revalidatedTags || []
       ),
-      ...Object.values(ctx.staticGenerationStore.pendingRevalidates || {}),
-      ...(ctx.staticGenerationStore.pendingRevalidateWrites || []),
+      ...Object.values(ctx.workStore.pendingRevalidates || {}),
+      ...(ctx.workStore.pendingRevalidateWrites || []),
     ])
     ctx.renderOpts.waitUntil = (p) => promises.then(() => p)
   }
 
   return new FlightRenderResult(flightReadableStream, {
-    fetchMetrics: ctx.staticGenerationStore.fetchMetrics,
+    fetchMetrics: ctx.workStore.fetchMetrics,
   })
 }
 
@@ -574,7 +571,7 @@ async function getRSCPayload(
       createMetadataComponents,
     },
     requestStore: { url },
-    staticGenerationStore,
+    workStore,
   } = ctx
   const initialTree = createFlightRouterStateFromLoaderTree(
     tree,
@@ -582,10 +579,7 @@ async function getRSCPayload(
     query
   )
 
-  const searchParams = createServerSearchParamsForMetadata(
-    query,
-    staticGenerationStore
-  )
+  const searchParams = createServerSearchParamsForMetadata(query, workStore)
   const [MetadataTree, getMetadataReady] = createMetadataComponents({
     tree,
     errorType: is404 ? 'not-found' : undefined,
@@ -593,12 +587,12 @@ async function getRSCPayload(
     metadataContext: createTrackedMetadataContext(
       url.pathname,
       ctx.renderOpts,
-      staticGenerationStore
+      workStore
     ),
     getDynamicParamFromSegment,
     appUsingSizeAdjustment,
     createServerParamsForMetadata,
-    staticGenerationStore,
+    workStore,
   })
 
   const preloadCallbacks: PreloadCallbacks = []
@@ -644,7 +638,7 @@ async function getRSCPayload(
     m: missingSlots,
     G: GlobalError,
     s: typeof ctx.renderOpts.postponed === 'string',
-    S: staticGenerationStore.isStaticGeneration,
+    S: workStore.isStaticGeneration,
   }
 }
 
@@ -677,13 +671,10 @@ async function getErrorRSCPayload(
     },
     requestStore: { url },
     requestId,
-    staticGenerationStore,
+    workStore,
   } = ctx
 
-  const searchParams = createServerSearchParamsForMetadata(
-    query,
-    staticGenerationStore
-  )
+  const searchParams = createServerSearchParamsForMetadata(query, workStore)
   const [MetadataTree] = createMetadataComponents({
     tree,
     searchParams,
@@ -694,7 +685,7 @@ async function getErrorRSCPayload(
     getDynamicParamFromSegment,
     appUsingSizeAdjustment,
     createServerParamsForMetadata,
-    staticGenerationStore,
+    workStore,
   })
 
   const initialHead = (
@@ -735,7 +726,7 @@ async function getErrorRSCPayload(
     f: [[initialTree, initialSeedData, initialHead]],
     G: GlobalError,
     s: typeof ctx.renderOpts.postponed === 'string',
-    S: staticGenerationStore.isStaticGeneration,
+    S: workStore.isStaticGeneration,
   } satisfies InitialRSCPayload
 }
 
@@ -859,7 +850,7 @@ async function renderToHTMLOrFlightImpl(
   query: NextParsedUrlQuery,
   renderOpts: RenderOpts,
   requestStore: RequestStore,
-  staticGenerationStore: WorkStore,
+  workStore: WorkStore,
   parsedRequestHeaders: ParsedRequestHeaders,
   requestEndedState: { ended?: boolean },
   postponedState: PostponedState | null
@@ -990,8 +981,8 @@ async function renderToHTMLOrFlightImpl(
     )
   }
 
-  staticGenerationStore.fetchMetrics = []
-  metadata.fetchMetrics = staticGenerationStore.fetchMetrics
+  workStore.fetchMetrics = []
+  metadata.fetchMetrics = workStore.fetchMetrics
 
   // don't modify original query object
   query = { ...query }
@@ -1017,7 +1008,7 @@ async function renderToHTMLOrFlightImpl(
    */
   const params = renderOpts.params ?? {}
 
-  const { isStaticGeneration, fallbackRouteParams } = staticGenerationStore
+  const { isStaticGeneration, fallbackRouteParams } = workStore
 
   const getDynamicParamFromSegment = makeGetDynamicParamFromSegment(
     params,
@@ -1031,7 +1022,7 @@ async function renderToHTMLOrFlightImpl(
     componentMod: ComponentMod,
     renderOpts,
     requestStore,
-    staticGenerationStore,
+    workStore,
     parsedRequestHeaders,
     getDynamicParamFromSegment,
     query,
@@ -1071,7 +1062,7 @@ async function renderToHTMLOrFlightImpl(
       res,
       ctx,
       metadata,
-      staticGenerationStore,
+      workStore,
       loaderTree
     )
 
@@ -1108,40 +1099,39 @@ async function renderToHTMLOrFlightImpl(
     }
     // If we have pending revalidates, wait until they are all resolved.
     if (
-      staticGenerationStore.pendingRevalidates ||
-      staticGenerationStore.pendingRevalidateWrites ||
-      staticGenerationStore.revalidatedTags
+      workStore.pendingRevalidates ||
+      workStore.pendingRevalidateWrites ||
+      workStore.revalidatedTags
     ) {
       options.waitUntil = Promise.all([
-        staticGenerationStore.incrementalCache?.revalidateTag(
-          staticGenerationStore.revalidatedTags || []
+        workStore.incrementalCache?.revalidateTag(
+          workStore.revalidatedTags || []
         ),
-        ...Object.values(staticGenerationStore.pendingRevalidates || {}),
-        ...(staticGenerationStore.pendingRevalidateWrites || []),
+        ...Object.values(workStore.pendingRevalidates || {}),
+        ...(workStore.pendingRevalidateWrites || []),
       ])
     }
 
-    addImplicitTags(staticGenerationStore, requestStore)
+    addImplicitTags(workStore, requestStore)
 
-    if (staticGenerationStore.tags) {
-      metadata.fetchTags = staticGenerationStore.tags.join(',')
+    if (workStore.tags) {
+      metadata.fetchTags = workStore.tags.join(',')
     }
 
     // If force static is specifically set to false, we should not revalidate
     // the page.
-    if (staticGenerationStore.forceStatic === false) {
-      staticGenerationStore.revalidate = 0
+    if (workStore.forceStatic === false) {
+      workStore.revalidate = 0
     }
 
     // Copy the revalidation value onto the render result metadata.
-    metadata.revalidate =
-      staticGenerationStore.revalidate ?? ctx.defaultRevalidate
+    metadata.revalidate = workStore.revalidate ?? ctx.defaultRevalidate
 
     // provide bailout info for debugging
     if (metadata.revalidate === 0) {
       metadata.staticBailoutInfo = {
-        description: staticGenerationStore.dynamicUsageDescription,
-        stack: staticGenerationStore.dynamicUsageStack,
+        description: workStore.dynamicUsageDescription,
+        stack: workStore.dynamicUsageStack,
       }
     }
 
@@ -1172,7 +1162,7 @@ async function renderToHTMLOrFlightImpl(
         ComponentMod,
         serverModuleMap,
         generateFlight: generateDynamicFlightRenderResult,
-        staticGenerationStore,
+        workStore,
         requestStore,
         serverActions,
         ctx,
@@ -1218,23 +1208,23 @@ async function renderToHTMLOrFlightImpl(
 
     // If we have pending revalidates, wait until they are all resolved.
     if (
-      staticGenerationStore.pendingRevalidates ||
-      staticGenerationStore.pendingRevalidateWrites ||
-      staticGenerationStore.revalidatedTags
+      workStore.pendingRevalidates ||
+      workStore.pendingRevalidateWrites ||
+      workStore.revalidatedTags
     ) {
       options.waitUntil = Promise.all([
-        staticGenerationStore.incrementalCache?.revalidateTag(
-          staticGenerationStore.revalidatedTags || []
+        workStore.incrementalCache?.revalidateTag(
+          workStore.revalidatedTags || []
         ),
-        ...Object.values(staticGenerationStore.pendingRevalidates || {}),
-        ...(staticGenerationStore.pendingRevalidateWrites || []),
+        ...Object.values(workStore.pendingRevalidates || {}),
+        ...(workStore.pendingRevalidateWrites || []),
       ])
     }
 
-    addImplicitTags(staticGenerationStore, requestStore)
+    addImplicitTags(workStore, requestStore)
 
-    if (staticGenerationStore.tags) {
-      metadata.fetchTags = staticGenerationStore.tags.join(',')
+    if (workStore.tags) {
+      metadata.fetchTags = workStore.tags.join(',')
     }
 
     // Create the new render result for the response.
@@ -1313,7 +1303,7 @@ export const renderToHTMLOrFlight: AppPageRender = (
           requestEndedState,
           isPrefetchRequest: Boolean(req.headers[NEXT_ROUTER_PREFETCH_HEADER]),
         },
-        (staticGenerationStore) =>
+        (workStore) =>
           renderToHTMLOrFlightImpl(
             req,
             res,
@@ -1321,7 +1311,7 @@ export const renderToHTMLOrFlight: AppPageRender = (
             query,
             renderOpts,
             requestStore,
-            staticGenerationStore,
+            workStore,
             parsedRequestHeaders,
             requestEndedState,
             postponedState
@@ -1719,10 +1709,8 @@ type PrerenderToStreamResult = {
 /**
  * Determines whether we should generate static flight data.
  */
-function shouldGenerateStaticFlightData(
-  staticGenerationStore: WorkStore
-): boolean {
-  const { fallbackRouteParams, isStaticGeneration } = staticGenerationStore
+function shouldGenerateStaticFlightData(workStore: WorkStore): boolean {
+  const { fallbackRouteParams, isStaticGeneration } = workStore
   if (!isStaticGeneration) return false
 
   if (fallbackRouteParams && fallbackRouteParams.size > 0) {
@@ -1737,7 +1725,7 @@ async function prerenderToStream(
   res: BaseNextResponse,
   ctx: AppRenderContext,
   metadata: AppPageRenderResultMetadata,
-  staticGenerationStore: WorkStore,
+  workStore: WorkStore,
   tree: LoaderTree
 ): Promise<PrerenderToStreamResult> {
   // When prerendering formState is always null. We still include it
@@ -1749,7 +1737,7 @@ async function prerenderToStream(
   const ComponentMod = renderOpts.ComponentMod
   // TODO: fix this typescript
   const clientReferenceManifest = renderOpts.clientReferenceManifest!
-  const fallbackRouteParams = staticGenerationStore.fallbackRouteParams
+  const fallbackRouteParams = workStore.fallbackRouteParams
 
   const { ServerInsertedHTMLProvider, renderServerInsertedHTML } =
     createServerInsertedHTML()
@@ -2096,7 +2084,7 @@ async function prerenderToStream(
           }
         } else {
           // Static case
-          if (staticGenerationStore.forceDynamic) {
+          if (workStore.forceDynamic) {
             throw new StaticGenBailoutError(
               'Invariant: a Page with `dynamic = "force-dynamic"` did not trigger the dynamic pathway. This is a bug in Next.js'
             )
@@ -2166,7 +2154,7 @@ async function prerenderToStream(
          * synchronously fill caches during this special rendering mode. For now this heuristic should work
          */
 
-        const cache = staticGenerationStore.incrementalCache
+        const cache = workStore.incrementalCache
         if (!cache) {
           throw new Error(
             'Expected incremental cache to exist. This is a bug in Next.js'
@@ -2372,32 +2360,32 @@ async function prerenderToStream(
           const dynamicReason = getFirstDynamicReason(dynamicTracking)
           if (dynamicReason) {
             throw new DynamicServerError(
-              `Route ${staticGenerationStore.route} couldn't be rendered statically because it used \`${dynamicReason}\`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
+              `Route ${workStore.route} couldn't be rendered statically because it used \`${dynamicReason}\`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
             )
           } else {
             throw new DynamicServerError(
-              `Route ${staticGenerationStore.route} couldn't be rendered statically because it used IO that was not cached in a Client Component. See more info here: https://nextjs.org/docs/messages/dynamic-io`
+              `Route ${workStore.route} couldn't be rendered statically because it used IO that was not cached in a Client Component. See more info here: https://nextjs.org/docs/messages/dynamic-io`
             )
           }
         } else if (reactServerIsSynchronouslyDynamic) {
           const dynamicReason = getFirstDynamicReason(dynamicTracking)
           if (dynamicReason) {
             throw new DynamicServerError(
-              `Route ${staticGenerationStore.route} couldn't be rendered statically because it used \`${dynamicReason}\`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
+              `Route ${workStore.route} couldn't be rendered statically because it used \`${dynamicReason}\`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
             )
           } else {
             console.error(
               'Expected Next.js to keep track of reason for opting out of static rendering but one was not found. This is a bug in Next.js'
             )
             throw new DynamicServerError(
-              `Route ${staticGenerationStore.route} couldn't be rendered statically because it used a dynamic API. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
+              `Route ${workStore.route} couldn't be rendered statically because it used a dynamic API. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
             )
           }
         } else if (reactServerIsDynamic) {
           // There was unfinished work after we aborted after the first render Task. This means there is some IO
           // that is not covered by a cache and we need to bail out of static generation.
           const err = new DynamicServerError(
-            `Route ${staticGenerationStore.route} couldn't be rendered statically because it used IO that was not cached in a Server Component. See more info here: https://nextjs.org/docs/messages/dynamic-io`
+            `Route ${workStore.route} couldn't be rendered statically because it used IO that was not cached in a Server Component. See more info here: https://nextjs.org/docs/messages/dynamic-io`
           )
           serverComponentsErrorHandler(err)
           throw err
@@ -2510,7 +2498,7 @@ async function prerenderToStream(
       // parts of the React Server render that might not be used in the SSR render.
       const flightData = await streamToBuffer(reactServerResult.asStream())
 
-      if (shouldGenerateStaticFlightData(staticGenerationStore)) {
+      if (shouldGenerateStaticFlightData(workStore)) {
         metadata.flightData = flightData
       }
 
@@ -2568,7 +2556,7 @@ async function prerenderToStream(
       } else {
         // Static case
         // We still have not used any dynamic APIs. At this point we can produce an entirely static prerender response
-        if (staticGenerationStore.forceDynamic) {
+        if (workStore.forceDynamic) {
           throw new StaticGenBailoutError(
             'Invariant: a Page with `dynamic = "force-dynamic"` did not trigger the dynamic pathway. This is a bug in Next.js'
           )
@@ -2656,7 +2644,7 @@ async function prerenderToStream(
         }
       )
 
-      if (shouldGenerateStaticFlightData(staticGenerationStore)) {
+      if (shouldGenerateStaticFlightData(workStore)) {
         metadata.flightData = await streamToBuffer(reactServerResult.asStream())
       }
 
@@ -2794,7 +2782,7 @@ async function prerenderToStream(
         },
       })
 
-      if (shouldGenerateStaticFlightData(staticGenerationStore)) {
+      if (shouldGenerateStaticFlightData(workStore)) {
         metadata.flightData = await streamToBuffer(
           reactServerPrerenderResult.asStream()
         )

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -11,7 +11,7 @@ import type {
   FlightData,
   InitialRSCPayload,
 } from './types'
-import type { StaticGenerationStore } from '../../client/components/static-generation-async-storage.external'
+import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
 import type { RequestStore } from '../../client/components/request-async-storage.external'
 import type { NextParsedUrlQuery } from '../request-meta'
 import type { LoaderTree } from '../lib/app-dir-module'
@@ -52,7 +52,7 @@ import {
   createMetadataContext,
 } from '../../lib/metadata/metadata-context'
 import { withRequestStore } from '../async-storage/with-request-store'
-import { withStaticGenerationStore } from '../async-storage/with-static-generation-store'
+import { withStaticGenerationStore } from '../async-storage/with-work-store'
 import { isNotFoundError } from '../../client/components/not-found'
 import {
   getURLFromRedirectError,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -906,8 +906,7 @@ async function renderToHTMLOrFlightImpl(
     isNodeNextRequest(req)
   ) {
     req.originalRequest.on('end', () => {
-      const staticGenStore =
-        ComponentMod.staticGenerationAsyncStorage.getStore()
+      const staticGenStore = ComponentMod.workAsyncStorage.getStore()
       const prerenderStore = prerenderAsyncStorage.getStore()
       const isPPR = !!prerenderStore?.dynamicTracking?.dynamicAccesses?.length
 
@@ -1295,7 +1294,7 @@ export const renderToHTMLOrFlight: AppPageRender = (
     },
     (requestStore) =>
       withWorkStore(
-        renderOpts.ComponentMod.staticGenerationAsyncStorage,
+        renderOpts.ComponentMod.workAsyncStorage,
         {
           page: renderOpts.routeModule.definition.page,
           fallbackRouteParams,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -11,7 +11,7 @@ import type {
   FlightData,
   InitialRSCPayload,
 } from './types'
-import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
+import type { WorkStore } from '../../client/components/work-async-storage.external'
 import type { RequestStore } from '../../client/components/request-async-storage.external'
 import type { NextParsedUrlQuery } from '../request-meta'
 import type { LoaderTree } from '../lib/app-dir-module'
@@ -52,7 +52,7 @@ import {
   createMetadataContext,
 } from '../../lib/metadata/metadata-context'
 import { withRequestStore } from '../async-storage/with-request-store'
-import { withStaticGenerationStore } from '../async-storage/with-work-store'
+import { withWorkStore } from '../async-storage/with-work-store'
 import { isNotFoundError } from '../../client/components/not-found'
 import {
   getURLFromRedirectError,
@@ -169,7 +169,7 @@ export type GetDynamicParamFromSegment = (
 export type GenerateFlight = typeof generateDynamicFlightRenderResult
 
 export type AppRenderContext = {
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
   requestStore: RequestStore
   componentMod: AppPageModule
   renderOpts: RenderOpts
@@ -859,7 +859,7 @@ async function renderToHTMLOrFlightImpl(
   query: NextParsedUrlQuery,
   renderOpts: RenderOpts,
   requestStore: RequestStore,
-  staticGenerationStore: StaticGenerationStore,
+  staticGenerationStore: WorkStore,
   parsedRequestHeaders: ParsedRequestHeaders,
   requestEndedState: { ended?: boolean },
   postponedState: PostponedState | null
@@ -1304,7 +1304,7 @@ export const renderToHTMLOrFlight: AppPageRender = (
       serverComponentsHmrCache,
     },
     (requestStore) =>
-      withStaticGenerationStore(
+      withWorkStore(
         renderOpts.ComponentMod.staticGenerationAsyncStorage,
         {
           page: renderOpts.routeModule.definition.page,
@@ -1720,7 +1720,7 @@ type PrerenderToStreamResult = {
  * Determines whether we should generate static flight data.
  */
 function shouldGenerateStaticFlightData(
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
 ): boolean {
   const { fallbackRouteParams, isStaticGeneration } = staticGenerationStore
   if (!isStaticGeneration) return false
@@ -1737,7 +1737,7 @@ async function prerenderToStream(
   res: BaseNextResponse,
   ctx: AppRenderContext,
   metadata: AppPageRenderResultMetadata,
-  staticGenerationStore: StaticGenerationStore,
+  staticGenerationStore: WorkStore,
   tree: LoaderTree
 ): Promise<PrerenderToStreamResult> {
   // When prerendering formState is always null. We still include it

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -20,7 +20,7 @@
  * read that data outside the cache and pass it in as an argument to the cached function.
  */
 
-import type { StaticGenerationStore } from '../../client/components/static-generation-async-storage.external'
+import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
 
 // Once postpone is in stable we should switch to importing the postpone export directly
 import React from 'react'
@@ -32,7 +32,7 @@ import {
   prerenderAsyncStorage,
   type PrerenderStore,
 } from './prerender-async-storage.external'
-import { staticGenerationAsyncStorage } from '../../client/components/static-generation-async-storage.external'
+import { staticGenerationAsyncStorage } from '../../client/components/work-async-storage.external'
 import { makeHangingPromise } from '../dynamic-rendering-utils'
 
 const hasPostpone = typeof React.unstable_postpone === 'function'

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -32,7 +32,7 @@ import {
   prerenderAsyncStorage,
   type PrerenderStore,
 } from './prerender-async-storage.external'
-import { staticGenerationAsyncStorage } from '../../client/components/work-async-storage.external'
+import { workAsyncStorage } from '../../client/components/work-async-storage.external'
 import { makeHangingPromise } from '../dynamic-rendering-utils'
 
 const hasPostpone = typeof React.unstable_postpone === 'function'
@@ -523,7 +523,7 @@ export function annotateDynamicAccess(
 
 export function useDynamicRouteParams(expression: string) {
   if (typeof window === 'undefined') {
-    const workStore = staticGenerationAsyncStorage.getStore()
+    const workStore = workAsyncStorage.getStore()
 
     if (
       workStore &&

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -523,13 +523,13 @@ export function annotateDynamicAccess(
 
 export function useDynamicRouteParams(expression: string) {
   if (typeof window === 'undefined') {
-    const staticGenerationStore = staticGenerationAsyncStorage.getStore()
+    const workStore = staticGenerationAsyncStorage.getStore()
 
     if (
-      staticGenerationStore &&
-      staticGenerationStore.isStaticGeneration &&
-      staticGenerationStore.fallbackRouteParams &&
-      staticGenerationStore.fallbackRouteParams.size > 0
+      workStore &&
+      workStore.isStaticGeneration &&
+      workStore.fallbackRouteParams &&
+      workStore.fallbackRouteParams.size > 0
     ) {
       // There are fallback route params, we should track these as dynamic
       // accesses.
@@ -544,14 +544,14 @@ export function useDynamicRouteParams(expression: string) {
         } else {
           // We're prerendering with PPR
           postponeWithTracking(
-            staticGenerationStore.route,
+            workStore.route,
             expression,
             prerenderStore.dynamicTracking
           )
         }
       } else {
         // We're prerendering in legacy mode
-        throwToInterruptStaticGeneration(expression, staticGenerationStore)
+        throwToInterruptStaticGeneration(expression, workStore)
       }
     }
   }

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -20,7 +20,7 @@
  * read that data outside the cache and pass it in as an argument to the cached function.
  */
 
-import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
+import type { WorkStore } from '../../client/components/work-async-storage.external'
 
 // Once postpone is in stable we should switch to importing the postpone export directly
 import React from 'react'
@@ -87,7 +87,7 @@ export function getFirstDynamicReason(
  * it during a normal prerender will cause the entire prerender to abort
  */
 export function markCurrentScopeAsDynamic(
-  store: StaticGenerationStore,
+  store: WorkStore,
   expression: string
 ): void {
   // inside cache scopes marking a scope as dynamic has no effect because the outer cache scope
@@ -152,7 +152,7 @@ export function markCurrentScopeAsDynamic(
  * @param expression The expression that was accessed dynamically
  */
 export function trackFallbackParamAccessed(
-  store: StaticGenerationStore,
+  store: WorkStore,
   expression: string
 ): void {
   const prerenderStore = prerenderAsyncStorage.getStore()
@@ -171,7 +171,7 @@ export function trackFallbackParamAccessed(
  * Also during a PPR Prerender we postpone
  */
 export function trackDynamicDataAccessed(
-  store: StaticGenerationStore,
+  store: WorkStore,
   expression: string
 ): void {
   if (store.isUnstableCacheCallback) {
@@ -229,7 +229,7 @@ export function trackDynamicDataAccessed(
  */
 export function throwToInterruptStaticGeneration(
   expression: string,
-  store: StaticGenerationStore
+  store: WorkStore
 ): never {
   store.revalidate = 0
 
@@ -250,7 +250,7 @@ export function throwToInterruptStaticGeneration(
  *
  * @internal
  */
-export function trackDynamicDataInDynamicRender(store: StaticGenerationStore) {
+export function trackDynamicDataInDynamicRender(store: WorkStore) {
   store.revalidate = 0
 }
 

--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -11,7 +11,7 @@ export { prerender } from 'react-server-dom-webpack/static.edge'
 
 import LayoutRouter from '../../client/components/layout-router'
 import RenderFromTemplateContext from '../../client/components/render-from-template-context'
-import { staticGenerationAsyncStorage } from '../../client/components/work-async-storage.external'
+import { workAsyncStorage } from '../../client/components/work-async-storage.external'
 import { requestAsyncStorage } from '../../client/components/request-async-storage.external'
 import { prerenderAsyncStorage } from './prerender-async-storage.external'
 import { actionAsyncStorage } from '../../client/components/action-async-storage.external'
@@ -42,7 +42,7 @@ import { taintObjectReference } from './rsc/taint'
 // in the experimental channel of React, so export it from here so that it comes from the bundled runtime
 function patchFetch() {
   return _patchFetch({
-    staticGenerationAsyncStorage,
+    workAsyncStorage,
     requestAsyncStorage,
     prerenderAsyncStorage,
   })
@@ -51,7 +51,7 @@ function patchFetch() {
 export {
   LayoutRouter,
   RenderFromTemplateContext,
-  staticGenerationAsyncStorage,
+  workAsyncStorage,
   requestAsyncStorage,
   actionAsyncStorage,
   createServerSearchParamsForServerPage,

--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -11,7 +11,7 @@ export { prerender } from 'react-server-dom-webpack/static.edge'
 
 import LayoutRouter from '../../client/components/layout-router'
 import RenderFromTemplateContext from '../../client/components/render-from-template-context'
-import { staticGenerationAsyncStorage } from '../../client/components/static-generation-async-storage.external'
+import { staticGenerationAsyncStorage } from '../../client/components/work-async-storage.external'
 import { requestAsyncStorage } from '../../client/components/request-async-storage.external'
 import { prerenderAsyncStorage } from './prerender-async-storage.external'
 import { actionAsyncStorage } from '../../client/components/action-async-storage.external'

--- a/packages/next/src/server/async-storage/with-work-store.ts
+++ b/packages/next/src/server/async-storage/with-work-store.ts
@@ -1,11 +1,11 @@
 import type { WithStore } from './with-store'
-import type { StaticGenerationStore } from '../../client/components/static-generation-async-storage.external'
+import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
 import type { AsyncLocalStorage } from 'async_hooks'
 import type { IncrementalCache } from '../lib/incremental-cache'
 import type { RenderOptsPartial } from '../app-render/types'
 import type { FetchMetric } from '../base-http'
 import type { RequestLifecycleOpts } from '../base-server'
-import type { FallbackRouteParams } from '../../server/request/fallback-params'
+import type { FallbackRouteParams } from '../request/fallback-params'
 import type { AppSegmentConfig } from '../../build/app-segments/app-segment-config'
 
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'

--- a/packages/next/src/server/async-storage/with-work-store.ts
+++ b/packages/next/src/server/async-storage/with-work-store.ts
@@ -1,5 +1,5 @@
 import type { WithStore } from './with-store'
-import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
+import type { WorkStore } from '../../client/components/work-async-storage.external'
 import type { AsyncLocalStorage } from 'async_hooks'
 import type { IncrementalCache } from '../lib/incremental-cache'
 import type { RenderOptsPartial } from '../app-render/types'
@@ -47,7 +47,7 @@ export type StaticGenerationContext = {
      * @deprecated should only be used as a temporary workaround
      */
     // TODO: remove this when we resolve accessing the store outside the execution context
-    store?: StaticGenerationStore
+    store?: WorkStore
   } & Pick<
     // Pull some properties from RenderOptsPartial so that the docs are also
     // mirrored.
@@ -62,11 +62,10 @@ export type StaticGenerationContext = {
     Partial<RequestLifecycleOpts>
 }
 
-export const withStaticGenerationStore: WithStore<
-  StaticGenerationStore,
-  StaticGenerationContext
-> = <Result>(
-  storage: AsyncLocalStorage<StaticGenerationStore>,
+export const withWorkStore: WithStore<WorkStore, StaticGenerationContext> = <
+  Result,
+>(
+  storage: AsyncLocalStorage<WorkStore>,
   {
     page,
     fallbackRouteParams,
@@ -74,7 +73,7 @@ export const withStaticGenerationStore: WithStore<
     requestEndedState,
     isPrefetchRequest,
   }: StaticGenerationContext,
-  callback: (store: StaticGenerationStore) => Result
+  callback: (store: WorkStore) => Result
 ): Result => {
   /**
    * Rules of Static & Dynamic HTML:
@@ -98,7 +97,7 @@ export const withStaticGenerationStore: WithStore<
     !renderOpts.isDraftMode &&
     !renderOpts.isServerAction
 
-  const store: StaticGenerationStore = {
+  const store: WorkStore = {
     isStaticGeneration,
     page,
     fallbackRouteParams,

--- a/packages/next/src/server/async-storage/with-work-store.ts
+++ b/packages/next/src/server/async-storage/with-work-store.ts
@@ -10,7 +10,7 @@ import type { AppSegmentConfig } from '../../build/app-segments/app-segment-conf
 
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 
-export type StaticGenerationContext = {
+export type WorkStoreContext = {
   /**
    * The page that is being rendered. This relates to the path to the page file.
    */
@@ -62,9 +62,7 @@ export type StaticGenerationContext = {
     Partial<RequestLifecycleOpts>
 }
 
-export const withWorkStore: WithStore<WorkStore, StaticGenerationContext> = <
-  Result,
->(
+export const withWorkStore: WithStore<WorkStore, WorkStoreContext> = <Result>(
   storage: AsyncLocalStorage<WorkStore>,
   {
     page,
@@ -72,7 +70,7 @@ export const withWorkStore: WithStore<WorkStore, StaticGenerationContext> = <
     renderOpts,
     requestEndedState,
     isPrefetchRequest,
-  }: StaticGenerationContext,
+  }: WorkStoreContext,
   callback: (store: WorkStore) => Result
 ): Result => {
   /**

--- a/packages/next/src/server/lib/patch-fetch.test.ts
+++ b/packages/next/src/server/lib/patch-fetch.test.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import type { RequestStore } from '../../client/components/request-async-storage.external'
-import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
+import type { WorkStore } from '../../client/components/work-async-storage.external'
 import type { IncrementalCache } from './incremental-cache'
 import { createPatchedFetcher } from './patch-fetch'
 import type { PrerenderStore } from '../app-render/prerender-async-storage.external'
@@ -22,8 +22,7 @@ describe('createPatchedFetcher', () => {
 
     mockFetch.mockResolvedValue(new Response(readableStream))
 
-    const staticGenerationAsyncStorage =
-      new AsyncLocalStorage<StaticGenerationStore>()
+    const staticGenerationAsyncStorage = new AsyncLocalStorage<WorkStore>()
 
     const prerenderAsyncStorage = new AsyncLocalStorage<PrerenderStore>()
 
@@ -47,15 +46,15 @@ describe('createPatchedFetcher', () => {
       lock: jest.fn(() => resolveIncrementalCacheSet),
     } as unknown as IncrementalCache
 
-    // We only need to provide a few of the StaticGenerationStore properties.
-    const staticGenerationStore: Partial<StaticGenerationStore> = {
+    // We only need to provide a few of the WorkStore properties.
+    const staticGenerationStore: Partial<WorkStore> = {
       page: '/',
       route: '/',
       incrementalCache,
     }
 
     await staticGenerationAsyncStorage.run(
-      staticGenerationStore as StaticGenerationStore,
+      staticGenerationStore as WorkStore,
       async () => {
         const response = await patchedFetch('https://example.com', {
           cache: 'force-cache',

--- a/packages/next/src/server/lib/patch-fetch.test.ts
+++ b/packages/next/src/server/lib/patch-fetch.test.ts
@@ -22,14 +22,14 @@ describe('createPatchedFetcher', () => {
 
     mockFetch.mockResolvedValue(new Response(readableStream))
 
-    const staticGenerationAsyncStorage = new AsyncLocalStorage<WorkStore>()
+    const workAsyncStorage = new AsyncLocalStorage<WorkStore>()
 
     const prerenderAsyncStorage = new AsyncLocalStorage<PrerenderStore>()
 
     const patchedFetch = createPatchedFetcher(mockFetch, {
       // requestAsyncStorage does not need to provide a store for this test.
       requestAsyncStorage: new AsyncLocalStorage<RequestStore>(),
-      staticGenerationAsyncStorage,
+      workAsyncStorage,
       prerenderAsyncStorage,
     })
 
@@ -53,7 +53,7 @@ describe('createPatchedFetcher', () => {
       incrementalCache,
     }
 
-    await staticGenerationAsyncStorage.run(workStore as WorkStore, async () => {
+    await workAsyncStorage.run(workStore as WorkStore, async () => {
       const response = await patchedFetch('https://example.com', {
         cache: 'force-cache',
       })

--- a/packages/next/src/server/lib/patch-fetch.test.ts
+++ b/packages/next/src/server/lib/patch-fetch.test.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import type { RequestStore } from '../../client/components/request-async-storage.external'
-import type { StaticGenerationStore } from '../../client/components/static-generation-async-storage.external'
+import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
 import type { IncrementalCache } from './incremental-cache'
 import { createPatchedFetcher } from './patch-fetch'
 import type { PrerenderStore } from '../app-render/prerender-async-storage.external'

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -1,6 +1,6 @@
 import type {
   StaticGenerationAsyncStorage,
-  StaticGenerationStore,
+  WorkStore,
 } from '../../client/components/work-async-storage.external'
 
 import { AppRenderSpan, NextNodeServerSpan } from './trace/constants'
@@ -138,7 +138,7 @@ const getDerivedTags = (pathname: string): string[] => {
 }
 
 export function addImplicitTags(
-  staticGenerationStore: StaticGenerationStore,
+  staticGenerationStore: WorkStore,
   requestStore: RequestStore | undefined
 ) {
   const newTags: string[] = []
@@ -173,7 +173,7 @@ export function addImplicitTags(
 }
 
 function trackFetchMetric(
-  staticGenerationStore: StaticGenerationStore,
+  staticGenerationStore: WorkStore,
   ctx: Omit<FetchMetric, 'end' | 'idx'>
 ) {
   // If the static generation store is not available, we can't track the fetch

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -1,7 +1,7 @@
 import type {
   StaticGenerationAsyncStorage,
   StaticGenerationStore,
-} from '../../client/components/static-generation-async-storage.external'
+} from '../../client/components/work-async-storage.external'
 
 import { AppRenderSpan, NextNodeServerSpan } from './trace/constants'
 import { getTracer, SpanKind } from './trace/tracer'

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -205,7 +205,7 @@ function trackFetchMetric(
 }
 
 interface PatchableModule {
-  staticGenerationAsyncStorage: StaticGenerationAsyncStorage
+  workAsyncStorage: StaticGenerationAsyncStorage
   requestAsyncStorage: RequestAsyncStorage
   prerenderAsyncStorage: PrerenderAsyncStorage
 }
@@ -213,7 +213,7 @@ interface PatchableModule {
 export function createPatchedFetcher(
   originFetch: Fetcher,
   {
-    staticGenerationAsyncStorage,
+    workAsyncStorage,
     requestAsyncStorage,
     prerenderAsyncStorage,
   }: PatchableModule
@@ -242,7 +242,7 @@ export function createPatchedFetcher(
     const isInternal = (init?.next as any)?.internal === true
     const hideSpan = process.env.NEXT_OTEL_FETCH_DISABLED === '1'
 
-    const workStore = staticGenerationAsyncStorage.getStore()
+    const workStore = workAsyncStorage.getStore()
 
     const result = getTracer().trace(
       isInternal ? NextNodeServerSpan.internalFetch : AppRenderSpan.fetch,
@@ -919,7 +919,7 @@ export function createPatchedFetcher(
   // but for external consumers to determine if the fetch function has been
   // patched.
   patched.__nextPatched = true as const
-  patched.__nextGetStaticStore = () => staticGenerationAsyncStorage
+  patched.__nextGetStaticStore = () => workAsyncStorage
   patched._nextOriginalFetch = originFetch
   ;(globalThis as Record<symbol, unknown>)[NEXT_PATCH_SYMBOL] = true
 

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -1,5 +1,5 @@
 import type {
-  StaticGenerationAsyncStorage,
+  WorkAsyncStorage,
   WorkStore,
 } from '../../client/components/work-async-storage.external'
 
@@ -32,7 +32,7 @@ type Fetcher = typeof fetch
 
 type PatchedFetcher = Fetcher & {
   readonly __nextPatched: true
-  readonly __nextGetStaticStore: () => StaticGenerationAsyncStorage
+  readonly __nextGetStaticStore: () => WorkAsyncStorage
   readonly _nextOriginalFetch: Fetcher
 }
 
@@ -205,7 +205,7 @@ function trackFetchMetric(
 }
 
 interface PatchableModule {
-  workAsyncStorage: StaticGenerationAsyncStorage
+  workAsyncStorage: WorkAsyncStorage
   requestAsyncStorage: RequestAsyncStorage
   prerenderAsyncStorage: PrerenderAsyncStorage
 }

--- a/packages/next/src/server/request/connection.ts
+++ b/packages/next/src/server/request/connection.ts
@@ -1,4 +1,4 @@
-import { staticGenerationAsyncStorage } from '../../client/components/static-generation-async-storage.external'
+import { staticGenerationAsyncStorage } from '../../client/components/work-async-storage.external'
 import {
   isDynamicIOPrerender,
   prerenderAsyncStorage,

--- a/packages/next/src/server/request/connection.ts
+++ b/packages/next/src/server/request/connection.ts
@@ -1,4 +1,4 @@
-import { staticGenerationAsyncStorage } from '../../client/components/work-async-storage.external'
+import { workAsyncStorage } from '../../client/components/work-async-storage.external'
 import {
   isDynamicIOPrerender,
   prerenderAsyncStorage,
@@ -17,7 +17,7 @@ import { makeHangingPromise } from '../dynamic-rendering-utils'
  * During prerendering it will never resolve and during rendering it resolves immediately.
  */
 export function connection(): Promise<void> {
-  const workStore = staticGenerationAsyncStorage.getStore()
+  const workStore = workAsyncStorage.getStore()
   const prerenderStore = prerenderAsyncStorage.getStore()
 
   if (workStore) {

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -4,7 +4,7 @@ import {
   RequestCookiesAdapter,
 } from '../../server/web/spec-extension/adapters/request-cookies'
 import { RequestCookies } from '../../server/web/spec-extension/cookies'
-import { staticGenerationAsyncStorage } from '../../client/components/static-generation-async-storage.external'
+import { staticGenerationAsyncStorage } from '../../client/components/work-async-storage.external'
 import {
   isDynamicIOPrerender,
   prerenderAsyncStorage,

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -4,7 +4,7 @@ import {
   RequestCookiesAdapter,
 } from '../../server/web/spec-extension/adapters/request-cookies'
 import { RequestCookies } from '../../server/web/spec-extension/cookies'
-import { staticGenerationAsyncStorage } from '../../client/components/work-async-storage.external'
+import { workAsyncStorage } from '../../client/components/work-async-storage.external'
 import {
   isDynamicIOPrerender,
   prerenderAsyncStorage,
@@ -51,7 +51,7 @@ export type UnsafeUnwrappedCookies = ReadonlyRequestCookies
 export function cookies(): Promise<ReadonlyRequestCookies> {
   const callingExpression = 'cookies'
   const requestStore = getExpectedRequestStore(callingExpression)
-  const workStore = staticGenerationAsyncStorage.getStore()
+  const workStore = workAsyncStorage.getStore()
   const prerenderStore = prerenderAsyncStorage.getStore()
 
   if (workStore) {

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -51,24 +51,24 @@ export type UnsafeUnwrappedCookies = ReadonlyRequestCookies
 export function cookies(): Promise<ReadonlyRequestCookies> {
   const callingExpression = 'cookies'
   const requestStore = getExpectedRequestStore(callingExpression)
-  const staticGenerationStore = staticGenerationAsyncStorage.getStore()
+  const workStore = staticGenerationAsyncStorage.getStore()
   const prerenderStore = prerenderAsyncStorage.getStore()
 
-  if (staticGenerationStore) {
-    if (staticGenerationStore.forceStatic) {
+  if (workStore) {
+    if (workStore.forceStatic) {
       // When using forceStatic we override all other logic and always just return an empty
       // cookies object without tracking
       const underlyingCookies = createEmptyCookies()
       return makeUntrackedExoticCookies(underlyingCookies)
     }
 
-    if (staticGenerationStore.isUnstableCacheCallback) {
+    if (workStore.isUnstableCacheCallback) {
       throw new Error(
-        `Route ${staticGenerationStore.route} used "cookies" inside a function cached with "unstable_cache(...)". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use "cookies" outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache`
+        `Route ${workStore.route} used "cookies" inside a function cached with "unstable_cache(...)". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use "cookies" outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache`
       )
-    } else if (staticGenerationStore.dynamicShouldError) {
+    } else if (workStore.dynamicShouldError) {
       throw new StaticGenBailoutError(
-        `Route ${staticGenerationStore.route} with \`dynamic = "error"\` couldn't be rendered statically because it used \`cookies\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`
+        `Route ${workStore.route} with \`dynamic = "error"\` couldn't be rendered statically because it used \`cookies\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`
       )
     }
 
@@ -83,7 +83,7 @@ export function cookies(): Promise<ReadonlyRequestCookies> {
         // We don't track dynamic access here because access will be tracked when you access
         // one of the properties of the cookies object.
         return makeDynamicallyTrackedExoticCookies(
-          staticGenerationStore.route,
+          workStore.route,
           prerenderStore
         )
       } else {
@@ -91,20 +91,20 @@ export function cookies(): Promise<ReadonlyRequestCookies> {
         // to keep continuity with how cookies has worked in PPR without dynamicIO.
         // TODO consider switching the semantic to throw on property access instead
         postponeWithTracking(
-          staticGenerationStore.route,
+          workStore.route,
           callingExpression,
           prerenderStore.dynamicTracking
         )
       }
-    } else if (staticGenerationStore.isStaticGeneration) {
+    } else if (workStore.isStaticGeneration) {
       // We are in a legacy static generation mode while prerendering
       // We track dynamic access here so we don't need to wrap the cookies in
       // individual property access tracking.
-      throwToInterruptStaticGeneration(callingExpression, staticGenerationStore)
+      throwToInterruptStaticGeneration(callingExpression, workStore)
     }
     // We fall through to the dynamic context below but we still track dynamic access
     // because in dev we can still error for things like using cookies inside a cache context
-    trackDynamicDataInDynamicRender(staticGenerationStore)
+    trackDynamicDataInDynamicRender(workStore)
   }
 
   // cookies is being called in a dynamic context
@@ -126,13 +126,10 @@ export function cookies(): Promise<ReadonlyRequestCookies> {
     underlyingCookies = requestStore.cookies
   }
 
-  if (
-    process.env.NODE_ENV === 'development' &&
-    !staticGenerationStore?.isPrefetchRequest
-  ) {
+  if (process.env.NODE_ENV === 'development' && !workStore?.isPrefetchRequest) {
     return makeUntrackedExoticCookiesWithDevWarnings(
       underlyingCookies,
-      staticGenerationStore?.route
+      workStore?.route
     )
   } else {
     return makeUntrackedExoticCookies(underlyingCookies)

--- a/packages/next/src/server/request/draft-mode.ts
+++ b/packages/next/src/server/request/draft-mode.ts
@@ -2,7 +2,7 @@ import { getExpectedRequestStore } from '../../client/components/request-async-s
 
 import type { DraftModeProvider } from '../../server/async-storage/draft-mode-provider'
 
-import { staticGenerationAsyncStorage } from '../../client/components/work-async-storage.external'
+import { workAsyncStorage } from '../../client/components/work-async-storage.external'
 import { trackDynamicDataAccessed } from '../app-render/dynamic-rendering'
 
 /**
@@ -34,7 +34,7 @@ export type UnsafeUnwrappedDraftMode = DraftMode
 export function draftMode(): Promise<DraftMode> {
   const callingExpression = 'draftMode'
   const requestStore = getExpectedRequestStore(callingExpression)
-  const workStore = staticGenerationAsyncStorage.getStore()
+  const workStore = workAsyncStorage.getStore()
 
   if (process.env.NODE_ENV === 'development' && !workStore?.isPrefetchRequest) {
     const route = workStore?.route
@@ -141,7 +141,7 @@ class DraftMode {
     return this._provider.isEnabled
   }
   public enable() {
-    const store = staticGenerationAsyncStorage.getStore()
+    const store = workAsyncStorage.getStore()
     if (store) {
       // We we have a store we want to track dynamic data access to ensure we
       // don't statically generate routes that manipulate draft mode.
@@ -150,7 +150,7 @@ class DraftMode {
     return this._provider.enable()
   }
   public disable() {
-    const store = staticGenerationAsyncStorage.getStore()
+    const store = workAsyncStorage.getStore()
     if (store) {
       // We we have a store we want to track dynamic data access to ensure we
       // don't statically generate routes that manipulate draft mode.

--- a/packages/next/src/server/request/draft-mode.ts
+++ b/packages/next/src/server/request/draft-mode.ts
@@ -2,7 +2,7 @@ import { getExpectedRequestStore } from '../../client/components/request-async-s
 
 import type { DraftModeProvider } from '../../server/async-storage/draft-mode-provider'
 
-import { staticGenerationAsyncStorage } from '../../client/components/static-generation-async-storage.external'
+import { staticGenerationAsyncStorage } from '../../client/components/work-async-storage.external'
 import { trackDynamicDataAccessed } from '../app-render/dynamic-rendering'
 
 /**

--- a/packages/next/src/server/request/draft-mode.ts
+++ b/packages/next/src/server/request/draft-mode.ts
@@ -34,13 +34,10 @@ export type UnsafeUnwrappedDraftMode = DraftMode
 export function draftMode(): Promise<DraftMode> {
   const callingExpression = 'draftMode'
   const requestStore = getExpectedRequestStore(callingExpression)
-  const staticGenerationStore = staticGenerationAsyncStorage.getStore()
+  const workStore = staticGenerationAsyncStorage.getStore()
 
-  if (
-    process.env.NODE_ENV === 'development' &&
-    !staticGenerationStore?.isPrefetchRequest
-  ) {
-    const route = staticGenerationStore?.route
+  if (process.env.NODE_ENV === 'development' && !workStore?.isPrefetchRequest) {
+    const route = workStore?.route
     return createExoticDraftModeWithDevWarnings(requestStore.draftMode, route)
   } else {
     return createExoticDraftMode(requestStore.draftMode)

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -2,7 +2,7 @@ import {
   HeadersAdapter,
   type ReadonlyHeaders,
 } from '../../server/web/spec-extension/adapters/headers'
-import { staticGenerationAsyncStorage } from '../../client/components/static-generation-async-storage.external'
+import { staticGenerationAsyncStorage } from '../../client/components/work-async-storage.external'
 import { getExpectedRequestStore } from '../../client/components/request-async-storage.external'
 import {
   isDynamicIOPrerender,

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -2,7 +2,7 @@ import {
   HeadersAdapter,
   type ReadonlyHeaders,
 } from '../../server/web/spec-extension/adapters/headers'
-import { staticGenerationAsyncStorage } from '../../client/components/work-async-storage.external'
+import { workAsyncStorage } from '../../client/components/work-async-storage.external'
 import { getExpectedRequestStore } from '../../client/components/request-async-storage.external'
 import {
   isDynamicIOPrerender,
@@ -56,7 +56,7 @@ export type UnsafeUnwrappedHeaders = ReadonlyHeaders
  */
 export function headers(): Promise<ReadonlyHeaders> {
   const requestStore = getExpectedRequestStore('headers')
-  const workStore = staticGenerationAsyncStorage.getStore()
+  const workStore = workAsyncStorage.getStore()
   const prerenderStore = prerenderAsyncStorage.getStore()
 
   if (workStore) {

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -49,16 +49,16 @@ export type UnsafeUnwrappedParams<P> =
 
 export function createPrerenderParamsFromClient(
   underlyingParams: Params,
-  staticGenerationStore: WorkStore
+  workStore: WorkStore
 ) {
-  return createPrerenderParams(underlyingParams, staticGenerationStore)
+  return createPrerenderParams(underlyingParams, workStore)
 }
 
 export function createRenderParamsFromClient(
   underlyingParams: Params,
-  staticGenerationStore: WorkStore
+  workStore: WorkStore
 ) {
-  return createRenderParams(underlyingParams, staticGenerationStore)
+  return createRenderParams(underlyingParams, workStore)
 }
 
 // generateMetadata always runs in RSC context so it is equivalent to a Server Page Component
@@ -68,34 +68,34 @@ export const createServerParamsForMetadata = createServerParamsForServerSegment
 // routes always runs in RSC context so it is equivalent to a Server Page Component
 export function createServerParamsForRoute(
   underlyingParams: Params,
-  staticGenerationStore: WorkStore
+  workStore: WorkStore
 ) {
-  if (staticGenerationStore.isStaticGeneration) {
-    return createPrerenderParams(underlyingParams, staticGenerationStore)
+  if (workStore.isStaticGeneration) {
+    return createPrerenderParams(underlyingParams, workStore)
   } else {
-    return createRenderParams(underlyingParams, staticGenerationStore)
+    return createRenderParams(underlyingParams, workStore)
   }
 }
 
 export function createServerParamsForServerSegment(
   underlyingParams: Params,
-  staticGenerationStore: WorkStore
+  workStore: WorkStore
 ): Promise<Params> {
-  if (staticGenerationStore.isStaticGeneration) {
-    return createPrerenderParams(underlyingParams, staticGenerationStore)
+  if (workStore.isStaticGeneration) {
+    return createPrerenderParams(underlyingParams, workStore)
   } else {
-    return createRenderParams(underlyingParams, staticGenerationStore)
+    return createRenderParams(underlyingParams, workStore)
   }
 }
 
 export function createPrerenderParamsForClientSegment(
   underlyingParams: Params,
-  staticGenerationStore: WorkStore
+  workStore: WorkStore
 ): Promise<Params> {
   const prerenderStore = prerenderAsyncStorage.getStore()
   if (prerenderStore) {
     if (isDynamicIOPrerender(prerenderStore)) {
-      const fallbackParams = staticGenerationStore.fallbackRouteParams
+      const fallbackParams = workStore.fallbackRouteParams
       if (fallbackParams) {
         for (let key in underlyingParams) {
           if (fallbackParams.has(key)) {
@@ -116,9 +116,9 @@ export function createPrerenderParamsForClientSegment(
 
 function createPrerenderParams(
   underlyingParams: Params,
-  staticGenerationStore: WorkStore
+  workStore: WorkStore
 ): Promise<Params> {
-  const fallbackParams = staticGenerationStore.fallbackRouteParams
+  const fallbackParams = workStore.fallbackRouteParams
   if (fallbackParams) {
     let hasSomeFallbackParams = false
     for (const key in underlyingParams) {
@@ -136,7 +136,7 @@ function createPrerenderParams(
           // We are in a dynamicIO (PPR or otherwise) prerender
           return makeAbortingExoticParams(
             underlyingParams,
-            staticGenerationStore.route,
+            workStore.route,
             prerenderStore
           )
         }
@@ -147,7 +147,7 @@ function createPrerenderParams(
       return makeErroringExoticParams(
         underlyingParams,
         fallbackParams,
-        staticGenerationStore,
+        workStore,
         prerenderStore
       )
     }
@@ -159,15 +159,12 @@ function createPrerenderParams(
 
 function createRenderParams(
   underlyingParams: Params,
-  staticGenerationStore: WorkStore
+  workStore: WorkStore
 ): Promise<Params> {
-  if (
-    process.env.NODE_ENV === 'development' &&
-    !staticGenerationStore.isPrefetchRequest
-  ) {
+  if (process.env.NODE_ENV === 'development' && !workStore.isPrefetchRequest) {
     return makeDynamicallyTrackedExoticParamsWithDevWarnings(
       underlyingParams,
-      staticGenerationStore
+      workStore
     )
   } else {
     return makeUntrackedExoticParams(underlyingParams)
@@ -249,7 +246,7 @@ function makeAbortingExoticParams(
 function makeErroringExoticParams(
   underlyingParams: Params,
   fallbackParams: FallbackRouteParams,
-  staticGenerationStore: WorkStore,
+  workStore: WorkStore,
   prerenderStore: undefined | PrerenderStore
 ): Promise<Params> {
   const cachedParams = CachedParams.get(underlyingParams)
@@ -307,15 +304,12 @@ function makeErroringExoticParams(
               // will be no `dynamic = "error"`
               if (prerenderStore) {
                 postponeWithTracking(
-                  staticGenerationStore.route,
+                  workStore.route,
                   expression,
                   prerenderStore.dynamicTracking
                 )
               } else {
-                throwToInterruptStaticGeneration(
-                  expression,
-                  staticGenerationStore
-                )
+                throwToInterruptStaticGeneration(expression, workStore)
               }
             },
             enumerable: true,
@@ -331,15 +325,12 @@ function makeErroringExoticParams(
               // will be no `dynamic = "error"`
               if (prerenderStore) {
                 postponeWithTracking(
-                  staticGenerationStore.route,
+                  workStore.route,
                   expression,
                   prerenderStore.dynamicTracking
                 )
               } else {
-                throwToInterruptStaticGeneration(
-                  expression,
-                  staticGenerationStore
-                )
+                throwToInterruptStaticGeneration(expression, workStore)
               }
             },
             set(newValue) {

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -1,4 +1,4 @@
-import type { StaticGenerationStore } from '../../client/components/static-generation-async-storage.external'
+import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
 import type { FallbackRouteParams } from './fallback-params'
 
 import { ReflectAdapter } from '../web/spec-extension/adapters/reflect'

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -1,4 +1,4 @@
-import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
+import type { WorkStore } from '../../client/components/work-async-storage.external'
 import type { FallbackRouteParams } from './fallback-params'
 
 import { ReflectAdapter } from '../web/spec-extension/adapters/reflect'
@@ -49,14 +49,14 @@ export type UnsafeUnwrappedParams<P> =
 
 export function createPrerenderParamsFromClient(
   underlyingParams: Params,
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
 ) {
   return createPrerenderParams(underlyingParams, staticGenerationStore)
 }
 
 export function createRenderParamsFromClient(
   underlyingParams: Params,
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
 ) {
   return createRenderParams(underlyingParams, staticGenerationStore)
 }
@@ -68,7 +68,7 @@ export const createServerParamsForMetadata = createServerParamsForServerSegment
 // routes always runs in RSC context so it is equivalent to a Server Page Component
 export function createServerParamsForRoute(
   underlyingParams: Params,
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
 ) {
   if (staticGenerationStore.isStaticGeneration) {
     return createPrerenderParams(underlyingParams, staticGenerationStore)
@@ -79,7 +79,7 @@ export function createServerParamsForRoute(
 
 export function createServerParamsForServerSegment(
   underlyingParams: Params,
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
 ): Promise<Params> {
   if (staticGenerationStore.isStaticGeneration) {
     return createPrerenderParams(underlyingParams, staticGenerationStore)
@@ -90,7 +90,7 @@ export function createServerParamsForServerSegment(
 
 export function createPrerenderParamsForClientSegment(
   underlyingParams: Params,
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
 ): Promise<Params> {
   const prerenderStore = prerenderAsyncStorage.getStore()
   if (prerenderStore) {
@@ -116,7 +116,7 @@ export function createPrerenderParamsForClientSegment(
 
 function createPrerenderParams(
   underlyingParams: Params,
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
 ): Promise<Params> {
   const fallbackParams = staticGenerationStore.fallbackRouteParams
   if (fallbackParams) {
@@ -159,7 +159,7 @@ function createPrerenderParams(
 
 function createRenderParams(
   underlyingParams: Params,
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
 ): Promise<Params> {
   if (
     process.env.NODE_ENV === 'development' &&
@@ -249,7 +249,7 @@ function makeAbortingExoticParams(
 function makeErroringExoticParams(
   underlyingParams: Params,
   fallbackParams: FallbackRouteParams,
-  staticGenerationStore: StaticGenerationStore,
+  staticGenerationStore: WorkStore,
   prerenderStore: undefined | PrerenderStore
 ): Promise<Params> {
   const cachedParams = CachedParams.get(underlyingParams)
@@ -414,7 +414,7 @@ function makeUntrackedExoticParams(underlyingParams: Params): Promise<Params> {
 
 function makeDynamicallyTrackedExoticParamsWithDevWarnings(
   underlyingParams: Params,
-  store: StaticGenerationStore
+  store: WorkStore
 ): Promise<Params> {
   const cachedParams = CachedParams.get(underlyingParams)
   if (cachedParams) {

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -1,4 +1,4 @@
-import type { StaticGenerationStore } from '../../client/components/static-generation-async-storage.external'
+import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
 
 import { ReflectAdapter } from '../web/spec-extension/adapters/reflect'
 import {

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -1,4 +1,4 @@
-import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
+import type { WorkStore } from '../../client/components/work-async-storage.external'
 
 import { ReflectAdapter } from '../web/spec-extension/adapters/reflect'
 import {
@@ -53,14 +53,14 @@ export type UnsafeUnwrappedSearchParams<P> =
   P extends Promise<infer U> ? Omit<U, 'then' | 'status' | 'value'> : never
 
 export function createPrerenderSearchParamsFromClient(
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
 ) {
   return createPrerenderSearchParams(staticGenerationStore)
 }
 
 export function createRenderSearchParamsFromClient(
   underlyingSearchParams: SearchParams,
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
 ) {
   return createRenderSearchParams(underlyingSearchParams, staticGenerationStore)
 }
@@ -71,7 +71,7 @@ export const createServerSearchParamsForMetadata =
 
 export function createServerSearchParamsForServerPage(
   underlyingSearchParams: SearchParams,
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
 ): Promise<SearchParams> {
   if (staticGenerationStore.isStaticGeneration) {
     return createPrerenderSearchParams(staticGenerationStore)
@@ -84,7 +84,7 @@ export function createServerSearchParamsForServerPage(
 }
 
 export function createPrerenderSearchParamsForClientPage(
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
 ): Promise<SearchParams> {
   if (staticGenerationStore.forceStatic) {
     // When using forceStatic we override all other logic and always just return an empty
@@ -107,7 +107,7 @@ export function createPrerenderSearchParamsForClientPage(
 }
 
 function createPrerenderSearchParams(
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
 ): Promise<SearchParams> {
   if (staticGenerationStore.forceStatic) {
     // When using forceStatic we override all other logic and always just return an empty
@@ -133,7 +133,7 @@ function createPrerenderSearchParams(
 
 function createRenderSearchParams(
   underlyingSearchParams: SearchParams,
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
 ): Promise<SearchParams> {
   if (staticGenerationStore.forceStatic) {
     // When using forceStatic we override all other logic and always just return an empty
@@ -266,7 +266,7 @@ function makeAbortingExoticSearchParams(
 }
 
 function makeErroringExoticSearchParams(
-  staticGenerationStore: StaticGenerationStore,
+  staticGenerationStore: WorkStore,
   prerenderStore: undefined | PrerenderStore
 ): Promise<SearchParams> {
   const cachedSearchParams = CachedSearchParams.get(staticGenerationStore)
@@ -432,7 +432,7 @@ function makeErroringExoticSearchParams(
 
 function makeUntrackedExoticSearchParams(
   underlyingSearchParams: SearchParams,
-  store: StaticGenerationStore
+  store: WorkStore
 ): Promise<SearchParams> {
   const cachedSearchParams = CachedSearchParams.get(underlyingSearchParams)
   if (cachedSearchParams) {
@@ -499,7 +499,7 @@ function makeUntrackedExoticSearchParams(
 
 function makeDynamicallyTrackedExoticSearchParamsWithDevWarnings(
   underlyingSearchParams: SearchParams,
-  store: StaticGenerationStore
+  store: WorkStore
 ): Promise<SearchParams> {
   const cachedSearchParams = CachedSearchParams.get(underlyingSearchParams)
   if (cachedSearchParams) {

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -16,7 +16,7 @@ import {
   type RequestContext,
 } from '../../async-storage/with-request-store'
 import {
-  withStaticGenerationStore,
+  withWorkStore,
   type StaticGenerationContext,
 } from '../../async-storage/with-work-store'
 import {
@@ -45,7 +45,7 @@ import { DynamicServerError } from '../../../client/components/hooks-server-cont
 import { requestAsyncStorage } from '../../../client/components/request-async-storage.external'
 import {
   staticGenerationAsyncStorage,
-  type StaticGenerationStore,
+  type WorkStore,
 } from '../../../client/components/work-async-storage.external'
 import {
   prerenderAsyncStorage,
@@ -315,7 +315,7 @@ export class AppRouteRouteModule extends RouteModule<
           this.requestAsyncStorage,
           requestContext,
           (requestStore) =>
-            withStaticGenerationStore(
+            withWorkStore(
               this.staticGenerationAsyncStorage,
               staticGenerationContext,
               (staticGenerationStore) => {
@@ -846,7 +846,7 @@ const forceStaticNextUrlHandlers = {
 
 function proxyNextRequest(
   request: NextRequest,
-  staticGenerationStore: StaticGenerationStore
+  staticGenerationStore: WorkStore
 ) {
   const nextUrlHandlers = {
     get(

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -318,19 +318,18 @@ export class AppRouteRouteModule extends RouteModule<
             withWorkStore(
               this.staticGenerationAsyncStorage,
               staticGenerationContext,
-              (staticGenerationStore) => {
+              (workStore) => {
                 // Check to see if we should bail out of static generation based on
                 // having non-static methods.
-                const isStaticGeneration =
-                  staticGenerationStore.isStaticGeneration
+                const isStaticGeneration = workStore.isStaticGeneration
 
                 if (this.hasNonStaticMethods) {
                   if (isStaticGeneration) {
                     const err = new DynamicServerError(
                       'Route is configured with methods that cannot be statically generated.'
                     )
-                    staticGenerationStore.dynamicUsageDescription = err.message
-                    staticGenerationStore.dynamicUsageStack = err.stack
+                    workStore.dynamicUsageDescription = err.message
+                    workStore.dynamicUsageStack = err.stack
                     throw err
                   } else {
                     // We aren't statically generating but since this route has non-static methods
@@ -338,7 +337,7 @@ export class AppRouteRouteModule extends RouteModule<
                     // @TODO this type of logic is too indirect. we need to refactor how we set fetch cache
                     // behavior. Prior to the most recent refactor this logic was buried deep in staticGenerationBailout
                     // so it is possible it was unintentional and then tests were written to assert the current behavior
-                    staticGenerationStore.revalidate = 0
+                    workStore.revalidate = 0
                   }
                 }
 
@@ -350,13 +349,13 @@ export class AppRouteRouteModule extends RouteModule<
                 switch (this.dynamic) {
                   case 'force-dynamic': {
                     // Routes of generated paths should be dynamic
-                    staticGenerationStore.forceDynamic = true
+                    workStore.forceDynamic = true
                     break
                   }
                   case 'force-static':
                     // The dynamic property is set to force-static, so we should
                     // force the page to be static.
-                    staticGenerationStore.forceStatic = true
+                    workStore.forceStatic = true
                     // We also Proxy the request to replace dynamic data on the request
                     // with empty stubs to allow for safely executing as static
                     request = new Proxy(rawRequest, forceStaticRequestHandlers)
@@ -364,7 +363,7 @@ export class AppRouteRouteModule extends RouteModule<
                   case 'error':
                     // The dynamic property is set to error, so we should throw an
                     // error if the page is being statically generated.
-                    staticGenerationStore.dynamicShouldError = true
+                    workStore.dynamicShouldError = true
                     if (isStaticGeneration)
                       request = new Proxy(
                         rawRequest,
@@ -373,17 +372,13 @@ export class AppRouteRouteModule extends RouteModule<
                     break
                   default:
                     // We proxy `NextRequest` to track dynamic access, and potentially bail out of static generation
-                    request = proxyNextRequest(
-                      rawRequest,
-                      staticGenerationStore
-                    )
+                    request = proxyNextRequest(rawRequest, workStore)
                 }
 
                 // If the static generation store does not have a revalidate value
                 // set, then we should set it the revalidate value from the userland
                 // module or default to false.
-                staticGenerationStore.revalidate ??=
-                  this.userland.revalidate ?? false
+                workStore.revalidate ??= this.userland.revalidate ?? false
 
                 // TODO: propagate this pathname from route matcher
                 const route = getPathnameFromAbsolutePath(this.resolvedPagePath)
@@ -409,7 +404,7 @@ export class AppRouteRouteModule extends RouteModule<
                       params: context.params
                         ? createServerParamsForRoute(
                             parsedUrlQueryToParams(context.params),
-                            staticGenerationStore
+                            workStore
                           )
                         : undefined,
                     }
@@ -487,14 +482,14 @@ export class AppRouteRouteModule extends RouteModule<
                           getFirstDynamicReason(dynamicTracking)
                         if (dynamicReason) {
                           throw new DynamicServerError(
-                            `Route ${staticGenerationStore.route} couldn't be rendered statically because it used \`${dynamicReason}\`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
+                            `Route ${workStore.route} couldn't be rendered statically because it used \`${dynamicReason}\`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
                           )
                         } else {
                           console.error(
                             'Expected Next.js to keep track of reason for opting out of static rendering but one was not found. This is a bug in Next.js'
                           )
                           throw new DynamicServerError(
-                            `Route ${staticGenerationStore.route} couldn't be rendered statically because it used a dynamic API. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
+                            `Route ${workStore.route} couldn't be rendered statically because it used a dynamic API. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
                           )
                         }
                       }
@@ -551,11 +546,7 @@ export class AppRouteRouteModule extends RouteModule<
                               if (!bodyHandled) {
                                 bodyHandled = true
                                 controller.abort()
-                                reject(
-                                  createDynamicIOError(
-                                    staticGenerationStore.route
-                                  )
-                                )
+                                reject(createDynamicIOError(workStore.route))
                               }
                             })
                           } catch (err) {
@@ -566,9 +557,7 @@ export class AppRouteRouteModule extends RouteModule<
                           if (!responseHandled) {
                             responseHandled = true
                             controller.abort()
-                            reject(
-                              createDynamicIOError(staticGenerationStore.route)
-                            )
+                            reject(createDynamicIOError(workStore.route))
                           }
                         })
                       })
@@ -580,21 +569,18 @@ export class AppRouteRouteModule extends RouteModule<
                         `No response is returned from route handler '${this.resolvedPagePath}'. Ensure you return a \`Response\` or a \`NextResponse\` in all branches of your handler.`
                       )
                     }
-                    context.renderOpts.fetchMetrics =
-                      staticGenerationStore.fetchMetrics
+                    context.renderOpts.fetchMetrics = workStore.fetchMetrics
 
                     context.renderOpts.pendingWaitUntil = Promise.all([
-                      staticGenerationStore.incrementalCache?.revalidateTag(
-                        staticGenerationStore.revalidatedTags || []
+                      workStore.incrementalCache?.revalidateTag(
+                        workStore.revalidatedTags || []
                       ),
-                      ...Object.values(
-                        staticGenerationStore.pendingRevalidates || {}
-                      ),
+                      ...Object.values(workStore.pendingRevalidates || {}),
                     ])
 
-                    addImplicitTags(staticGenerationStore, requestStore)
+                    addImplicitTags(workStore, requestStore)
                     ;(context.renderOpts as any).fetchTags =
-                      staticGenerationStore.tags?.join(',')
+                      workStore.tags?.join(',')
 
                     // It's possible cookies were set in the handler, so we need
                     // to merge the modified cookies and the returned response
@@ -844,10 +830,7 @@ const forceStaticNextUrlHandlers = {
   },
 }
 
-function proxyNextRequest(
-  request: NextRequest,
-  staticGenerationStore: WorkStore
-) {
+function proxyNextRequest(request: NextRequest, workStore: WorkStore) {
   const nextUrlHandlers = {
     get(
       target: NextURL & UrlSymbolTarget,
@@ -862,7 +845,7 @@ function proxyNextRequest(
         case 'toJSON':
         case 'toString':
         case 'origin': {
-          trackDynamicDataAccessed(staticGenerationStore, `nextUrl.${prop}`)
+          trackDynamicDataAccessed(workStore, `nextUrl.${prop}`)
           return ReflectAdapter.get(target, prop, receiver)
         }
         case 'clone':
@@ -897,7 +880,7 @@ function proxyNextRequest(
         case 'text':
         case 'arrayBuffer':
         case 'formData': {
-          trackDynamicDataAccessed(staticGenerationStore, `request.${prop}`)
+          trackDynamicDataAccessed(workStore, `request.${prop}`)
           // The receiver arg is intentionally the same as the target to fix an issue with
           // edge runtime, where attempting to access internal slots with the wrong `this` context
           // results in an error.

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -44,7 +44,7 @@ import { DynamicServerError } from '../../../client/components/hooks-server-cont
 
 import { requestAsyncStorage } from '../../../client/components/request-async-storage.external'
 import {
-  staticGenerationAsyncStorage,
+  workAsyncStorage,
   type WorkStore,
 } from '../../../client/components/work-async-storage.external'
 import {
@@ -155,7 +155,7 @@ export class AppRouteRouteModule extends RouteModule<
   /**
    * A reference to the static generation async storage.
    */
-  public readonly staticGenerationAsyncStorage = staticGenerationAsyncStorage
+  public readonly workAsyncStorage = workAsyncStorage
 
   /**
    * prerenderAsyncStorage is used to scope a prerender context for renders ocurring
@@ -316,7 +316,7 @@ export class AppRouteRouteModule extends RouteModule<
           requestContext,
           (requestStore) =>
             withWorkStore(
-              this.staticGenerationAsyncStorage,
+              this.workAsyncStorage,
               staticGenerationContext,
               (workStore) => {
                 // Check to see if we should bail out of static generation based on
@@ -394,8 +394,7 @@ export class AppRouteRouteModule extends RouteModule<
                   async () => {
                     // Patch the global fetch.
                     patchFetch({
-                      staticGenerationAsyncStorage:
-                        this.staticGenerationAsyncStorage,
+                      workAsyncStorage: this.workAsyncStorage,
                       requestAsyncStorage: this.requestAsyncStorage,
                       prerenderAsyncStorage: this.prerenderAsyncStorage,
                     })

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -17,7 +17,7 @@ import {
 } from '../../async-storage/with-request-store'
 import {
   withWorkStore,
-  type StaticGenerationContext,
+  type WorkStoreContext,
 } from '../../async-storage/with-work-store'
 import {
   handleBadRequestResponse,
@@ -82,7 +82,7 @@ export type AppRouteModule = typeof import('../../../build/templates/app-route')
  * handler for app routes.
  */
 export interface AppRouteRouteHandlerContext extends RouteModuleHandleContext {
-  renderOpts: StaticGenerationContext['renderOpts'] &
+  renderOpts: WorkStoreContext['renderOpts'] &
     Pick<RenderOptsPartial, 'onInstrumentationRequestError'>
   prerenderManifest: DeepReadonly<PrerenderManifest>
 }
@@ -292,7 +292,7 @@ export class AppRouteRouteModule extends RouteModule<
     const dynamicIOEnabled = !!context.renderOpts.experimental?.dynamicIO
 
     // Get the context for the static generation.
-    const staticGenerationContext: StaticGenerationContext = {
+    const staticGenerationContext: WorkStoreContext = {
       // App Routes don't support unknown route params.
       fallbackRouteParams: null,
       page: this.definition.page,

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -18,7 +18,7 @@ import {
 import {
   withStaticGenerationStore,
   type StaticGenerationContext,
-} from '../../async-storage/with-static-generation-store'
+} from '../../async-storage/with-work-store'
 import {
   handleBadRequestResponse,
   handleInternalServerErrorResponse,
@@ -46,7 +46,7 @@ import { requestAsyncStorage } from '../../../client/components/request-async-st
 import {
   staticGenerationAsyncStorage,
   type StaticGenerationStore,
-} from '../../../client/components/static-generation-async-storage.external'
+} from '../../../client/components/work-async-storage.external'
 import {
   prerenderAsyncStorage,
   type PrerenderStore,

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -12,7 +12,7 @@ import {
   createTemporaryReferenceSet as createClientTemporaryReferenceSet,
 } from 'react-server-dom-webpack/client.edge'
 
-import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
+import type { WorkStore } from '../../client/components/work-async-storage.external'
 import { staticGenerationAsyncStorage } from '../../client/components/work-async-storage.external'
 import type { CacheStore } from '../app-render/cache-async-storage.external'
 import { cacheAsyncStorage } from '../app-render/cache-async-storage.external'
@@ -76,7 +76,7 @@ cacheHandlerMap.set('default', {
 })
 
 function generateCacheEntry(
-  staticGenerationStore: StaticGenerationStore,
+  staticGenerationStore: WorkStore,
   clientReferenceManifest: DeepReadonly<ClientReferenceManifest>,
   cacheHandler: CacheHandler,
   serializedCacheKey: string | ArrayBuffer,
@@ -89,7 +89,7 @@ function generateCacheEntry(
   // Note: It is important that we await at least once before this because it lets us
   // pop out of any stack specific contexts as well - aka "Sync" Local Storage.
   return runInCleanSnapshot(
-    generateCacheEntryWithRestoredStaticGenerationStore,
+    generateCacheEntryWithRestoredWorkStore,
     staticGenerationStore,
     clientReferenceManifest,
     cacheHandler,
@@ -99,8 +99,8 @@ function generateCacheEntry(
   )
 }
 
-function generateCacheEntryWithRestoredStaticGenerationStore(
-  staticGenerationStore: StaticGenerationStore,
+function generateCacheEntryWithRestoredWorkStore(
+  staticGenerationStore: WorkStore,
   clientReferenceManifest: DeepReadonly<ClientReferenceManifest>,
   cacheHandler: CacheHandler,
   serializedCacheKey: string | ArrayBuffer,
@@ -111,7 +111,7 @@ function generateCacheEntryWithRestoredStaticGenerationStore(
   // Note: We explicitly don't restore the RequestStore nor the PrerenderStore.
   // We don't want any request specific information leaking an we don't want to create a
   // bloated fake request mock for every cache call. So any feature that currently lives
-  // in RequestStore but should be available to Caches need to move to StaticGenerationStore.
+  // in RequestStore but should be available to Caches need to move to WorkStore.
   // PrerenderStore is not needed inside the cache scope because the outer most one will
   // be the one to report its result to the outer Prerender.
   return staticGenerationAsyncStorage.run(
@@ -127,7 +127,7 @@ function generateCacheEntryWithRestoredStaticGenerationStore(
 }
 
 function generateCacheEntryWithCacheContext(
-  staticGenerationStore: StaticGenerationStore,
+  staticGenerationStore: WorkStore,
   clientReferenceManifest: DeepReadonly<ClientReferenceManifest>,
   cacheHandler: CacheHandler,
   serializedCacheKey: string | ArrayBuffer,
@@ -149,7 +149,7 @@ function generateCacheEntryWithCacheContext(
 }
 
 async function generateCacheEntryImpl(
-  staticGenerationStore: StaticGenerationStore,
+  staticGenerationStore: WorkStore,
   clientReferenceManifest: DeepReadonly<ClientReferenceManifest>,
   cacheHandler: CacheHandler,
   serializedCacheKey: string | ArrayBuffer,
@@ -249,7 +249,7 @@ export function cache(kind: string, id: string, fn: any) {
       const staticGenerationStore = staticGenerationAsyncStorage.getStore()
       if (staticGenerationStore === undefined) {
         throw new Error(
-          '"use cache" cannot be used outside of App Router. Expected a StaticGenerationStore.'
+          '"use cache" cannot be used outside of App Router. Expected a WorkStore.'
         )
       }
 

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -12,8 +12,8 @@ import {
   createTemporaryReferenceSet as createClientTemporaryReferenceSet,
 } from 'react-server-dom-webpack/client.edge'
 
-import type { StaticGenerationStore } from '../../client/components/static-generation-async-storage.external'
-import { staticGenerationAsyncStorage } from '../../client/components/static-generation-async-storage.external'
+import type { StaticGenerationStore } from '../../client/components/work-async-storage.external'
+import { staticGenerationAsyncStorage } from '../../client/components/work-async-storage.external'
 import type { CacheStore } from '../app-render/cache-async-storage.external'
 import { cacheAsyncStorage } from '../app-render/cache-async-storage.external'
 import { runInCleanSnapshot } from '../app-render/clean-async-snapshot.external'

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -13,7 +13,7 @@ import {
 } from 'react-server-dom-webpack/client.edge'
 
 import type { WorkStore } from '../../client/components/work-async-storage.external'
-import { staticGenerationAsyncStorage } from '../../client/components/work-async-storage.external'
+import { workAsyncStorage } from '../../client/components/work-async-storage.external'
 import type { CacheStore } from '../app-render/cache-async-storage.external'
 import { cacheAsyncStorage } from '../app-render/cache-async-storage.external'
 import { runInCleanSnapshot } from '../app-render/clean-async-snapshot.external'
@@ -114,7 +114,7 @@ function generateCacheEntryWithRestoredWorkStore(
   // in RequestStore but should be available to Caches need to move to WorkStore.
   // PrerenderStore is not needed inside the cache scope because the outer most one will
   // be the one to report its result to the outer Prerender.
-  return staticGenerationAsyncStorage.run(
+  return workAsyncStorage.run(
     workStore,
     generateCacheEntryWithCacheContext,
     workStore,
@@ -246,7 +246,7 @@ export function cache(kind: string, id: string, fn: any) {
   const name = fn.name
   const cachedFn = {
     [name]: async function (...args: any[]) {
-      const workStore = staticGenerationAsyncStorage.getStore()
+      const workStore = workAsyncStorage.getStore()
       if (workStore === undefined) {
         throw new Error(
           '"use cache" cannot be used outside of App Router. Expected a WorkStore.'

--- a/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
@@ -2,7 +2,7 @@ import type { RequestCookies } from '../cookies'
 
 import { ResponseCookies } from '../cookies'
 import { ReflectAdapter } from './reflect'
-import { staticGenerationAsyncStorage } from '../../../../client/components/static-generation-async-storage.external'
+import { staticGenerationAsyncStorage } from '../../../../client/components/work-async-storage.external'
 
 /**
  * @internal

--- a/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
@@ -108,10 +108,10 @@ export class MutableRequestCookiesAdapter {
     let modifiedValues: ResponseCookie[] = []
     const modifiedCookies = new Set<string>()
     const updateResponseCookies = () => {
-      // TODO-APP: change method of getting staticGenerationAsyncStore
-      const staticGenerationAsyncStore = workAsyncStorage.getStore()
-      if (staticGenerationAsyncStore) {
-        staticGenerationAsyncStore.pathWasRevalidated = true
+      // TODO-APP: change method of getting workStore
+      const workStore = workAsyncStorage.getStore()
+      if (workStore) {
+        workStore.pathWasRevalidated = true
       }
 
       const allCookies = responseCookies.getAll()

--- a/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
@@ -2,7 +2,7 @@ import type { RequestCookies } from '../cookies'
 
 import { ResponseCookies } from '../cookies'
 import { ReflectAdapter } from './reflect'
-import { staticGenerationAsyncStorage } from '../../../../client/components/work-async-storage.external'
+import { workAsyncStorage } from '../../../../client/components/work-async-storage.external'
 
 /**
  * @internal
@@ -109,7 +109,7 @@ export class MutableRequestCookiesAdapter {
     const modifiedCookies = new Set<string>()
     const updateResponseCookies = () => {
       // TODO-APP: change method of getting staticGenerationAsyncStore
-      const staticGenerationAsyncStore = staticGenerationAsyncStorage.getStore()
+      const staticGenerationAsyncStore = workAsyncStorage.getStore()
       if (staticGenerationAsyncStore) {
         staticGenerationAsyncStore.pathWasRevalidated = true
       }

--- a/packages/next/src/server/web/spec-extension/revalidate.ts
+++ b/packages/next/src/server/web/spec-extension/revalidate.ts
@@ -4,7 +4,7 @@ import {
   NEXT_CACHE_IMPLICIT_TAG_ID,
   NEXT_CACHE_SOFT_TAG_MAX_LENGTH,
 } from '../../../lib/constants'
-import { staticGenerationAsyncStorage } from '../../../client/components/work-async-storage.external'
+import { workAsyncStorage } from '../../../client/components/work-async-storage.external'
 
 /**
  * This function allows you to purge [cached data](https://nextjs.org/docs/app/building-your-application/caching) on-demand for a specific cache tag.
@@ -41,7 +41,7 @@ export function revalidatePath(originalPath: string, type?: 'layout' | 'page') {
 }
 
 function revalidate(tag: string, expression: string) {
-  const store = staticGenerationAsyncStorage.getStore()
+  const store = workAsyncStorage.getStore()
   if (!store || !store.incrementalCache) {
     throw new Error(
       `Invariant: static generation store missing in ${expression}`

--- a/packages/next/src/server/web/spec-extension/revalidate.ts
+++ b/packages/next/src/server/web/spec-extension/revalidate.ts
@@ -4,7 +4,7 @@ import {
   NEXT_CACHE_IMPLICIT_TAG_ID,
   NEXT_CACHE_SOFT_TAG_MAX_LENGTH,
 } from '../../../lib/constants'
-import { staticGenerationAsyncStorage } from '../../../client/components/static-generation-async-storage.external'
+import { staticGenerationAsyncStorage } from '../../../client/components/work-async-storage.external'
 
 /**
  * This function allows you to purge [cached data](https://nextjs.org/docs/app/building-your-application/caching) on-demand for a specific cache tag.

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -6,7 +6,7 @@ import {
   validateRevalidate,
   validateTags,
 } from '../../lib/patch-fetch'
-import { staticGenerationAsyncStorage } from '../../../client/components/static-generation-async-storage.external'
+import { staticGenerationAsyncStorage } from '../../../client/components/work-async-storage.external'
 import { requestAsyncStorage } from '../../../client/components/request-async-storage.external'
 import {
   CachedRouteKind,

--- a/packages/next/src/server/web/spec-extension/unstable-no-store.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-no-store.ts
@@ -1,4 +1,4 @@
-import { staticGenerationAsyncStorage } from '../../../client/components/work-async-storage.external'
+import { workAsyncStorage } from '../../../client/components/work-async-storage.external'
 import { markCurrentScopeAsDynamic } from '../../app-render/dynamic-rendering'
 
 /**
@@ -18,7 +18,7 @@ import { markCurrentScopeAsDynamic } from '../../app-render/dynamic-rendering'
  */
 export function unstable_noStore() {
   const callingExpression = 'unstable_noStore()'
-  const store = staticGenerationAsyncStorage.getStore()
+  const store = workAsyncStorage.getStore()
   if (!store) {
     // This generally implies we are being called in Pages router. We should probably not support
     // unstable_noStore in contexts outside of `react-server` condition but since we historically

--- a/packages/next/src/server/web/spec-extension/unstable-no-store.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-no-store.ts
@@ -1,4 +1,4 @@
-import { staticGenerationAsyncStorage } from '../../../client/components/static-generation-async-storage.external'
+import { staticGenerationAsyncStorage } from '../../../client/components/work-async-storage.external'
 import { markCurrentScopeAsDynamic } from '../../app-render/dynamic-rendering'
 
 /**

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/app-route/input.js
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/app-route/input.js
@@ -20,12 +20,12 @@ const routeModule = new AppRouteRouteModule({
 // Pull out the exports that we need to expose from the module. This should
 // be eliminated when we've moved the other routes to the new format. These
 // are used to hook into the route.
-const { requestAsyncStorage, staticGenerationAsyncStorage, serverHooks } = routeModule;
+const { requestAsyncStorage, workAsyncStorage, serverHooks } = routeModule;
 const originalPathname = 'VAR_ORIGINAL_PATHNAME';
 function patchFetch() {
     return _patchFetch({
         serverHooks,
-        staticGenerationAsyncStorage
+        workAsyncStorage
     });
 }
-export { routeModule, requestAsyncStorage, staticGenerationAsyncStorage, serverHooks, originalPathname, patchFetch,  };
+export { routeModule, requestAsyncStorage, workAsyncStorage, serverHooks, originalPathname, patchFetch,  };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/app-route/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/app-route/output.md
@@ -411,15 +411,15 @@ graph TD
         "patchFetch",
     ): 17,
     Export(
-        "workAsyncStorage",
-    ): 15,
-    Export(
         "requestAsyncStorage",
     ): 18,
     Export(
         "routeModule",
     ): 12,
     Exports: 19,
+    Export(
+        "workAsyncStorage",
+    ): 15,
     Export(
         "originalPathname",
     ): 1,
@@ -752,15 +752,15 @@ import "__TURBOPACK_PART__" assert {
         "serverHooks",
     ): 15,
     Export(
-        "workAsyncStorage",
-    ): 16,
-    Export(
         "requestAsyncStorage",
     ): 17,
     Export(
         "routeModule",
     ): 11,
     Exports: 19,
+    Export(
+        "workAsyncStorage",
+    ): 16,
     Export(
         "originalPathname",
     ): 1,

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/app-route/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/app-route/output.md
@@ -108,13 +108,13 @@ const routeModule = new AppRouteRouteModule({
 ## Item 10: Stmt 5, `VarDeclarator(0)`
 
 ```js
-const { requestAsyncStorage, staticGenerationAsyncStorage, serverHooks } = routeModule;
+const { requestAsyncStorage, workAsyncStorage, serverHooks } = routeModule;
 
 ```
 
-- Declares: `requestAsyncStorage`, `staticGenerationAsyncStorage`, `serverHooks`
+- Declares: `requestAsyncStorage`, `workAsyncStorage`, `serverHooks`
 - Reads: `routeModule`
-- Write: `requestAsyncStorage`, `staticGenerationAsyncStorage`, `serverHooks`
+- Write: `requestAsyncStorage`, `workAsyncStorage`, `serverHooks`
 
 ## Item 11: Stmt 6, `VarDeclarator(0)`
 
@@ -132,7 +132,7 @@ const originalPathname = 'VAR_ORIGINAL_PATHNAME';
 function patchFetch() {
     return _patchFetch({
         serverHooks,
-        staticGenerationAsyncStorage
+        workAsyncStorage
     });
 }
 
@@ -140,9 +140,9 @@ function patchFetch() {
 
 - Hoisted
 - Declares: `patchFetch`
-- Reads (eventual): `_patchFetch`, `serverHooks`, `staticGenerationAsyncStorage`
+- Reads (eventual): `_patchFetch`, `serverHooks`, `workAsyncStorage`
 - Write: `patchFetch`
-- Write (eventual): `serverHooks`, `staticGenerationAsyncStorage`
+- Write (eventual): `serverHooks`, `workAsyncStorage`
 
 # Phase 1
 ```mermaid
@@ -166,7 +166,7 @@ graph TD
     Item15;
     Item15["export requestAsyncStorage"];
     Item16;
-    Item16["export staticGenerationAsyncStorage"];
+    Item16["export workAsyncStorage"];
     Item17;
     Item17["export serverHooks"];
     Item18;
@@ -202,7 +202,7 @@ graph TD
     Item15;
     Item15["export requestAsyncStorage"];
     Item16;
-    Item16["export staticGenerationAsyncStorage"];
+    Item16["export workAsyncStorage"];
     Item17;
     Item17["export serverHooks"];
     Item18;
@@ -253,7 +253,7 @@ graph TD
     Item15;
     Item15["export requestAsyncStorage"];
     Item16;
-    Item16["export staticGenerationAsyncStorage"];
+    Item16["export workAsyncStorage"];
     Item17;
     Item17["export serverHooks"];
     Item18;
@@ -308,7 +308,7 @@ graph TD
     Item15;
     Item15["export requestAsyncStorage"];
     Item16;
-    Item16["export staticGenerationAsyncStorage"];
+    Item16["export workAsyncStorage"];
     Item17;
     Item17["export serverHooks"];
     Item18;
@@ -364,7 +364,7 @@ graph TD
     N12["Items: [ItemId(Export((&quot;routeModule&quot;, #2), &quot;routeModule&quot;))]"];
     N13["Items: [ItemId(5, VarDeclarator(0))]"];
     N14["Items: [ItemId(Export((&quot;serverHooks&quot;, #2), &quot;serverHooks&quot;))]"];
-    N15["Items: [ItemId(Export((&quot;staticGenerationAsyncStorage&quot;, #2), &quot;staticGenerationAsyncStorage&quot;))]"];
+    N15["Items: [ItemId(Export((&quot;workAsyncStorage&quot;, #2), &quot;workAsyncStorage&quot;))]"];
     N16["Items: [ItemId(7, Normal)]"];
     N17["Items: [ItemId(Export((&quot;patchFetch&quot;, #2), &quot;patchFetch&quot;))]"];
     N18["Items: [ItemId(Export((&quot;requestAsyncStorage&quot;, #2), &quot;requestAsyncStorage&quot;))]"];
@@ -411,7 +411,7 @@ graph TD
         "patchFetch",
     ): 17,
     Export(
-        "staticGenerationAsyncStorage",
+        "workAsyncStorage",
     ): 15,
     Export(
         "requestAsyncStorage",
@@ -608,11 +608,11 @@ import "__TURBOPACK_PART__" assert {
 import { f as routeModule } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
-const { requestAsyncStorage, staticGenerationAsyncStorage, serverHooks } = routeModule;
+const { requestAsyncStorage, workAsyncStorage, serverHooks } = routeModule;
 export { requestAsyncStorage as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
-export { staticGenerationAsyncStorage as h } from "__TURBOPACK_VAR__" assert {
+export { workAsyncStorage as h } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 export { serverHooks as i } from "__TURBOPACK_VAR__" assert {
@@ -636,10 +636,10 @@ export { serverHooks };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
-import { h as staticGenerationAsyncStorage } from "__TURBOPACK_PART__" assert {
+import { h as workAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
-export { staticGenerationAsyncStorage };
+export { workAsyncStorage };
 
 ```
 ## Part 16
@@ -656,7 +656,7 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 15
 };
-import { h as staticGenerationAsyncStorage } from "__TURBOPACK_PART__" assert {
+import { h as workAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
 import { b as _patchFetch } from "__TURBOPACK_PART__" assert {
@@ -668,7 +668,7 @@ import { i as serverHooks } from "__TURBOPACK_PART__" assert {
 function patchFetch() {
     return _patchFetch({
         serverHooks,
-        staticGenerationAsyncStorage
+        workAsyncStorage
     });
 }
 export { patchFetch as j } from "__TURBOPACK_VAR__" assert {
@@ -709,8 +709,8 @@ export { routeModule } from "__TURBOPACK_PART__" assert {
 export { serverHooks } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: "export serverHooks"
 };
-export { staticGenerationAsyncStorage } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export staticGenerationAsyncStorage"
+export { workAsyncStorage } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export workAsyncStorage"
 };
 export { patchFetch } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: "export patchFetch"
@@ -752,7 +752,7 @@ import "__TURBOPACK_PART__" assert {
         "serverHooks",
     ): 15,
     Export(
-        "staticGenerationAsyncStorage",
+        "workAsyncStorage",
     ): 16,
     Export(
         "requestAsyncStorage",
@@ -926,11 +926,11 @@ import "__TURBOPACK_PART__" assert {
 import { f as routeModule } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 10
 };
-const { requestAsyncStorage, staticGenerationAsyncStorage, serverHooks } = routeModule;
+const { requestAsyncStorage, workAsyncStorage, serverHooks } = routeModule;
 export { requestAsyncStorage as g } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
-export { staticGenerationAsyncStorage as h } from "__TURBOPACK_VAR__" assert {
+export { workAsyncStorage as h } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 export { serverHooks as i } from "__TURBOPACK_VAR__" assert {
@@ -946,7 +946,7 @@ import "__TURBOPACK_PART__" assert {
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
-import { h as staticGenerationAsyncStorage } from "__TURBOPACK_PART__" assert {
+import { h as workAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
 import { b as _patchFetch } from "__TURBOPACK_PART__" assert {
@@ -958,7 +958,7 @@ import { i as serverHooks } from "__TURBOPACK_PART__" assert {
 function patchFetch() {
     return _patchFetch({
         serverHooks,
-        staticGenerationAsyncStorage
+        workAsyncStorage
     });
 }
 export { patchFetch as j } from "__TURBOPACK_VAR__" assert {
@@ -993,10 +993,10 @@ export { serverHooks };
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
-import { h as staticGenerationAsyncStorage } from "__TURBOPACK_PART__" assert {
+import { h as workAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
-export { staticGenerationAsyncStorage };
+export { workAsyncStorage };
 
 ```
 ## Part 17
@@ -1044,8 +1044,8 @@ export { patchFetch } from "__TURBOPACK_PART__" assert {
 export { serverHooks } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: "export serverHooks"
 };
-export { staticGenerationAsyncStorage } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: "export staticGenerationAsyncStorage"
+export { workAsyncStorage } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: "export workAsyncStorage"
 };
 export { requestAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: "export requestAsyncStorage"


### PR DESCRIPTION
This has long been a misnomer since it's not just used for static generation but it's the outer context of all the "Work" we're currently doing.

A follow up will merge the other contexts into a "WorkUnitStore".
