### PR TITLE
codemod: unify comments prefix for dynamic api

### DIFF
--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-15.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-15.output.js
@@ -2,7 +2,7 @@ import { cookies } from "next/headers";
 
 async function MyComponent() {
   function asyncFunction() {
-    callSomething(/* Next.js Dynamic Async API Codemod: Manually await this call, if it's a Server Component. */
+    callSomething(/* Next.js Dynamic Async API Codemod: Manually await this call, if it's a Server Component */
     cookies());
   }
 }

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-15.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-15.output.js
@@ -2,7 +2,7 @@ import { cookies } from "next/headers";
 
 async function MyComponent() {
   function asyncFunction() {
-    callSomething(/* Next.js Dynamic Async API Codemod: please manually await this call, if it's a server component, you can turn it to async function */
+    callSomething(/* Next.js Dynamic Async API Codemod: Manually await this call, if it's a Server Component. */
     cookies());
   }
 }

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-15.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-15.output.js
@@ -2,7 +2,7 @@ import { cookies } from "next/headers";
 
 async function MyComponent() {
   function asyncFunction() {
-    callSomething(/* TODO: please manually await this call, if it's a server component, you can turn it to async function */
+    callSomething(/* Next.js Dynamic Async API Codemod: please manually await this call, if it's a server component, you can turn it to async function */
     cookies());
   }
 }

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-16.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-16.output.js
@@ -1,6 +1,6 @@
 import { cookies } from "next/headers";
 
 function MyComponent() {
-  callSomething(/* TODO: please manually await this call, if it's a server component, you can turn it to async function */
+  callSomething(/* Next.js Dynamic Async API Codemod: please manually await this call, if it's a server component, you can turn it to async function */
   cookies());
 }

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-16.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-16.output.js
@@ -1,6 +1,6 @@
 import { cookies } from "next/headers";
 
 function MyComponent() {
-  callSomething(/* Next.js Dynamic Async API Codemod: please manually await this call, if it's a server component, you can turn it to async function */
+  callSomething(/* Next.js Dynamic Async API Codemod: Manually await this call, if it's a Server Component */
   cookies());
 }

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-21.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-21.input.tsx
@@ -4,4 +4,4 @@ function myFunc() {
   nextHeaders.cookies()
 }
 
-const nextHeaders2 = /* The APIs under 'next/headers' are async now, need to be manually awaited. */ import('next/headers')
+const nextHeaders2 = /* Next.js Dynamic Async API Codemod: The APIs under 'next/headers' are async now, need to be manually awaited. */ import('next/headers')

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-21.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-21.output.tsx
@@ -1,8 +1,8 @@
-const nextHeaders = /* The APIs under 'next/headers' are async now, need to be manually awaited. */
+const nextHeaders = /* Next.js Dynamic Async API Codemod: The APIs under 'next/headers' are async now, need to be manually awaited. */
 import('next/headers')
 
 function myFunc() {
   nextHeaders.cookies()
 }
 
-const nextHeaders2 = /* The APIs under 'next/headers' are async now, need to be manually awaited. */ import('next/headers')
+const nextHeaders2 = /* Next.js Dynamic Async API Codemod: The APIs under 'next/headers' are async now, need to be manually awaited. */ import('next/headers')

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-type-cast-02.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-type-cast-02.output.js
@@ -6,7 +6,7 @@ import {
 } from 'next/headers'
 
 export function MyDraftComponent() {
-if (/* TODO: please manually await this call, if it's a server component, you can turn it to async function */
+if (/* Next.js Dynamic Async API Codemod: please manually await this call, if it's a server component, you can turn it to async function */
 draftMode().isEnabled) {
     return null
   }
@@ -15,13 +15,13 @@ draftMode().isEnabled) {
 }
 
 export function MyCookiesComponent() {
-  const c = /* TODO: please manually await this call, if it's a server component, you can turn it to async function */
+  const c = /* Next.js Dynamic Async API Codemod: please manually await this call, if it's a server component, you can turn it to async function */
   cookies()
   return c.get('name')
 }
 
 export function MyHeadersComponent() {
-  const h = /* TODO: please manually await this call, if it's a server component, you can turn it to async function */
+  const h = /* Next.js Dynamic Async API Codemod: please manually await this call, if it's a server component, you can turn it to async function */
   headers()
   return (
     <p>{h.get('x-foo')}</p>

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-type-cast-02.output.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-type-cast-02.output.js
@@ -6,7 +6,7 @@ import {
 } from 'next/headers'
 
 export function MyDraftComponent() {
-if (/* Next.js Dynamic Async API Codemod: please manually await this call, if it's a server component, you can turn it to async function */
+if (/* Next.js Dynamic Async API Codemod: Manually await this call, if it's a Server Component */
 draftMode().isEnabled) {
     return null
   }
@@ -15,13 +15,13 @@ draftMode().isEnabled) {
 }
 
 export function MyCookiesComponent() {
-  const c = /* Next.js Dynamic Async API Codemod: please manually await this call, if it's a server component, you can turn it to async function */
+  const c = /* Next.js Dynamic Async API Codemod: Manually await this call, if it's a Server Component */
   cookies()
   return c.get('name')
 }
 
 export function MyHeadersComponent() {
-  const h = /* Next.js Dynamic Async API Codemod: please manually await this call, if it's a server component, you can turn it to async function */
+  const h = /* Next.js Dynamic Async API Codemod: Manually await this call, if it's a Server Component */
   headers()
   return (
     <p>{h.get('x-foo')}</p>

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-18.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-18.output.tsx
@@ -1,10 +1,10 @@
 export default function Page(props: any) {
-  callback(/* 'props' is passed as an argument. Any asynchronous properties of 'props' must be awaited when accessed. */
+  callback(/* Next.js Dynamic Async API Codemod: 'props' is passed as an argument. Any asynchronous properties of 'props' must be awaited when accessed. */
   props, 1)
 }
 
 export function generateMetadata(props) {
-  callback2(/* 'props' is passed as an argument. Any asynchronous properties of 'props' must be awaited when accessed. */
+  callback2(/* Next.js Dynamic Async API Codemod: 'props' is passed as an argument. Any asynchronous properties of 'props' must be awaited when accessed. */
   props)
 }
 

--- a/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
@@ -11,7 +11,7 @@ import {
   insertCommentOnce,
 } from './utils'
 
-const DYNAMIC_IMPORT_WARN_COMMENT = ` The APIs under 'next/headers' are async now, need to be manually awaited. `
+const DYNAMIC_IMPORT_WARN_COMMENT = ` Next.js Dynamic Async API Codemod: The APIs under 'next/headers' are async now, need to be manually awaited. `
 
 function findDynamicImportsAndComment(root: Collection<any>, j: API['j']) {
   let modified = false
@@ -187,7 +187,7 @@ export function transformDynamicAPI(
                   root,
                   filePath,
                   insertedTypes,
-                  ` TODO: please manually await this call, if it's a server component, you can turn it to async function `
+                  ` Next.js Dynamic Async API Codemod: please manually await this call, if it's a server component, you can turn it to async function `
                 )
               }
             } else {
@@ -198,7 +198,7 @@ export function transformDynamicAPI(
                 root,
                 filePath,
                 insertedTypes,
-                ' TODO: please manually await this call, codemod cannot transform due to undetermined async scope '
+                ' Next.js Dynamic Async API Codemod: please manually await this call, codemod cannot transform due to undetermined async scope '
               )
             }
             modified = true

--- a/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
@@ -187,7 +187,7 @@ export function transformDynamicAPI(
                   root,
                   filePath,
                   insertedTypes,
-                  ` Next.js Dynamic Async API Codemod: please manually await this call, if it's a server component, you can turn it to async function `
+                  ` Next.js Dynamic Async API Codemod: Manually await this call, if it's a Server Component `
                 )
               }
             } else {

--- a/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-prop.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-prop.ts
@@ -382,7 +382,7 @@ export function transformDynamicProps(
           const propPassedAsArg = args.find(
             (arg) => j.Identifier.check(arg) && arg.name === argName
           )
-          const comment = ` '${argName}' is passed as an argument. Any asynchronous properties of 'props' must be awaited when accessed. `
+          const comment = ` Next.js Dynamic Async API Codemod: '${argName}' is passed as an argument. Any asynchronous properties of 'props' must be awaited when accessed. `
           insertCommentOnce(propPassedAsArg, j, comment)
 
           modified = true


### PR DESCRIPTION
Adding comment prefix `Next.js Dynamic Async API Codemod:` for all the comments left by dynamic API codemod