### PR TITLE
Add pathname to PrerenderStore

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1128,7 +1128,7 @@ async function renderToHTMLOrFlightImpl(
       ])
     }
 
-    addImplicitTags(workStore, requestStore, undefined)
+    addImplicitTags(workStore, requestStore, undefined, undefined)
 
     if (workStore.tags) {
       metadata.fetchTags = workStore.tags.join(',')
@@ -1237,7 +1237,7 @@ async function renderToHTMLOrFlightImpl(
       ])
     }
 
-    addImplicitTags(workStore, requestStore, undefined)
+    addImplicitTags(workStore, requestStore, undefined, undefined)
 
     if (workStore.tags) {
       metadata.fetchTags = workStore.tags.join(',')

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1852,6 +1852,7 @@ async function prerenderToStream(
         const cacheSignal = new CacheSignal()
         const prospectiveRenderPrerenderStore: PrerenderStore = {
           type: 'prerender',
+          pathname: ctx.requestStore.url.pathname,
           cacheSignal,
           // During the prospective render we don't want to synchronously abort on dynamic access
           // because it could prevent us from discovering all caches in siblings. So we omit the controller
@@ -1943,6 +1944,7 @@ async function prerenderToStream(
 
         const finalRenderPrerenderStore: PrerenderStore = {
           type: 'prerender',
+          pathname: ctx.requestStore.url.pathname,
           // During the final prerender we don't need to track cache access so we omit the signal
           cacheSignal: null,
           // During the final render we do want to abort synchronously on dynamic access so we
@@ -1998,6 +2000,7 @@ async function prerenderToStream(
         const SSRController = new AbortController()
         const ssrPrerenderStore: PrerenderStore = {
           type: 'prerender',
+          pathname: ctx.requestStore.url.pathname,
           // For HTML Generation we don't need to track cache reads (RSC only)
           cacheSignal: null,
           // We expect the SSR render to complete in a single Task and need to be able to synchronously abort
@@ -2202,6 +2205,7 @@ async function prerenderToStream(
         const cacheSignal = new CacheSignal()
         const prospectiveRenderPrerenderStore: PrerenderStore = {
           type: 'prerender',
+          pathname: ctx.requestStore.url.pathname,
           cacheSignal,
           // When PPR is off we can synchronously abort the prospective render because we will
           // always hit this path on the final render and thus we can skip the final render and just
@@ -2280,6 +2284,7 @@ async function prerenderToStream(
 
         const finalRenderPrerenderStore: PrerenderStore = {
           type: 'prerender',
+          pathname: ctx.requestStore.url.pathname,
           // During the final prerender we don't need to track cache access so we omit the signal
           cacheSignal: null,
           controller: flightController,
@@ -2289,6 +2294,7 @@ async function prerenderToStream(
         const SSRController = new AbortController()
         const ssrPrerenderStore: PrerenderStore = {
           type: 'prerender',
+          pathname: ctx.requestStore.url.pathname,
           // For HTML Generation we don't need to track cache reads (RSC only)
           cacheSignal: null,
           // We expect the SSR render to complete in a single Task and need to be able to synchronously abort
@@ -2469,6 +2475,7 @@ async function prerenderToStream(
       )
       const reactServerPrerenderStore: PrerenderStore = {
         type: 'prerender',
+        pathname: ctx.requestStore.url.pathname,
         cacheSignal: null,
         controller: null,
         dynamicTracking,
@@ -2496,6 +2503,7 @@ async function prerenderToStream(
 
       const ssrPrerenderStore: PrerenderStore = {
         type: 'prerender',
+        pathname: ctx.requestStore.url.pathname,
         cacheSignal: null,
         controller: null,
         dynamicTracking,
@@ -2653,6 +2661,7 @@ async function prerenderToStream(
     } else {
       const prerenderLegacyStore: PrerenderStore = {
         type: 'prerender-legacy',
+        pathname: ctx.requestStore.url.pathname,
       }
       // This is a regular static generation. We don't do dynamic tracking because we rely on
       // the old-school dynamic error handling to bail out of static generation

--- a/packages/next/src/server/app-render/prerender-async-storage.external.ts
+++ b/packages/next/src/server/app-render/prerender-async-storage.external.ts
@@ -18,6 +18,7 @@ import { prerenderAsyncStorage } from './prerender-async-storage-instance' with 
  */
 export type PrerenderStoreModern = {
   type: 'prerender'
+  pathname: string | undefined
   /**
    * This is the AbortController passed to React. It can be used to abort the prerender
    * if we encounter conditions that do not require further rendering
@@ -38,6 +39,7 @@ export type PrerenderStoreModern = {
 
 export type PrerenderStoreLegacy = {
   type: 'prerender-legacy'
+  pathname: string | undefined
 }
 
 export type PrerenderStore = PrerenderStoreLegacy | PrerenderStoreModern

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -145,7 +145,7 @@ const getDerivedTags = (pathname: string): string[] => {
 export function addImplicitTags(
   workStore: WorkStore,
   requestStore: RequestStore | undefined,
-  _prerenderStore: PrerenderStore | undefined,
+  prerenderStore: PrerenderStore | undefined,
   cacheStore: CacheStore | undefined
 ) {
   const newTags: string[] = []
@@ -176,10 +176,17 @@ export function addImplicitTags(
     newTags.push(tag)
   }
 
+  const renderedPathname =
+    requestStore !== undefined
+      ? requestStore.url.pathname
+      : prerenderStore !== undefined
+        ? prerenderStore.pathname
+        : undefined
+
   // Add the tags from the pathname. If the route has unknown params, we don't
   // want to add the pathname as a tag, as it will be invalid.
-  if (requestStore?.url.pathname && !hasFallbackRouteParams) {
-    const tag = `${NEXT_CACHE_IMPLICIT_TAG_ID}${requestStore.url.pathname}`
+  if (renderedPathname && !hasFallbackRouteParams) {
+    const tag = `${NEXT_CACHE_IMPLICIT_TAG_ID}${renderedPathname}`
     if (
       !cacheStore ||
       (cacheStore.type !== 'cache' && cacheStore.type !== 'unstable-cache')

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -18,6 +18,7 @@ import type {
   RequestAsyncStorage,
   RequestStore,
 } from '../../client/components/request-async-storage.external'
+import type { PrerenderStore } from '../app-render/prerender-async-storage.external'
 import {
   cacheAsyncStorage,
   type CacheStore,
@@ -144,6 +145,7 @@ const getDerivedTags = (pathname: string): string[] => {
 export function addImplicitTags(
   workStore: WorkStore,
   requestStore: RequestStore | undefined,
+  _prerenderStore: PrerenderStore | undefined,
   cacheStore: CacheStore | undefined
 ) {
   const newTags: string[] = []
@@ -263,6 +265,7 @@ export function createPatchedFetcher(
     const hideSpan = process.env.NEXT_OTEL_FETCH_DISABLED === '1'
 
     const workStore = workAsyncStorage.getStore()
+    const prerenderStore = prerenderAsyncStorage.getStore()
 
     const result = getTracer().trace(
       isInternal ? NextNodeServerSpan.internalFetch : AppRenderSpan.fetch,
@@ -345,6 +348,7 @@ export function createPatchedFetcher(
         const implicitTags = addImplicitTags(
           workStore,
           requestStore,
+          prerenderStore,
           cacheStore
         )
 
@@ -772,7 +776,6 @@ export function createPatchedFetcher(
               // We sometimes use the cache to dedupe fetches that do not specify a cache configuration
               // In these cases we want to make sure we still exclude them from prerenders if dynamicIO is on
               // so we introduce an artificial Task boundary here.
-              const prerenderStore = prerenderAsyncStorage.getStore()
               if (prerenderStore) {
                 await waitAtLeastOneReactRenderTask()
               }
@@ -953,7 +956,6 @@ export function createPatchedFetcher(
       }
     )
 
-    const prerenderStore = prerenderAsyncStorage.getStore()
     if (
       prerenderStore &&
       prerenderStore.type === 'prerender' &&

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -336,6 +336,7 @@ export class AppRouteRouteModule extends RouteModule<
         let dynamicTracking = createDynamicTrackingState(undefined)
         const prospectiveRoutePrerenderStore: PrerenderStore = {
           type: 'prerender',
+          pathname: requestStore.url.pathname,
           cacheSignal,
           // During prospective render we don't use a controller
           // because we need to let all caches fill.
@@ -403,6 +404,7 @@ export class AppRouteRouteModule extends RouteModule<
 
         const finalRoutePrerenderStore: PrerenderStore = {
           type: 'prerender',
+          pathname: requestStore.url.pathname,
           cacheSignal: null,
           controller,
           dynamicTracking,
@@ -466,6 +468,7 @@ export class AppRouteRouteModule extends RouteModule<
         res = await prerenderAsyncStorage.run(
           {
             type: 'prerender-legacy',
+            pathname: requestStore.url.pathname,
           },
           handler,
           request,

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -522,7 +522,7 @@ export class AppRouteRouteModule extends RouteModule<
       ...Object.values(workStore.pendingRevalidates || {}),
     ])
 
-    addImplicitTags(workStore, requestStore, undefined)
+    addImplicitTags(workStore, requestStore, undefined, undefined)
     ;(context.renderOpts as any).fetchTags = workStore.tags?.join(',')
 
     // It's possible cookies were set in the handler, so we need

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -196,6 +196,7 @@ export function unstable_cache<T extends Callback>(
         const implicitTags = addImplicitTags(
           workStore,
           requestStore,
+          prerenderStore,
           cacheStore
         )
 
@@ -305,7 +306,8 @@ export function unstable_cache<T extends Callback>(
           // @TODO check on this API. addImplicitTags mutates the store and returns the implicit tags. The naming
           // of this function is potentially a little confusing
           const implicitTags =
-            workStore && addImplicitTags(workStore, requestStore, cacheStore)
+            workStore &&
+            addImplicitTags(workStore, requestStore, prerenderStore, cacheStore)
 
           const cacheEntry = await incrementalCache.get(cacheKey, {
             kind: IncrementalCacheKind.FETCH,


### PR DESCRIPTION
This lets us use this for implicit tags when a full Request is not available. Required for #70819.

This should probably be more normalized but I only pass the path name instead of the full url to avoid leaking more dynamic information to the prerender.

This does not yet solve the case where we have nested caches (which we don't in unstable_cache but in use cache). In that case it's more complex because for an outer hit we'd need to add it to the inner cache entries.