### PR TITLE
[Turbopack] lmdb Backing Storage performance improvments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7904,9 +7910,9 @@ checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8467,6 +8473,7 @@ name = "turbo-tasks-backend"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
  "auto-hash-map",
  "byteorder",
@@ -8484,6 +8491,7 @@ dependencies = [
  "serde",
  "serde_path_to_error",
  "smallvec",
+ "thread_local",
  "tokio",
  "tokio-scoped",
  "tracing",

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -18,6 +18,7 @@ verify_serialization = []
 
 [dependencies]
 anyhow = { workspace = true }
+arc-swap = { version = "1.7.1" }
 async-trait = { workspace = true }
 auto-hash-map = { workspace = true }
 byteorder = "1.5.0"
@@ -38,6 +39,7 @@ smallvec = { workspace = true }
 tokio = { workspace = true }
 tokio-scoped = "0.2.0"
 tracing = { workspace = true }
+thread_local = { version = "1.1.8" }
 turbo-prehash = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-hash = { workspace = true }


### PR DESCRIPTION
### What?

Creating transactions is pretty expensive in LMDB so we use a thread local storage to cache them. This cache is reset after we store a new snapshot, to allow LMDB to free unused storage.

Also adds an optimization that skips querying the DB when we know it's empty.
