### PR TITLE
Port #70933 "fix: remove unnecessary line break in prompt"

### DIFF
--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -228,7 +228,7 @@ async function suggestCodemods(
     {
       type: 'multiselect',
       name: 'codemods',
-      message: `\nThe following ${chalk.blue('codemods')} are recommended for your upgrade. Would you like to apply them?`,
+      message: `The following ${chalk.blue('codemods')} are recommended for your upgrade. Select the ones to apply.`,
       choices: relevantCodemods.reverse().map(({ title, value, version }) => {
         return {
           title: `(v${version}) ${value}`,


### PR DESCRIPTION
The merged PR https://github.com/vercel/next.js/pull/70933 was targetting to graphite branch during rebase, but was manually merged. Merge to `canary`.