### PR TITLE
Use perf_hooks for fetch metrics timers

### DIFF
--- a/packages/next/src/server/dev/log-requests.ts
+++ b/packages/next/src/server/dev/log-requests.ts
@@ -93,7 +93,7 @@ function logFetchMetric(
 
     writeLine(
       white(
-        `${method} ${url} ${status} in ${end - start}ms ${formatCacheStatus(cacheStatus)}`
+        `${method} ${url} ${status} in ${Math.round(end - start)}ms ${formatCacheStatus(cacheStatus)}`
       ),
       1
     )

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -220,7 +220,7 @@ function trackFetchMetric(
 
   workStore.fetchMetrics.push({
     ...ctx,
-    end: Date.now(),
+    end: performance.timeOrigin + performance.now(),
     idx: workStore.nextFetchId || 0,
   })
 }
@@ -250,7 +250,7 @@ export function createPatchedFetcher(
       url = undefined
     }
     const fetchUrl = url?.href ?? ''
-    const fetchStart = Date.now()
+    const fetchStart = performance.timeOrigin + performance.now()
     const method = init?.method?.toUpperCase() || 'GET'
 
     // Do create a new span trace for internal fetches in the


### PR DESCRIPTION
These are better for telemetry and Date.now() will start to be dynamic in prerenders