### PR TITLE
chore(next-codemod): view current Next.js version, skip if already on or higher

### DIFF
--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -134,12 +134,6 @@ export async function runUpgrade(
     await runTransform(codemod, process.cwd(), { force: true })
   }
 
-  // Release https://github.com/vercel/next.js/releases/tag/v14.3.0-canary.45
-  // PR https://github.com/vercel/next.js/pull/65058
-  if (compareVersions(targetNextVersion, '14.3.0-canary.45') >= 0) {
-    await suggestReactCodemods(packageManager)
-  }
-
   console.log(
     `\n${pc.green('✔')} Your Next.js project has been upgraded successfully. ${pc.bold('Time to ship! 🚢')}`
   )
@@ -264,32 +258,4 @@ async function suggestCodemods(
   )
 
   return codemods
-}
-
-async function suggestReactCodemods(packageManager: PackageManager) {
-  const { runReactCodemod } = await prompts(
-    {
-      type: 'toggle',
-      name: 'runReactCodemod',
-      message: 'Do you want to run the React codemod?',
-      initial: true,
-      active: 'Yes',
-      inactive: 'No',
-    },
-    { onCancel }
-  )
-
-  if (runReactCodemod) {
-    const commandMap = {
-      yarn: 'yarn dlx',
-      pnpm: 'pnpx',
-      bun: 'bunx',
-      npm: 'npx',
-    }
-    const command = commandMap[packageManager] || 'npx'
-
-    execSync(`${command} codemod@latest react/19/migration-recipe`, {
-      stdio: 'inherit',
-    })
-  }
 }


### PR DESCRIPTION
### Why?

When installed Next version is on or higher than the target Next version, we skipped install and suggest codemod. This was not indicated and could cause confusion that the script is not working.