### PR TITLE
[Turbopack] Perf improvements new backend

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -201,12 +201,10 @@ impl TurboTasksBackendInner {
         unsafe { ExecuteContext::new_with_tx(self, tx, turbo_tasks) }
     }
 
-    #[inline]
     fn suspending_requested(&self) -> bool {
         (self.in_progress_operations.load(Ordering::Relaxed) & SNAPSHOT_REQUESTED_BIT) != 0
     }
 
-    #[inline]
     fn operation_suspend_point(&self, suspend: impl FnOnce() -> AnyOperation) {
         #[cold]
         fn operation_suspend_point_cold(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -614,18 +614,18 @@ impl AggregationUpdateQueue {
                 }
             }
             if is_aggregating_node(get_aggregation_number(&task)) {
-                // TODO if it has an `AggregateRoot` we can skip visiting the nested nodes since
+                // if it has an `AggregateRoot` we can skip visiting the nested nodes since
                 // this would already be scheduled by the `AggregateRoot`
                 if !task.has_key(&CachedDataItemKey::AggregateRoot {}) {
                     task.insert(CachedDataItem::AggregateRoot {
                         value: RootState::new(ActiveType::CachedActiveUntilClean, task_id),
                     });
-                }
-                let dirty_containers: Vec<_> = get_many!(task, AggregatedDirtyContainer { task } count if count.get(session_id) > 0 => *task);
-                if !dirty_containers.is_empty() {
-                    self.push(AggregationUpdateJob::FindAndScheduleDirty {
-                        task_ids: dirty_containers,
-                    });
+                    let dirty_containers: Vec<_> = get_many!(task, AggregatedDirtyContainer { task } count if count.get(session_id) > 0 => *task);
+                    if !dirty_containers.is_empty() {
+                        self.push(AggregationUpdateJob::FindAndScheduleDirty {
+                            task_ids: dirty_containers,
+                        });
+                    }
                 }
             }
         }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -13,7 +13,7 @@ use crate::{
             invalidate::make_task_dirty,
             AggregatedDataUpdate, ExecuteContext, Operation,
         },
-        storage::update_count,
+        storage::{update, update_count},
         TaskDataCategory,
     },
     data::{CachedDataItemKey, CellRef, CollectibleRef, CollectiblesRef},
