### PR TITLE
Revert "chore(next-codemod): move app-dir-runtime-config-experimental-edge to 13.1.2"

### DIFF
--- a/docs/02-app/01-building-your-application/11-upgrading/01-codemods.mdx
+++ b/docs/02-app/01-building-your-application/11-upgrading/01-codemods.mdx
@@ -26,6 +26,30 @@ Replacing `<transform>` and `<path>` with appropriate values.
 
 ### 15.0
 
+#### Transform App Router Route Segment Config `runtime` value from `experimental-edge` to `edge`
+
+##### `app-dir-runtime-config-experimental-edge`
+
+> **Note**: This codemod is App Router specific.
+
+```bash filename="Terminal"
+npx @next/codemod@latest app-dir-runtime-config-experimental-edge .
+```
+
+This codemod transforms [Route Segment Config `runtime`](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#runtime) value `experimental-edge` to `edge`.
+
+For example:
+
+```ts
+export const runtime = 'experimental-edge'
+```
+
+Transforms into:
+
+```ts
+export const runtime = 'edge'
+```
+
 #### Migrate to async Dynamic APIs
 
 APIs that opted into dynamic rendering that previously supported synchronous access are now asynchronous. You can read more about this breaking change in the [upgrade guide](/docs/app/building-your-application/upgrading/version-15).
@@ -285,32 +309,6 @@ Transforms into:
 
 ```js
 import { Inter } from 'next/font/google'
-```
-
-### 13.1.2
-
-#### Transform App Router Route Segment Config `runtime` value from `experimental-edge` to `edge`
-
-##### `app-dir-runtime-config-experimental-edge`
-
-> **Note**: This codemod is App Router specific.
-
-```bash filename="Terminal"
-npx @next/codemod@latest app-dir-runtime-config-experimental-edge .
-```
-
-This codemod transforms [Route Segment Config `runtime`](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#runtime) value `experimental-edge` to `edge`.
-
-For example:
-
-```ts
-export const runtime = 'experimental-edge'
-```
-
-Transforms into:
-
-```ts
-export const runtime = 'edge'
 ```
 
 ### 13.0

--- a/packages/next-codemod/lib/utils.ts
+++ b/packages/next-codemod/lib/utils.ts
@@ -83,12 +83,6 @@ export const TRANSFORMER_INQUIRER_CHOICES = [
     version: '13.0',
   },
   {
-    title:
-      'Transform App Router Route Segment Config `runtime` value from `experimental-edge` to `edge`',
-    value: 'app-dir-runtime-config-experimental-edge',
-    version: '13.1.2',
-  },
-  {
     title: 'Uninstall `@next/font` and transform imports to `next/font`',
     value: 'built-in-next-font',
     version: '13.2',
@@ -121,5 +115,11 @@ export const TRANSFORMER_INQUIRER_CHOICES = [
     title: 'Transforms usage of Next.js async Request APIs',
     value: 'next-async-request-api',
     version: '15.0.0-canary.171',
+  },
+  {
+    title:
+      'Transform App Router Route Segment Config `runtime` value from `experimental-edge` to `edge`',
+    value: 'app-dir-runtime-config-experimental-edge',
+    version: '15.0.0-canary.179',
   },
 ]


### PR DESCRIPTION
Reverts vercel/next.js#71081

We want to make sure this gets suggested as part of v15 since that's the breaking version.