### PR TITLE
Update loading cache handler

### DIFF
--- a/packages/next/src/server/after/builtin-request-context.ts
+++ b/packages/next/src/server/after/builtin-request-context.ts
@@ -1,3 +1,5 @@
+import type { CacheHandler } from '../lib/incremental-cache'
+
 export function getBuiltinRequestContext():
   | BuiltinRequestContextValue
   | undefined {
@@ -27,5 +29,8 @@ export type BuiltinRequestContext = {
   get(): BuiltinRequestContextValue | undefined
 }
 
-export type BuiltinRequestContextValue = { waitUntil?: WaitUntil }
+export type BuiltinRequestContextValue = {
+  waitUntil?: WaitUntil
+  NextCacheHandler?: typeof CacheHandler
+}
 export type WaitUntil = (promise: Promise<any>) => void

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -23,6 +23,7 @@ import {
 } from '../../../lib/constants'
 import { toRoute } from '../to-route'
 import { SharedRevalidateTimings } from './shared-revalidate-timings'
+import { getBuiltinRequestContext } from '../../after/builtin-request-context'
 
 export interface CacheHandlerContext {
   fs?: CacheFs
@@ -63,14 +64,6 @@ export class CacheHandler {
 
   public resetRequestCache(): void {}
 }
-
-export const NEXT_CACHE_HANDLER_SYMBOL = Symbol.for(
-  '__next_internal_cache_handler__'
-)
-
-// TODO(after): this is a temporary workaround.
-// Remove this when vercel builder is updated to provide '@next/request-context'. Same time as waitUntil
-const VERCEL_REQUEST_CONTEXT_SYMBOL = Symbol.for('@vercel/request-context')
 
 export class IncrementalCache implements IncrementalCacheType {
   readonly dev?: boolean
@@ -129,10 +122,7 @@ export class IncrementalCache implements IncrementalCacheType {
     const debug = !!process.env.NEXT_PRIVATE_DEBUG_CACHE
     this.hasCustomCacheHandler = Boolean(CurCacheHandler)
     if (!CurCacheHandler) {
-      const _globalThis: any = globalThis
-      const globalCacheHandler =
-        _globalThis[NEXT_CACHE_HANDLER_SYMBOL] ??
-        _globalThis[VERCEL_REQUEST_CONTEXT_SYMBOL]?.get()?.NextFetchCache
+      const globalCacheHandler = getBuiltinRequestContext()?.NextCacheHandler
 
       if (globalCacheHandler) {
         CurCacheHandler = globalCacheHandler

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -121,17 +121,21 @@ export class IncrementalCache implements IncrementalCacheType {
   }) {
     const debug = !!process.env.NEXT_PRIVATE_DEBUG_CACHE
     this.hasCustomCacheHandler = Boolean(CurCacheHandler)
-    if (!CurCacheHandler) {
-      const globalCacheHandler = getBuiltinRequestContext()?.NextCacheHandler
 
-      if (globalCacheHandler) {
-        CurCacheHandler = globalCacheHandler
-      } else if (fs && serverDistDir) {
+    const globalCacheHandler = getBuiltinRequestContext()?.NextCacheHandler
+
+    if (globalCacheHandler) {
+      CurCacheHandler = globalCacheHandler
+    }
+
+    if (!CurCacheHandler) {
+      if (fs && serverDistDir) {
         if (debug) {
           console.log('using filesystem cache handler')
         }
         CurCacheHandler = FileSystemCache
-      } else if (
+      }
+      if (
         FetchCache.isAvailable({ _requestHeaders: requestHeaders }) &&
         minimalMode &&
         fetchCache


### PR DESCRIPTION
This just allows loading cache handler via global symbol instead of just env or `next.config`. 