### PR TITLE
Fix clone response backport

### DIFF
--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -741,13 +741,15 @@ function createPatchedFetcher(
           const nextRevalidate = pendingResponse
             .then((res) => res.clone())
             .finally(() => {
-              // If the pending revalidate is not present in the store, then
-              // we have nothing to delete.
-              if (!staticGenerationStore.pendingRevalidates?.[cacheKey]) {
-                return
-              }
+              if (cacheKey) {
+                // If the pending revalidate is not present in the store, then
+                // we have nothing to delete.
+                if (!staticGenerationStore.pendingRevalidates?.[cacheKey]) {
+                  return
+                }
 
-              delete staticGenerationStore.pendingRevalidates[cacheKey]
+                delete staticGenerationStore.pendingRevalidates[cacheKey]
+              }
             })
 
           // Attach the empty catch here so we don't get a "unhandled promise

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -737,16 +737,26 @@ function createPatchedFetcher(
             const res: Response = await pendingRevalidate
             return res.clone()
           }
-          return (staticGenerationStore.pendingRevalidates[cacheKey] =
-            doOriginalFetch(true, cacheReasonOverride)
-              .then((res) => {
-                return res.clone()
-              })
-              .finally(async () => {
-                staticGenerationStore.pendingRevalidates ??= {}
-                delete staticGenerationStore.pendingRevalidates[cacheKey || '']
-                await handleUnlock()
-              }))
+          const pendingResponse = doOriginalFetch(true, cacheReasonOverride)
+          const nextRevalidate = pendingResponse
+            .then((res) => res.clone())
+            .finally(() => {
+              // If the pending revalidate is not present in the store, then
+              // we have nothing to delete.
+              if (!staticGenerationStore.pendingRevalidates?.[cacheKey]) {
+                return
+              }
+
+              delete staticGenerationStore.pendingRevalidates[cacheKey]
+            })
+
+          // Attach the empty catch here so we don't get a "unhandled promise
+          // rejection" warning
+          nextRevalidate.catch(() => {})
+
+          staticGenerationStore.pendingRevalidates[cacheKey] = nextRevalidate
+
+          return pendingResponse
         } else {
           return doOriginalFetch(false, cacheReasonOverride).finally(
             handleUnlock


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/70649 this tweaks the backport to properly clone and return original response so that pending revalidates aren't sharing an already used response. 

