### PR TITLE
Add Lucia auth warning in Docs

### DIFF
--- a/docs/02-app/01-building-your-application/09-authentication/index.mdx
+++ b/docs/02-app/01-building-your-application/09-authentication/index.mdx
@@ -1635,7 +1635,7 @@ Now that you've learned about authentication in Next.js, here are Next.js-compat
 - [Auth0](https://auth0.com/docs/quickstart/webapp/nextjs/01-login)
 - [Clerk](https://clerk.com/docs/quickstarts/nextjs)
 - [Kinde](https://kinde.com/docs/developer-tools/nextjs-sdk)
-- [Lucia](https://lucia-auth.com/getting-started/nextjs-app)
+- [Lucia](https://lucia-auth.com/getting-started/nextjs-app) (About to be [deprecated](https://github.com/lucia-auth/lucia/discussions/1707) early 2025)
 - [NextAuth.js](https://authjs.dev/getting-started/installation?framework=next.js)
 - [Stack Auth](https://docs.stack-auth.com/getting-started/setup)
 - [Supabase](https://supabase.com/docs/guides/getting-started/quickstarts/nextjs)

--- a/docs/02-app/01-building-your-application/09-authentication/index.mdx
+++ b/docs/02-app/01-building-your-application/09-authentication/index.mdx
@@ -1,4 +1,4 @@
----
+f---
 title: Authentication
 description: Learn how to implement authentication in your Next.js application.
 ---
@@ -1635,7 +1635,7 @@ Now that you've learned about authentication in Next.js, here are Next.js-compat
 - [Auth0](https://auth0.com/docs/quickstart/webapp/nextjs/01-login)
 - [Clerk](https://clerk.com/docs/quickstarts/nextjs)
 - [Kinde](https://kinde.com/docs/developer-tools/nextjs-sdk)
-- [Lucia](https://lucia-auth.com/getting-started/nextjs-app) ([About to be deprecated(https://github.com/lucia-auth/lucia/discussions/1707) early 2025])
+- [Lucia](https://lucia-auth.com/getting-started/nextjs-app) ([About to be deprecated early 2025](https://github.com/lucia-auth/lucia/discussions/1707))
 - [NextAuth.js](https://authjs.dev/getting-started/installation?framework=next.js)
 - [Stack Auth](https://docs.stack-auth.com/getting-started/setup)
 - [Supabase](https://supabase.com/docs/guides/getting-started/quickstarts/nextjs)

--- a/docs/02-app/01-building-your-application/09-authentication/index.mdx
+++ b/docs/02-app/01-building-your-application/09-authentication/index.mdx
@@ -1635,7 +1635,7 @@ Now that you've learned about authentication in Next.js, here are Next.js-compat
 - [Auth0](https://auth0.com/docs/quickstart/webapp/nextjs/01-login)
 - [Clerk](https://clerk.com/docs/quickstarts/nextjs)
 - [Kinde](https://kinde.com/docs/developer-tools/nextjs-sdk)
-- [Lucia](https://lucia-auth.com/getting-started/nextjs-app) (About to be [deprecated](https://github.com/lucia-auth/lucia/discussions/1707) early 2025)
+- [Lucia](https://lucia-auth.com/getting-started/nextjs-app) ([About to be deprecated(https://github.com/lucia-auth/lucia/discussions/1707) early 2025])
 - [NextAuth.js](https://authjs.dev/getting-started/installation?framework=next.js)
 - [Stack Auth](https://docs.stack-auth.com/getting-started/setup)
 - [Supabase](https://supabase.com/docs/guides/getting-started/quickstarts/nextjs)


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Added a note in the "Auth Libraries" section indicating that Lucia is about to be deprecated early 2025 with a link to the relevant discussion.
- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

- Updated documentation for "Authentication" section to note the deprecation of Lucia in early 2025, with a link to the official maintainer discussion on GitHub.

### Why?

- To inform users of the upcoming deprecation of Lucia in early 2025.

### How?

-

Closes NEXT-
Fixes #

-->
