### PR TITLE
Cache in CacheScopeStore in use cache

### DIFF
--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -46,7 +46,7 @@ import {
   type FallbackRouteParams,
 } from '../server/request/fallback-params'
 import { needsExperimentalReact } from '../lib/needs-experimental-react'
-import { runWithCacheScope } from '../server/async-storage/cache-scope'
+import { runWithCacheScope } from '../server/async-storage/cache-scope.external'
 import type { AppRouteRouteModule } from '../server/route-modules/app-route/module.compiled'
 
 const envConfig = require('../shared/lib/runtime-config.external')

--- a/packages/next/src/server/async-storage/cache-scope-instance.ts
+++ b/packages/next/src/server/async-storage/cache-scope-instance.ts
@@ -1,0 +1,6 @@
+import type { CacheScopeStore } from './cache-scope.external'
+
+import { createAsyncLocalStorage } from '../app-render/async-local-storage'
+
+export const cacheScopeAsyncLocalStorage =
+  createAsyncLocalStorage<CacheScopeStore>()

--- a/packages/next/src/server/async-storage/cache-scope.external.ts
+++ b/packages/next/src/server/async-storage/cache-scope.external.ts
@@ -1,11 +1,10 @@
-import { createAsyncLocalStorage } from '../app-render/async-local-storage'
+import { cacheScopeAsyncLocalStorage } from './cache-scope-instance' with { 'turbopack-transition': 'next-shared' }
 
 export interface CacheScopeStore {
-  cache?: Map<string, any>
+  cache: Map<string, any>
 }
 
