### PR TITLE
chore: polish warning for esmExternals

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -122,7 +122,7 @@ function warnCustomizedOption(
 
   if (!silent && current !== defaultValue) {
     Log.warn(
-      `The "${key}" option has been modified. ${customMessage ? customMessage + '. ' : ''}Please update your ${configFileName}.`
+      `The "${key}" option has been modified. ${customMessage ? customMessage + '. ' : ''}It should be removed from your ${configFileName}.`
     )
   }
 }

--- a/test/e2e/next-config-warnings/esm-externals-false/esm-externals-false.test.ts
+++ b/test/e2e/next-config-warnings/esm-externals-false/esm-externals-false.test.ts
@@ -16,7 +16,7 @@ import { findAllTelemetryEvents } from 'next-test-utils'
       await next.fetch('/')
 
       expect(next.cliOutput).toContain(
-        `The "experimental.esmExternals" option has been modified. experimental.esmExternals is not recommended to be modified as it may disrupt module resolution. Please update your next.config.js`
+        `The "experimental.esmExternals" option has been modified. experimental.esmExternals is not recommended to be modified as it may disrupt module resolution. It should be removed from your next.config.js`
       )
     })
 


### PR DESCRIPTION
### What

Make the action more explicit about how handle the `experimental.esmExternals` config in `next.config.js`. Recommend users to reomve instead of manually configure it.