### PR TITLE
Fix handling of hot reloader middlewares

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
@@ -76,7 +76,11 @@ export async function createOriginalStackFrame(
 }
 
 export function getOverlayMiddleware(project: Project) {
-  return async function (req: IncomingMessage, res: ServerResponse) {
+  return async function (
+    req: IncomingMessage,
+    res: ServerResponse,
+    next: () => void
+  ): Promise<void> {
     const { pathname, searchParams } = new URL(req.url!, 'http://n')
 
     const frame = {
@@ -97,7 +101,8 @@ export function getOverlayMiddleware(project: Project) {
 
       if (!originalStackFrame) {
         res.statusCode = 404
-        return res.end('Unable to resolve sourcemap')
+        res.end('Unable to resolve sourcemap')
+        return
       }
 
       return json(res, originalStackFrame)
@@ -119,5 +124,7 @@ export function getOverlayMiddleware(project: Project) {
 
       noContent(res)
     }
+
+    return next()
   }
 }

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware.ts
@@ -211,8 +211,8 @@ export function getOverlayMiddleware(options: {
   return async function (
     req: IncomingMessage,
     res: ServerResponse,
-    next: Function
-  ) {
+    next: () => void
+  ): Promise<void> {
     const { pathname, searchParams } = new URL(`http://n${req.url}`)
 
     const frame = {

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -560,7 +560,9 @@ export async function createHotReloaderTurbopack(
       2
     )
   )
-  const overlayMiddleware = getOverlayMiddleware(project)
+
+  const middlewares = [getOverlayMiddleware(project)]
+
   const versionInfoPromise = getVersionInfo(
     isTestMode || opts.telemetry.isEnabled
   )
@@ -610,7 +612,17 @@ export async function createHotReloaderTurbopack(
         }
       }
 
-      await overlayMiddleware(req, res)
+      for (const middleware of middlewares) {
+        let calledNext = false
+
+        await middleware(req, res, () => {
+          calledNext = true
+        })
+
+        if (!calledNext) {
+          return { finished: true }
+        }
+      }
 
       // Request was not finished.
       return { finished: undefined }


### PR DESCRIPTION
For every dev overlay middleware request (i.e. `/__nextjs_original-stack-frame` or `/__nextjs_launch-editor`) we are:
- creating a forever-hanging promise in the Webpack hot reloader,
- unnecessarily running through the `handleRequest` logic in the router server with the Turbopack hot reloader.

This PR fixes these two isses by correctly setting the `finished` status, when a hot reloader middleware has not called `next()`.