### PR TITLE
[Turbopack] change default module id strategy back to dev

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1274,7 +1274,7 @@ impl Project {
             }
             None => match *self.next_mode().await? {
                 NextMode::Development => Ok(Vc::upcast(DevModuleIdStrategy::new())),
-                NextMode::Build => Ok(Vc::upcast(GlobalModuleIdStrategyBuilder::build(self))),
+                NextMode::Build => Ok(Vc::upcast(DevModuleIdStrategy::new())),
             },
         }
     }

--- a/test/integration/module-id-strategies/next.config.js
+++ b/test/integration/module-id-strategies/next.config.js
@@ -1,4 +1,10 @@
 module.exports = {
   bundlePagesRouterDependencies: true,
   serverExternalPackages: ['opted-out-external-package'],
+  experimental: {
+    turbo: {
+      moduleIdStrategy:
+        process.env.NODE_ENV === 'production' ? 'deterministic' : undefined,
+    },
+  },
 }


### PR DESCRIPTION
### What?

Disable deterministic module ids by default until the performance issue is solved.
