### PR TITLE
Handle thrown values that aren't `Error` instances in App router

### DIFF
--- a/packages/next/src/client/components/is-next-router-error.ts
+++ b/packages/next/src/client/components/is-next-router-error.ts
@@ -1,11 +1,13 @@
-import { isNotFoundError } from './not-found'
-import { isRedirectError } from './redirect'
+import { isNotFoundError, type NotFoundError } from './not-found'
+import { isRedirectError, type RedirectError } from './redirect'
 
 /**
  * Returns true if the error is a navigation signal error. These errors are
  * thrown by user code to perform navigation operations and interrupt the React
  * render.
  */
-export function isNextRouterError(error: any): boolean {
+export function isNextRouterError(
+  error: unknown
+): error is RedirectError | NotFoundError {
   return isRedirectError(error) || isNotFoundError(error)
 }

--- a/packages/next/src/client/components/not-found.ts
+++ b/packages/next/src/client/components/not-found.ts
@@ -1,6 +1,6 @@
 const NOT_FOUND_ERROR_CODE = 'NEXT_NOT_FOUND'
 
-type NotFoundError = Error & { digest: typeof NOT_FOUND_ERROR_CODE }
+export type NotFoundError = Error & { digest: typeof NOT_FOUND_ERROR_CODE }
 
 /**
  * This function allows you to render the [not-found.js file](https://nextjs.org/docs/app/api-reference/file-conventions/not-found)

--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -7,6 +7,7 @@ import { isAbortError } from '../pipe-readable'
 import { isBailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
 import { isDynamicServerError } from '../../client/components/hooks-server-context'
 import { isNextRouterError } from '../../client/components/is-next-router-error'
+import { getProperError } from '../../lib/is-error'
 
 declare global {
   var __next_log_error__: undefined | ((err: unknown) => void)
@@ -22,30 +23,37 @@ export type DigestedError = Error & { digest: string }
 
 export function createFlightReactServerErrorHandler(
   dev: boolean,
-  onReactServerRenderError: (err: any) => void
+  onReactServerRenderError: (err: DigestedError) => void
 ): RSCErrorHandler {
-  return (err: any) => {
+  return (thrownValue: unknown) => {
+    if (typeof thrownValue === 'string') {
+      // TODO-APP: look at using webcrypto instead. Requires a promise to be awaited.
+      return stringHash(thrownValue).toString()
+    }
+
+    // If the response was closed, we don't need to log the error.
+    if (isAbortError(thrownValue)) return
+
+    // If we're bailing out to CSR, we don't need to log the error.
+    if (isBailoutToCSRError(thrownValue)) return thrownValue.digest
+
+    // If this is a navigation error, we don't need to log the error.
+    if (isNextRouterError(thrownValue)) return thrownValue.digest
+
+    // If this error occurs, we know that we should be stopping the static
+    // render. This is only thrown in static generation when PPR is not enabled,
+    // which causes the whole page to be marked as dynamic. We don't need to
+    // tell the user about this error, as it's not actionable.
+    if (isDynamicServerError(thrownValue)) return thrownValue.digest
+
+    const err = getProperError(thrownValue) as DigestedError
+
     // If the error already has a digest, respect the original digest,
     // so it won't get re-generated into another new error.
     if (!err.digest) {
       // TODO-APP: look at using webcrypto instead. Requires a promise to be awaited.
       err.digest = stringHash(err.message + err.stack || '').toString()
     }
-
-    // If the response was closed, we don't need to log the error.
-    if (isAbortError(err)) return
-
-    // If we're bailing out to CSR, we don't need to log the error.
-    if (isBailoutToCSRError(err)) return err.digest
-
-    // If this is a navigation error, we don't need to log the error.
-    if (isNextRouterError(err)) return err.digest
-
-    // If this error occurs, we know that we should be stopping the static
-    // render. This is only thrown in static generation when PPR is not enabled,
-    // which causes the whole page to be marked as dynamic. We don't need to
-    // tell the user about this error, as it's not actionable.
-    if (isDynamicServerError(err)) return err.digest
 
     // Format server errors in development to add more helpful error messages
     if (dev) {
@@ -73,9 +81,31 @@ export function createHTMLReactServerErrorHandler(
   isNextExport: boolean,
   reactServerErrors: Map<string, DigestedError>,
   silenceLogger: boolean,
-  onReactServerRenderError: undefined | ((err: any) => void)
+  onReactServerRenderError: undefined | ((err: DigestedError) => void)
 ): RSCErrorHandler {
-  return (err: any) => {
+  return (thrownValue: unknown) => {
+    if (typeof thrownValue === 'string') {
+      // TODO-APP: look at using webcrypto instead. Requires a promise to be awaited.
+      return stringHash(thrownValue).toString()
+    }
+
+    // If the response was closed, we don't need to log the error.
+    if (isAbortError(thrownValue)) return
+
+    // If we're bailing out to CSR, we don't need to log the error.
+    if (isBailoutToCSRError(thrownValue)) return thrownValue.digest
+
+    // If this is a navigation error, we don't need to log the error.
+    if (isNextRouterError(thrownValue)) return thrownValue.digest
+
+    // If this error occurs, we know that we should be stopping the static
+    // render. This is only thrown in static generation when PPR is not enabled,
+    // which causes the whole page to be marked as dynamic. We don't need to
+    // tell the user about this error, as it's not actionable.
+    if (isDynamicServerError(thrownValue)) return thrownValue.digest
+
+    const err = getProperError(thrownValue) as DigestedError
+
     // If the error already has a digest, respect the original digest,
     // so it won't get re-generated into another new error.
     if (!err.digest) {
@@ -83,26 +113,11 @@ export function createHTMLReactServerErrorHandler(
       err.digest = stringHash(err.message + (err.stack || '')).toString()
     }
 
-    // If the response was closed, we don't need to log the error.
-    if (isAbortError(err)) return
-
-    // If we're bailing out to CSR, we don't need to log the error.
-    if (isBailoutToCSRError(err)) return err.digest
-
-    // If this is a navigation error, we don't need to log the error.
-    if (isNextRouterError(err)) return err.digest
-
     // @TODO by putting this here and not at the top it is possible that
     // we don't error the build in places we actually expect to
     if (!reactServerErrors.has(err.digest)) {
       reactServerErrors.set(err.digest, err)
     }
-
-    // If this error occurs, we know that we should be stopping the static
-    // render. This is only thrown in static generation when PPR is not enabled,
-    // which causes the whole page to be marked as dynamic. We don't need to
-    // tell the user about this error, as it's not actionable.
-    if (isDynamicServerError(err)) return err.digest
 
     // Format server errors in development to add more helpful error messages
     if (dev) {
@@ -143,18 +158,36 @@ export function createHTMLErrorHandler(
   reactServerErrors: Map<string, DigestedError>,
   allCapturedErrors: Array<unknown>,
   silenceLogger: boolean,
-  onHTMLRenderSSRError: (err: any, errorInfo?: ErrorInfo) => void
+  onHTMLRenderSSRError: (err: DigestedError, errorInfo?: ErrorInfo) => void
 ): SSRErrorHandler {
-  return (err: any, errorInfo?: ErrorInfo) => {
+  return (thrownValue: unknown, errorInfo?: ErrorInfo) => {
     let isSSRError = true
 
+    allCapturedErrors.push(thrownValue)
+
+    // If the response was closed, we don't need to log the error.
+    if (isAbortError(thrownValue)) return
+
+    // If we're bailing out to CSR, we don't need to log the error.
+    if (isBailoutToCSRError(thrownValue)) return thrownValue.digest
+
+    // If this is a navigation error, we don't need to log the error.
+    if (isNextRouterError(thrownValue)) return thrownValue.digest
+
+    // If this error occurs, we know that we should be stopping the static
+    // render. This is only thrown in static generation when PPR is not enabled,
+    // which causes the whole page to be marked as dynamic. We don't need to
+    // tell the user about this error, as it's not actionable.
+    if (isDynamicServerError(thrownValue)) return thrownValue.digest
+
+    const err = getProperError(thrownValue) as DigestedError
     // If the error already has a digest, respect the original digest,
     // so it won't get re-generated into another new error.
     if (err.digest) {
       if (reactServerErrors.has(err.digest)) {
         // This error is likely an obfuscated error from react-server.
         // We recover the original error here.
-        err = reactServerErrors.get(err.digest)
+        thrownValue = reactServerErrors.get(err.digest)
         isSSRError = false
       } else {
         // The error is not from react-server but has a digest
@@ -165,23 +198,6 @@ export function createHTMLErrorHandler(
         err.message + (errorInfo?.componentStack || err.stack || '')
       ).toString()
     }
-
-    allCapturedErrors.push(err)
-
-    // If the response was closed, we don't need to log the error.
-    if (isAbortError(err)) return
-
-    // If we're bailing out to CSR, we don't need to log the error.
-    if (isBailoutToCSRError(err)) return err.digest
-
-    // If this is a navigation error, we don't need to log the error.
-    if (isNextRouterError(err)) return err.digest
-
-    // If this error occurs, we know that we should be stopping the static
-    // render. This is only thrown in static generation when PPR is not enabled,
-    // which causes the whole page to be marked as dynamic. We don't need to
-    // tell the user about this error, as it's not actionable.
-    if (isDynamicServerError(err)) return err.digest
 
     // Format server errors in development to add more helpful error messages
     if (dev) {

--- a/test/e2e/app-dir/errors/app/server-component/throw-null/page.js
+++ b/test/e2e/app-dir/errors/app/server-component/throw-null/page.js
@@ -1,0 +1,6 @@
+export const revalidate = 0
+
+export default function Page() {
+  // eslint-disable-next-line no-throw-literal -- testing bad values on purpose
+  throw null
+}

--- a/test/e2e/app-dir/errors/app/server-component/throw-string/page.js
+++ b/test/e2e/app-dir/errors/app/server-component/throw-string/page.js
@@ -1,0 +1,6 @@
+export const revalidate = 0
+
+export default function Page() {
+  // eslint-disable-next-line no-throw-literal -- testing bad values on purpose
+  throw 'this is a test'
+}

--- a/test/e2e/app-dir/errors/app/server-component/throw-undefined/page.js
+++ b/test/e2e/app-dir/errors/app/server-component/throw-undefined/page.js
@@ -1,0 +1,6 @@
+export const revalidate = 0
+
+export default function Page() {
+  // eslint-disable-next-line no-throw-literal -- testing bad values on purpose
+  throw undefined
+}

--- a/test/e2e/app-dir/errors/index.test.ts
+++ b/test/e2e/app-dir/errors/index.test.ts
@@ -73,6 +73,75 @@ describe('app-dir - errors', () => {
       )
     })
 
+    it('should trigger error component when undefined is thrown during server components rendering', async () => {
+      const browser = await next.browser('/server-component/throw-undefined')
+
+      expect(
+        await browser.waitForElementByCss('#error-boundary-message').text()
+      ).toBe(
+        isNextDev
+          ? 'undefined'
+          : 'An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.'
+      )
+      expect(
+        await browser.waitForElementByCss('#error-boundary-digest').text()
+        // Digest of the error message should be stable.
+      ).not.toBe('')
+      expect(stripAnsi(next.cliOutput)).toEqual(
+        expect.stringMatching(
+          isNextDev
+            ? /Error: An undefined error was thrown.*digest: "\d+"/s
+            : /Error: undefined.*digest: '\d+'/s
+        )
+      )
+    })
+
+    it('should trigger error component when null is thrown during server components rendering', async () => {
+      const browser = await next.browser('/server-component/throw-null')
+
+      expect(
+        await browser.waitForElementByCss('#error-boundary-message').text()
+      ).toBe(
+        isNextDev
+          ? 'null'
+          : 'An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.'
+      )
+      expect(
+        await browser.waitForElementByCss('#error-boundary-digest').text()
+        // Digest of the error message should be stable.
+      ).not.toBe('')
+      expect(stripAnsi(next.cliOutput)).toEqual(
+        expect.stringMatching(
+          isNextDev
+            ? /Error: A null error was thrown.*digest: "\d+"/s
+            : /Error: null.*digest: '\d+'/s
+        )
+      )
+    })
+
+    it('should trigger error component when a string is thrown during server components rendering', async () => {
+      const browser = await next.browser('/server-component/throw-string')
+
+      expect(
+        await browser.waitForElementByCss('#error-boundary-message').text()
+      ).toBe(
+        isNextDev
+          ? 'this is a test'
+          : 'An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.'
+      )
+      expect(
+        await browser.waitForElementByCss('#error-boundary-digest').text()
+        // Digest of the error message should be stable.
+      ).not.toBe('')
+      expect(stripAnsi(next.cliOutput)).toEqual(
+        expect.stringMatching(
+          isNextDev
+            ? /Error: this is a test.*digest: "\d+"/s
+            : /Error: An error occurred in the Server Components render.*digest: '\d+'/s
+        )
+      )
+    })
+
     it('should use default error boundary for prod and overlay for dev when no error component specified', async () => {
       const browser = await next.browser('/global-error-boundary/client')
       await browser.elementByCss('#error-trigger-button').click()


### PR DESCRIPTION
Added test cases for exotic thrown values (null, undefined, string) that
are currently not handled correctly.

This is mostly for soundness and to make the bad cases (thrown non-errors) not worse than they are.