### PR TITLE
codemod: do not await on invalid prop

### DIFF
--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-32.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-32.input.tsx
@@ -1,0 +1,6 @@
+export async function GET(
+  req: NextRequest,
+  ctx: any,
+): Promise<Response> {
+  callback(ctx.propDoesNotExist);
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-32.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-32.output.tsx
@@ -1,0 +1,6 @@
+export async function GET(
+  req: NextRequest,
+  ctx: any,
+): Promise<Response> {
+  callback(ctx.propDoesNotExist);
+}

--- a/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-prop.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-prop.ts
@@ -51,6 +51,15 @@ function awaitMemberAccessOfProp(
   memberAccess.forEach((memberAccessPath) => {
     const member = memberAccessPath.value
 
+    const memberProperty = member.property
+    const isAccessingMatchedProperty =
+      j.Identifier.check(memberProperty) &&
+      TARGET_PROP_NAMES.has(memberProperty.name)
+
+    if (!isAccessingMatchedProperty) {
+      return
+    }
+
     if (isParentPromiseAllCallExpression(memberAccessPath, j)) {
       return
     }


### PR DESCRIPTION
### What

if it's accessing other properties non-existed of page/layout props, or request handler ctx properties, do not await it
