### PR TITLE
Turbopack: Refactor resolver to accept bool instead of severity

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -57,7 +57,6 @@ use turbopack_core::{
     },
     file_source::FileSource,
     ident::AssetIdent,
-    issue::IssueSeverity,
     module::{Module, Modules},
     output::{OutputAsset, OutputAssets},
     raw_output::RawOutput,
@@ -604,7 +603,7 @@ impl AppProject {
                 "next/dist/client/app-next-turbopack.js".into(),
             ))),
             None,
-            IssueSeverity::Error.cell(),
+            false,
         )
         .resolve()
         .await?

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -20,7 +20,6 @@ use turbopack_core::{
         EvaluatableAsset,
     },
     context::AssetContext,
-    issue::IssueSeverity,
     module::Module,
     output::OutputAssets,
     reference::primary_referenced_modules,
@@ -318,7 +317,7 @@ async fn build_dynamic_imports_map_for_module(
             )),
             Request::parse(Value::new(Pattern::Constant(import.clone()))),
             Value::new(EcmaScriptModulesReferenceSubType::DynamicImport),
-            IssueSeverity::Error.cell(),
+            false,
             None,
         )
         .first_module()

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -47,7 +47,6 @@ use turbopack_core::{
     context::AssetContext,
     file_source::FileSource,
     ident::AssetIdent,
-    issue::IssueSeverity,
     module::{Module, Modules},
     output::{OutputAsset, OutputAssets},
     reference_type::{EcmaScriptModulesReferenceSubType, EntryReferenceSubType, ReferenceType},
@@ -576,7 +575,7 @@ impl PagesProject {
                 .into(),
             ))),
             Value::new(EcmaScriptModulesReferenceSubType::Undefined),
-            IssueSeverity::Error.cell(),
+            false,
             None,
         )
         .first_module()

--- a/crates/next-core/src/next_client/runtime_entry.rs
+++ b/crates/next-core/src/next_client/runtime_entry.rs
@@ -4,7 +4,6 @@ use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     chunk::{EvaluatableAsset, EvaluatableAssetExt, EvaluatableAssets},
     context::AssetContext,
-    issue::IssueSeverity,
     module::Module,
     resolve::{origin::PlainResolveOrigin, parse::Request},
     source::Source,
@@ -37,7 +36,7 @@ impl RuntimeEntry {
             Vc::upcast(PlainResolveOrigin::new(asset_context, path)),
             request,
             None,
-            IssueSeverity::Error.cell(),
+            false,
         )
         .resolve()
         .await?

