### PR TITLE
tweak static indicator style & behavior

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/app/hot-reloader-client.tsx
@@ -333,7 +333,20 @@ function processMessage(
           // as we'll receive the updated manifest before usePathname
           // triggers for new value
           if ((pathnameRef.current as string) in obj.data) {
-            dispatcher.onStaticIndicator(true)
+            // the indicator can be hidden for an hour.
+            // check if it's still hidden
+            const indicatorHiddenAt = Number(
+              localStorage?.getItem('__NEXT_DISMISS_PRERENDER_INDICATOR')
+            )
+
+            const isHidden =
+              indicatorHiddenAt &&
+              !isNaN(indicatorHiddenAt) &&
+              Date.now() < indicatorHiddenAt
+
+            if (!isHidden) {
+              dispatcher.onStaticIndicator(true)
+            }
           } else {
             dispatcher.onStaticIndicator(false)
           }
@@ -600,7 +613,18 @@ export default function HotReload({
 
       if (appIsrManifest) {
         if (pathname in appIsrManifest) {
-          dispatcher.onStaticIndicator(true)
+          const indicatorHiddenAt = Number(
+            localStorage?.getItem('__NEXT_DISMISS_PRERENDER_INDICATOR')
+          )
+
+          const isHidden =
+            indicatorHiddenAt &&
+            !isNaN(indicatorHiddenAt) &&
+            Date.now() < indicatorHiddenAt
+
+          if (!isHidden) {
+            dispatcher.onStaticIndicator(true)
+          }
         } else {
           dispatcher.onStaticIndicator(false)
         }

--- a/packages/next/src/client/components/react-dev-overlay/internal/components/Toast/Toast.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/components/Toast/Toast.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-export type ToastProps = {
+export type ToastProps = React.HTMLProps<HTMLDivElement> & {
   children?: React.ReactNode
   onClick?: () => void
   className?: string

--- a/packages/next/src/client/components/react-dev-overlay/internal/components/Toast/styles.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/components/Toast/styles.ts
@@ -27,25 +27,64 @@ const styles = css`
   }
 
   .nextjs-static-indicator-toast-wrapper {
-    padding: 8px 16px;
+    width: 30px;
+    height: 30px;
+    overflow: hidden;
+    border: 0;
     border-radius: var(--size-gap-triple);
     background: var(--color-background);
     color: var(--color-font);
+    transition: all 0.3s ease-in-out;
   }
 
-  .nextjs-static-indicator-toast-wrapper div {
+  .nextjs-static-indicator-toast-wrapper:hover {
+    width: 140px;
+  }
+
+  .nextjs-static-indicator-toast-icon {
     display: flex;
-    flex-direction: row;
     align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
   }
 
-  .nextjs-static-indicator-toast-wrapper span {
-    padding: 4px;
-    margin: 0;
+  .nextjs-static-indicator-toast-text {
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    white-space: nowrap;
+    transition: opacity 0.3s ease-in-out;
+    line-height: 30px;
+    position: absolute;
+    left: 30px;
+    top: 0;
+  }
+
+  .nextjs-static-indicator-toast-wrapper:hover
+    .nextjs-static-indicator-toast-text {
+    opacity: 1;
   }
 
   .nextjs-static-indicator-toast-wrapper button {
     color: var(--color-font);
+    opacity: 0.8;
+    background: none;
+    border: none;
+    margin-left: 6px;
+    margin-top: -2px;
+    outline: 0;
+  }
+
+  .nextjs-static-indicator-toast-wrapper button:focus {
+    opacity: 1;
+  }
+
+  .nextjs-static-indicator-toast-wrapper button > svg {
+    width: 16px;
+    height: 16px;
   }
 `
 

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/StaticIndicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/StaticIndicator.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import { Toast } from '../components/Toast'
 import { LightningBolt } from '../icons/LightningBolt'
 import { CloseIcon } from '../icons/CloseIcon'
@@ -5,19 +6,31 @@ import type { Dispatcher } from '../../app/hot-reloader-client'
 
 export function StaticIndicator({ dispatcher }: { dispatcher?: Dispatcher }) {
   return (
-    <Toast className="nextjs-static-indicator-toast-wrapper">
-      <LightningBolt />
-      <span>Static route </span>
-      <button
-        onClick={() => {
-          dispatcher?.onStaticIndicator(false)
-        }}
-        className="nextjs-toast-hide-button"
-        aria-label="Hide static indicator"
-        style={{ marginLeft: 'var(--size-gap)' }}
-      >
-        <CloseIcon />
-      </button>
+    <Toast className={`nextjs-static-indicator-toast-wrapper`}>
+      <div className="nextjs-static-indicator-toast-icon">
+        <LightningBolt />
+      </div>
+      <div className="nextjs-static-indicator-toast-text">
+        Static route
+        <button
+          onClick={() => {
+            // When dismissed, we hide the indicator for 1 hour. Store the
+            // timestamp for when to show it again.
+            const oneHourAway = Date.now() + 1 * 60 * 60 * 1000
+
+            localStorage?.setItem(
+              '__NEXT_DISMISS_PRERENDER_INDICATOR',
+              oneHourAway.toString()
+            )
+
+            dispatcher?.onStaticIndicator(false)
+          }}
+          className="nextjs-toast-hide-button"
+          aria-label="Hide static indicator"
+        >
+          <CloseIcon />
+        </button>
+      </div>
     </Toast>
   )
 }


### PR DESCRIPTION
Adjusts the styles of the prerender indicator to be smaller, and have it be expandable rather than always expanded, closer to the original behavior. This also restores the previous behavior of respecting the close preference for an hr.

### Before

<details>
<summary>Dark Mode</summary>

![CleanShot 2024-10-10 at 17 18 35@2x](https://github.com/user-attachments/assets/87c60922-06ea-4584-b485-36221ecfc8f9)



</details>

<details>
<summary>Light Mode</summary>

![CleanShot 2024-10-10 at 17 19 01@2x](https://github.com/user-attachments/assets/3c23aff9-0cc5-4b8e-af50-f937ce16f75f)



</details>

### After

<details>
<summary>Dark Mode</summary>


https://github.com/user-attachments/assets/a60bafaa-fcf5-4d07-853c-718e12f2b8aa



</details>

<details>
<summary>Light Mode</summary>

https://github.com/user-attachments/assets/ae03eaea-fc4a-4b95-be96-85d7d13b1176




</details>