### PR TITLE
Add `require-in-the-middle` to default externals

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/serverExternalPackages.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/serverExternalPackages.mdx
@@ -69,6 +69,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `prisma`
 - `puppeteer-core`
 - `puppeteer`
+- `require-in-the-middle`
 - `rimraf`
 - `sharp`
 - `shiki`

--- a/docs/03-pages/02-api-reference/04-next-config-js/serverExternalPackages.mdx
+++ b/docs/03-pages/02-api-reference/04-next-config-js/serverExternalPackages.mdx
@@ -69,6 +69,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `prisma`
 - `puppeteer-core`
 - `puppeteer`
+- `require-in-the-middle`
 - `rimraf`
 - `sharp`
 - `shiki`

--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -50,6 +50,7 @@
   "prisma",
   "puppeteer",
   "puppeteer-core",
+  "require-in-the-middle",
   "rimraf",
   "sharp",
   "shiki",


### PR DESCRIPTION
Closes PACK-3288
Closes https://github.com/vercel/next.js/issues/70424

Sentry uses `open-telemetry`, which uses `require-in-the-middle` which:
- overrides the global `Module.prototype.require`, even when bundled
- reads `require.cache` which when bundled is Turbopack's registry (not the outer Node.js one)


Because of this, `require-in-the-middle` is broken/results in a broken environment when it's bundled (e.g. via `instrumentation.js`).


