### PR TITLE
chore(next-codemod): add prompts for (un)installing packages

### DIFF
--- a/packages/next-codemod/bin/transform.ts
+++ b/packages/next-codemod/bin/transform.ts
@@ -134,18 +134,30 @@ export async function runTransform(
   }
 
   if (!dry && transformer === 'built-in-next-font') {
-    console.log('Uninstalling `@next/font`')
-    try {
+    const { uninstallNextFont } = await prompts({
+      type: 'confirm',
+      name: 'uninstallNextFont',
+      message: 'Do you want to uninstall `@next/font`?',
+      initial: true,
+    })
+
+    if (uninstallNextFont) {
+      console.log('Uninstalling `@next/font`')
       uninstallPackage('@next/font')
-    } catch {
-      console.error(
-        "Couldn't uninstall `@next/font`, please uninstall it manually"
-      )
     }
   }
 
   if (!dry && transformer === 'next-request-geo-ip') {
-    console.log('Installing `@vercel/functions`...')
-    installPackages(['@vercel/functions'])
+    const { installVercelFunctions } = await prompts({
+      type: 'confirm',
+      name: 'installVercelFunctions',
+      message: 'Do you want to install `@vercel/functions`?',
+      initial: true,
+    })
+
+    if (installVercelFunctions) {
+      console.log('Installing `@vercel/functions`...')
+      installPackages(['@vercel/functions'])
+    }
   }
 }

--- a/packages/next-codemod/lib/handle-package.ts
+++ b/packages/next-codemod/lib/handle-package.ts
@@ -41,7 +41,14 @@ export function uninstallPackage(
     command = 'remove'
   }
 
-  execa.sync(pkgManager, [command, packageToUninstall], { stdio: 'inherit' })
+  try {
+    execa.sync(pkgManager, [command, packageToUninstall], { stdio: 'inherit' })
+  } catch (error) {
+    throw new Error(
+      `Failed to uninstall "${packageToUninstall}". Please uninstall it manually.`,
+      { cause: error }
+    )
+  }
 }
 
 export function installPackages(


### PR DESCRIPTION
### Why?

When running codemods that require (un)installing packages, even if there's no tranformation, it still attempts to (un)install. Therefore we give the user a choice whether to (un)install it or not.