### PR TITLE
Skip deployments for Dynamic IO error tests

### DIFF
--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.platform-dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.platform-dynamic.test.ts
@@ -46,6 +46,7 @@ function runTests(options: { withMinification: boolean }) {
       const { next, isNextDev, skipped } = nextTestSetup({
         files: __dirname + '/fixtures/sync-random-with-fallback',
         skipStart: true,
+        skipDeployment: true,
       })
 
       if (skipped) {
@@ -91,6 +92,7 @@ function runTests(options: { withMinification: boolean }) {
       const { next, isNextDev, skipped } = nextTestSetup({
         files: __dirname + '/fixtures/sync-random-without-fallback',
         skipStart: true,
+        skipDeployment: true,
       })
 
       if (skipped) {

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-dynamic.test.ts
@@ -46,6 +46,7 @@ function runTests(options: { withMinification: boolean }) {
       const { next, isNextDev, skipped } = nextTestSetup({
         files: __dirname + '/fixtures/sync-client-search-with-fallback',
         skipStart: true,
+        skipDeployment: true,
       })
 
       if (skipped) {
@@ -91,6 +92,7 @@ function runTests(options: { withMinification: boolean }) {
       const { next, isNextDev, skipped } = nextTestSetup({
         files: __dirname + '/fixtures/sync-client-search-without-fallback',
         skipStart: true,
+        skipDeployment: true,
       })
 
       if (skipped) {
@@ -138,6 +140,7 @@ function runTests(options: { withMinification: boolean }) {
       const { next, isNextDev, skipped } = nextTestSetup({
         files: __dirname + '/fixtures/sync-server-search-with-fallback',
         skipStart: true,
+        skipDeployment: true,
       })
 
       if (skipped) {
@@ -183,6 +186,7 @@ function runTests(options: { withMinification: boolean }) {
       const { next, isNextDev, skipped } = nextTestSetup({
         files: __dirname + '/fixtures/sync-server-search-without-fallback',
         skipStart: true,
+        skipDeployment: true,
       })
 
       if (skipped) {
@@ -238,6 +242,7 @@ function runTests(options: { withMinification: boolean }) {
       const { next, isNextDev, skipped } = nextTestSetup({
         files: __dirname + '/fixtures/sync-cookies-with-fallback',
         skipStart: true,
+        skipDeployment: true,
       })
 
       if (skipped) {
@@ -283,6 +288,7 @@ function runTests(options: { withMinification: boolean }) {
       const { next, isNextDev, skipped } = nextTestSetup({
         files: __dirname + '/fixtures/sync-cookies-without-fallback',
         skipStart: true,
+        skipDeployment: true,
       })
 
       if (skipped) {

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
@@ -46,6 +46,7 @@ function runTests(options: { withMinification: boolean }) {
       const { next, isNextDev, skipped } = nextTestSetup({
         files: __dirname + '/fixtures/dynamic-metadata-static-route',
         skipStart: true,
+        skipDeployment: true,
       })
 
       if (skipped) {
@@ -87,6 +88,7 @@ function runTests(options: { withMinification: boolean }) {
       const { next, isNextDev, skipped } = nextTestSetup({
         files: __dirname + '/fixtures/dynamic-metadata-dynamic-route',
         skipStart: true,
+        skipDeployment: true,
       })
 
       if (skipped) {
@@ -127,6 +129,7 @@ function runTests(options: { withMinification: boolean }) {
       const { next, isNextDev, skipped } = nextTestSetup({
         files: __dirname + '/fixtures/dynamic-viewport-static-route',
         skipStart: true,
+        skipDeployment: true,
       })
 
       if (skipped) {
@@ -168,6 +171,7 @@ function runTests(options: { withMinification: boolean }) {
       const { next, isNextDev, skipped } = nextTestSetup({
         files: __dirname + '/fixtures/dynamic-viewport-dynamic-route',
         skipStart: true,
+        skipDeployment: true,
       })
 
       if (skipped) {
@@ -208,6 +212,7 @@ function runTests(options: { withMinification: boolean }) {
       const { next, isNextDev, skipped } = nextTestSetup({
         files: __dirname + '/fixtures/static',
         skipStart: true,
+        skipDeployment: true,
       })
 
       if (skipped) {
@@ -244,6 +249,7 @@ function runTests(options: { withMinification: boolean }) {
       const { next, isNextDev, skipped } = nextTestSetup({
         files: __dirname + '/fixtures/dynamic-root',
         skipStart: true,
+        skipDeployment: true,
       })
 
       if (skipped) {
@@ -301,6 +307,7 @@ function runTests(options: { withMinification: boolean }) {
       const { next, isNextDev, skipped } = nextTestSetup({
         files: __dirname + '/fixtures/dynamic-boundary',
         skipStart: true,
+        skipDeployment: true,
       })
 
       if (skipped) {


### PR DESCRIPTION
For some of these tests a deployment won't succeed because a build error is expected. For others, we can't do the deploy tests because they use `patchFile` which is not available in the deploy test mode.

These deploy test failures slipped through because #70734 was created from a fork.