### PR TITLE
Fix missing await of params in metadata route

### DIFF
--- a/crates/next-core/src/next_app/metadata/image.rs
+++ b/crates/next-core/src/next_app/metadata/image.rs
@@ -82,7 +82,7 @@ pub async fn dynamic_image_metadata_source(
             const imageModule = {{ {exported_fields_excluding_default} }}
 
             export default async function (props) {{
-                const {{ __metadata_id__: _, ...params }} = props.params
+                const {{ __metadata_id__: _, ...params }} = await props.params
                 const imageUrl = fillMetadataSegment({pathname_prefix}, params, {page_segment})
 
                 const {{ generateImageMetadata }} = imageModule

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -348,7 +348,7 @@ async fn dynamic_image_route_source(path: Vc<FileSystemPath>) -> Result<Vc<Box<d
 
             export async function GET(_, ctx) {{
                 const params = await ctx.params
-                const {{ __metadata_id__, ...rest }} =  || {{}}
+                const {{ __metadata_id__, ...rest }} = params || {{}}
                 const restParams = params ? rest : undefined
                 const targetId = __metadata_id__
                 let id = undefined

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -279,7 +279,7 @@ async fn dynamic_site_map_route_source(
             }}
 
             export async function GET(_, ctx) {{
-                const {{ __metadata_id__: id, ...params }} = ctx.params || {{}}
+                const {{ __metadata_id__: id, ...params }} = await ctx.params || {{}}
                 const hasXmlExtension = id ? id.endsWith('.xml') : false
                 if (id && !hasXmlExtension) {{
                     return new NextResponse('Not Found', {{
@@ -347,12 +347,14 @@ async fn dynamic_image_route_source(path: Vc<FileSystemPath>) -> Result<Vc<Box<d
             }}
 
             export async function GET(_, ctx) {{
-                const {{ __metadata_id__, ...params }} = ctx.params || {{}}
+                const params = await ctx.params
+                const {{ __metadata_id__, ...rest }} =  || {{}}
+                const restParams = params ? rest : undefined
                 const targetId = __metadata_id__
                 let id = undefined
 
                 if (generateImageMetadata) {{
-                    const imageMetadata = await generateImageMetadata({{ params }})
+                    const imageMetadata = await generateImageMetadata({{ params: restParams }})
                     id = imageMetadata.find((item) => {{
                         if (process.env.NODE_ENV !== 'production') {{
                             if (item?.id == null) {{
@@ -369,7 +371,7 @@ async fn dynamic_image_route_source(path: Vc<FileSystemPath>) -> Result<Vc<Box<d
                     }}
                 }}
 
-                return handler({{ params: ctx.params ? params : undefined, id }})
+                return handler({{ params: restParams, id }})
             }}
         "#,
         resource_path = StringifyJs(&format!("./{}.{}", stem, ext)),

--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -155,12 +155,14 @@ ${errorOnBadHandler(resourcePath)}
 ${await createReExportsCode(resourcePath, loaderContext)}
 
 export async function GET(_, ctx) {
-  const { __metadata_id__, ...params } = ctx.params || {}
+  const params = await ctx.params
+  const { __metadata_id__, ...rest } = params || {}
+  const restParams = params ? rest : undefined
   const targetId = __metadata_id__
   let id = undefined
   
   if (generateImageMetadata) {
-    const imageMetadata = await generateImageMetadata({ params })
+    const imageMetadata = await generateImageMetadata({ params: restParams })
     id = imageMetadata.find((item) => {
       if (process.env.NODE_ENV !== 'production') {
         if (item?.id == null) {
@@ -176,7 +178,7 @@ export async function GET(_, ctx) {
     }
   }
 
-  return handler({ params: ctx.params ? params : undefined, id })
+  return handler({ params: restParams, id })
 }
 `
 }
@@ -223,7 +225,7 @@ ${errorOnBadHandler(resourcePath)}
 ${await createReExportsCode(resourcePath, loaderContext)}
 
 export async function GET(_, ctx) {
-  const { __metadata_id__: id, ...params } = ctx.params || {}
+  const { __metadata_id__: id, ...params } = await ctx.params || {}
   const hasXmlExtension = id ? id.endsWith('.xml') : false
 
   if (id && !hasXmlExtension) {


### PR DESCRIPTION
Follow up of #70698 

The other params access in metadata loaders also need to be awaited