### PR TITLE
Use random port for cargo test

### DIFF
--- a/turbopack/crates/turbopack/tests/node-file-trace/integration/socket.io.js
+++ b/turbopack/crates/turbopack/tests/node-file-trace/integration/socket.io.js
@@ -1,6 +1,6 @@
 const http = require("http");
 const io = require("socket.io");
-const opts = { port: 3000 };
+const opts = { port: 0 };
 const server = http.createServer((req, res) => {});
 server.listen(opts.port);
 server.close(() => {


### PR DESCRIPTION
We can't guarantee this port will always be available so use random one instead 

x-ref: https://github.com/vercel/next.js/actions/runs/11221640914/job/31192432034