--- a/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -41,7 +41,6 @@ pub async fn get_swc_ecma_transform_rule_impl(
     use turbopack::{resolve_options, resolve_options_context::ResolveOptionsContext};
     use turbopack_core::{
         asset::Asset,
-        issue::IssueSeverity,
         reference_type::{CommonJsReferenceSubType, ReferenceType},
         resolve::{handle_resolve_error, parse::Request, pattern::Pattern, resolve},
     };
@@ -81,7 +80,7 @@ pub async fn get_swc_ecma_transform_rule_impl(
             project_path,
             request,
             resolve_options,
-            IssueSeverity::Error.cell(),
+            false,
             None,
         )
         .await?;

--- a/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
@@ -4,7 +4,6 @@ use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     chunk::{EvaluatableAsset, EvaluatableAssetExt, EvaluatableAssets},
     context::AssetContext,
-    issue::IssueSeverity,
     module::Module,
     resolve::{origin::PlainResolveOrigin, parse::Request},
     source::Source,
@@ -37,7 +36,7 @@ impl RuntimeEntry {
             Vc::upcast(PlainResolveOrigin::new(asset_context, path)),
             request,
             None,
-            IssueSeverity::Error.cell(),
+            false,
         )
         .resolve()
         .await?

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -460,6 +460,9 @@ impl ValueToString for ResolveResult {
     #[turbo_tasks::function]
     async fn to_string(&self) -> Result<Vc<RcStr>> {
         let mut result = String::new();
+        if self.is_unresolveable_ref() {
+            result.push_str("unresolveable");
+        }
         for (i, (request, item)) in self.primary.iter().enumerate() {
             if i > 0 {
                 result.push_str(", ");

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -492,6 +492,8 @@ pub struct ResolveOptions {
     pub plugins: Vec<Vc<Box<dyn AfterResolvePlugin>>>,
     /// Support resolving *.js requests to *.ts files
     pub enable_typescript_with_output_extension: bool,
+    /// Warn instead of error for resolve errors
+    pub loose_errors: bool,
 
     pub placeholder_for_future_extensions: (),
 }

--- a/turbopack/crates/turbopack-css/src/references/mod.rs
+++ b/turbopack/crates/turbopack-css/src/references/mod.rs
@@ -13,7 +13,7 @@ use swc_core::css::{
 };
 use turbo_tasks::{RcStr, Value, Vc};
 use turbopack_core::{
-    issue::{IssueSeverity, IssueSource},
+    issue::IssueSource,
     reference::ModuleReference,
     reference_type::{CssReferenceSubType, ImportContext, ReferenceType},
     resolve::{origin::ResolveOrigin, parse::Request, url_resolve, ModuleResolveResult},
@@ -250,6 +250,6 @@ pub fn css_resolve(
         request,
         Value::new(ReferenceType::Css(ty.into_value())),
         issue_source,
-        IssueSeverity::Error.cell(),
+        false,
     )
 }

--- a/turbopack/crates/turbopack-css/src/references/url.rs
+++ b/turbopack/crates/turbopack-css/src/references/url.rs
@@ -17,7 +17,7 @@ use turbopack_core::{
         ChunkingTypeOption,
     },
     ident::AssetIdent,
-    issue::{IssueSeverity, IssueSource},
+    issue::IssueSource,
     output::OutputAsset,
     reference::ModuleReference,
     reference_type::{ReferenceType, UrlReferenceSubType},
@@ -90,7 +90,7 @@ impl ModuleReference for UrlAssetReference {
             self.request,
             Value::new(ReferenceType::Url(UrlReferenceSubType::CssUrl)),
             Some(self.issue_source),
-            IssueSeverity::Error.cell(),
+            false,
         )
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -20,7 +20,7 @@ use turbopack_core::{
     reference::ModuleReference,
     resolve::{origin::ResolveOrigin, parse::Request, ModuleResolveResult},
 };
-use turbopack_resolve::ecmascript::{cjs_resolve, try_to_severity};
+use turbopack_resolve::ecmascript::cjs_resolve;
 
 use super::pattern_mapping::{PatternMapping, ResolveType::ChunkItem};
 use crate::{
@@ -64,7 +64,7 @@ impl ModuleReference for AmdDefineAssetReference {
             self.origin,
             self.request,
             Some(self.issue_source),
-            try_to_severity(self.in_try),
+            self.in_try,
         )
     }
 }
@@ -159,7 +159,7 @@ impl CodeGenerateable for AmdDefineWithDependenciesCodeGen {
                                 self.origin,
                                 *request,
                                 Some(self.issue_source),
-                                try_to_severity(self.in_try),
+                                self.in_try,
                             ),
                             Value::new(ChunkItem),
                         )

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -11,7 +11,7 @@ use turbopack_core::{
     reference::ModuleReference,
     resolve::{origin::ResolveOrigin, parse::Request, ModuleResolveResult},
 };
-use turbopack_resolve::ecmascript::{cjs_resolve, try_to_severity};
+use turbopack_resolve::ecmascript::cjs_resolve;
 
 use super::pattern_mapping::{PatternMapping, ResolveType::ChunkItem};
 use crate::{
@@ -55,7 +55,7 @@ impl ModuleReference for CjsAssetReference {
             self.origin,
             self.request,
             Some(self.issue_source),
-            try_to_severity(self.in_try),
+            self.in_try,
         )
     }
 }
@@ -111,7 +111,7 @@ impl ModuleReference for CjsRequireAssetReference {
             self.origin,
             self.request,
             Some(self.issue_source),
-            try_to_severity(self.in_try),
+            self.in_try,
         )
     }
 }
