### PR TITLE
Initial implementation of per-segment prefetch request handling

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -157,6 +157,7 @@ import {
   RSC_CONTENT_TYPE_HEADER,
   NEXT_ROUTER_STATE_TREE_HEADER,
   NEXT_DID_POSTPONE_HEADER,
+  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
 } from '../client/components/app-router-headers'
 import { webpackBuild } from './webpack-build'
 import { NextBuildContext, type MappedPages } from './build-context'
@@ -1259,7 +1260,7 @@ export default async function build(
               header: RSC_HEADER,
               // This vary header is used as a default. It is technically re-assigned in `base-server`,
               // and may include an additional Vary option for `Next-URL`.
-              varyHeader: `${RSC_HEADER}, ${NEXT_ROUTER_STATE_TREE_HEADER}, ${NEXT_ROUTER_PREFETCH_HEADER}`,
+              varyHeader: `${RSC_HEADER}, ${NEXT_ROUTER_STATE_TREE_HEADER}, ${NEXT_ROUTER_PREFETCH_HEADER}, ${NEXT_ROUTER_SEGMENT_PREFETCH_HEADER}`,
               prefetchHeader: NEXT_ROUTER_PREFETCH_HEADER,
               didPostponeHeader: NEXT_DID_POSTPONE_HEADER,
               contentTypeHeader: RSC_CONTENT_TYPE_HEADER,

--- a/packages/next/src/client/components/app-router-headers.ts
+++ b/packages/next/src/client/components/app-router-headers.ts
@@ -1,7 +1,16 @@
 export const RSC_HEADER = 'RSC' as const
 export const ACTION_HEADER = 'Next-Action' as const
+// TODO: Instead of sending the full router state, we only need to send the
+// segment path. Saves bytes. Then we could also use this field for segment
+// prefetches, which also need to specify a particular segment.
 export const NEXT_ROUTER_STATE_TREE_HEADER = 'Next-Router-State-Tree' as const
 export const NEXT_ROUTER_PREFETCH_HEADER = 'Next-Router-Prefetch' as const
+// This contains the path to the segment being prefetched.
+// TODO: If we change Next-Router-State-Tree to be a segment path, we can use
+// that instead. Then Next-Router-Prefetch and Next-Router-Segment-Prefetch can
+// be merged into a single enum.
+export const NEXT_ROUTER_SEGMENT_PREFETCH_HEADER =
+  'Next-Router-Segment-Prefetch' as const
 export const NEXT_HMR_REFRESH_HEADER = 'Next-HMR-Refresh' as const
 export const NEXT_URL = 'Next-Url' as const
 export const RSC_CONTENT_TYPE_HEADER = 'text/x-component' as const
@@ -11,6 +20,7 @@ export const FLIGHT_HEADERS = [
   NEXT_ROUTER_STATE_TREE_HEADER,
   NEXT_ROUTER_PREFETCH_HEADER,
   NEXT_HMR_REFRESH_HEADER,
+  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
 ] as const
 
 export const NEXT_RSC_UNION_QUERY = '_rsc' as const

--- a/packages/next/src/export/routes/types.ts
+++ b/packages/next/src/export/routes/types.ts
@@ -4,4 +4,5 @@ export type RouteMetadata = {
   status: number | undefined
   headers: OutgoingHttpHeaders | undefined
   postponed: string | undefined
+  segmentPaths: Array<string> | undefined
 }

--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -8,6 +8,8 @@ export const PRERENDER_REVALIDATE_ONLY_GENERATED_HEADER =
   'x-prerender-revalidate-if-generated'
 
 export const RSC_PREFETCH_SUFFIX = '.prefetch.rsc'
+export const RSC_SEGMENTS_DIR_SUFFIX = '.segments'
+export const RSC_SEGMENT_SUFFIX = '.segment.rsc'
 export const RSC_SUFFIX = '.rsc'
 export const ACTION_SUFFIX = '.action'
 export const NEXT_DATA_SUFFIX = '.json'

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1130,6 +1130,32 @@ async function renderToHTMLOrFlightImpl(
       }
     }
 
