### PR TITLE
Eagerly Pass Implicit Tags

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -58,7 +58,7 @@ import {
   isRedirectError,
   getRedirectStatusCodeFromError,
 } from '../../client/components/redirect'
-import { getImplicitTags } from '../lib/patch-fetch'
+import { getImplicitTags } from '../lib/implicit-tags'
 import { AppRenderSpan, NextNodeServerSpan } from '../lib/trace/constants'
 import { getTracer } from '../lib/trace/tracer'
 import { FlightRenderResult } from './flight-render-result'
@@ -1271,6 +1271,12 @@ export const renderToHTMLOrFlight: AppPageRender = (
     )
   }
 
+  const implicitTags = getImplicitTags(
+    renderOpts.routeModule.definition.page,
+    url,
+    fallbackRouteParams
+  )
+
   return withRequestStore(
     renderOpts.ComponentMod.workUnitAsyncStorage,
     {
@@ -1280,6 +1286,7 @@ export const renderToHTMLOrFlight: AppPageRender = (
       renderOpts,
       isHmrRefresh,
       serverComponentsHmrCache,
+      implicitTags,
     },
     (requestStore) => {
       if (requestStore.type !== 'request') {
@@ -1836,7 +1843,7 @@ async function prerenderToStream(
         const prospectiveRenderPrerenderStore: PrerenderStore =
           (prerenderStore = {
             type: 'prerender',
-            pathname: ctx.requestStore.url.pathname,
+            implicitTags: ctx.requestStore.implicitTags,
             renderSignal: flightController.signal,
             cacheSignal,
             // During the prospective render we don't want to synchronously abort on dynamic access
@@ -1848,13 +1855,8 @@ async function prerenderToStream(
             // will track it again there
             dynamicTracking: null,
             revalidate: INFINITE_CACHE,
-            tags: null,
+            tags: [...ctx.requestStore.implicitTags],
           })
-        // This cycle is a bit unfortunate.
-        prospectiveRenderPrerenderStore.tags = getImplicitTags(
-          workStore,
-          prospectiveRenderPrerenderStore
-        )
 
         let reactServerIsDynamic = false
         function onError(err: unknown) {
@@ -1934,7 +1936,7 @@ async function prerenderToStream(
 
         const finalRenderPrerenderStore: PrerenderStore = (prerenderStore = {
           type: 'prerender',
-          pathname: ctx.requestStore.url.pathname,
+          implicitTags: ctx.requestStore.implicitTags,
           renderSignal: flightController.signal,
           // During the final prerender we don't need to track cache access so we omit the signal
           cacheSignal: null,
@@ -1943,13 +1945,8 @@ async function prerenderToStream(
           controller: flightController,
           dynamicTracking,
           revalidate: INFINITE_CACHE,
-          tags: null,
+          tags: [...ctx.requestStore.implicitTags],
         })
-        // This cycle is a bit unfortunate.
-        finalRenderPrerenderStore.tags = getImplicitTags(
-          workStore,
-          finalRenderPrerenderStore
-        )
 
         function onPostpone(reason: string) {
           if (
@@ -1998,7 +1995,7 @@ async function prerenderToStream(
         const SSRController = new AbortController()
         const ssrPrerenderStore: PrerenderStore = {
           type: 'prerender',
-          pathname: ctx.requestStore.url.pathname,
+          implicitTags: ctx.requestStore.implicitTags,
           renderSignal: SSRController.signal,
           // For HTML Generation we don't need to track cache reads (RSC only)
           cacheSignal: null,
@@ -2009,10 +2006,8 @@ async function prerenderToStream(
           // dynamic during SSR
           dynamicTracking,
           revalidate: INFINITE_CACHE,
-          tags: null,
+          tags: [...ctx.requestStore.implicitTags],
         }
-        // This cycle is a bit unfortunate.
-        ssrPrerenderStore.tags = getImplicitTags(workStore, ssrPrerenderStore)
         let SSRIsDynamic = false
         function SSROnError(err: unknown, errorInfo: ErrorInfo) {
           if (
@@ -2215,7 +2210,7 @@ async function prerenderToStream(
         const prospectiveRenderPrerenderStore: PrerenderStore =
           (prerenderStore = {
             type: 'prerender',
-            pathname: ctx.requestStore.url.pathname,
+            implicitTags: ctx.requestStore.implicitTags,
             renderSignal: flightController.signal,
             cacheSignal,
             // When PPR is off we can synchronously abort the prospective render because we will
@@ -2224,13 +2219,8 @@ async function prerenderToStream(
             controller: flightController,
             dynamicTracking,
             revalidate: INFINITE_CACHE,
-            tags: null,
+            tags: [...ctx.requestStore.implicitTags],
           })
-        // This cycle is a bit unfortunate.
-        prospectiveRenderPrerenderStore.tags = getImplicitTags(
-          workStore,
-          prospectiveRenderPrerenderStore
-        )
 
         const firstAttemptRSCPayload = await workUnitAsyncStorage.run(
           prospectiveRenderPrerenderStore,
@@ -2302,25 +2292,20 @@ async function prerenderToStream(
 
         const finalRenderPrerenderStore: PrerenderStore = (prerenderStore = {
           type: 'prerender',
-          pathname: ctx.requestStore.url.pathname,
+          implicitTags: ctx.requestStore.implicitTags,
           renderSignal: flightController.signal,
           // During the final prerender we don't need to track cache access so we omit the signal
           cacheSignal: null,
           controller: flightController,
           dynamicTracking,
           revalidate: INFINITE_CACHE,
-          tags: null,
+          tags: [...ctx.requestStore.implicitTags],
         })
-        // This cycle is a bit unfortunate.
-        finalRenderPrerenderStore.tags = getImplicitTags(
-          workStore,
-          finalRenderPrerenderStore
-        )
 
         const SSRController = new AbortController()
         const ssrPrerenderStore: PrerenderStore = {
           type: 'prerender',
-          pathname: ctx.requestStore.url.pathname,
+          implicitTags: ctx.requestStore.implicitTags,
           renderSignal: SSRController.signal,
           // For HTML Generation we don't need to track cache reads (RSC only)
           cacheSignal: null,
@@ -2331,10 +2316,8 @@ async function prerenderToStream(
           // dynamic during SSR
           dynamicTracking,
           revalidate: INFINITE_CACHE,
-          tags: null,
+          tags: [...ctx.requestStore.implicitTags],
         }
-        // This cycle is a bit unfortunate.
-        ssrPrerenderStore.tags = getImplicitTags(workStore, ssrPrerenderStore)
 
         const finalAttemptRSCPayload = await workUnitAsyncStorage.run(
           finalRenderPrerenderStore,
@@ -2509,16 +2492,11 @@ async function prerenderToStream(
       )
       const reactServerPrerenderStore: PrerenderStore = (prerenderStore = {
         type: 'prerender-ppr',
-        pathname: ctx.requestStore.url.pathname,
+        implicitTags: ctx.requestStore.implicitTags,
         dynamicTracking,
         revalidate: INFINITE_CACHE,
-        tags: null,
+        tags: [...ctx.requestStore.implicitTags],
       })
-      // This cycle is a bit unfortunate.
-      reactServerPrerenderStore.tags = getImplicitTags(
-        workStore,
-        reactServerPrerenderStore
-      )
       const RSCPayload = await workUnitAsyncStorage.run(
         reactServerPrerenderStore,
         getRSCPayload,
@@ -2542,14 +2520,11 @@ async function prerenderToStream(
 
       const ssrPrerenderStore: PrerenderStore = {
         type: 'prerender-ppr',
-        pathname: ctx.requestStore.url.pathname,
+        implicitTags: ctx.requestStore.implicitTags,
         dynamicTracking,
         revalidate: INFINITE_CACHE,
-        tags: null,
+        tags: [...ctx.requestStore.implicitTags],
       }
-      // This cycle is a bit unfortunate.
-      ssrPrerenderStore.tags = getImplicitTags(workStore, ssrPrerenderStore)
-
       const prerender = require('react-dom/static.edge')
         .prerender as (typeof import('react-dom/static.edge'))['prerender']
       const { prelude, postponed } = await workUnitAsyncStorage.run(
@@ -2711,16 +2686,10 @@ async function prerenderToStream(
     } else {
       const prerenderLegacyStore: PrerenderStore = (prerenderStore = {
         type: 'prerender-legacy',
-        pathname: ctx.requestStore.url.pathname,
+        implicitTags: ctx.requestStore.implicitTags,
         revalidate: INFINITE_CACHE,
-        tags: null,
+        tags: [...ctx.requestStore.implicitTags],
       })
-      // This cycle is a bit unfortunate.
-      prerenderLegacyStore.tags = getImplicitTags(
-        workStore,
-        prerenderLegacyStore
-      )
-
       // This is a regular static generation. We don't do dynamic tracking because we rely on
       // the old-school dynamic error handling to bail out of static generation
       const RSCPayload = await workUnitAsyncStorage.run(
@@ -2873,13 +2842,10 @@ async function prerenderToStream(
 
     const prerenderLegacyStore: PrerenderStore = (prerenderStore = {
       type: 'prerender-legacy',
-      pathname: ctx.requestStore.url.pathname,
+      implicitTags: ctx.requestStore.implicitTags,
       revalidate: INFINITE_CACHE,
-      tags: null,
+      tags: [...ctx.requestStore.implicitTags],
     })
-    // This cycle is a bit unfortunate.
-    prerenderLegacyStore.tags = getImplicitTags(workStore, prerenderLegacyStore)
-
     const errorRSCPayload = await workUnitAsyncStorage.run(
       prerenderLegacyStore,
       getErrorRSCPayload,

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -37,6 +37,8 @@ export type RequestStore = {
   readonly isHmrRefresh?: boolean
   readonly serverComponentsHmrCache?: ServerComponentsHmrCache
 
+  readonly implicitTags: string[]
+
   // DEV-only
   usedDynamic?: boolean
 }
@@ -53,7 +55,7 @@ export type RequestStore = {
  */
 export type PrerenderStoreModern = {
   type: 'prerender'
-  pathname: string | undefined
+  readonly implicitTags: string[]
   /**
    * This is the AbortController passed to React. It can be used to abort the prerender
    * if we encounter conditions that do not require further rendering
@@ -83,7 +85,7 @@ export type PrerenderStoreModern = {
 
 export type PrerenderStorePPR = {
   type: 'prerender-ppr'
-  pathname: string | undefined
+  readonly implicitTags: string[]
   readonly dynamicTracking: null | DynamicTrackingState
   // Collected revalidate times and tags for this document during the prerender.
   revalidate: number // in seconds. 0 means dynamic. INFINITE_CACHE and higher means never revalidate.
@@ -92,7 +94,7 @@ export type PrerenderStorePPR = {
 
 export type PrerenderStoreLegacy = {
   type: 'prerender-legacy'
-  pathname: string | undefined
+  readonly implicitTags: string[]
   // Collected revalidate times and tags for this document during the prerender.
   revalidate: number // in seconds. 0 means dynamic. INFINITE_CACHE and higher means never revalidate.
   tags: null | string[]
@@ -105,6 +107,7 @@ export type PrerenderStore =
 
 export type UseCacheStore = {
   type: 'cache'
+  readonly implicitTags: string[]
   // Collected revalidate times and tags for this cache entry during the cache render.
   revalidate: number // implicit revalidate time from inner caches / fetches
   explicitRevalidate: undefined | number // explicit revalidate time from cacheLife() calls

--- a/packages/next/src/server/async-storage/with-request-store.ts
+++ b/packages/next/src/server/async-storage/with-request-store.ts
@@ -67,6 +67,7 @@ export type RequestContext = RequestResponsePair & {
   renderOpts?: WrapperRenderOpts
   isHmrRefresh?: boolean
   serverComponentsHmrCache?: ServerComponentsHmrCache
+  implicitTags?: string[] | undefined
 }
 
 type RequestResponsePair =
@@ -113,6 +114,7 @@ export const withRequestStore: WithStore<WorkUnitStore, RequestContext> = <
     renderOpts,
     isHmrRefresh,
     serverComponentsHmrCache,
+    implicitTags,
   }: RequestContext,
   callback: (store: RequestStore) => Result
 ): Result => {
@@ -131,6 +133,7 @@ export const withRequestStore: WithStore<WorkUnitStore, RequestContext> = <
 
   const store: RequestStore = {
     type: 'request',
+    implicitTags: implicitTags ?? [],
     // Rather than just using the whole `url` here, we pull the parts we want
     // to ensure we don't use parts of the URL that we shouldn't. This also
     // lets us avoid requiring an empty string for `search` in the type.

--- a/packages/next/src/server/lib/implicit-tags.ts
+++ b/packages/next/src/server/lib/implicit-tags.ts
@@ -1,0 +1,57 @@
+import { NEXT_CACHE_IMPLICIT_TAG_ID } from '../../lib/constants'
+import type { FallbackRouteParams } from '../request/fallback-params'
+
+const getDerivedTags = (pathname: string): string[] => {
+  const derivedTags: string[] = [`/layout`]
+
+  // we automatically add the current path segments as tags
+  // for revalidatePath handling
+  if (pathname.startsWith('/')) {
+    const pathnameParts = pathname.split('/')
+
+    for (let i = 1; i < pathnameParts.length + 1; i++) {
+      let curPathname = pathnameParts.slice(0, i).join('/')
+
+      if (curPathname) {
+        // all derived tags other than the page are layout tags
+        if (!curPathname.endsWith('/page') && !curPathname.endsWith('/route')) {
+          curPathname = `${curPathname}${
+            !curPathname.endsWith('/') ? '/' : ''
+          }layout`
+        }
+        derivedTags.push(curPathname)
+      }
+    }
+  }
+  return derivedTags
+}
+
+export function getImplicitTags(
+  page: string,
+  url: {
+    pathname: string
+    search?: string
+  },
+  fallbackRouteParams: null | FallbackRouteParams
+) {
+  // TODO: Cache the result
+  const newTags: string[] = []
+  const hasFallbackRouteParams =
+    fallbackRouteParams && fallbackRouteParams.size > 0
+
+  // Add the derived tags from the page.
+  const derivedTags = getDerivedTags(page)
+  for (let tag of derivedTags) {
+    tag = `${NEXT_CACHE_IMPLICIT_TAG_ID}${tag}`
+    newTags.push(tag)
+  }
+
+  // Add the tags from the pathname. If the route has unknown params, we don't
+  // want to add the pathname as a tag, as it will be invalid.
+  if (url.pathname && !hasFallbackRouteParams) {
+    const tag = `${NEXT_CACHE_IMPLICIT_TAG_ID}${url.pathname}`
+    newTags.push(tag)
+  }
+
+  return newTags
+}

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -20,7 +20,8 @@ import {
   type WorkStoreContext,
 } from '../../async-storage/with-work-store'
 import { type HTTP_METHOD, HTTP_METHODS, isHTTPMethod } from '../../web/http'
-import { getImplicitTags, patchFetch } from '../../lib/patch-fetch'
+import { getImplicitTags } from '../../lib/implicit-tags'
+import { patchFetch } from '../../lib/patch-fetch'
 import { getTracer } from '../../lib/trace/tracer'
 import { AppRouteRouteHandlersSpan } from '../../lib/trace/constants'
 import { getPathnameFromAbsolutePath } from './helpers/get-pathname-from-absolute-path'
@@ -279,6 +280,7 @@ export class AppRouteRouteModule extends RouteModule<
     actionStore: ActionStore,
     workStore: WorkStore,
     workUnitStore: WorkUnitStore,
+    implicitTags: string[],
     request: NextRequest,
     context: AppRouteRouteHandlerContext
   ) {
@@ -299,15 +301,6 @@ export class AppRouteRouteModule extends RouteModule<
           )
         : undefined,
     }
-
-    const pathname =
-      workUnitStore.type === 'request'
-        ? workUnitStore.url.pathname
-        : workUnitStore.type === 'prerender' ||
-            workUnitStore.type === 'prerender-ppr' ||
-            workUnitStore.type === 'prerender-legacy'
-          ? workUnitStore.pathname
-          : undefined
 
     let prerenderStore: null | PrerenderStore = null
 
@@ -350,21 +343,16 @@ export class AppRouteRouteModule extends RouteModule<
           const prospectiveRoutePrerenderStore: PrerenderStore =
             (prerenderStore = {
               type: 'prerender',
+              implicitTags: implicitTags,
               renderSignal: prospectiveController.signal,
-              pathname,
               cacheSignal,
               // During prospective render we don't use a controller
               // because we need to let all caches fill.
               controller: null,
               dynamicTracking,
               revalidate: defaultRevalidate,
-              tags: null,
+              tags: [...implicitTags],
             })
-          // This cycle is a bit unfortunate.
-          prospectiveRoutePrerenderStore.tags = getImplicitTags(
-            workStore,
-            prospectiveRoutePrerenderStore
-          )
 
           let prospectiveResult
           try {
@@ -427,19 +415,14 @@ export class AppRouteRouteModule extends RouteModule<
 
           const finalRoutePrerenderStore: PrerenderStore = (prerenderStore = {
             type: 'prerender',
+            implicitTags: implicitTags,
             renderSignal: finalController.signal,
-            pathname,
             cacheSignal: null,
             controller: finalController,
             dynamicTracking,
             revalidate: defaultRevalidate,
-            tags: null,
+            tags: [...implicitTags],
           })
-          // This cycle is a bit unfortunate.
-          finalRoutePrerenderStore.tags = getImplicitTags(
-            workStore,
-            finalRoutePrerenderStore
-          )
 
           let responseHandled = false
           res = await new Promise((resolve, reject) => {
@@ -507,12 +490,10 @@ export class AppRouteRouteModule extends RouteModule<
         } else {
           prerenderStore = {
             type: 'prerender-legacy',
-            pathname,
+            implicitTags: implicitTags,
             revalidate: defaultRevalidate,
-            tags: null,
+            tags: [...implicitTags],
           }
-          // This cycle is a bit unfortunate.
-          prerenderStore.tags = getImplicitTags(workStore, prerenderStore)
 
           res = await workUnitAsyncStorage.run(
             prerenderStore,
@@ -606,6 +587,13 @@ export class AppRouteRouteModule extends RouteModule<
     // Get the handler function for the given method.
     const handler = this.resolve(req.method)
 
+    const implicitTags = getImplicitTags(
+      this.definition.page,
+      req.nextUrl,
+      // App Routes don't support unknown route params.
+      null
+    )
+
     // Get the context for the request.
     const requestContext: RequestContext = {
       req,
@@ -614,6 +602,7 @@ export class AppRouteRouteModule extends RouteModule<
       renderOpts: {
         previewProps: context.prerenderManifest.preview,
       },
+      implicitTags,
     }
 
     // Get the context for the static generation.
@@ -712,6 +701,7 @@ export class AppRouteRouteModule extends RouteModule<
                       actionStore,
                       workStore,
                       workUnitStore,
+                      implicitTags,
                       request,
                       context
                     )

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -151,6 +151,7 @@ function generateCacheEntryWithCacheContext(
   // Initialize the Store for this Cache entry.
   const cacheStore: UseCacheStore = {
     type: 'cache',
+    implicitTags: outerWorkUnitStore === undefined || outerWorkUnitStore.type === 'unstable-cache' ? [] : outerWorkUnitStore.implicitTags,
     revalidate: defaultCacheLife.revalidate,
     explicitRevalidate: undefined,
     tags: null,

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -44,7 +44,10 @@ type CacheEntry = {
 }
 
 interface CacheHandler {
-  get(cacheKey: string | ArrayBuffer): Promise<undefined | CacheEntry>
+  get(
+    cacheKey: string | ArrayBuffer,
+    implicitTags: string[]
+  ): Promise<undefined | CacheEntry>
   set(cacheKey: string | ArrayBuffer, value: Promise<CacheEntry>): Promise<void>
 }
 
@@ -151,7 +154,11 @@ function generateCacheEntryWithCacheContext(
   // Initialize the Store for this Cache entry.
   const cacheStore: UseCacheStore = {
     type: 'cache',
-    implicitTags: outerWorkUnitStore === undefined || outerWorkUnitStore.type === 'unstable-cache' ? [] : outerWorkUnitStore.implicitTags,
+    implicitTags:
+      outerWorkUnitStore === undefined ||
+      outerWorkUnitStore.type === 'unstable-cache'
+        ? []
+        : outerWorkUnitStore.implicitTags,
     revalidate: defaultCacheLife.revalidate,
     explicitRevalidate: undefined,
     tags: null,
@@ -339,6 +346,11 @@ export function cache(kind: string, id: string, fn: any) {
 
       const workUnitStore = workUnitAsyncStorage.getStore()
 
+      const implicitTags =
+        workUnitStore === undefined || workUnitStore.type === 'unstable-cache'
+          ? []
+          : workUnitStore.implicitTags
+
       // Because the Action ID is not yet unique per implementation of that Action we can't
       // safely reuse the results across builds yet. In the meantime we add the buildId to the
       // arguments as a seed to ensure they're not reused. Remove this once Action IDs hash
@@ -363,8 +375,10 @@ export function cache(kind: string, id: string, fn: any) {
             // is not valid to use TextDecoder on this result.
             await new Response(encodedArguments).arrayBuffer()
 
-      let entry: undefined | CacheEntry =
-        await cacheHandler.get(serializedCacheKey)
+      let entry: undefined | CacheEntry = await cacheHandler.get(
+        serializedCacheKey,
+        implicitTags
+      )
 
       // Get the clientReferenceManifestSingleton while we're still in the outer Context.
       // In case getClientReferenceManifestSingleton is implemented using AsyncLocalStorage.

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -1,11 +1,7 @@
 import type { IncrementalCache } from '../../lib/incremental-cache'
 
 import { CACHE_ONE_YEAR } from '../../../lib/constants'
-import {
-  getImplicitTags,
-  validateRevalidate,
-  validateTags,
-} from '../../lib/patch-fetch'
+import { validateRevalidate, validateTags } from '../../lib/patch-fetch'
 import { workAsyncStorage } from '../../app-render/work-async-storage.external'
 import { workUnitAsyncStorage } from '../../app-render/work-unit-async-storage.external'
 import {
@@ -188,7 +184,10 @@ export function unstable_cache<T extends Callback>(
           }
         }
 
-        const implicitTags = getImplicitTags(workStore, workUnitStore)
+        const implicitTags =
+          !workUnitStore || workUnitStore.type === 'unstable-cache'
+            ? []
+            : workUnitStore.implicitTags
 
         const isNestedUnstableCache =
           workUnitStore && workUnitStore.type === 'unstable-cache'
@@ -299,9 +298,10 @@ export function unstable_cache<T extends Callback>(
 
         if (!incrementalCache.isOnDemandRevalidate) {
           // We aren't doing an on demand revalidation so we check use the cache if valid
-
           const implicitTags =
-            workStore && getImplicitTags(workStore, workUnitStore)
+            !workUnitStore || workUnitStore.type === 'unstable-cache'
+              ? []
+              : workUnitStore.implicitTags
 
           const cacheEntry = await incrementalCache.get(cacheKey, {
             kind: IncrementalCacheKind.FETCH,


### PR DESCRIPTION
The implicit tags set is the same for a whole page - typically. As soon as we have any cache read (tagged or not) we'll do it. Instead of computing the implicit tags every time we use it we now just compute it once up front and pass the same (immutable) instance through.

We could in theory out this on the WorkStore but I think that might need to be shielded with multiple different types of renders in the same one.

Another interesting case is whether or not the action scope should have implicit tags.

