### PR TITLE
fix(next/turbopack): Always preserve import attributes with esm modules

### DIFF
--- a/packages/next/taskfile-swc.js
+++ b/packages/next/taskfile-swc.js
@@ -16,12 +16,7 @@ module.exports = function (task) {
     function* (
       file,
       serverOrClient,
-      {
-        stripExtension,
-        keepImportAttributes = false,
-        interopClientDefaultExport = false,
-        esm = false,
-      } = {}
+      { stripExtension, interopClientDefaultExport = false, esm = false } = {}
     ) {
       // Don't compile .d.ts
       if (file.base.endsWith('.d.ts') || file.base.endsWith('.json')) return
@@ -51,7 +46,7 @@ module.exports = function (task) {
             tsx: file.base.endsWith('.tsx'),
           },
           experimental: {
-            keepImportAttributes,
+            keepImportAttributes: esm,
           },
           transform: {
             react: {
@@ -96,7 +91,7 @@ module.exports = function (task) {
             tsx: file.base.endsWith('.tsx'),
           },
           experimental: {
-            keepImportAttributes,
+            keepImportAttributes: esm,
           },
           transform: {
             react: {

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -2559,7 +2559,7 @@ export async function nextbuild_esm(task, opts) {
         '**/*.test.+(js|ts|tsx)',
       ],
     })
-    .swc('server', { dev: opts.dev, esm: true, keepImportAttributes: true })
+    .swc('server', { dev: opts.dev, esm: true })
     .target('dist/esm/build')
 }
 
@@ -2587,7 +2587,7 @@ export async function client(task, opts) {
 export async function client_esm(task, opts) {
   await task
     .source('src/client/**/!(*.test).+(js|ts|tsx)')
-    .swc('client', { dev: opts.dev, esm: true, keepImportAttributes: true })
+    .swc('client', { dev: opts.dev, esm: true })
     .target('dist/esm/client')
 }
 
@@ -2612,7 +2612,6 @@ export async function pages_app(task, opts) {
     .source('src/pages/_app.tsx')
     .swc('client', {
       dev: opts.dev,
-      keepImportAttributes: true,
       interopClientDefaultExport: true,
     })
     .target('dist/pages')
@@ -2623,7 +2622,6 @@ export async function pages_error(task, opts) {
     .source('src/pages/_error.tsx')
     .swc('client', {
       dev: opts.dev,
-      keepImportAttributes: true,
       interopClientDefaultExport: true,
     })
     .target('dist/pages')
@@ -2634,7 +2632,6 @@ export async function pages_document(task, opts) {
     .source('src/pages/_document.tsx')
     .swc('server', {
       dev: opts.dev,
-      keepImportAttributes: true,
     })
     .target('dist/pages')
 }
@@ -2644,7 +2641,6 @@ export async function pages_app_esm(task, opts) {
     .source('src/pages/_app.tsx')
     .swc('client', {
       dev: opts.dev,
-      keepImportAttributes: true,
       esm: true,
     })
     .target('dist/esm/pages')
@@ -2655,7 +2651,6 @@ export async function pages_error_esm(task, opts) {
     .source('src/pages/_error.tsx')
     .swc('client', {
       dev: opts.dev,
-      keepImportAttributes: true,
       esm: true,
     })
     .target('dist/esm/pages')
@@ -2666,7 +2661,6 @@ export async function pages_document_esm(task, opts) {
     .source('src/pages/_document.tsx')
     .swc('server', {
       dev: opts.dev,
-      keepImportAttributes: true,
       esm: true,
     })
     .target('dist/esm/pages')


### PR DESCRIPTION
While trying to figure out @lubieowoce's issue in https://github.com/vercel/next.js/compare/lubieowoce/next-shared-repro, @sokra discovered (using #71052) that modules in `src/server` were getting compiled into the wrong layer.

That appeared to be happening because the import annotations was stripped before being passed into turbopack.