+    // Per-segment prefetch data
+    //
+    // All of the segments for a page are generated simultaneously, including
+    // during revalidations. This is to ensure consistency, because it's
+    // possible for a mismatch between a layout and page segment can cause the
+    // client to error during rendering. We want to preserve the ability of the
+    // client to recover from such a mismatch by re-requesting all the segments
+    // to get a consistent view of the page.
+    //
+    // TODO (Per Segment Prefetching): This is placeholder data. Populate with
+    // the actual data generated during prerender.
+    if (renderOpts.experimental.isRoutePPREnabled === true) {
+      const placeholder = Buffer.from(
+        'TODO (Per Segment Prefetching): Not yet implemented\n'
+      )
+      metadata.segmentFlightData = new Map([
+        // Root segment
+        ['/', placeholder],
+        ['/blog', placeholder],
+        // TODO: Update the client to use the same encoding for segment paths that
+        // we use here, so we don't have to convert between them. Needs to be
+        // filesystem safe.
+        ['/blog/[post]-1-d', placeholder],
+      ])
+    }
+
     return new RenderResult(await streamToString(response.stream), options)
   } else {
     // We're rendering dynamically

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2145,6 +2145,13 @@ export default abstract class Server<
     const isDynamicRSCRequest =
       isRoutePPREnabled && isRSCRequest && !isPrefetchRSCRequest
 
+    // Need to read this before it's stripped by stripFlightHeaders. We don't
+    // need to transfer it to the request meta because it's only read
+    // within this function; the static segment data should have already been
+    // generated, so we will always either return a static response or a 404.
+    const segmentPrefetchHeader =
+      req.headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER.toLowerCase()]
+
     // we need to ensure the status code if /404 is visited directly
     if (is404Page && !isNextDataRequest && !isRSCRequest) {
       res.statusCode = 404
@@ -2755,6 +2762,7 @@ export default abstract class Server<
             rscData: metadata.flightData,
             postponed: metadata.postponed,
             status: res.statusCode,
+            segmentData: undefined,
           } satisfies CachedAppPageValue,
           revalidate: metadata.revalidate,
           isFallback: !!fallbackRouteParams,
@@ -3089,6 +3097,51 @@ export default abstract class Server<
         isRoutePPREnabled,
       }
     )
+
+    if (
+      isRoutePPREnabled &&
+      isPrefetchRSCRequest &&
+      typeof segmentPrefetchHeader === 'string'
+    ) {
+      if (cacheEntry?.value?.kind === CachedRouteKind.APP_PAGE) {
+        // This is a prefetch request for an individual segment's static data.
+        // Unless the segment is fully dynamic, the data should have already been
+        // loaded into the cache, when the page itself was generated. So we should
+        // always either return the cache entry. If no cache entry is available,
+        // it's a 404 — either the segment is fully dynamic, or an invalid segment
+        // path was requested.
+        if (cacheEntry.value.segmentData) {
+          const matchedSegment =
+            cacheEntry.value.segmentData[segmentPrefetchHeader]
+          if (matchedSegment !== undefined) {
+            return {
+              type: 'rsc',
+              body: RenderResult.fromStatic(matchedSegment),
+              // TODO: Eventually this should use revalidate time of the
+              // individual segment, not the whole page.
+              revalidate: cacheEntry.revalidate,
+            }
+          }
+        }
+        // If the segment is not found, return a 404. Since this is an RSC
+        // request, there's no reason to render a 404 page; just return an
+        // empty response.
+        res.statusCode = 404
+        return {
+          type: 'rsc',
+          body: RenderResult.fromStatic(''),
+          revalidate: cacheEntry.revalidate,
+        }
+      } else {
+        // Segment prefetches should never reach the application layer. If
+        // there's no cache entry for this page, it's a 404.
+        res.statusCode = 404
+        return {
+          type: 'rsc',
+          body: RenderResult.fromStatic(''),
+        }
+      }
+    }
 
     if (isPreviewMode) {
       res.setHeader(

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -103,6 +103,7 @@ import {
   RSC_HEADER,
   NEXT_RSC_UNION_QUERY,
   NEXT_ROUTER_PREFETCH_HEADER,
+  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
   NEXT_DID_POSTPONE_HEADER,
   NEXT_URL,
   NEXT_ROUTER_STATE_TREE_HEADER,
@@ -1910,7 +1911,7 @@ export default abstract class Server<
     isAppPath: boolean,
     resolvedPathname: string
   ): void {
-    const baseVaryHeader = `${RSC_HEADER}, ${NEXT_ROUTER_STATE_TREE_HEADER}, ${NEXT_ROUTER_PREFETCH_HEADER}`
+    const baseVaryHeader = `${RSC_HEADER}, ${NEXT_ROUTER_STATE_TREE_HEADER}, ${NEXT_ROUTER_PREFETCH_HEADER}, ${NEXT_ROUTER_SEGMENT_PREFETCH_HEADER}`
     const isRSCRequest = getRequestMeta(req, 'isRSCRequest') ?? false
 
     let addedNextUrlToVary = false

--- a/packages/next/src/server/render-result.ts
+++ b/packages/next/src/server/render-result.ts
@@ -32,6 +32,8 @@ export type AppPageRenderResultMetadata = {
   headers?: OutgoingHttpHeaders
   fetchTags?: string
   fetchMetrics?: FetchMetrics
+
+  segmentFlightData?: Map<string, Buffer>
 }
 
 export type PagesRenderResultMetadata = {

--- a/packages/next/src/server/response-cache/types.ts
+++ b/packages/next/src/server/response-cache/types.ts
@@ -77,6 +77,7 @@ export interface CachedAppPageValue {
   status: number | undefined
   postponed: string | undefined
   headers: OutgoingHttpHeaders | undefined
+  segmentData: { [segmentPath: string]: string } | undefined
 }
 
 export interface CachedPageValue {
@@ -117,6 +118,7 @@ export interface IncrementalCachedAppPageValue {
   headers: OutgoingHttpHeaders | undefined
   postponed: string | undefined
   status: number | undefined
+  segmentData: { [segmentPath: string]: string } | undefined
 }
 
 export interface IncrementalCachedPageValue {

--- a/packages/next/src/server/response-cache/utils.ts
+++ b/packages/next/src/server/response-cache/utils.ts
@@ -32,6 +32,7 @@ export async function fromResponseCacheEntry(
               rscData: cacheEntry.value.rscData,
               headers: cacheEntry.value.headers,
               status: cacheEntry.value.status,
+              segmentData: cacheEntry.value.segmentData,
             }
           : cacheEntry.value,
   }
@@ -70,6 +71,7 @@ export async function toResponseCacheEntry(
               headers: response.value.headers,
               status: response.value.status,
               postponed: response.value.postponed,
+              segmentData: response.value.segmentData,
             } satisfies CachedAppPageValue)
           : response.value,
   }

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -322,7 +322,7 @@ describe('app dir - basic', () => {
     const res = await next.fetch('/dashboard')
     expect(res.headers.get('x-edge-runtime')).toBe('1')
     expect(res.headers.get('vary')).toBe(
-      'RSC, Next-Router-State-Tree, Next-Router-Prefetch'
+      'RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch'
     )
   })
 
@@ -334,8 +334,8 @@ describe('app dir - basic', () => {
     })
     expect(res.headers.get('vary')).toBe(
       isNextDeploy
-        ? 'RSC, Next-Router-State-Tree, Next-Router-Prefetch'
-        : 'RSC, Next-Router-State-Tree, Next-Router-Prefetch, Accept-Encoding'
+        ? 'RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch'
+        : 'RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Accept-Encoding'
     )
   })
 

--- a/test/e2e/app-dir/ppr-navigations/simple/per-segment-prefetching.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/simple/per-segment-prefetching.test.ts
@@ -1,0 +1,46 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('per segment prefetching', () => {
+  const { next, isNextDev, isNextDeploy } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDev || isNextDeploy) {
+    test('ppr is disabled', () => {})
+    return
+  }
+
+  // This feature is only partially implemented; the client does not yet issue
+  // these types of requests. This tests that the server responds correctly.
+  // TODO: Replace with e2e tests once more is implemented.
+
+  it('prefetch an individual segment', async () => {
+    const response = await next.fetch('/en', {
+      headers: {
+        RSC: '1',
+        'Next-Router-Prefetch': '1',
+        'Next-Router-Segment-Prefetch': '/',
+      },
+    })
+    expect(response.status).toBe(200)
+    const responseText = await response.text()
+    expect(responseText.trim()).toBe(
+      // The actual data is not yet generated, but this indicates that the
+      // request was handled correctly.
+      'TODO (Per Segment Prefetching): Not yet implemented'
+    )
+  })
+
+  it('respond with 404 if the segment does not have prefetch data', async () => {
+    const response = await next.fetch('/en', {
+      headers: {
+        RSC: '1',
+        'Next-Router-Prefetch': '1',
+        'Next-Router-Segment-Prefetch': '/does-not-exist',
+      },
+    })
+    expect(response.status).toBe(404)
+    const responseText = await response.text()
+    expect(responseText.trim()).toBe('')
+  })
+})

