### PR TITLE
docs: fix URL for error message

### DIFF
--- a/errors/missing-root-layout-tags.mdx
+++ b/errors/missing-root-layout-tags.mdx
@@ -26,4 +26,4 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 
 ### Useful Links
 
-- [Root Layout](https://nextjs.org/docs/app/building-your-application/routing/layouts-and-templates#root-layout-required)
+- [Root Layout](https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts#root-layout-required)


### PR DESCRIPTION
Fix URL for https://nextjs.org/docs/messages/missing-root-layout-tags