### PR TITLE
Only add edge entries when there are other edge entries

### DIFF
--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -722,14 +722,12 @@ export async function createEntrypoints(
           let appDirLoader: string = ''
           if (isInstrumentation) {
             // Add instrumentation edge server entry when there's other edge server entries
-            if (Object.keys(edgeServer).length > 0) {
-              edgeServer[serverBundlePath.replace('src/', '')] =
-                getInstrumentationEntry({
-                  absolutePagePath,
-                  isEdgeServer: true,
-                  isDev: false,
-                })
-            }
+            edgeServer[serverBundlePath.replace('src/', '')] =
+              getInstrumentationEntry({
+                absolutePagePath,
+                isEdgeServer: true,
+                isDev: false,
+              })
           } else {
             if (pagesType === 'app') {
               const matchedAppPaths = appPathsPerRoute[normalizeAppPath(page)]

--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -721,12 +721,15 @@ export async function createEntrypoints(
         onEdgeServer: () => {
           let appDirLoader: string = ''
           if (isInstrumentation) {
-            edgeServer[serverBundlePath.replace('src/', '')] =
-              getInstrumentationEntry({
-                absolutePagePath,
-                isEdgeServer: true,
-                isDev: false,
-              })
+            // Add instrumentation edge server entry when there's other edge server entries
+            if (Object.keys(edgeServer).length > 0) {
+              edgeServer[serverBundlePath.replace('src/', '')] =
+                getInstrumentationEntry({
+                  absolutePagePath,
+                  isEdgeServer: true,
+                  isDev: false,
+                })
+            }
           } else {
             if (pagesType === 'app') {
               const matchedAppPaths = appPathsPerRoute[normalizeAppPath(page)]
@@ -791,7 +794,8 @@ export async function createEntrypoints(
 
   // Optimization: If there's only one instrumentation hook in edge compiler, which means there's no edge server entry.
   // We remove the edge instrumentation entry from edge compiler as it can be pure server side.
-  if (edgeServer.instrumentation && Object.keys(edgeServer).length === 1) {
+  const edgeServerEntriesCount = Object.keys(edgeServer).length
+  if (edgeServer.instrumentation && edgeServerEntriesCount <= 1) {
     delete edgeServer.instrumentation
   }
 

--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -795,7 +795,7 @@ export async function createEntrypoints(
   // Optimization: If there's only one instrumentation hook in edge compiler, which means there's no edge server entry.
   // We remove the edge instrumentation entry from edge compiler as it can be pure server side.
   const edgeServerEntriesCount = Object.keys(edgeServer).length
-  if (edgeServer.instrumentation && edgeServerEntriesCount <= 1) {
+  if (edgeServer.instrumentation && edgeServerEntriesCount === 1) {
     delete edgeServer.instrumentation
   }
 

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -902,23 +902,19 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
                 // TODO-APP: verify if child entry should support.
                 if (!isEdgeServerCompilation || !isEntry) return
                 entries[entryKey].status = BUILDING
-
                 if (isInstrumentation) {
                   const normalizedBundlePath = bundlePath.replace('src/', '')
-                  // Add instrumentation edge server entry when there's other edge server entries
-                  if (Object.keys(entrypoints).length > 0) {
-                    entrypoints[normalizedBundlePath] = finalizeEntrypoint({
-                      compilerType: COMPILER_NAMES.edgeServer,
-                      name: normalizedBundlePath,
-                      value: getInstrumentationEntry({
-                        absolutePagePath: entryData.absolutePagePath,
-                        isEdgeServer: true,
-                        isDev: true,
-                      }),
-                      isServerComponent: true,
-                      hasAppDir,
-                    })
-                  }
+                  entrypoints[normalizedBundlePath] = finalizeEntrypoint({
+                    compilerType: COMPILER_NAMES.edgeServer,
+                    name: normalizedBundlePath,
+                    value: getInstrumentationEntry({
+                      absolutePagePath: entryData.absolutePagePath,
+                      isEdgeServer: true,
+                      isDev: true,
+                    }),
+                    isServerComponent: true,
+                    hasAppDir,
+                  })
                   return
                 }
                 const appDirLoader = isAppPath

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -905,17 +905,20 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
 
                 if (isInstrumentation) {
                   const normalizedBundlePath = bundlePath.replace('src/', '')
-                  entrypoints[normalizedBundlePath] = finalizeEntrypoint({
-                    compilerType: COMPILER_NAMES.edgeServer,
-                    name: normalizedBundlePath,
-                    value: getInstrumentationEntry({
-                      absolutePagePath: entryData.absolutePagePath,
-                      isEdgeServer: true,
-                      isDev: true,
-                    }),
-                    isServerComponent: true,
-                    hasAppDir,
-                  })
+                  // Add instrumentation edge server entry when there's other edge server entries
+                  if (Object.keys(entrypoints).length > 0) {
+                    entrypoints[normalizedBundlePath] = finalizeEntrypoint({
+                      compilerType: COMPILER_NAMES.edgeServer,
+                      name: normalizedBundlePath,
+                      value: getInstrumentationEntry({
+                        absolutePagePath: entryData.absolutePagePath,
+                        isEdgeServer: true,
+                        isDev: true,
+                      }),
+                      isServerComponent: true,
+                      hasAppDir,
+                    })
+                  }
                   return
                 }
                 const appDirLoader = isAppPath

--- a/test/e2e/on-request-error/isr/isr.test.ts
+++ b/test/e2e/on-request-error/isr/isr.test.ts
@@ -19,6 +19,7 @@ describe('on-request-error - isr', () => {
       await next.fetch('/')
       expect(next.cliOutput).not.toContain('Module not found')
     })
+    return
   }
 
   async function matchRevalidateReason(

--- a/test/e2e/on-request-error/isr/isr.test.ts
+++ b/test/e2e/on-request-error/isr/isr.test.ts
@@ -15,10 +15,10 @@ describe('on-request-error - isr', () => {
   }
 
   if (isNextDev) {
-    it('should skip in development mode', () => {
-      // This ISR test is only applicable for production mode
+    it('should not have module not found error', async () => {
+      await next.fetch('/')
+      expect(next.cliOutput).not.toContain('Module not found')
     })
-    return
   }
 
   async function matchRevalidateReason(


### PR DESCRIPTION
Change all the webpack entry collections, before adding `instrumentation.js`, check if there're other edge server entires like pages and routes. If there's already other routes presented, then enque instrumentation edge server entry build. Otherwise it should be safe to always use Node.js API

x-ref: [slack](https://vercel.slack.com/archives/C03EWR7LGEN/p1728309334358469)