--- a/test/integration/custom-routes/test/index.test.js
+++ b/test/integration/custom-routes/test/index.test.js
@@ -2558,7 +2558,8 @@ const runTests = (isDev = false) => {
           header: 'RSC',
           contentTypeHeader: 'text/x-component',
           didPostponeHeader: 'x-nextjs-postponed',
-          varyHeader: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+          varyHeader:
+            'RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch',
           prefetchHeader: 'Next-Router-Prefetch',
           prefetchSuffix: '.prefetch.rsc',
           suffix: '.rsc',

--- a/test/integration/dynamic-routing/test/index.test.js
+++ b/test/integration/dynamic-routing/test/index.test.js
@@ -1513,7 +1513,8 @@ function runTests({ dev }) {
           header: 'RSC',
           contentTypeHeader: 'text/x-component',
           didPostponeHeader: 'x-nextjs-postponed',
-          varyHeader: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+          varyHeader:
+            'RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch',
           prefetchHeader: 'Next-Router-Prefetch',
           prefetchSuffix: '.prefetch.rsc',
           suffix: '.rsc',


### PR DESCRIPTION
Introduces a new type of request that will be used for prefetching individual segments. Requests are issued using the Next-Router-Segment-Prefetch header. It accepts a path to the segment that is being requested.

This feature part of PPR and will only be enabled when that flag is on.

Because these are prefetches, segment requests are always served from the cache. They must never reach the application layer or invoke a lambda. If a matching segment is not present in the cache, the server responds with a 404 and an empty body. Segments that are fully dynamic will also 404.

**In this PR, I have not yet implemented the actual segment generation**; I'm using placeholder data for now. The smoke test I added demonstrates that the placeholder data is correctly plumbed through the build, ISR, and server layers to respond to a basic request.