### PR TITLE
[Turbopack] make filesystem tasks session dependent instead of invalidating on startup

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -223,7 +223,9 @@ impl ProjectContainer {
         let project = self.project();
         let project_fs = project.project_fs().strongly_consistent().await?;
         if watch.enable {
-            project_fs.start_watching_with_invalidation_reason(watch.poll_interval)?;
+            project_fs
+                .start_watching_with_invalidation_reason(watch.poll_interval)
+                .await?;
         } else {
             project_fs.invalidate_with_reason();
         }
@@ -304,7 +306,9 @@ impl ProjectContainer {
         if !ReadRef::ptr_eq(&prev_project_fs, &project_fs) {
             if watch.enable {
                 // TODO stop watching: prev_project_fs.stop_watching()?;
-                project_fs.start_watching_with_invalidation_reason(watch.poll_interval)?;
+                project_fs
+                    .start_watching_with_invalidation_reason(watch.poll_interval)
+                    .await?;
             } else {
                 project_fs.invalidate_with_reason();
             }

--- a/turbopack/crates/node-file-trace/src/lib.rs
+++ b/turbopack/crates/node-file-trace/src/lib.rs
@@ -190,7 +190,7 @@ impl Args {
 async fn create_fs(name: &str, root: &str, watch: bool) -> Result<Vc<Box<dyn FileSystem>>> {
     let fs = DiskFileSystem::new(name.into(), root.into(), vec![]);
     if watch {
-        fs.await?.start_watching(None)?;
+        fs.await?.start_watching(None).await?;
     } else {
         fs.await?.invalidate_with_reason();
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -353,14 +353,8 @@ impl TurboTasksBackendInner {
                 task = ctx.task(task_id, TaskDataCategory::All);
             }
 
-            let is_dirty = get!(task, Dirty)
-                .map(|dirty_state| {
-                    dirty_state
-                        .clean_in_session
-                        .map(|clean_in_session| clean_in_session != self.session_id)
-                        .unwrap_or(true)
-                })
-                .unwrap_or(false);
+            let is_dirty =
+                get!(task, Dirty).map_or(false, |dirty_state| dirty_state.get(self.session_id));
 
             // Check the dirty count of the root node
             let dirty_tasks = get!(task, AggregatedDirtyContainerCount)

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -45,20 +45,14 @@ pub enum OutdatedEdge {
 }
 
 impl CleanupOldEdgesOperation {
-    pub fn run(
-        task_id: TaskId,
-        outdated: Vec<OutdatedEdge>,
-        data_update: Option<AggregationUpdateJob>,
-        mut ctx: ExecuteContext<'_>,
-    ) {
-        let mut queue = AggregationUpdateQueue::new();
-        queue.extend(data_update);
+    pub fn run(task_id: TaskId, outdated: Vec<OutdatedEdge>, ctx: &mut ExecuteContext<'_>) {
+        let queue = AggregationUpdateQueue::new();
         CleanupOldEdgesOperation::RemoveEdges {
             task_id,
             outdated,
             queue,
         }
-        .execute(&mut ctx);
+        .execute(ctx);
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -102,6 +102,18 @@ impl ConnectChildOperation {
             }
             drop(parent_task);
 
+            {
+                let mut task = ctx.task(child_task_id, TaskDataCategory::Data);
+                if !task.has_key(&CachedDataItemKey::Output {}) {
+                    let description = ctx.backend.get_task_desc_fn(child_task_id);
+                    let should_schedule = task.add(CachedDataItem::new_scheduled(description));
+                    drop(task);
+                    if should_schedule {
+                        ctx.schedule(child_task_id);
+                    }
+                }
+            }
+
             ConnectChildOperation::UpdateAggregation {
                 aggregation_update: queue,
             }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -38,12 +38,6 @@ impl ConnectChildOperation {
             task: child_task_id,
             value: (),
         }) {
-            // When task is added to a AggregateRoot is need to be scheduled,
-            // indirect connections are handled by the aggregation update.
-            let mut should_schedule = false;
-            if parent_task.has_key(&CachedDataItemKey::AggregateRoot {}) {
-                should_schedule = true;
-            }
             // Update the task aggregation
             let mut queue = AggregationUpdateQueue::new();
 
@@ -107,18 +101,6 @@ impl ConnectChildOperation {
                 });
             }
             drop(parent_task);
-
-            {
-                let mut task = ctx.task(child_task_id, TaskDataCategory::Data);
-                should_schedule = should_schedule || !task.has_key(&CachedDataItemKey::Output {});
-                if should_schedule {
-                    let description = ctx.backend.get_task_desc_fn(child_task_id);
-                    should_schedule = task.add(CachedDataItem::new_scheduled(description));
-                }
-            }
-            if should_schedule {
-                ctx.schedule(child_task_id);
-            }
 
             ConnectChildOperation::UpdateAggregation {
                 aggregation_update: queue,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -31,9 +31,15 @@ pub enum ConnectChildOperation {
 impl ConnectChildOperation {
     pub fn run(parent_task_id: TaskId, child_task_id: TaskId, mut ctx: ExecuteContext<'_>) {
         let mut parent_task = ctx.task(parent_task_id, TaskDataCategory::All);
-        parent_task.remove(&CachedDataItemKey::OutdatedChild {
-            task: child_task_id,
-        });
+        // Quick skip if the child was already connected before
+        if parent_task
+            .remove(&CachedDataItemKey::OutdatedChild {
+                task: child_task_id,
+            })
+            .is_some()
+        {
+            return;
+        }
         if parent_task.add(CachedDataItem::Child {
             task: child_task_id,
             value: (),

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
@@ -13,7 +13,7 @@ use crate::{
         storage::{get, get_mut},
         TaskDataCategory,
     },
-    data::{CachedDataItem, CachedDataItemKey, InProgressState},
+    data::{CachedDataItem, CachedDataItemKey, CachedDataItemValue, DirtyState, InProgressState},
 };
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -91,22 +91,54 @@ pub fn make_task_dirty_internal(
             *stale = true;
         }
     }
-    if task.add(CachedDataItem::Dirty { value: () }) {
-        let dirty_container = get!(task, AggregatedDirtyContainerCount)
-            .copied()
-            .unwrap_or_default();
-        if dirty_container == 0 {
-            queue.extend(AggregationUpdateJob::data_update(
-                task,
-                AggregatedDataUpdate::new().dirty_container(task_id),
-            ));
+    let old = task.insert(CachedDataItem::Dirty {
+        value: DirtyState {
+            clean_in_session: None,
+        },
+    });
+    let mut dirty_container = match old {
+        Some(CachedDataItemValue::Dirty {
+            value: DirtyState {
+                clean_in_session: None,
+            },
+        }) => {
+            // already dirty
+            return;
         }
-        let root = task.has_key(&CachedDataItemKey::AggregateRoot {});
-        if root {
-            let description = ctx.backend.get_task_desc_fn(task_id);
-            if task.add(CachedDataItem::new_scheduled(description)) {
-                ctx.schedule(task_id);
-            }
+        Some(CachedDataItemValue::Dirty {
+            value: DirtyState {
+                clean_in_session: Some(session_id),
+            },
+        }) => {
+            // Got dirty in that one session only
+            let mut dirty_container = get!(task, AggregatedDirtyContainerCount)
+                .copied()
+                .unwrap_or_default();
+            dirty_container.update_session_dependent(session_id, 1);
+            dirty_container
+        }
+        None => {
+            // Get dirty for all sessions
+            get!(task, AggregatedDirtyContainerCount)
+                .copied()
+                .unwrap_or_default()
+        }
+        _ => unreachable!(),
+    };
+    let aggregated_update = dirty_container.update_with_dirty_state(&DirtyState {
+        clean_in_session: None,
+    });
+    if !aggregated_update.is_default() {
+        queue.extend(AggregationUpdateJob::data_update(
+            task,
+            AggregatedDataUpdate::new().dirty_container_update(task_id, aggregated_update),
+        ));
+    }
+    let root = task.has_key(&CachedDataItemKey::AggregateRoot {});
+    if root {
+        let description = ctx.backend.get_task_desc_fn(task_id);
+        if task.add(CachedDataItem::new_scheduled(description)) {
+            ctx.schedule(task_id);
         }
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{KeyValuePair, TaskId, TurboTasksBackendApi};
+use turbo_tasks::{KeyValuePair, SessionId, TaskId, TurboTasksBackendApi};
 
 use crate::{
     backend::{
@@ -95,6 +95,10 @@ impl<'a> ExecuteContext<'a> {
             self.transaction = Some(tx);
             tx
         }
+    }
+
+    pub fn session_id(&self) -> SessionId {
+        self.backend.session_id()
     }
 
     pub fn task(&mut self, task_id: TaskId, category: TaskDataCategory) -> TaskGuard<'a> {

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use turbo_tasks::{backend::CachedTaskType, TaskId};
+use turbo_tasks::{backend::CachedTaskType, SessionId, TaskId};
 
 use crate::{
     backend::{AnyOperation, TaskDataCategory},
@@ -14,9 +14,11 @@ pub struct ReadTransaction(pub *const ());
 
 pub trait BackingStorage {
     fn next_free_task_id(&self) -> TaskId;
+    fn next_session_id(&self) -> SessionId;
     fn uncompleted_operations(&self) -> Vec<AnyOperation>;
     fn save_snapshot(
         &self,
+        session_id: SessionId,
         operations: Vec<Arc<AnyOperation>>,
         task_cache_updates: Vec<ChunkedVec<(Arc<CachedTaskType>, TaskId)>>,
         meta_updates: Vec<ChunkedVec<CachedDataUpdate>>,

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -90,6 +90,12 @@ pub struct DirtyState {
     pub clean_in_session: Option<SessionId>,
 }
 
+impl DirtyState {
+    pub fn get(&self, session: SessionId) -> bool {
+        self.clean_in_session != Some(session)
+    }
+}
+
 fn add_with_diff(v: &mut i32, u: i32) -> i32 {
     let old = *v;
     *v += u;

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -513,8 +513,7 @@ impl CachedDataItemKey {
 
     pub fn category(&self) -> TaskDataCategory {
         match self {
-            CachedDataItemKey::Output { .. }
-            | CachedDataItemKey::Collectible { .. }
+            CachedDataItemKey::Collectible { .. }
             | CachedDataItemKey::Child { .. }
             | CachedDataItemKey::CellData { .. }
             | CachedDataItemKey::CellTypeMaxIndex { .. }
@@ -533,7 +532,8 @@ impl CachedDataItemKey {
             | CachedDataItemKey::OutdatedChild { .. }
             | CachedDataItemKey::Error { .. } => TaskDataCategory::Data,
 
-            CachedDataItemKey::AggregationNumber { .. }
+            CachedDataItemKey::Output { .. }
+            | CachedDataItemKey::AggregationNumber { .. }
             | CachedDataItemKey::Dirty { .. }
             | CachedDataItemKey::Follower { .. }
             | CachedDataItemKey::Upper { .. }

--- a/turbopack/crates/turbo-tasks-backend/src/lmdb_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/lmdb_backing_storage.rs
@@ -158,7 +158,7 @@ impl BackingStorage for LmdbBackingStorage {
         get(self).unwrap_or_default()
     }
 
-    #[tracing::instrument(level = "trace", skip_all, fields(operations = operations.len(), task_cache_updates = task_cache_updates.len(), data_updates = data_updates.len()))]
+    #[tracing::instrument(level = "trace", skip_all, fields(operations = operations.len()))]
     fn save_snapshot(
         &self,
         session_id: SessionId,
@@ -184,15 +184,19 @@ impl BackingStorage for LmdbBackingStorage {
             // Start organizing the updates in parallel
             s.spawn(|_| {
                 let task_meta_updates = {
-                    let _span =
-                        tracing::trace_span!("organize task meta", updates = meta_updates.len())
-                            .entered();
+                    let _span = tracing::trace_span!(
+                        "organize task meta",
+                        updates = meta_updates.iter().map(|m| m.len()).sum::<usize>()
+                    )
+                    .entered();
                     organize_task_data(meta_updates)
                 };
                 let items_result = {
-                    let _span =
-                        tracing::trace_span!("restore task meta", tasks = task_meta_updates.len())
-                            .entered();
+                    let _span = tracing::trace_span!(
+                        "restore task meta",
+                        tasks = task_meta_updates.iter().map(|m| m.len()).sum::<usize>()
+                    )
+                    .entered();
                     restore_task_data(self, self.meta_db, task_meta_updates)
                 };
                 task_meta_items_result = items_result.and_then(|items| {
@@ -202,15 +206,19 @@ impl BackingStorage for LmdbBackingStorage {
             });
             s.spawn(|_| {
                 let task_data_updates = {
-                    let _span =
-                        tracing::trace_span!("organize task data", updates = data_updates.len())
-                            .entered();
+                    let _span = tracing::trace_span!(
+                        "organize task data",
+                        updates = data_updates.iter().map(|m| m.len()).sum::<usize>()
+                    )
+                    .entered();
                     organize_task_data(data_updates)
                 };
                 let items_result = {
-                    let _span =
-                        tracing::trace_span!("restore task data", tasks = task_data_updates.len())
-                            .entered();
+                    let _span = tracing::trace_span!(
+                        "restore task data",
+                        tasks = task_data_updates.iter().map(|m| m.len()).sum::<usize>()
+                    )
+                    .entered();
                     restore_task_data(self, self.data_db, task_data_updates)
                 };
                 task_data_items_result = items_result.and_then(|items| {
@@ -235,9 +243,11 @@ impl BackingStorage for LmdbBackingStorage {
                 as_u32(tx.get(self.infra_db, &IntKey::new(META_KEY_NEXT_FREE_TASK_ID)))
                     .unwrap_or(1);
             {
-                let _span =
-                    tracing::trace_span!("update task cache", items = task_cache_updates.len())
-                        .entered();
+                let _span = tracing::trace_span!(
+                    "update task cache",
+                    items = task_cache_updates.iter().map(|m| m.len()).sum::<usize>()
+                )
+                .entered();
                 for (task_type, task_id) in task_cache_updates.into_iter().flatten() {
                     let task_id = *task_id;
                     let task_type_bytes = pot::to_vec(&*task_type).with_context(|| {

--- a/turbopack/crates/turbo-tasks-env/src/command_line.rs
+++ b/turbopack/crates/turbo-tasks-env/src/command_line.rs
@@ -1,5 +1,5 @@
 use indexmap::IndexMap;
-use turbo_tasks::{RcStr, Vc};
+use turbo_tasks::{mark_session_dependent, RcStr, Vc};
 
 use crate::{sorted_env_vars, EnvMap, ProcessEnv, GLOBAL_ENV_LOCK};
 
@@ -25,6 +25,7 @@ fn env_snapshot() -> IndexMap<RcStr, RcStr> {
 impl ProcessEnv for CommandLineProcessEnv {
     #[turbo_tasks::function]
     fn read_all(&self) -> Vc<EnvMap> {
+        mark_session_dependent();
         Vc::cell(env_snapshot())
     }
 }

--- a/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
+++ b/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<()> {
         Box::pin(async {
             let root = current_dir().unwrap().to_str().unwrap().into();
             let disk_fs = DiskFileSystem::new("project".into(), root, vec![]);
-            disk_fs.await?.start_watching(None)?;
+            disk_fs.await?.start_watching(None).await?;
 
             // Smart Pointer cast
             let fs: Vc<Box<dyn FileSystem>> = Vc::upcast(disk_fs);

--- a/turbopack/crates/turbo-tasks-fs/examples/hash_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/examples/hash_glob.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
         Box::pin(async {
             let root = current_dir().unwrap().to_str().unwrap().into();
             let disk_fs = DiskFileSystem::new("project".into(), root, vec![]);
-            disk_fs.await?.start_watching(None)?;
+            disk_fs.await?.start_watching(None).await?;
 
             // Smart Pointer cast
             let fs: Vc<Box<dyn FileSystem>> = Vc::upcast(disk_fs);

--- a/turbopack/crates/turbo-tasks-fs/src/embed/dir.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/dir.rs
@@ -12,7 +12,7 @@ pub async fn directory_from_relative_path(
     path: RcStr,
 ) -> Result<Vc<Box<dyn FileSystem>>> {
     let disk_fs = DiskFileSystem::new(name, path, vec![]);
-    disk_fs.await?.start_watching(None)?;
+    disk_fs.await?.start_watching(None).await?;
 
     Ok(Vc::upcast(disk_fs))
 }

--- a/turbopack/crates/turbo-tasks-fs/src/embed/file.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/file.rs
@@ -23,7 +23,7 @@ pub async fn content_from_relative_path(
         root_path.to_string_lossy().into(),
         vec![],
     );
-    disk_fs.await?.start_watching(None)?;
+    disk_fs.await?.start_watching(None).await?;
 
     let fs_path = disk_fs.root().join(path.into());
     Ok(fs_path.read())

--- a/turbopack/crates/turbo-tasks-fs/src/invalidator_map.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/invalidator_map.rs
@@ -12,12 +12,18 @@ pub struct InvalidatorMap {
     map: Mutex<HashMap<String, HashSet<Invalidator>>>,
 }
 
-impl InvalidatorMap {
-    pub fn new() -> Self {
+impl Default for InvalidatorMap {
+    fn default() -> Self {
         Self {
             queue: ConcurrentQueue::unbounded(),
             map: Default::default(),
         }
+    }
+}
+
+impl InvalidatorMap {
+    pub fn new() -> Self {
+        Self::default()
     }
 
     pub fn lock(&self) -> LockResult<MutexGuard<'_, HashMap<String, HashSet<Invalidator>>>> {

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -517,6 +517,7 @@ impl Debug for DiskFileSystem {
 impl FileSystem for DiskFileSystem {
     #[turbo_tasks::function(fs)]
     async fn read(&self, fs_path: Vc<FileSystemPath>) -> Result<Vc<FileContent>> {
+        mark_session_dependent();
         let full_path = self.to_sys_path(fs_path).await?;
         self.register_invalidator(&full_path)?;
 

--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -18,7 +18,7 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 use tracing::instrument;
-use turbo_tasks::{spawn_thread, Invalidator, RcStr, SerializationInvalidator};
+use turbo_tasks::{spawn_thread, Invalidator, RcStr};
 
 use crate::{
     format_absolute_fs_path,
@@ -144,7 +144,6 @@ impl DiskWatcher {
         invalidator_map: Arc<InvalidatorMap>,
         dir_invalidator_map: Arc<InvalidatorMap>,
         poll_interval: Option<Duration>,
-        serialization_invalidator: SerializationInvalidator,
     ) -> Result<()> {
         let mut watcher_guard = self.watcher.lock().unwrap();
         if watcher_guard.is_some() {
@@ -215,7 +214,6 @@ impl DiskWatcher {
                     invalidator.invalidate()
                 });
             }
-            serialization_invalidator.invalidate();
         }
 
         watcher_guard.replace(watcher);

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -313,7 +313,7 @@ impl TurboTasksApi for VcStorage {
         // no-op
     }
 
-    fn mark_own_task_as_dirty_when_persisted(&self, _task: TaskId) {
+    fn mark_own_task_as_session_dependent(&self, _task: TaskId) {
         // no-op
     }
 

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -717,7 +717,7 @@ pub trait Backend: Sync + Send {
         // Do nothing by default
     }
 
-    fn mark_own_task_as_dirty_when_persisted(
+    fn mark_own_task_as_session_dependent(
         &self,
         _task: TaskId,
         _turbo_tasks: &dyn TurboTasksBackendApi<Self>,

--- a/turbopack/crates/turbo-tasks/src/id.rs
+++ b/turbopack/crates/turbo-tasks/src/id.rs
@@ -78,6 +78,7 @@ define_id!(ValueTypeId: u32);
 define_id!(TraitTypeId: u32);
 define_id!(BackendJobId: u32);
 define_id!(ExecutionId: u64, derive(Debug));
+define_id!(SessionId: u32, derive(Debug, Serialize, Deserialize), serde(transparent));
 define_id!(
     LocalCellId: u32,
     derive(Debug),

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -86,7 +86,8 @@ pub use collectibles::CollectiblesSource;
 pub use completion::{Completion, Completions};
 pub use display::ValueToString;
 pub use id::{
-    ExecutionId, FunctionId, LocalTaskId, TaskId, TraitTypeId, ValueTypeId, TRANSIENT_TASK_BIT,
+    ExecutionId, FunctionId, LocalTaskId, SessionId, TaskId, TraitTypeId, ValueTypeId,
+    TRANSIENT_TASK_BIT,
 };
 pub use invalidation::{
     get_invalidator, DynamicEqHash, InvalidationReason, InvalidationReasonKind,
@@ -96,7 +97,7 @@ pub use join_iter_ext::{JoinIterExt, TryFlatJoinIterExt, TryJoinIterExt};
 pub use key_value_pair::KeyValuePair;
 pub use magic_any::MagicAny;
 pub use manager::{
-    dynamic_call, dynamic_this_call, emit, mark_dirty_when_persisted, mark_finished, mark_stateful,
+    dynamic_call, dynamic_this_call, emit, mark_finished, mark_session_dependent, mark_stateful,
     prevent_gc, run_once, run_once_with_reason, spawn_blocking, spawn_thread, trait_call,
     turbo_tasks, turbo_tasks_scope, CurrentCellRef, ReadConsistency, TaskPersistence, TurboTasks,
     TurboTasksApi, TurboTasksBackendApi, TurboTasksBackendApiExt, TurboTasksCallApi, Unused,

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -183,7 +183,7 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
     fn read_own_task_cell(&self, task: TaskId, index: CellId) -> Result<TypedCellContent>;
     fn update_own_task_cell(&self, task: TaskId, index: CellId, content: CellContent);
     fn mark_own_task_as_finished(&self, task: TaskId);
-    fn mark_own_task_as_dirty_when_persisted(&self, task: TaskId);
+    fn mark_own_task_as_session_dependent(&self, task: TaskId);
 
     fn connect_task(&self, task: TaskId);
 
@@ -1408,9 +1408,8 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         self.backend.mark_own_task_as_finished(task, self);
     }
 
-    fn mark_own_task_as_dirty_when_persisted(&self, task: TaskId) {
-        self.backend
-            .mark_own_task_as_dirty_when_persisted(task, self);
+    fn mark_own_task_as_session_dependent(&self, task: TaskId) {
+        self.backend.mark_own_task_as_session_dependent(task, self);
     }
 
     /// Creates a future that inherits the current task id and task state. The current global task
@@ -1704,11 +1703,9 @@ pub fn current_task_for_testing() -> TaskId {
 }
 
 /// Marks the current task as dirty when restored from persistent cache.
-pub fn mark_dirty_when_persisted() {
+pub fn mark_session_dependent() {
     with_turbo_tasks(|tt| {
-        tt.mark_own_task_as_dirty_when_persisted(current_task(
-            "turbo_tasks::mark_dirty_when_persisted()",
-        ))
+        tt.mark_own_task_as_session_dependent(current_task("turbo_tasks::mark_session_dependent()"))
     });
 }
 

--- a/turbopack/crates/turbo-tasks/src/state.rs
+++ b/turbopack/crates/turbo-tasks/src/state.rs
@@ -9,7 +9,7 @@ use parking_lot::{Mutex, MutexGuard};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    get_invalidator, mark_dirty_when_persisted, mark_stateful, trace::TraceRawVcs, Invalidator,
+    get_invalidator, mark_session_dependent, mark_stateful, trace::TraceRawVcs, Invalidator,
     SerializationInvalidator,
 };
 
@@ -266,7 +266,7 @@ impl<T> TransientState<T> {
     /// as dependency of the state and will be invalidated when the state
     /// changes.
     pub fn get(&self) -> StateRef<'_, Option<T>> {
-        mark_dirty_when_persisted();
+        mark_session_dependent();
         let invalidator = get_invalidator();
         let mut inner = self.inner.lock();
         inner.add_invalidator(invalidator);

--- a/turbopack/crates/turbopack-cli/src/util.rs
+++ b/turbopack/crates/turbopack-cli/src/util.rs
@@ -62,13 +62,13 @@ pub fn normalize_entries(entries: &Option<Vec<String>>) -> Vec<RcStr> {
 #[turbo_tasks::function]
 pub async fn project_fs(project_dir: RcStr) -> Result<Vc<Box<dyn FileSystem>>> {
     let disk_fs = DiskFileSystem::new("project".into(), project_dir, vec![]);
-    disk_fs.await?.start_watching(None)?;
+    disk_fs.await?.start_watching(None).await?;
     Ok(Vc::upcast(disk_fs))
 }
 
 #[turbo_tasks::function]
 pub async fn output_fs(project_dir: RcStr) -> Result<Vc<Box<dyn FileSystem>>> {
     let disk_fs = DiskFileSystem::new("output".into(), project_dir, vec![]);
-    disk_fs.await?.start_watching(None)?;
+    disk_fs.await?.start_watching(None).await?;
     Ok(Vc::upcast(disk_fs))
 }

--- a/turbopack/crates/turbopack/examples/turbopack.rs
+++ b/turbopack/crates/turbopack/examples/turbopack.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
         Box::pin(async {
             let root: RcStr = current_dir().unwrap().to_str().unwrap().into();
             let disk_fs = DiskFileSystem::new(PROJECT_FILESYSTEM_NAME.into(), root, vec![]);
-            disk_fs.await?.start_watching(None)?;
+            disk_fs.await?.start_watching(None).await?;
 
             // Smart Pointer cast
             let fs: Vc<Box<dyn FileSystem>> = Vc::upcast(disk_fs);


### PR DESCRIPTION
### What?

Before we did invalidate all filesystem tasks when an incremental build starts. But that has a performance linear to the number of filesystem tasks. We like to avoid that.

This PR refactors that and introduces a new dirty state, which means "task is dirty in general, but considered as clean for a certain session". All filesystem tasks are marked this way. When an incremental build starts we only increment the session id, which makes all filesystem tasks considered as dirty. No looping over all filesystem tasks to make them dirty anymore.

### Why?

Most of the cost before was spend in updating the task aggregation when task where marked dirty. This requires to restore a lot of aggregated tasks. This cost has moved to the point when the filesystem task is recomputed. So it's per page. This has benefits for next dev which doesn't build all pages.
