### PR TITLE
[dynamicIO] warn in debug mode when prospective renders error

### DIFF
--- a/packages/next/src/server/app-render/prospective-render-utils.ts
+++ b/packages/next/src/server/app-render/prospective-render-utils.ts
@@ -1,0 +1,43 @@
+export function printDebugThrownValueForProspectiveRender(
+  thrownValue: unknown,
+  route: string
+) {
+  let message: undefined | string
+  if (
+    typeof thrownValue === 'object' &&
+    thrownValue !== null &&
+    typeof (thrownValue as any).message === 'string'
+  ) {
+    message = (thrownValue as any).message
+    if (typeof (thrownValue as any).stack === 'string') {
+      const originalErrorStack: string = (thrownValue as any).stack
+      const stackStart = originalErrorStack.indexOf('\n')
+      if (stackStart > -1) {
+        const error = new Error(
+          `Route ${route} errored during the prospective render. These errors are normally ignored and may not prevent the route from prerendering but are logged here because build debugging is enabled.
+          
+Original Error: ${message}`
+        )
+        error.stack =
+          'Error: ' + error.message + originalErrorStack.slice(stackStart)
+        console.error(error)
+        return
+      }
+    }
+  } else if (typeof thrownValue === 'string') {
+    message = thrownValue
+  }
+
+  if (message) {
+    console.error(`Route ${route} errored during the prospective render. These errors are normally ignored and may not prevent the route from prerendering but are logged here because build debugging is enabled. No stack was provided.
+          
+Original Message: ${message}`)
+    return
+  }
+
+  console.error(
+    `Route ${route} errored during the prospective render. These errors are normally ignored and may not prevent the route from prerendering but are logged here because build debugging is enabled. The thrown value is logged just following this message`
+  )
+  console.error(thrownValue)
+  return
+}

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -31,6 +31,7 @@ import {
 import { HeadersAdapter } from '../../web/spec-extension/adapters/headers'
 import { RequestCookiesAdapter } from '../../web/spec-extension/adapters/request-cookies'
 import { parsedUrlQueryToParams } from './helpers/parsed-url-query-to-params'
+import { printDebugThrownValueForProspectiveRender } from '../../app-render/prospective-render-utils'
 
 import * as serverHooks from '../../../client/components/hooks-server-context'
 import { DynamicServerError } from '../../../client/components/hooks-server-context'
@@ -327,7 +328,7 @@ export class AppRouteRouteModule extends RouteModule<
            *
            * Next we run the handler again and we check if we get a result back in a microtask.
            * Next.js expects the return value to be a Response or a Thenable that resolves to a Response.
-           * Unfortunately Response's do not allow for acessing the response body synchronously or in
+           * Unfortunately Response's do not allow for accessing the response body synchronously or in
            * a microtask so we need to allow one more task to unwrap the response body. This is a slightly
            * different semantic than what we have when we render and it means that certain tasks can still
            * execute before a prerender completes such as a carefully timed setImmediate.
@@ -370,6 +371,8 @@ export class AppRouteRouteModule extends RouteModule<
               // the route handler called an API which is always dynamic
               // there is no need to try again
               prospectiveRenderIsDynamic = true
+            } else if (process.env.NEXT_DEBUG_BUILD) {
+              printDebugThrownValueForProspectiveRender(err, workStore.route)
             }
           }
           if (
@@ -386,6 +389,11 @@ export class AppRouteRouteModule extends RouteModule<
                   // the route handler called an API which is always dynamic
                   // there is no need to try again
                   prospectiveRenderIsDynamic = true
+                } else if (process.env.NEXT_DEBUG_BUILD) {
+                  printDebugThrownValueForProspectiveRender(
+                    err,
+                    workStore.route
+                  )
                 }
               }
             )

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.prospective-errors.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.prospective-errors.test.ts
@@ -1,0 +1,280 @@
+import { nextTestSetup } from 'e2e-utils'
+
+const isTurbopack = !!process.env.TURBOPACK
+
+describe(`Dynamic IO Prospective Render Errors - Debug Build`, () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname + '/fixtures/prospective-render-errors',
+    env: { NEXT_DEBUG_BUILD: 'true' },
+  })
+
+  if (skipped) {
+    return
+  }
+
+  if (isNextDev) {
+    // In next dev there really isn't a prospective render but we still assert we error on the first visit to each page
+    it('should error on the first visit to each page', async () => {
+      let res
+
+      res = await next.fetch('/error')
+      expect(res.status).toBe(500)
+      res = await next.fetch('/error')
+      expect(res.status).toBe(200)
+      res = await next.fetch('/error')
+      expect(res.status).toBe(200)
+
+      res = await next.fetch('/routes/error')
+      expect(res.status).toBe(500)
+      res = await next.fetch('/routes/error')
+      expect(res.status).toBe(200)
+      res = await next.fetch('/routes/error')
+      expect(res.status).toBe(200)
+
+      res = await next.fetch('/null')
+      expect(res.status).toBe(500)
+      res = await next.fetch('/null')
+      expect(res.status).toBe(200)
+      res = await next.fetch('/null')
+      expect(res.status).toBe(200)
+
+      // To make disambiguating cli output in the prod tests I switch from null to undefined
+      // for the routes version of this tests. really we're just asserting we get a coherent message
+      // when the thrown value is not a string or Error so null or undefined is not very important itself
+      res = await next.fetch('/routes/undefined')
+      expect(res.status).toBe(500)
+      res = await next.fetch('/routes/undefined')
+      expect(res.status).toBe(200)
+      res = await next.fetch('/routes/undefined')
+      expect(res.status).toBe(200)
+
+      res = await next.fetch('/object')
+      expect(res.status).toBe(500)
+      res = await next.fetch('/object')
+      expect(res.status).toBe(200)
+      res = await next.fetch('/object')
+      expect(res.status).toBe(200)
+
+      res = await next.fetch('/routes/object')
+      expect(res.status).toBe(500)
+      res = await next.fetch('/routes/object')
+      expect(res.status).toBe(200)
+      res = await next.fetch('/routes/object')
+      expect(res.status).toBe(200)
+
+      res = await next.fetch('/string')
+      expect(res.status).toBe(500)
+      res = await next.fetch('/string')
+      expect(res.status).toBe(200)
+      res = await next.fetch('/string')
+      expect(res.status).toBe(200)
+
+      res = await next.fetch('/routes/string')
+      expect(res.status).toBe(500)
+      res = await next.fetch('/routes/string')
+      expect(res.status).toBe(200)
+      res = await next.fetch('/routes/string')
+      expect(res.status).toBe(200)
+    })
+  } else {
+    it('should log an error when the prospective render errors with an Error in a Page', async () => {
+      expect(next.cliOutput).toContain(
+        'Error: Route /error errored during the prospective render.'
+      )
+      expect(next.cliOutput).toContain('Original Error: BOOM (Error)')
+      if (!isTurbopack) {
+        // In turbopack we don't yet support disabling minification so this assertion won't work
+        expect(next.cliOutput).toContain('at ErrorFirstTime')
+      }
+    })
+
+    it('should log an error when the prospective render errors with a string in a Page', async () => {
+      expect(next.cliOutput).toContain(
+        'Route /string errored during the prospective render.'
+      )
+      expect(next.cliOutput).toContain('Original Message: BOOM (string)')
+    })
+
+    it('should log an error when the prospective render errors with null in a Page', async () => {
+      expect(next.cliOutput).toContain(
+        'Route /null errored during the prospective render.'
+      )
+      expect(next.cliOutput).toContain('\nnull\n')
+    })
+
+    it('should log an error when the prospective render errors with an object in a Page', async () => {
+      expect(next.cliOutput).toContain(
+        'Route /object errored during the prospective render.'
+      )
+      expect(next.cliOutput).toContain("{ boom: '(Object)' }")
+    })
+
+    it('should log an error when the prospective render errors with an Error in a route', async () => {
+      expect(next.cliOutput).toContain(
+        'Error: Route /routes/error errored during the prospective render.'
+      )
+      expect(next.cliOutput).toContain('Original Error: BOOM (Error route)')
+      if (!isTurbopack) {
+        // In turbopack we don't yet support disabling minification so this assertion won't work
+        expect(next.cliOutput).toContain('at errorFirstTime')
+      }
+    })
+
+    it('should log an error when the prospective render errors with a string in a route', async () => {
+      expect(next.cliOutput).toContain(
+        'Route /routes/string errored during the prospective render.'
+      )
+      expect(next.cliOutput).toContain('Original Message: BOOM (string route)')
+    })
+
+    it('should log an error when the prospective render errors with undefined in a route', async () => {
+      expect(next.cliOutput).toContain(
+        'Route /routes/undefined errored during the prospective render.'
+      )
+      expect(next.cliOutput).toContain('\nundefined\n')
+    })
+
+    it('should log an error when the prospective render errors with an object in a route', async () => {
+      expect(next.cliOutput).toContain(
+        'Route /routes/object errored during the prospective render.'
+      )
+      expect(next.cliOutput).toContain("{ boom: '(Object route)' }")
+    })
+  }
+})
+
+describe(`Dynamic IO Prospective Render Errors - Standard Build`, () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname + '/fixtures/prospective-render-errors',
+  })
+
+  if (skipped) {
+    return
+  }
+
+  if (isNextDev) {
+    // In next dev there really isn't a prospective render but we still assert we error on the first visit to each page
+    it('should error on the first visit to each page', async () => {
+      let res
+
+      res = await next.fetch('/error')
+      expect(res.status).toBe(500)
+      res = await next.fetch('/error')
+      expect(res.status).toBe(200)
+      res = await next.fetch('/error')
+      expect(res.status).toBe(200)
+
+      res = await next.fetch('/routes/error')
+      expect(res.status).toBe(500)
+      res = await next.fetch('/routes/error')
+      expect(res.status).toBe(200)
+      res = await next.fetch('/routes/error')
+      expect(res.status).toBe(200)
+
+      res = await next.fetch('/null')
+      expect(res.status).toBe(500)
+      res = await next.fetch('/null')
+      expect(res.status).toBe(200)
+      res = await next.fetch('/null')
+      expect(res.status).toBe(200)
+
+      // To make disambiguating cli output in the prod tests I switch from null to undefined
+      // for the routes version of this tests. really we're just asserting we get a coherent message
+      // when the thrown value is not a string or Error so null or undefined is not very important itself
+      res = await next.fetch('/routes/undefined')
+      expect(res.status).toBe(500)
+      res = await next.fetch('/routes/undefined')
+      expect(res.status).toBe(200)
+      res = await next.fetch('/routes/undefined')
+      expect(res.status).toBe(200)
+
+      res = await next.fetch('/object')
+      expect(res.status).toBe(500)
+      res = await next.fetch('/object')
+      expect(res.status).toBe(200)
+      res = await next.fetch('/object')
+      expect(res.status).toBe(200)
+
+      res = await next.fetch('/routes/object')
+      expect(res.status).toBe(500)
+      res = await next.fetch('/routes/object')
+      expect(res.status).toBe(200)
+      res = await next.fetch('/routes/object')
+      expect(res.status).toBe(200)
+
+      res = await next.fetch('/string')
+      expect(res.status).toBe(500)
+      res = await next.fetch('/string')
+      expect(res.status).toBe(200)
+      res = await next.fetch('/string')
+      expect(res.status).toBe(200)
+
+      res = await next.fetch('/routes/string')
+      expect(res.status).toBe(500)
+      res = await next.fetch('/routes/string')
+      expect(res.status).toBe(200)
+      res = await next.fetch('/routes/string')
+      expect(res.status).toBe(200)
+    })
+  } else {
+    it('should not log an error when the prospective render errors with an Error in a Page', async () => {
+      expect(next.cliOutput).not.toContain(
+        'Error: Route /error errored during the prospective render.'
+      )
+      expect(next.cliOutput).not.toContain('Original Error: BOOM (Error)')
+      expect(next.cliOutput).not.toContain('at ErrorFirstTime')
+    })
+
+    it('should not log an error when the prospective render errors with a string in a Page', async () => {
+      expect(next.cliOutput).not.toContain(
+        'Route /string errored during the prospective render.'
+      )
+      expect(next.cliOutput).not.toContain('Original Message: BOOM (string)')
+    })
+
+    it('should not log an error when the prospective render errors with null in a Page', async () => {
+      expect(next.cliOutput).not.toContain(
+        'Route /null errored during the prospective render.'
+      )
+      expect(next.cliOutput).not.toContain('\nnull\n')
+    })
+
+    it('should not log an error when the prospective render errors with an object in a Page', async () => {
+      expect(next.cliOutput).not.toContain(
+        'Route /object errored during the prospective render.'
+      )
+      expect(next.cliOutput).not.toContain("{ boom: '(Object)' }")
+    })
+
+    it('should not log an error when the prospective render errors with an Error in a route', async () => {
+      expect(next.cliOutput).not.toContain(
+        'Error: Route /routes/error errored during the prospective render.'
+      )
+      expect(next.cliOutput).not.toContain('Original Error: BOOM (Error route)')
+      expect(next.cliOutput).not.toContain('at errorFirstTime')
+    })
+
+    it('should not log an error when the prospective render errors with a string in a route', async () => {
+      expect(next.cliOutput).not.toContain(
+        'Route /routes/string errored during the prospective render.'
+      )
+      expect(next.cliOutput).not.toContain(
+        'Original Message: BOOM (string route)'
+      )
+    })
+
+    it('should not log an error when the prospective render errors with undefined in a route', async () => {
+      expect(next.cliOutput).not.toContain(
+        'Route /routes/undefined errored during the prospective render.'
+      )
+      expect(next.cliOutput).not.toContain('\nundefined\n')
+    })
+
+    it('should not log an error when the prospective render errors with an object in a route', async () => {
+      expect(next.cliOutput).not.toContain(
+        'Route /routes/object errored during the prospective render.'
+      )
+      expect(next.cliOutput).not.toContain("{ boom: '(Object route)' }")
+    })
+  }
+})

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/app/error/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/app/error/page.tsx
@@ -1,0 +1,25 @@
+import { Indirection } from '../indirection'
+
+let didError = false
+
+export default async function Page() {
+  return (
+    <>
+      <p>
+        This page errors during the prospective render during build. It errors
+        on the first render during dev.
+      </p>
+      <Indirection>
+        <ErrorFirstTime />
+      </Indirection>
+    </>
+  )
+}
+
+async function ErrorFirstTime() {
+  if (!didError) {
+    didError = true
+    throw new Error('BOOM (Error)')
+  }
+  return null
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/app/indirection.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/app/indirection.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export function Indirection({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/app/layout.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/app/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/app/null/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/app/null/page.tsx
@@ -1,0 +1,26 @@
+import { Indirection } from '../indirection'
+
+let didError = false
+
+export default async function Page() {
+  return (
+    <>
+      <p>
+        This page errors during the prospective render during build. It errors
+        on the first render during dev.
+      </p>
+      <Indirection>
+        <ErrorFirstTime />
+      </Indirection>
+    </>
+  )
+}
+
+async function ErrorFirstTime() {
+  if (!didError) {
+    didError = true
+    // eslint-disable-next-line no-throw-literal
+    throw null
+  }
+  return null
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/app/object/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/app/object/page.tsx
@@ -1,0 +1,26 @@
+import { Indirection } from '../indirection'
+
+let didError = false
+
+export default async function Page() {
+  return (
+    <>
+      <p>
+        This page errors during the prospective render during build. It errors
+        on the first render during dev.
+      </p>
+      <Indirection>
+        <ErrorFirstTime />
+      </Indirection>
+    </>
+  )
+}
+
+async function ErrorFirstTime() {
+  if (!didError) {
+    didError = true
+    // eslint-disable-next-line no-throw-literal
+    throw { boom: '(Object)' }
+  }
+  return null
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/app/routes/error/route.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/app/routes/error/route.tsx
@@ -1,0 +1,16 @@
+let didError = false
+
+export async function GET() {
+  errorFirstTime()
+  return new Response(
+    'This page errors during the prospective render during build. It errors on the first render during dev.'
+  )
+}
+
+function errorFirstTime() {
+  if (!didError) {
+    didError = true
+    throw new Error('BOOM (Error route)')
+  }
+  return null
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/app/routes/object/route.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/app/routes/object/route.tsx
@@ -1,0 +1,17 @@
+let didError = false
+
+export async function GET() {
+  errorFirstTime()
+  return new Response(
+    'This page errors during the prospective render during build. It errors on the first render during dev.'
+  )
+}
+
+function errorFirstTime() {
+  if (!didError) {
+    didError = true
+    // eslint-disable-next-line no-throw-literal
+    throw { boom: '(Object route)' }
+  }
+  return null
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/app/routes/string/route.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/app/routes/string/route.tsx
@@ -1,0 +1,17 @@
+let didError = false
+
+export async function GET() {
+  errorFirstTime()
+  return new Response(
+    'This page errors during the prospective render during build. It errors on the first render during dev.'
+  )
+}
+
+function errorFirstTime() {
+  if (!didError) {
+    didError = true
+    // eslint-disable-next-line no-throw-literal
+    throw 'BOOM (string route)'
+  }
+  return null
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/app/routes/undefined/route.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/app/routes/undefined/route.tsx
@@ -1,0 +1,17 @@
+let didError = false
+
+export async function GET() {
+  errorFirstTime()
+  return new Response(
+    'This page errors during the prospective render during build. It errors on the first render during dev.'
+  )
+}
+
+function errorFirstTime() {
+  if (!didError) {
+    didError = true
+    // eslint-disable-next-line no-throw-literal
+    throw undefined
+  }
+  return null
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/app/string/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/app/string/page.tsx
@@ -1,0 +1,26 @@
+import { Indirection } from '../indirection'
+
+let didError = false
+
+export default async function Page() {
+  return (
+    <>
+      <p>
+        This page errors during the prospective render during build. It errors
+        on the first render during dev.
+      </p>
+      <Indirection>
+        <ErrorFirstTime />
+      </Indirection>
+    </>
+  )
+}
+
+async function ErrorFirstTime() {
+  if (!didError) {
+    didError = true
+    // eslint-disable-next-line no-throw-literal
+    throw 'BOOM (string)'
+  }
+  return null
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/prospective-render-errors/next.config.js
@@ -1,0 +1,13 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    ppr: process.env.__NEXT_EXPERIMENTAL_PPR === 'true',
+    pprFallbacks: process.env.__NEXT_EXPERIMENTAL_PPR === 'true',
+    dynamicIO: true,
+    serverMinification: false,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
When prerendering pages and routes errors with dynamicIO enabled, errors during the prospective render may be supressed from logging. Normally this is expected and ok because the dynamic portion of a render may be expected to error during prerendering. However some codepaths are not hit the same between the prospective and final renders and so it can be useful to have the ability to get additional insight into the runtime behavior of the prospective render.

This change adds extra logging when `process.env.NEXT_DEBUG_BUILD` is enabled. When this environment variable is set we log errors that throw during the prospective render.