### PR TITLE
[i18n] Routing fix

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1017,6 +1017,14 @@ export default abstract class Server<
       req.headers['x-forwarded-proto'] ??= isHttps ? 'https' : 'http'
       req.headers['x-forwarded-for'] ??= originalRequest?.socket?.remoteAddress
 
+      // Validate that if i18n isn't configured or the passed parameters are not
+      // valid it should be removed from the query.
+      if (!this.i18nProvider?.validateQuery(parsedUrl.query)) {
+        delete parsedUrl.query.__nextLocale
+        delete parsedUrl.query.__nextDefaultLocale
+        delete parsedUrl.query.__nextInferredLocaleFromDefault
+      }
+
       // This should be done before any normalization of the pathname happens as
       // it captures the initial URL.
       this.attachRequestMeta(req, parsedUrl)

--- a/packages/next/src/server/lib/i18n-provider.ts
+++ b/packages/next/src/server/lib/i18n-provider.ts
@@ -135,6 +135,37 @@ export class I18NProvider {
   }
 
   /**
+   * Validates that the locale is valid.
+   *
+   * @param locale The locale to validate.
+   * @returns `true` if the locale is valid, `false` otherwise.
+   */
+  private validate(locale: string): boolean {
+    return this.lowerCaseLocales.includes(locale.toLowerCase())
+  }
+
+  /**
+   * Validates that the locales in the query object are valid.
+   *
+   * @param query The query object to validate.
+   * @returns `true` if the locale is valid, `false` otherwise.
+   */
+  public validateQuery(query: NextParsedUrlQuery) {
+    if (query.__nextLocale && !this.validate(query.__nextLocale)) {
+      return false
+    }
+
+    if (
+      query.__nextDefaultLocale &&
+      !this.validate(query.__nextDefaultLocale)
+    ) {
+      return false
+    }
+
+    return true
+  }
+
+  /**
    * Analyzes the pathname for a locale and returns the pathname without it.
    *
    * @param pathname The pathname that could contain a locale prefix.

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -218,6 +218,11 @@ export function getResolveRoutes(
           parsedUrl.pathname = maybeAddTrailingSlash(parsedUrl.pathname)
         }
       }
+    } else {
+      // As i18n isn't configured we remove the locale related query params.
+      delete parsedUrl.query.__nextLocale
+      delete parsedUrl.query.__nextDefaultLocale
+      delete parsedUrl.query.__nextInferredLocaleFromDefault
     }
 
     const checkLocaleApi = (pathname: string) => {


### PR DESCRIPTION
This fixes a bug where an incorrectly sanitized query parameter would cause an invalid routing condition resulting in the wrong route being served to users. This currently requires some specific edge conditions in order to trigger such as missing i18n configuration, self-hosted, specifically crafted query parameter, and a path-based middleware for authorization.
