### PR TITLE
Handle URL-encoded Turbopack client chunks when resolving source maps

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
@@ -171,7 +171,11 @@ export function getSourceMapMiddleware(project: Project, distDir: string) {
 
     try {
       if (filename.startsWith('/_next/static')) {
-        filename = path.join(distDir, filename.replace(/^\/_next\//, ''))
+        filename = path.join(
+          distDir,
+          // /_next/static/chunks/%5Bproject%5D... => static/chunks/[project]...
+          decodeURIComponent(filename.replace(/^\/_next\//, ''))
+        )
       }
 
       const sourceMapString = await project.getSourceMap(filename)


### PR DESCRIPTION
When using Turbopack, after a client-side navigation, the source map for a client chunk might be requested using an URL-encoded pathname, e.g. `/_next/static/chunks/%5Bproject%5D__48591b._.js` instead of `/_next/static/chunks/[project]__48591b._.js`. When trying to look up the source map this would fail with:

```
Failed to get source map: [Error: chunk/module is missing a sourcemap] { code: 'GenericFailure' }
```

To fix this, we're now decoding the filename.

## Test Plan

- start `pnpm next dev --turbo test/development/app-dir/source-mapping`
- go to `http://localhost:3000`
- click on "client component page" link
- open React DevTools Components view
- select `Form`
- click on `bar()` action (requires version 6.0) 
- you should end up in the the `actions.ts` source file