### PR TITLE
Enhance request memoization explanation with analogy

### DIFF
--- a/docs/02-app/01-building-your-application/04-caching/index.mdx
+++ b/docs/02-app/01-building-your-application/04-caching/index.mdx
@@ -75,7 +75,20 @@ const item = await getItem() // cache MISS
 const item = await getItem() // cache HIT
 ```
 
-**How Request Memoization Works**
+### Analogy
+
+Imagine you're at a store, and you ask the shopkeeper for a specific item. The shopkeeper immediately tells their assistant (the server) to go get that item for you. Now, **while the assistant is busy fetching the item** _(means the server-side component function is busy fetching the data from the API or server)_, you could keep asking the shopkeeper for the same thing, but he won’t send the assistant again. _(Means you can send multiple requests to the server component as much as you want—from the Layout, from the reusable component, or from any component—but it will not call the server-side function that fetches the data, though it will accept the request.)_ The shopkeeper knows the request has already been made and will just tell you to wait for a moment—it’s being handled.
+
+In this situation:
+- **The shopkeeper** is like the server-side component, managing your request.
+- **The assistant** is like the server, fetching the data (the item you asked for).
+- **The item** represents the data you want to get.
+
+Once the assistant brings you the item (the data is returned and the page is rendered), the process is complete. If you ask for the same item again after that (like refreshing or opening the page later), the shopkeeper will have to tell the assistant to fetch the item again, starting from scratch.
+
+---
+
+### How Request Memoization Works
 
 <Image
   alt="Diagram showing how fetch memoization works during React rendering."
@@ -85,10 +98,12 @@ const item = await getItem() // cache HIT
   height="742"
 />
 
-- While rendering a route, the first time a particular request is called, its result will not be in memory and it'll be a cache `MISS`.
-- Therefore, the function will be executed, and the data will be fetched from the external source, and the result will be stored in memory.
-- Subsequent function calls of the request in the same render pass will be a cache `HIT`, and the data will be returned from memory without executing the function.
-- Once the route has been rendered and the rendering pass is complete, memory is "reset" and all request memoization entries are cleared.
+- **While rendering a route**, the first time a particular request is called, its result will not be in memory, resulting in a cache `MISS`.  
+- Therefore, the function will be executed, the data will be fetched from the external source, and the result will be stored in memory.
+- **Subsequent function calls** of the same request within the same render pass (for example, in different components like Layout, Page, or other components) will be a cache `HIT`, meaning the request will only be executed **once**.  
+  - The data will be temporarily stored (like the shopkeeper remembering the request), and repeated calls for the same data will return the **cached result** without fetching it again.
+- Once the route has been fully rendered and the rendering pass is complete, memory is "reset", and all request memoization entries are cleared.  
+  - In simpler terms: once the page is fully rendered and sent to the client (like when the assistant delivers the item), the cache is cleared, and the server will need to fetch the data again for future requests.
 
 > **Good to know**:
 >


### PR DESCRIPTION
Enhanced the "Request Memoization" section by adding a practical analogy that simplifies the explanation for developers and non-technical users. The analogy compares memoization to a shopkeeper and assistant system, making it easier to understand the process of memoization in a real-world scenario.

### Whats new
The goal is to make the memoization concept easier to grasp, especially for developers who may struggle with the technical explanation alone. The analogy helps bridge the gap between technical terminology and practical understanding, ensuring clarity.

### How?

- Added an analogy section with a practical example.
- Combined technical details with the analogy to enhance understanding.
- Maintained the existing technical explanation for users who prefer a more direct explanation.
- Ensured the format and style follow the documentation guidelines.

