### PR TITLE
Run unstable_cache inside a CacheStore context

### DIFF
--- a/packages/next/src/client/components/request-async-storage.external.ts
+++ b/packages/next/src/client/components/request-async-storage.external.ts
@@ -50,10 +50,17 @@ export { requestAsyncStorage }
 export function getExpectedRequestStore(callingExpression: string) {
   const store = requestAsyncStorage.getStore()
   if (store) return store
-  if (cacheAsyncStorage.getStore()) {
-    throw new Error(
-      `\`${callingExpression}\` cannot be called inside "use cache". Call it outside and pass an argument instead. Read more: https://nextjs.org/docs/messages/next-request-in-use-cache`
-    )
+  const cacheStore = cacheAsyncStorage.getStore()
+  if (cacheStore) {
+    if (cacheStore.type === 'cache') {
+      throw new Error(
+        `\`${callingExpression}\` cannot be called inside "use cache". Call it outside and pass an argument instead. Read more: https://nextjs.org/docs/messages/next-request-in-use-cache`
+      )
+    } else if (cacheStore.type === 'unstable-cache') {
+      throw new Error(
+        `\`${callingExpression}\` cannot be called inside unstable_cache. Call it outside and pass an argument instead. Read more: https://nextjs.org/docs/app/api-reference/functions/unstable_cache`
+      )
+    }
   }
   throw new Error(
     `\`${callingExpression}\` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context`

--- a/packages/next/src/client/components/work-async-storage.external.ts
+++ b/packages/next/src/client/components/work-async-storage.external.ts
@@ -33,7 +33,6 @@ export interface WorkStore {
   readonly isOnDemandRevalidate?: boolean
   readonly isPrerendering?: boolean
   readonly isRevalidate?: boolean
-  readonly isUnstableCacheCallback?: boolean
 
   forceDynamic?: boolean
   fetchCache?: AppSegmentConfig['fetchCache']

--- a/packages/next/src/server/after/after.ts
+++ b/packages/next/src/server/after/after.ts
@@ -1,5 +1,6 @@
 import { getExpectedRequestStore } from '../../client/components/request-async-storage.external'
 import { workAsyncStorage } from '../../client/components/work-async-storage.external'
+import { cacheAsyncStorage } from '../../server/app-render/cache-async-storage.external'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 
 import { markCurrentScopeAsDynamic } from '../app-render/dynamic-rendering'
@@ -23,6 +24,7 @@ export function unstable_after<T>(task: AfterTask<T>) {
   }
 
   const workStore = workAsyncStorage.getStore()
+  const cacheStore = cacheAsyncStorage.getStore()
 
   if (workStore) {
     if (workStore.forceStatic) {
@@ -30,7 +32,7 @@ export function unstable_after<T>(task: AfterTask<T>) {
         `Route ${workStore.route} with \`dynamic = "force-static"\` couldn't be rendered statically because it used \`${callingExpression}\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`
       )
     } else {
-      markCurrentScopeAsDynamic(workStore, callingExpression)
+      markCurrentScopeAsDynamic(workStore, cacheStore, callingExpression)
     }
   }
 

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1111,7 +1111,7 @@ async function renderToHTMLOrFlightImpl(
       ])
     }
 
-    addImplicitTags(workStore, requestStore)
+    addImplicitTags(workStore, requestStore, undefined)
 
     if (workStore.tags) {
       metadata.fetchTags = workStore.tags.join(',')
@@ -1220,7 +1220,7 @@ async function renderToHTMLOrFlightImpl(
       ])
     }
 
-    addImplicitTags(workStore, requestStore)
+    addImplicitTags(workStore, requestStore, undefined)
 
     if (workStore.tags) {
       metadata.fetchTags = workStore.tags.join(',')

--- a/packages/next/src/server/app-render/cache-async-storage.external.ts
+++ b/packages/next/src/server/app-render/cache-async-storage.external.ts
@@ -3,13 +3,20 @@ import type { AsyncLocalStorage } from 'async_hooks'
 // Share the instance module in the next-shared layer
 import { cacheAsyncStorage } from './cache-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
 
+export type UseCacheStore = {
+  type: 'cache'
+  // TODO: Inside this scope we'll track tags and life times of this scope.
+}
+
+export type UnstableCacheStore = {
+  type: 'unstable-cache'
+}
+
 /**
  * The Cache store is for tracking information inside a "use cache" or unstable_cache context.
  * Inside this context we should never expose any request or page specific information.
  */
-export type CacheStore = {
-  // TODO: Inside this scope we'll track tags and life times of this scope.
-}
+export type CacheStore = UseCacheStore | UnstableCacheStore
 
 export type CacheAsyncStorage = AsyncLocalStorage<CacheStore>
 export { cacheAsyncStorage }

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -319,7 +319,11 @@ export function createPatchedFetcher(
         }
         const implicitTags = addImplicitTags(workStore, requestStore)
 
-        const pageFetchCacheMode = workStore.fetchCache
+        // Inside unstable-cache we treat it the same as force-no-store on the page.
+        const pageFetchCacheMode =
+          cacheStore && cacheStore.type === 'unstable-cache'
+            ? 'force-no-store'
+            : workStore.fetchCache
         const isUsingNoStore = !!workStore.isUnstableNoStore
 
         let currentFetchCacheConfig = getRequestMeta('cache')

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -18,6 +18,7 @@ import type {
   RequestAsyncStorage,
   RequestStore,
 } from '../../client/components/request-async-storage.external'
+import { cacheAsyncStorage } from '../../server/app-render/cache-async-storage.external'
 import {
   CachedRouteKind,
   IncrementalCacheKind,
@@ -264,6 +265,7 @@ export function createPatchedFetcher(
         }
 
         const requestStore = requestAsyncStorage.getStore()
+        const cacheStore = cacheAsyncStorage.getStore()
 
         // If the workStore is not available, we can't do any
         // special treatment of fetch, therefore fallback to the original
@@ -493,6 +495,7 @@ export function createPatchedFetcher(
           if (finalRevalidate === 0) {
             markCurrentScopeAsDynamic(
               workStore,
+              cacheStore,
               `revalidate: 0 fetch ${input} ${workStore.route}`
             )
           }
@@ -801,6 +804,7 @@ export function createPatchedFetcher(
             // If enabled, we should bail out of static generation.
             markCurrentScopeAsDynamic(
               workStore,
+              cacheStore,
               `no-store fetch ${input} ${workStore.route}`
             )
           }
@@ -817,6 +821,7 @@ export function createPatchedFetcher(
               // If enabled, we should bail out of static generation.
               markCurrentScopeAsDynamic(
                 workStore,
+                cacheStore,
                 `revalidate: 0 fetch ${input} ${workStore.route}`
               )
             }

--- a/packages/next/src/server/request/connection.ts
+++ b/packages/next/src/server/request/connection.ts
@@ -70,11 +70,11 @@ export function connection(): Promise<void> {
     } else if (workStore.isStaticGeneration) {
       // We are in a legacy static generation mode while prerendering
       // We treat this function call as a bailout of static generation
-      throwToInterruptStaticGeneration('connection', workStore)
+      throwToInterruptStaticGeneration('connection', workStore, cacheStore)
     }
     // We fall through to the dynamic context below but we still track dynamic access
     // because in dev we can still error for things like using headers inside a cache context
-    trackDynamicDataInDynamicRender(workStore)
+    trackDynamicDataInDynamicRender(workStore, cacheStore)
   }
 
   return Promise.resolve(undefined)

--- a/packages/next/src/server/request/connection.ts
+++ b/packages/next/src/server/request/connection.ts
@@ -3,6 +3,7 @@ import {
   isDynamicIOPrerender,
   prerenderAsyncStorage,
 } from '../app-render/prerender-async-storage.external'
+import { cacheAsyncStorage } from '../../server/app-render/cache-async-storage.external'
 import {
   postponeWithTracking,
   throwToInterruptStaticGeneration,
@@ -19,6 +20,7 @@ import { makeHangingPromise } from '../dynamic-rendering-utils'
 export function connection(): Promise<void> {
   const workStore = workAsyncStorage.getStore()
   const prerenderStore = prerenderAsyncStorage.getStore()
+  const cacheStore = cacheAsyncStorage.getStore()
 
   if (workStore) {
     if (workStore.forceStatic) {
@@ -27,11 +29,18 @@ export function connection(): Promise<void> {
       return Promise.resolve(undefined)
     }
 
-    if (workStore.isUnstableCacheCallback) {
-      throw new Error(
-        `Route ${workStore.route} used "connection" inside a function cached with "unstable_cache(...)". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual Request, but caches must be able to be produced before a Request so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache`
-      )
-    } else if (workStore.dynamicShouldError) {
+    if (cacheStore) {
+      if (cacheStore.type === 'cache') {
+        throw new Error(
+          `Route ${workStore.route} used "connection" inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual Request, but caches must be able to be produced before a Request so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`
+        )
+      } else if (cacheStore.type === 'unstable-cache') {
+        throw new Error(
+          `Route ${workStore.route} used "connection" inside a function cached with "unstable_cache(...)". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual Request, but caches must be able to be produced before a Request so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache`
+        )
+      }
+    }
+    if (workStore.dynamicShouldError) {
       throw new StaticGenBailoutError(
         `Route ${workStore.route} with \`dynamic = "error"\` couldn't be rendered statically because it used \`connection\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`
       )

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -109,11 +109,11 @@ export function cookies(): Promise<ReadonlyRequestCookies> {
       // We are in a legacy static generation mode while prerendering
       // We track dynamic access here so we don't need to wrap the cookies in
       // individual property access tracking.
-      throwToInterruptStaticGeneration(callingExpression, workStore)
+      throwToInterruptStaticGeneration(callingExpression, workStore, cacheStore)
     }
     // We fall through to the dynamic context below but we still track dynamic access
     // because in dev we can still error for things like using cookies inside a cache context
-    trackDynamicDataInDynamicRender(workStore)
+    trackDynamicDataInDynamicRender(workStore, cacheStore)
   }
 
   // cookies is being called in a dynamic context

--- a/packages/next/src/server/request/draft-mode.ts
+++ b/packages/next/src/server/request/draft-mode.ts
@@ -3,6 +3,7 @@ import { getExpectedRequestStore } from '../../client/components/request-async-s
 import type { DraftModeProvider } from '../../server/async-storage/draft-mode-provider'
 
 import { workAsyncStorage } from '../../client/components/work-async-storage.external'
+import { cacheAsyncStorage } from '../../server/app-render/cache-async-storage.external'
 import { trackDynamicDataAccessed } from '../app-render/dynamic-rendering'
 
 /**
@@ -142,19 +143,21 @@ class DraftMode {
   }
   public enable() {
     const store = workAsyncStorage.getStore()
+    const cacheStore = cacheAsyncStorage.getStore()
     if (store) {
       // We we have a store we want to track dynamic data access to ensure we
       // don't statically generate routes that manipulate draft mode.
-      trackDynamicDataAccessed(store, 'draftMode().enable()')
+      trackDynamicDataAccessed(store, cacheStore, 'draftMode().enable()')
     }
     return this._provider.enable()
   }
   public disable() {
     const store = workAsyncStorage.getStore()
+    const cacheStore = cacheAsyncStorage.getStore()
     if (store) {
       // We we have a store we want to track dynamic data access to ensure we
       // don't statically generate routes that manipulate draft mode.
-      trackDynamicDataAccessed(store, 'draftMode().disable()')
+      trackDynamicDataAccessed(store, cacheStore, 'draftMode().disable()')
     }
     return this._provider.disable()
   }

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -114,11 +114,11 @@ export function headers(): Promise<ReadonlyHeaders> {
       // We are in a legacy static generation mode while prerendering
       // We track dynamic access here so we don't need to wrap the headers in
       // individual property access tracking.
-      throwToInterruptStaticGeneration('headers', workStore)
+      throwToInterruptStaticGeneration('headers', workStore, cacheStore)
     }
     // We fall through to the dynamic context below but we still track dynamic access
     // because in dev we can still error for things like using headers inside a cache context
-    trackDynamicDataInDynamicRender(workStore)
+    trackDynamicDataInDynamicRender(workStore, cacheStore)
   }
 
   if (process.env.NODE_ENV === 'development' && !workStore?.isPrefetchRequest) {

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -9,6 +9,7 @@ import {
   prerenderAsyncStorage,
   type PrerenderStore,
 } from '../app-render/prerender-async-storage.external'
+import { cacheAsyncStorage } from '../../server/app-render/cache-async-storage.external'
 import {
   postponeWithTracking,
   abortAndThrowOnSynchronousDynamicDataAccess,
@@ -58,6 +59,7 @@ export function headers(): Promise<ReadonlyHeaders> {
   const requestStore = getExpectedRequestStore('headers')
   const workStore = workAsyncStorage.getStore()
   const prerenderStore = prerenderAsyncStorage.getStore()
+  const cacheStore = cacheAsyncStorage.getStore()
 
   if (workStore) {
     if (workStore.forceStatic) {
@@ -67,11 +69,18 @@ export function headers(): Promise<ReadonlyHeaders> {
       return makeUntrackedExoticHeaders(underlyingHeaders)
     }
 
-    if (workStore.isUnstableCacheCallback) {
-      throw new Error(
-        `Route ${workStore.route} used "headers" inside a function cached with "unstable_cache(...)". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use "headers" outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache`
-      )
-    } else if (workStore.dynamicShouldError) {
+    if (cacheStore) {
+      if (cacheStore.type === 'cache') {
+        throw new Error(
+          `Route ${workStore.route} used "headers" inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use "headers" outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`
+        )
+      } else if (cacheStore.type === 'unstable-cache') {
+        throw new Error(
+          `Route ${workStore.route} used "headers" inside a function cached with "unstable_cache(...)". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use "headers" outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache`
+        )
+      }
+    }
+    if (workStore.dynamicShouldError) {
       throw new StaticGenBailoutError(
         `Route ${workStore.route} with \`dynamic = "error"\` couldn't be rendered statically because it used \`headers\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`
       )

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -14,6 +14,7 @@ import {
   prerenderAsyncStorage,
   type PrerenderStore,
 } from '../app-render/prerender-async-storage.external'
+import { cacheAsyncStorage } from '../app-render/cache-async-storage.external'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { makeHangingPromise } from '../dynamic-rendering-utils'
 import {
@@ -316,7 +317,8 @@ function makeErroringExoticSearchParams(
               prerenderStore.dynamicTracking
             )
           } else {
-            throwToInterruptStaticGeneration(expression, workStore)
+            const cacheStore = cacheAsyncStorage.getStore()
+            throwToInterruptStaticGeneration(expression, workStore, cacheStore)
           }
           return
         }
@@ -335,7 +337,8 @@ function makeErroringExoticSearchParams(
               prerenderStore.dynamicTracking
             )
           } else {
-            throwToInterruptStaticGeneration(expression, workStore)
+            const cacheStore = cacheAsyncStorage.getStore()
+            throwToInterruptStaticGeneration(expression, workStore, cacheStore)
           }
           return
         }
@@ -357,7 +360,12 @@ function makeErroringExoticSearchParams(
                 prerenderStore.dynamicTracking
               )
             } else {
-              throwToInterruptStaticGeneration(expression, workStore)
+              const cacheStore = cacheAsyncStorage.getStore()
+              throwToInterruptStaticGeneration(
+                expression,
+                workStore,
+                cacheStore
+              )
             }
           }
           return ReflectAdapter.get(target, prop, receiver)
@@ -386,7 +394,8 @@ function makeErroringExoticSearchParams(
             prerenderStore.dynamicTracking
           )
         } else {
-          throwToInterruptStaticGeneration(expression, workStore)
+          const cacheStore = cacheAsyncStorage.getStore()
+          throwToInterruptStaticGeneration(expression, workStore, cacheStore)
         }
         return false
       }
@@ -407,7 +416,8 @@ function makeErroringExoticSearchParams(
           prerenderStore.dynamicTracking
         )
       } else {
-        throwToInterruptStaticGeneration(expression, workStore)
+        const cacheStore = cacheAsyncStorage.getStore()
+        throwToInterruptStaticGeneration(expression, workStore, cacheStore)
       }
     },
   })
@@ -463,7 +473,8 @@ function makeUntrackedExoticSearchParams(
       default: {
         Object.defineProperty(promise, prop, {
           get() {
-            trackDynamicDataInDynamicRender(store)
+            const cacheStore = cacheAsyncStorage.getStore()
+            trackDynamicDataInDynamicRender(store, cacheStore)
             return underlyingSearchParams[prop]
           },
           set(value) {
@@ -512,7 +523,8 @@ function makeDynamicallyTrackedExoticSearchParamsWithDevWarnings(
             expression
           )
         }
-        trackDynamicDataInDynamicRender(store)
+        const cacheStore = cacheAsyncStorage.getStore()
+        trackDynamicDataInDynamicRender(store, cacheStore)
       }
       return ReflectAdapter.get(target, prop, receiver)
     },

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -578,7 +578,7 @@ export class AppRouteRouteModule extends RouteModule<
                       ...Object.values(workStore.pendingRevalidates || {}),
                     ])
 
-                    addImplicitTags(workStore, requestStore)
+                    addImplicitTags(workStore, requestStore, undefined)
                     ;(context.renderOpts as any).fetchTags =
                       workStore.tags?.join(',')
 

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -52,6 +52,7 @@ import {
   type PrerenderStore,
 } from '../../app-render/prerender-async-storage.external'
 import { actionAsyncStorage } from '../../../client/components/action-async-storage.external'
+import { cacheAsyncStorage } from '../../../server/app-render/cache-async-storage.external'
 import * as sharedModules from './shared-modules'
 import { getIsServerAction } from '../../lib/server-action-request-meta'
 import { RequestCookies } from 'next/dist/compiled/@edge-runtime/cookies'
@@ -844,7 +845,8 @@ function proxyNextRequest(request: NextRequest, workStore: WorkStore) {
         case 'toJSON':
         case 'toString':
         case 'origin': {
-          trackDynamicDataAccessed(workStore, `nextUrl.${prop}`)
+          const cacheStore = cacheAsyncStorage.getStore()
+          trackDynamicDataAccessed(workStore, cacheStore, `nextUrl.${prop}`)
           return ReflectAdapter.get(target, prop, receiver)
         }
         case 'clone':
@@ -879,7 +881,8 @@ function proxyNextRequest(request: NextRequest, workStore: WorkStore) {
         case 'text':
         case 'arrayBuffer':
         case 'formData': {
-          trackDynamicDataAccessed(workStore, `request.${prop}`)
+          const cacheStore = cacheAsyncStorage.getStore()
+          trackDynamicDataAccessed(workStore, cacheStore, `request.${prop}`)
           // The receiver arg is intentionally the same as the target to fix an issue with
           // edge runtime, where attempting to access internal slots with the wrong `this` context
           // results in an error.

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -14,7 +14,7 @@ import {
 
 import type { WorkStore } from '../../client/components/work-async-storage.external'
 import { workAsyncStorage } from '../../client/components/work-async-storage.external'
-import type { CacheStore } from '../app-render/cache-async-storage.external'
+import type { UseCacheStore } from '../app-render/cache-async-storage.external'
 import { cacheAsyncStorage } from '../app-render/cache-async-storage.external'
 import { runInCleanSnapshot } from '../app-render/clean-async-snapshot.external'
 
@@ -135,7 +135,7 @@ function generateCacheEntryWithCacheContext(
   fn: any
 ) {
   // Initialize the Store for this Cache entry.
-  const cacheStore: CacheStore = {}
+  const cacheStore: UseCacheStore = { type: 'cache' }
   return cacheAsyncStorage.run(
     cacheStore,
     generateCacheEntryImpl,

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -238,7 +238,6 @@ export function unstable_cache<T extends Callback>(
                       // force any nested fetches to bypass cache so they revalidate
                       // when the unstable_cache call is revalidated
                       fetchCache: 'force-no-store',
-                      isUnstableCacheCallback: true,
                     },
                     () => cacheAsyncStorage.run(cacheStore, cb, ...args)
                   )
@@ -277,7 +276,6 @@ export function unstable_cache<T extends Callback>(
             // force any nested fetches to bypass cache so they revalidate
             // when the unstable_cache call is revalidated
             fetchCache: 'force-no-store',
-            isUnstableCacheCallback: true,
           },
           () => cacheAsyncStorage.run(cacheStore, cb, ...args)
         )
@@ -350,14 +348,13 @@ export function unstable_cache<T extends Callback>(
         // to allow tracking which "mode" we are in without the presence of a store or not. For now I have
         // maintained the existing behavior to limit the impact of the current refactor
         const result = await workAsyncStorage.run(
-          // We are making a fake store that is useful for scoping fetchCache: 'force-no-store' and isUnstableCacheCallback: true
+          // We are making a fake store that is useful for scoping fetchCache: 'force-no-store'
           // The fact that we need to construct this kind of fake store indicates the code is not factored correctly
           // @TODO refactor to not require this fake store object
           {
             // force any nested fetches to bypass cache so they revalidate
             // when the unstable_cache call is revalidated
             fetchCache: 'force-no-store',
-            isUnstableCacheCallback: true,
             route: '/',
             page: '/',
             isStaticGeneration: false,

--- a/packages/next/src/server/web/spec-extension/unstable-no-store.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-no-store.ts
@@ -1,4 +1,5 @@
 import { workAsyncStorage } from '../../../client/components/work-async-storage.external'
+import { cacheAsyncStorage } from '../../../server/app-render/cache-async-storage.external'
 import { markCurrentScopeAsDynamic } from '../../app-render/dynamic-rendering'
 
 /**
@@ -19,6 +20,7 @@ import { markCurrentScopeAsDynamic } from '../../app-render/dynamic-rendering'
 export function unstable_noStore() {
   const callingExpression = 'unstable_noStore()'
   const store = workAsyncStorage.getStore()
+  const cacheStore = cacheAsyncStorage.getStore()
   if (!store) {
     // This generally implies we are being called in Pages router. We should probably not support
     // unstable_noStore in contexts outside of `react-server` condition but since we historically
@@ -28,6 +30,6 @@ export function unstable_noStore() {
     return
   } else {
     store.isUnstableNoStore = true
-    markCurrentScopeAsDynamic(store, callingExpression)
+    markCurrentScopeAsDynamic(store, cacheStore, callingExpression)
   }
 }


### PR DESCRIPTION
The idea is that CacheStore context will merge with Action, Prerender and Request Context but this just makes a disjoint union of the two Caches unstable_cache and "use cache".

This replaces the `isUnstableCacheCallback: true` and `fetchCache: 'force-no-store'` override. Instead, we need to check manually whether we're in a cache context.

This lets us avoid cloning the WorkStore context object. Now there's only one copy which makes it safer to mutate it.