-export const cacheScopeAsyncLocalStorage =
-  createAsyncLocalStorage<CacheScopeStore>()
+export { cacheScopeAsyncLocalStorage }
 
 /**
  * For dynamic IO handling we want to have a scoped memory

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -10,7 +10,7 @@ import {
 import type { Revalidate } from '../revalidate'
 import type { DeepReadonly } from '../../../shared/lib/deep-readonly'
 
-import { cacheScopeAsyncLocalStorage } from '../../async-storage/cache-scope'
+import { cacheScopeAsyncLocalStorage } from '../../async-storage/cache-scope.external'
 import FetchCache from './fetch-cache'
 import FileSystemCache from './file-system-cache'
 import { normalizePagePath } from '../../../shared/lib/page-path/normalize-page-path'
@@ -414,7 +414,7 @@ export class IncrementalCache implements IncrementalCacheType {
     if (this.hasDynamicIO && ctx.kind === IncrementalCacheKind.FETCH) {
       const cacheScope = cacheScopeAsyncLocalStorage.getStore()
 
-      if (cacheScope?.cache) {
+      if (cacheScope) {
         const memoryCacheData = cacheScope.cache.get(cacheKey)
 
         if (memoryCacheData?.kind === CachedRouteKind.FETCH) {
@@ -538,7 +538,7 @@ export class IncrementalCache implements IncrementalCacheType {
     if (this.hasDynamicIO && data?.kind === CachedRouteKind.FETCH) {
       const cacheScope = cacheScopeAsyncLocalStorage.getStore()
 
-      if (cacheScope?.cache) {
+      if (cacheScope) {
         cacheScope.cache.set(pathname, data)
       }
     }

--- a/packages/next/src/server/lib/prefetch-cache-scopes.ts
+++ b/packages/next/src/server/lib/prefetch-cache-scopes.ts
@@ -1,4 +1,4 @@
-import type { CacheScopeStore } from '../async-storage/cache-scope'
+import type { CacheScopeStore } from '../async-storage/cache-scope.external'
 
 export class PrefetchCacheScopes {
   private cacheScopes = new Map<

--- a/test/e2e/app-dir/dynamic-io/app/cases/use_cache_cached/page.tsx
+++ b/test/e2e/app-dir/dynamic-io/app/cases/use_cache_cached/page.tsx
@@ -1,0 +1,40 @@
+import { getSentinelValue } from '../../getSentinelValue'
+
+export default async function Page() {
+  await 1
+  return (
+    <>
+      <p>
+        This page renders two components. Both call a simulated IO function
+        wrapped in `"use cache"`.
+      </p>
+      <p>Niether component is wrapped in a Suspense boundary</p>
+      <p>
+        With PPR this page should be entirely static because all IO is cached.
+      </p>
+      <p>Without PPR this page should be static because all IO is cached.</p>
+      <ComponentOne />
+      <ComponentTwo />
+      <div id="page">{getSentinelValue()}</div>
+    </>
+  )
+}
+
+async function ComponentOne() {
+  return <div>message 1: {await getCachedMessage('hello cached fast', 2)}</div>
+}
+
+async function ComponentTwo() {
+  return (
+    <>
+      <div>message 2: {await getCachedMessage('hello cached fast', 0)}</div>
+      <div>message 3: {await getCachedMessage('hello cached slow', 20)}</div>
+    </>
+  )
+}
+
+async function getCachedMessage(echo, delay) {
+  'use cache'
+  await new Promise((r) => setTimeout(r, delay))
+  return echo
+}

--- a/test/e2e/app-dir/dynamic-io/app/cases/use_cache_mixed/page.tsx
+++ b/test/e2e/app-dir/dynamic-io/app/cases/use_cache_mixed/page.tsx
@@ -1,0 +1,54 @@
+import { Suspense } from 'react'
+
+import { getSentinelValue } from '../../getSentinelValue'
+
+export default async function Page() {
+  await 1
+  return (
+    <>
+      <p>
+        This page renders two components. The first calls a simulated IO
+        function wrapped in `"use cache""`. The second calls the simulated IO
+        function without being wrapped in `"use cache""`.
+      </p>
+      <p>Each component is wrapped in a Suspense boundary</p>
+      <p>
+        With PPR this page should have a static shell that includes the cached
+        IO result and a loading state for the boundary surrounding the uncached
+        IO result.
+      </p>
+      <p>Without PPR this page should be dynamic.</p>
+      <Suspense fallback="loading...">
+        <ComponentOne />
+      </Suspense>
+      <Suspense fallback="loading too...">
+        <ComponentTwo />
+        <div id="inner">{getSentinelValue()}</div>
+      </Suspense>
+      <div id="page">{getSentinelValue()}</div>
+    </>
+  )
+}
+
+async function ComponentOne() {
+  return <div>message 1: {await getCachedMessage('hello cached fast', 2)}</div>
+}
+
+async function ComponentTwo() {
+  return (
+    <>
+      <div>message 2: {await getMessage('hello uncached fast', 0)}</div>
+      <div>message 3: {await getCachedMessage('hello cached slow', 20)}</div>
+    </>
+  )
+}
+
+async function getMessage(echo, delay) {
+  await new Promise((r) => setTimeout(r, delay))
+  return echo
+}
+
+async function getCachedMessage(echo, delay) {
+  'use cache'
+  return getMessage(echo, delay)
+}

--- a/test/e2e/app-dir/dynamic-io/app/routes/-edge/use_cache-cached/route.ts
+++ b/test/e2e/app-dir/dynamic-io/app/routes/-edge/use_cache-cached/route.ts
@@ -1,0 +1,24 @@
+import type { NextRequest } from 'next/server'
+
+import { getSentinelValue } from '../../../getSentinelValue'
+
+export const runtime = 'edge'
+
+export async function GET(request: NextRequest) {
+  const messagea = await getCachedMessage('hello cached fast', 0)
+  const messageb = await getCachedMessage('hello cached slow', 20)
+  return new Response(
+    JSON.stringify({
+      value: getSentinelValue(),
+      message1: messagea,
+      message2: messageb,
+    })
+  )
+}
+
+async function getCachedMessage(echo, delay) {
+  'use cache'
+  const tag = ((Math.random() * 10000) | 0).toString(16)
+  await new Promise((r) => setTimeout(r, delay))
+  return `${tag}:${echo}`
+}

--- a/test/e2e/app-dir/dynamic-io/app/routes/-edge/use_cache-mixed/route.ts
+++ b/test/e2e/app-dir/dynamic-io/app/routes/-edge/use_cache-mixed/route.ts
@@ -1,0 +1,28 @@
+import type { NextRequest } from 'next/server'
+
+import { getSentinelValue } from '../../../getSentinelValue'
+
+export const runtime = 'edge'
+
+export async function GET(request: NextRequest) {
+  const messagea = await getCachedMessage('hello cached fast', 0)
+  const messageb = await getMessage('hello uncached slow', 20)
+  return new Response(
+    JSON.stringify({
+      value: getSentinelValue(),
+      message1: messagea,
+      message2: messageb,
+    })
+  )
+}
+
+async function getMessage(echo, delay) {
+  const tag = ((Math.random() * 10000) | 0).toString(16)
+  await new Promise((r) => setTimeout(r, delay))
+  return `${tag}:${echo}`
+}
+
+async function getCachedMessage(echo, delay) {
+  'use cache'
+  return getMessage(echo, delay)
+}

--- a/test/e2e/app-dir/dynamic-io/app/routes/use_cache-cached/route.ts
+++ b/test/e2e/app-dir/dynamic-io/app/routes/use_cache-cached/route.ts
@@ -1,0 +1,22 @@
+import type { NextRequest } from 'next/server'
+
+import { getSentinelValue } from '../../getSentinelValue'
+
+export async function GET(request: NextRequest) {
+  const messagea = await getCachedMessage('hello cached fast', 0)
+  const messageb = await getCachedMessage('hello cached slow', 20)
+  return new Response(
+    JSON.stringify({
+      value: getSentinelValue(),
+      message1: messagea,
+      message2: messageb,
+    })
+  )
+}
+
+async function getCachedMessage(echo, delay) {
+  'use cache'
+  const tag = ((Math.random() * 10000) | 0).toString(16)
+  await new Promise((r) => setTimeout(r, delay))
+  return `${tag}:${echo}`
+}

--- a/test/e2e/app-dir/dynamic-io/app/routes/use_cache-mixed/route.ts
+++ b/test/e2e/app-dir/dynamic-io/app/routes/use_cache-mixed/route.ts
@@ -1,0 +1,26 @@
+import type { NextRequest } from 'next/server'
+
+import { getSentinelValue } from '../../getSentinelValue'
+
+export async function GET(request: NextRequest) {
+  const messagea = await getCachedMessage('hello cached fast', 0)
+  const messageb = await getMessage('hello uncached slow', 20)
+  return new Response(
+    JSON.stringify({
+      value: getSentinelValue(),
+      message1: messagea,
+      message2: messageb,
+    })
+  )
+}
+
+async function getMessage(echo, delay) {
+  const tag = ((Math.random() * 10000) | 0).toString(16)
+  await new Promise((r) => setTimeout(r, delay))
+  return `${tag}:${echo}`
+}
+
+async function getCachedMessage(echo, delay) {
+  'use cache'
+  return getMessage(echo, delay)
+}

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.routes.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.routes.test.ts
@@ -206,6 +206,54 @@ describe('dynamic-io', () => {
     expect(message2).toEqual(json.message2)
   })
 
+  it('should prerender GET route handlers that have entirely cached io ("use cache")', async () => {
+    let str = await next.render('/routes/use_cache-cached', {})
+    let json = JSON.parse(str)
+
+    let message1 = json.message1
+    let message2 = json.message2
+
+    if (isNextDev) {
+      expect(json.value).toEqual('at runtime')
+      expect(typeof message1).toBe('string')
+      expect(typeof message2).toBe('string')
+    } else {
+      expect(json.value).toEqual('at buildtime')
+      expect(typeof message1).toBe('string')
+      expect(typeof message2).toBe('string')
+    }
+
+    str = await next.render('/routes/use_cache-cached', {})
+    json = JSON.parse(str)
+
+    if (isNextDev) {
+      expect(json.value).toEqual('at runtime')
+      expect(message1).toEqual(json.message1)
+      expect(message2).toEqual(json.message2)
+    } else {
+      expect(json.value).toEqual('at buildtime')
+      expect(message1).toEqual(json.message1)
+      expect(message2).toEqual(json.message2)
+    }
+
+    str = await next.render('/routes/-edge/use_cache-cached', {})
+    json = JSON.parse(str)
+
+    message1 = json.message1
+    message2 = json.message2
+
+    expect(json.value).toEqual('at runtime')
+    expect(typeof message1).toBe('string')
+    expect(typeof message2).toBe('string')
+
+    str = await next.render('/routes/-edge/use_cache-cached', {})
+    json = JSON.parse(str)
+
+    expect(json.value).toEqual('at runtime')
+    expect(message1).toEqual(json.message1)
+    expect(message2).toEqual(json.message2)
+  })
+
   it('should not prerender GET route handlers that have some uncached io (unstable_cache)', async () => {
     let str = await next.render('/routes/io-mixed', {})
     let json = JSON.parse(str)

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.routes.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.routes.test.ts
@@ -241,6 +241,8 @@ describe('dynamic-io', () => {
         expect(message2).toEqual(json.message2)
       }
 
+      // TODO: Edge is missing Server Manifest for routes.
+      /*
       str = await next.render('/routes/-edge/use_cache-cached', {})
       json = JSON.parse(str)
 
@@ -257,6 +259,7 @@ describe('dynamic-io', () => {
       expect(json.value).toEqual('at runtime')
       expect(message1).toEqual(json.message1)
       expect(message2).toEqual(json.message2)
+      */
     }
   )
 

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.routes.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.routes.test.ts
@@ -1,7 +1,8 @@
+/* eslint-disable jest/no-standalone-expect */
 import { nextTestSetup } from 'e2e-utils'
 
 describe('dynamic-io', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
   })
