### PR TITLE
docs(typo): fix url to URL

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/rewrites.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/rewrites.mdx
@@ -326,7 +326,7 @@ module.exports = {
 
 </details>
 
-Rewrites allow you to rewrite to an external url. This is especially useful for incrementally adopting Next.js. The following is an example rewrite for redirecting the `/blog` route of your main app to an external site.
+Rewrites allow you to rewrite to an external URL. This is especially useful for incrementally adopting Next.js. The following is an example rewrite for redirecting the `/blog` route of your main app to an external site.
 
 ```js filename="next.config.js"
 module.exports = {

--- a/docs/02-app/02-api-reference/05-next-config-js/trailingSlash.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/trailingSlash.mdx
@@ -5,7 +5,7 @@ description: Configure Next.js pages to resolve with or without a trailing slash
 
 {/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
 
-By default Next.js will redirect urls with trailing slashes to their counterpart without a trailing slash. For example `/about/` will redirect to `/about`. You can configure this behavior to act the opposite way, where urls without trailing slashes are redirected to their counterparts with trailing slashes.
+By default Next.js will redirect URLs with trailing slashes to their counterpart without a trailing slash. For example `/about/` will redirect to `/about`. You can configure this behavior to act the opposite way, where URLs without trailing slashes are redirected to their counterparts with trailing slashes.
 
 Open `next.config.js` and add the `trailingSlash` config:
 
@@ -15,7 +15,7 @@ module.exports = {
 }
 ```
 
-With this option set, urls like `/about` will redirect to `/about/`.
+With this option set, URLs like `/about` will redirect to `/about/`.
 
 When used with [`output: "export"`](/docs/app/building-your-application/deploying/static-exports) configuration, the `/about` page will output `/about/index.html` (instead of the default `/about.html`).
 


### PR DESCRIPTION
## 📚 Improving Documentation

Hello, I've fixed the typo `URL`. It should be capitalized. `url` -> `URL`

In other documents, URL is written in uppercase.

![image](https://github.com/user-attachments/assets/bb55f02d-f9f9-4589-9fe7-33deb02af39c)
