### PR TITLE
fix(turbopack): Do not create self-referencing fragments

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -481,6 +481,10 @@ impl DepGraph {
                 .idx_graph
                 .neighbors_directed(ix as u32, petgraph::Direction::Outgoing)
             {
+                if dep == ix as u32 {
+                    continue;
+                }
+
                 if !part_deps_done.insert(dep) {
                     continue;
                 }

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/3/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/3/output.md
@@ -386,9 +386,6 @@ export { d3 as a } from "__TURBOPACK_VAR__" assert {
 import { a as d3 } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -0
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
 function c2_1() {
     return c2_2(d3);
 }
@@ -440,9 +437,6 @@ import { e as d2 } from "__TURBOPACK_PART__" assert {
 };
 import { f as d1 } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -4
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
 };
 function c1_1() {
     return c1_2();
@@ -591,9 +585,6 @@ export { d3 as a } from "__TURBOPACK_VAR__" assert {
 import { a as d3 } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -0
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
-};
 function c2_1() {
     return c2_2(d3);
 }
@@ -645,9 +636,6 @@ import { e as d2 } from "__TURBOPACK_PART__" assert {
 };
 import { f as d1 } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -4
-};
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
 };
 function c1_1() {
     return c1_2();

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/complex/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/complex/output.md
@@ -620,9 +620,6 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 9
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
 function setDog(newDog) {

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-2/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-2/output.md
@@ -847,9 +847,6 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 7
 };
 import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
-};
-import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
 const hasPostpone = typeof React.unstable_postpone === 'function';


### PR DESCRIPTION

### What?

Do not generate self-referencing imports.

### Why?

It's obviously bad.

### How?

