### PR TITLE
[dynamicIO] track Prerender environment name during dev

### DIFF
--- a/packages/next/src/server/app-render/app-render-render-utils.ts
+++ b/packages/next/src/server/app-render/app-render-render-utils.ts
@@ -1,0 +1,31 @@
+import { InvariantError } from '../../shared/lib/invariant-error'
+
+/**
+ * This is a utility function to make scheduling sequential tasks that run back to back easier.
+ * We schedule on the same queue (setImmediate) at the same time to ensure no other events can sneak in between.
+ */
+export function scheduleInSequentialTasks<R>(
+  render: () => R | Promise<R>,
+  followup: () => void
+): Promise<R> {
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    throw new InvariantError(
+      '`scheduleInSequentialTasks` should not be called in edge runtime.'
+    )
+  } else {
+    return new Promise((resolve, reject) => {
+      let pendingResult: R | Promise<R>
+      setImmediate(() => {
+        try {
+          pendingResult = render()
+        } catch (err) {
+          reject(err)
+        }
+      })
+      setImmediate(() => {
+        followup()
+        resolve(pendingResult)
+      })
+    })
+  }
+}

--- a/packages/next/types/$$compiled.internal.d.ts
+++ b/packages/next/types/$$compiled.internal.d.ts
@@ -48,7 +48,7 @@ declare module 'react-server-dom-webpack/server.edge' {
     },
     options?: {
       temporaryReferences?: string
-      environmentName?: string
+      environmentName?: string | (() => string)
       filterStackFrame?: (url: string, functionName: string) => boolean
       onError?: (error: unknown) => void
       onPostpone?: (reason: string) => void


### PR DESCRIPTION
When rendering in dev we track environment name to pass along server logs to the browser. Today the environment name is the default "Server" however when `dynamicIO` is enabled we want to have logs in the first Task where rendering starts be tagged with the environment "Prerender". This will help us understand what work is happening in the "Prerender" phase and what is happening in the dynamic "Server" phase while developing in dev mode.v