### PR TITLE
docs(typo): fix typo in `cms-sanity` example `README.md`

### DIFF
--- a/examples/cms-sanity/README.md
+++ b/examples/cms-sanity/README.md
@@ -54,7 +54,7 @@ npm run typegen
 # Configuration
 
 - [Step 1. Set up the environment](#step-1-set-up-the-environment)
-  - [Reuse remote envionment variables](#reuse-remote-envionment-variables)
+  - [Reuse remote environment variables](#reuse-remote-environment-variables)
   - [Using the Sanity CLI](#using-the-sanity-cli)
     - [Creating a read token](#creating-a-read-token)
 - [Step 2. Run Next.js locally in development mode](#step-2-run-nextjs-locally-in-development-mode)
@@ -64,7 +64,7 @@ npm run typegen
 
 ## Step 1. Set up the environment
 
-### Reuse remote envionment variables
+### Reuse remote environment variables
 
 If you started with [deploying your own](#deploy-your-own) then you can run this to reuse the environment variables from the Vercel project and skip to the next step:
 
@@ -121,7 +121,7 @@ Found existing NEXT_PUBLIC_SANITY_PROJECT_ID, replacing value.
 Found existing NEXT_PUBLIC_SANITY_DATASET, replacing value.
 ```
 
-It's important that when you're asked `Would you like to add configuration files for a Sanity project in this Next.js folder?` that you answer `No` as this example is alredy setup with the required configuration files.
+It's important that when you're asked `Would you like to add configuration files for a Sanity project in this Next.js folder?` that you answer `No` as this example is already setup with the required configuration files.
 
 #### Creating a read token
 


### PR DESCRIPTION
Fixing typos for the `cms-sanity` example [README.md](https://github.com/vercel/next.js/blob/canary/examples/cms-sanity/README.md):

`envionment` >  `environment`
`alredy` > `already`

Thanks!
