### PR TITLE
run CI for PPR + DIO

### DIFF
--- a/.github/workflows/test_ppr_dio.yml
+++ b/.github/workflows/test_ppr_dio.yml
@@ -1,0 +1,83 @@
+name: test-ppr-dynamic-io
+
+on:
+  push:
+    branches: ['canary']
+  pull_request:
+    types: [opened, synchronize]
+
+env:
+  VERCEL_TEST_TEAM: vtest314-next-e2e-tests
+  VERCEL_TEST_TOKEN: ${{ secrets.VERCEL_TEST_TOKEN }}
+  DATADOG_API_KEY: ${{ secrets.DATA_DOG_API_KEY }}
+  DD_ENV: 'ci'
+
+jobs:
+  changes:
+    name: Determine changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 25
+
+      - name: check for docs only change
+        id: docs-change
+        run: |
+          echo "DOCS_ONLY<<EOF" >> $GITHUB_OUTPUT;
+          echo "$(node scripts/run-for-change.js --not --type docs --exec echo 'false')" >> $GITHUB_OUTPUT;
+          echo 'EOF' >> $GITHUB_OUTPUT
+
+      - name: check for release
+        id: is-release
+        run: |
+          if [[ $(node ./scripts/check-is-release.js 2> /dev/null || :) = v* ]];
+            then
+              echo "IS_RELEASE=true" >> $GITHUB_OUTPUT
+            else
+              echo "IS_RELEASE=false" >> $GITHUB_OUTPUT
+          fi
+
+    outputs:
+      docs-only: ${{ steps.docs-change.outputs.DOCS_ONLY != 'false' }}
+      is-release: ${{ steps.is-release.outputs.IS_RELEASE == 'true' }}
+
+  run-tests:
+    if: ${{ (github.ref == 'refs/heads/canary' || github.head_ref == '10-10-run_ci_for_ppr_dio') }}
+    name: Run Tests
+    needs: changes
+    uses: ./.github/workflows/build_reusable.yml
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1/5, 2/5, 3/5, 4/5, 5/5, 6/6, 7/7, 8/8, 9/9, 10/10]
+    with:
+      afterBuild: __NEXT_EXPERIMENTAL_PPR=true __NEXT_EXPERIMENTAL_DIO=true NEXT_TEST_CONTINUE_ON_ERROR=1 NEXT_TEST_MODE=start node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type production
+      skipNativeBuild: 'yes'
+      skipNativeInstall: 'no'
+      stepName: 'test-ppr-dio-${{ matrix.group }}'
+      runs_on_labels: '["ubuntu-latest"]'
+
+  report-test-results-to-datadog:
+    needs: run-tests
+    if: ${{ always() }}
+
+    runs-on: ubuntu-latest
+    name: report test results to datadog
+    steps:
+      - name: Download test report artifacts
+        id: download-test-reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: test-reports-*
+          path: test
+          merge-multiple: true
+
+      - name: Upload test report to datadog
+        run: |
+          if [ -d ./test/test-junit-report ]; then
+            DD_ENV=ci npx @datadog/datadog-ci@2.23.1 junit upload --tags test.type:dynamicIO --service nextjs ./test/test-junit-report
+          fi

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1133,7 +1133,7 @@ export const defaultConfig: NextConfig = {
     parallelServerCompiles: false,
     parallelServerBuildTraces: false,
     ppr:
-      // TODO: remove once we've made PPR default
+      // TODO: remove once we've made PPR the default
       // If we're testing, and the `__NEXT_EXPERIMENTAL_PPR` environment variable
       // has been set to `true`, enable the experimental PPR feature so long as it
       // wasn't explicitly disabled in the config.
@@ -1156,7 +1156,15 @@ export const defaultConfig: NextConfig = {
     serverComponentsHmrCache: true,
     staticGenerationMaxConcurrency: 8,
     staticGenerationMinPagesPerWorker: 25,
-    dynamicIO: false,
+    dynamicIO:
+      // TODO: remove once we've made DynamicIO the default
+      // If we're testing, and the `__NEXT_EXPERIMENTAL_DIO` environment variable
+      // has been set to `true`, enable the experimental DIO feature so long as it
+      // wasn't explicitly disabled in the config.
+      !!(
+        process.env.__NEXT_TEST_MODE &&
+        process.env.__NEXT_EXPERIMENTAL_DIO === 'true'
+      ),
   },
   bundlePagesRouterDependencies: false,
 }

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -219,12 +219,18 @@ function assignDefaults(
     {}
   )
 
-  // TODO: remove these once we've made PPR default
+  // TODO: remove these once we've made PPR/DIO default
   // If this was defaulted to true, it implies that the configuration was
   // overridden for testing to be defaulted on.
   if (defaultConfig.experimental?.ppr) {
-    Log.warn(
+    Log.warnOnce(
       `\`experimental.ppr\` has been defaulted to \`true\` because \`__NEXT_EXPERIMENTAL_PPR\` was set to \`true\` during testing.`
+    )
+  }
+
+  if (defaultConfig.experimental?.dynamicIO) {
+    Log.warnOnce(
+      `\`experimental.dynamicIO\` has been defaulted to \`true\` because \`__NEXT_EXPERIMENTAL_DIO\` was set to \`true\` during testing.`
     )
   }
 


### PR DESCRIPTION
This runs the full test suite for DIO+PPR in a report-only mode and will be labeled in DD with type `dynamicIO`. This will allow visibility into what's failing across our test suite when these flags are enabled. 

Sample Run: https://github.com/vercel/next.js/actions/runs/11463985185?pr=71124

Closes NDX-363