### PR TITLE
next-upgrade: Ensure correct React and types version are resolved when upgrading to Next.js rc

### DIFF
--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -19,14 +19,18 @@ async function loadHighestNPMVersionMatching(query: string) {
     `npm --silent view "${query}" --json --field version`,
     { encoding: 'utf-8' }
   )
-  const versions = JSON.parse(versionsJSON)
-  if (versions.length < 1) {
+  const versionOrVersions = JSON.parse(versionsJSON)
+  if (versionOrVersions.length < 1) {
     throw new Error(
       `Found no React versions matching "${query}". This is a bug in the upgrade tool.`
     )
   }
-
-  return versions[versions.length - 1]
+  // npm-view returns an array if there are multiple versions matching the query.
+  if (Array.isArray(versionOrVersions)) {
+    // The last entry will be the latest version published.
+    return versionOrVersions[versionOrVersions.length - 1]
+  }
+  return versionOrVersions
 }
 
 export async function runUpgrade(
@@ -66,21 +70,9 @@ export async function runUpgrade(
   // E.g. in peerDependencies we could have `^18.2.0 || ^19.0.0 || 20.0.0-canary`
   // If we'd just `npm add` that, the manifest would read the same version query.
   // This is basically a `npm --save-exact react@$versionQuery` that works for every package manager.
-  const [
-    targetReactVersion,
-    targetReactTypesVersion,
-    targetReactDOMTypesVersion,
-  ] = await Promise.all([
-    loadHighestNPMVersionMatching(
-      `react@${targetNextPackageJson.peerDependencies['react']}`
-    ),
-    loadHighestNPMVersionMatching(
-      `@types/react@${targetNextPackageJson.peerDependencies['react']}`
-    ),
-    loadHighestNPMVersionMatching(
-      `@types/react-dom@${targetNextPackageJson.peerDependencies['react']}`
-    ),
-  ])
+  const targetReactVersion = await loadHighestNPMVersionMatching(
+    `react@${targetNextPackageJson.peerDependencies['react']}`
+  )
 
   if (compareVersions(targetNextVersion, '15.0.0-canary') >= 0) {
     await suggestTurbopack(appPackageJson)
@@ -107,6 +99,15 @@ export async function runUpgrade(
     reactDependencies.push(`@types/react@npm:types-react@rc`)
     reactDependencies.push(`@types/react-dom@npm:types-react-dom@rc`)
   } else {
+    const [targetReactTypesVersion, targetReactDOMTypesVersion] =
+      await Promise.all([
+        loadHighestNPMVersionMatching(
+          `@types/react@${targetNextPackageJson.peerDependencies['react']}`
+        ),
+        loadHighestNPMVersionMatching(
+          `@types/react-dom@${targetNextPackageJson.peerDependencies['react']}`
+        ),
+      ])
     reactDependencies.push(`@types/react@${targetReactTypesVersion}`)
     reactDependencies.push(`@types/react-dom@${targetReactDOMTypesVersion}`)
   }


### PR DESCRIPTION
`npm view react@$query` returns just a string when only a single version matches the query. This currently happens for `next@rc` and crashed the CLI. 

## test plan

Previously these failed before we resolved all relevant package versions and printed the designated Next.js version.

```bash
$ node ~/packages/next-codemod/bin/next-codemod.js upgrade rc
Upgrading your project to Next.js 15.0.0-rc.0...
$ node ~/packages/next-codemod/bin/next-codemod.js upgrade canary
Upgrading your project to Next.js 15.0.0-canary.17
```