### PR TITLE
codemod: add async transform for generate viewport

### DIFF
--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/generate-metadata-access-prop-02.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/generate-metadata-access-prop-02.input.tsx
@@ -1,0 +1,7 @@
+export function generateViewport({
+  params,
+}: {
+  params: { slug: string }
+}): Metadata {
+  params.slug
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/generate-metadata-access-prop-02.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/generate-metadata-access-prop-02.output.tsx
@@ -1,0 +1,8 @@
+export async function generateViewport(
+  props: {
+    params: Promise<{ slug: string }>
+  }
+): Promise<Metadata> {
+  const params = await props.params;
+  params.slug
+}

--- a/packages/next-codemod/transforms/lib/async-request-api/utils.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/utils.ts
@@ -27,6 +27,7 @@ export const TARGET_ROUTE_EXPORTS = new Set([
 export const TARGET_NAMED_EXPORTS = new Set([
   // For page and layout
   'generateMetadata',
+  'generateViewport',
   ...TARGET_ROUTE_EXPORTS,
 ])
 


### PR DESCRIPTION
Add support for async API `generateViewPort` transform to fit the new async params model

cc @alvarlagerlof