### PR TITLE
codemod: skip promise.all on params

### DIFF
--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-26.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-26.input.tsx
@@ -1,0 +1,21 @@
+interface Props {
+  params: Promise<{
+    slug: string;
+  }>
+  searchParams: Promise<{
+    a: string;
+  }>
+}
+
+export default async function Page(props: Props) {
+  const [
+    params,
+    searchParams
+  ] = await Promise.all([props.params, props.searchParams])
+}
+
+export async function generateMetadata(props: Props) {
+  const [
+    params,
+  ] = await Promise.all([props.params, props.searchParams])
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-26.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-26.output.tsx
@@ -1,0 +1,21 @@
+interface Props {
+  params: Promise<{
+    slug: string;
+  }>
+  searchParams: Promise<{
+    a: string;
+  }>
+}
+
+export default async function Page(props: Props) {
+  const [
+    params,
+    searchParams
+  ] = await Promise.all([props.params, props.searchParams])
+}
+
+export async function generateMetadata(props: Props) {
+  const [
+    params,
+  ] = await Promise.all([props.params, props.searchParams])
+}

--- a/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-prop.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-prop.ts
@@ -50,6 +50,10 @@ function awaitMemberAccessOfProp(
   memberAccess.forEach((memberAccessPath) => {
     const member = memberAccessPath.value
 
+    if (isParentPromiseAllCallExpression(memberAccessPath, j)) {
+      return
+    }
+
     // check if it's already awaited
     if (memberAccessPath.parentPath?.value.type === 'AwaitExpression') {
       return
@@ -82,6 +86,26 @@ function isParentUseCallExpression(path: ASTPath<any>, j: API['jscodeshift']) {
     // function name is `use`
     j.Identifier.check(path.parent.value.callee) &&
     path.parent.value.callee.name === 'use'
+  ) {
+    return true
+  }
+  return false
+}
+
+function isParentPromiseAllCallExpression(
+  path: ASTPath<any>,
+  j: API['jscodeshift']
+) {
+  const argsParent = path.parent
+  const callParent = argsParent?.parent
+  if (
+    j.ArrayExpression.check(argsParent.value) &&
+    j.CallExpression.check(callParent.value) &&
+    j.MemberExpression.check(callParent.value.callee) &&
+    j.Identifier.check(callParent.value.callee.object) &&
+    callParent.value.callee.object.name === 'Promise' &&
+    j.Identifier.check(callParent.value.callee.property) &&
+    callParent.value.callee.property.name === 'all'
   ) {
     return true
   }


### PR DESCRIPTION
If the `props.<param>` is wrapped under `Promise.all([])`, skip transform as they're also awaited