### PR TITLE
Hide stack for bad input by default

### DIFF
--- a/packages/next-codemod/bin/next-codemod.ts
+++ b/packages/next-codemod/bin/next-codemod.ts
@@ -12,6 +12,7 @@
 import { Command } from 'commander'
 import { runUpgrade } from './upgrade'
 import { runTransform } from './transform'
+import { BadInput } from './shared'
 
 const packageJson = require('../package.json')
 const program = new Command(packageJson.name)
@@ -68,6 +69,17 @@ program
   )
   .usage('[revision] [options]')
   .option('--verbose', 'Verbose output', false)
-  .action(runUpgrade)
+  .action(async (revision, options) => {
+    try {
+      await runUpgrade(revision, options)
+    } catch (error) {
+      if (!options.verbose && error instanceof BadInput) {
+        console.error(error.message)
+      } else {
+        console.error(error)
+      }
+      process.exit(1)
+    }
+  })
 
 program.parse(process.argv)

--- a/packages/next-codemod/bin/shared.ts
+++ b/packages/next-codemod/bin/shared.ts
@@ -1,0 +1,1 @@
+export class BadInput extends Error {}

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -8,6 +8,7 @@ import pc from 'picocolors'
 import { getPkgManager, installPackages } from '../lib/handle-package'
 import { runTransform } from './transform'
 import { onCancel, TRANSFORMER_INQUIRER_CHOICES } from '../lib/utils'
+import { BadInput } from './shared'
 
 type PackageManager = 'pnpm' | 'npm' | 'yarn' | 'bun'
 
@@ -57,7 +58,7 @@ export async function runUpgrade(
     'version' in targetNextPackageJson &&
     'peerDependencies' in targetNextPackageJson
   if (!validRevision) {
-    throw new Error(
+    throw new BadInput(
       `Invalid revision provided: "${revision}". Please provide a valid Next.js version or dist-tag (e.g. "latest", "canary", "rc", or "15.0.0").\nCheck available versions at https://www.npmjs.com/package/next?activeTab=versions.`
     )
   }
@@ -228,7 +229,7 @@ function getInstalledNextVersion(): string {
       })
     ).version
   } catch (error) {
-    throw new Error(
+    throw new BadInput(
       `Failed to get the installed Next.js version at "${process.cwd()}".\nIf you're using a monorepo, please run this command from the Next.js app directory.`,
       {
         cause: error,
@@ -245,7 +246,7 @@ function getInstalledReactVersion(): string {
       })
     ).version
   } catch (error) {
-    throw new Error(
+    throw new BadInput(
       `Failed to detect the installed React version in "${process.cwd()}".\nIf you're working in a monorepo, please run this command from the Next.js app directory.`,
       {
         cause: error,


### PR DESCRIPTION
For user input errors we likely don't need a stack. We hide it by default now unless `--verbose` is specified

## test plan

Stack only shown for verbose
```bash
$ node packages/next-codemod/bin/next-codemod.js upgrade asd
Invalid revision provided: "asd". Please provide a valid Next.js version or dist-tag (e.g. "latest", "canary", "rc", or "15.0.0").
Check available versions at https://www.npmjs.com/package/next?activeTab=versions.


$ node packages/next-codemod/bin/next-codemod.js upgrade --verbose asd
BadInput [Error]: Invalid revision provided: "asd". Please provide a valid Next.js version or dist-tag (e.g. "latest", "canary", "rc", or "15.0.0").
Check available versions at https://www.npmjs.com/package/next?activeTab=versions.
    at runUpgrade (/Users/sebbie/repos/next.js/packages/next-codemod/bin/upgrade.js:49:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Command.<anonymous> (/Users/sebbie/repos/next.js/packages/next-codemod/bin/next-codemod.js:51:9)
```

Normal workflow still works

```bash
$ node packages/next-codemod/bin/next-codemod.js upgrade canary . 
Current Next.js version: v15.0.0-canary.188
Current React version: v19.0.0-rc-70fb1363-20241010
✖ Enable Turbopack for next dev? … yes
```