### PR TITLE
codemod: comment on reexport

### DIFF
--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-28.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-28.input.tsx
@@ -1,0 +1,2 @@
+export { Page as default } from './page'
+export { generateMetadata } from './generate-metadata'

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-28.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-28.output.tsx
@@ -1,4 +1,4 @@
-export { /* Next.js Dynamic Async API Codemod: `default` export is re-exported. Check if this component uses `params` or `searchParams`*/
+export { /* Next.js Dynamic Async API Codemod: `Page` export is re-exported. Check if this component uses `params` or `searchParams`*/
 Page as default } from './page'
 export { /* Next.js Dynamic Async API Codemod: `generateMetadata` export is re-exported. Check if this component uses `params` or `searchParams`*/
 generateMetadata } from './generate-metadata'

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-28.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-28.output.tsx
@@ -1,0 +1,5 @@
+export { /* Next.js Dynamic Async API Codemod: `default` export is re-exported. Check if this component uses `params` or `searchParams`*/
+Page as default } from './page'
+export { /* Next.js Dynamic Async API Codemod: `generateMetadata` export is re-exported. Check if this component uses `params` or `searchParams`*/
+generateMetadata } from './generate-metadata'
+  

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-29.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-29.input.tsx
@@ -1,0 +1,3 @@
+import { generateMetadata } from './generate-metadata'
+export { default } from './page'
+export { generateMetadata }

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-29.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-29.output.tsx
@@ -1,0 +1,5 @@
+import { generateMetadata } from './generate-metadata'
+export { /* Next.js Dynamic Async API Codemod: `default` export is re-exported. Check if this component uses `params` or `searchParams`*/
+default } from './page'
+export { /* Next.js Dynamic Async API Codemod: `generateMetadata` export is re-exported. Check if this component uses `params` or `searchParams`*/
+generateMetadata }

--- a/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
@@ -29,8 +29,12 @@ function findDynamicImportsAndComment(root: Collection<any>, j: API['j']) {
   })
 
   importPaths.forEach((path) => {
-    insertCommentOnce(path.node, j, DYNAMIC_IMPORT_WARN_COMMENT)
-    modified = true
+    const inserted = insertCommentOnce(
+      path.node,
+      j,
+      DYNAMIC_IMPORT_WARN_COMMENT
+    )
+    modified ||= inserted
   })
   return modified
 }
@@ -180,7 +184,7 @@ export function transformDynamicAPI(
                 )
                 needsReactUseImport = true
               } else {
-                castTypesOrAddComment(
+                const casted = castTypesOrAddComment(
                   j,
                   path,
                   originRequestApiName,
@@ -189,9 +193,10 @@ export function transformDynamicAPI(
                   insertedTypes,
                   ` Next.js Dynamic Async API Codemod: Manually await this call, if it's a Server Component `
                 )
+                modified ||= casted
               }
             } else {
-              castTypesOrAddComment(
+              const casted = castTypesOrAddComment(
                 j,
                 path,
                 originRequestApiName,
@@ -200,8 +205,8 @@ export function transformDynamicAPI(
                 insertedTypes,
                 ' Next.js Dynamic Async API Codemod: please manually await this call, codemod cannot transform due to undetermined async scope '
               )
+              modified ||= casted
             }
-            modified = true
           }
         }
       })
@@ -263,9 +268,8 @@ export function transformDynamicAPI(
     insertReactUseImport(root, j)
   }
 
-  if (findDynamicImportsAndComment(root, j)) {
-    modified = true
-  }
+  const commented = findDynamicImportsAndComment(root, j)
+  modified ||= commented
 
   return modified ? root.toSource() : null
 }
@@ -286,10 +290,11 @@ function castTypesOrAddComment(
   insertedTypes: Set<string>,
   customMessage: string
 ) {
+  let modified = false
   const isTsFile = filePath.endsWith('.ts') || filePath.endsWith('.tsx')
   if (isTsFile) {
     // if the path of call expression is already being awaited, no need to cast
-    if (path.parentPath?.node?.type === 'AwaitExpression') return
+    if (path.parentPath?.node?.type === 'AwaitExpression') return false
 
     /* Do type cast for headers, cookies, draftMode
       import {
@@ -314,6 +319,7 @@ function castTypesOrAddComment(
     // Replace the original expression with the new cast expression,
     // also wrap () around the new cast expression.
     j(path).replaceWith(j.parenthesizedExpression(newCastExpression))
+    modified = true
 
     // If cast types are not imported, add them to the import list
     const importDeclaration = root.find(j.ImportDeclaration, {
@@ -343,8 +349,11 @@ function castTypesOrAddComment(
     }
   } else {
     // Otherwise for JS file, leave a message to the user to manually handle the transformation
-    insertCommentOnce(path.node, j, customMessage)
+    const inserted = insertCommentOnce(path.node, j, customMessage)
+    modified ||= inserted
   }
+
+  return modified
 }
 
 function findImportMappingFromNextHeaders(root: Collection<any>, j: API['j']) {

--- a/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-prop.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-prop.ts
@@ -221,20 +221,6 @@ function commentOnMatchedReExports(
           }
         }
       }
-      // if (j.Literal.check(path.value.source)) {
-
-      // } else if (path.value.source === null) {
-      //   for (const specifier of specifiers) {
-      //     if (
-      //       j.ExportSpecifier.check(specifier) &&
-      //       // Find matched named exports and default export
-      //       (TARGET_NAMED_EXPORTS.has(specifier.exported.name) ||
-      //         specifier.exported.name === 'default')
-      //     ) {
-
-      //     }
-      //   }
-      // }
     }
   })
   return modified

--- a/packages/next-codemod/transforms/lib/async-request-api/utils.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/utils.ts
@@ -427,16 +427,17 @@ export function insertCommentOnce(
   node: ASTPath<any>['node'],
   j: API['j'],
   comment: string
-) {
+): boolean {
   if (node.comments) {
     const hasComment = node.comments.some(
       (commentNode) => commentNode.value === comment
     )
     if (hasComment) {
-      return
+      return false
     }
   }
   node.comments = [j.commentBlock(comment), ...(node.comments || [])]
+  return true
 }
 
 export function getVariableDeclaratorId(


### PR DESCRIPTION
### What

For entry files, add comment for re-exports of entry exports, to tell users take care of the possible usage of handled async params and searchParams