@@ -144,7 +144,7 @@ impl CodeGenerateable for CjsRequireAssetReference {
                 self.origin,
                 self.request,
                 Some(self.issue_source),
-                try_to_severity(self.in_try),
+                self.in_try,
             ),
             Value::new(ChunkItem),
         )
@@ -218,7 +218,7 @@ impl ModuleReference for CjsRequireResolveAssetReference {
             self.origin,
             self.request,
             Some(self.issue_source),
-            try_to_severity(self.in_try),
+            self.in_try,
         )
     }
 }
@@ -251,7 +251,7 @@ impl CodeGenerateable for CjsRequireResolveAssetReference {
                 self.origin,
                 self.request,
                 Some(self.issue_source),
-                try_to_severity(self.in_try),
+                self.in_try,
             ),
             Value::new(ChunkItem),
         )

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -175,7 +175,7 @@ impl ModuleReference for EsmAssetReference {
             self.get_origin().resolve().await?,
             self.request,
             Value::new(ty),
-            IssueSeverity::Error.cell(),
+            false,
             Some(self.issue_source),
         );
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -13,7 +13,7 @@ use turbopack_core::{
     reference_type::EcmaScriptModulesReferenceSubType,
     resolve::{origin::ResolveOrigin, parse::Request, ModuleResolveResult},
 };
-use turbopack_resolve::ecmascript::{esm_resolve, try_to_severity};
+use turbopack_resolve::ecmascript::esm_resolve;
 
 use super::super::pattern_mapping::{PatternMapping, ResolveType};
 use crate::{
@@ -63,7 +63,7 @@ impl ModuleReference for EsmAsyncAssetReference {
             self.origin,
             self.request,
             Value::new(EcmaScriptModulesReferenceSubType::DynamicImport),
-            try_to_severity(self.in_try),
+            self.in_try,
             Some(self.issue_source),
         )
     }
@@ -102,7 +102,7 @@ impl CodeGenerateable for EsmAsyncAssetReference {
                 self.origin,
                 self.request,
                 Value::new(EcmaScriptModulesReferenceSubType::DynamicImport),
-                try_to_severity(self.in_try),
+                self.in_try,
                 Some(self.issue_source),
             ),
             if matches!(

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -17,7 +17,6 @@ use turbopack_core::{
         origin::ResolveOrigin, parse::Request, url_resolve, ExternalType, ModuleResolveResult,
     },
 };
