### PR TITLE
ensure export workers that are killed bubble up to parent process

### DIFF
--- a/packages/next/src/lib/worker.ts
+++ b/packages/next/src/lib/worker.ts
@@ -80,6 +80,9 @@ export class Worker {
               logger.error(
                 `Static worker exited with code: ${code} and signal: ${signal}`
               )
+
+              // if a child process doesn't exit gracefully, we want to bubble up the exit code to the parent process
+              process.exit(code ?? 1)
             }
           })
 

--- a/test/production/app-dir/worker-restart/fixtures/worker-kill/app/bad-page/page.js
+++ b/test/production/app-dir/worker-restart/fixtures/worker-kill/app/bad-page/page.js
@@ -1,0 +1,5 @@
+export default function Page() {
+  process.kill(process.pid, 'SIGKILL')
+
+  return <div>Kaboom</div>
+}

--- a/test/production/app-dir/worker-restart/fixtures/worker-kill/app/layout.js
+++ b/test/production/app-dir/worker-restart/fixtures/worker-kill/app/layout.js
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/worker-restart/fixtures/worker-kill/app/page.js
+++ b/test/production/app-dir/worker-restart/fixtures/worker-kill/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Hello World</div>
+}

--- a/test/production/app-dir/worker-restart/fixtures/worker-kill/next.config.js
+++ b/test/production/app-dir/worker-restart/fixtures/worker-kill/next.config.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/test/production/app-dir/worker-restart/worker-restart.test.ts
+++ b/test/production/app-dir/worker-restart/worker-restart.test.ts
@@ -43,4 +43,20 @@ describe('worker-restart', () => {
     )
     expect(output).toContain('Failed to build /page: / after 3 attempts.')
   })
+
+  it('should fail the build if a worker process is killed', async () => {
+    const { stdout, stderr } = await nextBuild(
+      __dirname + '/fixtures/worker-kill',
+      [],
+      {
+        stdout: true,
+        stderr: true,
+      }
+    )
+
+    const output = stdout + stderr
+    expect(output).toContain(
+      'Static worker exited with code: null and signal: SIGKILL'
+    )
+  })
 })


### PR DESCRIPTION
When a static worker exits, we log the error but it doesn't get propagated to the parent process, which can cause the build to hang. If we're going to log an error about a static worker being forced to exit, this calls exit on the parent process. 

Closes NDX-364