### PR TITLE
Make cacheLife profiles configurable

### DIFF
--- a/packages/next/cache.d.ts
+++ b/packages/next/cache.d.ts
@@ -4,3 +4,5 @@ export {
   revalidatePath,
 } from 'next/dist/server/web/spec-extension/revalidate'
 export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
+export { cacheLife as unstable_cacheLife } from 'next/dist/server/use-cache/cache-life'
+export { cacheTag as unstable_cacheTag } from 'next/dist/server/use-cache/cache-tag'

--- a/packages/next/cache.js
+++ b/packages/next/cache.js
@@ -8,8 +8,9 @@ const cacheExports = {
   unstable_noStore:
     require('next/dist/server/web/spec-extension/unstable-no-store')
       .unstable_noStore,
-  unstable_cacheLife: require('next/dist/server/use-cache/cache-life'),
-  unstable_cacheTag: require('next/dist/server/use-cache/cache-tag'),
+  unstable_cacheLife: require('next/dist/server/use-cache/cache-life')
+    .cacheLife,
+  unstable_cacheTag: require('next/dist/server/use-cache/cache-tag').cacheTag,
 }
 
 // https://nodejs.org/api/esm.html#commonjs-namespaces
@@ -21,3 +22,5 @@ exports.unstable_cache = cacheExports.unstable_cache
 exports.revalidatePath = cacheExports.revalidatePath
 exports.revalidateTag = cacheExports.revalidateTag
 exports.unstable_noStore = cacheExports.unstable_noStore
