### PR TITLE
docs: fix typos in route handler documentation

### DIFF
--- a/docs/02-app/01-building-your-application/06-optimizing/10-open-telemetry.mdx
+++ b/docs/02-app/01-building-your-application/06-optimizing/10-open-telemetry.mdx
@@ -279,7 +279,7 @@ This span can be turned off by setting `NEXT_OTEL_FETCH_DISABLED=1` in your envi
 
 - `next.span_type`: `AppRouteRouteHandlers.runHandler`.
 
-This span represents the execution of an API route handler in the app router.
+This span represents the execution of an API Route Handler in the app router.
 
 Attributes:
 

--- a/docs/02-app/01-building-your-application/07-configuring/11-draft-mode.mdx
+++ b/docs/02-app/01-building-your-application/07-configuring/11-draft-mode.mdx
@@ -84,7 +84,7 @@ export async function GET(request: Request) {
   const slug = searchParams.get('slug')
 
   // Check the secret and next parameters
-  // This secret should only be known to this route handler and the CMS
+  // This secret should only be known to this Route Handler and the CMS
   if (secret !== 'MY_SECRET_TOKEN' || !slug) {
     return new Response('Invalid token', { status: 401 })
   }
@@ -118,7 +118,7 @@ export async function GET(request) {
   const slug = searchParams.get('slug')
 
   // Check the secret and next parameters
-  // This secret should only be known to this route handler and the CMS
+  // This secret should only be known to this Route Handler and the CMS
   if (secret !== 'MY_SECRET_TOKEN' || !slug) {
     return new Response('Invalid token', { status: 401 })
   }

--- a/docs/02-app/02-api-reference/02-file-conventions/route.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/route.mdx
@@ -22,7 +22,7 @@ export async function DELETE(request: Request) {}
 
 export async function PATCH(request: Request) {}
 
-// If `OPTIONS` is not defined, Next.js will automatically implement `OPTIONS` and set the appropriate Response `Allow` header depending on the other methods defined in the route handler.
+// If `OPTIONS` is not defined, Next.js will automatically implement `OPTIONS` and set the appropriate Response `Allow` header depending on the other methods defined in the Route Handler.
 export async function OPTIONS(request: Request) {}
 ```
 
@@ -39,7 +39,7 @@ export async function DELETE(request) {}
 
 export async function PATCH(request) {}
 
-// If `OPTIONS` is not defined, Next.js will automatically implement `OPTIONS` and set the appropriate Response `Allow` header depending on the other methods defined in the route handler.
+// If `OPTIONS` is not defined, Next.js will automatically implement `OPTIONS` and set the appropriate Response `Allow` header depending on the other methods defined in the Route Handler.
 export async function OPTIONS(request) {}
 ```
 


### PR DESCRIPTION
Hi, This PR aims to improve the consistency of the documentation, especially regarding the use of the "Route Handler" terminology.

Changes:
1. Change all instances of "route handler" and `route handler` to `Route Handler`.
2. Ensure consistent use of "Route Handler" throughout the documentation.

Reasons:
- Improve the professionalism and consistency of the documentation
- Reduce potential confusion for readers