### PR TITLE
chore(turbo-tasks-backend): Clean up internal macros

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1313,14 +1313,26 @@ impl TurboTasksBackendInner {
                 );
                 task = ctx.task(task_id, TaskDataCategory::All);
             }
-            for collectible in iter_many!(task, AggregatedCollectible { collectible } count if collectible.collectible_type == collectible_type && count > 0 => collectible.cell)
-            {
+            for collectible in iter_many!(
+                task,
+                AggregatedCollectible {
+                    collectible
+                } count if collectible.collectible_type == collectible_type && count > 0 => {
+                    collectible.cell
+                }
+            ) {
                 *collectibles
                     .entry(RawVc::TaskCell(collectible.task, collectible.cell))
                     .or_insert(0) += 1;
             }
-            for (collectible, count) in iter_many!(task, Collectible { collectible } count if collectible.collectible_type == collectible_type => (collectible.cell, count))
-            {
+            for (collectible, count) in iter_many!(
+                task,
+                Collectible {
+                    collectible
+                } count if collectible.collectible_type == collectible_type => {
+                    (collectible.cell, count)
+                }
+            ) {
                 *collectibles
                     .entry(RawVc::TaskCell(collectible.task, collectible.cell))
                     .or_insert(0) += count;

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -133,8 +133,14 @@ impl AggregatedDataUpdate {
             if dirty_container_count > 0 {
                 dirty = true;
             }
-            for collectible in iter_many!(task, AggregatedCollectible { collectible } count if count > 0 => collectible)
-            {
+            for collectible in iter_many!(
+                task,
+                AggregatedCollectible {
+                    collectible
+                } count if count > 0 => {
+                    collectible
+                }
+            ) {
                 collectibles_update.push((collectible, 1));
             }
         }
@@ -249,7 +255,15 @@ impl AggregatedDataUpdate {
             );
             if added || removed {
                 let ty = collectible.collectible_type;
-                let dependent: SmallVec<[TaskId; 4]> = get_many!(task, CollectiblesDependent { collectible_type, task } if *collectible_type == ty => *task);
+                let dependent: SmallVec<[TaskId; 4]> = get_many!(
+                    task,
+                    CollectiblesDependent {
+                        collectible_type,
+                        task,
+                    } if collectible_type == ty => {
+                        task
+                    }
+                );
                 if !dependent.is_empty() {
                     queue.push(AggregationUpdateJob::Invalidate {
                         task_ids: dependent,


### PR DESCRIPTION
Figured it was easier to fix these myself than to try to suggest changes on #70798:

- Fix some inconsistency inside `iter_many` about how derefing happens depending on how arguments are used.
- Simplify `get_many`'s argument passthrough to `iter_many` using a `tt` group: https://veykril.github.io/tlborm/decl-macros/patterns/tt-bundling.html
- Manually line-wrap macros, which rustfmt does not do.
- Rename some of `iter_many` arguments (the name "`value`" was a little too overloaded here) and add some really basic documentation.
- Eliminate a few branches using `?` repetitions instead: https://veykril.github.io/tlborm/decl-macros/macros-methodical.html#repetitions
- The `value_pattern` (previously `value_ident`) of `iter_many` can technically be any pattern (even though nothing currently needs that), so broaden the type from `ident` to `tt`.