### PR TITLE
chore(next/image): update priority prop docs with loading prop side effect warning

### DIFF
--- a/docs/02-app/02-api-reference/01-components/image.mdx
+++ b/docs/02-app/02-api-reference/01-components/image.mdx
@@ -260,7 +260,7 @@ priority={false} // {false} | {true}
 ```
 
 When true, the image will be considered high priority and
-[preload](https://web.dev/preload-responsive-images/). Lazy loading is automatically disabled for images using `priority`. If the [`loading`](#loading) property is also used and set to `lazy`, the `priority` property can't be used. The [`loading`](#loading) property is only meant for advanced use cases, consider unsetting it when using the `loading` property.
+[preload](https://web.dev/preload-responsive-images/). Lazy loading is automatically disabled for images using `priority`. If the [`loading`](#loading) property is also used and set to `lazy`, the `priority` property can't be used. The [`loading`](#loading) property is only meant for advanced use cases. Remove `loading` when `priority` is needed.
 
 You should use the `priority` property on any image detected as the [Largest Contentful Paint (LCP)](https://nextjs.org/learn/seo/web-performance/lcp) element. It may be appropriate to have multiple priority images, as different images may be the LCP element for different viewport sizes.
 

--- a/docs/02-app/02-api-reference/01-components/image.mdx
+++ b/docs/02-app/02-api-reference/01-components/image.mdx
@@ -260,7 +260,7 @@ priority={false} // {false} | {true}
 ```
 
 When true, the image will be considered high priority and
-[preload](https://web.dev/preload-responsive-images/). Lazy loading is automatically disabled for images using `priority`.
+[preload](https://web.dev/preload-responsive-images/). Lazy loading is automatically disabled for images using `priority`. If the [`loading`](#loading) property is also used and set to `lazy`, the `priority` property can't be used. The [`loading`](#loading) property is only meant for advanced use cases, consider unsetting it when using the `loading` property.
 
 You should use the `priority` property on any image detected as the [Largest Contentful Paint (LCP)](https://nextjs.org/learn/seo/web-performance/lcp) element. It may be appropriate to have multiple priority images, as different images may be the LCP element for different viewport sizes.
 


### PR DESCRIPTION
### What?

Updated the Image  `priority` prop docs section with information about using the `priority` prop with the `loading` prop.

### Why?

Using these props together can cause an undocumented error:
```
Error: Image with src "..." has both "priority" and "loading='lazy'" properties. Only one should be used.
```

The existing documentation made no mention of this, and was unclear about if you could use these props together:
> Lazy loading is automatically disabled for images using priority.
This line on its own made it sound like the `lazy` prop would be disabled automatically. (it is not if you have set it)

### How?

Added clarity about what happens when you use `lazy` and `priority` and a suggestion to unset `lazy` when using `priority`