### PR TITLE
fix(next-upgrade): prompts has no `default` option, is `initial`

### DIFF
--- a/packages/next-codemod/bin/transform.ts
+++ b/packages/next-codemod/bin/transform.ts
@@ -45,7 +45,7 @@ export async function runTransform(
       type: 'text',
       name: 'path',
       message: 'On which files or directory should the codemods be applied?',
-      default: '.',
+      initial: '.',
     })
 
     directory = res.path


### PR DESCRIPTION
`default` is from `inquirier`, for prompts, it's `initial`.

x-ref: https://www.npmjs.com/package/prompts

This made directory value undefined when user `Enter`ed the default value.

Before:

![CleanShot 2024-10-08 at 05 39 17](https://github.com/user-attachments/assets/1e10abe0-0138-4505-a694-2fb3278258a4)

After:

![CleanShot 2024-10-08 at 05 39 48](https://github.com/user-attachments/assets/bf24d708-4458-4396-8115-d467d100571f)
