### PR TITLE
test: fix flaky tests for hydration error with 18.3

### DIFF
--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -197,7 +197,12 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
+    const totalAmount = await getRedboxTotalErrorCount(browser)
+    if (isReact18) {
+      expect(totalAmount).toBeGreaterThanOrEqual(2)
+    } else {
+      expect(totalAmount).toBe(1)
+    }
 
     const pseudoHtml = await session.getRedboxComponentStack()
     if (isTurbopack) {


### PR DESCRIPTION
### What

Since pages router with react 18.3 could throw multi hydration errors due to retry, and this is quite flaky, change from 3 to 2 or more as it's not a critical number

https://github.com/vercel/next.js/actions/runs/11327523718/job/31502267910