### PR TITLE
refactor(turbopack/next-{api,core}): Remove remaining uses of vc generics in non-test code

### DIFF
--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -25,7 +25,7 @@ use turbopack_core::{
     chunk::{ChunkItemExt, ChunkableModule, ChunkingContext, EvaluatableAsset},
     context::AssetContext,
     file_source::FileSource,
-    module::Module,
+    module::{Module, Modules},
     output::OutputAsset,
     reference::primary_referenced_modules,
     reference_type::{EcmaScriptModulesReferenceSubType, ReferenceType},
@@ -47,7 +47,7 @@ use turbopack_ecmascript::{
 /// loader.
 pub(crate) async fn create_server_actions_manifest(
     rsc_entry: Vc<Box<dyn Module>>,
-    server_reference_modules: Vc<Vec<Vc<Box<dyn Module>>>>,
+    server_reference_modules: Vc<Modules>,
     project_path: Vc<FileSystemPath>,
     node_root: Vc<FileSystemPath>,
     page_name: &str,
@@ -171,7 +171,7 @@ async fn build_manifest(
 #[turbo_tasks::function]
 async fn get_actions(
     rsc_entry: Vc<Box<dyn Module>>,
-    server_reference_modules: Vc<Vec<Vc<Box<dyn Module>>>>,
+    server_reference_modules: Vc<Modules>,
     asset_context: Vc<Box<dyn AssetContext>>,
 ) -> Result<Vc<AllActions>> {
     async move {

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -4,7 +4,7 @@ use tracing::Instrument;
 use turbo_tasks::{RcStr, TryFlatJoinIterExt, TryJoinIterExt, Value, ValueToString, Vc};
 use turbopack_core::{
     chunk::{availability_info::AvailabilityInfo, ChunkingContext, ChunkingContextExt},
-    module::Module,
+    module::{Module, Modules},
     output::OutputAssets,
 };
 
@@ -313,7 +313,7 @@ pub async fn get_app_client_references_chunks(
 #[turbo_tasks::function]
 pub async fn get_app_server_reference_modules(
     app_client_reference_types: Vc<ClientReferenceTypes>,
-) -> Result<Vc<Vec<Vc<Box<dyn Module>>>>> {
+) -> Result<Vc<Modules>> {
     Ok(Vc::cell(
         app_client_reference_types
             .await?


### PR DESCRIPTION
After this change, `cargo check` on a branch that deletes vc generics support compiles successfully.

## Why?

Rather than extended support for `Vc` generics to `ResolvedVc`, I plan to remove support for them entirely. That means fixing all the callsites (there's not many).

Removing this is needed to get us to a point where 100% of structs can be `ResolvedValue`, because structs using these fields cannot otherwise be ported over to `ResolvedVc`.

## Okay, but Why?

Explained here: https://github.com/vercel/turborepo/pull/8843#issuecomment-2253158412

I expect removing support for this will decrease the overall size of the codebase, as the logic for supporting generics is rather complicated.