### PR TITLE
fix: enable hard navigate on 404

### DIFF
--- a/packages/next/src/build/webpack/plugins/define-env-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/define-env-plugin.ts
@@ -174,8 +174,8 @@ export function getDefineEnv({
     'process.env.NEXT_RUNTIME': isEdgeServer
       ? 'edge'
       : isNodeServer
-        ? 'nodejs'
-        : '',
+      ? 'nodejs'
+      : '',
     'process.env.NEXT_MINIMAL': '',
     'process.env.__NEXT_APP_NAV_FAIL_HANDLING': Boolean(
       config.experimental.appNavFailHandling
@@ -195,6 +195,8 @@ export function getDefineEnv({
         }),
     'process.env.__NEXT_MANUAL_CLIENT_BASE_PATH':
       config.experimental.manualClientBasePath ?? false,
+    'process.env.__NEXT_HARD_NAVIGATE_404':
+      config.experimental.hardNavigate404 ?? false,
     'process.env.__NEXT_CLIENT_ROUTER_DYNAMIC_STALETIME': JSON.stringify(
       isNaN(Number(config.experimental.staleTimes?.dynamic))
         ? 0

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -308,6 +308,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         largePageDataBytes: z.number().optional(),
         linkNoTouchStart: z.boolean().optional(),
         manualClientBasePath: z.boolean().optional(),
+        hardNavigate404: z.boolean().optional(),
         middlewarePrefetch: z.enum(['strict', 'flexible']).optional(),
         multiZoneDraftMode: z.boolean().optional(),
         cssChunking: z.enum(['strict', 'loose']).optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -273,6 +273,7 @@ export interface ExperimentalConfig {
   expireTime?: ExpireTime
   middlewarePrefetch?: 'strict' | 'flexible'
   manualClientBasePath?: boolean
+  hardNavigate404?: boolean
   /**
    * CSS Chunking strategy. Defaults to 'loose', which guesses dependencies
    * between CSS files to keep ordering of them.
@@ -1034,6 +1035,7 @@ export const defaultConfig: NextConfig = {
     middlewarePrefetch: 'flexible',
     optimisticClientCache: true,
     manualClientBasePath: false,
+    hardNavigate404: false,
     cpus: Math.max(
       1,
       (Number(process.env.CIRCLE_NODE_TOTAL) ||

--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -1776,6 +1776,10 @@ export default class Router implements BaseRouter {
           routeInfo.props.pageProps.statusCode = 500
         }
 
+        if (this.pathname === '/404' && process.env.__NEXT_HARD_NAVIGATE_404) {
+          handleHardNavigation({ url: as, router: this })
+        }
+
         try {
           await this.set(upcomingRouterState, routeInfo, upcomingScrollState)
         } catch (err) {
@@ -1921,8 +1925,9 @@ export default class Router implements BaseRouter {
 
     try {
       let props: Record<string, any> | undefined
-      const { page: Component, styleSheets } =
-        await this.fetchComponent('/_error')
+      const { page: Component, styleSheets } = await this.fetchComponent(
+        '/_error'
+      )
 
       const routeInfo: CompletePrivateRouteInfo = {
         props,


### PR DESCRIPTION
Related to https://github.com/vercel/next.js/pull/71194 and https://github.com/vercel/next.js/pull/71193

Additional feature flag that will enable hard navigate on `/404` routes.

### Why

Given the following proxy setup:

```
rewrites:
 - source: /(!?internal/):path*
   destination: https://another-nextjs-site.vercel.app/:path*
```

the client-side router is unaware that `/internal/*` belongs to the parent, and will render a 404 page.

### How

Adding a `hardNavigate404=true` flag will always hard navigate on 404.