### PR TITLE
Skip `Math.random` test with route handler and `'use cache'`

### DIFF
--- a/test/e2e/app-dir/node-extensions/node-extensions.random.test.ts
+++ b/test/e2e/app-dir/node-extensions/node-extensions.random.test.ts
@@ -5,6 +5,7 @@ describe('Node Extensions', () => {
     describe('Dynamic IO', () => {
       const { next, skipped } = nextTestSetup({
         files: __dirname + '/fixtures/random/dynamic-io',
+        skipDeployment: true,
       })
 
       if (skipped) {
@@ -64,7 +65,7 @@ describe('Node Extensions', () => {
         expect($('li').length).toBe(2)
       })
 
-      it('should not error when accessing routes that use Math.random() in App Router', async () => {
+      it.skip('should not error when accessing routes that use Math.random() in App Router', async () => {
         let res, body
 
         res = await next.fetch('/app/prerendered/uncached/api')


### PR DESCRIPTION
Using `'use cache'` in route handlers is not yet fully supported, and fails in isolation, e.g. in a deployment test, because it implicitly relies on the fact that a page must have been compiled before the route. Otherwise rendering the route errors with "Missing manifest for Server Actions.".

This deploy test failure slipped through because #70837 was created from a fork.