### PR TITLE
Tracing: Always end write stream on shutdown in dev

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -86,7 +86,7 @@ const handleSessionStop = async (signal: NodeJS.Signals | number | null) => {
   }
 
   sessionSpan.stop()
-  await flushAllTraces()
+  await flushAllTraces({ end: true })
 
   try {
     const { eventCliSessionStopped } =

--- a/packages/next/src/trace/report/index.ts
+++ b/packages/next/src/trace/report/index.ts
@@ -10,8 +10,8 @@ class MultiReporter implements Reporter {
     this.reporters = reporters
   }
 
-  async flushAll() {
-    await Promise.all(this.reporters.map((reporter) => reporter.flushAll()))
+  async flushAll(opts?: { end: boolean }) {
+    await Promise.all(this.reporters.map((reporter) => reporter.flushAll(opts)))
   }
 
   report(event: TraceEvent) {

--- a/packages/next/src/trace/report/to-json.ts
+++ b/packages/next/src/trace/report/to-json.ts
@@ -147,12 +147,12 @@ const reportToLocalHost = (event: TraceEvent) => {
 }
 
 export default {
-  flushAll: () =>
+  flushAll: (opts?: { end: boolean }) =>
     batch
       ? batch.flushAll().then(() => {
           const phase = traceGlobals.get('phase')
           // Only end writeStream when manually flushing in production
-          if (phase !== PHASE_DEVELOPMENT_SERVER) {
+          if (opts?.end || phase !== PHASE_DEVELOPMENT_SERVER) {
             return writeStream.end()
           }
         })

--- a/packages/next/src/trace/report/types.ts
+++ b/packages/next/src/trace/report/types.ts
@@ -1,6 +1,6 @@
 import type { TraceEvent } from '../types'
 
 export type Reporter = {
-  flushAll: () => Promise<void> | void
+  flushAll: (opts?: { end: boolean }) => Promise<void> | void
   report: (event: TraceEvent) => void
 }

--- a/packages/next/src/trace/trace.ts
+++ b/packages/next/src/trace/trace.ts
@@ -159,7 +159,8 @@ export const trace = (
   return new Span({ name, parentId, attrs })
 }
 
-export const flushAllTraces = () => reporter.flushAll()
+export const flushAllTraces = (opts?: { end: boolean }) =>
+  reporter.flushAll(opts)
 
 // This code supports workers by serializing the state of tracers when the
 // worker is initialized, and serializing the trace events from the worker back


### PR DESCRIPTION
While we don’t want to end the write stream in other situations in dev, we _do_ want to do this when shutting down the web server.

This previously resulted in some spans, including the top-level `next-dev` span, not always being written to disk as the process would exit before it was flushed.

Test Plan: Ensured `next-dev` span is written to trace on devserver shutdown
