### PR TITLE
fix: leverage x-matched-path when externalMiddlewareRewritesResolve=true

### DIFF
--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -187,8 +187,12 @@ function getMiddlewareData<T extends FetchDataOutput>(
     rewriteTarget = matchedPath
   }
 
-  if (matchedPath && process.env.__NEXT_EXTERNAL_MIDDLEWARE_REWRITE_RESOLVE) {
-    // when externalMiddlewareRewritesResolve=true, leverage x-matched-path to detect rewrites
+  if (
+    !rewriteTarget &&
+    matchedPath &&
+    process.env.__NEXT_EXTERNAL_MIDDLEWARE_REWRITE_RESOLVE
+  ) {
+    // when externalMiddlewareRewritesResolve=true, leverage x-matched-path to detect rewrites as a fallback
     rewriteTarget = matchedPath
   }
 

--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -177,6 +177,15 @@ function getMiddlewareData<T extends FetchDataOutput>(
   const matchedPath = response.headers.get('x-matched-path')
 
   if (
+    !rewriteTarget &&
+    matchedPath &&
+    process.env.__NEXT_EXTERNAL_MIDDLEWARE_REWRITE_RESOLVE
+  ) {
+    // when externalMiddlewareRewritesResolve=true, leverage x-matched-path to detect rewrites as a fallback
+    rewriteTarget = matchedPath
+  }
+
+  if (
     matchedPath &&
     !rewriteTarget &&
     !matchedPath.includes('__next_data_catchall') &&
@@ -184,15 +193,6 @@ function getMiddlewareData<T extends FetchDataOutput>(
     !matchedPath.includes('/404')
   ) {
     // leverage x-matched-path to detect next.config.js rewrites
-    rewriteTarget = matchedPath
-  }
-
-  if (
-    !rewriteTarget &&
-    matchedPath &&
-    process.env.__NEXT_EXTERNAL_MIDDLEWARE_REWRITE_RESOLVE
-  ) {
-    // when externalMiddlewareRewritesResolve=true, leverage x-matched-path to detect rewrites as a fallback
     rewriteTarget = matchedPath
   }
 

--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -187,6 +187,11 @@ function getMiddlewareData<T extends FetchDataOutput>(
     rewriteTarget = matchedPath
   }
 
+  if (matchedPath && process.env.__NEXT_EXTERNAL_MIDDLEWARE_REWRITE_RESOLVE) {
+    // when externalMiddlewareRewritesResolve=true, leverage x-matched-path to detect rewrites
+    rewriteTarget = matchedPath
+  }
+
   if (rewriteTarget) {
     if (
       rewriteTarget.startsWith('/') ||
@@ -1921,8 +1926,9 @@ export default class Router implements BaseRouter {
 
     try {
       let props: Record<string, any> | undefined
-      const { page: Component, styleSheets } =
-        await this.fetchComponent('/_error')
+      const { page: Component, styleSheets } = await this.fetchComponent(
+        '/_error'
+      )
 
       const routeInfo: CompletePrivateRouteInfo = {
         props,

--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -176,12 +176,8 @@ function getMiddlewareData<T extends FetchDataOutput>(
 
   const matchedPath = response.headers.get('x-matched-path')
 
-  if (
-    !rewriteTarget &&
-    matchedPath &&
-    process.env.__NEXT_EXTERNAL_MIDDLEWARE_REWRITE_RESOLVE
-  ) {
-    // when externalMiddlewareRewritesResolve=true, leverage x-matched-path to detect rewrites as a fallback
+  if (matchedPath && process.env.__NEXT_EXTERNAL_MIDDLEWARE_REWRITE_RESOLVE) {
+    // when externalMiddlewareRewritesResolve=true, leverage x-matched-path to detect rewrites instead of x-nextjs-rewrite or x-nextjs-matched-path
     rewriteTarget = matchedPath
   }
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

When a (1st) nextjs site uses a middleware to forward requests (forward proxy) to another (2nd) nextjs site that also leverages a middleware to rewrite the request (reverse proxy), the client throws **an application error** when clicking on a prefetched link.

### Why?

With any other forward proxies (cloudflare workers, nginx, etc), this setup works fine, but when a middleware is leveraged as a forward proxy, the nextjs headers can get muddled.

### How?

When externalMiddlewareRewritesResolve=true, it seems to be explicit that we want to respect headers that we want to prioritize the rewrites resolved by an external middleware.

This is accomplished via an escape hatch for the 2nd next.js middleware, which can explicitly set the `x-matched-path` and allow the router to ignore the `x-nextjs-rewrite` or `x-nextjs-matched-path` set by the 1st next.js middleware.

In use:
https://github.com/fern-api/fern-platform/blob/ui%400.74.52/packages/ui/docs-bundle/src/middleware.ts#L135

In test:
https://github.com/fern-api/fern-platform/blob/ui%400.74.52/test/docs-e2e/nginx-proxy/index.test.ts#L86-L102