### PR TITLE
Reapply "Dedupe sync access warning on the Server by callsite" (#70672)

### DIFF
--- a/packages/next/src/server/create-deduped-by-callsite-server-error-loger.ts
+++ b/packages/next/src/server/create-deduped-by-callsite-server-error-loger.ts
@@ -1,0 +1,52 @@
+import * as React from 'react'
+
+const errorRef: { current: null | string } = { current: null }
+// We don't want to dedupe across requests.
+// The developer might've just attempted to fix the warning so we should warn again if it still happens.
+const flushCurrentErrorIfNew = React.cache(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- cache key
+  (key: unknown) => {
+    try {
+      console.error(errorRef.current)
+    } finally {
+      errorRef.current = null
+    }
+  }
+)
+
+/**
+ * Creates a function that logs an error message that is deduped by the userland
+ * callsite.
+ * This requires no indirection between the call of this function and the userland
+ * callsite i.e. there's only a single library frame above this.
+ * Do not use on the Client where sourcemaps and ignore listing might be enabled.
+ * Only use that for warnings need a fix independent of the callstack.
+ *
+ * @param getMessage
+ * @returns
+ */
+export function createDedupedByCallsiteServerErrorLoggerDev<Args extends any[]>(
+  getMessage: (...args: Args) => string
+) {
+  return function logDedupedError(...args: Args) {
+    const message = getMessage(...args)
+
+    if (process.env.NODE_ENV !== 'production') {
+      const callStackFrames = new Error().stack?.split('\n')
+      if (callStackFrames === undefined || callStackFrames.length < 4) {
+        console.error(message)
+      } else {
+        // Error:
+        //   logDedupedError
+        //   asyncApiBeingAccessedSynchronously
+        //   <userland callsite>
+        // TODO: This breaks if sourcemaps with ignore lists are enabled.
+        const key = callStackFrames[3]
+        errorRef.current = message
+        flushCurrentErrorIfNew(key)
+      }
+    } else {
+      console.error(message)
+    }
+  }
+}

--- a/packages/next/src/server/create-deduped-by-callsite-server-error-loger.ts
+++ b/packages/next/src/server/create-deduped-by-callsite-server-error-loger.ts
@@ -1,9 +1,16 @@
 import * as React from 'react'
 
 const errorRef: { current: null | string } = { current: null }
+
+// React.cache is currently only available in canary/experimental React channels.
+const cache =
+  typeof React.cache === 'function'
+    ? React.cache
+    : (fn: (key: unknown) => void) => fn
+
 // We don't want to dedupe across requests.
 // The developer might've just attempted to fix the warning so we should warn again if it still happens.
-const flushCurrentErrorIfNew = React.cache(
+const flushCurrentErrorIfNew = cache(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- cache key
   (key: unknown) => {
     try {

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -22,6 +22,7 @@ import { actionAsyncStorage } from '../../client/components/action-async-storage
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 import { makeResolvedReactPromise } from './utils'
 import { makeHangingPromise } from '../dynamic-rendering-utils'
+import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-loger'
 
 /**
  * In this version of Next.js `cookies()` returns a Promise however you can still reference the properties of the underlying cookies object
@@ -521,25 +522,30 @@ const noop = () => {}
 const warnForSyncIteration = process.env
   .__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS
   ? noop
-  : function warnForSyncIteration(route?: string) {
-      const prefix = route ? ` In route ${route} ` : ''
-      console.error(
-        `${prefix}cookies were iterated over. ` +
+  : createDedupedByCallsiteServerErrorLoggerDev(
+      function getSyncIterationMessage(route?: string) {
+        const prefix = route ? ` In route ${route} ` : ''
+        return (
+          `${prefix}cookies were iterated over. ` +
           `\`cookies()\` should be awaited before using its value. ` +
           `Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis`
-      )
-    }
+        )
+      }
+    )
 
 const warnForSyncAccess = process.env.__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS
   ? noop
-  : function warnForSyncAccess(route: undefined | string, expression: string) {
+  : createDedupedByCallsiteServerErrorLoggerDev(function getSyncAccessMessage(
+      route: undefined | string,
+      expression: string
+    ) {
       const prefix = route ? ` In route ${route} a ` : 'A '
-      console.error(
+      return (
         `${prefix}cookie property was accessed directly with \`${expression}\`. ` +
-          `\`cookies()\` should be awaited before using its value. ` +
-          `Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis`
+        `\`cookies()\` should be awaited before using its value. ` +
+        `Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis`
       )
-    }
+    })
 
 function polyfilledResponseCookiesIterator(
   this: ResponseCookies

--- a/packages/next/src/server/request/draft-mode.ts
+++ b/packages/next/src/server/request/draft-mode.ts
@@ -5,6 +5,7 @@ import type { DraftModeProvider } from '../../server/async-storage/draft-mode-pr
 import { workAsyncStorage } from '../../client/components/work-async-storage.external'
 import { cacheAsyncStorage } from '../../server/app-render/cache-async-storage.external'
 import { trackDynamicDataAccessed } from '../app-render/dynamic-rendering'
+import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-loger'
 
 /**
  * In this version of Next.js `draftMode()` returns a Promise however you can still reference the properties of the underlying draftMode object
@@ -167,11 +168,14 @@ const noop = () => {}
 
 const warnForSyncAccess = process.env.__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS
   ? noop
-  : function warnForSyncAccess(route: undefined | string, expression: string) {
+  : createDedupedByCallsiteServerErrorLoggerDev(function getSyncAccessWarning(
+      route: undefined | string,
+      expression: string
+    ) {
       const prefix = route ? ` In route ${route} a ` : 'A '
-      console.error(
+      return (
         `${prefix}\`draftMode()\` property was accessed directly with \`${expression}\`. ` +
-          `\`draftMode()\` should be awaited before using its value. ` +
-          `Learn more: https://nextjs.org/docs/messages/draft-mode-sync-access`
+        `\`draftMode()\` should be awaited before using its value. ` +
+        `Learn more: https://nextjs.org/docs/messages/draft-mode-sync-access`
       )
-    }
+    })

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -19,6 +19,7 @@ import {
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 import { makeResolvedReactPromise } from './utils'
 import { makeHangingPromise } from '../dynamic-rendering-utils'
+import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-loger'
 
 /**
  * In this version of Next.js `headers()` returns a Promise however you can still reference the properties of the underlying Headers instance
@@ -436,25 +437,30 @@ const noop = () => {}
 const warnForSyncIteration = process.env
   .__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS
   ? noop
-  : function warnForSyncIteration(route?: string) {
-      const prefix = route ? ` In route ${route} ` : ''
-      console.error(
-        `${prefix}headers were iterated over. ` +
+  : createDedupedByCallsiteServerErrorLoggerDev(
+      function getSyncIterationMessage(route?: string) {
+        const prefix = route ? ` In route ${route} ` : ''
+        return (
+          `${prefix}headers were iterated over. ` +
           `\`headers()\` should be awaited before using its value. ` +
           `Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis`
-      )
-    }
+        )
+      }
+    )
 
 const warnForSyncAccess = process.env.__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS
   ? noop
-  : function warnForSyncAccess(route: undefined | string, expression: string) {
+  : createDedupedByCallsiteServerErrorLoggerDev(function getSyncAccessMessage(
+      route: undefined | string,
+      expression: string
+    ) {
       const prefix = route ? ` In route ${route} a ` : 'A '
-      console.error(
+      return (
         `${prefix}header property was accessed directly with \`${expression}\`. ` +
-          `\`headers()\` should be awaited before using its value. ` +
-          `Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis`
+        `\`headers()\` should be awaited before using its value. ` +
+        `Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis`
       )
-    }
+    })
 
 type HeadersExtensions = {
   [K in keyof ReadonlyHeaders]: unknown

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -17,6 +17,7 @@ import {
 import { cacheAsyncStorage } from '../app-render/cache-async-storage.external'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { makeHangingPromise } from '../dynamic-rendering-utils'
+import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-loger'
 import {
   describeStringPropertyAccess,
   describeHasCheckingStringProperty,
@@ -659,18 +660,21 @@ const noop = () => {}
 
 const warnForSyncAccess = process.env.__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS
   ? noop
-  : function warnForSyncAccess(route: undefined | string, expression: string) {
+  : createDedupedByCallsiteServerErrorLoggerDev(function getSyncAccessMessage(
+      route: undefined | string,
+      expression: string
+    ) {
       const prefix = route ? ` In route ${route} a ` : 'A '
-      console.error(
+      return (
         `${prefix}searchParam property was accessed directly with ${expression}. ` +
-          `\`searchParams\` should be awaited before accessing properties. ` +
-          `Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis`
+        `\`searchParams\` should be awaited before accessing properties. ` +
+        `Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis`
       )
-    }
+    })
 
 const warnForEnumeration = process.env.__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS
   ? noop
-  : function warnForEnumeration(
+  : createDedupedByCallsiteServerErrorLoggerDev(function getEnumerationMessage(
       route: undefined | string,
       missingProperties: Array<string>
     ) {
@@ -678,19 +682,19 @@ const warnForEnumeration = process.env.__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS
       if (missingProperties.length) {
         const describedMissingProperties =
           describeListOfPropertyNames(missingProperties)
-        console.error(
+        return (
           `${prefix}searchParams are being enumerated incompletely missing these properties: ${describedMissingProperties}. ` +
-            `\`searchParams\` should be awaited before accessing its properties. ` +
-            `Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis`
+          `\`searchParams\` should be awaited before accessing its properties. ` +
+          `Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis`
         )
       } else {
-        console.error(
+        return (
           `${prefix}searchParams are being enumerated. ` +
-            `\`searchParams\` should be awaited before accessing its properties. ` +
-            `Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis`
+          `\`searchParams\` should be awaited before accessing its properties. ` +
+          `Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis`
         )
       }
-    }
+    })
 
 function describeListOfPropertyNames(properties: Array<string>) {
   switch (properties.length) {

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -3,6 +3,7 @@
 
 e2e/**/tsconfig.json
 production/**/tsconfig.json
+development/**/tsconfig.json
 
 test-junit-report/
 turbopack-test-junit-report/

--- a/test/development/app-dir/dynamic-io-warnings/app/layout.tsx
+++ b/test/development/app-dir/dynamic-io-warnings/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/dynamic-io-warnings/app/pages/cookies/page.tsx
+++ b/test/development/app-dir/dynamic-io-warnings/app/pages/cookies/page.tsx
@@ -1,0 +1,19 @@
+import { cookies, type UnsafeUnwrappedCookies } from 'next/headers'
+
+function Component() {
+  ;(cookies() as unknown as UnsafeUnwrappedCookies).get('component')
+  ;(cookies() as unknown as UnsafeUnwrappedCookies).has('component')
+
+  const allCookies = [...(cookies() as unknown as UnsafeUnwrappedCookies)]
+  return <pre>{JSON.stringify(allCookies, null, 2)}</pre>
+}
+
+export default function Page() {
+  ;(cookies() as unknown as UnsafeUnwrappedCookies).get('page')
+  return (
+    <>
+      <Component />
+      <Component />
+    </>
+  )
+}

--- a/test/development/app-dir/dynamic-io-warnings/app/pages/draftMode/page.tsx
+++ b/test/development/app-dir/dynamic-io-warnings/app/pages/draftMode/page.tsx
@@ -1,0 +1,24 @@
+import { draftMode, type UnsafeUnwrappedDraftMode } from 'next/headers'
+
+function Component() {
+  const isEnabled = (draftMode() as unknown as UnsafeUnwrappedDraftMode)
+    .isEnabled
+  ;(draftMode() as unknown as UnsafeUnwrappedDraftMode).enable()
+
+  const clonedDraftMode = {
+    ...(draftMode() as unknown as UnsafeUnwrappedDraftMode),
+  }
+  return <pre>{JSON.stringify({ clonedDraftMode, isEnabled }, null, 2)}</pre>
+}
+
+export default function Page() {
+  const isEnabled = (draftMode() as unknown as UnsafeUnwrappedDraftMode)
+    .isEnabled
+  return (
+    <>
+      <pre>{JSON.stringify({ isEnabled }, null, 2)}</pre>
+      <Component />
+      <Component />
+    </>
+  )
+}

--- a/test/development/app-dir/dynamic-io-warnings/app/pages/headers/page.tsx
+++ b/test/development/app-dir/dynamic-io-warnings/app/pages/headers/page.tsx
@@ -1,0 +1,19 @@
+import { headers, type UnsafeUnwrappedHeaders } from 'next/headers'
+
+function Component() {
+  ;(headers() as unknown as UnsafeUnwrappedHeaders).get('component')
+  ;(headers() as unknown as UnsafeUnwrappedHeaders).has('component')
+
+  const allHeaders = [...(headers() as unknown as UnsafeUnwrappedHeaders)]
+  return <pre>{JSON.stringify(allHeaders, null, 2)}</pre>
+}
+
+export default function Page() {
+  ;(headers() as unknown as UnsafeUnwrappedHeaders).get('page')
+  return (
+    <>
+      <Component />
+      <Component />
+    </>
+  )
+}

--- a/test/development/app-dir/dynamic-io-warnings/app/pages/params/[slug]/page.tsx
+++ b/test/development/app-dir/dynamic-io-warnings/app/pages/params/[slug]/page.tsx
@@ -1,0 +1,19 @@
+function Component({ params }: { params: { slug: string } }) {
+  const a = params.slug
+  const b = params.slug
+
+  const clonedParams = { ...params }
+  return <pre>{JSON.stringify({ clonedParams, a, b }, null, 2)}</pre>
+}
+
+export default function Page({ params }: { params: { slug: string } }) {
+  const slug = params.slug
+
+  return (
+    <>
+      <pre>{JSON.stringify({ slug }, null, 2)}</pre>
+      <Component params={params} />
+      <Component params={params} />
+    </>
+  )
+}

--- a/test/development/app-dir/dynamic-io-warnings/app/pages/searchParams/page.tsx
+++ b/test/development/app-dir/dynamic-io-warnings/app/pages/searchParams/page.tsx
@@ -1,0 +1,27 @@
+function Component({
+  searchParams,
+}: {
+  searchParams: Record<string, unknown>
+}) {
+  const a = searchParams.slug
+  const b = searchParams.slug
+
+  const clonedSearchParams = { ...searchParams }
+  return <pre>{JSON.stringify({ clonedSearchParams, a, b }, null, 2)}</pre>
+}
+
+export default function Page({
+  searchParams,
+}: {
+  searchParams: Record<string, unknown>
+}) {
+  const slug = searchParams.slug
+
+  return (
+    <>
+      <pre>{JSON.stringify({ slug }, null, 2)}</pre>
+      <Component searchParams={searchParams} />
+      <Component searchParams={searchParams} />
+    </>
+  )
+}

--- a/test/development/app-dir/dynamic-io-warnings/dynamic-io.warnings.test.ts
+++ b/test/development/app-dir/dynamic-io-warnings/dynamic-io.warnings.test.ts
@@ -1,0 +1,232 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('dynamic-requests warnings', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('warnings on sync cookie access', async () => {
+    const nextDevBootstrapOutputIndex = next.cliOutput.length
+
+    const browser = await next.browser('/pages/cookies')
+
+    const browserLogsserLogs = await browser.log()
+    const browserConsoleErrors = browserLogsserLogs
+      .filter((log) => log.source === 'error')
+      .map((log) => log.message)
+    const terminalOutput = next.cliOutput.slice(nextDevBootstrapOutputIndex)
+    const terminalCookieErrors = terminalOutput.split('\n').filter((line) => {
+      return line.includes('In route /pages/cookies')
+    })
+    expect({ browserConsoleErrors, terminalCookieErrors }).toEqual({
+      browserConsoleErrors: [
+        expect.stringContaining(
+          "In route /pages/cookies a cookie property was accessed directly with `cookies().get('page')`."
+        ),
+        expect.stringContaining(
+          "In route /pages/cookies a cookie property was accessed directly with `cookies().get('component')`."
+        ),
+        expect.stringContaining(
+          "In route /pages/cookies a cookie property was accessed directly with `cookies().has('component')`."
+        ),
+        expect.stringContaining(
+          'In route /pages/cookies cookies were iterated over'
+        ),
+      ],
+      terminalCookieErrors: [
+        expect.stringContaining(
+          "In route /pages/cookies a cookie property was accessed directly with `cookies().get('page')`."
+        ),
+        expect.stringContaining(
+          "In route /pages/cookies a cookie property was accessed directly with `cookies().get('component')`."
+        ),
+        expect.stringContaining(
+          "In route /pages/cookies a cookie property was accessed directly with `cookies().has('component')`."
+        ),
+        expect.stringContaining(
+          'In route /pages/cookies cookies were iterated over'
+        ),
+      ],
+    })
+  })
+
+  it('warnings on sync draftMode access', async () => {
+    const nextDevBootstrapOutputIndex = next.cliOutput.length
+
+    const browser = await next.browser('/pages/draftMode')
+
+    const browserLogsserLogs = await browser.log()
+    const browserConsoleErrors = browserLogsserLogs
+      .filter((log) => log.source === 'error')
+      .map((log) => log.message)
+    const terminalOutput = next.cliOutput.slice(nextDevBootstrapOutputIndex)
+    const terminalCookieErrors = terminalOutput.split('\n').filter((line) => {
+      return line.includes('In route /pages/draftMode')
+    })
+    expect({ browserConsoleErrors, terminalCookieErrors }).toEqual({
+      browserConsoleErrors: [
+        expect.stringContaining(
+          'In route /pages/draftMode a `draftMode()` property was accessed directly with `draftMode().isEnabled`.'
+        ),
+        expect.stringContaining(
+          'In route /pages/draftMode a `draftMode()` property was accessed directly with `draftMode().isEnabled`.'
+        ),
+        expect.stringContaining(
+          'In route /pages/draftMode a `draftMode()` property was accessed directly with `draftMode().enable()`.'
+        ),
+        expect.stringContaining(
+          'In route /pages/draftMode a `draftMode()` property was accessed directly with `draftMode().isEnabled`.'
+        ),
+      ],
+      terminalCookieErrors: [
+        expect.stringContaining(
+          'In route /pages/draftMode a `draftMode()` property was accessed directly with `draftMode().isEnabled`.'
+        ),
+        expect.stringContaining(
+          'In route /pages/draftMode a `draftMode()` property was accessed directly with `draftMode().isEnabled`.'
+        ),
+        expect.stringContaining(
+          'In route /pages/draftMode a `draftMode()` property was accessed directly with `draftMode().enable()`.'
+        ),
+        expect.stringContaining(
+          'In route /pages/draftMode a `draftMode()` property was accessed directly with `draftMode().isEnabled`.'
+        ),
+      ],
+    })
+  })
+
+  it('warnings on sync headers access', async () => {
+    const nextDevBootstrapOutputIndex = next.cliOutput.length
+
+    const browser = await next.browser('/pages/headers')
+
+    const browserLogsserLogs = await browser.log()
+    const browserConsoleErrors = browserLogsserLogs
+      .filter((log) => log.source === 'error')
+      .map((log) => log.message)
+    const terminalOutput = next.cliOutput.slice(nextDevBootstrapOutputIndex)
+    const terminalCookieErrors = terminalOutput.split('\n').filter((line) => {
+      return line.includes('In route /pages/headers')
+    })
+    expect({ browserConsoleErrors, terminalCookieErrors }).toEqual({
+      browserConsoleErrors: [
+        expect.stringContaining(
+          "In route /pages/headers a header property was accessed directly with `headers().get('page')`."
+        ),
+        expect.stringContaining(
+          "In route /pages/headers a header property was accessed directly with `headers().get('component')`."
+        ),
+        expect.stringContaining(
+          "In route /pages/headers a header property was accessed directly with `headers().has('component')`."
+        ),
+        expect.stringContaining(
+          'In route /pages/headers headers were iterated over'
+        ),
+      ],
+      terminalCookieErrors: [
+        expect.stringContaining(
+          "In route /pages/headers a header property was accessed directly with `headers().get('page')`."
+        ),
+        expect.stringContaining(
+          "In route /pages/headers a header property was accessed directly with `headers().get('component')`."
+        ),
+        expect.stringContaining(
+          "In route /pages/headers a header property was accessed directly with `headers().has('component')`."
+        ),
+        expect.stringContaining(
+          'In route /pages/headers headers were iterated over'
+        ),
+      ],
+    })
+  })
+
+  it('warnings on sync params access', async () => {
+    const nextDevBootstrapOutputIndex = next.cliOutput.length
+
+    const browser = await next.browser('/pages/params/[slug]')
+
+    const browserLogsserLogs = await browser.log()
+    const browserConsoleErrors = browserLogsserLogs
+      .filter((log) => log.source === 'error')
+      .map((log) => log.message)
+    const terminalOutput = next.cliOutput.slice(nextDevBootstrapOutputIndex)
+    const terminalCookieErrors = terminalOutput.split('\n').filter((line) => {
+      return line.includes('In route /pages/params/[slug]')
+    })
+    expect({ browserConsoleErrors, terminalCookieErrors }).toEqual({
+      browserConsoleErrors: [
+        expect.stringContaining(
+          'In route /pages/params/[slug] a param property was accessed directly with `params.slug`.'
+        ),
+        expect.stringContaining(
+          'In route /pages/params/[slug] a param property was accessed directly with `params.slug`.'
+        ),
+        expect.stringContaining(
+          'In route /pages/params/[slug] a param property was accessed directly with `params.slug`.'
+        ),
+        expect.stringContaining(
+          'In route /pages/params/[slug] params are being enumerated'
+        ),
+      ],
+      terminalCookieErrors: [
+        expect.stringContaining(
+          'In route /pages/params/[slug] a param property was accessed directly with `params.slug`.'
+        ),
+        expect.stringContaining(
+          'In route /pages/params/[slug] a param property was accessed directly with `params.slug`.'
+        ),
+        expect.stringContaining(
+          'In route /pages/params/[slug] a param property was accessed directly with `params.slug`.'
+        ),
+        expect.stringContaining(
+          'In route /pages/params/[slug] params are being enumerated'
+        ),
+      ],
+    })
+  })
+
+  it('warnings on sync searchParams access', async () => {
+    const nextDevBootstrapOutputIndex = next.cliOutput.length
+
+    const browser = await next.browser('/pages/searchParams')
+
+    const browserLogsserLogs = await browser.log()
+    const browserConsoleErrors = browserLogsserLogs
+      .filter((log) => log.source === 'error')
+      .map((log) => log.message)
+    const terminalOutput = next.cliOutput.slice(nextDevBootstrapOutputIndex)
+    const terminalCookieErrors = terminalOutput.split('\n').filter((line) => {
+      return line.includes('In route /pages/searchParams')
+    })
+    expect({ browserConsoleErrors, terminalCookieErrors }).toEqual({
+      browserConsoleErrors: [
+        expect.stringContaining(
+          'In route /pages/searchParams a searchParam property was accessed directly with `searchParams.slug`.'
+        ),
+        expect.stringContaining(
+          'In route /pages/searchParams a searchParam property was accessed directly with `searchParams.slug`.'
+        ),
+        expect.stringContaining(
+          'In route /pages/searchParams a searchParam property was accessed directly with `searchParams.slug`.'
+        ),
+        expect.stringContaining(
+          'In route /pages/searchParams searchParams are being enumerated'
+        ),
+      ],
+      terminalCookieErrors: [
+        expect.stringContaining(
+          'In route /pages/searchParams a searchParam property was accessed directly with `searchParams.slug`.'
+        ),
+        expect.stringContaining(
+          'In route /pages/searchParams a searchParam property was accessed directly with `searchParams.slug`.'
+        ),
+        expect.stringContaining(
+          'In route /pages/searchParams a searchParam property was accessed directly with `searchParams.slug`.'
+        ),
+        expect.stringContaining(
+          'In route /pages/searchParams searchParams are being enumerated'
+        ),
+      ],
+    })
+  })
+})

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.params.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.params.test.ts
@@ -1773,8 +1773,6 @@ describe('dynamic-io', () => {
           expect($('#param-key-count').text()).toBe('2')
           expect(getLines('In route /params')).toEqual([
             expect.stringContaining('params are being enumerated.'),
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1800,8 +1798,6 @@ describe('dynamic-io', () => {
           expect($('#param-key-count').text()).toBe('2')
           expect(getLines('In route /params')).toEqual([
             expect.stringContaining('params are being enumerated.'),
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1827,8 +1823,6 @@ describe('dynamic-io', () => {
           expect($('#param-key-count').text()).toBe('2')
           expect(getLines('In route /params')).toEqual([
             expect.stringContaining('params are being enumerated.'),
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1857,8 +1851,6 @@ describe('dynamic-io', () => {
           expect($('#param-key-count').text()).toBe('2')
           expect(getLines('In route /params')).toEqual([
             expect.stringContaining('params are being enumerated.'),
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -2007,8 +1999,6 @@ describe('dynamic-io', () => {
           expect($('#param-key-count').text()).toBe('2')
           expect(getLines('In route /params')).toEqual([
             expect.stringContaining('params are being enumerated.'),
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -2034,8 +2024,6 @@ describe('dynamic-io', () => {
           expect($('#param-key-count').text()).toBe('2')
           expect(getLines('In route /params')).toEqual([
             expect.stringContaining('params are being enumerated.'),
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -2124,8 +2112,6 @@ describe('dynamic-io', () => {
           expect($('#param-key-count').text()).toBe('2')
           expect(getLines('In route /params')).toEqual([
             expect.stringContaining('params are being enumerated.'),
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at runtime')
@@ -2152,8 +2138,6 @@ describe('dynamic-io', () => {
           expect($('#param-key-count').text()).toBe('2')
           expect(getLines('In route /params')).toEqual([
             expect.stringContaining('params are being enumerated.'),
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at runtime')
@@ -2339,8 +2323,6 @@ describe('dynamic-io', () => {
           ),
           expect.stringContaining('accessed directly with `params.dyn`'),
           expect.stringContaining('accessed directly with `params.value`'),
-          expect.stringContaining('accessed directly with `params.dyn`'),
-          expect.stringContaining('accessed directly with `params.value`'),
         ])
       } else {
         expect($('#layout').text()).toBe('at runtime')
@@ -2370,8 +2352,6 @@ describe('dynamic-io', () => {
           expect.stringContaining(
             'missing these properties: `then` and `status`.'
           ),
-          expect.stringContaining('accessed directly with `params.dyn`'),
-          expect.stringContaining('accessed directly with `params.value`'),
           expect.stringContaining('accessed directly with `params.dyn`'),
           expect.stringContaining('accessed directly with `params.value`'),
         ])

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.search.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.search.test.ts
@@ -397,13 +397,6 @@ describe('dynamic-io', () => {
           expect.stringContaining(
             'searchParams are being enumerated incompletely'
           ),
-          expect.stringContaining(
-            'accessed directly with `searchParams.sentinel`'
-          ),
-          expect.stringContaining('accessed directly with `searchParams.foo`'),
-          expect.stringContaining(
-            'accessed directly with `searchParams.value`'
-          ),
         ])
       } else {
         expect(searchWarnings).toHaveLength(0)
@@ -431,10 +424,6 @@ describe('dynamic-io', () => {
         expect($('#page').text()).toBe('at runtime')
         expect(searchWarnings).toEqual([
           expect.stringContaining('searchParams are being enumerated.'),
-          expect.stringContaining(
-            'accessed directly with `searchParams.sentinel`'
-          ),
-          expect.stringContaining('accessed directly with `searchParams.foo`'),
         ])
       } else {
         expect(searchWarnings).toHaveLength(0)
@@ -705,13 +694,6 @@ describe('dynamic-io', () => {
           expect.stringContaining(
             'searchParams are being enumerated incompletely'
           ),
-          expect.stringContaining(
-            'accessed directly with `searchParams.sentinel`'
-          ),
-          expect.stringContaining('accessed directly with `searchParams.foo`'),
-          expect.stringContaining(
-            'accessed directly with `searchParams.value`'
-          ),
         ])
       } else {
         expect(searchWarnings).toHaveLength(0)
@@ -735,10 +717,6 @@ describe('dynamic-io', () => {
         expect($('#page').text()).toBe('at runtime')
         expect(searchWarnings).toEqual([
           expect.stringContaining('searchParams are being enumerated.'),
-          expect.stringContaining(
-            'accessed directly with `searchParams.sentinel`'
-          ),
-          expect.stringContaining('accessed directly with `searchParams.foo`'),
         ])
       } else {
         expect(searchWarnings).toHaveLength(0)


### PR DESCRIPTION
Relands https://github.com/vercel/next.js/pull/70672 with fixes that were failing in CI. 

[x-ref](https://github.com/vercel/next.js/actions/runs/11153352206/job/31002090099)