### PR TITLE
Increase retry duration for HMR fetch logging tests

### DIFF
--- a/test/development/app-dir/server-components-hmr-cache/server-components-hmr-cache.test.ts
+++ b/test/development/app-dir/server-components-hmr-cache/server-components-hmr-cache.test.ts
@@ -29,6 +29,7 @@ describe('server-components-hmr-cache', () => {
           await retry(async () => {
             const updatedContent = await browser.elementById('content').text()
             expect(updatedContent).toBe('bar')
+            // TODO: remove custom duration in case we increase the default.
           }, 5000)
 
           const valueAfterPatch = await browser.elementById('value').text()
@@ -45,6 +46,7 @@ describe('server-components-hmr-cache', () => {
       await retry(async () => {
         const valueAfterRefresh = await browser.elementById('value').text()
         expect(valueBeforeRefresh).not.toEqual(valueAfterRefresh)
+        // TODO: remove custom duration in case we increase the default.
       }, 5000)
     })
 
@@ -65,6 +67,7 @@ describe('server-components-hmr-cache', () => {
             await retry(async () => {
               const updatedContent = await browser.elementById('content').text()
               expect(updatedContent).toBe('bar')
+              // TODO: remove custom duration in case we increase the default.
             }, 5000)
 
             const valueAfterPatch = getLoggedAfterValue()
@@ -83,6 +86,7 @@ describe('server-components-hmr-cache', () => {
         await retry(async () => {
           const valueAfterRefresh = getLoggedAfterValue()
           expect(valueBeforeRefresh).not.toEqual(valueAfterRefresh)
+          // TODO: remove custom duration in case we increase the default.
         }, 5000)
       })
     })
@@ -117,6 +121,7 @@ describe('server-components-hmr-cache', () => {
             await retry(async () => {
               const updatedContent = await browser.elementById('content').text()
               expect(updatedContent).toBe('bar')
+              // TODO: remove custom duration in case we increase the default.
             }, 5000)
 
             const valueAfterPatch = await browser.elementById('value').text()
@@ -144,6 +149,7 @@ describe('server-components-hmr-cache', () => {
                   .elementById('content')
                   .text()
                 expect(updatedContent).toBe('bar')
+                // TODO: remove custom duration in case we increase the default.
               }, 5000)
 
               const valueAfterPatch = await retry(() => getLoggedAfterValue())

--- a/test/e2e/app-dir/logging/fetch-logging.test.ts
+++ b/test/e2e/app-dir/logging/fetch-logging.test.ts
@@ -242,7 +242,8 @@ describe('app-dir - logging', () => {
                 const logs = stripAnsi(next.cliOutput.slice(outputIndex))
                 expect(logs).toInclude(' GET /fetch-no-store')
                 expect(logs).not.toInclude(` │ GET `)
-              })
+                // TODO: remove custom duration in case we increase the default.
+              }, 5000)
           )
         })
 
@@ -285,7 +286,8 @@ describe('app-dir - logging', () => {
                   expect(logs).toInclude(
                     ` │ GET ${expectedUrl}?request-input 200 in 1ms (HMR cache)`
                   )
-                })
+                  // TODO: remove custom duration in case we increase the default.
+                }, 5000)
               }
             )
           })

--- a/test/e2e/on-request-error/basic/basic.test.ts
+++ b/test/e2e/on-request-error/basic/basic.test.ts
@@ -31,6 +31,7 @@ describe('on-request-error - basic', () => {
       expect(recordLogLines).toEqual(
         expect.arrayContaining([expect.stringContaining(errorMessage)])
       )
+      // TODO: remove custom duration in case we increase the default.
     }, 5000)
 
     const json = await getOutputLogJson(next, outputLogPath)

--- a/test/e2e/on-request-error/dynamic-routes/dynamic-routes.test.ts
+++ b/test/e2e/on-request-error/dynamic-routes/dynamic-routes.test.ts
@@ -23,6 +23,7 @@ describe('on-request-error - dynamic-routes', () => {
       expect(recordLogLines).toEqual(
         expect.arrayContaining([expect.stringContaining(errorMessage)])
       )
+      // TODO: remove custom duration in case we increase the default.
     }, 5000)
 
     const json = await getOutputLogJson(next, outputLogPath)

--- a/test/e2e/on-request-error/server-action-error/server-action-error.test.ts
+++ b/test/e2e/on-request-error/server-action-error/server-action-error.test.ts
@@ -30,6 +30,7 @@ describe('on-request-error - server-action-error', () => {
       expect(recordLogLines).toEqual(
         expect.arrayContaining([expect.stringContaining(errorMessage)])
       )
+      // TODO: remove custom duration in case we increase the default.
     }, 5000)
 
     const json = await getOutputLogJson(next, outputLogPath)


### PR DESCRIPTION
As we've learned in #70467, compilation times can be quite high in CI, when testing HMR behaviour. The fetch logging HMR tests are frequently failing. Increasing the `retry` timeout should mitigate the flakiness.