### PR TITLE
refactor(turbopack/next-core): Remove uses of generic vc collections

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -5,7 +5,7 @@ use next_core::{
     app_segment_config::NextSegmentConfig,
     app_structure::{
         get_entrypoints, AppPageLoaderTree, Entrypoint as AppEntrypoint,
-        Entrypoints as AppEntrypoints, MetadataItem,
+        Entrypoints as AppEntrypoints, FileSystemPathVec, MetadataItem,
     },
     get_edge_resolve_options_context, get_next_package,
     next_app::{
@@ -705,7 +705,7 @@ enum AppEndpointType {
     },
     Route {
         path: Vc<FileSystemPath>,
-        root_layouts: Vc<Vec<Vc<FileSystemPath>>>,
+        root_layouts: Vc<FileSystemPathVec>,
     },
     Metadata {
         metadata: MetadataItem,
@@ -737,7 +737,7 @@ impl AppEndpoint {
     async fn app_route_entry(
         &self,
         path: Vc<FileSystemPath>,
-        root_layouts: Vc<Vec<Vc<FileSystemPath>>>,
+        root_layouts: Vc<FileSystemPathVec>,
         next_config: Vc<NextConfig>,
     ) -> Result<Vc<AppEntry>> {
         let root_layouts = root_layouts.await?;
@@ -747,7 +747,7 @@ impl AppEndpoint {
             let mut config = NextSegmentConfig::default();
 
             for layout in root_layouts.iter().rev() {
-                let source = Vc::upcast(FileSource::new(*layout));
+                let source = Vc::upcast(FileSource::new(**layout));
                 let layout_config = parse_segment_config_from_source(source);
                 config.apply_parent_config(&*layout_config.await?);
             }


### PR DESCRIPTION
Removes the uses of generic vc collections in `next-core/src/app_structure.rs` and it's callsites.

## Why?

Rather than extended support for `Vc` generics to `ResolvedVc`, I plan to remove support for them entirely. That means fixing all the callsites (there's not many).

Removing this is needed to get us to a point where 100% of structs can be `ResolvedValue`, because structs using these fields cannot otherwise be ported over to `ResolvedVc`.

## Okay, but Why?

Explained here: https://github.com/vercel/turborepo/pull/8843#issuecomment-2253158412

I expect removing support for this will decrease the overall size of the codebase, as the logic for supporting generics is rather complicated.