### PR TITLE
docs(typo): add punctuations and fix cases

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/staleTimes.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/staleTimes.mdx
@@ -39,7 +39,7 @@ You can learn more about the Client Router Cache [here](/docs/app/building-your-
 
 ### Version History
 
-| Version   | Changes                                                 |
-| --------- | ------------------------------------------------------- |
-| `v15.0.0` | The `dynamic` staleTime default changed from 30s to 0s. |
-| `v14.2.0` | Experimental `staleTimes` introduced.                   |
+| Version   | Changes                                                    |
+| --------- | ---------------------------------------------------------- |
+| `v15.0.0` | The `dynamic` `staleTimes` default changed from 30s to 0s. |
+| `v14.2.0` | Experimental `staleTimes` introduced.                      |

--- a/docs/02-app/02-api-reference/05-next-config-js/staleTimes.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/staleTimes.mdx
@@ -39,7 +39,7 @@ You can learn more about the Client Router Cache [here](/docs/app/building-your-
 
 ### Version History
 
-| Version   | Changes                                                |
-| --------- | ------------------------------------------------------ |
-| `v15.0.0` | The `dynamic` staleTime default changed from 30s to 0s |
-| `v14.2.0` | experimental `staleTimes` introduced                   |
+| Version   | Changes                                                 |
+| --------- | ------------------------------------------------------- |
+| `v15.0.0` | The `dynamic` staleTime default changed from 30s to 0s. |
+| `v14.2.0` | Experimental `staleTimes` introduced.                   |

--- a/docs/02-app/02-api-reference/05-next-config-js/urlImports.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/urlImports.mdx
@@ -37,8 +37,8 @@ This feature is being designed with **security as the top priority**. To start, 
 When using URL imports, Next.js will create a `next.lock` directory containing a lockfile and fetched assets.
 This directory **must be committed to Git**, not ignored by `.gitignore`.
 
-- When running `next dev`, Next.js will download and add all newly discovered URL Imports to your lockfile
-- When running `next build`, Next.js will use only the lockfile to build the application for production
+- When running `next dev`, Next.js will download and add all newly discovered URL Imports to your lockfile.
+- When running `next build`, Next.js will use only the lockfile to build the application for production.
 
 Typically, no network requests are needed and any outdated lockfile will cause the build to fail.
 One exception is resources that respond with `Cache-Control: no-cache`.


### PR DESCRIPTION
## 📚 Improving Documentation

Hello, I've added some punctuations and fixed cases. Additionally, I wrapped staleTime in inline code blocks and added an `s`. I think this is a more appropriate way.

Other version changes have punctuation at the end of the sentence.

![image](https://github.com/user-attachments/assets/b6c17bc1-b1a7-4f3d-b19b-054ec37c770d)

