### PR TITLE
refactor(next-upgrade): ensures prompts are cancelled when user exits

### DIFF
--- a/packages/next-codemod/bin/transform.ts
+++ b/packages/next-codemod/bin/transform.ts
@@ -3,7 +3,11 @@ import globby from 'globby'
 import prompts from 'prompts'
 import { join } from 'node:path'
 import { installPackages, uninstallPackage } from '../lib/handle-package'
-import { checkGitStatus, TRANSFORMER_INQUIRER_CHOICES } from '../lib/utils'
+import {
+  checkGitStatus,
+  onCancel,
+  TRANSFORMER_INQUIRER_CHOICES,
+} from '../lib/utils'
 
 function expandFilePathsIfNeeded(filesBeforeExpansion) {
   const shouldExpandFiles = filesBeforeExpansion.some((file) =>
@@ -41,22 +45,28 @@ export async function runTransform(
   }
 
   if (!path) {
-    const res = await prompts({
-      type: 'text',
-      name: 'path',
-      message: 'On which files or directory should the codemods be applied?',
-      initial: '.',
-    })
+    const res = await prompts(
+      {
+        type: 'text',
+        name: 'path',
+        message: 'On which files or directory should the codemods be applied?',
+        initial: '.',
+      },
+      { onCancel }
+    )
 
     directory = res.path
   }
   if (!transform) {
-    const res = await prompts({
-      type: 'select',
-      name: 'transformer',
-      message: 'Which transform would you like to apply?',
-      choices: TRANSFORMER_INQUIRER_CHOICES,
-    })
+    const res = await prompts(
+      {
+        type: 'select',
+        name: 'transformer',
+        message: 'Which transform would you like to apply?',
+        choices: TRANSFORMER_INQUIRER_CHOICES,
+      },
+      { onCancel }
+    )
 
     transformer = res.transformer
   }

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -7,6 +7,7 @@ import chalk from 'chalk'
 import { availableCodemods } from '../lib/codemods'
 import { getPkgManager, installPackages } from '../lib/handle-package'
 import { runTransform } from './transform'
+import { onCancel } from '../lib/utils'
 
 type PackageManager = 'pnpm' | 'npm' | 'yarn' | 'bun'
 
@@ -162,11 +163,7 @@ async function suggestTurbopack(packageJson: any): Promise<void> {
       message: 'Turbopack is now the stable default for dev mode. Enable it?',
       initial: true,
     },
-    {
-      onCancel: () => {
-        process.exit(0)
-      },
-    }
+    { onCancel }
   )
 
   if (!responseTurbopack.enable) {
@@ -181,12 +178,15 @@ async function suggestTurbopack(packageJson: any): Promise<void> {
     return
   }
 
-  const responseCustomDevScript = await prompts({
-    type: 'text',
-    name: 'customDevScript',
-    message: 'Please add `--turbo` to your dev command:',
-    initial: devScript,
-  })
+  const responseCustomDevScript = await prompts(
+    {
+      type: 'text',
+      name: 'customDevScript',
+      message: 'Please add `--turbo` to your dev command:',
+      initial: devScript,
+    },
+    { onCancel }
+  )
 
   packageJson.scripts['dev'] =
     responseCustomDevScript.customDevScript || devScript
@@ -233,11 +233,7 @@ async function suggestCodemods(
         }
       }),
     },
-    {
-      onCancel: () => {
-        process.exit(0)
-      },
-    }
+    { onCancel }
   )
 
   return codemods

--- a/packages/next-codemod/lib/utils.ts
+++ b/packages/next-codemod/lib/utils.ts
@@ -31,6 +31,10 @@ export function checkGitStatus(force) {
   }
 }
 
+export function onCancel() {
+  process.exit(1)
+}
+
 export const TRANSFORMER_INQUIRER_CHOICES = [
   {
     title:


### PR DESCRIPTION
Without `onCancel` handling, even if `CTRL + C`, the prompt will not exit and continue to next step. Added it to missing prompts calls.