### PR TITLE
fix(turbopack): Fix option to disable tree shaking

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1126,6 +1126,7 @@ impl NextConfig {
             .and_then(|v| v.tree_shaking);
 
         OptionTreeShaking(match tree_shaking {
+            // Allow disabling tree shaking completely
             Some(false) => Some(TreeShakingMode::ReexportsOnly),
             Some(true) => Some(TreeShakingMode::ModuleFragments),
             None => {
@@ -1140,15 +1141,26 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub fn tree_shaking_mode_for_user_code(
-        self: Vc<Self>,
-        is_development: bool,
-    ) -> Vc<OptionTreeShaking> {
-        Vc::cell(Some(if is_development {
-            TreeShakingMode::ReexportsOnly
-        } else {
-            TreeShakingMode::ModuleFragments
-        }))
+    pub fn tree_shaking_mode_for_user_code(&self, is_development: bool) -> Vc<OptionTreeShaking> {
+        let tree_shaking = self
+            .experimental
+            .turbo
+            .as_ref()
+            .and_then(|v| v.tree_shaking);
+
+        OptionTreeShaking(match tree_shaking {
+            // Allow disabling tree shaking completely
+            Some(false) => Some(TreeShakingMode::ReexportsOnly),
+            Some(true) => Some(TreeShakingMode::ModuleFragments),
+            None => {
+                if is_development {
+                    Some(TreeShakingMode::ReexportsOnly)
+                } else {
+                    Some(TreeShakingMode::ModuleFragments)
+                }
+            }
+        })
+        .cell()
     }
 
     #[turbo_tasks::function]


### PR DESCRIPTION
### What?

Ensure that `treeShaking: false` disables tree shaking.

### Why?

The implementation is far from perfect.

### How?

Closes NEXT-
Fixes #

-->
