### PR TITLE
support running React 18 tests on PRs with a label

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -204,7 +204,7 @@ jobs:
       matrix:
         exclude:
           # Excluding React 18 tests unless on `canary` branch until budget is approved.
-          - react: ${{ github.event_name == 'pull_request' && '18.3.1' }}
+          - react: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-react-18-tests') && '18.3.1' }}
         group: [1/5, 2/5, 3/5, 4/5, 5/5]
         # Empty value uses default
         react: ['', '18.3.1']
@@ -224,7 +224,7 @@ jobs:
       matrix:
         exclude:
           # Excluding React 18 tests unless on `canary` branch until budget is approved.
-          - react: ${{ github.event_name == 'pull_request' && '18.3.1' }}
+          - react: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-react-18-tests') && '18.3.1' }}
         group: [1/5, 2/5, 3/5, 4/5, 5/5]
         # Empty value uses default
         react: ['']
@@ -245,7 +245,7 @@ jobs:
       matrix:
         exclude:
           # Excluding React 18 tests unless on `canary` branch until budget is approved.
-          - react: ${{ github.event_name == 'pull_request' && '18.3.1' }}
+          - react: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-react-18-tests') && '18.3.1' }}
         group: [1/5, 2/5, 3/5, 4/5, 5/5]
         # Empty value uses default
         # TODO: Run with React 18.
@@ -383,7 +383,7 @@ jobs:
       matrix:
         exclude:
           # Excluding React 18 tests unless on `canary` branch until budget is approved.
-          - react: ${{ github.event_name == 'pull_request' && '18.3.1' }}
+          - react: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-react-18-tests') && '18.3.1' }}
         group: [1/4, 2/4, 3/4, 4/4]
         # Empty value uses default
         react: ['', '18.3.1']
@@ -403,7 +403,7 @@ jobs:
       matrix:
         exclude:
           # Excluding React 18 tests unless on `canary` branch until budget is approved.
-          - react: ${{ github.event_name == 'pull_request' && '18.3.1' }}
+          - react: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-react-18-tests') && '18.3.1' }}
         group: [1/5, 2/5, 3/5, 4/5, 5/5]
         # Empty value uses default
         react: ['', '18.3.1']


### PR DESCRIPTION
When we make changes that we want to assert pass on the React 18.3 matrix, we should have a way to do so on PRs so that we can avoid failures hitting canary.

This adds a label that will make the 18.3.1 tests run on PRs. 