### PR TITLE
fix scrollbar color in react-dev-overlay

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/components/Dialog/styles.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/components/Dialog/styles.ts
@@ -14,6 +14,13 @@ const styles = css`
       rgba(0, 0, 0, 0.25);
     max-height: calc(100% - 56px);
     overflow-y: hidden;
+    color-scheme: light;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    [data-nextjs-dialog] {
+      color-scheme: dark;
+    }
   }
 
   @media (max-height: 812px) {


### PR DESCRIPTION
This PR updates the css of the dev error overlay to use a dark scrollbar, if user theme is set to dark.

|BEFORE|AFTER|
|---|---|
|![Screenshot From 2024-10-03 19-38-45](https://github.com/user-attachments/assets/93d2fa8a-f03f-4857-9c62-f856aced2712)|![Screenshot From 2024-10-03 19-38-15](https://github.com/user-attachments/assets/e706a3d0-a063-4368-9212-ed193088901e)| 


