### PR TITLE
misc(next-codemod): inform user whether current version is higher or on target version

### DIFF
--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -68,9 +68,15 @@ export async function runUpgrade(
 
   const targetNextVersion = targetNextPackageJson.version
 
-  if (compareVersions(installedNextVersion, targetNextVersion) >= 0) {
+  if (compareVersions(installedNextVersion, targetNextVersion) === 0) {
     console.log(
-      `${pc.green('✓')} Current Next.js version is already on or higher than the target version "v${targetNextVersion}".`
+      `${pc.green('✓')} Current Next.js version is already on the target version "v${targetNextVersion}".`
+    )
+    return
+  }
+  if (compareVersions(installedNextVersion, targetNextVersion) > 0) {
+    console.log(
+      `${pc.green('✓')} Current Next.js version is higher than the target version "v${targetNextVersion}".`
     )
     return
   }


### PR DESCRIPTION
"is already on or higher than" is sloppy. Inform correctly to the user.