### PR TITLE
codemod: install core deps based on package.json group

### DIFF
--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -186,7 +186,16 @@ export async function runUpgrade(
     if (appPackageJson.devDependencies?.[packageName]) {
       devDependenciesToInstall.push(corePackageNameVersionMapping[packageName])
     } else {
-      dependenciesToInstall.push(corePackageNameVersionMapping[packageName])
+      const isPeerDep = appPackageJson.peerDependencies?.[packageName]
+      const isDep = appPackageJson.dependencies?.[packageName]
+
+      //
+      if (isPeerDep && !isDep) {
+        // Skip installation if it's a peer-dependency only dependency
+        continue
+      } else {
+        dependenciesToInstall.push(corePackageNameVersionMapping[packageName])
+      }
     }
   }
 

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -63,17 +63,8 @@ function addDependencyIfNeeded(
   // If it's not, fallback into dependencies.
   if (appPackageJson.devDependencies?.[packageName]) {
     devDependenciesToInstall.push(specifiedDependency)
-  } else {
-    const isPeerDep = appPackageJson.peerDependencies?.[packageName]
-    const isDep = appPackageJson.dependencies?.[packageName]
-
-    //
-    if (isPeerDep && !isDep) {
-      // Skip installation if it's a peer-dependency only dependency
-      return
-    } else if (appPackageJson.dependencies?.[packageName]) {
-      dependenciesToInstall.push(specifiedDependency)
-    }
+  } else if (appPackageJson.dependencies?.[packageName]) {
+    dependenciesToInstall.push(specifiedDependency)
   }
 }
 

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -185,17 +185,8 @@ export async function runUpgrade(
     // If it's not, fallback into dependencies.
     if (appPackageJson.devDependencies?.[packageName]) {
       devDependenciesToInstall.push(corePackageNameVersionMapping[packageName])
-    } else {
-      const isPeerDep = appPackageJson.peerDependencies?.[packageName]
-      const isDep = appPackageJson.dependencies?.[packageName]
-
-      //
-      if (isPeerDep && !isDep) {
-        // Skip installation if it's a peer-dependency only dependency
-        continue
-      } else {
-        dependenciesToInstall.push(corePackageNameVersionMapping[packageName])
-      }
+    } else if (appPackageJson.dependencies?.[packageName]) {
+      dependenciesToInstall.push(corePackageNameVersionMapping[packageName])
     }
   }
 

--- a/packages/next-codemod/lib/handle-package.ts
+++ b/packages/next-codemod/lib/handle-package.ts
@@ -76,6 +76,8 @@ export function installPackages(
     dev?: boolean
   } = {}
 ) {
+  if (packageToInstall.length === 0) return
+
   const {
     packageManager = getPkgManager(process.cwd()),
     silent = false,


### PR DESCRIPTION
### What

Install the core packages (`react`, `react-dom`,`next`) into either `devDependencies` or `dependencies` based on what they specified in the package.json. If they're not specified anywhere, use `dependencies` by default.

#### Test Plan

Upgrade a nextjs app with `next@14` and specified in devDependencies. The upgrade is successful