### PR TITLE
chore(next-upgrade): improve revision usage messages

### DIFF
--- a/packages/next-codemod/bin/next-codemod.ts
+++ b/packages/next-codemod/bin/next-codemod.ts
@@ -46,16 +46,16 @@ program
   .description(
     'Upgrade Next.js apps to desired versions with a single command.'
   )
-
   .argument(
     '[revision]',
-    'NPM dist tag or exact version to upgrade to (e.g. "latest" or "15.0.0-canary.167"). Valid dist-tags are "latest", "canary" or "rc".',
+    'Specify the target Next.js version using an NPM dist tag (e.g. "latest", "canary", "rc") or an exact version number (e.g. "15.0.0").',
     packageJson.version.includes('-canary.')
       ? 'canary'
       : packageJson.version.includes('-rc.')
         ? 'rc'
         : 'latest'
   )
+  .usage('[revision] [options]')
   .option('--verbose', 'Verbose output', false)
   .action(runUpgrade)
 

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -58,7 +58,7 @@ export async function runUpgrade(
     'peerDependencies' in targetNextPackageJson
   if (!validRevision) {
     console.error(
-      `${pc.red('⨯')} ${pc.yellow(`next@${revision}`)} does not exist. Make sure you entered a valid Next.js version or dist-tag. Check available versions at ${pc.underline('https://www.npmjs.com/package/next?activeTab=versions')}.`
+      `${pc.red('⨯')} Invalid revision provided: "${revision}". Please provide a valid Next.js version or dist-tag (e.g. "latest", "canary", "rc", or "15.0.0").\nCheck available versions at https://www.npmjs.com/package/next?activeTab=versions.`
     )
     process.exit(1)
   }
@@ -141,6 +141,7 @@ function getInstalledNextVersion(): string {
     ).version
   } catch (error) {
     console.error(
+      // TODO: Better monorepo handling
       `${pc.red('⨯')} Failed to get the installed Next.js version at "${process.cwd()}".\nIf you're using a monorepo, please run this command from the Next.js app directory.`
     )
     process.exit(1)


### PR DESCRIPTION
### Why?

WIthout specific usage example, it could be hard to do it right in the first time to pass the correct version (e.g. 15.0.0 instead of 15). Therefore improve messages and added help message usage.