### PR TITLE
`cache: "default"` shouldn't get cached in route handlers

### DIFF
--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -409,6 +409,7 @@ export function createPatchedFetcher(
          * - Fetch cache configs are not set. Specifically:
          *    - A page fetch cache mode is not set (export const fetchCache=...)
          *    - A fetch cache mode is not set in the fetch call (fetch(url, { cache: ... }))
+         *      or the fetch cache mode is set to 'default'
          *    - A fetch revalidate value is not set in the fetch call (fetch(url, { revalidate: ... }))
          * - OR the fetch comes after a configuration that triggered dynamic rendering (e.g., reading cookies())
          *   and the fetch was considered uncacheable (e.g., POST method or has authorization headers)
@@ -417,7 +418,10 @@ export function createPatchedFetcher(
           // eslint-disable-next-line eqeqeq
           pageFetchCacheMode == undefined &&
           // eslint-disable-next-line eqeqeq
-          currentFetchCacheConfig == undefined &&
+          (currentFetchCacheConfig == undefined ||
+            // when considering whether to opt into the default "no-cache" fetch semantics,
+            // a "default" cache config should be treated the same as no cache config
+            currentFetchCacheConfig === 'default') &&
           // eslint-disable-next-line eqeqeq
           currentFetchRevalidate == undefined
         const autoNoCache =

--- a/test/e2e/app-dir/app-static/app/(new)/default-config-fetch/api/route.js
+++ b/test/e2e/app-dir/app-static/app/(new)/default-config-fetch/api/route.js
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  const data = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?default-config-fetch',
+    { cache: 'default' }
+  ).then((res) => res.text())
+
+  return NextResponse.json({ data })
+}

--- a/test/e2e/app-dir/app-static/app/(new)/default-config-fetch/page.js
+++ b/test/e2e/app-dir/app-static/app/(new)/default-config-fetch/page.js
@@ -1,0 +1,13 @@
+export default async function Page() {
+  const data = await fetch(
+    `https://next-data-api-endpoint.vercel.app/api/random`,
+    { cache: 'default' }
+  ).then((res) => res.text())
+
+  return (
+    <>
+      <p>/default-config-fetch</p>
+      <p id="data">{data}</p>
+    </>
+  )
+}


### PR DESCRIPTION
In Next 15, route handlers should no longer cache any `fetch` requests by default. We do this by bailing out of caching if no explicit cache config is defined. However, this misses the case where `cache: "default"` is specified. Since the default caching behavior is to not cache, this should also opt into the automatic no cache behavior.

This adds a test for the route handler and still validates that it doesn't impact page-level ISR cache.