### PR TITLE
next-upgrade: Ensure path-like revisions are rejected

### DIFF
--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -45,9 +45,15 @@ export async function runUpgrade(
   const res = await fetch(`https://registry.npmjs.org/next/${revision}`)
   if (res.status === 200) {
     targetNextPackageJson = await res.json()
-  } else {
+  }
+  const validRevision =
+    targetNextPackageJson !== null &&
+    typeof targetNextPackageJson === 'object' &&
+    'version' in targetNextPackageJson &&
+    'peerDependencies' in targetNextPackageJson
+  if (!validRevision) {
     throw new Error(
-      `${chalk.yellow(`next@${revision}`)} does not exist. Check available versions at ${chalk.underline('https://www.npmjs.com/package/next?activeTab=versions')}.`
+      `${chalk.yellow(`next@${revision}`)} does not exist. Make sure you entered a valid Next.js version or dist-tag. Check available versions at ${chalk.underline('https://www.npmjs.com/package/next?activeTab=versions')}.`
     )
   }
 


### PR DESCRIPTION
`.` and `..` can hit valid API endpoints but are not valid revisions.
Instead of parsing the revision (which may become outdated as we add dist-tags),
we can continue to let the registry handle that aspect.

## test plan

```bash
$ node ~/packages/next-codemod/bin/next-codemod.js  upgrade .
~/packages/next-codemod/bin/upgrade.js:42
        throw new Error(`${chalk_1.default.yellow(`next@${revision}`)} does not exist. Check available versions at ${chalk_1.default.underline('https://www.npmjs.com/package/next?activeTab=versions')}.`);
              ^

Error: next@. does not exist. Make sure you entered a valid Next.js version or dist-tag. Check available versions at https://www.npmjs.com/package/next?activeTab=versions.

$ node /Users/sebbie/repos/next.js/packages/next-codemod/bin/next-codemod.js  upgrade rc
# still works
```