### PR TITLE
Revert "chore(next-upgrade): use process exit instead of throwing (#7…

### DIFF
--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -21,10 +21,9 @@ async function loadHighestNPMVersionMatching(query: string) {
   )
   const versionOrVersions = JSON.parse(versionsJSON)
   if (versionOrVersions.length < 1) {
-    console.error(
-      `${pc.red('⨯')} Found no React versions matching "${query}". This is a bug in the upgrade tool.`
+    throw new Error(
+      `Found no React versions matching "${query}". This is a bug in the upgrade tool.`
     )
-    process.exit(1)
   }
   // npm-view returns an array if there are multiple versions matching the query.
   if (Array.isArray(versionOrVersions)) {
@@ -57,10 +56,9 @@ export async function runUpgrade(
     'version' in targetNextPackageJson &&
     'peerDependencies' in targetNextPackageJson
   if (!validRevision) {
-    console.error(
-      `${pc.red('⨯')} ${pc.yellow(`next@${revision}`)} does not exist. Make sure you entered a valid Next.js version or dist-tag. Check available versions at ${pc.underline('https://www.npmjs.com/package/next?activeTab=versions')}.`
+    throw new Error(
+      `${pc.yellow(`next@${revision}`)} does not exist. Make sure you entered a valid Next.js version or dist-tag. Check available versions at ${pc.underline('https://www.npmjs.com/package/next?activeTab=versions')}.`
     )
-    process.exit(1)
   }
 
   const installedNextVersion = getInstalledNextVersion()
@@ -140,10 +138,12 @@ function getInstalledNextVersion(): string {
       })
     ).version
   } catch (error) {
-    console.error(
-      `${pc.red('⨯')} Failed to get the installed Next.js version at "${process.cwd()}".\nIf you're using a monorepo, please run this command from the Next.js app directory.`
+    throw new Error(
+      `Failed to get the installed Next.js version at "${process.cwd()}".\nIf you're using a monorepo, please run this command from the Next.js app directory.`,
+      {
+        cause: error,
+      }
     )
-    process.exit(1)
   }
 }
 


### PR DESCRIPTION
### Why?

From @eps1lon:

> ...the process.exit() since it's not safe. It may not exit immediate whereas throwing does and it doesn't give stack.