+exports.unstable_cacheLife = cacheExports.unstable_cacheLife
+exports.unstable_cacheTag = cacheExports.unstable_cacheTag

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1217,6 +1217,7 @@ export async function buildAppStaticPaths({
   segments,
   isrFlushToDisk,
   cacheHandler,
+  cacheLifeProfiles,
   requestHeaders,
   maxMemoryCacheSize,
   fetchCacheKeyPrefix,
@@ -1235,6 +1236,9 @@ export async function buildAppStaticPaths({
   isrFlushToDisk?: boolean
   fetchCacheKeyPrefix?: string
   cacheHandler?: string
+  cacheLifeProfiles?: {
+    [profile: string]: import('../server/use-cache/cache-life').CacheLife
+  }
   maxMemoryCacheSize?: number
   requestHeaders: IncrementalCache['requestHeaders']
   nextConfigOutput: 'standalone' | 'export' | undefined
@@ -1305,6 +1309,7 @@ export async function buildAppStaticPaths({
       fallbackRouteParams: null,
       renderOpts: {
         incrementalCache,
+        cacheLifeProfiles,
         supportsDynamicResponse: true,
         isRevalidate: false,
         experimental: {
@@ -1489,6 +1494,7 @@ export async function isPageStatic({
   maxMemoryCacheSize,
   nextConfigOutput,
   cacheHandler,
+  cacheLifeProfiles,
   pprConfig,
   isAppPPRFallbacksEnabled,
   buildId,
@@ -1510,6 +1516,9 @@ export async function isPageStatic({
   isrFlushToDisk?: boolean
   maxMemoryCacheSize?: number
   cacheHandler?: string
+  cacheLifeProfiles?: {
+    [profile: string]: import('../server/use-cache/cache-life').CacheLife
+  }
   nextConfigOutput: 'standalone' | 'export' | undefined
   pprConfig: ExperimentalPPRConfig | undefined
   isAppPPRFallbacksEnabled: boolean | undefined
@@ -1632,6 +1641,7 @@ export async function isPageStatic({
               isrFlushToDisk,
               maxMemoryCacheSize,
               cacheHandler,
+              cacheLifeProfiles,
               ComponentMod,
               nextConfigOutput,
               isRoutePPREnabled,

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1931,6 +1931,7 @@ export default async function getBaseWebpackConfig(
           isEdgeServer,
           pageExtensions: config.pageExtensions,
           typedRoutes: enableTypedRoutes,
+          cacheLifeConfig: config.experimental.cacheLife,
           originalRewrites,
           originalRedirects,
         }),

--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.test.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.test.ts
@@ -12,6 +12,7 @@ describe('next-types-plugin', () => {
       isEdgeServer: false,
       pageExtensions: ['tsx', 'ts', 'jsx', 'js'],
       typedRoutes: false,
+      cacheLifeConfig: undefined,
       originalRewrites: undefined,
       originalRedirects: undefined,
     })
@@ -40,6 +41,7 @@ describe('next-types-plugin', () => {
       isEdgeServer: false,
       pageExtensions: ['tsx', 'ts', 'jsx', 'js'],
       typedRoutes: false,
+      cacheLifeConfig: undefined,
       originalRewrites: undefined,
       originalRedirects: undefined,
     })
@@ -60,6 +62,7 @@ describe('next-types-plugin', () => {
       isEdgeServer: false,
       pageExtensions: ['tsx', 'ts', 'jsx', 'js'],
       typedRoutes: false,
+      cacheLifeConfig: undefined,
       originalRewrites: undefined,
       originalRedirects: undefined,
     })

--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
@@ -17,6 +17,7 @@ import { getPageFromPath } from '../../../entries'
 import type { PageExtensions } from '../../../page-extensions-type'
 import { devPageFiles } from './shared'
 import { getProxiedPluginState } from '../../../build-context'
+import type { CacheLife } from '../../../../server/use-cache/cache-life'
 
 const PLUGIN_NAME = 'NextTypesPlugin'
 
@@ -34,6 +35,7 @@ interface Options {
   isEdgeServer: boolean
   pageExtensions: PageExtensions
   typedRoutes: boolean
+  cacheLifeConfig: undefined | { [profile: string]: CacheLife }
   originalRewrites: Rewrites | undefined
   originalRedirects: Redirect[] | undefined
 }
@@ -525,6 +527,40 @@ declare module 'next/form' {
 `
 }
 
+function createCustomCacheLifeDefinitions(cacheLife: {
+  [profile: string]: CacheLife
+}) {
+  const profiles = Object.keys(cacheLife)
+  if (!profiles.includes('default')) {
+    profiles.push('default')
+  }
+  for (let i = 0; i < profiles.length; i++) {
+    profiles[i] = JSON.stringify(profiles[i])
+  }
+
+  // TODO: Annotate each option with their expanded values for IDE support.
+  const profilesEnum = profiles.join(' | ')
+
+  // Redefine the cacheLife() accepted arguments.
+  return `// Type definitions for Next.js cacheLife configs
+
+declare module 'next/cache' {
+  export { unstable_cache } from 'next/dist/server/web/spec-extension/unstable-cache'
+  export {
+    revalidateTag,
+    revalidatePath,
+  } from 'next/dist/server/web/spec-extension/revalidate'
+  export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
+
+  import type { CacheLife } from 'next/dist/server/use-cache/cache-life'
+
+  export function unstable_cacheLife(profile: ${profilesEnum} | CacheLife): void
+
+  export { cacheTag as unstable_cacheTag } from 'next/dist/server/use-cache/cache-tag'
+}
+`
+}
+
 const appTypesBasePath = path.join('types', 'app')
 
 export class NextTypesPlugin {
@@ -536,6 +572,7 @@ export class NextTypesPlugin {
   pageExtensions: string[]
   pagesDir: string
   typedRoutes: boolean
+  cacheLifeConfig: undefined | { [profile: string]: CacheLife }
   distDirAbsolutePath: string
 
   constructor(options: Options) {
@@ -547,6 +584,7 @@ export class NextTypesPlugin {
     this.pageExtensions = options.pageExtensions
     this.pagesDir = path.join(this.appDir, '..', 'pages')
     this.typedRoutes = options.typedRoutes
+    this.cacheLifeConfig = options.cacheLifeConfig
     this.distDirAbsolutePath = path.join(this.dir, this.distDir)
     if (this.typedRoutes && !redirectsRewritesTypesProcessed) {
       redirectsRewritesTypesProcessed = true
@@ -777,6 +815,17 @@ export class NextTypesPlugin {
 
             assets[linkAssetPath] = new sources.RawSource(
               createRouteDefinitions()
+            ) as unknown as webpack.sources.RawSource
+          }
+
+          if (this.cacheLifeConfig) {
+            const cacheLifeAssetPath = path.join(
+              assetDirRelative,
+              'types/cache-life.d.ts'
+            )
+
+            assets[cacheLifeAssetPath] = new sources.RawSource(
+              createCustomCacheLifeDefinitions(this.cacheLifeConfig)
             ) as unknown as webpack.sources.RawSource
           }
 

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -341,6 +341,7 @@ async function exportAppImpl(
     largePageDataBytes: nextConfig.experimental.largePageDataBytes,
     serverActions: nextConfig.experimental.serverActions,
     serverComponents: enabledDirectories.app,
+    cacheLifeProfiles: nextConfig.experimental.cacheLife,
     nextFontManifest: require(
       join(distDir, 'server', `${NEXT_FONT_MANIFEST}.json`)
     ),

--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -40,6 +40,11 @@ export async function exportAppRoute(
   page: string,
   module: AppRouteRouteModule,
   incrementalCache: IncrementalCache | undefined,
+  cacheLifeProfiles:
+    | undefined
+    | {
+        [profile: string]: import('../../server/use-cache/cache-life').CacheLife
+      },
   htmlFilepath: string,
   fileWriter: FileWriter,
   experimental: Required<Pick<ExperimentalConfig, 'after' | 'dynamicIO'>>,
@@ -79,6 +84,7 @@ export async function exportAppRoute(
       waitUntil: afterRunner.context.waitUntil,
       onClose: afterRunner.context.onClose,
       onAfterTaskError: afterRunner.context.onTaskError,
+      cacheLifeProfiles,
       buildId,
     },
   }

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -251,6 +251,7 @@ async function exportPageImpl(
         page,
         components.routeModule as AppRouteRouteModule,
         input.renderOpts.incrementalCache,
+        input.renderOpts.cacheLifeProfiles,
         htmlFilepath,
         fileWriter,
         input.renderOpts.experimental,

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -147,6 +147,9 @@ export interface RenderOptsPartial {
   nextFontManifest?: DeepReadonly<NextFontManifest>
   isBot?: boolean
   incrementalCache?: import('../lib/incremental-cache').IncrementalCache
+  cacheLifeProfiles?: {
+    [profile: string]: import('../use-cache/cache-life').CacheLife
+  }
   setAppIsrStatus?: (key: string, value: boolean | null) => void
   isRevalidate?: boolean
   nextExport?: boolean

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -6,6 +6,7 @@ import type { FallbackRouteParams } from '../request/fallback-params'
 import type { DeepReadonly } from '../../shared/lib/deep-readonly'
 import type { AppSegmentConfig } from '../../build/segment-config/app/app-segment-config'
 import type { AfterContext } from '../after/after-context'
+import type { CacheLife } from '../use-cache/cache-life'
 
 // Share the instance module in the next-shared layer
 import { workAsyncStorage } from './work-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
@@ -31,6 +32,8 @@ export interface WorkStore {
   readonly fallbackRouteParams: FallbackRouteParams | null
 
   readonly incrementalCache?: IncrementalCache
+  readonly cacheLifeProfiles?: { [profile: string]: CacheLife }
+
   readonly isOnDemandRevalidate?: boolean
   readonly isPrerendering?: boolean
   readonly isRevalidate?: boolean

--- a/packages/next/src/server/async-storage/with-work-store.ts
+++ b/packages/next/src/server/async-storage/with-work-store.ts
@@ -7,6 +7,7 @@ import type { FetchMetric } from '../base-http'
 import type { RequestLifecycleOpts } from '../base-server'
 import type { FallbackRouteParams } from '../request/fallback-params'
 import type { AppSegmentConfig } from '../../build/segment-config/app/app-segment-config'
+import type { CacheLife } from '../use-cache/cache-life'
 
 import { AfterContext } from '../after/after-context'
 
@@ -26,6 +27,7 @@ export type WorkStoreContext = {
   requestEndedState?: { ended?: boolean }
   isPrefetchRequest?: boolean
   renderOpts: {
+    cacheLifeProfiles?: { [profile: string]: CacheLife }
     incrementalCache?: IncrementalCache
     isOnDemandRevalidate?: boolean
     fetchCache?: AppSegmentConfig['fetchCache']
@@ -108,6 +110,7 @@ export const withWorkStore: WithStore<WorkStore, WorkStoreContext> = <Result>(
       // we fallback to a global incremental cache for edge-runtime locally
       // so that it can access the fs cache without mocks
       renderOpts.incrementalCache || (globalThis as any).__incrementalCache,
+    cacheLifeProfiles: renderOpts.cacheLifeProfiles,
     isRevalidate: renderOpts.isRevalidate,
     isPrerendering: renderOpts.nextExport,
     fetchCache: renderOpts.fetchCache,

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -581,6 +581,7 @@ export default abstract class Server<
       domainLocales: this.nextConfig.i18n?.domains,
       distDir: this.distDir,
       serverComponents: this.enabledDirectories.app,
+      cacheLifeProfiles: this.nextConfig.experimental.cacheLife,
       enableTainting: this.nextConfig.experimental.taint,
       crossOrigin: this.nextConfig.crossOrigin
         ? this.nextConfig.crossOrigin
@@ -2513,6 +2514,7 @@ export default abstract class Server<
               },
               supportsDynamicResponse,
               incrementalCache,
+              cacheLifeProfiles: this.nextConfig.experimental?.cacheLife,
               isRevalidate: isSSG,
               waitUntil: this.getWaitUntil(),
               onClose: res.onClose.bind(res),

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -270,6 +270,15 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
             static: z.number().optional(),
           })
           .optional(),
+        cacheLife: z
+          .record(
+            z.object({
+              stale: z.number().optional(),
+              revalidate: z.number().optional(),
+              expire: z.number().optional(),
+            })
+          )
+          .optional(),
         clientRouterFilter: z.boolean().optional(),
         clientRouterFilterRedirects: z.boolean().optional(),
         clientRouterFilterAllowedRate: z.number().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -258,6 +258,19 @@ export interface ExperimentalConfig {
     dynamic?: number
     static?: number
   }
+  cacheLife?: {
+    [profile: string]: {
+      // How long the client can cache a value without checking with the server.
+      stale?: number
+      // How frequently you want the cache to refresh on the server.
+      // Stale values may be served while revalidating.
+      revalidate?: number
+      // In the worst case scenario, where you haven't had traffic in a while,
+      // how stale can a value be until you prefer deopting to dynamic.
+      // Must be longer than revalidate.
+      expire?: number
+    }
+  }
   // decimal for percent for possible false positives
   // e.g. 0.01 for 10% potential false matches lower
   // percent increases size of the filter
@@ -1014,6 +1027,13 @@ export const defaultConfig: NextConfig = {
   modularizeImports: undefined,
   outputFileTracingRoot: process.env.NEXT_PRIVATE_OUTPUT_TRACE_ROOT || '',
   experimental: {
+    cacheLife: {
+      default: {
+        stale: undefined, // defaults to staleTimes.static
+        revalidate: 900,
+        expire: Infinity,
+      },
+    },
     multiZoneDraftMode: false,
     appNavFailHandling: Boolean(process.env.NEXT_PRIVATE_FLYING_SHUTTLE),
     flyingShuttle: Boolean(process.env.NEXT_PRIVATE_FLYING_SHUTTLE)

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -13,6 +13,7 @@ import type { SizeLimit } from '../types'
 import type { ExpireTime } from './lib/revalidate'
 import type { SupportedTestRunners } from '../cli/next-test'
 import type { ExperimentalPPRConfig } from './lib/experimental/ppr'
+import { INFINITE_CACHE } from '../lib/constants'
 
 export type NextConfigComplete = Required<NextConfig> & {
   images: Required<ImageConfigComplete>
@@ -1031,7 +1032,7 @@ export const defaultConfig: NextConfig = {
       default: {
         stale: undefined, // defaults to staleTimes.static
         revalidate: 900,
-        expire: Infinity,
+        expire: INFINITE_CACHE,
       },
     },
     multiZoneDraftMode: false,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -807,6 +807,35 @@ function assignDefaults(
     }
   }
 
+  if (result.experimental?.cacheLife) {
+    const defaultDefault = defaultConfig.experimental?.cacheLife?.['default']
+    if (
+      !defaultDefault ||
+      defaultDefault.revalidate === undefined ||
+      defaultDefault.expire === undefined ||
+      !defaultConfig.experimental?.staleTimes?.static
+    ) {
+      throw new Error('No default cacheLife profile.')
+    }
+    const defaultCacheLifeProfile = result.experimental.cacheLife['default']
+    if (!defaultCacheLifeProfile) {
+      result.experimental.cacheLife['default'] = defaultDefault
+    } else {
+      if (defaultCacheLifeProfile.stale === undefined) {
+        const staticStaleTime = result.experimental.staleTimes?.static
+        defaultCacheLifeProfile.stale =
+          staticStaleTime ?? defaultConfig.experimental?.staleTimes?.static
+      }
+      if (defaultCacheLifeProfile.revalidate === undefined) {
+        defaultCacheLifeProfile.revalidate = defaultDefault.revalidate
+      }
+      if (defaultCacheLifeProfile.expire === undefined) {
+        defaultCacheLifeProfile.expire =
+          result.expireTime ?? defaultDefault.expire
+      }
+    }
+  }
+
   const userProvidedModularizeImports = result.modularizeImports
   // Unfortunately these packages end up re-exporting 10600 modules, for example: https://unpkg.com/browse/@mui/icons-material@5.11.16/esm/index.js.
   // Leveraging modularizeImports tremendously reduces compile times for these.

--- a/packages/next/src/server/dev/static-paths-worker.ts
+++ b/packages/next/src/server/dev/static-paths-worker.ts
@@ -46,6 +46,7 @@ export async function loadStaticPaths({
   maxMemoryCacheSize,
   requestHeaders,
   cacheHandler,
+  cacheLifeProfiles,
   nextConfigOutput,
   isAppPPRFallbacksEnabled,
   buildId,
@@ -64,6 +65,9 @@ export async function loadStaticPaths({
   maxMemoryCacheSize?: number
   requestHeaders: IncrementalCache['requestHeaders']
   cacheHandler?: string
+  cacheLifeProfiles?: {
+    [profile: string]: import('../../server/use-cache/cache-life').CacheLife
+  }
   nextConfigOutput: 'standalone' | 'export' | undefined
   isAppPPRFallbacksEnabled: boolean | undefined
   buildId: string
@@ -97,6 +101,7 @@ export async function loadStaticPaths({
       distDir,
       requestHeaders,
       cacheHandler,
+      cacheLifeProfiles,
       isrFlushToDisk,
       fetchCacheKeyPrefix,
       maxMemoryCacheSize,

--- a/packages/next/src/server/use-cache/cache-life.ts
+++ b/packages/next/src/server/use-cache/cache-life.ts
@@ -19,7 +19,7 @@ export type CacheLife = {
 // The default revalidates relatively frequently but doesn't expire to ensure it's always
 // able to serve fast results but by default doesn't hang.
 
-type CacheLifeProfiles = 'default' // TODO: Generate from the config
+type CacheLifeProfiles = 'default' // This gets overridden by the next-types-plugin
 
 function validateCacheLife(profile: CacheLife) {
   if (profile.stale !== undefined) {

--- a/packages/next/src/server/use-cache/cache-life.ts
+++ b/packages/next/src/server/use-cache/cache-life.ts
@@ -1,3 +1,4 @@
+import { workAsyncStorage } from '../app-render/work-async-storage.external'
 import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
 
 export type CacheLife = {
@@ -15,18 +16,8 @@ export type CacheLife = {
 // Cache-Control: max-age=[stale],s-max-age=[revalidate],stale-while-revalidate=[expire-revalidate],stale-if-error=[expire-revalidate]
 // Except that stale-while-revalidate/stale-if-error only applies to shared caches - not private caches.
 
-const cacheLifeProfileMap: Map<string, CacheLife> = new Map()
-
 // The default revalidates relatively frequently but doesn't expire to ensure it's always
 // able to serve fast results but by default doesn't hang.
-
-export const defaultCacheLife = {
-  stale: Number(process.env.__NEXT_CLIENT_ROUTER_STATIC_STALETIME),
-  revalidate: 15 * 60, // Note: This is a new take on the defaults.
-  expire: Infinity,
-}
-
-cacheLifeProfileMap.set('default', defaultCacheLife)
 
 type CacheLifeProfiles = 'default' // TODO: Generate from the config
 
@@ -99,9 +90,22 @@ export function cacheLife(profile: CacheLifeProfiles | CacheLife): void {
   }
 
   if (typeof profile === 'string') {
-    const configuredProfile = cacheLifeProfileMap.get(profile)
+    const workStore = workAsyncStorage.getStore()
+    if (!workStore) {
+      throw new Error(
+        'cacheLife() can only be called during App Router rendering at the moment.'
+      )
+    }
+    if (!workStore.cacheLifeProfiles) {
+      throw new Error(
+        'cacheLifeProfiles should always be provided. This is a bug in Next.js.'
+      )
+    }
+
+    // TODO: This should be globally available and not require an AsyncLocalStorage.
+    const configuredProfile = workStore.cacheLifeProfiles[profile]
     if (configuredProfile === undefined) {
-      if (cacheLifeProfileMap.has(profile.trim())) {
+      if (workStore.cacheLifeProfiles[profile.trim()]) {
         throw new Error(
           `Unknown cacheLife profile "${profile}" is not configured in next.config.js\n` +
             `Did you mean "${profile.trim()}" without the spaces?`

--- a/packages/next/src/server/use-cache/cache-life.ts
+++ b/packages/next/src/server/use-cache/cache-life.ts
@@ -19,7 +19,7 @@ export type CacheLife = {
 // The default revalidates relatively frequently but doesn't expire to ensure it's always
 // able to serve fast results but by default doesn't hang.
 
-type CacheLifeProfiles = 'default' // This gets overridden by the next-types-plugin
+type CacheLifeProfiles = string // This gets overridden by the next-types-plugin
 
 function validateCacheLife(profile: CacheLife) {
   if (profile.stale !== undefined) {

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -59,8 +59,9 @@ const defaultCacheStorage: Map<string, Promise<CacheEntry>> = new Map()
 cacheHandlerMap.set('default', {
   async get(cacheKey: string): Promise<undefined | CacheEntry> {
     // TODO: Implement proper caching.
-    const entry = await defaultCacheStorage.get(cacheKey)
-    if (entry !== undefined) {
+    const promiseOfEntry = defaultCacheStorage.get(cacheKey)
+    if (promiseOfEntry !== undefined) {
+      const entry = await promiseOfEntry
       if (
         performance.timeOrigin + performance.now() >
         entry.timestamp + entry.revalidate * 1000

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -180,9 +180,9 @@ function generateCacheEntryWithCacheContext(
   const defaultCacheLife = workStore.cacheLifeProfiles['default']
   if (
     !defaultCacheLife ||
-    defaultCacheLife.revalidate === undefined ||
-    defaultCacheLife.expire === undefined ||
-    defaultCacheLife.stale === undefined
+    defaultCacheLife.revalidate == null ||
+    defaultCacheLife.expire == null ||
+    defaultCacheLife.stale == null
   ) {
     throw new Error(
       'A default cacheLife profile must always be provided. This is a bug in Next.js.'

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -29,7 +29,6 @@ import {
   getClientReferenceManifestSingleton,
   getServerModuleMap,
 } from '../app-render/encryption-utils'
-import { defaultCacheLife } from './cache-life'
 import type { CacheScopeStore } from '../async-storage/cache-scope.external'
 
 const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'
@@ -76,7 +75,7 @@ cacheHandlerMap.set('default', {
         value: returnStream,
         timestamp: entry.timestamp,
         revalidate: entry.revalidate,
-        expire: entry.revalidate,
+        expire: entry.expire,
         stale: entry.stale,
         tags: entry.tags,
       }
@@ -172,6 +171,22 @@ function generateCacheEntryWithCacheContext(
   encodedArguments: FormData | string,
   fn: any
 ) {
+  if (!workStore.cacheLifeProfiles) {
+    throw new Error(
+      'cacheLifeProfiles should always be provided. This is a bug in Next.js.'
+    )
+  }
+  const defaultCacheLife = workStore.cacheLifeProfiles['default']
+  if (
+    !defaultCacheLife ||
+    defaultCacheLife.revalidate === undefined ||
+    defaultCacheLife.expire === undefined ||
+    defaultCacheLife.stale === undefined
+  ) {
+    throw new Error(
+      'A default cacheLife profile must always be provided. This is a bug in Next.js.'
+    )
+  }
   // Initialize the Store for this Cache entry.
   const cacheStore: UseCacheStore = {
     type: 'cache',
@@ -434,7 +449,7 @@ async function loadCacheEntry(
   } else {
     propagateCacheLifeAndTags(workUnitStore, entry)
 
-    if (currentTime > entry.timestamp + entry.revalidate) {
+    if (currentTime > entry.timestamp + entry.revalidate * 1000) {
       // If this is stale, and we're not in a prerender (i.e. this is dynamic render),
       // then we should warm up the cache with a fresh revalidated entry.
       const ignoredStream = await generateCacheEntry(
@@ -530,9 +545,10 @@ export function cache(kind: string, id: string, fn: any) {
 
       let stream: ReadableStream
 
+      const disable = true // TODO: Reenable the cache scope
       const cacheScope: undefined | CacheScopeStore =
         cacheScopeAsyncLocalStorage.getStore()
-      if (cacheScope) {
+      if (cacheScope && !disable) {
         // String cache key for easier hash mapping.
         // Note that we're not worried about collisions between string and base64
         // since the string form will always be JSON which doesn't overlap with base64.

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -255,6 +255,8 @@ export async function adapter(
                 page: '/', // Fake Work
                 fallbackRouteParams: null,
                 renderOpts: {
+                  cacheLifeProfiles:
+                    params.request.nextConfig?.experimental?.cacheLife,
                   experimental: {
                     after: isAfterEnabled,
                     isRoutePPREnabled: false,

--- a/packages/next/src/server/web/types.ts
+++ b/packages/next/src/server/web/types.ts
@@ -15,7 +15,7 @@ export interface RequestData {
     basePath?: string
     i18n?: I18NConfig | null
     trailingSlash?: boolean
-    experimental?: Pick<ExperimentalConfig, 'after'>
+    experimental?: Pick<ExperimentalConfig, 'after' | 'cacheLife'>
   }
   page?: {
     name?: string

--- a/test/e2e/app-dir/use-cache-route-handler-only/app/route.ts
+++ b/test/e2e/app-dir/use-cache-route-handler-only/app/route.ts
@@ -5,8 +5,6 @@ async function getCachedRandom() {
 
 export async function GET() {
   const rand1 = await getCachedRandom()
-  // TODO: Remove this extra micro task when bug in use cache wrapper is fixed.
-  await Promise.resolve()
   const rand2 = await getCachedRandom()
 
   const response = JSON.stringify({ rand1, rand2 })

--- a/test/e2e/app-dir/use-cache-route-handler-only/app/route.ts
+++ b/test/e2e/app-dir/use-cache-route-handler-only/app/route.ts
@@ -5,6 +5,8 @@ async function getCachedRandom() {
 
 export async function GET() {
   const rand1 = await getCachedRandom()
+  // TODO: Remove this extra micro task when bug in use cache wrapper is fixed.
+  await Promise.resolve()
   const rand2 = await getCachedRandom()
 
   const response = JSON.stringify({ rand1, rand2 })

--- a/test/e2e/app-dir/use-cache/app/api/route.ts
+++ b/test/e2e/app-dir/use-cache/app/api/route.ts
@@ -5,6 +5,8 @@ async function getCachedRandom() {
 
 export async function GET() {
   const rand1 = await getCachedRandom()
+  // TODO: Remove this extra micro task when bug in use cache wrapper is fixed.
+  await Promise.resolve()
   const rand2 = await getCachedRandom()
 
   const response = JSON.stringify({ rand1, rand2 })

--- a/test/e2e/app-dir/use-cache/app/cache-life/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/cache-life/page.tsx
@@ -1,0 +1,12 @@
+import { unstable_cacheLife as cacheLife } from 'next/cache'
+
+async function getCachedRandom() {
+  'use cache'
+  cacheLife('frequent' as any) // TODO: Generate types
+  return Math.random()
+}
+
+export default async function Page() {
+  const x = await getCachedRandom()
+  return <p id="x">{x}</p>
+}

--- a/test/e2e/app-dir/use-cache/app/cache-life/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/cache-life/page.tsx
@@ -2,7 +2,7 @@ import { unstable_cacheLife as cacheLife } from 'next/cache'
 
 async function getCachedRandom() {
   'use cache'
-  cacheLife('frequent' as any) // TODO: Generate types
+  cacheLife('frequent')
   return Math.random()
 }
 

--- a/test/e2e/app-dir/use-cache/app/cache-tag/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/cache-tag/page.tsx
@@ -1,0 +1,18 @@
+import { unstable_cacheTag as cacheTag } from 'next/cache'
+
+async function getCachedWithTag(tag) {
+  'use cache'
+  cacheTag(tag, 'c')
+  return Math.random()
+}
+
+export default async function Page() {
+  const x = await getCachedWithTag('a')
+  const y = await getCachedWithTag('b')
+  return (
+    <p>
+      {x}
+      {y}
+    </p>
+  )
+}

--- a/test/e2e/app-dir/use-cache/next.config.js
+++ b/test/e2e/app-dir/use-cache/next.config.js
@@ -4,6 +4,11 @@
 const nextConfig = {
   experimental: {
     dynamicIO: true,
+    cacheLife: {
+      frequent: {
+        revalidate: 100,
+      },
+    },
   },
 }
 

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -5,9 +5,10 @@ const GENERIC_RSC_ERROR =
   'An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.'
 
 describe('use-cache', () => {
-  const { next, isNextDev, isNextDeploy, isTurbopack } = nextTestSetup({
-    files: __dirname,
-  })
+  const { next, isNextDev, isNextDeploy, isNextStart, isTurbopack } =
+    nextTestSetup({
+      files: __dirname,
+    })
 
   const itSkipTurbopack = isTurbopack ? it.skip : it
 
@@ -81,4 +82,24 @@ describe('use-cache', () => {
 
     expect(rand1).toEqual(rand2)
   })
+
+  if (isNextStart) {
+    it('should match the expected revalidate config on the prerender manifest', async () => {
+      const prerenderManifest = JSON.parse(
+        await next.readFile('.next/prerender-manifest.json')
+      )
+
+      expect(prerenderManifest.version).toBe(4)
+      expect(
+        prerenderManifest.routes['/cache-life'].initialRevalidateSeconds
+      ).toBe(100)
+    })
+
+    it('should propagate unstable_cache tags correctly', async () => {
+      const meta = JSON.parse(
+        await next.readFile('.next/server/app/cache-tag.meta')
+      )
+      expect(meta.headers['x-next-cache-tags']).toContain('a,c,b')
+    })
+  }
 })

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -84,22 +84,28 @@ describe('use-cache', () => {
   })
 
   if (isNextStart) {
-    it('should match the expected revalidate config on the prerender manifest', async () => {
-      const prerenderManifest = JSON.parse(
-        await next.readFile('.next/prerender-manifest.json')
-      )
+    itSkipTurbopack(
+      'should match the expected revalidate config on the prerender manifest',
+      async () => {
+        const prerenderManifest = JSON.parse(
+          await next.readFile('.next/prerender-manifest.json')
+        )
 
-      expect(prerenderManifest.version).toBe(4)
-      expect(
-        prerenderManifest.routes['/cache-life'].initialRevalidateSeconds
-      ).toBe(100)
-    })
+        expect(prerenderManifest.version).toBe(4)
+        expect(
+          prerenderManifest.routes['/cache-life'].initialRevalidateSeconds
+        ).toBe(100)
+      }
+    )
 
-    it('should propagate unstable_cache tags correctly', async () => {
-      const meta = JSON.parse(
-        await next.readFile('.next/server/app/cache-tag.meta')
-      )
-      expect(meta.headers['x-next-cache-tags']).toContain('a,c,b')
-    })
+    itSkipTurbopack(
+      'should propagate unstable_cache tags correctly',
+      async () => {
+        const meta = JSON.parse(
+          await next.readFile('.next/server/app/cache-tag.meta')
+        )
+        expect(meta.headers['x-next-cache-tags']).toContain('a,c,b')
+      }
+    )
   }
 })


### PR DESCRIPTION
This should really be a global config but we don't have an easy way to get the config from a module. Might need a loader. So this just plumbs it through a bunch of contexts.

I'm also generate the enum type based on the config.