### PR TITLE
Ensure CI on `canary` runs with React 19

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -206,8 +206,7 @@ jobs:
           # Excluding React 18 tests unless on `canary` branch until budget is approved.
           - react: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-react-18-tests') && '18.3.1' }}
         group: [1/5, 2/5, 3/5, 4/5, 5/5]
-        # Empty value uses default
-        react: ['', '18.3.1']
+        react: ['19', '18.3.1']
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: RUST_BACKTRACE=0 NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/turbopack-dev-tests-manifest.json" TURBOPACK=1 TURBOPACK_DEV=1  NEXT_E2E_TEST_TIMEOUT=240000 NEXT_TEST_MODE=dev NEXT_TEST_REACT_VERSION="${{ matrix.react }}" node run-tests.js --test-pattern '^(test\/(development|e2e))/.*\.test\.(js|jsx|ts|tsx)$' --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY}
@@ -226,8 +225,11 @@ jobs:
           # Excluding React 18 tests unless on `canary` branch until budget is approved.
           - react: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-react-18-tests') && '18.3.1' }}
         group: [1/5, 2/5, 3/5, 4/5, 5/5]
-        # Empty value uses default
-        react: ['']
+        # TODO: Run with React 18.
+        # Integration tests use the installed React version in next/package.json.include:
+        # We can't easily switch like we do for e2e tests.
+        # Skipping this dimensions until we can figure out a way to test multiple React versions.
+        react: ['19']
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: 18.18.2
@@ -247,12 +249,7 @@ jobs:
           # Excluding React 18 tests unless on `canary` branch until budget is approved.
           - react: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-react-18-tests') && '18.3.1' }}
         group: [1/5, 2/5, 3/5, 4/5, 5/5]
-        # Empty value uses default
-        # TODO: Run with React 18.
-        # Integration tests use the installed React version in next/package.json.include:
-        # We can't easily switch like we do for e2e tests.
-        # Skipping this dimensions until we can figure out a way to test multiple React versions.
-        react: ['', '18.3.1']
+        react: ['19', '18.3.1']
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: 18.18.2
@@ -385,8 +382,7 @@ jobs:
           # Excluding React 18 tests unless on `canary` branch until budget is approved.
           - react: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-react-18-tests') && '18.3.1' }}
         group: [1/4, 2/4, 3/4, 4/4]
-        # Empty value uses default
-        react: ['', '18.3.1']
+        react: ['19', '18.3.1']
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: NEXT_TEST_MODE=dev NEXT_TEST_REACT_VERSION="${{ matrix.react }}" node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type development
@@ -405,8 +401,7 @@ jobs:
           # Excluding React 18 tests unless on `canary` branch until budget is approved.
           - react: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-react-18-tests') && '18.3.1' }}
         group: [1/5, 2/5, 3/5, 4/5, 5/5]
-        # Empty value uses default
-        react: ['', '18.3.1']
+        react: ['19', '18.3.1']
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: NEXT_TEST_MODE=start NEXT_TEST_REACT_VERSION="${{ matrix.react }}" node run-tests.js --timings -g ${{ matrix.group }} -c ${TEST_CONCURRENCY} --type production
@@ -435,11 +430,11 @@ jobs:
           - 11/12
           - 12/12
           # Empty value uses default
-          # TODO: Run with React 18.
-          # Integration tests use the installed React version in next/package.json.include:
+        # TODO: Run with React 18.
+        # Integration tests use the installed React version in next/package.json.include:
         # We can't easily switch like we do for e2e tests.
         # Skipping this dimensions until we can figure out a way to test multiple React versions.
-        react: ['']
+        react: ['19']
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: 18.18.2

--- a/run-tests.js
+++ b/run-tests.js
@@ -20,7 +20,7 @@ const { getTestFilter } = require('./test/get-test-filter')
 
 // Do not rename or format. sync-react script relies on this line.
 // prettier-ignore
-const nextjsReactPeerVersion = "19.0.0-rc-70fb1363-20241010";
+const supportedReact19Version = "19.0.0-rc-70fb1363-20241010";
 
 let argv = require('yargs/yargs')(process.argv.slice(2))
   .string('type')
@@ -412,8 +412,11 @@ ${ENDGROUP}`)
     // a starter Next.js install to re-use to speed up tests to avoid having to
     // run `pnpm install` each time.
     console.log(`${GROUP}Creating shared Next.js install`)
+    const specifiedReactVersion = process.env.NEXT_TEST_REACT_VERSION
     const reactVersion =
-      process.env.NEXT_TEST_REACT_VERSION || nextjsReactPeerVersion
+      specifiedReactVersion === '19' || !specifiedReactVersion
+        ? supportedReact19Version
+        : specifiedReactVersion
     const { installDir, pkgPaths, tmpRepoDir } = await createNextInstall({
       parentSpan: mockTrace(),
       dependencies: {

--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -307,8 +307,8 @@ Or, run this command with no arguments to use the most recently published versio
     const filePath = path.join(cwd, fileName)
     const previousSource = await fsp.readFile(filePath, 'utf-8')
     const updatedSource = previousSource.replace(
-      `const nextjsReactPeerVersion = "${baseVersionStr}";`,
-      `const nextjsReactPeerVersion = "${newVersionStr}";`
+      `const supportedReact19Version = "${baseVersionStr}";`,
+      `const supportedReact19Version = "${newVersionStr}";`
     )
     if (updatedSource === previousSource) {
       errors.push(

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -51,7 +51,7 @@ type OmitFirstArgument<F> = F extends (
 
 // Do not rename or format. sync-react script relies on this line.
 // prettier-ignore
-const nextjsReactPeerVersion = "19.0.0-rc-70fb1363-20241010";
+const supportedReact19Version = "19.0.0-rc-70fb1363-20241010";
 
 export class NextInstance {
   protected files: FileRef | { [filename: string]: string | FileRef }
@@ -164,8 +164,11 @@ export class NextInstance {
           }`
         )
 
+        const specifiedReactVersion = process.env.NEXT_TEST_REACT_VERSION
         const reactVersion =
-          process.env.NEXT_TEST_REACT_VERSION || nextjsReactPeerVersion
+          !specifiedReactVersion || specifiedReactVersion === '19'
+            ? supportedReact19Version
+            : specifiedReactVersion
         const finalDependencies = {
           react: reactVersion,
           'react-dom': reactVersion,


### PR DESCRIPTION
On `canary`, ` ${{ github.event_name == 'pull_request' && '18.3.1' }}` evaluates to `false` which excludes the empty string from the matrix and therefore only 18.3.1 tests run on `canary`. Ternaries are not available in expressions in GitHub actions so we use `19` to indicate the supported 19 version should be used.