### PR TITLE
docs: add `app-dir-runtime-config-experimental-edge` codemod

### DIFF
--- a/docs/02-app/01-building-your-application/11-upgrading/01-codemods.mdx
+++ b/docs/02-app/01-building-your-application/11-upgrading/01-codemods.mdx
@@ -26,6 +26,30 @@ Replacing `<transform>` and `<path>` with appropriate values.
 
 ### 15.0
 
+#### Replace App Router Route Segment Config `runtime` value from `experimental-edge` to `edge`
+
+##### `app-dir-runtime-config-experimental-edge`
+
+> **Note**: This codemod is App Router specific.
+
+```bash filename="Terminal"
+npx @next/codemod@latest app-dir-runtime-config-experimental-edge .
+```
+
+This codemod transforms [Route Segment Config `runtime`](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#runtime) value `experimental-edge` to `edge`.
+
+For example:
+
+```ts
+export const runtime = 'experimental-edge'
+```
+
+Transforms into:
+
+```ts
+export const runtime = 'edge'
+```
+
 #### Migrate to async Dynamic APIs
 
 ##### `next-async-request-api`

--- a/docs/02-app/01-building-your-application/11-upgrading/01-codemods.mdx
+++ b/docs/02-app/01-building-your-application/11-upgrading/01-codemods.mdx
@@ -26,7 +26,7 @@ Replacing `<transform>` and `<path>` with appropriate values.
 
 ### 15.0
 
-#### Replace App Router Route Segment Config `runtime` value from `experimental-edge` to `edge`
+#### Transform App Router Route Segment Config `runtime` value from `experimental-edge` to `edge`
 
 ##### `app-dir-runtime-config-experimental-edge`
 

--- a/packages/next-codemod/lib/utils.ts
+++ b/packages/next-codemod/lib/utils.ts
@@ -118,7 +118,7 @@ export const TRANSFORMER_INQUIRER_CHOICES = [
   },
   {
     title:
-      'Transforms `experimental-edge` to `edge` in the `runtime` route segment configuration within the App Router',
+      'Transform App Router Route Segment Config `runtime` value from `experimental-edge` to `edge`',
     value: 'app-dir-runtime-config-experimental-edge',
     version: '15.0.0-canary.179',
   },


### PR DESCRIPTION
Added missing docs for codemod https://github.com/vercel/next.js/pull/70968