### PR TITLE
fix: allow custom app routes for metadata conventions

### DIFF
--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -67,7 +67,10 @@ import {
   isInternalComponent,
   isNonRoutePagesPage,
 } from '../lib/is-internal-component'
-import { isMetadataRoute } from '../lib/metadata/is-metadata-route'
+import {
+  isMetadataRoute,
+  isMetadataRouteFile,
+} from '../lib/metadata/is-metadata-route'
 import { RouteKind } from '../server/route-kind'
 import { encodeToBase64 } from './webpack/loaders/utils'
 import { normalizeCatchAllRoutes } from './normalize-catchall-routes'
@@ -267,7 +270,11 @@ export async function createPagesMapping({
 
     let route = pagesType === 'app' ? normalizeMetadataRoute(pageKey) : pageKey
 
-    if (isMetadataRoute(route) && pagesType === 'app') {
+    if (
+      isMetadataRoute(route) &&
+      pagesType === 'app' &&
+      isMetadataRouteFile(pagePath, pageExtensions, true)
+    ) {
       const filePath = join(appDir!, pagePath)
       const staticInfo = await getPageStaticInfo({
         nextConfig: {},

--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -67,10 +67,7 @@ import {
   isInternalComponent,
   isNonRoutePagesPage,
 } from '../lib/is-internal-component'
-import {
-  isMetadataRoute,
-  isMetadataRouteFile,
-} from '../lib/metadata/is-metadata-route'
+import { isMetadataRouteFile } from '../lib/metadata/is-metadata-route'
 import { RouteKind } from '../server/route-kind'
 import { encodeToBase64 } from './webpack/loaders/utils'
 import { normalizeCatchAllRoutes } from './normalize-catchall-routes'
@@ -271,7 +268,6 @@ export async function createPagesMapping({
     let route = pagesType === 'app' ? normalizeMetadataRoute(pageKey) : pageKey
 
     if (
-      isMetadataRoute(route) &&
       pagesType === 'app' &&
       isMetadataRouteFile(pagePath, pageExtensions, true)
     ) {

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -84,6 +84,7 @@ import { generateEncryptionKeyBase64 } from '../app-render/encryption-utils-serv
 import { isAppPageRouteDefinition } from '../route-definitions/app-page-route-definition'
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 import { getNodeDebugType } from '../lib/utils'
+import { isMetadataRouteFile } from '../../lib/metadata/is-metadata-route'
 // import { getSupportedBrowsers } from '../../build/utils'
 
 const wsServer = new ws.Server({ noServer: true })
@@ -936,10 +937,17 @@ export async function createHotReloaderTurbopack(
       }
 
       const isInsideAppDir = routeDef.bundlePath.startsWith('app/')
-      const normalizedAppPage = normalizedPageToTurbopackStructureRoute(
-        page,
-        extname(routeDef.filename)
+      const isEntryMetadataRouteFile = isMetadataRouteFile(
+        routeDef.filename.replace(opts.appDir || '', ''),
+        nextConfig.pageExtensions,
+        true
       )
+      const normalizedAppPage = isEntryMetadataRouteFile
+        ? normalizedPageToTurbopackStructureRoute(
+            page,
+            extname(routeDef.filename)
+          )
+        : page
 
       const route = isInsideAppDir
         ? currentEntrypoints.app.get(normalizedAppPage)

--- a/packages/next/src/server/dev/turbopack/manifest-loader.ts
+++ b/packages/next/src/server/dev/turbopack/manifest-loader.ts
@@ -55,6 +55,21 @@ type TurbopackMiddlewareManifest = MiddlewareManifest & {
   instrumentation?: InstrumentationDefinition
 }
 
+const getManifestPath = (page: string, distDir: string, name: string, type: string) => {
+  let manifestPath = posix.join(
+    distDir,
+    `server`,
+    type,
+    type === 'middleware' || type === 'instrumentation'
+      ? ''
+      : type === 'app'
+        ? page
+        : getAssetPathFromRoute(page),
+    name
+  )
+  return manifestPath
+}
+
 async function readPartialManifest<T>(
   distDir: string,
   name:
@@ -70,34 +85,14 @@ async function readPartialManifest<T>(
   pageName: string,
   type: 'pages' | 'app' | 'middleware' | 'instrumentation' = 'pages'
 ): Promise<T> {
-  const page = pageName.replace(/\/sitemap\/route$/, '/sitemap.xml/route')
+  const page = pageName
 
-  let manifestPath = posix.join(
-    distDir,
-    `server`,
-    type,
-    type === 'middleware' || type === 'instrumentation'
-      ? ''
-      : type === 'app'
-        ? page
-        : getAssetPathFromRoute(page),
-    name
-  )
+  let manifestPath = getManifestPath(page, distDir, name, type)
   // existsSync is faster than using the async version
   if(!existsSync(manifestPath) && page.endsWith('/route')) {
     // TODO: Improve implementation of metadata routes, currently it requires this extra check for the variants of the files that can be written.
     const metadataPage = addRouteSuffix(addMetadataIdToRoute(removeRouteSuffix(page.replace(/\/sitemap\.xml\/route$/, '/sitemap/route'))))
-    manifestPath = posix.join(
-      distDir,
-      `server`,
-      type,
-      type === 'middleware' || type === 'instrumentation'
-        ? ''
-        : type === 'app'
-          ? metadataPage
-          : getAssetPathFromRoute(metadataPage),
-      name
-    )
+    manifestPath = getManifestPath(metadataPage, distDir, name, type)
   }
   return JSON.parse(await readFile(posix.join(manifestPath), 'utf-8')) as T
 }

--- a/packages/next/src/server/dev/turbopack/manifest-loader.ts
+++ b/packages/next/src/server/dev/turbopack/manifest-loader.ts
@@ -91,7 +91,7 @@ async function readPartialManifest<T>(
   // existsSync is faster than using the async version
   if(!existsSync(manifestPath) && page.endsWith('/route')) {
     // TODO: Improve implementation of metadata routes, currently it requires this extra check for the variants of the files that can be written.
-    const metadataPage = addRouteSuffix(addMetadataIdToRoute(removeRouteSuffix(page.replace(/\/sitemap\.xml\/route$/, '/sitemap/route'))))
+    let metadataPage = addRouteSuffix(addMetadataIdToRoute(removeRouteSuffix(page.replace(/\/sitemap\/route$/, '/sitemap.xml/route'))))
     manifestPath = getManifestPath(metadataPage, distDir, name, type)
   }
   return JSON.parse(await readFile(posix.join(manifestPath), 'utf-8')) as T

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -86,7 +86,10 @@ import {
   ModuleBuildError,
   TurbopackInternalError,
 } from '../../dev/turbopack-utils'
-import { isMetadataRoute } from '../../../lib/metadata/is-metadata-route'
+import {
+  isMetadataRoute,
+  isMetadataRouteFile,
+} from '../../../lib/metadata/is-metadata-route'
 import { normalizeMetadataPageToRoute } from '../../../lib/metadata/get-metadata-route'
 import { createEnvDefinitions } from '../experimental/create-env-definitions'
 import { JsConfigPathsPlugin } from '../../../build/webpack/plugins/jsconfig-paths-plugin'
@@ -429,7 +432,15 @@ async function startWatcher(opts: SetupOpts) {
           pagesType: isAppPath ? PAGE_TYPES.APP : PAGE_TYPES.PAGES,
         })
 
-        if (isAppPath && isMetadataRoute(pageName)) {
+        if (
+          isAppPath &&
+          isMetadataRoute(pageName) &&
+          isMetadataRouteFile(
+            fileName.replace(appDir!, ''),
+            nextConfig.pageExtensions,
+            true
+          )
+        ) {
           const staticInfo = await getPageStaticInfo({
             pageFilePath: fileName,
             nextConfig: {},

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -86,10 +86,7 @@ import {
   ModuleBuildError,
   TurbopackInternalError,
 } from '../../dev/turbopack-utils'
-import {
-  isMetadataRoute,
-  isMetadataRouteFile,
-} from '../../../lib/metadata/is-metadata-route'
+import { isMetadataRouteFile } from '../../../lib/metadata/is-metadata-route'
 import { normalizeMetadataPageToRoute } from '../../../lib/metadata/get-metadata-route'
 import { createEnvDefinitions } from '../experimental/create-env-definitions'
 import { JsConfigPathsPlugin } from '../../../build/webpack/plugins/jsconfig-paths-plugin'
@@ -434,9 +431,9 @@ async function startWatcher(opts: SetupOpts) {
 
         if (
           isAppPath &&
-          isMetadataRoute(pageName) &&
+          appDir &&
           isMetadataRouteFile(
-            fileName.replace(appDir!, ''),
+            fileName.replace(appDir, ''),
             nextConfig.pageExtensions,
             true
           )

--- a/packages/next/src/server/route-matcher-providers/dev/dev-app-route-route-matcher-provider.ts
+++ b/packages/next/src/server/route-matcher-providers/dev/dev-app-route-route-matcher-provider.ts
@@ -68,8 +68,8 @@ export class DevAppRouteRouteMatcherProvider extends FileCacheRouteMatcherProvid
           // We'll map the filename before normalization:
           // sitemap.ts -> sitemap.xml/route.ts
           // icon.ts -> icon/route.ts
-          const metadataPage = normalizeMetadataPageToRoute(page, false) // this.normalizers.page.normalize(dummyFilename)
-          const metadataPathname = normalizeMetadataPageToRoute(pathname, false) // this.normalizers.pathname.normalize(dummyFilename)
+          const metadataPage = normalizeMetadataPageToRoute(page, false)
+          const metadataPathname = normalizeMetadataPageToRoute(pathname, false)
           const metadataBundlePath = normalizeMetadataPageToRoute(
             bundlePath,
             false

--- a/packages/next/src/server/route-matcher-providers/dev/dev-app-route-route-matcher-provider.ts
+++ b/packages/next/src/server/route-matcher-providers/dev/dev-app-route-route-matcher-provider.ts
@@ -7,9 +7,11 @@ import { isAppRouteRoute } from '../../../lib/is-app-route-route'
 import { DevAppNormalizers } from '../../normalizers/built/app'
 import {
   isMetadataRoute,
+  isMetadataRouteFile,
   isStaticMetadataRoute,
 } from '../../../lib/metadata/is-metadata-route'
 import { normalizeMetadataPageToRoute } from '../../../lib/metadata/get-metadata-route'
+import path from '../../../shared/lib/isomorphic/path'
 
 export class DevAppRouteRouteMatcherProvider extends FileCacheRouteMatcherProvider<AppRouteRouteMatcher> {
   private readonly normalizers: {
@@ -17,6 +19,7 @@ export class DevAppRouteRouteMatcherProvider extends FileCacheRouteMatcherProvid
     pathname: Normalizer
     bundlePath: Normalizer
   }
+  private readonly appDir: string
 
   constructor(
     appDir: string,
@@ -25,6 +28,7 @@ export class DevAppRouteRouteMatcherProvider extends FileCacheRouteMatcherProvid
   ) {
     super(appDir, reader)
 
+    this.appDir = appDir
     this.normalizers = new DevAppNormalizers(appDir, extensions)
   }
 
@@ -43,8 +47,18 @@ export class DevAppRouteRouteMatcherProvider extends FileCacheRouteMatcherProvid
 
       const pathname = this.normalizers.pathname.normalize(filename)
       const bundlePath = this.normalizers.bundlePath.normalize(filename)
+      const ext = path.extname(filename).slice(1)
+      const isEntryMetadataRouteFile = isMetadataRouteFile(
+        filename.replace(this.appDir, ''),
+        [ext],
+        true
+      )
 
-      if (isMetadataRoute(page) && !isStaticMetadataRoute(page)) {
+      if (
+        isMetadataRoute(page) &&
+        !isStaticMetadataRoute(page) &&
+        isEntryMetadataRouteFile
+      ) {
         // Matching dynamic metadata routes.
         // Add 2 possibilities for both single and multiple routes:
         {
@@ -59,7 +73,7 @@ export class DevAppRouteRouteMatcherProvider extends FileCacheRouteMatcherProvid
           const metadataBundlePath = normalizeMetadataPageToRoute(
             bundlePath,
             false
-          ) // this.normalizers.bundlePath.normalize(dummyFilename)
+          )
 
           const matcher = new AppRouteRouteMatcher({
             kind: RouteKind.APP_ROUTE,

--- a/packages/next/src/server/route-matcher-providers/dev/dev-app-route-route-matcher-provider.ts
+++ b/packages/next/src/server/route-matcher-providers/dev/dev-app-route-route-matcher-provider.ts
@@ -6,7 +6,6 @@ import { FileCacheRouteMatcherProvider } from './file-cache-route-matcher-provid
 import { isAppRouteRoute } from '../../../lib/is-app-route-route'
 import { DevAppNormalizers } from '../../normalizers/built/app'
 import {
-  isMetadataRoute,
   isMetadataRouteFile,
   isStaticMetadataRoute,
 } from '../../../lib/metadata/is-metadata-route'
@@ -54,11 +53,7 @@ export class DevAppRouteRouteMatcherProvider extends FileCacheRouteMatcherProvid
         true
       )
 
-      if (
-        isMetadataRoute(page) &&
-        !isStaticMetadataRoute(page) &&
-        isEntryMetadataRouteFile
-      ) {
+      if (!isStaticMetadataRoute(page) && isEntryMetadataRouteFile) {
         // Matching dynamic metadata routes.
         // Add 2 possibilities for both single and multiple routes:
         {

--- a/test/e2e/app-dir/metadata-non-standard-custom-routes/app/layout.tsx
+++ b/test/e2e/app-dir/metadata-non-standard-custom-routes/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/metadata-non-standard-custom-routes/app/page.tsx
+++ b/test/e2e/app-dir/metadata-non-standard-custom-routes/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/metadata-non-standard-custom-routes/app/sitemap/route.ts
+++ b/test/e2e/app-dir/metadata-non-standard-custom-routes/app/sitemap/route.ts
@@ -1,0 +1,20 @@
+// custom /sitemap route, with xml content
+export function GET() {
+  return new Response(
+    `<?xml version="1.0" encoding="UTF-8"?>
+      <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      <url>
+      <loc>https://example.com</loc>
+      <lastmod>2021-01-01</lastmod>
+      <changefreq>weekly</changefreq>
+      <priority>0.5</priority>
+      </url>
+      </urlset>
+    `.trim(),
+    {
+      headers: {
+        'Content-Type': 'application/xml',
+      },
+    }
+  )
+}

--- a/test/e2e/app-dir/metadata-non-standard-custom-routes/metadata-non-standard-custom-routes.test.ts
+++ b/test/e2e/app-dir/metadata-non-standard-custom-routes/metadata-non-standard-custom-routes.test.ts
@@ -9,6 +9,16 @@ describe('app-dir - metadata-non-standard-custom-routes', () => {
     const res = await next.fetch('/sitemap')
     expect(res.status).toBe(200)
     expect(res.headers.get('content-type')).toBe('application/xml')
-    expect(await res.text()).toMatchInlineSnapshot(``)
+    expect(await res.text()).toMatchInlineSnapshot(`
+      "<?xml version="1.0" encoding="UTF-8"?>
+            <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            <url>
+            <loc>https://example.com</loc>
+            <lastmod>2021-01-01</lastmod>
+            <changefreq>weekly</changefreq>
+            <priority>0.5</priority>
+            </url>
+            </urlset>"
+    `)
   })
 })

--- a/test/e2e/app-dir/metadata-non-standard-custom-routes/metadata-non-standard-custom-routes.test.ts
+++ b/test/e2e/app-dir/metadata-non-standard-custom-routes/metadata-non-standard-custom-routes.test.ts
@@ -1,0 +1,14 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('app-dir - metadata-non-standard-custom-routes', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should work with custom sitemap route', async () => {
+    const res = await next.fetch('/sitemap')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('application/xml')
+    expect(await res.text()).toMatchInlineSnapshot(``)
+  })
+})


### PR DESCRIPTION
### What

Should be able to use app custom routes to create the Metadata like API routes such as sitemap. This was a regression introduced in #66477 , where we always normalized the Metadata like routes. This fix now ensure we only do the Metadata routes normalizing when the page is actually matched the Metadata file convention files.

For turbopack, since we couldn't access the entry filename, so that we need to check if the app manifest is existed. For sitemap specifically since it could have various paths: `/sitemap`(user customized route), `/sitemap.xml` (single metadata route), `/sitemap/[id].xml` (dynamic metadata route). So we fallback two times to check if the manifest existed.

Fixes #71119