### PR TITLE
fix(turbo-tasks-macros): Always use the correct trait method in TaskInput

### DIFF
--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_input_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_input_macro.rs
@@ -59,7 +59,7 @@ pub fn derive_task_input(input: TokenStream) -> TokenStream {
                 capture,
                 quote! {
                     {#(
-                        #fields.is_resolved() &&
+                        turbo_tasks::TaskInput::is_resolved(#fields) &&
                     )* true}
                 },
             )
@@ -70,7 +70,7 @@ pub fn derive_task_input(input: TokenStream) -> TokenStream {
                 capture,
                 quote! {
                     {#(
-                        #fields.is_resolved() &&
+                        turbo_tasks::TaskInput::is_resolved(#fields) &&
                     )* true}
                 },
             )
@@ -85,7 +85,7 @@ pub fn derive_task_input(input: TokenStream) -> TokenStream {
                 capture,
                 quote! {
                     {#(
-                        #fields.is_transient() ||
+                        turbo_tasks::TaskInput::is_transient(#fields) ||
                     )* false}
                 },
             )
@@ -96,7 +96,7 @@ pub fn derive_task_input(input: TokenStream) -> TokenStream {
                 capture,
                 quote! {
                     {#(
-                        #fields.is_transient() ||
+                        turbo_tasks::TaskInput::is_transient(#fields) ||
                     )* false}
                 },
             )
@@ -112,7 +112,7 @@ pub fn derive_task_input(input: TokenStream) -> TokenStream {
                 quote! {
                     {
                         #(
-                            let #fields = #fields.resolve().await?;
+                            let #fields = turbo_tasks::TaskInput::resolve(#fields).await?;
                         )*
                         Ok(#ident { #(#fields),* })
                     }
@@ -126,7 +126,7 @@ pub fn derive_task_input(input: TokenStream) -> TokenStream {
                 quote! {
                     {
                         #(
-                            let #fields = #fields.resolve().await?;
+                            let #fields = turbo_tasks::TaskInput::resolve(#fields).await?;
                         )*
                         Ok(#ident(#(#fields),*))
                     }


### PR DESCRIPTION
Without this, method resolution will look for an inherent impl on the type or it autoderefs to first, as inherent impls are preferred over trait methods.

For `Vc<T>` this is fine, as the function signature is the same, but for `ResolvedVc<T>`, this causes us to autoderef to `Vc::resolve(...)`, which returns `Vc<T>` instead of `ResolvedVc<T>`.

This can lead to confusing error messages inside the macro if you try to `#[derive(TaskInput)]` for a type containing `ResolvedVc<T>`.

General best-practice for macros is to be as specific as possible with things like methods.