### PR TITLE
docs: module resolution for `next.config.ts` is currently limited to `CommonJS`

### DIFF
--- a/docs/02-app/01-building-your-application/07-configuring/01-typescript.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/01-typescript.mdx
@@ -103,7 +103,7 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-> **Good to know**: You can import Native ESM modules in `next.config.ts` without any additional configuration. Supports importing extensions like `.cjs`, `.cts`, `.mjs`, and `.mts`.
+> **Note**: Module resolutions for `next.config.ts` are currently limited to `CommonJS`.
 
 <AppOnly>
 

--- a/docs/02-app/01-building-your-application/07-configuring/01-typescript.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/01-typescript.mdx
@@ -103,7 +103,7 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-> **Note**: Module resolution in `next.config.ts` is currently limited to `CommonJS`. This may cause incompatibilities with ESM only packages being loaded in `next.config.ts`. 
+> **Note**: Module resolution in `next.config.ts` is currently limited to `CommonJS`. This may cause incompatibilities with ESM only packages being loaded in `next.config.ts`.
 
 <AppOnly>
 

--- a/docs/02-app/01-building-your-application/07-configuring/01-typescript.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/01-typescript.mdx
@@ -103,7 +103,7 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-> **Note**: Module resolutions for `next.config.ts` are currently limited to `CommonJS`.
+> **Note**: Module resolution in `next.config.ts` is currently limited to `CommonJS`. This may cause incompatibilities with ESM only packages being loaded in `next.config.ts`. 
 
 <AppOnly>
 


### PR DESCRIPTION
### Why?

In current state, `next.config.ts` cannot resolve Native ESM syntax. Therefore it may import extensions `.js`, `.mjs`, `.cjs`, it will throw when the imported module uses Native ESM syntax like top-level await.

Closes NDX-368