### PR TITLE
fix(next-codemod): get package manager is inconsistent in monorepo

### DIFF
--- a/packages/next-codemod/package.json
+++ b/packages/next-codemod/package.json
@@ -13,6 +13,7 @@
     "commander": "12.1.0",
     "compare-versions": "6.1.1",
     "execa": "4.0.3",
+    "find-up": "4.1.0",
     "globby": "11.0.1",
     "is-git-clean": "1.1.0",
     "jscodeshift": "17.0.0",
@@ -34,6 +35,7 @@
   },
   "bin": "./bin/next-codemod.js",
   "devDependencies": {
+    "@types/find-up": "4.0.0",
     "@types/jscodeshift": "0.11.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -863,7 +863,7 @@ importers:
         version: 0.5.13
       babel-plugin-react-compiler:
         specifier: '*'
-        version: 0.0.0-experimental-734b737-20241003
+        version: 0.0.0-experimental-58c2b1c-20241007
       busboy:
         specifier: 1.6.0
         version: 1.6.0
@@ -1520,6 +1520,9 @@ importers:
       execa:
         specifier: 4.0.3
         version: 4.0.3
+      find-up:
+        specifier: 4.1.0
+        version: 4.1.0
       globby:
         specifier: 11.0.1
         version: 11.0.1
@@ -1536,6 +1539,9 @@ importers:
         specifier: 2.4.2
         version: 2.4.2
     devDependencies:
+      '@types/find-up':
+        specifier: 4.0.0
+        version: 4.0.0
       '@types/jscodeshift':
         specifier: 0.11.0
         version: 0.11.0
@@ -5024,6 +5030,10 @@ packages:
   '@types/express@4.17.2':
     resolution: {integrity: sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==}
 
+  '@types/find-up@4.0.0':
+    resolution: {integrity: sha512-QlRNKeOPFWKisbNtKVOOGXw3AeLbkw8UmT/EyEGM6brfqpYffKBcch7f1y40NYN9O90aK2+K0xBMDJfOAsg2qg==}
+    deprecated: This is a stub types definition. find-up provides its own type definitions, so you do not need this installed.
+
   '@types/fontkit@2.0.0':
     resolution: {integrity: sha512-Qe+6szpPLTNsqkDFs2MScJyB51d5Hpobyg/T0QoUWO53WuNOTNLsV8fkE4QQPOJbhOMN5wlwmNeDdsh/e6Uqdg==}
 
@@ -5956,8 +5966,8 @@ packages:
     peerDependencies:
       '@babel/core': 7.22.5
 
-  babel-plugin-react-compiler@0.0.0-experimental-734b737-20241003:
-    resolution: {integrity: sha512-jdcHsQwYAPuB2u/wpyCXCMI2B9n4weLAx8csvjNwYBw9drXYv4GmoxMyboigR9NJqDdcpIgjCBvt9qnIZM7AhA==}
+  babel-plugin-react-compiler@0.0.0-experimental-58c2b1c-20241007:
+    resolution: {integrity: sha512-46X+FyBb7q+EVea7EFa1GNWpEkvE/ZNZr9jqHKfy5dOvusCJC8qHUzVRSMRikky73MNhLk9XziQ16v+mzs1c9g==}
 
   babel-plugin-react-compiler@0.0.0-experimental-c23de8d-20240515:
     resolution: {integrity: sha512-0XN2gmpT55QtAz5n7d5g91y1AuO9tRhWBaLgCRyc4ExHrlr7+LfxW+YTb3mOwxngkkiggwM8HyYsaEK9MqhnlQ==}
@@ -19582,6 +19592,10 @@ snapshots:
       '@types/express-serve-static-core': 4.17.33
       '@types/serve-static': 1.13.3
 
+  '@types/find-up@4.0.0':
+    dependencies:
+      find-up: 4.1.0
+
   '@types/fontkit@2.0.0':
     dependencies:
       '@types/node': 20.12.3
@@ -20691,7 +20705,7 @@ snapshots:
       - supports-color
     optional: true
 
-  babel-plugin-react-compiler@0.0.0-experimental-734b737-20241003:
+  babel-plugin-react-compiler@0.0.0-experimental-58c2b1c-20241007:
     dependencies:
       '@babel/generator': 7.2.0
       '@babel/types': 7.22.5


### PR DESCRIPTION
### Why?

Uses `npm add` on pnpm workspace as whenever error occurs during the process, it uses `npm` which may not be consistent.

![CleanShot 2024-10-09 at 06 32 34](https://github.com/user-attachments/assets/f4180974-a685-4b3f-a23e-654dd9945baf)

### How?

Use `find-up` to traverse and look for lock files.