### PR TITLE
fix(turbopack): Skip tree shaking on `next/dynamic` instead of ESM `import()`

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/util.rs
@@ -399,8 +399,18 @@ pub fn should_skip_tree_shaking(m: &Program, special_exports: &[RcStr]) -> bool 
             match item {
                 // Skip turbopack helpers.
                 ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
-                    with, specifiers, ..
+                    src,
+                    with,
+                    specifiers,
+                    ..
                 })) => {
+                    // We detect imports from next/dynamic in various places.
+                    // See collect_next_dynamic_imports. We need to preserve the import of
+                    // `next/dynamic`.
+                    if src.value == "next/dynamic" {
+                        return false;
+                    }
+
                     if let Some(with) = with.as_deref().and_then(|v| v.as_import_with()) {
                         for item in with.values.iter() {
                             if item.key.sym == *TURBOPACK_HELPER {

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/util.rs
@@ -504,16 +504,6 @@ impl Visit for ShouldSkip {
         n.visit_children_with(self);
     }
 
-    fn visit_callee(&mut self, n: &Callee) {
-        // TOOD(PACK-3231): Tree shaking work with dynamic imports
-        if matches!(n, Callee::Import(..)) {
-            self.skip = true;
-            return;
-        }
-
-        n.visit_children_with(self);
-    }
-
     fn visit_expr(&mut self, n: &Expr) {
         if self.skip {
             return;


### PR DESCRIPTION
### What?

Imports from `next/dynamic` is statically analyzed, and tree shaking breaks that analysis. 

### Why?

Previously, we gave up tree shaking if there was an ESM dynamic import, but it turns out that the only problematic thing is `next/dynamic`.

### How?

Closes PACK-3231
