### PR TITLE
Move AfterContext to WorkStore

### DIFF
--- a/packages/next/src/client/components/request-async-storage.external.ts
+++ b/packages/next/src/client/components/request-async-storage.external.ts
@@ -6,7 +6,6 @@ import type { ReadonlyRequestCookies } from '../../server/web/spec-extension/ada
 
 // Share the instance module in the next-shared layer
 import { requestAsyncStorage } from './request-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
-import type { AfterContext } from '../../server/after/after-context'
 import type { ServerComponentsHmrCache } from '../../server/response-cache'
 
 import { cacheAsyncStorage } from '../../server/app-render/cache-async-storage.external'
@@ -34,7 +33,6 @@ export interface RequestStore {
   readonly cookies: ReadonlyRequestCookies
   readonly mutableCookies: ResponseCookies
   readonly draftMode: DraftModeProvider
-  readonly afterContext: AfterContext | undefined
   readonly isHmrRefresh?: boolean
   readonly serverComponentsHmrCache?: ServerComponentsHmrCache
 }

--- a/packages/next/src/client/components/work-async-storage.external.ts
+++ b/packages/next/src/client/components/work-async-storage.external.ts
@@ -6,6 +6,7 @@ import type { Revalidate } from '../../server/lib/revalidate'
 import type { FallbackRouteParams } from '../../server/request/fallback-params'
 import type { DeepReadonly } from '../../shared/lib/deep-readonly'
 import type { AppSegmentConfig } from '../../build/segment-config/app/app-segment-config'
+import type { AfterContext } from '../../server/after/after-context'
 
 // Share the instance module in the next-shared layer
 import { workAsyncStorage } from './work-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
@@ -43,6 +44,7 @@ export interface WorkStore {
   dynamicShouldError?: boolean
   pendingRevalidates?: Record<string, Promise<any>>
   pendingRevalidateWrites?: Array<Promise<void>> // This is like pendingRevalidates but isn't used for deduping.
+  readonly afterContext: AfterContext | undefined
 
   dynamicUsageDescription?: string
   dynamicUsageStack?: string

--- a/packages/next/src/server/after/after.ts
+++ b/packages/next/src/server/after/after.ts
@@ -1,4 +1,3 @@
-import { requestAsyncStorage } from '../../client/components/request-async-storage.external'
 import { workAsyncStorage } from '../../client/components/work-async-storage.external'
 import { cacheAsyncStorage } from '../../server/app-render/cache-async-storage.external'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
@@ -11,28 +10,20 @@ export type AfterCallback<T = unknown> = () => T | Promise<T>
 /**
  * This function allows you to schedule callbacks to be executed after the current request finishes.
  */
-export function unstable_after<T>(task: AfterTask<T>) {
-  const callingExpression = 'unstable_after'
-
-  // TODO: This is not safe. afterContext should move to WorkStore.
-  const requestStore = requestAsyncStorage.getStore()
-  if (!requestStore) {
-    throw new Error(
-      `\`${callingExpression}\` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context`
-    )
-  }
-
-  const { afterContext } = requestStore
-  if (!afterContext) {
-    throw new Error(
-      '`unstable_after()` must be explicitly enabled by setting `experimental.after: true` in your next.config.js.'
-    )
-  }
-
+export function unstable_after<T>(task: AfterTask<T>): void {
   const workStore = workAsyncStorage.getStore()
   const cacheStore = cacheAsyncStorage.getStore()
 
   if (workStore) {
+    const { afterContext } = workStore
+    if (!afterContext) {
+      throw new Error(
+        '`unstable_after()` must be explicitly enabled by setting `experimental.after: true` in your next.config.js.'
+      )
+    }
+
+    // TODO: After should not cause dynamic.
+    const callingExpression = 'unstable_after'
     if (workStore.forceStatic) {
       throw new StaticGenBailoutError(
         `Route ${workStore.route} with \`dynamic = "force-static"\` couldn't be rendered statically because it used \`${callingExpression}\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`
@@ -40,7 +31,9 @@ export function unstable_after<T>(task: AfterTask<T>) {
     } else {
       markCurrentScopeAsDynamic(workStore, cacheStore, callingExpression)
     }
-  }
 
-  return afterContext.after(task)
+    afterContext.after(task)
+  } else {
+    // TODO: Error for pages?
+  }
 }

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -554,9 +554,6 @@ export class AppRouteRouteModule extends RouteModule<
       url: req.nextUrl,
       renderOpts: {
         previewProps: context.prerenderManifest.preview,
-        waitUntil: context.renderOpts.waitUntil,
-        onClose: context.renderOpts.onClose,
-        experimental: context.renderOpts.experimental,
       },
     }
 

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -356,6 +356,7 @@ export function unstable_cache<T extends Callback>(
             isStaticGeneration: false,
             fallbackRouteParams: null,
             buildId: '', // Since this is a fake one it can't "use cache" anyway.
+            afterContext: undefined, // TODO: Support Pages after()
           },
           () => cacheAsyncStorage.run(innerCacheStore, cb, ...args)
         )


### PR DESCRIPTION
We want to support `after()` to run after all work has completed. Ideally in any scenario that runs the parent. If there's multiple units of work (e.g. batched Actions) or inner work like `"use cache"` / `unstable_cache`, they should ideally all run at the end to avoid blocking the other work.

It's difficult to remember how to wire this up each time we shadow a unit or work. It's simpler just to put this on WorkStore which is where we already have all internal "after" like `pendingRevalidates` and `pendingRevalidateWrites`.

This is dependent on having a [WorkStore in Middleware](https://github.com/vercel/next.js/pull/70808/) where we currently support `after()`. We do not support `after()` in `pages/`.