@@ -82,6 +82,11 @@ impl Operation for CleanupOldEdgesOperation {
                                 for &child_id in children.iter() {
                                     task.remove(&CachedDataItemKey::Child { task: child_id });
                                 }
+                                update!(task, ChildrenCount, |count: Option<u32>| {
+                                    // If this underflows, we messed up counting somewhere
+                                    let count = count.unwrap_or_default() - children.len() as u32;
+                                    (count != 0).then_some(count)
+                                });
                                 if is_aggregating_node(get_aggregation_number(&task)) {
                                     queue.push(AggregationUpdateJob::InnerLostFollowers {
                                         upper_ids: vec![task_id],

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -82,9 +82,10 @@ impl Operation for CleanupOldEdgesOperation {
                                 for &child_id in children.iter() {
                                     task.remove(&CachedDataItemKey::Child { task: child_id });
                                 }
+                                let remove_children_count = u32::try_from(children.len()).unwrap();
                                 update!(task, ChildrenCount, |count: Option<u32>| {
                                     // If this underflows, we messed up counting somewhere
-                                    let count = count.unwrap_or_default() - children.len() as u32;
+                                    let count = count.unwrap_or_default() - remove_children_count;
                                     (count != 0).then_some(count)
                                 });
                                 if is_aggregating_node(get_aggregation_number(&task)) {

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -313,6 +313,9 @@ pub enum CachedDataItem {
         task: TaskId,
         value: (),
     },
+    ChildrenCount {
+        value: u32,
+    },
 
     // Cells
     CellData {
@@ -438,6 +441,7 @@ impl CachedDataItem {
             }
             CachedDataItem::Dirty { .. } => true,
             CachedDataItem::Child { task, .. } => !task.is_transient(),
+            CachedDataItem::ChildrenCount { .. } => true,
             CachedDataItem::CellData { .. } => true,
             CachedDataItem::CellTypeMaxIndex { .. } => true,
             CachedDataItem::OutputDependency { target, .. } => !target.is_transient(),
@@ -502,6 +506,7 @@ impl CachedDataItemKey {
             }
             CachedDataItemKey::Dirty { .. } => true,
             CachedDataItemKey::Child { task, .. } => !task.is_transient(),
+            CachedDataItemKey::ChildrenCount {} => true,
             CachedDataItemKey::CellData { .. } => true,
             CachedDataItemKey::CellTypeMaxIndex { .. } => true,
             CachedDataItemKey::OutputDependency { target, .. } => !target.is_transient(),
@@ -534,6 +539,7 @@ impl CachedDataItemKey {
         match self {
             CachedDataItemKey::Collectible { .. }
             | CachedDataItemKey::Child { .. }
+            | CachedDataItemKey::ChildrenCount { .. }
             | CachedDataItemKey::CellData { .. }
             | CachedDataItemKey::CellTypeMaxIndex { .. }
             | CachedDataItemKey::OutputDependency { .. }
@@ -678,6 +684,7 @@ impl CachedDataItemValue {
 #[derive(Debug)]
 pub struct CachedDataUpdate {
     pub task: TaskId,
+    // TODO generate CachedDataItemUpdate to avoid repeating the variant field 3 times
     pub key: CachedDataItemKey,
     pub value: Option<CachedDataItemValue>,
     pub old_value: Option<CachedDataItemValue>,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -70,7 +70,6 @@ pub enum ModuleResolveResultItem {
     Error(Vc<RcStr>),
     Empty,
     Custom(u8),
-    Unresolveable,
 }
 
 #[turbo_tasks::value(shared)]
@@ -398,7 +397,6 @@ pub enum ResolveResultItem {
     Error(Vc<RcStr>),
     Empty,
     Custom(u8),
-    Unresolveable,
 }
 
 /// Represents the key for a request that leads to a certain results during
@@ -490,9 +488,6 @@ impl ValueToString for ResolveResult {
                 }
                 ResolveResultItem::Custom(_) => {
                     result.push_str("custom");
-                }
-                ResolveResultItem::Unresolveable => {
-                    result.push_str("unresolveable");
                 }
             }
             result.push('\n');
@@ -683,9 +678,6 @@ impl ResolveResult {
                                 ResolveResultItem::Error(e) => ModuleResolveResultItem::Error(e),
                                 ResolveResultItem::Custom(u8) => {
                                     ModuleResolveResultItem::Custom(u8)
-                                }
-                                ResolveResultItem::Unresolveable => {
-                                    ModuleResolveResultItem::Unresolveable
                                 }
                             },
                         ))

--- a/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
@@ -135,7 +135,7 @@ impl AsyncModule {
                         }
                     }
                     ReferencedAsset::External(..) => None,
-                    ReferencedAsset::None => None,
+                    ReferencedAsset::None | ReferencedAsset::Unresolveable => None,
                 })
             })
             .try_flat_join()

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -205,7 +205,7 @@ impl CodeGenerateable for UrlAssetReference {
                             request
                         )
                     }
-                    ReferencedAsset::None => {}
+                    ReferencedAsset::None | ReferencedAsset::Unresolveable => {}
                 }
             }
             UrlRewriteBehavior::Full => {
@@ -293,7 +293,7 @@ impl CodeGenerateable for UrlAssetReference {
                             request
                         )
                     }
-                    ReferencedAsset::None => {}
+                    ReferencedAsset::None | ReferencedAsset::Unresolveable => {}
                 }
             }
             UrlRewriteBehavior::None => {


### PR DESCRIPTION
### What?

A bunch of small performance optimizations

* split operation_suspend_point in inlined and cold part
* keep children count instead of iterating children every time
* avoid bubbling find and schedule into already scheduling parts of the graph
* reduce number of turbo-tasks function calls in EsmAssertReference::code_generation
* avoid creating empty maps

Sadly no measurable effect...