### PR TITLE
Handle thrown values that aren't `Error` instances in App router

### DIFF
--- a/packages/next/src/client/components/is-next-router-error.ts
+++ b/packages/next/src/client/components/is-next-router-error.ts
@@ -1,11 +1,13 @@
-import { isNotFoundError } from './not-found'
-import { isRedirectError } from './redirect'
+import { isNotFoundError, type NotFoundError } from './not-found'
+import { isRedirectError, type RedirectError } from './redirect'
 
 /**
  * Returns true if the error is a navigation signal error. These errors are
  * thrown by user code to perform navigation operations and interrupt the React
  * render.
  */
-export function isNextRouterError(error: any): boolean {
+export function isNextRouterError(
+  error: any
+): error is RedirectError | NotFoundError {
   return isRedirectError(error) || isNotFoundError(error)
 }

--- a/packages/next/src/client/components/not-found.ts
+++ b/packages/next/src/client/components/not-found.ts
@@ -1,6 +1,6 @@
 const NOT_FOUND_ERROR_CODE = 'NEXT_NOT_FOUND'
 
-type NotFoundError = Error & { digest: typeof NOT_FOUND_ERROR_CODE }
+export type NotFoundError = Error & { digest: typeof NOT_FOUND_ERROR_CODE }
 
 /**
  * This function allows you to render the [not-found.js file](https://nextjs.org/docs/app/api-reference/file-conventions/not-found)


### PR DESCRIPTION
Noticed unsound access of `error.digest` when debugging. Test and explainer of refactor will follow. Need the opinion of CI first.