### PR TITLE
chore(turbopack): Delete a bunch of dead/unused structs

### DIFF
--- a/turbopack/crates/turbopack-core/src/module.rs
+++ b/turbopack/crates/turbopack-core/src/module.rs
@@ -1,5 +1,4 @@
-use indexmap::IndexSet;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 
 use crate::{asset::Asset, ident::AssetIdent, reference::ModuleReferences};
 
@@ -35,17 +34,3 @@ impl Modules {
         Vc::cell(Vec::new())
     }
 }
-
-/// A set of [Module]s
-#[turbo_tasks::value(transparent)]
-pub struct ModulesSet(IndexSet<ResolvedVc<Box<dyn Module>>>);
-
-#[turbo_tasks::value_impl]
-impl ModulesSet {
-    #[turbo_tasks::function]
-    pub fn empty() -> Vc<Self> {
-        Vc::cell(IndexSet::new())
-    }
-}
-
-// TODO All Vc::try_resolve_downcast::<Box<dyn Module>> calls should be removed

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -10,9 +10,7 @@ use anyhow::{bail, Result};
 use indexmap::{indexmap, IndexMap, IndexSet};
 use serde::{Deserialize, Serialize};
 use tracing::{Instrument, Level};
-use turbo_tasks::{
-    trace::TraceRawVcs, RcStr, ResolvedVc, TaskInput, TryJoinIterExt, Value, ValueToString, Vc,
-};
+use turbo_tasks::{trace::TraceRawVcs, RcStr, TaskInput, TryJoinIterExt, Value, ValueToString, Vc};
 use turbo_tasks_fs::{
     util::normalize_request, FileSystemEntryType, FileSystemPath, RealPathResult,
 };
@@ -367,22 +365,6 @@ impl ModuleResolveResult {
                 })
                 .collect(),
         )
-    }
-}
-
-#[turbo_tasks::value(transparent)]
-pub struct ModuleResolveResultOption(Option<ResolvedVc<ModuleResolveResult>>);
-
-#[turbo_tasks::value_impl]
-impl ModuleResolveResultOption {
-    #[turbo_tasks::function]
-    pub fn some(result: ResolvedVc<ModuleResolveResult>) -> Vc<Self> {
-        ModuleResolveResultOption(Some(result)).cell()
-    }
-
-    #[turbo_tasks::function]
-    pub fn none() -> Vc<Self> {
-        ModuleResolveResultOption(None).cell()
     }
 }
 
@@ -1293,7 +1275,6 @@ async fn find_package(
                     }
                 }
             }
