### PR TITLE
[Turbopack] add support for collectibles to new backend

### DIFF
--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -249,6 +249,7 @@ export interface NapiUpdateInfo {
 }
 /**
  * Subscribes to lifecycle events of the compilation.
+ *
  * Emits an [UpdateMessage::Start] event when any computation starts.
  * Emits an [UpdateMessage::End] event when there was no computation for the
  * specified time (`aggregation_ms`). The [UpdateMessage::End] event contains

--- a/turbopack/crates/turbo-tasks-auto-hash-map/src/map.rs
+++ b/turbopack/crates/turbo-tasks-auto-hash-map/src/map.rs
@@ -547,6 +547,14 @@ impl<'a, K: Eq + Hash, V, H: BuildHasher + Default + 'a, const I: usize> Entry<'
             Entry::Vacant(entry) => entry.insert(default()),
         }
     }
+
+    /// see [HashMap::Entry::or_insert](https://doc.rust-lang.org/std/collections/hash_map/enum.Entry.html#method.or_insert)
+    pub fn or_insert(self, default: V) -> &'a mut V {
+        match self {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(default),
+        }
+    }
 }
 
 impl<'a, K: Eq + Hash, V: Default, H: BuildHasher + Default + 'a, const I: usize>

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -361,7 +361,7 @@ impl TurboTasksBackendInner {
                     // active and this task won't stale. CachedActiveUntilClean
                     // is automatically removed when this task is clean.
                     task.add_new(CachedDataItem::AggregateRoot {
-                        value: RootState::new(ActiveType::CachedActiveUntilClean),
+                        value: RootState::new(ActiveType::CachedActiveUntilClean, task_id),
                     });
                     get!(task, AggregateRoot).unwrap()
                 };
@@ -1442,7 +1442,7 @@ impl TurboTasksBackendInner {
                 },
             });
             task.add(CachedDataItem::AggregateRoot {
-                value: RootState::new(root_type),
+                value: RootState::new(root_type, task_id),
             });
             task.add(CachedDataItem::new_scheduled(move || match root_type {
                 ActiveType::RootTask => "Root Task".to_string(),

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1390,7 +1390,7 @@ impl TurboTasksBackendInner {
                 collectible_type,
                 cell,
             },
-            -(count as i32),
+            -(i32::try_from(count).unwrap()),
             self.execute_context(turbo_tasks),
         );
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -213,10 +213,6 @@ impl AggregatedDataUpdate {
                         result.dirty_container_update = Some((task_id, -1));
                     }
                 }
-                println!(
-                    "AggregatedDirtyContainerCount: {:?} {} -> {}",
-                    task_id, old, new
-                );
                 (new != 0).then_some(new)
             });
             if let Some((_, count)) = result.dirty_container_update.as_ref() {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -213,11 +213,15 @@ impl AggregatedDataUpdate {
                         result.dirty_container_update = Some((task_id, -1));
                     }
                 }
+                println!(
+                    "AggregatedDirtyContainerCount: {:?} {} -> {}",
+                    task_id, old, new
+                );
                 (new != 0).then_some(new)
             });
             if let Some((_, count)) = result.dirty_container_update.as_ref() {
-                if let Some(root_state) = get!(task, AggregateRoot) {
-                    if *count < 0 {
+                if *count < 0 {
+                    if let Some(root_state) = get!(task, AggregateRoot) {
                         root_state.all_clean_event.notify(usize::MAX);
                         if matches!(root_state.ty, ActiveType::CachedActiveUntilClean) {
                             task.remove(&CachedDataItemKey::AggregateRoot {});
@@ -572,7 +576,7 @@ impl AggregationUpdateQueue {
             if is_aggregating_node(get_aggregation_number(&task)) {
                 if !task.has_key(&CachedDataItemKey::AggregateRoot {}) {
                     task.insert(CachedDataItem::AggregateRoot {
-                        value: RootState::new(ActiveType::CachedActiveUntilClean),
+                        value: RootState::new(ActiveType::CachedActiveUntilClean, task_id),
                     });
                 }
                 let dirty_containers: Vec<_> =

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -11,11 +11,12 @@ use crate::{
                 AggregationUpdateQueue,
             },
             invalidate::make_task_dirty,
-            ExecuteContext, Operation,
+            AggregatedDataUpdate, ExecuteContext, Operation,
         },
+        storage::update_count,
         TaskDataCategory,
     },
-    data::{CachedDataItemKey, CellRef},
+    data::{CachedDataItemKey, CellRef, CollectibleRef, CollectiblesRef},
 };
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -36,8 +37,10 @@ pub enum CleanupOldEdgesOperation {
 #[derive(Serialize, Deserialize, Clone)]
 pub enum OutdatedEdge {
     Child(TaskId),
+    Collectible(CollectibleRef, i32),
     CellDependency(CellRef),
     OutputDependency(TaskId),
+    CollectiblesDependency(CollectiblesRef),
     RemovedCellDependent(TaskId),
 }
 
@@ -72,20 +75,50 @@ impl Operation for CleanupOldEdgesOperation {
                     if let Some(edge) = outdated.pop() {
                         match edge {
                             OutdatedEdge::Child(child_id) => {
+                                let mut children = Vec::new();
+                                children.push(child_id);
+                                outdated.retain(|e| match e {
+                                    OutdatedEdge::Child(id) => {
+                                        children.push(*id);
+                                        false
+                                    }
+                                    _ => true,
+                                });
                                 let mut task = ctx.task(task_id, TaskDataCategory::All);
-                                task.remove(&CachedDataItemKey::Child { task: child_id });
+                                for &child_id in children.iter() {
+                                    task.remove(&CachedDataItemKey::Child { task: child_id });
+                                }
                                 if is_aggregating_node(get_aggregation_number(&task)) {
-                                    queue.push(AggregationUpdateJob::InnerLostFollower {
+                                    queue.push(AggregationUpdateJob::InnerLostFollowers {
                                         upper_ids: vec![task_id],
-                                        lost_follower_id: child_id,
+                                        lost_follower_ids: children,
                                     });
                                 } else {
                                     let upper_ids = get_uppers(&task);
-                                    queue.push(AggregationUpdateJob::InnerLostFollower {
+                                    queue.push(AggregationUpdateJob::InnerLostFollowers {
                                         upper_ids,
-                                        lost_follower_id: child_id,
+                                        lost_follower_ids: children,
                                     });
                                 }
+                            }
+                            OutdatedEdge::Collectible(collectible, count) => {
+                                let mut collectibles = Vec::new();
+                                collectibles.push((collectible, count));
+                                outdated.retain(|e| match e {
+                                    OutdatedEdge::Collectible(collectible, count) => {
+                                        collectibles.push((*collectible, -*count));
+                                        false
+                                    }
+                                    _ => true,
+                                });
+                                let mut task = ctx.task(task_id, TaskDataCategory::All);
+                                for &(collectible, count) in collectibles.iter() {
+                                    update_count!(task, Collectible { collectible }, count);
+                                }
+                                queue.extend(AggregationUpdateJob::data_update(
+                                    &mut task,
+                                    AggregatedDataUpdate::new().collectibles_update(collectibles),
+                                ));
                             }
                             OutdatedEdge::CellDependency(CellRef {
                                 task: cell_task_id,
@@ -119,6 +152,28 @@ impl Operation for CleanupOldEdgesOperation {
                                     let mut task = ctx.task(task_id, TaskDataCategory::Data);
                                     task.remove(&CachedDataItemKey::OutputDependency {
                                         target: output_task_id,
+                                    });
+                                }
+                            }
+                            OutdatedEdge::CollectiblesDependency(CollectiblesRef {
+                                collectible_type,
+                                task: dependent_task_id,
+                            }) => {
+                                {
+                                    let mut task =
+                                        ctx.task(dependent_task_id, TaskDataCategory::Data);
+                                    task.remove(&CachedDataItemKey::CollectiblesDependent {
+                                        collectible_type,
+                                        task: task_id,
+                                    });
+                                }
+                                {
+                                    let mut task = ctx.task(task_id, TaskDataCategory::Data);
+                                    task.remove(&CachedDataItemKey::CollectiblesDependency {
+                                        target: CollectiblesRef {
+                                            collectible_type,
+                                            task: dependent_task_id,
+                                        },
                                     });
                                 }
                             }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -113,7 +113,7 @@ impl Operation for CleanupOldEdgesOperation {
                                 });
                                 let mut task = ctx.task(task_id, TaskDataCategory::All);
                                 for &(collectible, count) in collectibles.iter() {
-                                    update_count!(task, Collectible { collectible }, count);
+                                    update_count!(task, Collectible { collectible }, -count);
                                 }
                                 queue.extend(AggregationUpdateJob::data_update(
                                     &mut task,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
@@ -84,7 +84,7 @@ pub fn make_task_dirty(
         if dirty_container == 0 {
             queue.extend(AggregationUpdateJob::data_update(
                 &mut task,
-                AggregatedDataUpdate::dirty_container(task_id),
+                AggregatedDataUpdate::new().dirty_container(task_id),
             ));
         }
         let root = task.has_key(&CachedDataItemKey::AggregateRoot {});

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -423,6 +423,10 @@ impl TaskGuard<'_> {
         self.task.get(key)
     }
 
+    pub fn get_mut(&mut self, key: &CachedDataItemKey) -> Option<&mut CachedDataItemValue> {
+        self.task.get_mut(key)
+    }
+
     pub fn has_key(&self, key: &CachedDataItemKey) -> bool {
         self.task.has_key(key)
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -3,6 +3,7 @@ mod cleanup_old_edges;
 mod connect_child;
 mod invalidate;
 mod update_cell;
+mod update_collectible;
 mod update_output;
 
 use std::{
@@ -531,5 +532,6 @@ pub use self::{
     },
     cleanup_old_edges::OutdatedEdge,
     update_cell::UpdateCellOperation,
+    update_collectible::UpdateCollectibleOperation,
     update_output::UpdateOutputOperation,
 };

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -500,6 +500,7 @@ macro_rules! impl_operation {
 pub enum AnyOperation {
     ConnectChild(connect_child::ConnectChildOperation),
     Invalidate(invalidate::InvalidateOperation),
+    UpdateOutput(update_output::UpdateOutputOperation),
     CleanupOldEdges(cleanup_old_edges::CleanupOldEdgesOperation),
     AggregationUpdate(aggregation_update::AggregationUpdateQueue),
     Nested(Vec<AnyOperation>),
@@ -510,6 +511,7 @@ impl AnyOperation {
         match self {
             AnyOperation::ConnectChild(op) => op.execute(ctx),
             AnyOperation::Invalidate(op) => op.execute(ctx),
+            AnyOperation::UpdateOutput(op) => op.execute(ctx),
             AnyOperation::CleanupOldEdges(op) => op.execute(ctx),
             AnyOperation::AggregationUpdate(op) => op.execute(ctx),
             AnyOperation::Nested(ops) => {
@@ -523,6 +525,7 @@ impl AnyOperation {
 
 impl_operation!(ConnectChild connect_child::ConnectChildOperation);
 impl_operation!(Invalidate invalidate::InvalidateOperation);
+impl_operation!(UpdateOutput update_output::UpdateOutputOperation);
 impl_operation!(CleanupOldEdges cleanup_old_edges::CleanupOldEdgesOperation);
 impl_operation!(AggregationUpdate aggregation_update::AggregationUpdateQueue);
 
@@ -533,5 +536,4 @@ pub use self::{
     cleanup_old_edges::OutdatedEdge,
     update_cell::UpdateCellOperation,
     update_collectible::UpdateCollectibleOperation,
-    update_output::UpdateOutputOperation,
 };

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_collectible.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_collectible.rs
@@ -1,0 +1,56 @@
+use std::cmp::min;
+
+use turbo_tasks::TaskId;
+
+use crate::{
+    backend::{
+        operation::{
+            AggregatedDataUpdate, AggregationUpdateJob, AggregationUpdateQueue, ExecuteContext,
+            Operation,
+        },
+        storage::{get, update_count},
+        TaskDataCategory,
+    },
+    data::CollectibleRef,
+};
+
+pub struct UpdateCollectibleOperation;
+
+impl UpdateCollectibleOperation {
+    pub fn run(
+        task_id: TaskId,
+        collectible: CollectibleRef,
+        count: i32,
+        mut ctx: ExecuteContext<'_>,
+    ) {
+        let mut queue = AggregationUpdateQueue::new();
+        let mut task = ctx.task(task_id, TaskDataCategory::All);
+        let outdated = get!(task, OutdatedCollectible { collectible }).copied();
+        if let Some(outdated) = outdated {
+            if count > 0 && outdated > 0 {
+                update_count!(
+                    task,
+                    OutdatedCollectible { collectible },
+                    -min(count, outdated)
+                );
+            } else if count < 0 && outdated < 0 {
+                update_count!(
+                    task,
+                    OutdatedCollectible { collectible },
+                    min(-count, -outdated)
+                );
+            } else {
+                // Not reduced from outdated
+            }
+        }
+        update_count!(task, Collectible { collectible }, count);
+        queue.extend(AggregationUpdateJob::data_update(
+            &mut task,
+            AggregatedDataUpdate::new().collectibles_update(vec![(collectible, count)]),
+        ));
+
+        drop(task);
+
+        queue.execute(&mut ctx);
+    }
+}

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
@@ -44,6 +44,10 @@ impl UpdateOutputOperation {
         mut ctx: ExecuteContext<'_>,
     ) {
         let mut task = ctx.task(task_id, TaskDataCategory::Data);
+        if let Some(InProgressState::InProgress { stale: true, .. }) = get!(task, InProgress) {
+            // Skip updating the output when the task is stale
+            return;
+        }
         let old_error = task.remove(&CachedDataItemKey::Error {});
         let current_output = task.get(&CachedDataItemKey::Output {});
         let output_value = match output {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
@@ -10,10 +10,13 @@ use crate::{
             invalidate::{make_task_dirty, make_task_dirty_internal},
             AggregationUpdateQueue, ExecuteContext, Operation,
         },
-        storage::get_many,
+        storage::{get, get_many},
         TaskDataCategory,
     },
-    data::{CachedDataItem, CachedDataItemKey, CachedDataItemValue, CellRef, OutputValue},
+    data::{
+        CachedDataItem, CachedDataItemKey, CachedDataItemValue, CellRef, InProgressState,
+        OutputValue,
+    },
 };
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -101,7 +104,7 @@ impl UpdateOutputOperation {
 
         let mut queue = AggregationUpdateQueue::new();
 
-        make_task_dirty_internal(&mut task, task_id, &mut queue, &mut ctx);
+        make_task_dirty_internal(&mut task, task_id, false, &mut queue, &mut ctx);
 
         drop(task);
         drop(old_content);
@@ -143,7 +146,7 @@ impl Operation for UpdateOutputOperation {
                     if let Some(child_id) = children.pop() {
                         let mut child_task = ctx.task(child_id, TaskDataCategory::Data);
                         if !child_task.has_key(&CachedDataItemKey::Output {}) {
-                            make_task_dirty_internal(&mut child_task, child_id, queue, ctx);
+                            make_task_dirty_internal(&mut child_task, child_id, false, queue, ctx);
                         }
                     }
                     if children.is_empty() {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -238,6 +238,10 @@ where
         self.get_map(key).and_then(|m| m.get(key))
     }
 
+    pub fn get_mut(&mut self, key: &T::Key) -> Option<&mut T::Value> {
+        self.get_map_mut(key).get_mut(key)
+    }
+
     pub fn has_key(&self, key: &T::Key) -> bool {
         self.get_map(key)
             .map(|m| m.contains_key(key))
@@ -403,6 +407,20 @@ macro_rules! get {
     };
 }
 
+macro_rules! get_mut {
+    ($task:ident, $key:ident $input:tt) => {
+        if let Some($crate::data::CachedDataItemValue::$key { value }) = $task.get_mut(&$crate::data::CachedDataItemKey::$key $input).as_mut() {
+            let () = $crate::data::allow_mut_access::$key;
+            Some(value)
+        } else {
+            None
+        }
+    };
+    ($task:ident, $key:ident) => {
+        $crate::backend::storage::get_mut!($task, $key {})
+    };
+}
+
 macro_rules! iter_many {
     ($task:ident, $key:ident $input:tt => $value:expr) => {
         $task
@@ -524,6 +542,7 @@ macro_rules! remove {
 
 pub(crate) use get;
 pub(crate) use get_many;
+pub(crate) use get_mut;
 pub(crate) use iter_many;
 pub(crate) use remove;
 pub(crate) use update;

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -404,11 +404,27 @@ macro_rules! get {
 }
 
 macro_rules! iter_many {
-    ($task:ident, $key:ident $input:tt => $value:ident) => {
+    ($task:ident, $key:ident $input:tt => $value:expr) => {
         $task
             .iter($crate::data::indicies::$key)
             .filter_map(|(key, _)| match *key {
                 $crate::data::CachedDataItemKey::$key $input => Some($value),
+                _ => None,
+            })
+    };
+    ($task:ident, $key:ident $input:tt => $value:expr) => {
+        $task
+            .iter($crate::data::indicies::$key)
+            .filter_map(|(key, _)| match key {
+                $crate::data::CachedDataItemKey::$key $input => Some($value),
+                _ => None,
+            })
+    };
+    ($task:ident, $key:ident $input:tt if $cond:expr => $value:expr) => {
+        $task
+            .iter($crate::data::indicies::$key)
+            .filter_map(|(key, _)| match key {
+                $crate::data::CachedDataItemKey::$key $input if $cond => Some($value),
                 _ => None,
             })
     };
@@ -431,8 +447,14 @@ macro_rules! iter_many {
 }
 
 macro_rules! get_many {
-    ($task:ident, $key:ident $input:tt => $value:ident) => {
+    ($task:ident, $key:ident $input:tt => $value:expr) => {
         $crate::backend::storage::iter_many!($task, $key $input => $value).collect()
+    };
+    ($task:ident, $key:ident $input:tt => $value:expr) => {
+        $crate::backend::storage::iter_many!($task, $key $input => $value).collect()
+    };
+    ($task:ident, $key:ident $input:tt if $cond:expr => $value:expr) => {
+        $crate::backend::storage::iter_many!($task, $key $input if $cond => $value).collect()
     };
     ($task:ident, $key:ident $input:tt $value_ident:ident => $value:expr) => {
         $crate::backend::storage::iter_many!($task, $key $input $value_ident => $value).collect()

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -414,6 +414,11 @@ impl CachedDataItemKey {
     }
 }
 
+#[allow(non_upper_case_globals, dead_code)]
+pub mod allow_mut_access {
+    pub const InProgress: () = ();
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CachedDataItemIndex {
     Children,

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -71,10 +71,10 @@ pub struct RootState {
 }
 
 impl RootState {
-    pub fn new(ty: ActiveType) -> Self {
+    pub fn new(ty: ActiveType, id: TaskId) -> Self {
         Self {
             ty,
-            all_clean_event: Event::new(|| "RootState::all_clean_event".to_string()),
+            all_clean_event: Event::new(move || format!("RootState::all_clean_event {:?}", id)),
         }
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -414,6 +414,9 @@ impl CachedDataItemKey {
     }
 }
 
+/// Used by the [`get_mut`][crate::backend::storage::get_mut] macro to restrict mutable access to a
+/// subset of types. No mutable access should be allowed for persisted data, since that would break
+/// persisting.
 #[allow(non_upper_case_globals, dead_code)]
 pub mod allow_mut_access {
     pub const InProgress: () = ();

--- a/turbopack/crates/turbo-tasks-backend/tests/collectibles.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/collectibles.rs
@@ -1,0 +1,1 @@
+../../turbo-tasks-testing/tests/collectibles.rs

--- a/turbopack/crates/turbo-tasks-backend/tests/dirty_in_progress.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/dirty_in_progress.rs
@@ -1,0 +1,1 @@
+../../turbo-tasks-testing/tests/dirty_in_progress.rs

--- a/turbopack/crates/turbo-tasks-backend/tests/recompute_collectibles.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/recompute_collectibles.rs
@@ -1,0 +1,1 @@
+../../turbo-tasks-testing/tests/recompute_collectibles.rs

--- a/turbopack/crates/turbo-tasks-testing/tests/dirty_in_progress.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/dirty_in_progress.rs
@@ -38,6 +38,7 @@ async fn dirty_in_progress() {
             let read = output.strongly_consistent().await?;
             assert_eq!(read.value, value);
             assert_eq!(read.collectible, collectible);
+            println!("\n");
         }
         anyhow::Ok(())
     })


### PR DESCRIPTION
### What?

add support for collectibles to new backend

also fix some bugs in the backend:

* make in progress tasks as stale
* skip updating output for stale tasks
* flag task as dirty when they get output set

and add and enable all remaining tests
