### PR TITLE
feat(turbopack): Remove special exports

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -42,7 +42,6 @@ use crate::{
         get_next_client_resolved_map,
     },
     next_shared::{
-        next_js_special_exports,
         resolve::{
             get_invalid_server_only_resolve_plugin, ModuleFeatureReportResolvePlugin,
             NextSharedRuntimeResolvePlugin,
@@ -290,7 +289,6 @@ pub async fn get_client_module_options_context(
         tree_shaking_mode: tree_shaking_mode_for_user_code,
         enable_postcss_transform,
         side_effect_free_packages: next_config.optimize_package_imports().await?.clone_value(),
-        special_exports: Some(next_js_special_exports()),
         ..Default::default()
     };
 

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -47,7 +47,6 @@ use crate::{
     next_import_map::get_next_server_import_map,
     next_server::resolve::ExternalPredicate,
     next_shared::{
-        next_js_special_exports,
         resolve::{
             get_invalid_client_only_resolve_plugin, get_invalid_styled_jsx_resolve_plugin,
             ModuleFeatureReportResolvePlugin, NextExternalResolvePlugin,
@@ -500,7 +499,6 @@ pub async fn get_server_module_options_context(
         },
         tree_shaking_mode: tree_shaking_mode_for_user_code,
         side_effect_free_packages: next_config.optimize_package_imports().await?.clone_value(),
-        special_exports: Some(next_js_special_exports()),
         ..Default::default()
     };
 

--- a/crates/next-core/src/next_shared/mod.rs
+++ b/crates/next-core/src/next_shared/mod.rs
@@ -1,31 +1,3 @@
-use turbo_tasks::{RcStr, Vc};
-
 pub(crate) mod resolve;
 pub(crate) mod transforms;
 pub(crate) mod webpack_rules;
-
-#[turbo_tasks::function]
-pub fn next_js_special_exports() -> Vc<Vec<RcStr>> {
-    Vc::cell(
-        [
-            "config",
-            "middleware",
-            "runtime",
-            "revalidate",
-            "dynamic",
-            "dynamicParams",
-            "fetchCache",
-            "preferredRegion",
-            "maxDuration",
-            "generateStaticParams",
-            "metadata",
-            "generateMetadata",
-            "getServerSideProps",
-            "getInitialProps",
-            "getStaticProps",
-        ]
-        .into_iter()
-        .map(RcStr::from)
-        .collect::<Vec<RcStr>>(),
-    )
-}

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -380,7 +380,7 @@ pub async fn parse_config_from_source(module: Vc<Box<dyn Module>>) -> Result<Vc<
             globals,
             eval_context,
             ..
-        } = &*ecmascript_asset.failsafe_parse().await?
+        } = &*ecmascript_asset.parse_original().await?
         {
             for item in &module_ast.body {
                 if let Some(decl) = item

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -147,14 +147,6 @@ pub struct EcmascriptOptions {
     /// If false, they will reference the whole directory. If true, they won't
     /// reference anything and lead to an runtime error instead.
     pub ignore_dynamic_requests: bool,
-    /// The list of export names that should make tree shaking bail off. This is
-    /// required because tree shaking can split imports like `export const
-    /// runtime = 'edge'` as a separate module.
-    ///
-    /// Currently the analysis of these exports are statically verified by `NextPageStaticInfo`,
-    /// which is a `CustomTransformer` implementation and we don't have a way to apply it after
-    /// tree shaking.
-    pub special_exports: Vc<Vec<RcStr>>,
 }
 
 #[turbo_tasks::value(serialization = "auto_for_input")]

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -447,7 +447,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
 
     let parsed = if let Some(part) = part {
         let parsed = parse(source, ty, transforms);
-        let split_data = split(source.ident(), source, parsed, options.special_exports);
+        let split_data = split(source.ident(), source, parsed);
         part_of_module(split_data, part)
     } else {
         module.failsafe_parse()

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -35,12 +35,7 @@ impl EcmascriptParsable for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     async fn failsafe_parse(&self) -> Result<Vc<ParseResult>> {
         let parsed = self.full_module.failsafe_parse();
-        let split_data = split(
-            self.full_module.ident(),
-            self.full_module.source(),
-            parsed,
-            self.full_module.options().await?.special_exports,
-        );
+        let split_data = split(self.full_module.ident(), self.full_module.source(), parsed);
         Ok(part_of_module(split_data, self.part))
     }
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -419,12 +419,7 @@ impl PartialEq for SplitResult {
 
 #[turbo_tasks::function]
 pub(super) async fn split_module(asset: Vc<EcmascriptModuleAsset>) -> Result<Vc<SplitResult>> {
-    Ok(split(
-        asset.source().ident(),
-        asset.source(),
-        asset.parse(),
-        asset.options().await?.special_exports,
-    ))
+    Ok(split(asset.source().ident(), asset.source(), asset.parse()))
 }
 
 #[turbo_tasks::function]
@@ -432,7 +427,6 @@ pub(super) async fn split(
     ident: Vc<AssetIdent>,
     source: Vc<Box<dyn Source>>,
     parsed: Vc<ParseResult>,
-    special_exports: Vc<Vec<RcStr>>,
 ) -> Result<Vc<SplitResult>> {
     // Do not split already split module
     if ident.await?.part.is_some() {
@@ -464,7 +458,7 @@ pub(super) async fn split(
             ..
         } => {
             // If the script file is a common js file, we cannot split the module
-            if util::should_skip_tree_shaking(program, &[]) {
+            if util::should_skip_tree_shaking(program) {
                 return Ok(SplitResult::Failed {
                     parse_result: parsed,
                 }

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -464,7 +464,7 @@ pub(super) async fn split(
             ..
         } => {
             // If the script file is a common js file, we cannot split the module
-            if util::should_skip_tree_shaking(program, &special_exports.await?) {
+            if util::should_skip_tree_shaking(program, &[]) {
                 return Ok(SplitResult::Failed {
                     parse_result: parsed,
                 }

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/util.rs
@@ -14,7 +14,6 @@ use swc_core::{
         visit::{noop_visit_type, Visit, VisitWith},
     },
 };
-use turbo_tasks::RcStr;
 
 use crate::TURBOPACK_HELPER;
 
@@ -393,7 +392,7 @@ where
     v.bindings
 }
 
-pub fn should_skip_tree_shaking(m: &Program, special_exports: &[RcStr]) -> bool {
+pub fn should_skip_tree_shaking(m: &Program) -> bool {
     if let Program::Module(m) = m {
         for item in m.body.iter() {
             match item {
@@ -434,30 +433,6 @@ pub fn should_skip_tree_shaking(m: &Program, special_exports: &[RcStr]) -> bool 
                                 return true;
                             }
                         }
-                    }
-                }
-
-                // Skip special reexports that are recognized by next.js
-                ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                    decl: Decl::Var(box VarDecl { decls, .. }),
-                    ..
-                })) => {
-                    for decl in decls {
-                        if let Pat::Ident(name) = &decl.name {
-                            if special_exports.iter().any(|s| **s == *name.sym) {
-                                return true;
-                            }
-                        }
-                    }
-                }
-
-                // Skip special reexports that are recognized by next.js
-                ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                    decl: Decl::Fn(f),
-                    ..
-                })) => {
-                    if special_exports.iter().any(|s| **s == *f.ident.sym) {
-                        return true;
                     }
                 }
 

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -93,7 +93,6 @@ impl ModuleOptions {
             execution_context,
             ref rules,
             tree_shaking_mode,
-            special_exports,
             ..
         } = *module_options_context.await?;
 
@@ -136,7 +135,6 @@ impl ModuleOptions {
             import_externals,
             ignore_dynamic_requests,
             refresh,
-            special_exports: special_exports.unwrap_or_else(|| Vc::cell(vec![])),
             ..Default::default()
         };
         let ecmascript_options_vc = ecmascript_options.cell();

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -125,8 +125,6 @@ pub struct ModuleOptionsContext {
     pub side_effect_free_packages: Vec<RcStr>,
     pub tree_shaking_mode: Option<TreeShakingMode>,
 
-    pub special_exports: Option<Vc<Vec<RcStr>>>,
-
     /// Custom rules to be applied after all default rules.
     pub module_rules: Vec<ModuleRule>,
     /// A list of rules to use a different module option context for certain


### PR DESCRIPTION
### What?

This PR removes special exports from tree shaking to apply it to more modules

### Why?

Previously tree shaking pass simply gave up if there's a special export.

### How?

