### PR TITLE
Refactor prerender workUnitStores

### DIFF
--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -64,8 +64,19 @@ export type PrerenderStoreModern = {
   readonly cacheSignal: null | CacheSignal
 
   /**
+   * This signal is used to clean up the prerender once it is complete.
+   */
+  readonly renderSignal: AbortSignal
+
+  /**
    * During some prerenders we want to track dynamic access.
    */
+  readonly dynamicTracking: null | DynamicTrackingState
+}
+
+export type PrerenderStorePPR = {
+  type: 'prerender-ppr'
+  pathname: string | undefined
   readonly dynamicTracking: null | DynamicTrackingState
 }
 
@@ -74,14 +85,10 @@ export type PrerenderStoreLegacy = {
   pathname: string | undefined
 }
 
-export type PrerenderStore = PrerenderStoreLegacy | PrerenderStoreModern
-
-export function isDynamicIOPrerender(workUnitStore: WorkUnitStore): boolean {
-  return (
-    workUnitStore.type === 'prerender' &&
-    !!(workUnitStore.controller || workUnitStore.cacheSignal)
-  )
-}
+export type PrerenderStore =
+  | PrerenderStoreLegacy
+  | PrerenderStorePPR
+  | PrerenderStoreModern
 
 export type UseCacheStore = {
   type: 'cache'
@@ -114,6 +121,7 @@ export function getExpectedRequestStore(
     }
     if (
       workUnitStore.type === 'prerender' ||
+      workUnitStore.type === 'prerender-ppr' ||
       workUnitStore.type === 'prerender-legacy'
     ) {
       // This should not happen because we should have checked it already.

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -175,6 +175,7 @@ export function addImplicitTags(
       ? workUnitStore.type === 'request'
         ? workUnitStore.url.pathname
         : workUnitStore.type === 'prerender' ||
+            workUnitStore.type === 'prerender-ppr' ||
             workUnitStore.type === 'prerender-legacy'
           ? workUnitStore.pathname
           : undefined
@@ -642,7 +643,7 @@ export function createPatchedFetcher(
               (isCacheableRevalidate || requestStore?.serverComponentsHmrCache)
             ) {
               if (workUnitStore && workUnitStore.type === 'prerender') {
-                // We are prerendering at build time or revalidate time so we need to
+                // We are prerendering at build time or revalidate time with dynamicIO so we need to
                 // buffer the response so we can guarantee it can be read in a microtask
 
                 const bodyBuffer = await res.arrayBuffer()

--- a/packages/next/src/server/node-environment-extensions/utils.tsx
+++ b/packages/next/src/server/node-environment-extensions/utils.tsx
@@ -1,17 +1,10 @@
 import { workAsyncStorage } from '../../client/components/work-async-storage.external'
-import {
-  isDynamicIOPrerender,
-  workUnitAsyncStorage,
-} from '../app-render/work-unit-async-storage.external'
+import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
 import { abortOnSynchronousDynamicDataAccess } from '../app-render/dynamic-rendering'
 
 export function io(expression: string) {
   const workUnitStore = workUnitAsyncStorage.getStore()
-  if (
-    workUnitStore &&
-    workUnitStore.type === 'prerender' &&
-    isDynamicIOPrerender(workUnitStore)
-  ) {
+  if (workUnitStore && workUnitStore.type === 'prerender') {
     const workStore = workAsyncStorage.getStore()
     const route = workStore ? workStore.route : ''
     if (workStore) {

--- a/packages/next/src/server/request/connection.ts
+++ b/packages/next/src/server/request/connection.ts
@@ -1,8 +1,5 @@
 import { workAsyncStorage } from '../../client/components/work-async-storage.external'
-import {
-  isDynamicIOPrerender,
-  workUnitAsyncStorage,
-} from '../app-render/work-unit-async-storage.external'
+import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
 import {
   postponeWithTracking,
   throwToInterruptStaticGeneration,
@@ -44,31 +41,24 @@ export function connection(): Promise<void> {
       )
     }
 
-    if (workUnitStore && workUnitStore.type === 'prerender') {
-      // We are in PPR and/or dynamicIO mode and prerendering
-
-      if (isDynamicIOPrerender(workUnitStore)) {
-        // We use the controller and cacheSignal as an indication we are in dynamicIO mode.
-        // When resolving headers for a prerender with dynamic IO we return a forever promise
-        // along with property access tracked synchronous headers.
-
-        // We don't track dynamic access here because access will be tracked when you access
-        // one of the properties of the headers object.
+    if (workUnitStore) {
+      if (workUnitStore.type === 'prerender') {
+        // dynamicIO Prerender
+        // We return a promise that never resolves to allow the prender to stall at this point
         return makeHangingPromise()
-      } else {
-        // We are prerendering with PPR. We need track dynamic access here eagerly
-        // to keep continuity with how headers has worked in PPR without dynamicIO.
-        // TODO consider switching the semantic to throw on property access intead
+      } else if (workUnitStore.type === 'prerender-ppr') {
+        // PPR Prerender (no dynamicIO)
+        // We use React's postpone API to interrupt rendering here to create a dynamic hole
         postponeWithTracking(
           workStore.route,
           'connection',
           workUnitStore.dynamicTracking
         )
+      } else if (workUnitStore.type === 'prerender-legacy') {
+        // Legacy Prerender
+        // We throw an error here to interrupt prerendering to mark the route as dynamic
+        throwToInterruptStaticGeneration('connection', workStore, workUnitStore)
       }
-    } else if (workStore.isStaticGeneration) {
-      // We are in a legacy static generation mode while prerendering
-      // We treat this function call as a bailout of static generation
-      throwToInterruptStaticGeneration('connection', workStore, workUnitStore)
     }
     // We fall through to the dynamic context below but we still track dynamic access
     // because in dev we can still error for things like using headers inside a cache context

--- a/packages/next/src/server/request/draft-mode.ts
+++ b/packages/next/src/server/request/draft-mode.ts
@@ -43,6 +43,7 @@ export function draftMode(): Promise<DraftMode> {
     (workUnitStore.type === 'cache' ||
       workUnitStore.type === 'unstable-cache' ||
       workUnitStore.type === 'prerender' ||
+      workUnitStore.type === 'prerender-ppr' ||
       workUnitStore.type === 'prerender-legacy')
   ) {
     // Return empty draft mode


### PR DESCRIPTION
This continues the refactor by adding an explicit type for PPR without dynamicIO. It gets rid of `isDynamicIOPrerender` helper in favor or just using a new discriminated type. It narrows the function arguments where possible. dynamicIO prerenders encompass both PPR and non-PPR since prerendering semnatics aren't different even when PPR is enabled. It also sets up passing an AbortSignal into the dynamicIO prerender stores. We don't use it yet but we will end up relying on it to clean up hanging promises after the render is complete