### PR TITLE
auto import with `create::` prefix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -96,5 +96,6 @@
     "--ignore-revs-file",
     "${workspaceRoot}/.git-blame-ignore-revs"
   ],
-  "astGrep.serverPath": "node_modules/@ast-grep/cli/ast-grep"
+  "astGrep.serverPath": "node_modules/@ast-grep/cli/ast-grep",
+  "rust-analyzer.imports.prefix": "crate"
 }


### PR DESCRIPTION
### Why?

Consistency
