### PR TITLE
Expand PrerenderStore to include the legacy mode static generation too

### DIFF
--- a/packages/next/src/server/app-render/prerender-async-storage.external.ts
+++ b/packages/next/src/server/app-render/prerender-async-storage.external.ts
@@ -16,7 +16,8 @@ import { prerenderAsyncStorage } from './prerender-async-storage-instance' with 
  * only needs to happen during the RSC prerender when we are prospectively prerendering
  * to fill all caches.
  */
-export type PrerenderStore = {
+export type PrerenderStoreModern = {
+  type: 'prerender'
   /**
    * This is the AbortController passed to React. It can be used to abort the prerender
    * if we encounter conditions that do not require further rendering
@@ -35,8 +36,17 @@ export type PrerenderStore = {
   readonly dynamicTracking: null | DynamicTrackingState
 }
 
+export type PrerenderStoreLegacy = {
+  type: 'prerender-legacy'
+}
+
+export type PrerenderStore = PrerenderStoreLegacy | PrerenderStoreModern
+
 export function isDynamicIOPrerender(prerenderStore: PrerenderStore): boolean {
-  return !!(prerenderStore.controller || prerenderStore.cacheSignal)
+  return (
+    prerenderStore.type === 'prerender' &&
+    !!(prerenderStore.controller || prerenderStore.cacheSignal)
+  )
 }
 
 export type PrerenderAsyncStorage = AsyncLocalStorage<PrerenderStore>

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -950,7 +950,11 @@ export function createPatchedFetcher(
     )
 
     const prerenderStore = prerenderAsyncStorage.getStore()
-    if (prerenderStore && prerenderStore.cacheSignal) {
+    if (
+      prerenderStore &&
+      prerenderStore.type === 'prerender' &&
+      prerenderStore.cacheSignal
+    ) {
       // During static generation we track cache reads so we can reason about when they fill
       const cacheSignal = prerenderStore.cacheSignal
       cacheSignal.beginRead()

--- a/packages/next/src/server/request/connection.ts
+++ b/packages/next/src/server/request/connection.ts
@@ -46,7 +46,7 @@ export function connection(): Promise<void> {
       )
     }
 
-    if (prerenderStore) {
+    if (prerenderStore && prerenderStore.type === 'prerender') {
       // We are in PPR and/or dynamicIO mode and prerendering
 
       if (isDynamicIOPrerender(prerenderStore)) {

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -8,7 +8,7 @@ import { workAsyncStorage } from '../../client/components/work-async-storage.ext
 import {
   isDynamicIOPrerender,
   prerenderAsyncStorage,
-  type PrerenderStore,
+  type PrerenderStoreModern,
 } from '../app-render/prerender-async-storage.external'
 import { cacheAsyncStorage } from '../../server/app-render/cache-async-storage.external'
 import {
@@ -81,7 +81,7 @@ export function cookies(): Promise<ReadonlyRequestCookies> {
       )
     }
 
-    if (prerenderStore) {
+    if (prerenderStore && prerenderStore.type === 'prerender') {
       // We are in PPR and/or dynamicIO mode and prerendering
 
       if (isDynamicIOPrerender(prerenderStore)) {
@@ -157,7 +157,7 @@ const CachedCookies = new WeakMap<
 
 function makeDynamicallyTrackedExoticCookies(
   route: string,
-  prerenderStore: PrerenderStore
+  prerenderStore: PrerenderStoreModern
 ): Promise<ReadonlyRequestCookies> {
   const cachedPromise = CachedCookies.get(prerenderStore)
   if (cachedPromise) {

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -7,7 +7,7 @@ import { getExpectedRequestStore } from '../../client/components/request-async-s
 import {
   isDynamicIOPrerender,
   prerenderAsyncStorage,
-  type PrerenderStore,
+  type PrerenderStoreModern,
 } from '../app-render/prerender-async-storage.external'
 import { cacheAsyncStorage } from '../../server/app-render/cache-async-storage.external'
 import {
@@ -86,7 +86,7 @@ export function headers(): Promise<ReadonlyHeaders> {
       )
     }
 
-    if (prerenderStore) {
+    if (prerenderStore && prerenderStore.type === 'prerender') {
       // We are in PPR and/or dynamicIO mode and prerendering
 
       if (isDynamicIOPrerender(prerenderStore)) {
@@ -136,7 +136,7 @@ const CachedHeaders = new WeakMap<CacheLifetime, Promise<ReadonlyHeaders>>()
 
 function makeDynamicallyTrackedExoticHeaders(
   route: string,
-  prerenderStore: PrerenderStore
+  prerenderStore: PrerenderStoreModern
 ): Promise<ReadonlyHeaders> {
   const cachedHeaders = CachedHeaders.get(prerenderStore)
   if (cachedHeaders) {

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -12,6 +12,7 @@ import {
   isDynamicIOPrerender,
   prerenderAsyncStorage,
   type PrerenderStore,
+  type PrerenderStoreModern,
 } from '../app-render/prerender-async-storage.external'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { makeResolvedReactPromise, describeStringPropertyAccess } from './utils'
@@ -93,7 +94,7 @@ export function createPrerenderParamsForClientSegment(
   workStore: WorkStore
 ): Promise<Params> {
   const prerenderStore = prerenderAsyncStorage.getStore()
-  if (prerenderStore) {
+  if (prerenderStore && prerenderStore.type === 'prerender') {
     if (isDynamicIOPrerender(prerenderStore)) {
       const fallbackParams = workStore.fallbackRouteParams
       if (fallbackParams) {
@@ -131,7 +132,7 @@ function createPrerenderParams(
     if (hasSomeFallbackParams) {
       // params need to be treated as dynamic because we have at least one fallback param
       const prerenderStore = prerenderAsyncStorage.getStore()
-      if (prerenderStore) {
+      if (prerenderStore && prerenderStore.type === 'prerender') {
         if (isDynamicIOPrerender(prerenderStore)) {
           // We are in a dynamicIO (PPR or otherwise) prerender
           return makeAbortingExoticParams(
@@ -177,7 +178,7 @@ const CachedParams = new WeakMap<CacheLifetime, Promise<Params>>()
 function makeAbortingExoticParams(
   underlyingParams: Params,
   route: string,
-  prerenderStore: PrerenderStore
+  prerenderStore: PrerenderStoreModern
 ): Promise<Params> {
   const cachedParams = CachedParams.get(underlyingParams)
   if (cachedParams) {
@@ -302,7 +303,7 @@ function makeErroringExoticParams(
               // fallback shells
               // TODO remove this comment when dynamicIO is the default since there
               // will be no `dynamic = "error"`
-              if (prerenderStore) {
+              if (prerenderStore && prerenderStore.type === 'prerender') {
                 postponeWithTracking(
                   workStore.route,
                   expression,
@@ -323,7 +324,7 @@ function makeErroringExoticParams(
               // fallback shells
               // TODO remove this comment when dynamicIO is the default since there
               // will be no `dynamic = "error"`
-              if (prerenderStore) {
+              if (prerenderStore && prerenderStore.type === 'prerender') {
                 postponeWithTracking(
                   workStore.route,
                   expression,

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -13,6 +13,7 @@ import {
   isDynamicIOPrerender,
   prerenderAsyncStorage,
   type PrerenderStore,
+  type PrerenderStoreModern,
 } from '../app-render/prerender-async-storage.external'
 import { cacheAsyncStorage } from '../app-render/cache-async-storage.external'
 import { InvariantError } from '../../shared/lib/invariant-error'
@@ -112,7 +113,7 @@ function createPrerenderSearchParams(
   }
 
   const prerenderStore = prerenderAsyncStorage.getStore()
-  if (prerenderStore) {
+  if (prerenderStore && prerenderStore.type === 'prerender') {
     if (prerenderStore.controller || prerenderStore.cacheSignal) {
       // We are in a dynamicIO (PPR or otherwise) prerender
       return makeAbortingExoticSearchParams(workStore.route, prerenderStore)
@@ -152,7 +153,7 @@ const CachedSearchParams = new WeakMap<CacheLifetime, Promise<SearchParams>>()
 
 function makeAbortingExoticSearchParams(
   route: string,
-  prerenderStore: PrerenderStore
+  prerenderStore: PrerenderStoreModern
 ): Promise<SearchParams> {
   const cachedSearchParams = CachedSearchParams.get(prerenderStore)
   if (cachedSearchParams) {
@@ -310,7 +311,7 @@ function makeErroringExoticSearchParams(
               workStore.route,
               expression
             )
-          } else if (prerenderStore) {
+          } else if (prerenderStore && prerenderStore.type === 'prerender') {
             postponeWithTracking(
               workStore.route,
               expression,
@@ -330,7 +331,7 @@ function makeErroringExoticSearchParams(
               workStore.route,
               expression
             )
-          } else if (prerenderStore) {
+          } else if (prerenderStore && prerenderStore.type === 'prerender') {
             postponeWithTracking(
               workStore.route,
               expression,
@@ -353,7 +354,7 @@ function makeErroringExoticSearchParams(
                 workStore.route,
                 expression
               )
-            } else if (prerenderStore) {
+            } else if (prerenderStore && prerenderStore.type === 'prerender') {
               postponeWithTracking(
                 workStore.route,
                 expression,
@@ -387,7 +388,7 @@ function makeErroringExoticSearchParams(
             workStore.route,
             expression
           )
-        } else if (prerenderStore) {
+        } else if (prerenderStore && prerenderStore.type === 'prerender') {
           postponeWithTracking(
             workStore.route,
             expression,
@@ -409,7 +410,7 @@ function makeErroringExoticSearchParams(
           workStore.route,
           expression
         )
-      } else if (prerenderStore) {
+      } else if (prerenderStore && prerenderStore.type === 'prerender') {
         postponeWithTracking(
           workStore.route,
           expression,

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -434,6 +434,7 @@ export class AppRouteRouteModule extends RouteModule<
                       let dynamicTracking =
                         createDynamicTrackingState(undefined)
                       const prospectiveRoutePrerenderStore: PrerenderStore = {
+                        type: 'prerender',
                         cacheSignal,
                         // During prospective render we don't use a controller
                         // because we need to let all caches fill.
@@ -501,6 +502,7 @@ export class AppRouteRouteModule extends RouteModule<
                       dynamicTracking = createDynamicTrackingState(undefined)
 
                       const finalRoutePrerenderStore: PrerenderStore = {
+                        type: 'prerender',
                         cacheSignal: null,
                         controller,
                         dynamicTracking,
@@ -561,6 +563,15 @@ export class AppRouteRouteModule extends RouteModule<
                           }
                         })
                       })
+                    } else if (isStaticGeneration) {
+                      res = await prerenderAsyncStorage.run(
+                        {
+                          type: 'prerender-legacy',
+                        },
+                        handler,
+                        request,
+                        handlerContext
+                      )
                     } else {
                       res = await handler(request, handlerContext)
                     }

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -117,7 +117,10 @@ export function unstable_cache<T extends Callback>(
     const incrementalCache = maybeIncrementalCache
 
     const prerenderStore = prerenderAsyncStorage.getStore()
-    const cacheSignal = prerenderStore?.cacheSignal
+    const cacheSignal =
+      prerenderStore && prerenderStore.type === 'prerender'
+        ? prerenderStore.cacheSignal
+        : null
     if (cacheSignal) {
       cacheSignal.beginRead()
     }


### PR DESCRIPTION
The "type" prepares for the "WorkUnit" model where everything has a WorkUnit but it is the type that determines this.

The goal of this change is to be able to move the tracking of revalidate time and tags from the WorkStore to the PrerenderStore since it's only prerenders that collects such information, and it needs to be shielded by CacheStore.

We should in theory be able to use this check instead of isStaticGeneration now too.