### PR TITLE
refactor(next-upgrade): tailor turbopack suggestion message

### DIFF
--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -153,14 +153,14 @@ function getInstalledNextVersion(): string {
  *    showing the current dev command as the initial value.
  */
 async function suggestTurbopack(packageJson: any): Promise<void> {
-  const devScript = packageJson.scripts['dev']
+  const devScript: string = packageJson.scripts['dev']
   if (devScript.includes('--turbo')) return
 
   const responseTurbopack = await prompts(
     {
       type: 'confirm',
       name: 'enable',
-      message: 'Turbopack is now the stable default for dev mode. Enable it?',
+      message: 'Enable Turbopack for next dev?',
       initial: true,
     },
     { onCancel }
@@ -178,11 +178,15 @@ async function suggestTurbopack(packageJson: any): Promise<void> {
     return
   }
 
+  console.log(
+    `${chalk.yellow('⚠')} Could not find "${chalk.bold('next dev')}" in your dev script.`
+  )
+
   const responseCustomDevScript = await prompts(
     {
       type: 'text',
       name: 'customDevScript',
-      message: 'Please add `--turbo` to your dev command:',
+      message: 'Please add "--turbo" to your dev command manually.',
       initial: devScript,
     },
     { onCancel }

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -186,7 +186,7 @@ async function suggestTurbopack(packageJson: any): Promise<void> {
     {
       type: 'text',
       name: 'customDevScript',
-      message: 'Please add "--turbo" to your dev command manually.',
+      message: 'Please manually add "--turbo" to your dev command.',
       initial: devScript,
     },
     { onCancel }


### PR DESCRIPTION
Lower a bit of certainty in stableness with Turbopack dev yet. Inform user clearly to add `--turbo` manually if `next dev` wasn't found.