### PR TITLE
chore(next-codemod): add verbose option to transform

### DIFF
--- a/packages/next-codemod/bin/next-codemod.ts
+++ b/packages/next-codemod/bin/next-codemod.ts
@@ -33,7 +33,11 @@ const program = new Command(packageJson.name)
   .helpOption('-h, --help', 'Display this help message.')
   .option('-f, --force', 'Bypass Git safety checks and forcibly run codemods')
   .option('-d, --dry', 'Dry run (no changes are made to files)')
-  .option('-p, --print', 'Print transformed files to your terminal')
+  .option(
+    '-p, --print',
+    'Print transformed files to stdout, useful for development'
+  )
+  .option('--verbose', 'Show more information about the transform process')
   .option(
     '-j, --jscodeshift',
     '(Advanced) Pass options directly to jscodeshift'

--- a/packages/next-codemod/bin/next-codemod.ts
+++ b/packages/next-codemod/bin/next-codemod.ts
@@ -44,6 +44,13 @@ const program = new Command(packageJson.name)
   )
   .action(runTransform)
   .allowUnknownOption()
+  // This is needed for options for subcommands to be passed correctly.
+  // Because by default the options are not positional, which will pass options
+  // to the main command "@next/codemod" even if it was passed after subcommands,
+  // e.g. "@next/codemod upgrade --verbose" will be treated as "next-codemod --verbose upgrade"
+  // By enabling this, it will respect the position of the options and pass it to subcommands.
+  // x-ref: https://github.com/tj/commander.js/pull/1427
+  .enablePositionalOptions()
 
 program
   .command('upgrade')

--- a/packages/next-codemod/bin/transform.ts
+++ b/packages/next-codemod/bin/transform.ts
@@ -95,7 +95,7 @@ export async function runTransform(
 
   let args = []
 
-  const { dry, print, runInBand, jscodeshift } = options
+  const { dry, print, runInBand, jscodeshift, verbose } = options
 
   if (dry) {
     args.push('--dry')
@@ -106,8 +106,9 @@ export async function runTransform(
   if (runInBand) {
     args.push('--run-in-band')
   }
-
-  args.push('--verbose=2')
+  if (verbose) {
+    args.push('--verbose=2')
+  }
 
   args.push('--ignore-pattern=**/node_modules/**')
   args.push('--ignore-pattern=**/.next/**')

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -131,7 +131,7 @@ export async function runUpgrade(
   })
 
   for (const codemod of codemods) {
-    await runTransform(codemod, process.cwd(), { force: true })
+    await runTransform(codemod, process.cwd(), { force: true, verbose })
   }
 
   console.log() // new line


### PR DESCRIPTION
### Why?

Since we passed `--verbose=2` (Show all transform status e.g. `OKK`, `NOC`, `SKIP`, `ERR`) by default, it got too noisy when running upgrade with multiple codemods.

### How?

Unless passed `--verbose`, show the `ERR` status only.