### PR TITLE
Move tracking of revalidate and tags from WorkStore to WorkUnitStore

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1336,7 +1336,7 @@ export async function buildAppStaticPaths({
             store.fetchCache = current.config.fetchCache
           }
           if (typeof current.config?.revalidate !== 'undefined') {
-            store.revalidate = current.config.revalidate
+            store.revalidateSegmentConfig = current.config.revalidate
           }
           if (current.config?.dynamic === 'force-dynamic') {
             store.forceDynamic = true

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1336,7 +1336,7 @@ export async function buildAppStaticPaths({
             store.fetchCache = current.config.fetchCache
           }
           if (typeof current.config?.revalidate !== 'undefined') {
-            store.revalidateSegmentConfig = current.config.revalidate
+            // TODO: Is this needed for anything?
           }
           if (current.config?.dynamic === 'force-dynamic') {
             store.forceDynamic = true

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1332,14 +1332,11 @@ export async function buildAppStaticPaths({
         const params: Params[] = []
 
         if (current.generateStaticParams) {
+          // fetchCache can be used to inform the fetch() defaults used inside
+          // of generateStaticParams. revalidate and dynamic options don't come into
+          // play within generateStaticParams.
           if (typeof current.config?.fetchCache !== 'undefined') {
             store.fetchCache = current.config.fetchCache
-          }
-          if (typeof current.config?.revalidate !== 'undefined') {
-            // TODO: Is this needed for anything?
-          }
-          if (current.config?.dynamic === 'force-dynamic') {
-            store.forceDynamic = true
           }
 
           if (parentsParams.length > 0) {

--- a/packages/next/src/client/components/work-async-storage.external.ts
+++ b/packages/next/src/client/components/work-async-storage.external.ts
@@ -39,7 +39,7 @@ export interface WorkStore {
   forceDynamic?: boolean
   fetchCache?: AppSegmentConfig['fetchCache']
 
-  revalidate?: Revalidate
+  revalidateSegmentConfig?: Revalidate
   forceStatic?: boolean
   dynamicShouldError?: boolean
   pendingRevalidates?: Record<string, Promise<any>>
@@ -52,8 +52,6 @@ export interface WorkStore {
 
   nextFetchId?: number
   pathWasRevalidated?: boolean
-
-  tags?: string[]
 
   revalidatedTags?: string[]
   fetchMetrics?: FetchMetrics

--- a/packages/next/src/client/components/work-async-storage.external.ts
+++ b/packages/next/src/client/components/work-async-storage.external.ts
@@ -2,7 +2,6 @@ import type { AsyncLocalStorage } from 'async_hooks'
 import type { IncrementalCache } from '../../server/lib/incremental-cache'
 import type { DynamicServerError } from './hooks-server-context'
 import type { FetchMetrics } from '../../server/base-http'
-import type { Revalidate } from '../../server/lib/revalidate'
 import type { FallbackRouteParams } from '../../server/request/fallback-params'
 import type { DeepReadonly } from '../../shared/lib/deep-readonly'
 import type { AppSegmentConfig } from '../../build/segment-config/app/app-segment-config'
@@ -39,7 +38,6 @@ export interface WorkStore {
   forceDynamic?: boolean
   fetchCache?: AppSegmentConfig['fetchCache']
 
-  revalidateSegmentConfig?: Revalidate
   forceStatic?: boolean
   dynamicShouldError?: boolean
   pendingRevalidates?: Record<string, Promise<any>>

--- a/packages/next/src/client/components/work-unit-async-storage.external.ts
+++ b/packages/next/src/client/components/work-unit-async-storage.external.ts
@@ -72,17 +72,27 @@ export type PrerenderStoreModern = {
    * During some prerenders we want to track dynamic access.
    */
   readonly dynamicTracking: null | DynamicTrackingState
+
+  // Collected revalidate times and tags for this document during the prerender.
+  revalidate: number // in seconds. 0 means dynamic. INFINITE_CACHE and higher means never revalidate.
+  tags: null | string[]
 }
 
 export type PrerenderStorePPR = {
   type: 'prerender-ppr'
   pathname: string | undefined
   readonly dynamicTracking: null | DynamicTrackingState
+  // Collected revalidate times and tags for this document during the prerender.
+  revalidate: number // in seconds. 0 means dynamic. INFINITE_CACHE and higher means never revalidate.
+  tags: null | string[]
 }
 
 export type PrerenderStoreLegacy = {
   type: 'prerender-legacy'
   pathname: string | undefined
+  // Collected revalidate times and tags for this document during the prerender.
+  revalidate: number // in seconds. 0 means dynamic. INFINITE_CACHE and higher means never revalidate.
+  tags: null | string[]
 }
 
 export type PrerenderStore =
@@ -92,7 +102,9 @@ export type PrerenderStore =
 
 export type UseCacheStore = {
   type: 'cache'
-  // TODO: Inside this scope we'll track tags and life times of this scope.
+  // Collected revalidate times and tags for this cache entry during the cache render.
+  revalidate: number // in seconds. INFINITE_CACHE and higher means never revalidate.
+  tags: null | string[]
 }
 
 export type UnstableCacheStore = {

--- a/packages/next/src/client/components/work-unit-async-storage.external.ts
+++ b/packages/next/src/client/components/work-unit-async-storage.external.ts
@@ -36,6 +36,9 @@ export type RequestStore = {
   readonly draftMode: DraftModeProvider
   readonly isHmrRefresh?: boolean
   readonly serverComponentsHmrCache?: ServerComponentsHmrCache
+
+  // DEV-only
+  usedDynamic?: boolean
 }
 
 /**

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -49,7 +49,6 @@ import { isAppRouteRoute } from '../lib/is-app-route-route'
 import { isAppPageRoute } from '../lib/is-app-page-route'
 import isError from '../lib/is-error'
 import { formatManifest } from '../build/manifests/formatter/format-manifest'
-import { validateRevalidate } from '../server/lib/patch-fetch'
 import { TurborepoAccessTraceResult } from '../build/turborepo-access-trace'
 import { createProgress } from '../build/progress'
 import type { DeepReadonly } from '../shared/lib/deep-readonly'
@@ -599,7 +598,7 @@ async function exportAppImpl(
       // Update path info by path.
       const info = collector.byPath.get(path) ?? {}
       if (typeof result.revalidate !== 'undefined') {
-        info.revalidate = validateRevalidate(result.revalidate, path)
+        info.revalidate = result.revalidate
       }
       if (typeof result.metadata !== 'undefined') {
         info.metadata = result.metadata

--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -5,6 +5,7 @@ import type { IncrementalCache } from '../../server/lib/incremental-cache'
 
 import { join } from 'path'
 import {
+  INFINITE_CACHE,
   NEXT_BODY_SUFFIX,
   NEXT_CACHE_TAGS_HEADER,
   NEXT_META_SUFFIX,
@@ -119,12 +120,13 @@ export async function exportAppRoute(
 
     const blob = await response.blob()
     const revalidate =
-      typeof context.renderOpts.store?.revalidate === 'undefined'
+      typeof (context.renderOpts as any).collectedRevalidate === 'undefined' ||
+      (context.renderOpts as any).collectedRevalidate >= INFINITE_CACHE
         ? false
-        : context.renderOpts.store.revalidate
+        : (context.renderOpts as any).collectedRevalidate
 
     const headers = toNodeOutgoingHttpHeaders(response.headers)
-    const cacheTags = (context.renderOpts as any).fetchTags
+    const cacheTags = (context.renderOpts as any).collectedTags
 
     if (cacheTags) {
       headers[NEXT_CACHE_TAGS_HEADER] = cacheTags

--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -32,6 +32,11 @@ export const NEXT_CACHE_IMPLICIT_TAG_ID = '_N_T_'
 // in seconds
 export const CACHE_ONE_YEAR = 31536000
 
+// in seconds, represents revalidate=false. I.e. never revaliate.
+// We use this value since it can be represented as a V8 SMI for optimal performance.
+// It can also be serialized as JSON if it ever leaks accidentally as an actual value.
+export const INFINITE_CACHE = 0xfffffffe
+
 // Patterns to detect middleware files
 export const MIDDLEWARE_FILENAME = 'middleware'
 export const MIDDLEWARE_LOCATION_REGEXP = `(?:src/)?${MIDDLEWARE_FILENAME}`

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1133,8 +1133,8 @@ async function renderToHTMLOrFlightImpl(
 
     addImplicitTags(workStore, requestStore)
 
-    if (workStore.tags) {
-      metadata.fetchTags = workStore.tags.join(',')
+    if (response.collectedTags) {
+      metadata.fetchTags = response.collectedTags.join(',')
     }
 
     // If force static is specifically set to false, we should not revalidate
@@ -1143,7 +1143,8 @@ async function renderToHTMLOrFlightImpl(
       metadata.revalidate = 0
     } else {
       // Copy the revalidation value onto the render result metadata.
-      metadata.revalidate = workStore.revalidate ?? ctx.defaultRevalidate
+      metadata.revalidate =
+        response.collectedRevalidate ?? ctx.defaultRevalidate
     }
 
     // provide bailout info for debugging
@@ -1241,10 +1242,6 @@ async function renderToHTMLOrFlightImpl(
     }
 
     addImplicitTags(workStore, requestStore)
-
-    if (workStore.tags) {
-      metadata.fetchTags = workStore.tags.join(',')
-    }
 
     // Create the new render result for the response.
     return new RenderResult(stream, options)
@@ -1720,6 +1717,8 @@ type PrerenderToStreamResult = {
   digestErrorsMap: Map<string, DigestedError>
   ssrErrors: Array<unknown>
   dynamicTracking?: null | DynamicTrackingState
+  collectedRevalidate: number
+  collectedTags: null | string[]
 }
 
 /**
@@ -2127,6 +2126,9 @@ async function prerenderToStream(
               getServerInsertedHTML,
             }),
             dynamicTracking,
+            // TODO: Should this include the SSR pass?
+            collectedRevalidate: finalRenderPrerenderStore.revalidate,
+            collectedTags: finalRenderPrerenderStore.tags,
           }
         } else {
           // Static case
@@ -2179,6 +2181,9 @@ async function prerenderToStream(
               getServerInsertedHTML,
             }),
             dynamicTracking,
+            // TODO: Should this include the SSR pass?
+            collectedRevalidate: finalRenderPrerenderStore.revalidate,
+            collectedTags: finalRenderPrerenderStore.tags,
           }
         }
       } else {
@@ -2492,6 +2497,9 @@ async function prerenderToStream(
             validateRootLayout,
           }),
           dynamicTracking,
+          // TODO: Should this include the SSR pass?
+          collectedRevalidate: finalRenderPrerenderStore.revalidate,
+          collectedTags: finalRenderPrerenderStore.tags,
         }
       }
     } else if (renderOpts.experimental.isRoutePPREnabled) {
@@ -2617,6 +2625,9 @@ async function prerenderToStream(
             getServerInsertedHTML,
           }),
           dynamicTracking,
+          // TODO: Should this include the SSR pass?
+          collectedRevalidate: reactServerPrerenderStore.revalidate,
+          collectedTags: reactServerPrerenderStore.tags,
         }
       } else if (fallbackRouteParams && fallbackRouteParams.size > 0) {
         // Rendering the fallback case.
@@ -2629,6 +2640,9 @@ async function prerenderToStream(
             getServerInsertedHTML,
           }),
           dynamicTracking,
+          // TODO: Should this include the SSR pass?
+          collectedRevalidate: reactServerPrerenderStore.revalidate,
+          collectedTags: reactServerPrerenderStore.tags,
         }
       } else {
         // Static case
@@ -2682,6 +2696,9 @@ async function prerenderToStream(
             getServerInsertedHTML,
           }),
           dynamicTracking,
+          // TODO: Should this include the SSR pass?
+          collectedRevalidate: reactServerPrerenderStore.revalidate,
+          collectedTags: reactServerPrerenderStore.tags,
         }
       }
     } else {
@@ -2761,6 +2778,9 @@ async function prerenderToStream(
           getServerInsertedHTML,
           serverInsertedHTMLToHead: true,
         }),
+        // TODO: Should this include the SSR pass?
+        collectedRevalidate: prerenderLegacyStore.revalidate,
+        collectedTags: prerenderLegacyStore.tags,
       }
     }
   } catch (err) {
@@ -2912,6 +2932,9 @@ async function prerenderToStream(
           validateRootLayout,
         }),
         dynamicTracking: null,
+        // TODO: What should error state have as revalidate?
+        collectedRevalidate: 0,
+        collectedTags: null,
       }
     } catch (finalErr: any) {
       if (process.env.NODE_ENV === 'development' && isNotFoundError(finalErr)) {

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -157,6 +157,7 @@ import { CacheSignal } from './cache-signal'
 import { getTracedMetadata } from '../lib/trace/utils'
 
 import './clean-async-snapshot.external'
+import { INFINITE_CACHE } from '../../lib/constants'
 
 export type GetDynamicParamFromSegment = (
   // [slug] / [[slug]] / [...slug]
@@ -1139,11 +1140,11 @@ async function renderToHTMLOrFlightImpl(
     // If force static is specifically set to false, we should not revalidate
     // the page.
     if (workStore.forceStatic === false) {
-      workStore.revalidate = 0
+      metadata.revalidate = 0
+    } else {
+      // Copy the revalidation value onto the render result metadata.
+      metadata.revalidate = workStore.revalidate ?? ctx.defaultRevalidate
     }
-
-    // Copy the revalidation value onto the render result metadata.
-    metadata.revalidate = workStore.revalidate ?? ctx.defaultRevalidate
 
     // provide bailout info for debugging
     if (metadata.revalidate === 0) {
@@ -1872,6 +1873,8 @@ async function prerenderToStream(
           // because we will always do a final render after caches have filled and we
           // will track it again there
           dynamicTracking: null,
+          revalidate: INFINITE_CACHE,
+          tags: null,
         }
 
         let reactServerIsDynamic = false
@@ -1960,6 +1963,8 @@ async function prerenderToStream(
           // include the flight controller in the store.
           controller: flightController,
           dynamicTracking,
+          revalidate: INFINITE_CACHE,
+          tags: null,
         }
 
         function onPostpone(reason: string) {
@@ -2019,6 +2024,8 @@ async function prerenderToStream(
           // We do track dynamic access because searchParams and certain hooks can still be
           // dynamic during SSR
           dynamicTracking,
+          revalidate: INFINITE_CACHE,
+          tags: null,
         }
         let SSRIsDynamic = false
         function SSROnError(err: unknown, errorInfo: ErrorInfo) {
@@ -2223,6 +2230,8 @@ async function prerenderToStream(
           // consider the route dynamic.
           controller: flightController,
           dynamicTracking,
+          revalidate: INFINITE_CACHE,
+          tags: null,
         }
 
         const firstAttemptRSCPayload = await workUnitAsyncStorage.run(
@@ -2301,6 +2310,8 @@ async function prerenderToStream(
           cacheSignal: null,
           controller: flightController,
           dynamicTracking,
+          revalidate: INFINITE_CACHE,
+          tags: null,
         }
 
         const SSRController = new AbortController()
@@ -2316,6 +2327,8 @@ async function prerenderToStream(
           // We do track dynamic access because searchParams and certain hooks can still be
           // dynamic during SSR
           dynamicTracking,
+          revalidate: INFINITE_CACHE,
+          tags: null,
         }
 
         const finalAttemptRSCPayload = await workUnitAsyncStorage.run(
@@ -2490,6 +2503,8 @@ async function prerenderToStream(
         type: 'prerender-ppr',
         pathname: ctx.requestStore.url.pathname,
         dynamicTracking,
+        revalidate: INFINITE_CACHE,
+        tags: null,
       }
       const RSCPayload = await workUnitAsyncStorage.run(
         reactServerPrerenderStore,
@@ -2516,6 +2531,8 @@ async function prerenderToStream(
         type: 'prerender-ppr',
         pathname: ctx.requestStore.url.pathname,
         dynamicTracking,
+        revalidate: INFINITE_CACHE,
+        tags: null,
       }
 
       const prerender = require('react-dom/static.edge')
@@ -2671,6 +2688,8 @@ async function prerenderToStream(
       const prerenderLegacyStore: PrerenderStore = {
         type: 'prerender-legacy',
         pathname: ctx.requestStore.url.pathname,
+        revalidate: INFINITE_CACHE,
+        tags: null,
       }
       // This is a regular static generation. We don't do dynamic tracking because we rely on
       // the old-school dynamic error handling to bail out of static generation

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2857,6 +2857,8 @@ async function prerenderToStream(
     const prerenderLegacyStore: PrerenderStore = {
       type: 'prerender-legacy',
       pathname: ctx.requestStore.url.pathname,
+      revalidate: INFINITE_CACHE,
+      tags: null,
     }
     const errorRSCPayload = await workUnitAsyncStorage.run(
       prerenderLegacyStore,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -17,7 +17,6 @@ import type { NextParsedUrlQuery } from '../request-meta'
 import type { LoaderTree } from '../lib/app-dir-module'
 import type { AppPageModule } from '../route-modules/app-page/module'
 import type { ClientReferenceManifest } from '../../build/webpack/plugins/flight-manifest-plugin'
-import type { Revalidate } from '../lib/revalidate'
 import type { DeepReadonly } from '../../shared/lib/deep-readonly'
 import type { BaseNextRequest, BaseNextResponse } from '../base-http'
 import type { IncomingHttpHeaders } from 'http'
@@ -185,7 +184,6 @@ export type AppRenderContext = {
   appUsingSizeAdjustment: boolean
   flightRouterState?: FlightRouterState
   requestId: string
-  defaultRevalidate: Revalidate
   pagePath: string
   clientReferenceManifest: DeepReadonly<ClientReferenceManifest>
   assetPrefix: string
@@ -1051,7 +1049,6 @@ async function renderToHTMLOrFlightImpl(
     appUsingSizeAdjustment,
     flightRouterState,
     requestId,
-    defaultRevalidate: false,
     pagePath,
     clientReferenceManifest,
     assetPrefix,
@@ -1143,8 +1140,7 @@ async function renderToHTMLOrFlightImpl(
       metadata.revalidate = 0
     } else {
       // Copy the revalidation value onto the render result metadata.
-      metadata.revalidate =
-        response.collectedRevalidate ?? ctx.defaultRevalidate
+      metadata.revalidate = response.collectedRevalidate
     }
 
     // provide bailout info for debugging

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1140,7 +1140,10 @@ async function renderToHTMLOrFlightImpl(
       metadata.revalidate = 0
     } else {
       // Copy the revalidation value onto the render result metadata.
-      metadata.revalidate = response.collectedRevalidate
+      metadata.revalidate =
+        response.collectedRevalidate >= INFINITE_CACHE
+          ? false
+          : response.collectedRevalidate
     }
 
     // provide bailout info for debugging

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -243,11 +243,11 @@ async function createComponentTreeInternal({
     ctx.defaultRevalidate = layoutOrPageMod.revalidate as number
 
     if (
-      typeof workStore.revalidate === 'undefined' ||
-      (typeof workStore.revalidate === 'number' &&
-        workStore.revalidate > ctx.defaultRevalidate)
+      typeof workStore.revalidateSegmentConfig === 'undefined' ||
+      (typeof workStore.revalidateSegmentConfig === 'number' &&
+        workStore.revalidateSegmentConfig > ctx.defaultRevalidate)
     ) {
-      workStore.revalidate = ctx.defaultRevalidate
+      workStore.revalidateSegmentConfig = ctx.defaultRevalidate
     }
 
     if (

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -240,20 +240,20 @@ async function createComponentTreeInternal({
   }
 
   if (typeof layoutOrPageMod?.revalidate === 'number') {
-    ctx.defaultRevalidate = layoutOrPageMod.revalidate as number
+    const defaultRevalidate = layoutOrPageMod.revalidate as number
 
     if (
       typeof workStore.revalidateSegmentConfig === 'undefined' ||
       (typeof workStore.revalidateSegmentConfig === 'number' &&
-        workStore.revalidateSegmentConfig > ctx.defaultRevalidate)
+        workStore.revalidateSegmentConfig > defaultRevalidate)
     ) {
-      workStore.revalidateSegmentConfig = ctx.defaultRevalidate
+      workStore.revalidateSegmentConfig = defaultRevalidate
     }
 
     if (
       !workStore.forceStatic &&
       workStore.isStaticGeneration &&
-      ctx.defaultRevalidate === 0 &&
+      defaultRevalidate === 0 &&
       // If the postpone API isn't available, we can't postpone the render and
       // therefore we can't use the dynamic API.
       !experimental.isRoutePPREnabled

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -170,8 +170,13 @@ export function markCurrentScopeAsDynamic(
       store.dynamicUsageStack = err.stack
 
       throw err
+    } else if (
+      process.env.NODE_ENV === 'development' &&
+      workUnitStore &&
+      workUnitStore.type === 'request'
+    ) {
+      workUnitStore.usedDynamic = true
     }
-    // We fall through in all other cases to just tracking that something dynamic happened on the work store
   }
 }
 
@@ -251,6 +256,12 @@ export function trackDynamicDataAccessed(
       store.dynamicUsageStack = err.stack
 
       throw err
+    } else if (
+      process.env.NODE_ENV === 'development' &&
+      workUnitStore &&
+      workUnitStore.type === 'request'
+    ) {
+      workUnitStore.usedDynamic = true
     }
   }
 }
@@ -272,7 +283,7 @@ export function throwToInterruptStaticGeneration(
   )
 
   prerenderStore.revalidate = 0
- 
+
   store.dynamicUsageDescription = expression
   store.dynamicUsageStack = err.stack
 
@@ -305,6 +316,12 @@ export function trackDynamicDataInDynamicRender(
       workUnitStore.type === 'prerender-legacy'
     ) {
       workUnitStore.revalidate = 0
+    }
+    if (
+      process.env.NODE_ENV === 'development' &&
+      workUnitStore.type === 'request'
+    ) {
+      workUnitStore.usedDynamic = true
     }
   }
 }

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -160,7 +160,7 @@ export function markCurrentScopeAsDynamic(
         workUnitStore.dynamicTracking
       )
     } else if (workUnitStore.type === 'prerender-legacy') {
-      store.revalidate = 0
+      workUnitStore.revalidate = 0
 
       // We aren't prerendering but we are generating a static page. We need to bail out of static generation
       const err = new DynamicServerError(
@@ -173,7 +173,6 @@ export function markCurrentScopeAsDynamic(
     }
     // We fall through in all other cases to just tracking that something dynamic happened on the work store
   }
-  store.revalidate = 0
 }
 
 /**
@@ -243,7 +242,7 @@ export function trackDynamicDataAccessed(
       )
     } else if (workUnitStore.type === 'prerender-legacy') {
       // legacy Prerender
-      store.revalidate = 0
+      workUnitStore.revalidate = 0
 
       const err = new DynamicServerError(
         `Route ${store.route} couldn't be rendered statically because it used \`${expression}\`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
@@ -253,8 +252,6 @@ export function trackDynamicDataAccessed(
 
       throw err
     }
-  } else {
-    store.revalidate = 0
   }
 }
 
@@ -267,17 +264,15 @@ export function trackDynamicDataAccessed(
 export function throwToInterruptStaticGeneration(
   expression: string,
   store: WorkStore,
-  // We don't actually use this store but making it part of the function signature enforces
-  // that it is only called in contexts where we are in fact performing a legacy prerender
-  _prerenderStore: PrerenderStoreLegacy
+  prerenderStore: PrerenderStoreLegacy
 ): never {
   // We aren't prerendering but we are generating a static page. We need to bail out of static generation
   const err = new DynamicServerError(
     `Route ${store.route} couldn't be rendered statically because it used \`${expression}\`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
   )
 
-  store.revalidate = 0
-
+  prerenderStore.revalidate = 0
+ 
   store.dynamicUsageDescription = expression
   store.dynamicUsageStack = err.stack
 
@@ -292,7 +287,7 @@ export function throwToInterruptStaticGeneration(
  * @internal
  */
 export function trackDynamicDataInDynamicRender(
-  store: WorkStore,
+  _store: WorkStore,
   workUnitStore: void | WorkUnitStore
 ) {
   if (workUnitStore) {
@@ -305,8 +300,13 @@ export function trackDynamicDataInDynamicRender(
       // forbidden inside a cache scope.
       return
     }
+    if (
+      workUnitStore.type === 'prerender' ||
+      workUnitStore.type === 'prerender-legacy'
+    ) {
+      workUnitStore.revalidate = 0
+    }
   }
-  store.revalidate = 0
 }
 
 // Despite it's name we don't actually abort unless we have a controller to call abort on

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -145,7 +145,7 @@ export interface RenderOptsPartial {
   nextFontManifest?: DeepReadonly<NextFontManifest>
   isBot?: boolean
   incrementalCache?: import('../lib/incremental-cache').IncrementalCache
-  setAppIsrStatus?: (key: string, value: false | number | null) => void
+  setAppIsrStatus?: (key: string, value: boolean | null) => void
   isRevalidate?: boolean
   nextExport?: boolean
   nextConfigOutput?: 'standalone' | 'export'

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -130,6 +130,7 @@ import {
 } from './web/utils'
 import {
   CACHE_ONE_YEAR,
+  INFINITE_CACHE,
   NEXT_CACHE_TAGS_HEADER,
   NEXT_RESUME_HEADER,
 } from '../lib/constants'
@@ -2526,7 +2527,7 @@ export default abstract class Server<
               context.renderOpts as any
             ).fetchMetrics
 
-            const cacheTags = (context.renderOpts as any).fetchTags
+            const cacheTags = (context.renderOpts as any).collectedTags
 
             // If the request is for a static response, we can cache it so long
             // as it's not edge.
@@ -2544,7 +2545,13 @@ export default abstract class Server<
                 headers['content-type'] = blob.type
               }
 
-              const revalidate = context.renderOpts.store?.revalidate ?? false
+              const revalidate =
+                typeof (context.renderOpts as any).collectedRevalidate ===
+                  'undefined' ||
+                (context.renderOpts as any).collectedRevalidate >=
+                  INFINITE_CACHE
+                  ? false
+                  : (context.renderOpts as any).collectedRevalidate
 
               // Create the cache entry for the response.
               const cacheEntry: ResponseCacheEntry = {

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -111,7 +111,7 @@ export interface TurbopackConnectedAction {
 
 export interface AppIsrManifestAction {
   action: HMR_ACTIONS_SENT_TO_BROWSER.APP_ISR_MANIFEST
-  data: Record<string, false | number>
+  data: Record<string, boolean>
 }
 
 export type HMR_ACTION_TYPES =

--- a/packages/next/src/server/lib/dev-bundler-service.ts
+++ b/packages/next/src/server/lib/dev-bundler-service.ts
@@ -14,8 +14,8 @@ export class DevBundlerService {
   // can't leverage LRU type directly here as it
   // isn't a direct dependency
   public appIsrManifestInner: {
-    get(key: string): number | false
-    set(key: string, value: number | false): void
+    get(key: string): boolean
+    set(key: string, value: boolean): void
     del(key: string): void
     keys(): string[]
   }
@@ -92,17 +92,15 @@ export class DevBundlerService {
   }
 
   public get appIsrManifest() {
-    const serializableManifest: Record<string, false | number> = {}
+    const serializableManifest: Record<string, boolean> = {}
 
     for (const key of this.appIsrManifestInner.keys() as string[]) {
-      serializableManifest[key] = this.appIsrManifestInner.get(key) as
-        | false
-        | number
+      serializableManifest[key] = this.appIsrManifestInner.get(key) as boolean
     }
     return serializableManifest
   }
 
-  public setAppIsrStatus(key: string, value: false | number | null) {
+  public setAppIsrStatus(key: string, value: boolean | null) {
     if (value === null) {
       this.appIsrManifestInner.del(key)
     } else {

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -138,34 +138,20 @@ const getDerivedTags = (pathname: string): string[] => {
   return derivedTags
 }
 
-export function addImplicitTags(
+export function getImplicitTags(
   workStore: WorkStore,
   workUnitStore: WorkUnitStore | undefined
 ) {
+  // TODO: Cache the result
   const newTags: string[] = []
   const { page, fallbackRouteParams } = workStore
   const hasFallbackRouteParams =
     fallbackRouteParams && fallbackRouteParams.size > 0
 
-  // Init the tags array if it doesn't exist.
-  let collectedTags: null | string[] = null
-  if (
-    workUnitStore &&
-    (workUnitStore.type === 'cache' ||
-      workUnitStore.type === 'prerender' ||
-      workUnitStore.type === 'prerender-legacy')
-  ) {
-    // Collect tags onto parent caches or parent prerenders.
-    collectedTags = workUnitStore.tags ?? (workUnitStore.tags = [])
-  }
-
   // Add the derived tags from the page.
   const derivedTags = getDerivedTags(page)
   for (let tag of derivedTags) {
     tag = `${NEXT_CACHE_IMPLICIT_TAG_ID}${tag}`
-    if (collectedTags !== null && collectedTags.includes(tag)) {
-      collectedTags.push(tag)
-    }
     newTags.push(tag)
   }
 
@@ -184,9 +170,6 @@ export function addImplicitTags(
   // want to add the pathname as a tag, as it will be invalid.
   if (renderedPathname && !hasFallbackRouteParams) {
     const tag = `${NEXT_CACHE_IMPLICIT_TAG_ID}${renderedPathname}`
-    if (collectedTags !== null && collectedTags.includes(tag)) {
-      collectedTags.push(tag)
-    }
     newTags.push(tag)
   }
 
@@ -339,7 +322,7 @@ export function createPatchedFetcher(
           }
         }
 
-        const implicitTags = addImplicitTags(workStore, workUnitStore)
+        const implicitTags = getImplicitTags(workStore, workUnitStore)
 
         // Inside unstable-cache we treat it the same as force-no-store on the page.
         const pageFetchCacheMode =

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -550,9 +550,6 @@ export function createPatchedFetcher(
         const fetchIdx = workStore.nextFetchId ?? 1
         workStore.nextFetchId = fetchIdx + 1
 
-        const normalizedRevalidate =
-          typeof finalRevalidate !== 'number' ? CACHE_ONE_YEAR : finalRevalidate
-
         let handleUnlock = () => Promise.resolve()
 
         const doOriginalFetch = async (
@@ -625,6 +622,13 @@ export function createPatchedFetcher(
               cacheKey &&
               (isCacheableRevalidate || requestStore?.serverComponentsHmrCache)
             ) {
+              const normalizedRevalidate =
+                finalRevalidate >= INFINITE_CACHE
+                  ? CACHE_ONE_YEAR
+                  : finalRevalidate
+              const externalRevalidate =
+                finalRevalidate >= INFINITE_CACHE ? false : finalRevalidate
+
               if (workUnitStore && workUnitStore.type === 'prerender') {
                 // We are prerendering at build time or revalidate time with dynamicIO so we need to
                 // buffer the response so we can guarantee it can be read in a microtask
@@ -650,7 +654,7 @@ export function createPatchedFetcher(
                   },
                   {
                     fetchCache: true,
-                    revalidate: finalRevalidate,
+                    revalidate: externalRevalidate,
                     fetchUrl,
                     fetchIdx,
                     tags,
@@ -696,7 +700,7 @@ export function createPatchedFetcher(
                         },
                         {
                           fetchCache: true,
-                          revalidate: finalRevalidate,
+                          revalidate: externalRevalidate,
                           fetchUrl,
                           fetchIdx,
                           tags,

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -123,7 +123,7 @@ export type ServerFields = {
   interceptionRoutes?: ReturnType<
     typeof import('./filesystem').buildCustomRoute
   >[]
-  setAppIsrStatus?: (key: string, value: false | number | null) => void
+  setAppIsrStatus?: (key: string, value: boolean) => void
   resetFetch?: () => void
 }
 

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -313,188 +313,199 @@ export class AppRouteRouteModule extends RouteModule<
 
     let res: unknown
     try {
-      if (isStaticGeneration && dynamicIOEnabled) {
-        /**
-         * When we are attempting to statically prerender the GET handler of a route.ts module
-         * and dynamicIO is on we follow a similar pattern to rendering.
-         *
-         * We first run the handler letting caches fill. If something synchronously dynamic occurs
-         * during this prospective render then we can infer it will happen on every render and we
-         * just bail out of prerendering.
-         *
-         * Next we run the handler again and we check if we get a result back in a microtask.
-         * Next.js expects the return value to be a Response or a Thenable that resolves to a Response.
-         * Unfortunately Response's do not allow for acessing the response body synchronously or in
-         * a microtask so we need to allow one more task to unwrap the response body. This is a slightly
-         * different semantic than what we have when we render and it means that certain tasks can still
-         * execute before a prerender completes such as a carefully timed setImmediate.
-         *
-         * Functionally though IO should still take longer than the time it takes to unwrap the response body
-         * so our heuristic of excluding any IO should be preserved.
-         */
-        const prospectiveController = new AbortController()
-        let prospectiveRenderIsDynamic = false
-        const cacheSignal = new CacheSignal()
-        let dynamicTracking = createDynamicTrackingState(undefined)
+      if (isStaticGeneration) {
+        const userlandRevalidate = this.userland.revalidate
+        const defaultRevalidate: number =
+          // If the static generation store does not have a revalidate value
+          // set, then we should set it the revalidate value from the userland
+          // module or default to false.
+          userlandRevalidate === false || userlandRevalidate === undefined
+            ? INFINITE_CACHE
+            : userlandRevalidate
 
-        const prospectiveRoutePrerenderStore: PrerenderStore = (prerenderStore =
-          {
+        if (dynamicIOEnabled) {
+          /**
+           * When we are attempting to statically prerender the GET handler of a route.ts module
+           * and dynamicIO is on we follow a similar pattern to rendering.
+           *
+           * We first run the handler letting caches fill. If something synchronously dynamic occurs
+           * during this prospective render then we can infer it will happen on every render and we
+           * just bail out of prerendering.
+           *
+           * Next we run the handler again and we check if we get a result back in a microtask.
+           * Next.js expects the return value to be a Response or a Thenable that resolves to a Response.
+           * Unfortunately Response's do not allow for acessing the response body synchronously or in
+           * a microtask so we need to allow one more task to unwrap the response body. This is a slightly
+           * different semantic than what we have when we render and it means that certain tasks can still
+           * execute before a prerender completes such as a carefully timed setImmediate.
+           *
+           * Functionally though IO should still take longer than the time it takes to unwrap the response body
+           * so our heuristic of excluding any IO should be preserved.
+           */
+          const prospectiveController = new AbortController()
+          let prospectiveRenderIsDynamic = false
+          const cacheSignal = new CacheSignal()
+          let dynamicTracking = createDynamicTrackingState(undefined)
+
+          const prospectiveRoutePrerenderStore: PrerenderStore =
+            (prerenderStore = {
+              type: 'prerender',
+              renderSignal: prospectiveController.signal,
+              pathname,
+              cacheSignal,
+              // During prospective render we don't use a controller
+              // because we need to let all caches fill.
+              controller: null,
+              dynamicTracking,
+              revalidate: defaultRevalidate,
+              tags: null,
+            })
+          let prospectiveResult
+          try {
+            prospectiveResult = this.workUnitAsyncStorage.run(
+              prospectiveRoutePrerenderStore,
+              handler,
+              request,
+              handlerContext
+            )
+          } catch (err) {
+            if (isPrerenderInterruptedError(err)) {
+              // the route handler called an API which is always dynamic
+              // there is no need to try again
+              prospectiveRenderIsDynamic = true
+            }
+          }
+          if (
+            typeof prospectiveResult === 'object' &&
+            prospectiveResult !== null &&
+            typeof (prospectiveResult as any).then === 'function'
+          ) {
+            // The handler returned a Thenable. We'll listen for rejections to determine
+            // if the route is erroring for dynamic reasons.
+            ;(prospectiveResult as any as Promise<unknown>).then(
+              () => {},
+              (err) => {
+                if (isPrerenderInterruptedError(err)) {
+                  // the route handler called an API which is always dynamic
+                  // there is no need to try again
+                  prospectiveRenderIsDynamic = true
+                }
+              }
+            )
+          }
+          await cacheSignal.cacheReady()
+
+          if (prospectiveRenderIsDynamic) {
+            // the route handler called an API which is always dynamic
+            // there is no need to try again
+            const dynamicReason = getFirstDynamicReason(dynamicTracking)
+            if (dynamicReason) {
+              throw new DynamicServerError(
+                `Route ${workStore.route} couldn't be rendered statically because it used \`${dynamicReason}\`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
+              )
+            } else {
+              console.error(
+                'Expected Next.js to keep track of reason for opting out of static rendering but one was not found. This is a bug in Next.js'
+              )
+              throw new DynamicServerError(
+                `Route ${workStore.route} couldn't be rendered statically because it used a dynamic API. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
+              )
+            }
+          }
+
+          // TODO start passing this controller to the route handler. We should expose
+          // it so the handler to abort inflight requests and other operations if we abort
+          // the prerender.
+          const finalController = new AbortController()
+          dynamicTracking = createDynamicTrackingState(undefined)
+
+          const finalRoutePrerenderStore: PrerenderStore = (prerenderStore = {
             type: 'prerender',
-            renderSignal: prospectiveController.signal,
+            renderSignal: finalController.signal,
             pathname,
-            cacheSignal,
-            // During prospective render we don't use a controller
-            // because we need to let all caches fill.
-            controller: null,
+            cacheSignal: null,
+            controller: finalController,
             dynamicTracking,
-            revalidate: INFINITE_CACHE,
+            revalidate: defaultRevalidate,
             tags: null,
           })
-        let prospectiveResult
-        try {
-          prospectiveResult = this.workUnitAsyncStorage.run(
-            prospectiveRoutePrerenderStore,
+
+          let responseHandled = false
+          res = await new Promise((resolve, reject) => {
+            scheduleImmediate(async () => {
+              try {
+                const result = await (this.workUnitAsyncStorage.run(
+                  finalRoutePrerenderStore,
+                  handler,
+                  request,
+                  handlerContext
+                ) as Promise<Response>)
+                if (responseHandled) {
+                  // we already rejected in the followup task
+                  return
+                } else if (!(result instanceof Response)) {
+                  // This is going to error but we let that happen below
+                  resolve(result)
+                  return
+                }
+
+                responseHandled = true
+
+                let bodyHandled = false
+                result.arrayBuffer().then((body) => {
+                  if (!bodyHandled) {
+                    bodyHandled = true
+
+                    resolve(
+                      new Response(body, {
+                        headers: result.headers,
+                        status: result.status,
+                        statusText: result.statusText,
+                      })
+                    )
+                  }
+                }, reject)
+                scheduleImmediate(() => {
+                  if (!bodyHandled) {
+                    bodyHandled = true
+                    finalController.abort()
+                    reject(createDynamicIOError(workStore.route))
+                  }
+                })
+              } catch (err) {
+                reject(err)
+              }
+            })
+            scheduleImmediate(() => {
+              if (!responseHandled) {
+                responseHandled = true
+                finalController.abort()
+                reject(createDynamicIOError(workStore.route))
+              }
+            })
+          })
+          if (finalController.signal.aborted) {
+            // We aborted from within the execution
+            throw createDynamicIOError(workStore.route)
+          } else {
+            // We didn't abort during the execution. We can abort now as a matter of semantics
+            // though at the moment nothing actually consumes this signal so it won't halt any
+            // inflight work.
+            finalController.abort()
+          }
+        } else {
+          res = await workUnitAsyncStorage.run(
+            (prerenderStore = {
+              type: 'prerender-legacy',
+              pathname,
+              revalidate: defaultRevalidate,
+              tags: null,
+            }),
             handler,
             request,
             handlerContext
           )
-        } catch (err) {
-          if (isPrerenderInterruptedError(err)) {
-            // the route handler called an API which is always dynamic
-            // there is no need to try again
-            prospectiveRenderIsDynamic = true
-          }
         }
-        if (
-          typeof prospectiveResult === 'object' &&
-          prospectiveResult !== null &&
-          typeof (prospectiveResult as any).then === 'function'
-        ) {
-          // The handler returned a Thenable. We'll listen for rejections to determine
-          // if the route is erroring for dynamic reasons.
-          ;(prospectiveResult as any as Promise<unknown>).then(
-            () => {},
-            (err) => {
-              if (isPrerenderInterruptedError(err)) {
-                // the route handler called an API which is always dynamic
-                // there is no need to try again
-                prospectiveRenderIsDynamic = true
-              }
-            }
-          )
-        }
-        await cacheSignal.cacheReady()
-
-        if (prospectiveRenderIsDynamic) {
-          // the route handler called an API which is always dynamic
-          // there is no need to try again
-          const dynamicReason = getFirstDynamicReason(dynamicTracking)
-          if (dynamicReason) {
-            throw new DynamicServerError(
-              `Route ${workStore.route} couldn't be rendered statically because it used \`${dynamicReason}\`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
-            )
-          } else {
-            console.error(
-              'Expected Next.js to keep track of reason for opting out of static rendering but one was not found. This is a bug in Next.js'
-            )
-            throw new DynamicServerError(
-              `Route ${workStore.route} couldn't be rendered statically because it used a dynamic API. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
-            )
-          }
-        }
-
-        // TODO start passing this controller to the route handler. We should expose
-        // it so the handler to abort inflight requests and other operations if we abort
-        // the prerender.
-        const finalController = new AbortController()
-        dynamicTracking = createDynamicTrackingState(undefined)
-
-        const finalRoutePrerenderStore: PrerenderStore = (prerenderStore = {
-          type: 'prerender',
-          renderSignal: finalController.signal,
-          pathname,
-          cacheSignal: null,
-          controller: finalController,
-          dynamicTracking,
-          revalidate: INFINITE_CACHE,
-          tags: null,
-        })
-
-        let responseHandled = false
-        res = await new Promise((resolve, reject) => {
-          scheduleImmediate(async () => {
-            try {
-              const result = await (this.workUnitAsyncStorage.run(
-                finalRoutePrerenderStore,
-                handler,
-                request,
-                handlerContext
-              ) as Promise<Response>)
-              if (responseHandled) {
-                // we already rejected in the followup task
-                return
-              } else if (!(result instanceof Response)) {
-                // This is going to error but we let that happen below
-                resolve(result)
-                return
-              }
-
-              responseHandled = true
-
-              let bodyHandled = false
-              result.arrayBuffer().then((body) => {
-                if (!bodyHandled) {
-                  bodyHandled = true
-
-                  resolve(
-                    new Response(body, {
-                      headers: result.headers,
-                      status: result.status,
-                      statusText: result.statusText,
-                    })
-                  )
-                }
-              }, reject)
-              scheduleImmediate(() => {
-                if (!bodyHandled) {
-                  bodyHandled = true
-                  finalController.abort()
-                  reject(createDynamicIOError(workStore.route))
-                }
-              })
-            } catch (err) {
-              reject(err)
-            }
-          })
-          scheduleImmediate(() => {
-            if (!responseHandled) {
-              responseHandled = true
-              finalController.abort()
-              reject(createDynamicIOError(workStore.route))
-            }
-          })
-        })
-        if (finalController.signal.aborted) {
-          // We aborted from within the execution
-          throw createDynamicIOError(workStore.route)
-        } else {
-          // We didn't abort during the execution. We can abort now as a matter of semantics
-          // though at the moment nothing actually consumes this signal so it won't halt any
-          // inflight work.
-          finalController.abort()
-        }
-      } else if (isStaticGeneration) {
-        res = await workUnitAsyncStorage.run(
-          (prerenderStore = {
-            type: 'prerender-legacy',
-            pathname,
-            revalidate: INFINITE_CACHE,
-            tags: null,
-          }),
-          handler,
-          request,
-          handlerContext
-        )
       } else {
         res = await handler(request, handlerContext)
       }
@@ -631,13 +642,6 @@ export class AppRouteRouteModule extends RouteModule<
                     workStore.dynamicUsageDescription = err.message
                     workStore.dynamicUsageStack = err.stack
                     throw err
-                  } else {
-                    // We aren't statically generating but since this route has non-static methods
-                    // we still need to set the default caching to no cache by setting revalidate = 0
-                    // @TODO this type of logic is too indirect. we need to refactor how we set fetch cache
-                    // behavior. Prior to the most recent refactor this logic was buried deep in staticGenerationBailout
-                    // so it is possible it was unintentional and then tests were written to assert the current behavior
-                    workStore.revalidateSegmentConfig = 0
                   }
                 }
 
@@ -671,12 +675,6 @@ export class AppRouteRouteModule extends RouteModule<
                     // We proxy `NextRequest` to track dynamic access, and potentially bail out of static generation
                     request = proxyNextRequest(req, workStore)
                 }
-
-                // If the static generation store does not have a revalidate value
-                // set, then we should set it the revalidate value from the userland
-                // module or default to false.
-                workStore.revalidateSegmentConfig ??=
-                  this.userland.revalidate ?? false
 
                 // TODO: propagate this pathname from route matcher
                 const route = getPathnameFromAbsolutePath(this.resolvedPagePath)

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -76,6 +76,7 @@ import {
 } from '../../../client/components/redirect'
 import { isNotFoundError } from '../../../client/components/not-found'
 import { RedirectStatusCode } from '../../../client/components/redirect-status-code'
+import { INFINITE_CACHE } from '../../../lib/constants'
 
 export class WrappedNextRouterError {
   constructor(
@@ -343,6 +344,8 @@ export class AppRouteRouteModule extends RouteModule<
           // because we need to let all caches fill.
           controller: null,
           dynamicTracking,
+          revalidate: INFINITE_CACHE,
+          tags: null,
         }
         let prospectiveResult
         try {
@@ -410,6 +413,8 @@ export class AppRouteRouteModule extends RouteModule<
           cacheSignal: null,
           controller: finalController,
           dynamicTracking,
+          revalidate: INFINITE_CACHE,
+          tags: null,
         }
 
         let responseHandled = false
@@ -480,6 +485,8 @@ export class AppRouteRouteModule extends RouteModule<
           {
             type: 'prerender-legacy',
             pathname,
+            revalidate: INFINITE_CACHE,
+            tags: null,
           },
           handler,
           request,
@@ -622,7 +629,7 @@ export class AppRouteRouteModule extends RouteModule<
                     // @TODO this type of logic is too indirect. we need to refactor how we set fetch cache
                     // behavior. Prior to the most recent refactor this logic was buried deep in staticGenerationBailout
                     // so it is possible it was unintentional and then tests were written to assert the current behavior
-                    workStore.revalidate = 0
+                    workStore.revalidateSegmentConfig = 0
                   }
                 }
 
@@ -660,7 +667,8 @@ export class AppRouteRouteModule extends RouteModule<
                 // If the static generation store does not have a revalidate value
                 // set, then we should set it the revalidate value from the userland
                 // module or default to false.
-                workStore.revalidate ??= this.userland.revalidate ?? false
+                workStore.revalidateSegmentConfig ??=
+                  this.userland.revalidate ?? false
 
                 // TODO: propagate this pathname from route matcher
                 const route = getPathnameFromAbsolutePath(this.resolvedPagePath)

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -24,6 +24,7 @@ import {
   getClientReferenceManifestSingleton,
   getServerModuleMap,
 } from '../app-render/encryption-utils'
+import { INFINITE_CACHE } from '../../lib/constants'
 
 const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'
 
@@ -135,7 +136,11 @@ function generateCacheEntryWithCacheContext(
   fn: any
 ) {
   // Initialize the Store for this Cache entry.
-  const cacheStore: UseCacheStore = { type: 'cache' }
+  const cacheStore: UseCacheStore = {
+    type: 'cache',
+    revalidate: INFINITE_CACHE,
+    tags: null,
+  }
   return workUnitAsyncStorage.run(
     cacheStore,
     generateCacheEntryImpl,

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -161,6 +161,7 @@ export function unstable_cache<T extends Callback>(
           workUnitStore &&
           (workUnitStore.type === 'cache' ||
             workUnitStore.type === 'prerender' ||
+            workUnitStore.type === 'prerender-ppr' ||
             workUnitStore.type === 'prerender-legacy')
         ) {
           // options.revalidate === undefined doesn't affect timing.

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -2,7 +2,7 @@ import type { IncrementalCache } from '../../lib/incremental-cache'
 
 import { CACHE_ONE_YEAR } from '../../../lib/constants'
 import {
-  addImplicitTags,
+  getImplicitTags,
   validateRevalidate,
   validateTags,
 } from '../../lib/patch-fetch'
@@ -187,9 +187,7 @@ export function unstable_cache<T extends Callback>(
           }
         }
 
-        // @TODO check on this API. addImplicitTags mutates the store and returns the implicit tags. The naming
-        // of this function is potentially a little confusing
-        const implicitTags = addImplicitTags(workStore, workUnitStore)
+        const implicitTags = getImplicitTags(workStore, workUnitStore)
 
         const isNestedUnstableCache =
           workUnitStore && workUnitStore.type === 'unstable-cache'
@@ -301,10 +299,8 @@ export function unstable_cache<T extends Callback>(
         if (!incrementalCache.isOnDemandRevalidate) {
           // We aren't doing an on demand revalidation so we check use the cache if valid
 
-          // @TODO check on this API. addImplicitTags mutates the store and returns the implicit tags. The naming
-          // of this function is potentially a little confusing
           const implicitTags =
-            workStore && addImplicitTags(workStore, workUnitStore)
+            workStore && getImplicitTags(workStore, workUnitStore)
 
           const cacheEntry = await incrementalCache.get(cacheKey, {
             kind: IncrementalCacheKind.FETCH,

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -152,54 +152,51 @@ export function unstable_cache<T extends Callback>(
       if (workStore) {
         workStore.nextFetchId = fetchIdx + 1
 
-        const isNestedCache =
-          workUnitStore &&
-          (workUnitStore.type === 'unstable-cache' ||
-            workUnitStore.type === 'cache')
-
         // We are in an App Router context. We try to return the cached entry if it exists and is valid
         // If the entry is fresh we return it. If the entry is stale we return it but revalidate the entry in
         // the background. If the entry is missing or invalid we generate a new entry and return it.
 
         // We update the store's revalidate property if the option.revalidate is a higher precedence
-        if (!isNestedCache) {
+        if (
+          workUnitStore &&
+          (workUnitStore.type === 'cache' ||
+            workUnitStore.type === 'prerender' ||
+            workUnitStore.type === 'prerender-legacy')
+        ) {
+          // options.revalidate === undefined doesn't affect timing.
+          // options.revalidate === false doesn't shrink timing. it stays at the maximum.
           if (typeof options.revalidate === 'number') {
-            if (
-              typeof workStore.revalidate === 'number' &&
-              workStore.revalidate < options.revalidate
-            ) {
+            if (workUnitStore.revalidate < options.revalidate) {
               // The store is already revalidating on a shorter time interval, leave it alone
             } else {
-              workStore.revalidate = options.revalidate
+              workUnitStore.revalidate = options.revalidate
             }
-          } else if (
-            options.revalidate === false &&
-            typeof workStore.revalidate === 'undefined'
-          ) {
-            // The store has not defined revalidate type so we can use the false option
-            workStore.revalidate = options.revalidate
           }
 
           // We need to accumulate the tags for this invocation within the store
-          if (!workStore.tags) {
-            workStore.tags = tags.slice()
+          const collectedTags = workUnitStore.tags
+          if (collectedTags === null) {
+            workUnitStore.tags = tags.slice()
           } else {
             for (const tag of tags) {
               // @TODO refactor tags to be a set to avoid this O(n) lookup
-              if (!workStore.tags.includes(tag)) {
-                workStore.tags.push(tag)
+              if (!collectedTags.includes(tag)) {
+                collectedTags.push(tag)
               }
             }
           }
         }
+
         // @TODO check on this API. addImplicitTags mutates the store and returns the implicit tags. The naming
         // of this function is potentially a little confusing
         const implicitTags = addImplicitTags(workStore, workUnitStore)
 
+        const isNestedUnstableCache =
+          workUnitStore && workUnitStore.type === 'unstable-cache'
         if (
           // when we are nested inside of other unstable_cache's
           // we should bypass cache similar to fetches
-          !isNestedCache &&
+          !isNestedUnstableCache &&
           workStore.fetchCache !== 'force-no-store' &&
           !workStore.isOnDemandRevalidate &&
           !incrementalCache.isOnDemandRevalidate &&

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -1648,7 +1648,7 @@ describe('app-dir static/dynamic handling', () => {
             ],
             "initialHeaders": {
               "content-type": "application/json",
-              "x-next-cache-tags": "thankyounext,_N_T_/layout,_N_T_/route-handler/layout,_N_T_/route-handler/revalidate-360-isr/layout,_N_T_/route-handler/revalidate-360-isr/route,_N_T_/route-handler/revalidate-360-isr",
+              "x-next-cache-tags": "_N_T_/layout,_N_T_/route-handler/layout,_N_T_/route-handler/revalidate-360-isr/layout,_N_T_/route-handler/revalidate-360-isr/route,_N_T_/route-handler/revalidate-360-isr,thankyounext",
             },
             "initialRevalidateSeconds": 10,
             "srcRoute": "/route-handler/revalidate-360-isr",

--- a/test/production/standalone-mode/required-server-files/required-server-files-app.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-app.test.ts
@@ -163,19 +163,19 @@ describe('required server files app router', () => {
     for (const [path, tags] of [
       [
         '/isr/first',
-        'isr-page,_N_T_/layout,_N_T_/isr/layout,_N_T_/isr/[slug]/layout,_N_T_/isr/[slug]/page,_N_T_/isr/first',
+        '_N_T_/layout,_N_T_/isr/layout,_N_T_/isr/[slug]/layout,_N_T_/isr/[slug]/page,_N_T_/isr/first,isr-page',
       ],
       [
         '/isr/second',
-        'isr-page,_N_T_/layout,_N_T_/isr/layout,_N_T_/isr/[slug]/layout,_N_T_/isr/[slug]/page,_N_T_/isr/second',
+        '_N_T_/layout,_N_T_/isr/layout,_N_T_/isr/[slug]/layout,_N_T_/isr/[slug]/page,_N_T_/isr/second,isr-page',
       ],
       [
         '/api/isr/first',
-        'isr-page,_N_T_/layout,_N_T_/api/layout,_N_T_/api/isr/layout,_N_T_/api/isr/[slug]/layout,_N_T_/api/isr/[slug]/route,_N_T_/api/isr/first',
+        '_N_T_/layout,_N_T_/api/layout,_N_T_/api/isr/layout,_N_T_/api/isr/[slug]/layout,_N_T_/api/isr/[slug]/route,_N_T_/api/isr/first,isr-page',
       ],
       [
         '/api/isr/second',
-        'isr-page,_N_T_/layout,_N_T_/api/layout,_N_T_/api/isr/layout,_N_T_/api/isr/[slug]/layout,_N_T_/api/isr/[slug]/route,_N_T_/api/isr/second',
+        '_N_T_/layout,_N_T_/api/layout,_N_T_/api/isr/layout,_N_T_/api/isr/[slug]/layout,_N_T_/api/isr/[slug]/route,_N_T_/api/isr/second,isr-page',
       ],
     ]) {
       require('console').error('checking', { path, tags })

--- a/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
@@ -292,19 +292,19 @@ describe('required server files app router', () => {
     for (const [path, tags] of [
       [
         '/isr/first',
-        'isr-page,_N_T_/layout,_N_T_/isr/layout,_N_T_/isr/[slug]/layout,_N_T_/isr/[slug]/page,_N_T_/isr/first',
+        '_N_T_/layout,_N_T_/isr/layout,_N_T_/isr/[slug]/layout,_N_T_/isr/[slug]/page,_N_T_/isr/first,isr-page',
       ],
       [
         '/isr/second',
-        'isr-page,_N_T_/layout,_N_T_/isr/layout,_N_T_/isr/[slug]/layout,_N_T_/isr/[slug]/page,_N_T_/isr/second',
+        '_N_T_/layout,_N_T_/isr/layout,_N_T_/isr/[slug]/layout,_N_T_/isr/[slug]/page,_N_T_/isr/second,isr-page',
       ],
       [
         '/api/isr/first',
-        'isr-page,_N_T_/layout,_N_T_/api/layout,_N_T_/api/isr/layout,_N_T_/api/isr/[slug]/layout,_N_T_/api/isr/[slug]/route,_N_T_/api/isr/first',
+        '_N_T_/layout,_N_T_/api/layout,_N_T_/api/isr/layout,_N_T_/api/isr/[slug]/layout,_N_T_/api/isr/[slug]/route,_N_T_/api/isr/first,isr-page',
       ],
       [
         '/api/isr/second',
-        'isr-page,_N_T_/layout,_N_T_/api/layout,_N_T_/api/isr/layout,_N_T_/api/isr/[slug]/layout,_N_T_/api/isr/[slug]/route,_N_T_/api/isr/second',
+        '_N_T_/layout,_N_T_/api/layout,_N_T_/api/isr/layout,_N_T_/api/isr/[slug]/layout,_N_T_/api/isr/[slug]/route,_N_T_/api/isr/second,isr-page',
       ],
     ]) {
       require('console').error('checking', { path, tags })


### PR DESCRIPTION
This allows to have individually track the tags / revalidate for each scope - such as the smallest revalidate number within a cache scope. Instead of the whole page.

Currently, we don't use the collected revalidate/tags for a dynamic render so the RequestStore doesn't collect them. Only the Prerender and Cache store. Also not unstable_cache since it doesn't have nested caches.

Instead of using `false` to mean don't cache, I use a very large number to mean "Infinity". This is the largest SMI. I.e. 31-bit signed integer. Which ensures that we're not deopting into Floats in V8. This number is also serializable through JSON so if we leak it, it still makes sense.

