### PR TITLE
turn withRequestStore into createRequestStore

### DIFF
--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -8,6 +8,7 @@ import type { AppPageModule } from '../route-modules/app-page/module'
 import type { SwrDelta } from '../lib/revalidate'
 import type { LoadingModuleData } from '../../shared/lib/app-router-context.shared-runtime'
 import type { DeepReadonly } from '../../shared/lib/deep-readonly'
+import type { __ApiPreviewProps } from '../api-utils'
 
 import s from 'next/dist/compiled/superstruct'
 import type { RequestLifecycleOpts } from '../base-server'
@@ -130,6 +131,7 @@ export type ServerOnInstrumentationRequestError = (
 ) => void | Promise<void>
 
 export interface RenderOptsPartial {
+  previewProps: __ApiPreviewProps | undefined
   err?: Error | null
   dev?: boolean
   buildId: string

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -12,7 +12,7 @@ import { stripInternalSearchParams } from '../internal-utils'
 import { normalizeRscURL } from '../../shared/lib/router/utils/app-paths'
 import { FLIGHT_HEADERS } from '../../client/components/app-router-headers'
 import { ensureInstrumentationRegistered } from './globals'
-import { withRequestStore } from '../async-storage/with-request-store'
+import { createRequestStoreForAPI } from '../async-storage/request-store'
 import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
 import {
   withWorkStore,
@@ -236,7 +236,18 @@ export async function adapter(
         },
         async () => {
           try {
+            const onUpdateCookies = (cookies: Array<string>) => {
+              cookiesFromResponse = cookies
+            }
             const previewProps = getEdgePreviewProps()
+
+            const requestStore = createRequestStoreForAPI(
+              request,
+              request.nextUrl,
+              undefined,
+              onUpdateCookies,
+              previewProps
+            )
 
             return await withWorkStore(
               workAsyncStorage,
@@ -262,21 +273,11 @@ export async function adapter(
                 ),
               },
               () =>
-                withRequestStore(
-                  workUnitAsyncStorage,
-                  {
-                    req: request,
-                    res: undefined,
-                    phase: 'action',
-                    url: request.nextUrl,
-                    renderOpts: {
-                      onUpdateCookies: (cookies) => {
-                        cookiesFromResponse = cookies
-                      },
-                      previewProps,
-                    },
-                  },
-                  () => params.handler(request, event)
+                workUnitAsyncStorage.run(
+                  requestStore,
+                  params.handler,
+                  request,
+                  event
                 )
             )
           } finally {


### PR DESCRIPTION
The wrapper implies that the scoping of a request store is one to one with the construction of a request store. This won't be the case in the future so I've updated the with wrapper to simply be a factory function and updated callsites to call workUnitAsyncStorage.run directly.

There are two sub-types of requestStore. One for page renders and one for APIs. I've updated  the factories to disambiguate these cases and narrow the input arguments.