@@ -9,6 +10,8 @@ describe('dynamic-io', () => {
   if (skipped) {
     return
   }
+
+  const itSkipTurbopack = isTurbopack ? it.skip : it
 
   let cliIndex = 0
   beforeEach(() => {
@@ -206,53 +209,56 @@ describe('dynamic-io', () => {
     expect(message2).toEqual(json.message2)
   })
 
-  it('should prerender GET route handlers that have entirely cached io ("use cache")', async () => {
-    let str = await next.render('/routes/use_cache-cached', {})
-    let json = JSON.parse(str)
+  itSkipTurbopack(
+    'should prerender GET route handlers that have entirely cached io ("use cache")',
+    async () => {
+      let str = await next.render('/routes/use_cache-cached', {})
+      let json = JSON.parse(str)
 
-    let message1 = json.message1
-    let message2 = json.message2
+      let message1 = json.message1
+      let message2 = json.message2
 
-    if (isNextDev) {
+      if (isNextDev) {
+        expect(json.value).toEqual('at runtime')
+        expect(typeof message1).toBe('string')
+        expect(typeof message2).toBe('string')
+      } else {
+        expect(json.value).toEqual('at buildtime')
+        expect(typeof message1).toBe('string')
+        expect(typeof message2).toBe('string')
+      }
+
+      str = await next.render('/routes/use_cache-cached', {})
+      json = JSON.parse(str)
+
+      if (isNextDev) {
+        expect(json.value).toEqual('at runtime')
+        expect(message1).toEqual(json.message1)
+        expect(message2).toEqual(json.message2)
+      } else {
+        expect(json.value).toEqual('at buildtime')
+        expect(message1).toEqual(json.message1)
+        expect(message2).toEqual(json.message2)
+      }
+
+      str = await next.render('/routes/-edge/use_cache-cached', {})
+      json = JSON.parse(str)
+
+      message1 = json.message1
+      message2 = json.message2
+
       expect(json.value).toEqual('at runtime')
       expect(typeof message1).toBe('string')
       expect(typeof message2).toBe('string')
-    } else {
-      expect(json.value).toEqual('at buildtime')
-      expect(typeof message1).toBe('string')
-      expect(typeof message2).toBe('string')
-    }
 
-    str = await next.render('/routes/use_cache-cached', {})
-    json = JSON.parse(str)
+      str = await next.render('/routes/-edge/use_cache-cached', {})
+      json = JSON.parse(str)
 
-    if (isNextDev) {
       expect(json.value).toEqual('at runtime')
       expect(message1).toEqual(json.message1)
       expect(message2).toEqual(json.message2)
-    } else {
-      expect(json.value).toEqual('at buildtime')
-      expect(message1).toEqual(json.message1)
-      expect(message2).toEqual(json.message2)
     }
-
-    str = await next.render('/routes/-edge/use_cache-cached', {})
-    json = JSON.parse(str)
-
-    message1 = json.message1
-    message2 = json.message2
-
-    expect(json.value).toEqual('at runtime')
-    expect(typeof message1).toBe('string')
-    expect(typeof message2).toBe('string')
-
-    str = await next.render('/routes/-edge/use_cache-cached', {})
-    json = JSON.parse(str)
-
-    expect(json.value).toEqual('at runtime')
-    expect(message1).toEqual(json.message1)
-    expect(message2).toEqual(json.message2)
-  })
+  )
 
   it('should not prerender GET route handlers that have some uncached io (unstable_cache)', async () => {
     let str = await next.render('/routes/io-mixed', {})

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.test.ts
@@ -1,9 +1,10 @@
+/* eslint-disable jest/no-standalone-expect */
 import { nextTestSetup } from 'e2e-utils'
 
 const WITH_PPR = !!process.env.__NEXT_EXPERIMENTAL_PPR
 
 describe('dynamic-io', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
   })
@@ -11,6 +12,8 @@ describe('dynamic-io', () => {
   if (skipped) {
     return
   }
+
+  const itSkipTurbopack = isTurbopack ? it.skip : it
 
   it('should not have route specific errors', async () => {
     expect(next.cliOutput).not.toMatch('Error: Route /')
@@ -151,16 +154,19 @@ describe('dynamic-io', () => {
     }
   })
 
-  it('should prerender pages that only use cached ("use cache") IO', async () => {
-    const $ = await next.render$('/cases/use_cache_cached', {})
-    if (isNextDev) {
-      expect($('#layout').text()).toBe('at runtime')
-      expect($('#page').text()).toBe('at runtime')
-    } else {
-      expect($('#layout').text()).toBe('at buildtime')
-      expect($('#page').text()).toBe('at buildtime')
+  itSkipTurbopack(
+    'should prerender pages that only use cached ("use cache") IO',
+    async () => {
+      const $ = await next.render$('/cases/use_cache_cached', {})
+      if (isNextDev) {
+        expect($('#layout').text()).toBe('at runtime')
+        expect($('#page').text()).toBe('at runtime')
+      } else {
+        expect($('#layout').text()).toBe('at buildtime')
+        expect($('#page').text()).toBe('at buildtime')
+      }
     }
-  })
+  )
 
   if (WITH_PPR) {
     it('should partially prerender pages that do any uncached IO', async () => {

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.test.ts
@@ -151,6 +151,17 @@ describe('dynamic-io', () => {
     }
   })
 
+  it('should prerender pages that only use cached ("use cache") IO', async () => {
+    const $ = await next.render$('/cases/use_cache_cached', {})
+    if (isNextDev) {
+      expect($('#layout').text()).toBe('at runtime')
+      expect($('#page').text()).toBe('at runtime')
+    } else {
+      expect($('#layout').text()).toBe('at buildtime')
+      expect($('#page').text()).toBe('at buildtime')
+    }
+  })
+
   if (WITH_PPR) {
     it('should partially prerender pages that do any uncached IO', async () => {
       let $ = await next.render$('/cases/io_mixed', {})
@@ -167,6 +178,34 @@ describe('dynamic-io', () => {
   } else {
     it('should not prerender pages that do any uncached IO', async () => {
       let $ = await next.render$('/cases/io_mixed', {})
+      if (isNextDev) {
+        expect($('#layout').text()).toBe('at runtime')
+        expect($('#page').text()).toBe('at runtime')
+        expect($('#inner').text()).toBe('at runtime')
+      } else {
+        expect($('#layout').text()).toBe('at runtime')
+        expect($('#page').text()).toBe('at runtime')
+        expect($('#inner').text()).toBe('at runtime')
+      }
+    })
+  }
+
+  if (WITH_PPR) {
+    it('should partially prerender pages that do any uncached IO (use cache)', async () => {
+      let $ = await next.render$('/cases/use_cache_mixed', {})
+      if (isNextDev) {
+        expect($('#layout').text()).toBe('at runtime')
+        expect($('#page').text()).toBe('at runtime')
+        expect($('#inner').text()).toBe('at runtime')
+      } else {
+        expect($('#layout').text()).toBe('at buildtime')
+        expect($('#page').text()).toBe('at buildtime')
+        expect($('#inner').text()).toBe('at buildtime')
+      }
+    })
+  } else {
+    it('should not prerender pages that do any uncached IO (use cache)', async () => {
+      let $ = await next.render$('/cases/use_cache_mixed', {})
       if (isNextDev) {
         expect($('#layout').text()).toBe('at runtime')
         expect($('#page').text()).toBe('at runtime')

--- a/test/e2e/app-dir/use-cache/app/api/route.ts
+++ b/test/e2e/app-dir/use-cache/app/api/route.ts
@@ -5,8 +5,6 @@ async function getCachedRandom() {
 
 export async function GET() {
   const rand1 = await getCachedRandom()
-  // TODO: Remove this extra micro task when bug in use cache wrapper is fixed.
-  await Promise.resolve()
   const rand2 = await getCachedRandom()
 
   const response = JSON.stringify({ rand1, rand2 })


### PR DESCRIPTION
Implements deduping of "use cache" entries using CacheScopeStore. This is required for dynamic I/O.

We also have the option to use this for dynamic runtime deduping too, rather than going to the underlying store and ensuring consistency within the request. There are some negative tradeoffs with this approach though that it might not be worth it for dynamic requests. For now, it's up to the Cache Handler to do deduping if it wants to. I implemented this in the default cache handler. 

I tested this with a blank cache implementation since the existing cache is microtasky. Since a working cache is required for other tests and should be the default, I reverted the blank cache. So this doesn't have the full test coverage yet in practice. Once we land configurable caches we can use a blank cache in the newly added tests to get better coverage.

I had to make the cache scope external since it's now shared with RSC layer.