### PR TITLE
chore(turbo-tasks-backend): Disable flaky performance test by default

### DIFF
--- a/turbopack/crates/turbo-tasks-testing/tests/performance.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/performance.rs
@@ -14,6 +14,14 @@ const COUNT2: u32 = 2000;
 
 #[tokio::test]
 async fn many_calls_to_many_children() {
+    if matches!(
+        std::env::var("TURBOPACK_TEST_PERFORMANCE").ok().as_deref(),
+        None | Some("") | Some("no") | Some("false")
+    ) {
+        println!("Skipping test, pass `TURBOPACK_TEST_PERFORMANCE=yes` to run it");
+        return;
+    }
+
     run(&REGISTRATION, || async {
         // The first call will actually execute many_children and its children.
         let start = std::time::Instant::now();


### PR DESCRIPTION
The CI environment is **very** noisy and this test can (and does) flake: https://github.com/vercel/next.js/pull/69667#discussion_r1792296524

```
cargo nextest r -p turbo-tasks-memory many_calls_to_many_children --no-capture
```

```
TURBOPACK_TEST_PERFORMANCE=yes cargo nextest r -p turbo-tasks-memory many_calls_to_many_children --no-capture
```

The plan to solve this is to integrate codspeed, which should guarantee low noise via an emulated CPU.