### PR TITLE
docs(typo): remove unnecessary spaces

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/exportPathMap.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/exportPathMap.mdx
@@ -10,7 +10,7 @@ description: Customize the pages that will be exported as HTML files when using 
 
 <details>
   <summary>Examples</summary>
-  
+
 - [Static Export](https://github.com/vercel/next.js/tree/canary/examples/with-static-export)
 
 </details>

--- a/docs/03-pages/01-building-your-application/06-configuring/07-amp.mdx
+++ b/docs/03-pages/01-building-your-application/06-configuring/07-amp.mdx
@@ -5,7 +5,7 @@ description: With minimal config, and without leaving React, you can start addin
 
 <details>
   <summary>Examples</summary>
-  
+
 - [AMP](https://github.com/vercel/next.js/tree/canary/examples/amp)
 
 </details>


### PR DESCRIPTION
## 📚 Improving Documentation

Hello, I've removed some unnecessary spaces in documents. It works well without the spaces.