### PR TITLE
codemod(turbopack): Rewrite more Vc fields in structs as ResolvedVc

### DIFF
--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -162,7 +162,7 @@ pub(crate) async fn collect_next_dynamic_imports(
                     .iter()
                     .map(|module| async move {
                         Ok(NextDynamicVisitEntry::Module(
-                            module.resolve().await?.to_resolved().await?,
+                            module.to_resolved().await?,
                             module.ident().to_string().await?,
                         ))
                     })

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -11,7 +11,7 @@ use tracing::{Instrument, Level};
 use turbo_tasks::{
     graph::{GraphTraversal, NonDeterministic, VisitControlFlow, VisitedNodes},
     trace::TraceRawVcs,
-    FxIndexMap, RcStr, ReadRef, TryJoinIterExt, Value, ValueToString, Vc,
+    FxIndexMap, RcStr, ReadRef, ResolvedVc, TryJoinIterExt, Value, ValueToString, Vc,
 };
 use turbopack_core::{
     chunk::{
@@ -162,7 +162,7 @@ pub(crate) async fn collect_next_dynamic_imports(
                     .iter()
                     .map(|module| async move {
                         Ok(NextDynamicVisitEntry::Module(
-                            module.resolve().await?,
+                            module.resolve().await?.to_resolved().await?,
                             module.ident().to_string().await?,
                         ))
                     })
@@ -209,8 +209,8 @@ pub(crate) async fn collect_next_dynamic_imports(
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, TraceRawVcs, Serialize, Deserialize)]
 enum NextDynamicVisitEntry {
-    Module(Vc<Box<dyn Module>>, ReadRef<RcStr>),
-    DynamicImportsMap(Vc<DynamicImportsMap>),
+    Module(ResolvedVc<Box<dyn Module>>, ReadRef<RcStr>),
+    DynamicImportsMap(ResolvedVc<DynamicImportsMap>),
 }
 
 #[turbo_tasks::value(transparent)]
@@ -227,7 +227,7 @@ async fn get_next_dynamic_edges(
         .iter()
         .map(|&referenced_module| async move {
             Ok(NextDynamicVisitEntry::Module(
-                referenced_module,
+                referenced_module.to_resolved().await?,
                 referenced_module.ident().to_string().await?,
             ))
         })
@@ -236,7 +236,7 @@ async fn get_next_dynamic_edges(
     if let Some(dynamic_imports_map) = *dynamic_imports_map.await? {
         edges.reserve_exact(1);
         edges.push(NextDynamicVisitEntry::DynamicImportsMap(
-            dynamic_imports_map,
+            dynamic_imports_map.to_resolved().await?,
         ));
     }
     Ok(Vc::cell(edges))
@@ -264,7 +264,7 @@ impl turbo_tasks::graph::Visit<NextDynamicVisitEntry> for NextDynamicVisit {
         };
         let client_asset_context = self.client_asset_context;
         async move {
-            Ok(get_next_dynamic_edges(client_asset_context, module)
+            Ok(get_next_dynamic_edges(client_asset_context, *module)
                 .await?
                 .into_iter()
                 .cloned())

--- a/crates/next-core/src/next_app/include_modules_module.rs
+++ b/crates/next-core/src/next_app/include_modules_module.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{RcStr, TryJoinIterExt, ValueToString, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -19,13 +19,13 @@ use turbopack_ecmascript::chunk::{
 #[turbo_tasks::value]
 pub struct IncludeModulesModule {
     ident: Vc<AssetIdent>,
-    modules: Vec<Vc<Box<dyn Module>>>,
+    modules: Vec<ResolvedVc<Box<dyn Module>>>,
 }
 
 #[turbo_tasks::value_impl]
 impl IncludeModulesModule {
     #[turbo_tasks::function]
-    pub fn new(ident: Vc<AssetIdent>, modules: Vec<Vc<Box<dyn Module>>>) -> Vc<Self> {
+    pub fn new(ident: Vc<AssetIdent>, modules: Vec<ResolvedVc<Box<dyn Module>>>) -> Vc<Self> {
         Self { ident, modules }.cell()
     }
 }
@@ -50,7 +50,7 @@ impl Module for IncludeModulesModule {
                 .iter()
                 .map(|&module| async move {
                     Ok(Vc::upcast(
-                        IncludedModuleReference::new(module).resolve().await?,
+                        IncludedModuleReference::new(*module).resolve().await?,
                     ))
                 })
                 .try_join()

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -1,7 +1,7 @@
 use std::iter::once;
 
 use anyhow::Result;
-use turbo_tasks::{FxIndexMap, RcStr, Value, Vc};
+use turbo_tasks::{FxIndexMap, RcStr, ResolvedVc, Value, Vc};
 use turbo_tasks_env::EnvMap;
 use turbo_tasks_fs::{FileSystem, FileSystemPath};
 use turbopack::{
@@ -193,8 +193,8 @@ fn internal_assets_conditions() -> ContextCondition {
 #[turbo_tasks::function]
 pub async fn get_client_module_options_context(
     project_path: Vc<FileSystemPath>,
-    execution_context: Vc<ExecutionContext>,
-    env: Vc<Environment>,
+    execution_context: ResolvedVc<ExecutionContext>,
+    env: ResolvedVc<Environment>,
     ty: Value<ClientContextType>,
     mode: Vc<NextMode>,
     next_config: Vc<NextConfig>,
@@ -202,7 +202,7 @@ pub async fn get_client_module_options_context(
     let next_mode = mode.await?;
 
     let resolve_options_context =
-        get_client_resolve_options_context(project_path, ty, mode, next_config, execution_context);
+        get_client_resolve_options_context(project_path, ty, mode, next_config, *execution_context);
 
     let tsconfig = get_typescript_transform_options(project_path);
     let decorators_options = get_decorators_transform_options(project_path);
@@ -312,7 +312,7 @@ pub async fn get_client_module_options_context(
         ecmascript: EcmascriptOptionsContext {
             enable_jsx: Some(jsx_runtime_options),
             enable_typescript_transform: Some(tsconfig),
-            enable_decorators: Some(decorators_options),
+            enable_decorators: Some(decorators_options.to_resolved().await?),
             ..module_options_context.ecmascript.clone()
         },
         enable_webpack_loaders,
@@ -408,8 +408,10 @@ pub async fn get_client_runtime_entries(
         // because the bootstrap contains JSX which requires Refresh's global
         // functions to be available.
         if let Some(request) = enable_react_refresh {
-            runtime_entries
-                .push(RuntimeEntry::Request(request, project_root.join("_".into())).cell())
+            runtime_entries.push(
+                RuntimeEntry::Request(request.to_resolved().await?, project_root.join("_".into()))
+                    .cell(),
+            )
         };
     }
 
@@ -418,7 +420,9 @@ pub async fn get_client_runtime_entries(
             RuntimeEntry::Request(
                 Request::parse(Value::new(Pattern::Constant(
                     "next/dist/client/app-next-turbopack.js".into(),
-                ))),
+                )))
+                .to_resolved()
+                .await?,
                 project_root.join("_".into()),
             )
             .cell(),

--- a/crates/next-core/src/next_client/runtime_entry.rs
+++ b/crates/next-core/src/next_client/runtime_entry.rs
@@ -12,8 +12,8 @@ use turbopack_ecmascript::resolve::cjs_resolve;
 
 #[turbo_tasks::value(shared)]
 pub enum RuntimeEntry {
-    Request(Vc<Request>, Vc<FileSystemPath>),
-    Evaluatable(Vc<Box<dyn EvaluatableAsset>>),
+    Request(ResolvedVc<Request>, Vc<FileSystemPath>),
+    Evaluatable(ResolvedVc<Box<dyn EvaluatableAsset>>),
     Source(ResolvedVc<Box<dyn Source>>),
 }
 
@@ -25,7 +25,7 @@ impl RuntimeEntry {
         asset_context: Vc<Box<dyn AssetContext>>,
     ) -> Result<Vc<EvaluatableAssets>> {
         let (request, path) = match *self.await? {
-            RuntimeEntry::Evaluatable(e) => return Ok(EvaluatableAssets::one(e)),
+            RuntimeEntry::Evaluatable(e) => return Ok(EvaluatableAssets::one(*e)),
             RuntimeEntry::Source(source) => {
                 return Ok(EvaluatableAssets::one(source.to_evaluatable(asset_context)));
             }
@@ -34,7 +34,7 @@ impl RuntimeEntry {
 
         let modules = cjs_resolve(
             Vc::upcast(PlainResolveOrigin::new(asset_context, path)),
-            request,
+            *request,
             None,
             false,
         )

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value as JsonValue;
-use turbo_tasks::{trace::TraceRawVcs, FxIndexMap, RcStr, TaskInput, Vc};
+use turbo_tasks::{trace::TraceRawVcs, FxIndexMap, RcStr, ResolvedVc, TaskInput, Vc};
 use turbo_tasks_env::EnvMap;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{
@@ -481,7 +481,7 @@ pub enum ReactCompilerOptionsOrBoolean {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct OptionalReactCompilerOptions(Option<Vc<ReactCompilerOptions>>);
+pub struct OptionalReactCompilerOptions(Option<ResolvedVc<ReactCompilerOptions>>);
 
 #[turbo_tasks::value(eq = "manual")]
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -1080,11 +1080,11 @@ impl NextConfig {
                         compilation_mode: None,
                         panic_threshold: None,
                     }
-                    .cell(),
+                    .resolved_cell(),
                 ))
             }
             Some(ReactCompilerOptionsOrBoolean::Option(options)) => OptionalReactCompilerOptions(
-                Some(ReactCompilerOptions { ..options.clone() }.cell()),
+                Some(ReactCompilerOptions { ..options.clone() }.resolved_cell()),
             ),
             _ => OptionalReactCompilerOptions(None),
         };

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{FxIndexMap, RcStr, Value, Vc};
+use turbo_tasks::{FxIndexMap, RcStr, ResolvedVc, Value, Vc};
 use turbo_tasks_env::EnvMap;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::resolve_options_context::ResolveOptionsContext;
@@ -60,7 +60,7 @@ async fn next_edge_defines(define_env: Vc<EnvMap>) -> Result<Vc<CompileTimeDefin
 /// See [here](https://github.com/vercel/next.js/blob/160bb99b06e9c049f88e25806fd995f07f4cc7e1/packages/next/src/build/webpack-config.ts#L1715-L1718) how webpack configures it.
 #[turbo_tasks::function]
 async fn next_edge_free_vars(
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
     define_env: Vc<EnvMap>,
 ) -> Result<Vc<FreeVarReferences>> {
     Ok(free_var_references!(

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -1,7 +1,7 @@
 use std::iter::once;
 
 use anyhow::{bail, Result};
-use turbo_tasks::{FxIndexMap, RcStr, Value, Vc};
+use turbo_tasks::{FxIndexMap, RcStr, ResolvedVc, Value, Vc};
 use turbo_tasks_env::{EnvMap, ProcessEnv};
 use turbo_tasks_fs::{FileSystem, FileSystemPath};
 use turbopack::{
@@ -179,7 +179,7 @@ pub async fn get_server_resolve_options_context(
     let server_external_packages_plugin = ExternalCjsModulesResolvePlugin::new(
         project_path,
         project_path.root(),
-        ExternalPredicate::Only(Vc::cell(external_packages)).cell(),
+        ExternalPredicate::Only(ResolvedVc::cell(external_packages)).cell(),
         *next_config.import_externals().await?,
     );
 
@@ -202,7 +202,7 @@ pub async fn get_server_resolve_options_context(
         ExternalCjsModulesResolvePlugin::new(
             project_path,
             project_path.root(),
-            ExternalPredicate::AllExcept(Vc::cell(transpiled_packages)).cell(),
+            ExternalPredicate::AllExcept(ResolvedVc::cell(transpiled_packages)).cell(),
             *next_config.import_externals().await?,
         )
     };
@@ -375,7 +375,7 @@ fn internal_assets_conditions() -> ContextCondition {
 #[turbo_tasks::function]
 pub async fn get_server_module_options_context(
     project_path: Vc<FileSystemPath>,
-    execution_context: Vc<ExecutionContext>,
+    execution_context: ResolvedVc<ExecutionContext>,
     ty: Value<ServerContextType>,
     mode: Vc<NextMode>,
     next_config: Vc<NextConfig>,
@@ -569,7 +569,7 @@ pub async fn get_server_module_options_context(
                 ecmascript: EcmascriptOptionsContext {
                     enable_jsx: Some(jsx_runtime_options),
                     enable_typescript_transform: Some(tsconfig),
-                    enable_decorators: Some(decorators_options),
+                    enable_decorators: Some(decorators_options.to_resolved().await?),
                     ..module_options_context.ecmascript
                 },
                 enable_webpack_loaders,
@@ -632,7 +632,7 @@ pub async fn get_server_module_options_context(
                 ecmascript: EcmascriptOptionsContext {
                     enable_jsx: Some(jsx_runtime_options),
                     enable_typescript_transform: Some(tsconfig),
-                    enable_decorators: Some(decorators_options),
+                    enable_decorators: Some(decorators_options.to_resolved().await?),
                     ..module_options_context.ecmascript
                 },
                 enable_webpack_loaders,
@@ -706,7 +706,7 @@ pub async fn get_server_module_options_context(
                 ecmascript: EcmascriptOptionsContext {
                     enable_jsx: Some(rsc_jsx_runtime_options),
                     enable_typescript_transform: Some(tsconfig),
-                    enable_decorators: Some(decorators_options),
+                    enable_decorators: Some(decorators_options.to_resolved().await?),
                     ..module_options_context.ecmascript
                 },
                 enable_webpack_loaders,
@@ -779,7 +779,7 @@ pub async fn get_server_module_options_context(
                 ecmascript: EcmascriptOptionsContext {
                     enable_jsx: Some(rsc_jsx_runtime_options),
                     enable_typescript_transform: Some(tsconfig),
-                    enable_decorators: Some(decorators_options),
+                    enable_decorators: Some(decorators_options.to_resolved().await?),
                     ..module_options_context.ecmascript
                 },
                 enable_webpack_loaders,
@@ -869,7 +869,7 @@ pub async fn get_server_module_options_context(
                 ecmascript: EcmascriptOptionsContext {
                     enable_jsx: Some(jsx_runtime_options),
                     enable_typescript_transform: Some(tsconfig),
-                    enable_decorators: Some(decorators_options),
+                    enable_decorators: Some(decorators_options.to_resolved().await?),
                     ..module_options_context.ecmascript
                 },
                 enable_webpack_loaders,

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{trace::TraceRawVcs, RcStr, Value, Vc};
+use turbo_tasks::{trace::TraceRawVcs, RcStr, ResolvedVc, Value, Vc};
 use turbo_tasks_fs::{self, glob::Glob, FileJsonContent, FileSystemPath};
 use turbopack_core::{
     issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
@@ -24,10 +24,10 @@ use turbopack_core::{
 pub enum ExternalPredicate {
     /// Mark all modules as external if they're not listed in the list.
     /// Applies only to imports outside of node_modules.
-    AllExcept(Vc<Vec<RcStr>>),
+    AllExcept(ResolvedVc<Vec<RcStr>>),
     /// Only mark modules listed as external, whether inside node_modules or
     /// not.
-    Only(Vc<Vec<RcStr>>),
+    Only(ResolvedVc<Vec<RcStr>>),
 }
 
 /// Mark modules as external, so they're resolved at runtime instead of bundled.
@@ -111,7 +111,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                     return Ok(ResolveResultOption::none());
                 }
 
-                let exception_glob = packages_glob(*exceptions).await?;
+                let exception_glob = packages_glob(**exceptions).await?;
 
                 if let Some(PackagesGlobs {
                     path_glob,
@@ -127,7 +127,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                 false
             }
             ExternalPredicate::Only(externals) => {
-                let external_glob = packages_glob(*externals).await?;
+                let external_glob = packages_glob(**externals).await?;
 
                 if let Some(PackagesGlobs {
                     path_glob,

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -122,7 +122,7 @@ impl EcmascriptChunkPlaceable for NextServerComponentModule {
                 exports,
                 star_exports: vec![module_reference],
             }
-            .cell(),
+            .resolved_cell(),
         )
         .cell()
     }

--- a/crates/next-core/src/pages_structure.rs
+++ b/crates/next-core/src/pages_structure.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use tracing::Instrument;
-use turbo_tasks::{RcStr, ValueToString, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{
     DirectoryContent, DirectoryEntry, FileSystemEntryType, FileSystemPath, FileSystemPathOption,
 };
@@ -12,7 +12,7 @@ use crate::next_import_map::get_next_package;
 pub struct PagesStructureItem {
     pub base_path: Vc<FileSystemPath>,
     pub extensions: Vc<Vec<RcStr>>,
-    pub fallback_path: Option<Vc<FileSystemPath>>,
+    pub fallback_path: Option<ResolvedVc<FileSystemPath>>,
 
     /// Pathname of this item in the Next.js router.
     pub next_router_path: Vc<FileSystemPath>,
@@ -29,7 +29,7 @@ impl PagesStructureItem {
     fn new(
         base_path: Vc<FileSystemPath>,
         extensions: Vc<Vec<RcStr>>,
-        fallback_path: Option<Vc<FileSystemPath>>,
+        fallback_path: Option<ResolvedVc<FileSystemPath>>,
         next_router_path: Vc<FileSystemPath>,
         original_path: Vc<FileSystemPath>,
     ) -> Vc<Self> {
@@ -53,7 +53,7 @@ impl PagesStructureItem {
             }
         }
         if let Some(fallback_path) = self.fallback_path {
-            Ok(fallback_path)
+            Ok(*fallback_path)
         } else {
             Ok(self.base_path)
         }

--- a/turbopack/crates/turbo-tasks-testing/tests/all_in_one.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/all_in_one.rs
@@ -3,7 +3,7 @@
 #![feature(arbitrary_self_types_pointers)]
 
 use anyhow::{anyhow, bail, Result};
-use turbo_tasks::{RcStr, Value, ValueToString, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, Value, ValueToString, Vc};
 use turbo_tasks_testing::{register, run, Registration};
 
 static REGISTRATION: Registration = register!();
@@ -22,7 +22,7 @@ async fn all_in_one() {
 
         let c = MyStructValue {
             value: 42,
-            next: Some(MyStructValue::new(a)),
+            next: Some(MyStructValue::new(a).to_resolved().await?),
         }
         .into();
 
@@ -101,7 +101,7 @@ impl ValueToString for MyEnumValue {
 #[turbo_tasks::value(shared)]
 struct MyStructValue {
     value: u32,
-    next: Option<Vc<MyStructValue>>,
+    next: Option<ResolvedVc<MyStructValue>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbo-tasks-testing/tests/debug.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/debug.rs
@@ -47,7 +47,7 @@ async fn enum_none_debug() {
 #[tokio::test]
 async fn enum_transparent_debug() {
     run(&REGISTRATION, || async {
-        let a: Vc<Enum> = Enum::Transparent(Transparent(42).resolved_cell()).cell();
+        let a: Vc<Enum> = Enum::Transparent(Transparent(42).cell()).cell();
         assert_eq!(
             format!("{:?}", a.dbg().await?),
             r#"Enum :: Transparent(
@@ -63,7 +63,7 @@ async fn enum_transparent_debug() {
 #[tokio::test]
 async fn enum_inner_vc_debug() {
     run(&REGISTRATION, || async {
-        let a: Vc<Enum> = Enum::Enum(Enum::None.resolved_cell()).cell();
+        let a: Vc<Enum> = Enum::Enum(Enum::None.cell()).cell();
         assert_eq!(
             format!("{:?}", a.dbg().await?),
             r#"Enum :: Enum(
@@ -163,8 +163,8 @@ struct Transparent(u32);
 #[turbo_tasks::value(shared)]
 enum Enum {
     None,
-    Transparent(ResolvedVc<Transparent>),
-    Enum(ResolvedVc<Enum>),
+    Transparent(Vc<Transparent>),
+    Enum(Vc<Enum>),
 }
 
 #[turbo_tasks::value(shared)]

--- a/turbopack/crates/turbopack-browser/src/react_refresh.rs
+++ b/turbopack/crates/turbopack-browser/src/react_refresh.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{Value, Vc};
+use turbo_tasks::{ResolvedVc, Value, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
@@ -23,14 +23,14 @@ fn react_refresh_request_in_next() -> Vc<Request> {
 #[turbo_tasks::value]
 pub enum ResolveReactRefreshResult {
     NotFound,
-    Found(Vc<Request>),
+    Found(ResolvedVc<Request>),
 }
 
 impl ResolveReactRefreshResult {
     pub fn as_request(&self) -> Option<Vc<Request>> {
         match self {
             ResolveReactRefreshResult::NotFound => None,
-            ResolveReactRefreshResult::Found(r) => Some(*r),
+            ResolveReactRefreshResult::Found(r) => Some(**r),
         }
     }
     pub fn is_found(&self) -> bool {
@@ -62,7 +62,7 @@ pub async fn assert_can_resolve_react_refresh(
         .first_source();
 
         if result.await?.is_some() {
-            return Ok(ResolveReactRefreshResult::Found(request).cell());
+            return Ok(ResolveReactRefreshResult::Found(request.to_resolved().await?).cell());
         }
     }
     ReactRefreshResolvingIssue { path }.cell().emit();

--- a/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use turbo_tasks::{ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     chunk::{EvaluatableAsset, EvaluatableAssetExt, EvaluatableAssets},
@@ -12,8 +12,8 @@ use turbopack_resolve::ecmascript::cjs_resolve;
 
 #[turbo_tasks::value(shared)]
 pub enum RuntimeEntry {
-    Request(Vc<Request>, Vc<FileSystemPath>),
-    Evaluatable(Vc<Box<dyn EvaluatableAsset>>),
+    Request(ResolvedVc<Request>, ResolvedVc<FileSystemPath>),
+    Evaluatable(ResolvedVc<Box<dyn EvaluatableAsset>>),
     Source(Vc<Box<dyn Source>>),
 }
 
@@ -25,7 +25,7 @@ impl RuntimeEntry {
         asset_context: Vc<Box<dyn AssetContext>>,
     ) -> Result<Vc<EvaluatableAssets>> {
         let (request, path) = match *self.await? {
-            RuntimeEntry::Evaluatable(e) => return Ok(EvaluatableAssets::one(e)),
+            RuntimeEntry::Evaluatable(e) => return Ok(EvaluatableAssets::one(*e)),
             RuntimeEntry::Source(source) => {
                 return Ok(EvaluatableAssets::one(source.to_evaluatable(asset_context)));
             }
@@ -33,8 +33,8 @@ impl RuntimeEntry {
         };
 
         let modules = cjs_resolve(
-            Vc::upcast(PlainResolveOrigin::new(asset_context, path)),
-            request,
+            Vc::upcast(PlainResolveOrigin::new(asset_context, *path)),
+            *request,
             None,
             false,
         )

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use anyhow::Result;
-use turbo_tasks::{RcStr, Value, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, Value, Vc};
 use turbo_tasks_fs::{FileSystem, FileSystemPath};
 use turbopack::{
     ecmascript::{EcmascriptInputTransform, TreeShakingMode},
@@ -98,8 +98,8 @@ pub async fn get_client_resolve_options_context(
 #[turbo_tasks::function]
 async fn get_client_module_options_context(
     project_path: Vc<FileSystemPath>,
-    execution_context: Vc<ExecutionContext>,
-    env: Vc<Environment>,
+    execution_context: ResolvedVc<ExecutionContext>,
+    env: ResolvedVc<Environment>,
     node_env: Vc<NodeEnv>,
 ) -> Result<Vc<ModuleOptionsContext>> {
     let module_options_context = ModuleOptionsContext {

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use turbo_tasks::{RcStr, TryJoinIterExt, Value, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, TryJoinIterExt, Value, Vc};
 use turbo_tasks_env::ProcessEnv;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_browser::{react_refresh::assert_can_resolve_react_refresh, BrowserChunkingContext};
@@ -52,21 +52,27 @@ pub fn get_client_chunking_context(
 
 #[turbo_tasks::function]
 pub async fn get_client_runtime_entries(
-    project_path: Vc<FileSystemPath>,
+    project_path: ResolvedVc<FileSystemPath>,
 ) -> Result<Vc<RuntimeEntries>> {
-    let resolve_options_context = get_client_resolve_options_context(project_path);
+    let resolve_options_context = get_client_resolve_options_context(*project_path);
 
     let mut runtime_entries = Vec::new();
 
     let enable_react_refresh =
-        assert_can_resolve_react_refresh(project_path, resolve_options_context)
+        assert_can_resolve_react_refresh(*project_path, resolve_options_context)
             .await?
             .as_request();
     // It's important that React Refresh come before the regular bootstrap file,
     // because the bootstrap contains JSX which requires Refresh's global
     // functions to be available.
     if let Some(request) = enable_react_refresh {
-        runtime_entries.push(RuntimeEntry::Request(request, project_path.join("_".into())).cell())
+        runtime_entries.push(
+            RuntimeEntry::Request(
+                request.to_resolved().await?,
+                project_path.join("_".into()).to_resolved().await?,
+            )
+            .cell(),
+        )
     };
 
     runtime_entries.push(

--- a/turbopack/crates/turbopack-core/src/chunk/available_chunk_items.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/available_chunk_items.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{
-    debug::ValueDebugFormat, trace::TraceRawVcs, FxIndexMap, TryFlatJoinIterExt, TryJoinIterExt,
-    ValueToString, Vc,
+    debug::ValueDebugFormat, trace::TraceRawVcs, FxIndexMap, ResolvedVc, TryFlatJoinIterExt,
+    TryJoinIterExt, ValueToString, Vc,
 };
 use turbo_tasks_hash::Xxh3Hash64Hasher;
 
@@ -24,7 +24,7 @@ pub struct AvailableChunkItemInfoMap(FxIndexMap<Vc<Box<dyn ChunkItem>>, Availabl
 /// `include` queries.
 #[turbo_tasks::value]
 pub struct AvailableChunkItems {
-    parent: Option<Vc<AvailableChunkItems>>,
+    parent: Option<ResolvedVc<AvailableChunkItems>>,
     chunk_items: Vc<AvailableChunkItemInfoMap>,
 }
 
@@ -57,7 +57,7 @@ impl AvailableChunkItems {
             .try_flat_join()
             .await?;
         Ok(AvailableChunkItems {
-            parent: Some(self),
+            parent: Some(self.to_resolved().await?),
             chunk_items: Vc::cell(chunk_items.into_iter().collect()),
         }
         .cell())

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::{FxIndexMap, RcStr, Vc};
+use turbo_tasks::{FxIndexMap, RcStr, ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::environment::Environment;
@@ -203,7 +203,7 @@ impl CompileTimeDefines {
 pub enum FreeVarReference {
     EcmaScriptModule {
         request: RcStr,
-        lookup_path: Option<Vc<FileSystemPath>>,
+        lookup_path: Option<ResolvedVc<FileSystemPath>>,
         export: Option<RcStr>,
     },
     Value(CompileTimeDefineValue),

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -23,7 +23,7 @@ pub struct AssetIdent {
     /// The part of the asset that is a (ECMAScript) module
     pub part: Option<ResolvedVc<ModulePart>>,
     /// The asset layer the asset was created from.
-    pub layer: Option<Vc<RcStr>>,
+    pub layer: Option<ResolvedVc<RcStr>>,
 }
 
 impl AssetIdent {
@@ -158,7 +158,7 @@ impl AssetIdent {
     }
 
     #[turbo_tasks::function]
-    pub fn with_layer(&self, layer: Vc<RcStr>) -> Vc<Self> {
+    pub fn with_layer(&self, layer: ResolvedVc<RcStr>) -> Vc<Self> {
         let mut this = self.clone();
         this.layer = Some(layer);
         Self::new(Value::new(this))

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -429,7 +429,7 @@ impl CapturedIssues {
 #[derive(Clone, Debug)]
 pub struct IssueSource {
     source: Vc<Box<dyn Source>>,
-    range: Option<Vc<SourceRange>>,
+    range: Option<ResolvedVc<SourceRange>>,
 }
 
 /// The end position is the first character after the range
@@ -460,7 +460,7 @@ impl IssueSource {
     ) -> Vc<Self> {
         Self::cell(IssueSource {
             source,
-            range: Some(SourceRange::LineColumn(start, end).cell()),
+            range: Some(SourceRange::LineColumn(start, end).resolved_cell()),
         })
     }
 
@@ -492,7 +492,7 @@ impl IssueSource {
             if let Some((source, start, end)) = mapped {
                 return Ok(Self::cell(IssueSource {
                     source,
-                    range: Some(SourceRange::LineColumn(start, end).cell()),
+                    range: Some(SourceRange::LineColumn(start, end).resolved_cell()),
                 }));
             }
         }
@@ -514,9 +514,11 @@ impl IssueSource {
             source,
             range: match (start == 0, end == 0) {
                 (true, true) => None,
-                (false, false) => Some(SourceRange::ByteOffset(start - 1, end - 1).cell()),
-                (false, true) => Some(SourceRange::ByteOffset(start - 1, start - 1).cell()),
-                (true, false) => Some(SourceRange::ByteOffset(end - 1, end - 1).cell()),
+                (false, false) => Some(SourceRange::ByteOffset(start - 1, end - 1).resolved_cell()),
+                (false, true) => {
+                    Some(SourceRange::ByteOffset(start - 1, start - 1).resolved_cell())
+                }
+                (true, false) => Some(SourceRange::ByteOffset(end - 1, end - 1).resolved_cell()),
             },
         })
     }
@@ -541,7 +543,7 @@ impl IssueSource {
             range: if let FileLinesContent::Lines(lines) = &*source.content().lines().await? {
                 let start = find_line_and_column(lines.as_ref(), start);
                 let end = find_line_and_column(lines.as_ref(), end);
-                Some(SourceRange::LineColumn(start, end).cell())
+                Some(SourceRange::LineColumn(start, end).resolved_cell())
             } else {
                 None
             },

--- a/turbopack/crates/turbopack-core/src/issue/resolve.rs
+++ b/turbopack/crates/turbopack-core/src/issue/resolve.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
 use anyhow::Result;
-use turbo_tasks::{RcStr, ReadRef, ValueToString, Vc};
+use turbo_tasks::{RcStr, ReadRef, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use super::{Issue, IssueSource, IssueStage, OptionIssueSource, OptionStyledString, StyledString};
@@ -22,7 +22,7 @@ pub struct ResolvingIssue {
     pub file_path: Vc<FileSystemPath>,
     pub resolve_options: Vc<ResolveOptions>,
     pub error_message: Option<String>,
-    pub source: Option<Vc<IssueSource>>,
+    pub source: Option<ResolvedVc<IssueSource>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -10,8 +10,8 @@ use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use tracing::{Instrument, Level};
 use turbo_tasks::{
-    fxindexmap, fxindexset, trace::TraceRawVcs, FxIndexMap, RcStr, TaskInput, TryJoinIterExt,
-    Value, ValueToString, Vc,
+    fxindexmap, fxindexset, trace::TraceRawVcs, FxIndexMap, RcStr, ResolvedVc, TaskInput,
+    TryJoinIterExt, Value, ValueToString, Vc,
 };
 use turbo_tasks_fs::{
     util::normalize_request, FileSystemEntryType, FileSystemPath, RealPathResult,
@@ -67,7 +67,7 @@ pub enum ModuleResolveResultItem {
     OutputAsset(Vc<Box<dyn OutputAsset>>),
     External(RcStr, ExternalType),
     Ignore,
-    Error(Vc<RcStr>),
+    Error(ResolvedVc<RcStr>),
     Empty,
     Custom(u8),
 }
@@ -675,7 +675,9 @@ impl ResolveResult {
                                 }
                                 ResolveResultItem::Ignore => ModuleResolveResultItem::Ignore,
                                 ResolveResultItem::Empty => ModuleResolveResultItem::Empty,
-                                ResolveResultItem::Error(e) => ModuleResolveResultItem::Error(e),
+                                ResolveResultItem::Error(e) => {
+                                    ModuleResolveResultItem::Error(e.to_resolved().await?)
+                                }
                                 ResolveResultItem::Custom(u8) => {
                                     ModuleResolveResultItem::Custom(u8)
                                 }
@@ -1202,8 +1204,8 @@ pub async fn find_context_file_or_package_key(
 
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, Debug)]
 enum FindPackageItem {
-    PackageDirectory(Vc<FileSystemPath>),
-    PackageFile(Vc<FileSystemPath>),
+    PackageDirectory(ResolvedVc<FileSystemPath>),
+    PackageFile(ResolvedVc<FileSystemPath>),
 }
 
 #[turbo_tasks::value]
@@ -1236,7 +1238,9 @@ async fn find_package(
                             if let Some(fs_path) =
                                 dir_exists(fs_path, &mut affecting_sources).await?
                             {
-                                packages.push(FindPackageItem::PackageDirectory(fs_path));
+                                packages.push(FindPackageItem::PackageDirectory(
+                                    fs_path.to_resolved().await?,
+                                ));
                             }
                         }
                     }
@@ -1259,10 +1263,14 @@ async fn find_package(
                 {
                     match ty {
                         FileSystemEntryType::Directory => {
-                            packages.push(FindPackageItem::PackageDirectory(package_dir));
+                            packages.push(FindPackageItem::PackageDirectory(
+                                package_dir.to_resolved().await?,
+                            ));
                         }
                         FileSystemEntryType::File => {
-                            packages.push(FindPackageItem::PackageFile(package_dir));
+                            packages.push(FindPackageItem::PackageFile(
+                                package_dir.to_resolved().await?,
+                            ));
                         }
                         _ => {}
                     }
@@ -1274,7 +1282,9 @@ async fn find_package(
                     let package_file = package_dir.append(extension.clone());
                     if let Some(package_file) = exists(package_file, &mut affecting_sources).await?
                     {
-                        packages.push(FindPackageItem::PackageFile(package_file));
+                        packages.push(FindPackageItem::PackageFile(
+                            package_file.to_resolved().await?,
+                        ));
                     }
                 }
             }
@@ -1435,7 +1445,7 @@ pub async fn url_resolve(
     origin: Vc<Box<dyn ResolveOrigin>>,
     request: Vc<Request>,
     reference_type: Value<ReferenceType>,
-    issue_source: Option<Vc<IssueSource>>,
+    issue_source: Option<ResolvedVc<IssueSource>>,
     is_optional: bool,
 ) -> Result<Vc<ModuleResolveResult>> {
     let resolve_options = origin.resolve_options(reference_type.clone());
@@ -2362,7 +2372,7 @@ async fn resolve_module_request(
             FindPackageItem::PackageDirectory(package_path) => {
                 results.push(resolve_into_package(
                     Value::new(path.clone()),
-                    package_path,
+                    *package_path,
                     query,
                     fragment,
                     options,
@@ -2372,7 +2382,7 @@ async fn resolve_module_request(
                 if path.is_match("") {
                     let resolved = resolved(
                         RequestKey::new(".".into()),
-                        package_path,
+                        *package_path,
                         lookup_path,
                         request,
                         options_value,
@@ -2721,7 +2731,7 @@ pub async fn handle_resolve_error(
     request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
     is_optional: bool,
-    source: Option<Vc<IssueSource>>,
+    source: Option<ResolvedVc<IssueSource>>,
 ) -> Result<Vc<ModuleResolveResult>> {
     async fn is_unresolvable(result: Vc<ModuleResolveResult>) -> Result<bool> {
         Ok(*result.resolve().await?.is_unresolvable().await?)
@@ -2765,7 +2775,7 @@ pub async fn handle_resolve_source_error(
     request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
     is_optional: bool,
-    source: Option<Vc<IssueSource>>,
+    source: Option<ResolvedVc<IssueSource>>,
 ) -> Result<Vc<ResolveResult>> {
     async fn is_unresolvable(result: Vc<ResolveResult>) -> Result<bool> {
         Ok(*result.resolve().await?.is_unresolvable().await?)
@@ -2809,7 +2819,7 @@ async fn emit_resolve_error_issue(
     request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
     err: anyhow::Error,
-    source: Option<Vc<IssueSource>>,
+    source: Option<ResolvedVc<IssueSource>>,
 ) -> Result<()> {
     let severity = if is_optional || resolve_options.await?.loose_errors {
         IssueSeverity::Warning.cell()
@@ -2836,7 +2846,7 @@ async fn emit_unresolvable_issue(
     reference_type: Value<ReferenceType>,
     request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
-    source: Option<Vc<IssueSource>>,
+    source: Option<ResolvedVc<IssueSource>>,
 ) -> Result<()> {
     let severity = if is_optional || resolve_options.await?.loose_errors {
         IssueSeverity::Warning.cell()
@@ -2875,7 +2885,7 @@ pub enum ModulePart {
     /// all exports are unused.
     Evaluation,
     /// Represents an export of a module.
-    Export(Vc<RcStr>),
+    Export(ResolvedVc<RcStr>),
     /// Represents a renamed export of a module.
     RenamedExport {
         original_export: Vc<RcStr>,
@@ -2902,7 +2912,7 @@ impl ModulePart {
     }
     #[turbo_tasks::function]
     pub fn export(export: RcStr) -> Vc<Self> {
-        ModulePart::Export(Vc::cell(export)).cell()
+        ModulePart::Export(ResolvedVc::cell(export)).cell()
     }
     #[turbo_tasks::function]
     pub fn renamed_export(original_export: RcStr, export: RcStr) -> Vc<Self> {

--- a/turbopack/crates/turbopack-core/src/resolve/node.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/node.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use super::options::{
@@ -7,7 +7,7 @@ use super::options::{
 };
 
 #[turbo_tasks::function]
-pub fn node_cjs_resolve_options(root: Vc<FileSystemPath>) -> Vc<ResolveOptions> {
+pub fn node_cjs_resolve_options(root: ResolvedVc<FileSystemPath>) -> Vc<ResolveOptions> {
     let conditions: ResolutionConditions = [
         ("node".into(), ConditionValue::Set),
         ("require".into(), ConditionValue::Set),
@@ -37,7 +37,7 @@ pub fn node_cjs_resolve_options(root: Vc<FileSystemPath>) -> Vc<ResolveOptions> 
 }
 
 #[turbo_tasks::function]
-pub fn node_esm_resolve_options(root: Vc<FileSystemPath>) -> Vc<ResolveOptions> {
+pub fn node_esm_resolve_options(root: ResolvedVc<FileSystemPath>) -> Vc<ResolveOptions> {
     let conditions: ResolutionConditions = [
         ("node".into(), ConditionValue::Set),
         ("import".into(), ConditionValue::Set),

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -3,8 +3,8 @@ use std::{collections::BTreeMap, future::Future, pin::Pin};
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{
-    debug::ValueDebugFormat, trace::TraceRawVcs, FxIndexSet, RcStr, TryJoinIterExt, Value,
-    ValueToString, Vc,
+    debug::ValueDebugFormat, trace::TraceRawVcs, FxIndexSet, RcStr, ResolvedVc, TryJoinIterExt,
+    Value, ValueToString, Vc,
 };
 use turbo_tasks_fs::{glob::Glob, FileSystemPath};
 
@@ -31,7 +31,7 @@ pub struct ExcludedExtensions(pub FxIndexSet<RcStr>);
 pub enum ResolveModules {
     /// when inside of path, use the list of directories to
     /// resolve inside these
-    Nested(Vc<FileSystemPath>, Vec<RcStr>),
+    Nested(ResolvedVc<FileSystemPath>, Vec<RcStr>),
     /// look into that directory, unless the request has an excluded extension
     Path {
         dir: Vc<FileSystemPath>,
@@ -95,7 +95,7 @@ pub enum ResolveInPackage {
 pub enum ImportMapping {
     External(Option<RcStr>, ExternalType),
     /// An already resolved result that will be returned directly.
-    Direct(Vc<ResolveResult>),
+    Direct(ResolvedVc<ResolveResult>),
     /// A request alias that will be resolved first, and fall back to resolving
     /// the original request if it fails. Useful for the tsconfig.json
     /// `compilerOptions.paths` option and Next aliases.
@@ -152,7 +152,7 @@ impl AliasTemplate for Vc<ImportMapping> {
                 ImportMapping::PrimaryAlternative(name, context) => {
                     ReplacedImportMapping::PrimaryAlternative((*name).clone().into(), *context)
                 }
-                ImportMapping::Direct(v) => ReplacedImportMapping::Direct(*v),
+                ImportMapping::Direct(v) => ReplacedImportMapping::Direct(**v),
                 ImportMapping::Ignore => ReplacedImportMapping::Ignore,
                 ImportMapping::Empty => ReplacedImportMapping::Empty,
                 ImportMapping::Alternatives(alternatives) => ReplacedImportMapping::Alternatives(
@@ -189,7 +189,7 @@ impl AliasTemplate for Vc<ImportMapping> {
                         *context,
                     )
                 }
-                ImportMapping::Direct(v) => ReplacedImportMapping::Direct(*v),
+                ImportMapping::Direct(v) => ReplacedImportMapping::Direct(**v),
                 ImportMapping::Ignore => ReplacedImportMapping::Ignore,
                 ImportMapping::Empty => ReplacedImportMapping::Empty,
                 ImportMapping::Alternatives(alternatives) => ReplacedImportMapping::Alternatives(

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -238,7 +238,10 @@ impl CssChunkItem for CssModuleChunkItem {
                         if let Some(css_item) =
                             Vc::try_resolve_downcast::<Box<dyn CssChunkItem>>(item).await?
                         {
-                            imports.push(CssImport::Internal(import_ref, css_item));
+                            imports.push(CssImport::Internal(
+                                import_ref.to_resolved().await?,
+                                css_item,
+                            ));
                         }
                     }
                 }
@@ -260,7 +263,7 @@ impl CssChunkItem for CssModuleChunkItem {
                         if let Some(css_item) =
                             Vc::try_resolve_downcast::<Box<dyn CssChunkItem>>(item).await?
                         {
-                            imports.push(CssImport::Composes(css_item));
+                            imports.push(CssImport::Composes(css_item.to_resolved().await?));
                         }
                     }
                 }

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -4,7 +4,9 @@ pub mod source_map;
 use std::fmt::Write;
 
 use anyhow::{bail, Result};
-use turbo_tasks::{FxIndexSet, RcStr, TryJoinIterExt, Value, ValueDefault, ValueToString, Vc};
+use turbo_tasks::{
+    FxIndexSet, RcStr, ResolvedVc, TryJoinIterExt, Value, ValueDefault, ValueToString, Vc,
+};
 use turbo_tasks_fs::{rope::Rope, File, FileSystem};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -350,8 +352,8 @@ pub trait CssChunkPlaceable: ChunkableModule + Module + Asset {}
 #[turbo_tasks::value(shared)]
 pub enum CssImport {
     External(Vc<RcStr>),
-    Internal(Vc<ImportAssetReference>, Vc<Box<dyn CssChunkItem>>),
-    Composes(Vc<Box<dyn CssChunkItem>>),
+    Internal(ResolvedVc<ImportAssetReference>, Vc<Box<dyn CssChunkItem>>),
+    Composes(ResolvedVc<Box<dyn CssChunkItem>>),
 }
 
 #[derive(Debug)]

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -5,8 +5,8 @@ use std::{
 
 use anyhow::Result;
 use turbo_tasks::{
-    fxindexset, Completion, FxIndexMap, FxIndexSet, RcStr, State, TryJoinIterExt, Value,
-    ValueToString, Vc,
+    fxindexset, Completion, FxIndexMap, FxIndexSet, RcStr, ResolvedVc, State, TryJoinIterExt,
+    Value, ValueToString, Vc,
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -338,7 +338,10 @@ impl Introspectable for AssetGraphContentSource {
         Ok(Vc::cell(
             root_asset_children
                 .chain(expanded_asset_children)
-                .chain(once((expanded_key, Vc::upcast(FullyExpaned(self).cell()))))
+                .chain(once((
+                    expanded_key,
+                    Vc::upcast(FullyExpaned(self.to_resolved().await?).cell()),
+                )))
                 .collect(),
         ))
     }
@@ -350,7 +353,7 @@ fn fully_expaned_introspectable_type() -> Vc<RcStr> {
 }
 
 #[turbo_tasks::value]
-struct FullyExpaned(Vc<AssetGraphContentSource>);
+struct FullyExpaned(ResolvedVc<AssetGraphContentSource>);
 
 #[turbo_tasks::value_impl]
 impl Introspectable for FullyExpaned {

--- a/turbopack/crates/turbopack-dev-server/src/source/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/mod.rs
@@ -89,9 +89,9 @@ pub struct StaticContent {
 /// The content of a result that is returned by a content source.
 pub enum ContentSourceContent {
     NotFound,
-    Static(Vc<StaticContent>),
-    HttpProxy(Vc<ProxyResult>),
-    Rewrite(Vc<Rewrite>),
+    Static(ResolvedVc<StaticContent>),
+    HttpProxy(ResolvedVc<ProxyResult>),
+    Rewrite(ResolvedVc<Rewrite>),
     /// Continue with the next route
     Next,
 }
@@ -119,31 +119,33 @@ impl GetContentSourceContent for ContentSourceContent {
 #[turbo_tasks::value_impl]
 impl ContentSourceContent {
     #[turbo_tasks::function]
-    pub fn static_content(content: Vc<Box<dyn VersionedContent>>) -> Vc<ContentSourceContent> {
+    pub fn static_content(
+        content: ResolvedVc<Box<dyn VersionedContent>>,
+    ) -> Vc<ContentSourceContent> {
         ContentSourceContent::Static(
             StaticContent {
-                content,
+                content: *content,
                 status_code: 200,
                 headers: HeaderList::empty(),
             }
-            .cell(),
+            .resolved_cell(),
         )
         .cell()
     }
 
     #[turbo_tasks::function]
     pub fn static_with_headers(
-        content: Vc<Box<dyn VersionedContent>>,
+        content: ResolvedVc<Box<dyn VersionedContent>>,
         status_code: u16,
-        headers: Vc<HeaderList>,
+        headers: ResolvedVc<HeaderList>,
     ) -> Vc<ContentSourceContent> {
         ContentSourceContent::Static(
             StaticContent {
-                content,
+                content: *content,
                 status_code,
-                headers,
+                headers: *headers,
             }
-            .cell(),
+            .resolved_cell(),
         )
         .cell()
     }

--- a/turbopack/crates/turbopack-dev-server/src/source/wrapping_source.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/wrapping_source.rs
@@ -79,7 +79,7 @@ impl GetContentSourceContent for WrappedGetContentSourceContent {
                     response_headers: rewrite.response_headers,
                     request_headers: rewrite.request_headers,
                 }
-                .cell(),
+                .resolved_cell(),
             )
             .cell());
         }

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -99,14 +99,9 @@ async fn side_effects_from_package_json(
                     })
                     .try_flat_join()
                     .await?;
-                return Ok(SideEffectsValue::Glob(
-                    Glob::alternatives(globs)
-                        .resolve()
-                        .await?
-                        .to_resolved()
-                        .await?,
-                )
-                .cell());
+                return Ok(
+                    SideEffectsValue::Glob(Glob::alternatives(globs).to_resolved().await?).cell(),
+                );
             } else {
                 SideEffectsInPackageJsonIssue {
                     path: package_json,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -218,12 +218,12 @@ async fn handle_declared_export(
                     .await?
                 {
                     return Ok(ControlFlow::Break(FollowExportsResult {
-                        module,
+                        module: *module,
                         export_name: Some(name.clone()),
                         ty: FoundExportType::SideEffects,
                     }));
                 }
-                return Ok(ControlFlow::Continue((module, name.clone())));
+                return Ok(ControlFlow::Continue((*module, name.clone())));
             }
         }
         EsmExport::ImportedNamespace(reference) => {
@@ -231,7 +231,7 @@ async fn handle_declared_export(
                 *ReferencedAsset::from_resolve_result(reference.resolve_reference()).await?
             {
                 return Ok(ControlFlow::Break(FollowExportsResult {
-                    module: m,
+                    module: *m,
                     export_name: None,
                     ty: FoundExportType::Found,
                 }));
@@ -290,7 +290,7 @@ async fn get_all_export_names(
                 if let ReferencedAsset::Some(m) =
                     *ReferencedAsset::from_resolve_result(esm_ref.resolve_reference()).await?
                 {
-                    Some(get_all_export_names(m))
+                    Some(get_all_export_names(*m))
                 } else {
                     None
                 },
@@ -341,8 +341,8 @@ pub async fn expand_star_exports(
                     if let ReferencedAsset::Some(asset) =
                         &*ReferencedAsset::from_resolve_result(esm_ref.resolve_reference()).await?
                     {
-                        if checked_modules.insert(*asset) {
-                            queue.push((*asset, asset.get_exports()));
+                        if checked_modules.insert(**asset) {
+                            queue.push((**asset, asset.get_exports()));
                         }
                     }
                 }
@@ -444,7 +444,7 @@ impl EsmExports {
                 continue;
             };
 
-            let export_info = expand_star_exports(*asset).await?;
+            let export_info = expand_star_exports(**asset).await?;
 
             for export in &export_info.star_exports {
                 if !exports.contains_key(export) {
@@ -456,7 +456,7 @@ impl EsmExports {
             }
 
             if export_info.has_dynamic_exports {
-                dynamic_exports.push(*asset);
+                dynamic_exports.push(**asset);
             }
         }
 

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -255,7 +255,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
             star_exports,
         }
         .cell();
-        Ok(EcmascriptExports::EsmExports(exports).cell())
+        Ok(EcmascriptExports::EsmExports(exports.to_resolved().await?).cell())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -94,7 +94,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleLocalsModule {
             star_exports: vec![],
         }
         .cell();
-        Ok(EcmascriptExports::EsmExports(exports).cell())
+        Ok(EcmascriptExports::EsmExports(exports.to_resolved().await?).cell())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Context, Result};
 use swc_core::{common::DUMMY_SP, ecma::ast::Ident, quote};
-use turbo_tasks::{RcStr, ValueToString, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
     chunk::{
         ChunkItemExt, ChunkableModule, ChunkableModuleReference, ChunkingContext, ChunkingType,
@@ -25,7 +25,7 @@ use crate::{
 #[turbo_tasks::value]
 pub struct EcmascriptModulePartReference {
     pub module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
-    pub part: Option<Vc<ModulePart>>,
+    pub part: Option<ResolvedVc<ModulePart>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -33,7 +33,7 @@ impl EcmascriptModulePartReference {
     #[turbo_tasks::function]
     pub fn new_part(
         module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
-        part: Vc<ModulePart>,
+        part: ResolvedVc<ModulePart>,
     ) -> Vc<Self> {
         EcmascriptModulePartReference {
             module,
@@ -77,7 +77,7 @@ impl ModuleReference for EcmascriptModulePartReference {
                 | ModulePart::Facade
                 | ModulePart::RenamedExport { .. }
                 | ModulePart::RenamedNamespace { .. } => {
-                    Vc::upcast(EcmascriptModuleFacadeModule::new(self.module, part))
+                    Vc::upcast(EcmascriptModuleFacadeModule::new(self.module, *part))
                 }
                 ModulePart::Export(..) | ModulePart::Internal(..) => {
                     bail!(

--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -18,7 +18,7 @@ use swc_core::{
     },
     quote,
 };
-use turbo_tasks::{RcStr, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     environment::Environment,
@@ -30,7 +30,7 @@ use turbopack_core::{
 pub enum EcmascriptInputTransform {
     CommonJs,
     Plugin(Vc<TransformPlugin>),
-    PresetEnv(Vc<Environment>),
+    PresetEnv(ResolvedVc<Environment>),
     React {
         #[serde(default)]
         development: bool,

--- a/turbopack/crates/turbopack-image/src/process/mod.rs
+++ b/turbopack/crates/turbopack-image/src/process/mod.rs
@@ -17,7 +17,7 @@ use image::{
 use mime::Mime;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
-use turbo_tasks::{debug::ValueDebugFormat, trace::TraceRawVcs, Vc};
+use turbo_tasks::{debug::ValueDebugFormat, trace::TraceRawVcs, ResolvedVc, Vc};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
     error::PrettyPrintError,
@@ -170,7 +170,7 @@ fn load_image_internal(
                     .into(),
             )
             .cell(),
-            title: Some(StyledString::Text("AVIF image not supported".into()).cell()),
+            title: Some(StyledString::Text("AVIF image not supported".into()).resolved_cell()),
             issue_severity: Some(IssueSeverity::Warning.into()),
         }
         .cell()
@@ -188,7 +188,7 @@ fn load_image_internal(
                     .into(),
             )
             .cell(),
-            title: Some(StyledString::Text("WEBP image not supported".into()).cell()),
+            title: Some(StyledString::Text("WEBP image not supported".into()).resolved_cell()),
             issue_severity: Some(IssueSeverity::Warning.into()),
         }
         .cell()
@@ -479,7 +479,7 @@ pub async fn optimize(
 struct ImageProcessingIssue {
     path: Vc<FileSystemPath>,
     message: Vc<StyledString>,
-    title: Option<Vc<StyledString>>,
+    title: Option<ResolvedVc<StyledString>>,
     issue_severity: Option<Vc<IssueSeverity>>,
 }
 
@@ -502,8 +502,9 @@ impl Issue for ImageProcessingIssue {
 
     #[turbo_tasks::function]
     fn title(&self) -> Vc<StyledString> {
-        self.title
-            .unwrap_or(StyledString::Text("Processing image failed".into()).cell())
+        *self
+            .title
+            .unwrap_or(StyledString::Text("Processing image failed".into()).resolved_cell())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-node/src/render/node_api_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/node_api_source.rs
@@ -127,30 +127,34 @@ impl GetContentSourceContent for NodeApiContentSource {
             return Err(anyhow!("Missing request data"));
         };
         let entry = self.entry.entry(data.clone()).await?;
-        Ok(ContentSourceContent::HttpProxy(render_proxy(
-            self.cwd,
-            self.env,
-            self.server_root.join(path.clone()),
-            entry.module,
-            entry.runtime_entries,
-            entry.chunking_context,
-            entry.intermediate_output_path,
-            entry.output_root,
-            entry.project_dir,
-            RenderData {
-                params: params.clone(),
-                method: method.clone(),
-                url: url.clone(),
-                original_url: original_url.clone(),
-                raw_query: raw_query.clone(),
-                raw_headers: raw_headers.clone(),
-                path: format!("/{}", path).into(),
-                data: Some(self.render_data.await?),
-            }
-            .cell(),
-            *body,
-            self.debug,
-        ))
+        Ok(ContentSourceContent::HttpProxy(
+            render_proxy(
+                self.cwd,
+                self.env,
+                self.server_root.join(path.clone()),
+                entry.module,
+                entry.runtime_entries,
+                entry.chunking_context,
+                entry.intermediate_output_path,
+                entry.output_root,
+                entry.project_dir,
+                RenderData {
+                    params: params.clone(),
+                    method: method.clone(),
+                    url: url.clone(),
+                    original_url: original_url.clone(),
+                    raw_query: raw_query.clone(),
+                    raw_headers: raw_headers.clone(),
+                    path: format!("/{}", path).into(),
+                    data: Some(self.render_data.await?),
+                }
+                .cell(),
+                *body,
+                self.debug,
+            )
+            .to_resolved()
+            .await?,
+        )
         .cell())
     }
 }

--- a/turbopack/crates/turbopack-node/src/render/render_static.rs
+++ b/turbopack/crates/turbopack-node/src/render/render_static.rs
@@ -7,8 +7,8 @@ use futures::{
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{
-    duration_span, mark_finished, prevent_gc, util::SharedError, RawVc, TaskInput, ValueToString,
-    Vc,
+    duration_span, mark_finished, prevent_gc, util::SharedError, RawVc, ResolvedVc, TaskInput,
+    ValueToString, Vc,
 };
 use turbo_tasks_bytes::{Bytes, Stream};
 use turbo_tasks_env::ProcessEnv;
@@ -46,7 +46,7 @@ pub enum StaticResult {
         headers: Vc<HeaderList>,
         body: Body,
     },
-    Rewrite(Vc<Rewrite>),
+    Rewrite(ResolvedVc<Rewrite>),
 }
 
 #[turbo_tasks::value_impl]
@@ -66,7 +66,7 @@ impl StaticResult {
     }
 
     #[turbo_tasks::function]
-    pub fn rewrite(rewrite: Vc<Rewrite>) -> Vc<Self> {
+    pub fn rewrite(rewrite: ResolvedVc<Rewrite>) -> Vc<Self> {
         StaticResult::Rewrite(rewrite).cell()
     }
 }

--- a/turbopack/crates/turbopack-node/src/render/rendered_source.rs
+++ b/turbopack/crates/turbopack-node/src/render/rendered_source.rs
@@ -236,10 +236,12 @@ impl GetContentSourceContent for NodeRenderContentSource {
                     headers: headers.await?.clone_value(),
                     body: body.clone(),
                 }
-                .cell(),
+                .resolved_cell(),
             )
             .cell(),
-            StaticResult::Rewrite(rewrite) => ContentSourceContent::Rewrite(rewrite).cell(),
+            StaticResult::Rewrite(rewrite) => {
+                ContentSourceContent::Rewrite(rewrite.to_resolved().await?).cell()
+            }
         })
     }
 }

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -7,7 +7,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
 use serde_with::serde_as;
 use turbo_tasks::{
-    trace::TraceRawVcs, Completion, RcStr, TaskInput, TryJoinIterExt, Value, ValueToString, Vc,
+    trace::TraceRawVcs, Completion, RcStr, ResolvedVc, TaskInput, TryJoinIterExt, Value,
+    ValueToString, Vc,
 };
 use turbo_tasks_bytes::stream::SingleValue;
 use turbo_tasks_env::ProcessEnv;
@@ -229,7 +230,7 @@ impl WebpackLoadersProcessedAsset {
             context_ident_for_issue: this.source.ident(),
             asset_context: evaluate_context,
             chunking_context,
-            resolve_options_context: Some(transform.resolve_options_context),
+            resolve_options_context: Some(transform.resolve_options_context.to_resolved().await?),
             args: vec![
                 Vc::cell(content.into()),
                 // We need to pass the query string to the loader
@@ -380,7 +381,7 @@ pub struct WebpackLoaderContext {
     pub context_ident_for_issue: Vc<AssetIdent>,
     pub asset_context: Vc<Box<dyn AssetContext>>,
     pub chunking_context: Vc<Box<dyn ChunkingContext>>,
-    pub resolve_options_context: Option<Vc<ResolveOptionsContext>>,
+    pub resolve_options_context: Option<ResolvedVc<ResolveOptionsContext>>,
     pub args: Vec<Vc<JsonValue>>,
     pub additional_invalidation: Vc<Completion>,
 }
@@ -498,7 +499,7 @@ impl EvaluateContext for WebpackLoaderContext {
                 };
                 let lookup_path = self.cwd.join(lookup_path);
                 let request = Request::parse(Value::new(Pattern::Constant(request)));
-                let options = resolve_options(lookup_path, resolve_options_context);
+                let options = resolve_options(lookup_path, *resolve_options_context);
 
                 let options = apply_webpack_resolve_options(options, webpack_options);
 

--- a/turbopack/crates/turbopack-resolve/src/ecmascript.rs
+++ b/turbopack/crates/turbopack-resolve/src/ecmascript.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{Value, Vc};
+use turbo_tasks::{ResolvedVc, Value, Vc};
 use turbopack_core::{
     issue::IssueSource,
     reference_type::{CommonJsReferenceSubType, EcmaScriptModulesReferenceSubType, ReferenceType},
@@ -80,7 +80,7 @@ pub async fn esm_resolve(
     request: Vc<Request>,
     ty: Value<EcmaScriptModulesReferenceSubType>,
     is_optional: bool,
-    issue_source: Option<Vc<IssueSource>>,
+    issue_source: Option<ResolvedVc<IssueSource>>,
 ) -> Result<Vc<ModuleResolveResult>> {
     let ty = Value::new(ReferenceType::EcmaScriptModules(ty.into_value()));
     let options = apply_esm_specific_options(origin.resolve_options(ty.clone()), ty.clone())
@@ -93,7 +93,7 @@ pub async fn esm_resolve(
 pub async fn cjs_resolve(
     origin: Vc<Box<dyn ResolveOrigin>>,
     request: Vc<Request>,
-    issue_source: Option<Vc<IssueSource>>,
+    issue_source: Option<ResolvedVc<IssueSource>>,
     is_optional: bool,
 ) -> Result<Vc<ModuleResolveResult>> {
     // TODO pass CommonJsReferenceSubType
@@ -106,9 +106,9 @@ pub async fn cjs_resolve(
 
 #[turbo_tasks::function]
 pub async fn cjs_resolve_source(
-    origin: Vc<Box<dyn ResolveOrigin>>,
-    request: Vc<Request>,
-    issue_source: Option<Vc<IssueSource>>,
+    origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+    request: ResolvedVc<Request>,
+    issue_source: Option<ResolvedVc<IssueSource>>,
     is_optional: bool,
 ) -> Result<Vc<ResolveResult>> {
     // TODO pass CommonJsReferenceSubType
@@ -119,7 +119,7 @@ pub async fn cjs_resolve_source(
     let result = resolve(
         origin.origin_path().parent().resolve().await?,
         ty.clone(),
-        request,
+        *request,
         options,
     );
 
@@ -127,7 +127,7 @@ pub async fn cjs_resolve_source(
         result,
         ty,
         origin.origin_path(),
-        request,
+        *request,
         options,
         is_optional,
         issue_source,
@@ -141,7 +141,7 @@ async fn specific_resolve(
     options: Vc<ResolveOptions>,
     reference_type: Value<ReferenceType>,
     is_optional: bool,
-    issue_source: Option<Vc<IssueSource>>,
+    issue_source: Option<ResolvedVc<IssueSource>>,
 ) -> Result<Vc<ModuleResolveResult>> {
     let result = origin.resolve_asset(request, options, reference_type.clone());
 

--- a/turbopack/crates/turbopack-resolve/src/resolve.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve.rs
@@ -213,14 +213,20 @@ async fn base_resolve_options(
         extensions,
         modules: if let Some(environment) = emulating {
             if *environment.resolve_node_modules().await? {
-                vec![ResolveModules::Nested(root, vec!["node_modules".into()])]
+                vec![ResolveModules::Nested(
+                    root.to_resolved().await?,
+                    vec!["node_modules".into()],
+                )]
             } else {
                 Vec::new()
             }
         } else {
             let mut mods = Vec::new();
             if let Some(dir) = opt.enable_node_modules {
-                mods.push(ResolveModules::Nested(dir, vec!["node_modules".into()]));
+                mods.push(ResolveModules::Nested(
+                    dir.to_resolved().await?,
+                    vec!["node_modules".into()],
+                ));
             }
             mods
         },

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -286,7 +286,7 @@ async fn run_test(prepared_test: Vc<PreparedTest>) -> Result<Vc<RunTestResult>> 
                 import_externals: true,
                 ..Default::default()
             },
-            preset_env_versions: Some(env),
+            preset_env_versions: Some(env.to_resolved().await?),
             tree_shaking_mode: options.tree_shaking_mode,
             rules: vec![(
                 ContextCondition::InDirectory("node_modules".into()),

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -278,7 +278,7 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                 use_swc_css: options.use_swc_css,
                 ..Default::default()
             },
-            preset_env_versions: Some(env),
+            preset_env_versions: Some(env.to_resolved().await?),
             rules: vec![(
                 ContextCondition::InDirectory("node_modules".into()),
                 ModuleOptionsContext {

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -106,7 +106,7 @@ async fn apply_module_type(
     module_type: Vc<ModuleType>,
     reference_type: Value<ReferenceType>,
     part: Option<Vc<ModulePart>>,
-    inner_assets: Option<Vc<InnerAssets>>,
+    inner_assets: Option<ResolvedVc<InnerAssets>>,
     runtime_code: bool,
 ) -> Result<Vc<ProcessResult>> {
     let module_type = &*module_type.await?;

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -140,7 +140,9 @@ impl ModuleOptions {
         let ecmascript_options_vc = ecmascript_options.cell();
 
         if let Some(env) = preset_env_versions {
-            transforms.push(EcmascriptInputTransform::PresetEnv(env));
+            transforms.push(EcmascriptInputTransform::PresetEnv(
+                env.to_resolved().await?,
+            ));
         }
 
         if let Some(enable_typeof_window_inlining) = enable_typeof_window_inlining {
@@ -418,13 +420,13 @@ impl ModuleOptions {
                     vec![ModuleRuleEffect::SourceTransforms(Vc::cell(vec![
                         Vc::upcast(PostCssTransform::new(
                             node_evaluate_asset_context(
-                                execution_context,
+                                *execution_context,
                                 Some(import_map),
                                 None,
                                 "postcss".into(),
                                 true,
                             ),
-                            execution_context,
+                            *execution_context,
                             options.config_location,
                         )),
                     ]))],
@@ -562,13 +564,13 @@ impl ModuleOptions {
                     vec![ModuleRuleEffect::SourceTransforms(Vc::cell(vec![
                         Vc::upcast(WebpackLoaders::new(
                             node_evaluate_asset_context(
-                                execution_context,
+                                *execution_context,
                                 Some(import_map),
                                 None,
                                 "webpack_loaders".into(),
                                 false,
                             ),
-                            execution_context,
+                            *execution_context,
                             rule.loaders,
                             rule.rename_as.clone(),
                             resolve_options_context,

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{trace::TraceRawVcs, FxIndexMap, RcStr, ValueDefault, Vc};
+use turbo_tasks::{trace::TraceRawVcs, FxIndexMap, RcStr, ResolvedVc, ValueDefault, Vc};
 use turbopack_core::{
     chunk::MinifyType, condition::ContextCondition, environment::Environment,
     resolve::options::ImportMapping,
@@ -119,8 +119,8 @@ pub struct ModuleOptionsContext {
     pub enable_mdx: bool,
     pub enable_mdx_rs: Option<Vc<MdxTransformOptions>>,
 
-    pub preset_env_versions: Option<Vc<Environment>>,
-    pub execution_context: Option<Vc<ExecutionContext>>,
+    pub preset_env_versions: Option<ResolvedVc<Environment>>,
+    pub execution_context: Option<ResolvedVc<ExecutionContext>>,
     pub side_effect_free_packages: Vec<RcStr>,
     pub tree_shaking_mode: Option<TreeShakingMode>,
 
@@ -142,7 +142,7 @@ pub struct EcmascriptOptionsContext {
     /// normal resolution.
     pub enable_types: bool,
     pub enable_typescript_transform: Option<Vc<TypescriptTransformOptions>>,
-    pub enable_decorators: Option<Vc<DecoratorsOptions>>,
+    pub enable_decorators: Option<ResolvedVc<DecoratorsOptions>>,
     pub esm_url_rewrite_behavior: Option<UrlRewriteBehavior>,
     /// References to externals from ESM imports should use `import()` and make
     /// async modules.


### PR DESCRIPTION
**This is a** *(mostly)* **machine-generated PR.**

This uses a much updated version of the ast-grep based codemod script from #70927, which can now match a bunch more patterns.

Codemod scripts: https://github.com/vercel/turbopack-resolved-vc-codemod/tree/90518e64cfaf9328546ff4688692f16f54d4fc3e

I did a small bit of cleanup after running the script with:

```bash
sg -U --pattern '$OBJ.resolve().await?.to_resolved().await?' -r '$OBJ.to_resolved().await?'
```

Notable additions since last time are:
- Runs the compiler/fixer in a loop a few times, as fixing an issue often allows compilation to get further, creating new errors.
- Can apply compiler-suggested edits (usually these are manual derefs needed with `*`)
- Knows how to rewrite `$OBJ.cell()` to `$OBJ.resolved_cell()`
- Knows how to rewrite `Vc::cell($ARG)` to `ResolvedVc::cell($ARG)`
- Knows how to rewrite `$TYPE::cell($ARG)` to `$TYPE::resolved_cell($ARG)`.
- Knows how to add `.to_resolved().await?` to expressions.

Closes PACK-3455