### PR TITLE
fix(turbopack): Use module fragment for async module analysis

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -104,7 +104,7 @@ impl EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     pub async fn is_async_module(self: Vc<Self>) -> Result<Vc<bool>> {
         let this = self.await?;
-        let result = this.full_module.analyze();
+        let result = analyze(this.full_module, this.part);
 
         if let Some(async_module) = *result.await?.async_module.await? {
             Ok(async_module.is_self_async(self.references()))


### PR DESCRIPTION
### What?

Make `EcmascriptModulePartAsset::is_async_module`  specify `ModulePart` correctly while analyzing

### Why?

The previous code makes all dependencies of a module to be loaded.

### How?

