### PR TITLE
codemod: prettier the version logging at the beginning

### DIFF
--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -2,7 +2,7 @@ import prompts from 'prompts'
 import fs from 'fs'
 import semver from 'semver'
 import compareVersions from 'semver/functions/compare'
-import { execSync } from 'child_process'
+import { execSync, spawnSync } from 'child_process'
 import path from 'path'
 import pc from 'picocolors'
 import { getPkgManager, installPackages } from '../lib/handle-package'
@@ -81,9 +81,6 @@ export async function runUpgrade(
 
   const installedNextVersion = getInstalledNextVersion()
 
-  // Align the prefix spaces
-  console.log(`  Current Next.js version: v${installedNextVersion}`)
-
   const targetNextVersion = targetNextPackageJson.version
 
   if (compareVersions(installedNextVersion, targetNextVersion) === 0) {
@@ -102,7 +99,10 @@ export async function runUpgrade(
   }
 
   const installedReactVersion = getInstalledReactVersion()
-  console.log(`Current React version: v${installedReactVersion}`)
+  // Align the prefix spaces
+  console.log(`  Detected installed versions:`)
+  console.log(`  - React: v${installedReactVersion}`)
+  console.log(`  - Next.js: v${installedNextVersion}`)
   let shouldStayOnReact18 = false
   if (
     // From release v14.3.0-canary.45, Next.js expects the React version to be 19.0.0-beta.0
@@ -219,17 +219,6 @@ export async function runUpgrade(
     await runTransform(codemod, process.cwd(), { force: true, verbose })
   }
 
-  // To reduce user-side burden of selecting which codemods to run as it needs additional
-  // understanding of the codemods, we run all of the applicable codemods.
-  if (shouldRunReactCodemods) {
-    // https://react.dev/blog/2024/04/25/react-19-upgrade-guide#run-all-react-19-codemods
-    execSync(
-      // `--no-interactive` skips the interactive prompt that asks for confirmation
-      // https://github.com/codemod-com/codemod/blob/c0cf00d13161a0ec0965b6cc6bc5d54076839cc8/apps/cli/src/flags.ts#L160
-      `${execCommand} codemod@latest react/19/migration-recipe --no-interactive`,
-      { stdio: 'inherit' }
-    )
-  }
   if (shouldRunReactTypesCodemods) {
     // https://react.dev/blog/2024/04/25/react-19-upgrade-guide#typescript-changes
     // `--yes` skips prompts and applies all codemods automatically
@@ -237,6 +226,24 @@ export async function runUpgrade(
     execSync(`${execCommand} types-react-codemod@latest --yes preset-19 .`, {
       stdio: 'inherit',
     })
+  }
+
+  // To reduce user-side burden of selecting which codemods to run as it needs additional
+  // understanding of the codemods, we run all of the applicable codemods.
+  if (shouldRunReactCodemods) {
+    // Note: Run react/19/migration codemods at the end to hide the noisy logs,
+    // as verbose mode cannot be disabled.
+
+    // x-ref: https://react.dev/blog/2024/04/25/react-19-upgrade-guide#run-all-react-19-codemods
+    const child = spawnSync(
+      // `--no-interactive` skips the interactive prompt that asks for confirmation
+      // https://github.com/codemod-com/codemod/blob/c0cf00d13161a0ec0965b6cc6bc5d54076839cc8/apps/cli/src/flags.ts#L160
+      `${execCommand} codemod@latest react/19/migration-recipe --no-interactive`,
+      { stdio: 'ignore' }
+    )
+    if (child.stderr) {
+      console.error(child.stderr.toString())
+    }
   }
 
   console.log() // new line


### PR DESCRIPTION
### What

Prettify the version logging at the beginning


#### Test plan

Running codemod in a next 14 repo setup with yarn. Only applying one nextjs codemod and react 19 codemod

```
➜  focu-next-14 git:(main) ✗ node ~/workspace/next.js/packages/next-codemod/bin/next-codemod.js upgrade
  Detected installed versions:
  - React: v18.3.1
  - Next.js: v14.2.15
✔ The following codemods are recommended for your upgrade. Select the ones to apply. › (v15.0.0-canary.44) next-dynamic-access-named-export
✔ Would you like to run the React 19 upgrade codemod? … No / Yes
✔ Would you like to run the React 19 Types upgrade codemod? … No / Yes
Upgrading your project to Next.js 15.0.0-canary.190...

WARNING: Git directory is not clean. Forcibly continuing.
Executing command: jscodeshift --no-babel --ignore-pattern=**/node_modules/** --ignore-pattern=**/.next/** --extensions=tsx,ts,jsx,js --transform /Users/huozhi/workspace/next.j
s/packages/next-codemod/transforms/next-dynamic-access-named-export.js /Users/huozhi/workspace/tests/nextjs/focu-next-14
Processing 9 files...
Spawning 7 workers...
Sending 2 files to free worker...
Sending 2 files to free worker...
Sending 2 files to free worker...
Sending 2 files to free worker...
Sending 1 files to free worker...
All done.
Results:
0 errors
9 unmodified
0 skipped
0 ok
Time elapsed: 0.434seconds

✔ Codemods have been applied successfully.

Please review the local changes and read the Next.js 15 migration guide to complete the migration.
https://nextjs.org/docs/canary/app/building-your-application/upgrading/version-15
```