-            ResolveModules::Registry(_, _) => todo!(),
         }
     }
     Ok(FindPackageResult::cell(FindPackageResult {

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -4,8 +4,7 @@ use anyhow::{bail, Result};
 use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{
-    debug::ValueDebugFormat, trace::TraceRawVcs, RcStr, ResolvedVc, TryJoinIterExt, Value,
-    ValueToString, Vc,
+    debug::ValueDebugFormat, trace::TraceRawVcs, RcStr, TryJoinIterExt, Value, ValueToString, Vc,
 };
 use turbo_tasks_fs::{glob::Glob, FileSystemPath};
 
@@ -38,10 +37,6 @@ pub enum ResolveModules {
         dir: Vc<FileSystemPath>,
         excluded_extensions: Vc<ExcludedExtensions>,
     },
-    /// lookup versions based on lockfile in the registry filesystem
-    /// registry filesystem is assumed to have structure like
-    /// @scope/module/version/<path-in-package>
-    Registry(ResolvedVc<FileSystemPath>, ResolvedVc<LockedVersions>),
 }
 
 #[derive(TraceRawVcs, Hash, PartialEq, Eq, Clone, Copy, Debug, Serialize, Deserialize)]

--- a/turbopack/crates/turbopack-core/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/mod.rs
@@ -1,13 +1,12 @@
 use std::{borrow::Cow, io::Write, ops::Deref, sync::Arc};
 
 use anyhow::Result;
-use indexmap::IndexMap;
 use once_cell::sync::Lazy;
 use ref_cast::RefCast;
 use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sourcemap::{DecodedMap, SourceMap as RegularMap, SourceMapBuilder, SourceMapIndex};
-use turbo_tasks::{RcStr, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
+use turbo_tasks::{RcStr, TryJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::{
     rope::{Rope, RopeBuilder},
     File, FileContent, FileSystem, FileSystemPath, VirtualFileSystem,
@@ -55,9 +54,6 @@ pub enum SourceMap {
     /// different regions of the file.
     Sectioned(#[turbo_tasks(trace_ignore)] SectionedSourceMap),
 }
-
-#[turbo_tasks::value(transparent)]
-pub struct SectionMapping(IndexMap<String, ResolvedVc<Box<dyn GenerateSourceMap>>>);
 
 #[turbo_tasks::value(transparent)]
 pub struct OptionSourceMap(Option<Vc<SourceMap>>);

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -5,7 +5,7 @@ use std::fmt::Write;
 
 use anyhow::{bail, Result};
 use indexmap::IndexSet;
-use turbo_tasks::{RcStr, ResolvedVc, TryJoinIterExt, Value, ValueDefault, ValueToString, Vc};
+use turbo_tasks::{RcStr, TryJoinIterExt, Value, ValueDefault, ValueToString, Vc};
 use turbo_tasks_fs::{rope::Rope, File, FileSystem};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -35,9 +35,6 @@ pub struct CssChunk {
     pub chunking_context: Vc<Box<dyn ChunkingContext>>,
     pub content: Vc<CssChunkContent>,
 }
-
-#[turbo_tasks::value(transparent)]
-pub struct CssChunks(Vec<ResolvedVc<CssChunk>>);
 
 #[turbo_tasks::value_impl]
 impl CssChunk {
@@ -349,9 +346,6 @@ impl CssChunkContext {
 // TODO: remove
 #[turbo_tasks::value_trait]
 pub trait CssChunkPlaceable: ChunkableModule + Module + Asset {}
-
-#[turbo_tasks::value(transparent)]
-pub struct CssChunkPlaceables(Vec<ResolvedVc<Box<dyn CssChunkPlaceable>>>);
 
 #[derive(Clone, Debug)]
 #[turbo_tasks::value(shared)]

--- a/turbopack/crates/turbopack-css/src/code_gen.rs
+++ b/turbopack/crates/turbopack-css/src/code_gen.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::Vc;
 use turbopack_core::chunk::ChunkingContext;
 
 use crate::chunk::CssImport;
@@ -24,6 +24,3 @@ pub trait CodeGenerateable {
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Vc<CodeGeneration>;
 }
-
-#[turbo_tasks::value(transparent)]
-pub struct CodeGenerateables(Vec<ResolvedVc<Box<dyn CodeGenerateable>>>);

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/emotion.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/emotion.rs
@@ -14,7 +14,7 @@ use swc_core::{
         visit::FoldWith,
     },
 };
-use turbo_tasks::{trace::TraceRawVcs, ResolvedVc, ValueDefault, Vc};
+use turbo_tasks::{trace::TraceRawVcs, ValueDefault, Vc};
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
 
 #[derive(Clone, PartialEq, Eq, Debug, TraceRawVcs, Serialize, Deserialize)]
@@ -24,9 +24,6 @@ pub enum EmotionLabelKind {
     Always,
     Never,
 }
-
-#[turbo_tasks::value(transparent)]
-pub struct OptionEmotionTransformConfig(Option<ResolvedVc<EmotionTransformConfig>>);
 
 //[TODO]: need to support importmap, there are type mismatch between
 //next.config.js to swc's emotion options

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/styled_components.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/styled_components.rs
@@ -6,13 +6,8 @@ use swc_core::{
     common::{comments::NoopComments, FileName},
     ecma::{ast::Program, atoms::JsWord, visit::VisitMutWith},
 };
-use turbo_tasks::{ResolvedVc, ValueDefault, Vc};
+use turbo_tasks::{ValueDefault, Vc};
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
-
-#[turbo_tasks::value(transparent)]
-pub struct OptionStyledComponentsTransformConfig(
-    Option<ResolvedVc<StyledComponentsTransformConfig>>,
-);
 
 #[turbo_tasks::value(shared)]
 #[derive(Clone, Debug)]

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{trace::TraceRawVcs, ResolvedVc, Upcast, ValueToString, Vc};
+use turbo_tasks::{trace::TraceRawVcs, Upcast, ValueToString, Vc};
 use turbo_tasks_fs::rope::Rope;
 use turbopack_core::{
     chunk::{AsyncModuleInfo, ChunkItem, ChunkItemExt, ChunkingContext},
@@ -264,9 +264,3 @@ async fn module_factory_with_code_generation_issue(
         },
     )
 }
-
-#[turbo_tasks::value(transparent)]
-pub struct EcmascriptChunkItemsChunk(Vec<ResolvedVc<Box<dyn EcmascriptChunkItem>>>);
-
-#[turbo_tasks::value(transparent)]
-pub struct EcmascriptChunkItems(pub(super) Vec<ResolvedVc<Box<dyn EcmascriptChunkItem>>>);

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -7,7 +7,7 @@ pub(crate) mod placeable;
 use std::fmt::Write;
 
 use anyhow::{bail, Result};
-use turbo_tasks::{RcStr, ResolvedVc, Value, ValueToString, Vc};
+use turbo_tasks::{RcStr, Value, ValueToString, Vc};
 use turbo_tasks_fs::FileSystem;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -30,7 +30,7 @@ pub use self::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkItemExt,
         EcmascriptChunkItemOptions,
     },
-    placeable::{EcmascriptChunkPlaceable, EcmascriptChunkPlaceables, EcmascriptExports},
+    placeable::{EcmascriptChunkPlaceable, EcmascriptExports},
 };
 
 #[turbo_tasks::value]
@@ -38,9 +38,6 @@ pub struct EcmascriptChunk {
     pub chunking_context: Vc<Box<dyn ChunkingContext>>,
     pub content: Vc<EcmascriptChunkContent>,
 }
-
-#[turbo_tasks::value(transparent)]
-pub struct EcmascriptChunks(Vec<ResolvedVc<EcmascriptChunk>>);
 
 #[turbo_tasks::value_impl]
 impl EcmascriptChunk {

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{ResolvedVc, TryFlatJoinIterExt, Vc};
+use turbo_tasks::{TryFlatJoinIterExt, Vc};
 use turbo_tasks_fs::{glob::Glob, FileJsonContent, FileSystemPath};
 use turbopack_core::{
     asset::Asset,
@@ -186,17 +186,6 @@ pub async fn is_marked_as_side_effect_free(
     }
 
     Ok(Vc::cell(false))
-}
-
-#[turbo_tasks::value(transparent)]
-pub struct EcmascriptChunkPlaceables(Vec<ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>>);
-
-#[turbo_tasks::value_impl]
-impl EcmascriptChunkPlaceables {
-    #[turbo_tasks::function]
-    pub fn empty() -> Vc<Self> {
-        Vc::cell(Vec::new())
-    }
 }
 
 #[turbo_tasks::value(shared)]

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -56,8 +56,8 @@ use swc_core::{
     },
 };
 pub use transform::{
-    CustomTransformer, EcmascriptInputTransform, EcmascriptInputTransforms, OptionTransformPlugin,
-    TransformContext, TransformPlugin, UnsupportedServerActionIssue,
+    CustomTransformer, EcmascriptInputTransform, EcmascriptInputTransforms, TransformContext,
+    TransformPlugin, UnsupportedServerActionIssue,
 };
 use turbo_tasks::{
     trace::TraceRawVcs, RcStr, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, Value,
@@ -280,14 +280,6 @@ pub trait EcmascriptAnalyzable {
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Vc<EcmascriptModuleContent>>;
 }
-
-/// An optional [EcmascriptModuleAsset]
-#[turbo_tasks::value(transparent)]
-pub struct OptionEcmascriptModuleAsset(Option<ResolvedVc<EcmascriptModuleAsset>>);
-
-/// A list of [EcmascriptModuleAsset]s
-#[turbo_tasks::value(transparent)]
-pub struct EcmascriptModuleAssets(Vec<ResolvedVc<EcmascriptModuleAsset>>);
 
 impl EcmascriptModuleAsset {
     pub fn builder(

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -5,7 +5,7 @@ use swc_core::{
     ecma::ast::{Decl, Expr, ExprStmt, Ident, Stmt},
     quote,
 };
-use turbo_tasks::{RcStr, ResolvedVc, Value, ValueToString, Vc};
+use turbo_tasks::{RcStr, Value, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     chunk::{
@@ -103,10 +103,6 @@ pub struct EsmAssetReference {
     pub export_name: Option<Vc<ModulePart>>,
     pub import_externals: bool,
 }
-
-/// A list of [EsmAssetReference]s
-#[turbo_tasks::value(transparent)]
-pub struct EsmAssetReferences(Vec<ResolvedVc<EsmAssetReference>>);
 
 impl EsmAssetReference {
     fn get_origin(&self) -> Vc<Box<dyn ResolveOrigin>> {

--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -18,7 +18,7 @@ use swc_core::{
     },
     quote,
 };
-use turbo_tasks::{RcStr, ResolvedVc, ValueDefault, Vc};
+use turbo_tasks::{RcStr, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     environment::Environment,
@@ -80,17 +80,6 @@ pub trait CustomTransformer: Debug {
 )]
 #[derive(Debug)]
 pub struct TransformPlugin(#[turbo_tasks(trace_ignore)] Box<dyn CustomTransformer + Send + Sync>);
-
-#[turbo_tasks::value(transparent)]
-pub struct OptionTransformPlugin(Option<ResolvedVc<TransformPlugin>>);
-
-#[turbo_tasks::value_impl]
-impl ValueDefault for OptionTransformPlugin {
-    #[turbo_tasks::function]
-    fn value_default() -> Vc<Self> {
-        Vc::cell(None)
-    }
-}
 
 #[async_trait]
 impl CustomTransformer for TransformPlugin {

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -1,6 +1,6 @@
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{trace::TraceRawVcs, RcStr, ResolvedVc, ValueDefault, Vc};
+use turbo_tasks::{trace::TraceRawVcs, RcStr, ValueDefault, Vc};
 use turbopack_core::{
     condition::ContextCondition, environment::Environment, resolve::options::ImportMapping,
 };
@@ -33,10 +33,6 @@ pub struct WebpackLoadersOptions {
     pub rules: Vc<WebpackRules>,
     pub loader_runner_package: Option<Vc<ImportMapping>>,
 }
-
-#[derive(Default)]
-#[turbo_tasks::value(transparent)]
-pub struct OptionWebpackLoadersOptions(Option<ResolvedVc<WebpackLoadersOptions>>);
 
 /// The kind of decorators transform to use.
 /// [TODO]: might need bikeshed for the name (Ecma)


### PR DESCRIPTION
It turns out the codemod I made for #70987 is also a pretty good dead code detector, because dead code tends not to trigger any compilation errors when field types are changed 😆

Delete these structs.