### PR TITLE
codemod: ensure install commands run in terminal

### DIFF
--- a/packages/next-codemod/lib/handle-package.ts
+++ b/packages/next-codemod/lib/handle-package.ts
@@ -42,7 +42,10 @@ export function uninstallPackage(
   }
 
   try {
-    execa.sync(pkgManager, [command, packageToUninstall], { stdio: 'inherit' })
+    execa.sync(pkgManager, [command, packageToUninstall], {
+      stdio: 'inherit',
+      shell: true,
+    })
   } catch (error) {
     throw new Error(
       `Failed to uninstall "${packageToUninstall}". Please uninstall it manually.`,
@@ -64,6 +67,7 @@ export function installPackages(
     execa.sync(packageManager, ['add', ...packageToInstall], {
       // Keeping stderr since it'll likely be relevant later when it fails.
       stdio: silent ? ['ignore', 'ignore', 'inherit'] : 'inherit',
+      shell: true,
     })
   } catch (error) {
     throw new Error(


### PR DESCRIPTION
When it's installing dependencies, `shell: true` will ensure the indicator from install cmd can also be displayed in current terminal.

![image](https://github.com/user-attachments/assets/797980a9-5148-4196-8ee6-de82e9dc5691)
