### PR TITLE
Fix i686 next-swc build due to int overflow

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/lmdb_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/lmdb_backing_storage.rs
@@ -69,7 +69,9 @@ impl LmdbBackingStorage {
             )
             .set_max_readers((available_parallelism().map_or(16, |v| v.get()) * 8) as u32)
             .set_max_dbs(5)
-            .set_map_size(40 * 1024 * 1024 * 1024)
+            // value must be less than max 32 bit int size
+            // since we compile for i686
+            .set_map_size(4 * 1024 * 1024 * 1024 - 1)
             .open(path)?;
         let infra_db = env.create_db(Some("infra"), DatabaseFlags::INTEGER_KEY)?;
         let data_db = env.create_db(Some("data"), DatabaseFlags::INTEGER_KEY)?;

--- a/turbopack/crates/turbo-tasks-backend/src/lmdb_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/lmdb_backing_storage.rs
@@ -61,6 +61,12 @@ pub struct LmdbBackingStorage {
 impl LmdbBackingStorage {
     pub fn new(path: &Path) -> Result<Self> {
         create_dir_all(path)?;
+
+        #[cfg(target_arch = "x86")]
+        const MAP_SIZE: usize = usize::MAX;
+        #[cfg(not(target_arch = "x86"))]
+        const MAP_SIZE: usize = 40 * 1024 * 1024 * 1024;
+
         let env = Environment::new()
             .set_flags(
                 EnvironmentFlags::WRITE_MAP
@@ -69,9 +75,7 @@ impl LmdbBackingStorage {
             )
             .set_max_readers((available_parallelism().map_or(16, |v| v.get()) * 8) as u32)
             .set_max_dbs(5)
-            // value must be less than max 32 bit int size
-            // since we compile for i686
-            .set_map_size(3 * 1024 * 1024 * 1024)
+            .set_map_size(MAP_SIZE)
             .open(path)?;
         let infra_db = env.create_db(Some("infra"), DatabaseFlags::INTEGER_KEY)?;
         let data_db = env.create_db(Some("data"), DatabaseFlags::INTEGER_KEY)?;

--- a/turbopack/crates/turbo-tasks-backend/src/lmdb_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/lmdb_backing_storage.rs
@@ -71,7 +71,7 @@ impl LmdbBackingStorage {
             .set_max_dbs(5)
             // value must be less than max 32 bit int size
             // since we compile for i686
-            .set_map_size(4 * 1024 * 1024 * 1024 - 1)
+            .set_map_size(3 * 1024 * 1024 * 1024)
             .open(path)?;
         let infra_db = env.create_db(Some("infra"), DatabaseFlags::INTEGER_KEY)?;
         let data_db = env.create_db(Some("data"), DatabaseFlags::INTEGER_KEY)?;


### PR DESCRIPTION
This ensures we don't hit the max 32 bit int size on our i686 Windows build for `next-swc`. Validated fix against run here https://github.com/vercel/next.js/actions/runs/11246045657/job/31267205387

x-ref: https://github.com/vercel/next.js/actions/runs/11245312094/job/31265087281
x-ref: https://github.com/vercel/next.js/pull/69668