### PR TITLE
Run after() callbacks in the same context as the outer function

### DIFF
--- a/packages/next/src/client/components/async-local-storage.ts
+++ b/packages/next/src/client/components/async-local-storage.ts
@@ -27,6 +27,10 @@ class FakeAsyncLocalStorage<Store extends {}>
   enterWith(): void {
     throw sharedAsyncLocalStorageNotAvailableError
   }
+
+  static bind<T>(fn: T): T {
+    return fn
+  }
 }
 
 const maybeGlobalAsyncLocalStorage =
@@ -39,6 +43,13 @@ export function createAsyncLocalStorage<
     return new maybeGlobalAsyncLocalStorage()
   }
   return new FakeAsyncLocalStorage()
+}
+
+export function bindSnapshot<T>(fn: T): T {
+  if (maybeGlobalAsyncLocalStorage) {
+    return maybeGlobalAsyncLocalStorage.bind(fn)
+  }
+  return FakeAsyncLocalStorage.bind(fn)
 }
 
 export function createSnapshot(): <R, TArgs extends any[]>(

--- a/packages/next/src/server/after/after-context.ts
+++ b/packages/next/src/server/after/after-context.ts
@@ -1,16 +1,11 @@
 import PromiseQueue from 'next/dist/compiled/p-queue'
-import {
-  workUnitAsyncStorage,
-  type RequestStore,
-  type WorkUnitStore,
-} from '../../server/app-render/work-unit-async-storage.external'
-import { ResponseCookies } from '../web/spec-extension/cookies'
 import type { RequestLifecycleOpts } from '../base-server'
 import type { AfterCallback, AfterTask } from './after'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { isThenable } from '../../shared/lib/is-thenable'
 import { workAsyncStorage } from '../../client/components/work-async-storage.external'
 import { withExecuteRevalidates } from './revalidation-utils'
+import { bindSnapshot } from '../../client/components/async-local-storage'
 
 export type AfterContextOpts = {
   waitUntil: RequestLifecycleOpts['waitUntil'] | undefined
@@ -20,8 +15,6 @@ export type AfterContextOpts = {
 export class AfterContext {
   private waitUntil: RequestLifecycleOpts['waitUntil'] | undefined
   private onClose: RequestLifecycleOpts['onClose'] | undefined
-
-  private workUnitStore: WorkUnitStore | undefined
 
   private runCallbacksOnClosePromise: Promise<void> | undefined
   private callbackQueue: PromiseQueue
@@ -56,12 +49,6 @@ export class AfterContext {
     if (!this.waitUntil) {
       errorWaitUntilNotAvailable()
     }
-    if (!this.workUnitStore) {
-      // We just stash the first request store we have but this is not sufficient.
-      // TODO: We should store a request store per callback since each callback might
-      // be inside a different store. E.g. inside different batched actions, prerenders or caches.
-      this.workUnitStore = workUnitAsyncStorage.getStore()
-    }
     if (!this.onClose) {
       throw new InvariantError(
         'unstable_after: Missing `onClose` implementation'
@@ -78,7 +65,14 @@ export class AfterContext {
       this.waitUntil(this.runCallbacksOnClosePromise)
     }
 
-    const wrappedCallback = async () => {
+    // We bind the store to the current execution context. That's because
+    // after(() => x())
+    // is the same as
+    // after(x())
+    // which should be equivalent to
+    // await x()
+    // in every regard except timing.
+    const wrappedCallback = bindSnapshot(async () => {
       try {
         await callback()
       } catch (err) {
@@ -88,38 +82,25 @@ export class AfterContext {
           err
         )
       }
-    }
+    })
 
     this.callbackQueue.add(wrappedCallback)
   }
 
   private async runCallbacksOnClose() {
     await new Promise<void>((resolve) => this.onClose!(resolve))
-    return this.runCallbacks(this.workUnitStore)
+    return this.runCallbacks()
   }
 
-  private async runCallbacks(
-    workUnitStore: undefined | WorkUnitStore
-  ): Promise<void> {
+  private async runCallbacks(): Promise<void> {
     if (this.callbackQueue.size === 0) return
-
-    const readonlyRequestStore: undefined | WorkUnitStore =
-      workUnitStore === undefined || workUnitStore.type !== 'request'
-        ? undefined
-        : // TODO: This is not sufficient. It should just be the same store that mutates.
-          wrapRequestStoreForAfterCallbacks(workUnitStore)
 
     const workStore = workAsyncStorage.getStore()
 
-    return withExecuteRevalidates(workStore, () =>
-      // Clearing it out or running the first request store.
-      // TODO: This needs to be the request store that was active at the time the
-      // callback was scheduled but p-queue makes this hard so need further refactoring.
-      workUnitAsyncStorage.run(readonlyRequestStore as any, async () => {
-        this.callbackQueue.start()
-        await this.callbackQueue.onIdle()
-      })
-    )
+    return withExecuteRevalidates(workStore, () => {
+      this.callbackQueue.start()
+      return this.callbackQueue.onIdle()
+    })
   }
 }
 
@@ -127,27 +108,4 @@ function errorWaitUntilNotAvailable(): never {
   throw new Error(
     '`unstable_after()` will not work correctly, because `waitUntil` is not available in the current environment.'
   )
-}
-
-/** Disable mutations of `requestStore` within `after()` and disallow nested after calls.  */
-function wrapRequestStoreForAfterCallbacks(
-  requestStore: RequestStore
-): RequestStore {
-  return {
-    type: 'request',
-    url: requestStore.url,
-    get headers() {
-      return requestStore.headers
-    },
-    get cookies() {
-      return requestStore.cookies
-    },
-    get draftMode() {
-      return requestStore.draftMode
-    },
-    // TODO(after): calling a `cookies.set()` in an after() that's in an action doesn't currently error.
-    mutableCookies: new ResponseCookies(new Headers()),
-    isHmrRefresh: requestStore.isHmrRefresh,
-    serverComponentsHmrCache: requestStore.serverComponentsHmrCache,
-  }
 }


### PR DESCRIPTION
Stacked on #70806.

We want `after` callbacks to run in the same ALS context that `after` was called in. This can be achieved via https://nodejs.org/api/async_context.html#static-method-asynclocalstoragebindfn

We want this be cause these should be as close as possible in every way (except timing):
```
after(() => x())
after(x())
await x()
```

We'll need a different approach for disabling setting cookies (and revalidate). This will be done in a follow up.