### PR TITLE
chore(next-codemod): move app-dir-runtime-config-experimental-edge to 13.1.2

### DIFF
--- a/docs/02-app/01-building-your-application/11-upgrading/01-codemods.mdx
+++ b/docs/02-app/01-building-your-application/11-upgrading/01-codemods.mdx
@@ -26,30 +26,6 @@ Replacing `<transform>` and `<path>` with appropriate values.
 
 ### 15.0
 
-#### Transform App Router Route Segment Config `runtime` value from `experimental-edge` to `edge`
-
-##### `app-dir-runtime-config-experimental-edge`
-
-> **Note**: This codemod is App Router specific.
-
-```bash filename="Terminal"
-npx @next/codemod@latest app-dir-runtime-config-experimental-edge .
-```
-
-This codemod transforms [Route Segment Config `runtime`](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#runtime) value `experimental-edge` to `edge`.
-
-For example:
-
-```ts
-export const runtime = 'experimental-edge'
-```
-
-Transforms into:
-
-```ts
-export const runtime = 'edge'
-```
-
 #### Migrate to async Dynamic APIs
 
 APIs that opted into dynamic rendering that previously supported synchronous access are now asynchronous. You can read more about this breaking change in the [upgrade guide](/docs/app/building-your-application/upgrading/version-15)
@@ -309,6 +285,32 @@ Transforms into:
 
 ```js
 import { Inter } from 'next/font/google'
+```
+
+### 13.1.2
+
+#### Transform App Router Route Segment Config `runtime` value from `experimental-edge` to `edge`
+
+##### `app-dir-runtime-config-experimental-edge`
+
+> **Note**: This codemod is App Router specific.
+
+```bash filename="Terminal"
+npx @next/codemod@latest app-dir-runtime-config-experimental-edge .
+```
+
+This codemod transforms [Route Segment Config `runtime`](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#runtime) value `experimental-edge` to `edge`.
+
+For example:
+
+```ts
+export const runtime = 'experimental-edge'
+```
+
+Transforms into:
+
+```ts
+export const runtime = 'edge'
 ```
 
 ### 13.0

--- a/packages/next-codemod/lib/utils.ts
+++ b/packages/next-codemod/lib/utils.ts
@@ -83,6 +83,12 @@ export const TRANSFORMER_INQUIRER_CHOICES = [
     version: '13.0',
   },
   {
+    title:
+      'Transform App Router Route Segment Config `runtime` value from `experimental-edge` to `edge`',
+    value: 'app-dir-runtime-config-experimental-edge',
+    version: '13.1.2',
+  },
+  {
     title: 'Uninstall `@next/font` and transform imports to `next/font`',
     value: 'built-in-next-font',
     version: '13.2',
@@ -115,11 +121,5 @@ export const TRANSFORMER_INQUIRER_CHOICES = [
     title: 'Transforms usage of Next.js async Request APIs',
     value: 'next-async-request-api',
     version: '15.0.0-canary.171',
-  },
-  {
-    title:
-      'Transform App Router Route Segment Config `runtime` value from `experimental-edge` to `edge`',
-    value: 'app-dir-runtime-config-experimental-edge',
-    version: '15.0.0-canary.179',
   },
 ]


### PR DESCRIPTION
### Why?

Although the breaking change for `export runtime = 'experimental-edge'` for App Router was recent at https://github.com/vercel/next.js/pull/70480, we did move from experimental to `edge` at https://github.com/vercel/next.js/pull/44045, and added log at https://github.com/vercel/next.js/pull/44563 (release [v13.1.2](https://github.com/vercel/next.js/releases/tag/v13.1.2))

Therefore we lower the target codemod version to 13.1.2.