### PR TITLE
fix complete state for event spans

### DIFF
--- a/turbopack/crates/turbopack-trace-server/src/reader/turbopack.rs
+++ b/turbopack/crates/turbopack-trace-server/src/reader/turbopack.rs
@@ -207,6 +207,7 @@ impl TurbopackFormat {
                     ts,
                     &mut self.outdated_spans,
                 );
+                store.complete_span(id);
             }
             TraceRow::Allocation {
                 ts: _,


### PR DESCRIPTION
### What?

Spans reported by events should be also considered as completed and shouldn't show as incomplete spans
