### PR TITLE
update docs links checker to ignore canary prefix

### DIFF
--- a/.github/actions/validate-docs-links/src/index.ts
+++ b/.github/actions/validate-docs-links/src/index.ts
@@ -189,7 +189,8 @@ async function prepareDocumentMapEntry(
 // Checks if the links point to existing documents
 function validateInternalLink(errors: Errors, href: string): void {
   // /docs/api/example#heading -> ["api/example", "heading""]
-  const [link, hash] = href.replace(DOCS_PATH, '').split('#', 2)
+  // /docs/canary/api/example#heading -> ["api/example", "heading"]
+  const [link, hash] = href.replace(/^\/docs(\/canary)?\//, '').split('#', 2)
 
   let foundPage
 


### PR DESCRIPTION
We should be able to specifically link to the latest docs (versioned via `/docs/canary`) in new docs changes, ie to self reference documentation that is only available on canary. Otherwise things like migration guides will point links that don't contain the referenced changes. 