### PR TITLE
docs: update `headers` API reference to reflect async Dynamic APIs breaking change

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/headers.mdx
+++ b/docs/02-app/02-api-reference/04-functions/headers.mdx
@@ -12,19 +12,41 @@ This API extends the [Web Headers API](https://developer.mozilla.org/docs/Web/AP
 ```tsx filename="app/page.tsx" switcher
 import { headers } from 'next/headers'
 
+// Async page component
+export default async function Page() {
+  const headersList = await headers()
+  const referer = headersList.get('referer')
+
+  return <div>Referer: {referer}</div>
+}
+
+// Sync page component
+import { use } from "react"
+
 export default function Page() {
-  const headersList = headers()
+  const headersList = use(headers())
   const referer = headersList.get('referer')
 
   return <div>Referer: {referer}</div>
 }
 ```
 
-```jsx filename="app/page.js" switcher
+```jsx filename="app/page.jsx" switcher
 import { headers } from 'next/headers'
 
+// Async page component
+export default async function Page() {
+  const headersList = await headers()
+  const referer = headersList.get('referer')
+
+  return <div>Referer: {referer}</div>
+}
+
+// Sync page component
+import { use } from "react"
+
 export default function Page() {
-  const headersList = headers()
+  const headersList = use(headers())
   const referer = headersList.get('referer')
 
   return <div>Referer: {referer}</div>
@@ -33,12 +55,18 @@ export default function Page() {
 
 > **Good to know**:
 >
-> - `headers()` is a **[Dynamic Function](/docs/app/building-your-application/rendering/server-components#server-rendering-strategies#dynamic-functions)** whose returned values cannot be known ahead of time. Using it in a layout or page will opt a route into **[dynamic rendering](/docs/app/building-your-application/rendering/server-components#dynamic-rendering)** at request time.
+> - `headers()` is an async **[Dynamic Function](/docs/app/building-your-application/rendering/server-components#server-rendering-strategies#dynamic-functions)** whose returned values cannot be known ahead of time. Using it in a layout or page will opt a route into **[dynamic rendering](/docs/app/building-your-application/rendering/server-components#dynamic-rendering)** at request time.
 
 ### API Reference
 
 ```tsx
-const headersList = headers()
+// async server component
+const headersList = await headers()
+
+// sync server component
+import { use } from "react"
+
+const headersList = use(headers())
 ```
 
 #### Parameters
@@ -47,7 +75,7 @@ const headersList = headers()
 
 #### Returns
 
-`headers` returns a **read-only** [Web Headers](https://developer.mozilla.org/docs/Web/API/Headers) object.
+`headers` returns a promise **read-only** [Web Headers](https://developer.mozilla.org/docs/Web/API/Headers) object.
 
 - [`Headers.entries()`](https://developer.mozilla.org/docs/Web/API/Headers/entries): Returns an [`iterator`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Iteration_protocols) allowing to go through all key/value pairs contained in this object.
 - [`Headers.forEach()`](https://developer.mozilla.org/docs/Web/API/Headers/forEach): Executes a provided function once for each key/value pair in this `Headers` object.
@@ -67,7 +95,7 @@ import { Suspense } from 'react'
 import { headers } from 'next/headers'
 
 async function User() {
-  const authorization = headers().get('authorization')
+  const authorization = (await headers()).get('authorization')
   const res = await fetch('...', {
     headers: { authorization }, // Forward the authorization header
   })
@@ -93,15 +121,15 @@ export default function Page() {
 import { Suspense } from 'react'
 import { headers } from 'next/headers'
 
-function IP() {
+async function IP() {
   const FALLBACK_IP_ADDRESS = '0.0.0.0'
-  const forwardedFor = headers().get('x-forwarded-for')
+  const forwardedFor = (await headers()).get('x-forwarded-for')
 
   if (forwardedFor) {
     return forwardedFor.split(',')[0] ?? FALLBACK_IP_ADDRESS
   }
 
-  return headers().get('x-real-ip') ?? FALLBACK_IP_ADDRESS
+  return (await headers()).get('x-real-ip') ?? FALLBACK_IP_ADDRESS
 }
 
 export default function Page() {
@@ -125,3 +153,4 @@ In addition to `x-forwarded-for`, `headers()` can also read:
 | Version   | Changes               |
 | --------- | --------------------- |
 | `v13.0.0` | `headers` introduced. |
+| `v15.0.0` | `headers` returns a promise |


### PR DESCRIPTION
**Why?**
The canary version of the docs doesn't currently reflect the async Dynamic APIs breaking change: https://github.com/vercel/next.js/pull/68812#issue-2462004027

**What?**
This change aims to update the `headers` API reference to reflect these changes accurately.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
