### PR TITLE
Fix symbol for cache

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -43,8 +43,6 @@ export interface CacheHandlerValue {
   value: IncrementalCacheValue | null
 }
 
-export const cacheHandlersSymbol = Symbol('@next/cache-handlers')
-
 export class CacheHandler {
   // eslint-disable-next-line
   constructor(_ctx: CacheHandlerContext) {}
@@ -123,6 +121,7 @@ export class IncrementalCache implements IncrementalCacheType {
     const debug = !!process.env.NEXT_PRIVATE_DEBUG_CACHE
     this.hasCustomCacheHandler = Boolean(CurCacheHandler)
 
+    const cacheHandlersSymbol = Symbol.for('@next/cache-handlers')
     const _globalThis: typeof globalThis & {
       [cacheHandlersSymbol]?: {
         FetchCache?: typeof CacheHandler


### PR DESCRIPTION
Small follow-up to https://github.com/vercel/next.js/pull/71263 this should be `Symbol.for` so we use the same reference instead creating a new Symbol. 