### PR TITLE
tests: deprecate `check` & disable flaky app-action deploy test

### DIFF
--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -3,7 +3,8 @@
   "suites": {
     "test/e2e/app-dir/actions/app-action.test.ts": {
       "failed": [
-        "app-dir action handling fetch actions should invalidate client cache when path is revalidated"
+        "app-dir action handling fetch actions should invalidate client cache when path is revalidated",
+        "app-dir action handling fetch actions should handle revalidateTag"
       ]
     },
     "test/e2e/app-dir/app-static/app-static.test.ts": {

--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -3,8 +3,7 @@
   "suites": {
     "test/e2e/app-dir/actions/app-action.test.ts": {
       "failed": [
-        "app-dir action handling fetch actions should invalidate client cache when path is revalidated",
-        "app-dir action handling fetch actions should handle revalidateTag"
+        "app-dir action handling fetch actions should invalidate client cache when path is revalidated"
       ]
     },
     "test/e2e/app-dir/app-static/app-static.test.ts": {

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -2,8 +2,8 @@
 import { nextTestSetup } from 'e2e-utils'
 import {
   assertHasRedbox,
-  check,
   retry,
+  check,
   waitFor,
   getRedboxSource,
 } from 'next-test-utils'
@@ -62,16 +62,23 @@ describe('app-dir action handling', () => {
     expect(cnt).toBe('0')
 
     await browser.elementByCss('#inc').click()
-    await check(() => browser.elementById('count').text(), '1')
+    await retry(async () => {
+      expect(await browser.elementById('count').text()).toBe('1')
+    })
 
     await browser.elementByCss('#inc').click()
-    await check(() => browser.elementById('count').text(), '2')
-
+    await retry(async () => {
+      expect(await browser.elementById('count').text()).toBe('2')
+    })
     await browser.elementByCss('#double').click()
-    await check(() => browser.elementById('count').text(), '4')
+    await retry(async () => {
+      expect(await browser.elementById('count').text()).toBe('4')
+    })
 
     await browser.elementByCss('#dec').click()
-    await check(() => browser.elementById('count').text(), '3')
+    await retry(async () => {
+      expect(await browser.elementById('count').text()).toBe('3')
+    })
   })
 
   it('should report errors with bad inputs correctly', async () => {
@@ -145,41 +152,49 @@ describe('app-dir action handling', () => {
     const browser = await next.browser('/header')
 
     await browser.elementByCss('#cookie').click()
-    await check(async () => {
+    await retry(async () => {
       const res = (await browser.elementByCss('h1').text()) || ''
       const id = res.split(':', 2)
-      return id[0] === id[1] && id[0] ? 'same' : 'different'
-    }, 'same')
+      expect(id[0]).toBeDefined()
+      expect(id[0]).toBe(id[1])
+    })
 
     await browser.elementByCss('#header').click()
-    await check(async () => {
+    await retry(async () => {
       const res = (await browser.elementByCss('h1').text()) || ''
-      return res.includes('Mozilla') ? 'UA' : ''
-    }, 'UA')
+      expect(res).toContain('Mozilla')
+    })
 
     // Set cookies
     await browser.elementByCss('#setCookie').click()
-    await check(async () => {
+    await retry(async () => {
       const res = (await browser.elementByCss('h1').text()) || ''
       const id = res.split(':', 3)
-      return id[0] === id[1] && id[0] === id[2] && id[0] ? 'same' : 'different'
-    }, 'same')
+
+      expect(id[0]).toBeDefined()
+      expect(id[0]).toBe(id[1])
+      expect(id[0]).toBe(id[2])
+    })
   })
 
   it('should push new route when redirecting', async () => {
     const browser = await next.browser('/header')
 
     await browser.elementByCss('#setCookieAndRedirect').click()
-    await check(async () => {
-      return (await browser.elementByCss('#redirected').text()) || ''
-    }, 'redirected')
+    await retry(async () => {
+      expect(await browser.elementByCss('#redirected').text()).toBe(
+        'redirected'
+      )
+    })
 
     // Ensure we can navigate back
     await browser.back()
 
-    await check(async () => {
-      return (await browser.elementByCss('#setCookieAndRedirect').text()) || ''
-    }, 'setCookieAndRedirect')
+    await retry(async () => {
+      expect(await browser.elementByCss('#setCookieAndRedirect').text()).toBe(
+        'setCookieAndRedirect'
+      )
+    })
   })
 
   it('should replace current route when redirecting with type set to replace', async () => {
@@ -190,9 +205,11 @@ describe('app-dir action handling', () => {
     expect(historyLen).toBe(2)
 
     await browser.elementByCss('#setCookieAndRedirectReplace').click()
-    await check(async () => {
-      return (await browser.elementByCss('#redirected').text()) || ''
-    }, 'redirected')
+    await retry(async () => {
+      expect(await browser.elementByCss('#redirected').text()).toBe(
+        'redirected'
+      )
+    })
 
     // Ensure we cannot navigate back
     historyLen = await browser.eval('window.history.length')
@@ -216,16 +233,17 @@ describe('app-dir action handling', () => {
 
     // we don't have access to runtime logs on deploy
     if (!isNextDeploy) {
-      await check(() => {
-        return logs.some((log) =>
-          log.includes('accept header: text/x-component')
-        )
-          ? 'yes'
-          : ''
-      }, 'yes')
+      await retry(() => {
+        expect(
+          logs.some((log) => log.includes('accept header: text/x-component'))
+        ).toBe(true)
+      })
     }
 
-    await check(() => browser.eval('document.cookie'), /test-cookie/)
+    await retry(async () => {
+      const cookie = await browser.eval('document.cookie')
+      expect(cookie).toContain('test-cookie')
+    })
 
     expect(
       await browser.eval('+document.cookie.match(/test-cookie=(\\d+)/)[1]')
@@ -244,17 +262,19 @@ describe('app-dir action handling', () => {
     const browser = await next.browser('/non-action-form')
     await browser.elementByCss('button').click()
 
-    await check(() => browser.url(), next.url + '/', true, 2)
+    await retry(async () => {
+      expect(await browser.url()).toBe(`${next.url}/`)
+    })
 
     // we don't have access to runtime logs on deploy
     if (!isNextDeploy) {
-      await check(() => {
-        return logs.some((log) =>
-          log.includes('Failed to find Server Action "null"')
-        )
-          ? 'error'
-          : ''
-      }, '')
+      await retry(() => {
+        expect(
+          logs.some((log) =>
+            log.includes('Failed to find Server Action "null"')
+          )
+        ).toBe(false)
+      })
     }
   })
 
@@ -274,9 +294,11 @@ describe('app-dir action handling', () => {
     await browser.eval(`document.getElementById('name').value = 'test'`)
     await browser.elementByCss('#submit').click()
 
-    await check(() => {
-      return browser.eval('window.location.pathname + window.location.search')
-    }, '/header?name=test&hidden-info=hi')
+    await retry(async () => {
+      expect(await browser.url()).toBe(
+        `${next.url}/header?name=test&hidden-info=hi`
+      )
+    })
   })
 
   it('should support .bind', async () => {
@@ -285,9 +307,9 @@ describe('app-dir action handling', () => {
     await browser.eval(`document.getElementById('n').value = '123'`)
     await browser.elementByCss('#minus-one').click()
 
-    await check(() => {
-      return browser.eval('window.location.pathname + window.location.search')
-    }, '/header?result=122')
+    await retry(async () => {
+      expect(await browser.url()).toBe(`${next.url}/header?result=122`)
+    })
   })
 
   it('should support chained .bind', async () => {
@@ -295,9 +317,9 @@ describe('app-dir action handling', () => {
 
     await browser.elementByCss('#add3').click()
 
-    await check(() => {
-      return browser.eval('window.location.pathname + window.location.search')
-    }, '/header?result=6')
+    await retry(async () => {
+      expect(await browser.url()).toBe(`${next.url}/header?result=6`)
+    })
   })
 
   it('should support notFound (javascript disabled)', async () => {
@@ -308,9 +330,9 @@ describe('app-dir action handling', () => {
 
     await browser.elementByCss('#nowhere').click()
 
-    await check(() => {
-      return browser.elementByCss('h1').text()
-    }, 'my-not-found')
+    await retry(async () => {
+      expect(await browser.elementByCss('h1').text()).toBe('my-not-found')
+    })
   })
 
   it('should support notFound', async () => {
@@ -318,9 +340,9 @@ describe('app-dir action handling', () => {
 
     await browser.elementByCss('#nowhere').click()
 
-    await check(() => {
-      return browser.elementByCss('h1').text()
-    }, 'my-not-found')
+    await retry(async () => {
+      expect(await browser.elementByCss('h1').text()).toBe('my-not-found')
+    })
   })
 
   it('should support uploading files', async () => {
@@ -346,13 +368,13 @@ describe('app-dir action handling', () => {
 
     // we don't have access to runtime logs on deploy
     if (!isNextDeploy) {
-      await check(() => {
-        return logs.some((log) =>
-          log.includes('File name: hello你好テスト.txt size: 5')
-        )
-          ? 'yes'
-          : ''
-      }, 'yes')
+      await retry(() => {
+        expect(
+          logs.some((log) =>
+            log.includes('File name: hello你好テスト.txt size: 5')
+          )
+        ).toBe(true)
+      })
     }
   })
 
@@ -362,20 +384,25 @@ describe('app-dir action handling', () => {
 
     await browser.elementByCss('#authed').click()
 
-    await check(
-      () => {
-        return browser.elementByCss('h1').text()
-      },
-      isNextDev ? 'Error: Unauthorized request' : GENERIC_RSC_ERROR
-    )
+    await retry(async () => {
+      if (isNextDev) {
+        expect(await browser.elementByCss('h1').text()).toBe(
+          'Error: Unauthorized request'
+        )
+      } else {
+        expect(await browser.elementByCss('h1').text()).toBe(GENERIC_RSC_ERROR)
+      }
+    })
 
     await browser.eval(`document.cookie = 'auth=1'`)
 
     await browser.elementByCss('#authed').click()
 
-    await check(() => {
-      return browser.elementByCss('h1').text()
-    }, 'Prefix: HELLO, WORLD')
+    await retry(async () => {
+      expect(await browser.elementByCss('h1').text()).toBe(
+        'Prefix: HELLO, WORLD'
+      )
+    })
   })
 
   it('should support importing actions in client components', async () => {
@@ -385,16 +412,23 @@ describe('app-dir action handling', () => {
     expect(cnt).toBe('0')
 
     await browser.elementByCss('#inc').click()
-    await check(() => browser.elementById('count').text(), '1')
+    await retry(async () => {
+      expect(await browser.elementById('count').text()).toBe('1')
+    })
 
     await browser.elementByCss('#inc').click()
-    await check(() => browser.elementById('count').text(), '2')
+    await retry(async () => {
+      expect(await browser.elementById('count').text()).toBe('2')
+    })
 
     await browser.elementByCss('#double').click()
-    await check(() => browser.elementById('count').text(), '4')
-
+    await retry(async () => {
+      expect(await browser.elementById('count').text()).toBe('4')
+    })
     await browser.elementByCss('#dec').click()
-    await check(() => browser.elementById('count').text(), '3')
+    await retry(async () => {
+      expect(await browser.elementById('count').text()).toBe('3')
+    })
   })
 
   it('should support importing the same action module instance in both server and action layers', async () => {
@@ -404,10 +438,14 @@ describe('app-dir action handling', () => {
     expect(v).toBe('Value = 0')
 
     await browser.elementByCss('#server-inc').click()
-    await check(() => browser.elementByCss('#value').text(), 'Value = 1')
+    await retry(async () => {
+      expect(await browser.elementByCss('#value').text()).toBe('Value = 1')
+    })
 
     await browser.elementByCss('#client-inc').click()
-    await check(() => browser.elementByCss('#value').text(), 'Value = 2')
+    await retry(async () => {
+      expect(await browser.elementByCss('#value').text()).toBe('Value = 2')
+    })
   })
 
   it('should not block navigation events while a server action is in flight', async () => {
@@ -455,13 +493,13 @@ describe('app-dir action handling', () => {
     await browser.elementByCss('#navigate-server').click()
 
     // wait for the action to be completed
-    await check(async () => {
+    await retry(async () => {
       const newRandomNumber = await browser
         .elementByCss('#random-number')
         .text()
 
-      return newRandomNumber === initialRandomNumber ? 'fail' : 'success'
-    }, 'success')
+      expect(newRandomNumber).not.toBe(initialRandomNumber)
+    })
   })
 
   it('should trigger a refresh for a server action that also dispatches a navigation event', async () => {
@@ -492,29 +530,29 @@ describe('app-dir action handling', () => {
   it('should support next/dynamic with ssr: false', async () => {
     const browser = await next.browser('/dynamic-csr')
 
-    await check(() => {
-      return browser.elementByCss('button').text()
-    }, '0')
+    await retry(async () => {
+      expect(await browser.elementByCss('button').text()).toBe('0')
+    })
 
     await browser.elementByCss('button').click()
 
-    await check(() => {
-      return browser.elementByCss('button').text()
-    }, '1')
+    await retry(async () => {
+      expect(await browser.elementByCss('button').text()).toBe('1')
+    })
   })
 
   it('should support next/dynamic with ssr: false (edge)', async () => {
     const browser = await next.browser('/dynamic-csr/edge')
 
-    await check(() => {
-      return browser.elementByCss('button').text()
-    }, '0')
+    await retry(async () => {
+      expect(await browser.elementByCss('button').text()).toBe('0')
+    })
 
     await browser.elementByCss('button').click()
 
-    await check(() => {
-      return browser.elementByCss('button').text()
-    }, '1')
+    await retry(async () => {
+      expect(await browser.elementByCss('button').text()).toBe('1')
+    })
   })
 
   it('should only submit action once when resubmitting an action after navigation', async () => {
@@ -534,13 +572,17 @@ describe('app-dir action handling', () => {
     async function submitForm() {
       await browser.elementById('name').type('foo')
       await browser.elementById('submit').click()
-      await check(() => browser.url(), /header/)
+      await retry(async () => {
+        expect(await browser.url()).toContain('/header')
+      })
     }
 
     await submitForm()
 
     await browser.elementById('navigate-server').click()
-    await check(() => browser.url(), /server/)
+    await retry(async () => {
+      expect(await browser.url()).toContain('/server')
+    })
     await browser.waitForIdleNetwork()
 
     requestCount = 0
@@ -564,6 +606,10 @@ describe('app-dir action handling', () => {
     })
 
     expect(await browser.elementByCss('h1').text()).toBe('Transition is: idle')
+
+    // The initial page request shouldn't count towards the request count.
+    requestCount = 0
+
     const button = await browser.elementById('action-button')
 
     // fire off 6 successive requests by clicking the button 6 times
@@ -579,9 +625,19 @@ describe('app-dir action handling', () => {
       'Transition is: pending'
     )
 
-    await check(() => requestCount, 6)
-
-    await check(() => browser.elementByCss('h1').text(), 'Transition is: idle')
+    // each action takes 1 second,
+    // so we override the default retry interval to 1 second
+    // and duration to 6 seconds to allow for all actions to complete
+    await retry(
+      async () => {
+        expect(await browser.elementByCss('h1').text()).toBe(
+          'Transition is: idle'
+        )
+        expect(requestCount).toBe(6)
+      },
+      6000,
+      1000
+    )
   })
 
   it('should reset the form state when the action redirects to a page that contains the same form', async () => {
@@ -678,9 +734,10 @@ describe('app-dir action handling', () => {
         body: 'foo=bar',
       })
 
-      await check(
-        () => next.cliOutput,
-        /Failed to find Server Action "abc123". This request might be from an older or newer deployment./
+      await retry(async () =>
+        expect(next.cliOutput).toMatch(
+          /Failed to find Server Action "abc123". This request might be from an older or newer deployment./
+        )
       )
     })
   }
@@ -855,18 +912,20 @@ describe('app-dir action handling', () => {
           expect(cnt).toBe('0')
 
           await browser.elementByCss('#inc').click()
-          await check(() => browser.elementById('count').text(), '1')
+          await retry(async () => {
+            expect(await browser.elementById('count').text()).toBe('1')
+          })
 
           await next.patchFile(
             filePath,
             origContent.replace('return value + 1', 'return value + 1000')
           )
 
-          await check(async () => {
+          await retry(async () => {
             await browser.elementByCss('#inc').click()
             const val = Number(await browser.elementById('count').text())
-            return val > 1000 ? 'success' : val
-          }, 'success')
+            expect(val).toBeGreaterThan(1000)
+          })
         } finally {
           await next.patchFile(filePath, origContent)
         }
@@ -905,16 +964,22 @@ describe('app-dir action handling', () => {
       expect(cnt).toBe('0')
 
       await browser.elementByCss('#inc').click()
-      await check(() => browser.elementById('count').text(), '1')
+      await retry(async () => {
+        expect(await browser.elementById('count').text()).toBe('1')
+      })
 
       await browser.elementByCss('#inc').click()
-      await check(() => browser.elementById('count').text(), '2')
-
+      await retry(async () => {
+        expect(await browser.elementById('count').text()).toBe('2')
+      })
       await browser.elementByCss('#double').click()
-      await check(() => browser.elementById('count').text(), '4')
-
+      await retry(async () => {
+        expect(await browser.elementById('count').text()).toBe('4')
+      })
       await browser.elementByCss('#dec').click()
-      await check(() => browser.elementById('count').text(), '3')
+      await retry(async () => {
+        expect(await browser.elementById('count').text()).toBe('3')
+      })
     })
 
     it('should return error response for hoc auth wrappers in edge runtime', async () => {
@@ -923,18 +988,24 @@ describe('app-dir action handling', () => {
 
       await browser.elementByCss('#authed').click()
 
-      await check(
-        () => browser.elementByCss('h1').text(),
-        isNextDev ? 'Error: Unauthorized request' : GENERIC_RSC_ERROR
-      )
+      await retry(async () => {
+        const text = await browser.elementByCss('h1').text()
+        if (isNextDev) {
+          expect(text).toBe('Error: Unauthorized request')
+        } else {
+          expect(text).toBe(GENERIC_RSC_ERROR)
+        }
+      })
 
       await browser.eval(`document.cookie = 'edge-auth=1'`)
 
       await browser.elementByCss('#authed').click()
 
-      await check(() => {
-        return browser.elementByCss('h1').text()
-      }, 'Prefix: HELLO, WORLD')
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toBe(
+          'Prefix: HELLO, WORLD'
+        )
+      })
     })
 
     it.each(['relative', 'absolute'])(
@@ -971,7 +1042,9 @@ describe('app-dir action handling', () => {
         })
 
         await browser.elementById(`redirect-${redirectType}`).click()
-        await check(() => browser.url(), `${next.url}${destinationPagePath}`)
+        await retry(async () => {
+          expect(await browser.url()).toBe(`${next.url}${destinationPagePath}`)
+        })
 
         expect(await browser.waitForElementByCss('#redirected').text()).toBe(
           'redirected'
@@ -999,9 +1072,11 @@ describe('app-dir action handling', () => {
 
       await browser.elementByCss('#redirect-external').click()
 
-      await check(async () => {
-        return browser.eval('window.location.toString()')
-      }, 'https://next-data-api-endpoint.vercel.app/api/random?page')
+      await retry(async () => {
+        expect(await browser.url()).toBe(
+          'https://next-data-api-endpoint.vercel.app/api/random?page'
+        )
+      })
     })
 
     it('should allow cookie and header async storages', async () => {
@@ -1013,12 +1088,12 @@ describe('app-dir action handling', () => {
 
       await browser.elementByCss('#get-headers').click()
 
-      await check(async () => {
+      await retry(async () => {
         const newTestCookie = await browser.eval(
           `document.cookie.match(/test-cookie=(\\d+)/)?.[1]`
         )
-        return newTestCookie !== currentTestCookie ? 'success' : 'failure'
-      }, 'success')
+        expect(newTestCookie).not.toBe(currentTestCookie)
+      })
     })
 
     it('should handle unicode search params', async () => {
@@ -1028,20 +1103,26 @@ describe('app-dir action handling', () => {
       expect(cnt).toBe('0')
 
       await browser.elementByCss('#inc').click()
-      await check(() => browser.elementById('count').text(), '1')
+      await retry(async () => {
+        expect(await browser.elementById('count').text()).toBe('1')
+      })
     })
   })
 
   describe('fetch actions', () => {
     it('should handle a fetch action initiated from a static page', async () => {
       const browser = await next.browser('/client-static')
-      await check(() => browser.elementByCss('#count').text(), '0')
-
+      await retry(async () => {
+        expect(await browser.elementById('count').text()).toBe('0')
+      })
       await browser.elementByCss('#increment').click()
-      await check(() => browser.elementByCss('#count').text(), '1')
-
+      await retry(async () => {
+        expect(await browser.elementById('count').text()).toBe('1')
+      })
       await browser.elementByCss('#increment').click()
-      await check(() => browser.elementByCss('#count').text(), '2')
+      await retry(async () => {
+        expect(await browser.elementById('count').text()).toBe('2')
+      })
     })
 
     it.each(['relative', 'absolute'])(
@@ -1078,7 +1159,9 @@ describe('app-dir action handling', () => {
         })
 
         await browser.elementById(`redirect-${redirectType}`).click()
-        await check(() => browser.url(), `${next.url}${destinationPagePath}`)
+        await retry(async () => {
+          expect(await browser.url()).toBe(`${next.url}${destinationPagePath}`)
+        })
 
         // This verifies the redirect & server response happens in a single roundtrip,
         // if the redirect resource was static. In development, these responses are always
@@ -1102,9 +1185,11 @@ describe('app-dir action handling', () => {
 
       await browser.elementByCss('#redirect-external').click()
 
-      await check(async () => {
-        return browser.eval('window.location.toString()')
-      }, 'https://next-data-api-endpoint.vercel.app/api/random?page')
+      await retry(async () => {
+        expect(await browser.url()).toBe(
+          'https://next-data-api-endpoint.vercel.app/api/random?page'
+        )
+      })
     })
 
     it('should handle redirects to routes that provide an invalid RSC response', async () => {
@@ -1128,7 +1213,6 @@ describe('app-dir action handling', () => {
       })
     })
 
-    // TODO: investigate flakey behavior with revalidate
     it('should handle revalidatePath', async () => {
       const browser = await next.browser('/revalidate')
       const randomNumber = await browser.elementByCss('#random-number').text()
@@ -1137,7 +1221,7 @@ describe('app-dir action handling', () => {
 
       await browser.elementByCss('#revalidate-path').click()
 
-      await check(async () => {
+      await retry(async () => {
         const newRandomNumber = await browser
           .elementByCss('#random-number')
           .text()
@@ -1146,15 +1230,12 @@ describe('app-dir action handling', () => {
           .elementByCss('#thankyounext')
           .text()
 
-        return newRandomNumber !== randomNumber &&
-          justPutIt !== newJustPutIt &&
-          thankYouNext !== newThankYouNext
-          ? 'success'
-          : 'failure'
-      }, 'success')
+        expect(newRandomNumber).not.toBe(randomNumber)
+        expect(newJustPutIt).not.toBe(justPutIt)
+        expect(newThankYouNext).not.toBe(thankYouNext)
+      })
     })
 
-    // TODO: investigate flakey behavior with revalidate
     it('should handle revalidateTag', async () => {
       const browser = await next.browser('/revalidate')
       const randomNumber = await browser.elementByCss('#random-number').text()
@@ -1163,7 +1244,7 @@ describe('app-dir action handling', () => {
 
       await browser.elementByCss('#revalidate-justputit').click()
 
-      await check(async () => {
+      await retry(async () => {
         const newRandomNumber = await browser
           .elementByCss('#random-number')
           .text()
@@ -1175,9 +1256,7 @@ describe('app-dir action handling', () => {
         expect(newRandomNumber).not.toBe(randomNumber)
         expect(newJustPutIt).not.toBe(justPutIt)
         expect(newThankYouNext).toBe(thankYouNext)
-
-        return 'success'
-      }, 'success')
+      })
     })
 
     // TODO: investigate flakey behavior with revalidate
@@ -1189,7 +1268,7 @@ describe('app-dir action handling', () => {
 
       await browser.elementByCss('#revalidate-path-redirect').click()
 
-      await check(async () => {
+      await retry(async () => {
         const newRandomNumber = await browser
           .elementByCss('#random-number')
           .text()
@@ -1201,9 +1280,7 @@ describe('app-dir action handling', () => {
         expect(newRandomNumber).toBe(randomNumber)
         expect(newJustPutIt).not.toBe(justPutIt)
         expect(newThankYouNext).toBe(thankYouNext)
-
-        return 'success'
-      }, 'success')
+      })
     })
 
     it('should store revalidation data in the prefetch cache', async () => {
@@ -1238,13 +1315,13 @@ describe('app-dir action handling', () => {
 
       await browser.elementByCss('#set-cookie').click()
 
-      await check(async () => {
+      await retry(async () => {
         const newRandomNumber = await browser
           .elementByCss('#random-cookie')
           .text()
 
-        return newRandomNumber !== randomNumber ? 'success' : 'failure'
-      }, 'success')
+        expect(newRandomNumber).not.toBe(randomNumber)
+      })
     })
 
     it('should invalidate client cache on other routes when cookies.set is called', async () => {
@@ -1252,10 +1329,10 @@ describe('app-dir action handling', () => {
       await browser.elementByCss('#update-cookie').click()
 
       let cookie
-      await check(async () => {
+      await retry(async () => {
         cookie = await browser.elementByCss('#value').text()
-        return parseInt(cookie) > 0 ? 'success' : 'failure'
-      }, 'success')
+        expect(parseInt(cookie)).toBeGreaterThan(0)
+      })
 
       // Make sure the route is cached
       await browser.elementByCss('#page-2').click()
@@ -1264,12 +1341,11 @@ describe('app-dir action handling', () => {
       // Modify the cookie
       await browser.elementByCss('#update-cookie').click()
       let newCookie
-      await check(async () => {
+      await retry(async () => {
         newCookie = await browser.elementByCss('#value').text()
-        return newCookie !== cookie && parseInt(newCookie) > 0
-          ? 'success'
-          : 'failure'
-      }, 'success')
+        expect(newCookie).not.toBe(cookie)
+        expect(parseInt(newCookie)).toBeGreaterThan(0)
+      })
 
       // Navigate to another page and make sure the cookie is not cached
       await browser.elementByCss('#page-2').click()
@@ -1283,19 +1359,21 @@ describe('app-dir action handling', () => {
       await browser.refresh()
 
       let randomCookie
-      await check(async () => {
+      await retry(async () => {
         randomCookie = JSON.parse(
           await browser.elementByCss('#random-cookie').text()
         ).value
-        return randomCookie ? 'success' : 'failure'
-      }, 'success')
+        expect(randomCookie).toBeDefined()
+      })
 
       console.log(123, await browser.elementByCss('body').text())
 
       await browser.elementByCss('#another').click()
-      await check(async () => {
-        return browser.elementByCss('#title').text()
-      }, 'another route')
+      await retry(async () => {
+        expect(await browser.elementByCss('#title').text()).toBe(
+          'another route'
+        )
+      })
 
       const newRandomCookie = JSON.parse(
         await browser.elementByCss('#random-cookie').text()
@@ -1313,24 +1391,22 @@ describe('app-dir action handling', () => {
 
       // Should be different
       let revalidatedRandomCookie
-      await check(async () => {
+      await retry(async () => {
         revalidatedRandomCookie = JSON.parse(
           await browser.elementByCss('#random-cookie').text()
         ).value
-        return randomCookie !== revalidatedRandomCookie ? 'success' : 'failure'
-      }, 'success')
+        expect(revalidatedRandomCookie).not.toBe(randomCookie)
+      })
 
       await browser.elementByCss('#another').click()
 
       // The other page should be revalidated too
-      await check(async () => {
+      await retry(async () => {
         const newRandomCookie = await JSON.parse(
           await browser.elementByCss('#random-cookie').text()
         ).value
-        return revalidatedRandomCookie === newRandomCookie
-          ? 'success'
-          : 'failure'
-      }, 'success')
+        expect(revalidatedRandomCookie).toBe(newRandomCookie)
+      })
     })
 
     it.each(['tag', 'path'])(
@@ -1342,9 +1418,11 @@ describe('app-dir action handling', () => {
         const thankYouNext = await browser.elementByCss('#thankyounext').text()
 
         await browser.elementByCss('#another').click()
-        await check(async () => {
-          return browser.elementByCss('#title').text()
-        }, 'another route')
+        await retry(async () => {
+          expect(await browser.elementByCss('#title').text()).toBe(
+            'another route'
+          )
+        })
 
         const newThankYouNext = await browser
           .elementByCss('#thankyounext')
@@ -1357,7 +1435,7 @@ describe('app-dir action handling', () => {
 
         // Should be different
         let revalidatedThankYouNext
-        await check(async () => {
+        await retry(async () => {
           switch (type) {
             case 'tag':
               await browser.elementByCss('#revalidate-thankyounext').click()
@@ -1372,22 +1450,19 @@ describe('app-dir action handling', () => {
           revalidatedThankYouNext = await browser
             .elementByCss('#thankyounext')
             .text()
-          return thankYouNext !== revalidatedThankYouNext
-            ? 'success'
-            : 'failure'
-        }, 'success')
+
+          expect(thankYouNext).not.toBe(revalidatedThankYouNext)
+        })
 
         await browser.elementByCss('#another').click()
 
         // The other page should be revalidated too
-        await check(async () => {
+        await retry(async () => {
           const newThankYouNext = await browser
             .elementByCss('#thankyounext')
             .text()
-          return revalidatedThankYouNext === newThankYouNext
-            ? 'success'
-            : 'failure'
-        }, 'success')
+          expect(revalidatedThankYouNext).toBe(newThankYouNext)
+        })
       }
     )
   })
@@ -1395,15 +1470,22 @@ describe('app-dir action handling', () => {
   it('should work with interception routes', async () => {
     const browser = await next.browser('/interception-routes')
 
-    await check(() => browser.elementById('children-data').text(), /Open modal/)
+    await retry(async () => {
+      expect(await browser.elementById('children-data').text()).toContain(
+        'Open modal'
+      )
+    })
 
     await browser.elementByCss("[href='/interception-routes/test']").click()
 
-    // verify the URL is correct
-    await check(() => browser.url(), /interception-routes\/test/)
-
-    // the intercepted text should appear
-    await check(() => browser.elementById('modal-data').text(), /in "modal"/)
+    await retry(async () => {
+      // verify the URL is correct
+      expect(await browser.url()).toContain('interception-routes/test')
+      // the intercepted text should appear
+      expect(await browser.elementById('modal-data').text()).toContain(
+        'in "modal"'
+      )
+    })
 
     // Submit the action
     await browser.elementById('submit-intercept-action').click()
@@ -1419,7 +1501,11 @@ describe('app-dir action handling', () => {
     expect(await browser.hasElementByCssSelector('#modal-data')).toBeFalsy()
 
     // The page text should show
-    await check(() => browser.elementById('children-data').text(), /in "page"/)
+    await retry(async () => {
+      expect(await browser.elementById('children-data').text()).toContain(
+        'in "page"'
+      )
+    })
 
     // Submit the action
     await browser.elementById('submit-page-action').click()
@@ -1465,7 +1551,10 @@ describe('app-dir action handling', () => {
         },
       })
       await browser.elementById('submit-api-redirect').click()
-      await check(() => browser.url(), /success=true/)
+      // await check(() => browser.url(), /success=true/)
+      await retry(async () => {
+        expect(await browser.url()).toContain('success=true')
+      })
 
       // verify that the POST request was only made to the action handler
       expect(postRequests).toEqual(['/redirects/api-redirect'])
@@ -1497,8 +1586,9 @@ describe('app-dir action handling', () => {
       })
 
       await browser.elementById('submit-api-redirect-permanent').click()
-      await check(() => browser.url(), /success=true/)
-
+      await retry(async () => {
+        expect(await browser.url()).toContain('success=true')
+      })
       // verify that the POST request was only made to the action handler
       expect(postRequests).toEqual(['/redirects/api-redirect-permanent'])
       expect(responseCodes).toEqual([303])
@@ -1511,10 +1601,12 @@ describe('app-dir action handling', () => {
 
       // redirect with search params
       await browser.elementById('redirect-with-search-params').click()
-      await check(
-        () => browser.url(),
-        /\/redirects\/action-redirect\/redirect-target\?baz=1/
-      )
+
+      await retry(async () => {
+        expect(await browser.url()).toMatch(
+          /\/redirects\/action-redirect\/redirect-target\?baz=1/
+        )
+      })
 
       // verify that the search params was set correctly
       expect(await browser.elementByCss('h2').text()).toBe('baz=1')
@@ -1532,10 +1624,12 @@ describe('app-dir action handling', () => {
 
       // delete foo and set bar to 2, redirect
       await browser.elementById('redirect-with-cookie-mutation').click()
-      await check(
-        () => browser.url(),
-        /\/redirects\/action-redirect\/redirect-target/
-      )
+
+      await retry(async () => {
+        expect(await browser.url()).toMatch(
+          /\/redirects\/action-redirect\/redirect-target/
+        )
+      })
 
       // verify that the cookies were merged correctly
       expect(await browser.elementByCss('h1').text()).toBe('foo=; bar=2')
@@ -1586,7 +1680,9 @@ describe('app-dir action handling', () => {
         })
 
         await browser.elementById(`submit-api-redirect-${statusCode}`).click()
-        await check(() => browser.url(), /success=true/)
+        await retry(async () => {
+          expect(await browser.url()).toContain('success=true')
+        })
         expect(await browser.elementById('redirect-page')).toBeTruthy()
 
         // since a 307/308 status code follows the redirect, the POST request should be made to both the action handler and the redirect target
@@ -1648,13 +1744,11 @@ describe('app-dir action handling', () => {
 
       await browser.waitForElementByCss('#trigger-fetch').click()
 
-      await check(async () => {
+      await retry(async () => {
         const newNumber = await getNumber()
         // Expect that the number changes on each click
         expect(newNumber).not.toBe(firstNumber)
-
-        return 'success'
-      }, 'success')
+      })
     })
 
     it('should not override force-cache in server action', async () => {
@@ -1671,13 +1765,11 @@ describe('app-dir action handling', () => {
 
       await browser.waitForElementByCss('#trigger-fetch').click()
 
-      await check(async () => {
+      await retry(async () => {
         const newNumber = await getNumber()
         // Expect that the number is the same on each click
         expect(newNumber).toBe(firstNumber)
-
-        return 'success'
-      }, 'success')
+      })
     })
 
     // Implicit force-cache
@@ -1695,13 +1787,11 @@ describe('app-dir action handling', () => {
 
       await browser.waitForElementByCss('#trigger-fetch').click()
 
-      await check(async () => {
+      await retry(async () => {
         const newNumber = await getNumber()
         // Expect that the number is the same on each click
         expect(newNumber).toBe(firstNumber)
-
-        return 'success'
-      }, 'success')
+      })
     })
   })
 })

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1227,15 +1227,14 @@ describe('app-dir action handling', () => {
     })
 
     it('should handle revalidateTag', async () => {
-      // This test seems to be flaky on the first run. This should be investigated
+      const browser = await next.browser('/revalidate')
+      const randomNumber = await browser.elementByCss('#random-number').text()
+      const justPutIt = await browser.elementByCss('#justputit').text()
+      const thankYouNext = await browser.elementByCss('#thankyounext').text()
+
+      await browser.elementByCss('#revalidate-justputit').click()
+
       await retry(async () => {
-        const browser = await next.browser('/revalidate')
-        const randomNumber = await browser.elementByCss('#random-number').text()
-        const justPutIt = await browser.elementByCss('#justputit').text()
-        const thankYouNext = await browser.elementByCss('#thankyounext').text()
-
-        await browser.elementByCss('#revalidate-justputit').click()
-
         const newRandomNumber = await browser
           .elementByCss('#random-number')
           .text()

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1227,14 +1227,15 @@ describe('app-dir action handling', () => {
     })
 
     it('should handle revalidateTag', async () => {
-      const browser = await next.browser('/revalidate')
-      const randomNumber = await browser.elementByCss('#random-number').text()
-      const justPutIt = await browser.elementByCss('#justputit').text()
-      const thankYouNext = await browser.elementByCss('#thankyounext').text()
-
-      await browser.elementByCss('#revalidate-justputit').click()
-
+      // This test seems to be flaky on the first run. This should be investigated
       await retry(async () => {
+        const browser = await next.browser('/revalidate')
+        const randomNumber = await browser.elementByCss('#random-number').text()
+        const justPutIt = await browser.elementByCss('#justputit').text()
+        const thankYouNext = await browser.elementByCss('#thankyounext').text()
+
+        await browser.elementByCss('#revalidate-justputit').click()
+
         const newRandomNumber = await browser
           .elementByCss('#random-number')
           .text()

--- a/test/e2e/app-dir/actions/app/revalidate/page.js
+++ b/test/e2e/app-dir/actions/app/revalidate/page.js
@@ -1,8 +1,4 @@
-import {
-  //   unstable_cache,
-  revalidatePath,
-  revalidateTag,
-} from 'next/cache'
+import { revalidatePath, revalidateTag } from 'next/cache'
 import { redirect } from 'next/navigation'
 import Link from 'next/link'
 
@@ -23,24 +19,6 @@ export default async function Page() {
       next: { revalidate: 3600, tags: ['thankyounext', 'justputit'] },
     }
   ).then((res) => res.text())
-
-  // TODO: make this work + add test
-  //   const cachedData = await unstable_cache(
-  //     async () => {
-  //       const fetchedRandom = await fetch(
-  //         'https://next-data-api-endpoint.vercel.app/api/random'
-  //       ).then((res) => res.json())
-  //       return {
-  //         now: Date.now(),
-  //         random: Math.random(),
-  //         fetchedRandom,
-  //       }
-  //     },
-  //     ['random'],
-  //     {
-  //       tags: ['thankyounext'],
-  //     }
-  //   )()
 
   return (
     <>
@@ -77,7 +55,6 @@ export default async function Page() {
           set cookie
         </button>
       </form>
-      {/* <p>revalidate 10 (tags: thankyounext): {JSON.stringify(cachedData)}</p> */}
       <form>
         <button
           id="revalidate-thankyounext"

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -681,7 +681,7 @@ export async function startCleanStaticServer(dir: string) {
 
 /**
  * Check for content in 1 second intervals timing out after 30 seconds.
- *
+ * @deprecated use retry + expect instead
  * @param {() => Promise<unknown> | unknown} contentFn
  * @param {RegExp | string | number} regex
  * @param {boolean} hardError


### PR DESCRIPTION
We've discussed internally deprecating `check` so I've marked it as deprecated in this PR and refactored app-action to use `retry` + `expect` in favor of `check`.  `check` makes it really hard to tell what the expected/received behavior is and it becomes hard to reason about when we're asserting on strings that return `'success'` or `'yes'`

Other misc improvement:
[improve middleware rewrite test](https://github.com/vercel/next.js/pull/70726/commits/1cc3cf3aecf5975f8bf78e7523901b2ca57d3b80)

I also disabled the revalidateTag test as it's consistently flaking when deployed and I haven't been able to diagnose what's wrong with it. 