### PR TITLE
Added pnpm-lock to the gitignore templates

### DIFF
--- a/packages/create-next-app/templates/app-empty/js/gitignore
+++ b/packages/create-next-app/templates/app-empty/js/gitignore
@@ -9,6 +9,7 @@
 !.yarn/plugins
 !.yarn/releases
 !.yarn/versions
+pnpm-lock.yaml
 
 # testing
 /coverage
@@ -29,8 +30,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
-.env*.local
+# env files (can opt-in for commiting if needed)
+.env*
 
 # vercel
 .vercel

--- a/packages/create-next-app/templates/app-empty/ts/gitignore
+++ b/packages/create-next-app/templates/app-empty/ts/gitignore
@@ -9,6 +9,7 @@
 !.yarn/plugins
 !.yarn/releases
 !.yarn/versions
+pnpm-lock.yaml
 
 # testing
 /coverage
@@ -29,8 +30,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
-.env*.local
+# env files (can opt-in for commiting if needed)
+.env*
 
 # vercel
 .vercel

--- a/packages/create-next-app/templates/app-tw-empty/js/gitignore
+++ b/packages/create-next-app/templates/app-tw-empty/js/gitignore
@@ -9,6 +9,7 @@
 !.yarn/plugins
 !.yarn/releases
 !.yarn/versions
+pnpm-lock.yaml
 
 # testing
 /coverage
@@ -29,8 +30,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
-.env*.local
+# env files (can opt-in for commiting if needed)
+.env*
 
 # vercel
 .vercel

--- a/packages/create-next-app/templates/app-tw-empty/ts/gitignore
+++ b/packages/create-next-app/templates/app-tw-empty/ts/gitignore
@@ -9,6 +9,7 @@
 !.yarn/plugins
 !.yarn/releases
 !.yarn/versions
+pnpm-lock.yaml
 
 # testing
 /coverage
@@ -29,8 +30,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
-.env*.local
+# env files (can opt-in for commiting if needed)
+.env*
 
 # vercel
 .vercel

--- a/packages/create-next-app/templates/app-tw/js/gitignore
+++ b/packages/create-next-app/templates/app-tw/js/gitignore
@@ -9,6 +9,7 @@
 !.yarn/plugins
 !.yarn/releases
 !.yarn/versions
+pnpm-lock.yaml
 
 # testing
 /coverage

--- a/packages/create-next-app/templates/app-tw/ts/gitignore
+++ b/packages/create-next-app/templates/app-tw/ts/gitignore
@@ -9,6 +9,7 @@
 !.yarn/plugins
 !.yarn/releases
 !.yarn/versions
+pnpm-lock.yaml
 
 # testing
 /coverage

--- a/packages/create-next-app/templates/app/js/gitignore
+++ b/packages/create-next-app/templates/app/js/gitignore
@@ -9,6 +9,7 @@
 !.yarn/plugins
 !.yarn/releases
 !.yarn/versions
+pnpm-lock.yaml
 
 # testing
 /coverage

--- a/packages/create-next-app/templates/app/ts/gitignore
+++ b/packages/create-next-app/templates/app/ts/gitignore
@@ -9,6 +9,7 @@
 !.yarn/plugins
 !.yarn/releases
 !.yarn/versions
+pnpm-lock.yaml
 
 # testing
 /coverage

--- a/packages/create-next-app/templates/default-empty/js/gitignore
+++ b/packages/create-next-app/templates/default-empty/js/gitignore
@@ -9,6 +9,7 @@
 !.yarn/plugins
 !.yarn/releases
 !.yarn/versions
+pnpm-lock.yaml
 
 # testing
 /coverage
@@ -29,8 +30,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
-.env*.local
+# env files (can opt-in for commiting if needed)
+.env*
 
 # vercel
 .vercel

--- a/packages/create-next-app/templates/default-empty/ts/gitignore
+++ b/packages/create-next-app/templates/default-empty/ts/gitignore
@@ -9,6 +9,7 @@
 !.yarn/plugins
 !.yarn/releases
 !.yarn/versions
+pnpm-lock.yaml
 
 # testing
 /coverage
@@ -29,8 +30,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
-.env*.local
+# env files (can opt-in for commiting if needed)
+.env*
 
 # vercel
 .vercel

--- a/packages/create-next-app/templates/default-tw-empty/js/gitignore
+++ b/packages/create-next-app/templates/default-tw-empty/js/gitignore
@@ -9,6 +9,7 @@
 !.yarn/plugins
 !.yarn/releases
 !.yarn/versions
+pnpm-lock.yaml
 
 # testing
 /coverage
@@ -29,8 +30,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
-.env*.local
+# env files (can opt-in for commiting if needed)
+.env*
 
 # vercel
 .vercel

--- a/packages/create-next-app/templates/default-tw-empty/ts/gitignore
+++ b/packages/create-next-app/templates/default-tw-empty/ts/gitignore
@@ -9,6 +9,7 @@
 !.yarn/plugins
 !.yarn/releases
 !.yarn/versions
+pnpm-lock.yaml
 
 # testing
 /coverage
@@ -29,8 +30,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
-.env*.local
+# env files (can opt-in for commiting if needed)
+.env*
 
 # vercel
 .vercel

--- a/packages/create-next-app/templates/default-tw/js/gitignore
+++ b/packages/create-next-app/templates/default-tw/js/gitignore
@@ -9,6 +9,7 @@
 !.yarn/plugins
 !.yarn/releases
 !.yarn/versions
+pnpm-lock.yaml
 
 # testing
 /coverage

--- a/packages/create-next-app/templates/default-tw/ts/gitignore
+++ b/packages/create-next-app/templates/default-tw/ts/gitignore
@@ -9,6 +9,7 @@
 !.yarn/plugins
 !.yarn/releases
 !.yarn/versions
+pnpm-lock.yaml
 
 # testing
 /coverage

--- a/packages/create-next-app/templates/default/js/gitignore
+++ b/packages/create-next-app/templates/default/js/gitignore
@@ -9,6 +9,7 @@
 !.yarn/plugins
 !.yarn/releases
 !.yarn/versions
+pnpm-lock.yaml
 
 # testing
 /coverage

--- a/packages/create-next-app/templates/default/ts/gitignore
+++ b/packages/create-next-app/templates/default/ts/gitignore
@@ -9,6 +9,7 @@
 !.yarn/plugins
 !.yarn/releases
 !.yarn/versions
+pnpm-lock.yaml
 
 # testing
 /coverage


### PR DESCRIPTION
### What?
Added the `pnpm-lock.yaml` to the `gitignore` files of the templates for the `create-next-app` package.

### Why?
Else pnpm users have to manually add it to their project every time they create a new project with the CLI, which can be pretty annoying.