-use turbopack_resolve::ecmascript::try_to_severity;
 
 use super::base::ReferencedAsset;
 use crate::{
@@ -96,7 +95,7 @@ impl ModuleReference for UrlAssetReference {
             self.request,
             Value::new(ReferenceType::Url(UrlReferenceSubType::EcmaScriptNewUrl)),
             Some(self.issue_source),
-            try_to_severity(self.in_try),
+            self.in_try,
         )
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2567,7 +2567,7 @@ async fn require_resolve_visitor(
     Ok(if args.len() == 1 {
         let pat = js_value_to_pattern(&args[0]);
         let request = Request::parse(Value::new(pat.clone()));
-        let resolved = cjs_resolve_source(origin, request, None, IssueSeverity::Warning.cell())
+        let resolved = cjs_resolve_source(origin, request, None, true)
             .resolve()
             .await?;
         let mut values = resolved
@@ -2634,7 +2634,7 @@ async fn require_context_visitor(
         options.include_subdirs,
         Vc::cell(options.filter),
         None,
-        IssueSeverity::Warning.cell(),
+        true,
     );
 
     Ok(JsValue::WellKnownFunction(

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -22,13 +22,13 @@ use turbopack_core::{
         ChunkingContext,
     },
     ident::AssetIdent,
-    issue::{IssueSeverity, IssueSource},
+    issue::IssueSource,
     module::Module,
     reference::{ModuleReference, ModuleReferences},
     resolve::{origin::ResolveOrigin, parse::Request, ModuleResolveResult},
     source::Source,
 };
-use turbopack_resolve::ecmascript::{cjs_resolve, try_to_severity};
+use turbopack_resolve::ecmascript::cjs_resolve;
 
 use crate::{
     chunk::{
@@ -165,7 +165,7 @@ impl RequireContextMap {
         recursive: bool,
         filter: Vc<Regex>,
         issue_source: Option<Vc<IssueSource>>,
-        issue_severity: Vc<IssueSeverity>,
+        is_optional: bool,
     ) -> Result<Vc<Self>> {
         let origin_path = &*origin.origin_path().parent().await?;
 
@@ -176,7 +176,7 @@ impl RequireContextMap {
         for (context_relative, path) in list {
             if let Some(origin_relative) = origin_path.get_relative_path_to(&*path.await?) {
                 let request = Request::parse(Value::new(origin_relative.clone().into()));
-                let result = cjs_resolve(origin, request, issue_source, issue_severity);
+                let result = cjs_resolve(origin, request, issue_source, is_optional);
 
                 map.insert(
                     context_relative.clone(),
@@ -228,7 +228,7 @@ impl RequireContextAssetReference {
             include_subdirs,
             filter,
             issue_source,
-            try_to_severity(in_try),
+            in_try,
         );
         let inner = RequireContextAsset {
             source,

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -12,7 +12,6 @@ use turbopack_core::{
     reference_type::{ReferenceType, WorkerReferenceSubType},
     resolve::{origin::ResolveOrigin, parse::Request, url_resolve, ModuleResolveResult},
 };
-use turbopack_resolve::ecmascript::try_to_severity;
 
 use crate::{
     code_gen::{CodeGenerateable, CodeGeneration},
@@ -61,7 +60,7 @@ impl WorkerAssetReference {
             // TODO support more worker types
             Value::new(ReferenceType::Worker(WorkerReferenceSubType::WebWorker)),
             Some(self.issue_source),
-            try_to_severity(self.in_try),
+            self.in_try,
         );
 
         let Some(module) = *module.first_module().await? else {

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -5,7 +5,6 @@ use turbo_tasks_fs::DirectoryContent;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     ident::AssetIdent,
-    issue::IssueSeverity,
     module::Module,
     raw_module::RawModule,
     reference::{ModuleReference, ModuleReferences},
@@ -182,7 +181,7 @@ impl CompilerReference {
 impl ModuleReference for CompilerReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        cjs_resolve(self.origin, self.request, None, IssueSeverity::Error.cell())
+        cjs_resolve(self.origin, self.request, None, false)
     }
 }
 
@@ -251,7 +250,7 @@ impl TsNodeRequireReference {
 impl ModuleReference for TsNodeRequireReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        cjs_resolve(self.origin, self.request, None, IssueSeverity::Error.cell())
+        cjs_resolve(self.origin, self.request, None, false)
     }
 }
 

--- a/turbopack/crates/turbopack-resolve/src/resolve.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve.rs
@@ -259,6 +259,7 @@ async fn base_resolve_options(
         resolved_map: opt.resolved_map,
         plugins,
         before_resolve_plugins: opt.before_resolve_plugins.clone(),
+        loose_errors: opt.loose_errors,
         ..Default::default()
     }
     .into())

--- a/turbopack/crates/turbopack-resolve/src/resolve_options_context.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve_options_context.rs
@@ -72,6 +72,9 @@ pub struct ResolveOptionsContext {
     /// Plugins which get applied before and after resolving.
     pub after_resolve_plugins: Vec<Vc<Box<dyn AfterResolvePlugin>>>,
     pub before_resolve_plugins: Vec<Vc<Box<dyn BeforeResolvePlugin>>>,
+    /// Warn instead of error for resolve errors
+    pub loose_errors: bool,
+
     #[serde(default)]
     pub placeholder_for_future_extensions: (),
 }

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -456,7 +456,7 @@ pub async fn type_resolve(
         origin.origin_path(),
         request,
         options,
-        IssueSeverity::Error.cell(),
+        false,
         None,
     )
     .await


### PR DESCRIPTION
I pulled out the core change from https://github.com/vercel/next.js/pull/71155

- Refactor resolve functions to accept a `is_optional` boolean instead of an explicit severity
- Add `ResolveOptions::loose_errors` to only emit warnings instead of errors

Not sure if `loose_errors` is the best name. `warn_instead_of_errors`, `emit_warnings_only` ?