### PR TITLE
codemod: extend ignore pattern list

### DIFF
--- a/packages/next-codemod/lib/run-jscodeshift.ts
+++ b/packages/next-codemod/lib/run-jscodeshift.ts
@@ -9,7 +9,20 @@ export default function runJscodeshift(
   // we run jscodeshift in the same process to be able to
   // share state between the main CRA transform and sub-transforms
   return Runner.run(transformerPath, files, {
-    ignorePattern: ['**/node_modules/**', '**/.next/**', '**/build/**'],
+    ignorePattern: [
+      '**/node_modules/**',
+      '**/.next/**',
+      '**/build/**',
+      // type files
+      '**/*.d.ts',
+      '**/*.d.cts',
+      '**/*.d.mts',
+      // test files
+      '**/*.test.*',
+      '**/*.spec.*',
+      '**/__tests__/**',
+      '**/__mocks__/**',
+    ],
     extensions: 'tsx,ts,jsx,js',
     parser: 'tsx',
     verbose: 2,

--- a/packages/next-codemod/transforms/lib/async-request-api/index.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/index.ts
@@ -3,11 +3,6 @@ import { transformDynamicProps } from './next-async-dynamic-prop'
 import { transformDynamicAPI } from './next-async-dynamic-api'
 
 export default function transform(file: FileInfo, api: API) {
-  const filePath = file.path
-  // if it's node_modules or types file, skip
-  if (/node_modules/.test(filePath) || /\.d\.(m|c)?ts$/.test(filePath)) {
-    return file.source
-  }
   const transforms = [transformDynamicProps, transformDynamicAPI]
 
   return transforms.reduce<string>((source, transformFn) => {


### PR DESCRIPTION
Apply the ignorePatterns to all codemod:

* Ignore test files: `__tests__`, `__mocks__`, `.(spec|test).*`
* Ignore ts types: `.d.ts`, `.d.mts`, `.d.cts`

This is an early return before entering the codemode transformers