### PR TITLE
codemod: handle the async api type

### DIFF
--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-23.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-23.input.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export type Cookie = typeof cookies
-export function foo(c: typeof cookies) {
+export type Cookie = ReturnType<typeof cookies>
+export function foo(c: ReturnType<typeof cookies>) {
   return c
 }

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-23.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-23.input.tsx
@@ -1,0 +1,6 @@
+import { cookies } from 'next/headers'
+
+export type Cookie = typeof cookies
+export function foo(c: typeof cookies) {
+  return c
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-23.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-23.output.tsx
@@ -1,0 +1,7 @@
+import { cookies } from 'next/headers'
+
+export type Cookie = Awaited<typeof cookies>;
+export function foo(c: Awaited<typeof cookies>) {
+  return c
+}
+

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-23.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-23.output.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 
-export type Cookie = Awaited<typeof cookies>;
-export function foo(c: Awaited<typeof cookies>) {
+export type Cookie = Awaited<ReturnType<typeof cookies>>
+export function foo(c: Awaited<ReturnType<typeof cookies>>) {
   return c
 }
 

--- a/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
@@ -207,24 +207,24 @@ export function transformDynamicAPI(
       })
 
     // Handle type usage of async API, e.g. `type Cookie = typeof cookies`
-    root.find(j.Identifier, { name: asyncRequestApiName }).forEach((path) => {
-      const parentNode = path.parentPath?.value
-      // If it's just "typeof cookies", wrap it with Awaited<>.
-      // e.g. `type Cookie = Awaited<typeof cookies>`
-      if (
-        parentNode &&
-        j.TSTypeQuery.check(parentNode) &&
-        j.Identifier.check(parentNode.exprName) &&
-        parentNode.exprName.name === asyncRequestApiName
-      ) {
-        const newTypeQuery = j.identifier(
-          `Awaited<typeof ${asyncRequestApiName}>`
-        )
-        j(path.parentPath).replaceWith(newTypeQuery)
+    root
+      .find(j.TSTypeQuery, { exprName: { name: asyncRequestApiName } })
+      .forEach((path) => {
+        const queryNode = path.value
+        // If it's just "typeof cookies", wrap it with Awaited<>.
+        // e.g. `type Cookie = Awaited<typeof cookies>`
+        if (
+          j.Identifier.check(queryNode.exprName) &&
+          queryNode.exprName.name === asyncRequestApiName
+        ) {
+          const newTypeQuery = j.identifier(
+            `Awaited<typeof ${asyncRequestApiName}>`
+          )
+          j(path).replaceWith(newTypeQuery)
 
-        modified = true
-      }
-    })
+          modified = true
+        }
+      })
   }
 
   const isClientComponent = determineClientDirective(root, j)

--- a/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
@@ -205,6 +205,26 @@ export function transformDynamicAPI(
           }
         }
       })
+
+    // Handle type usage of async API, e.g. `type Cookie = typeof cookies`
+    root.find(j.Identifier, { name: asyncRequestApiName }).forEach((path) => {
+      const parentNode = path.parentPath?.value
+      // If it's just "typeof cookies", wrap it with Awaited<>.
+      // e.g. `type Cookie = Awaited<typeof cookies>`
+      if (
+        parentNode &&
+        j.TSTypeQuery.check(parentNode) &&
+        j.Identifier.check(parentNode.exprName) &&
+        parentNode.exprName.name === asyncRequestApiName
+      ) {
+        const newTypeQuery = j.identifier(
+          `Awaited<typeof ${asyncRequestApiName}>`
+        )
+        j(path.parentPath).replaceWith(newTypeQuery)
+
+        modified = true
+      }
+    })
   }
 
   const isClientComponent = determineClientDirective(root, j)


### PR DESCRIPTION
if there's typeof async api, wrap it with Awaited

```ts
import { cookies } from 'next/headers'

export type Cookie = ReturnType<typeof cookies>
export function foo(c: ReturnType<typeof cookies>) {
  return c
}
```
output

```ts
import { cookies } from 'next/headers'

export type Cookie = Awaited<ReturnType<typeof cookies>>
export function foo(c: Awaited<ReturnType<typeof cookies>>) {
  return c
}
```
