### PR TITLE
codemod: update react-is if needed

### DIFF
--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -51,25 +51,6 @@ function endMessage() {
   )
 }
 
-const requiredPackages = new Set(['react', 'react-dom', 'next'])
-
-function addDependency(
-  packageName: string,
-  version: string,
-  appPackageJson: any,
-  dependenciesToInstall: string[],
-  devDependenciesToInstall: string[]
-) {
-  const specifiedDependency = `${packageName}@${version}`
-  // First check if it's dev dependencies, then add into dev deps;
-  // If it's not, fallback into dependencies.
-  if (appPackageJson.devDependencies?.[packageName]) {
-    devDependenciesToInstall.push(specifiedDependency)
-  } else {
-    dependenciesToInstall.push(specifiedDependency)
-  }
-}
-
 export async function runUpgrade(
   revision: string | undefined,
   options: { verbose: boolean }
@@ -194,43 +175,27 @@ export async function runUpgrade(
   const dependenciesToInstall = []
   const devDependenciesToInstall = []
 
-  const corePackageNameVersionMapping = {
-    // required
-    react: targetReactVersion,
-    'react-dom': targetReactVersion,
-    next: targetNextVersion,
-    // optional
-    'react-is': targetReactVersion,
-  }
-
-  const allDependencyKeys = new Set(
-    Object.keys({
-      ...appPackageJson.dependencies,
-      ...appPackageJson.devDependencies,
-    })
-  )
-  for (const packageName of Object.keys(corePackageNameVersionMapping)) {
-    if (
-      allDependencyKeys.has(packageName) ||
-      requiredPackages.has(packageName)
-    ) {
-      addDependency(
-        packageName,
-        corePackageNameVersionMapping[packageName],
-        appPackageJson,
-        dependenciesToInstall,
-        devDependenciesToInstall
-      )
+  const versionMapping: Record<string, { version: string; required: boolean }> =
+    {
+      next: { version: targetNextVersion, required: true },
+      react: { version: targetReactVersion, required: true },
+      'react-dom': { version: targetReactVersion, required: true },
+      'react-is': { version: targetReactVersion, required: false },
     }
-  }
 
   if (
     targetReactVersion.startsWith('19.0.0-canary') ||
     targetReactVersion.startsWith('19.0.0-beta') ||
     targetReactVersion.startsWith('19.0.0-rc')
   ) {
-    corePackageNameVersionMapping['@types/react'] = 'npm:types-react@rc'
-    corePackageNameVersionMapping['@types/react-dom'] = 'npm:types-react-dom@rc'
+    versionMapping['@types/react'] = {
+      version: `npm:types-react@rc`,
+      required: false,
+    }
+    versionMapping['@types/react-dom'] = {
+      version: `npm:types-react-dom@rc`,
+      required: false,
+    }
   } else {
     const [targetReactTypesVersion, targetReactDOMTypesVersion] =
       await Promise.all([
@@ -241,9 +206,25 @@ export async function runUpgrade(
           `@types/react-dom@${targetNextPackageJson.peerDependencies['react']}`
         ),
       ])
-    corePackageNameVersionMapping['@types/react'] = targetReactTypesVersion
-    corePackageNameVersionMapping['@types/react-dom'] =
-      targetReactDOMTypesVersion
+
+    versionMapping['@types/react'] = {
+      version: targetReactTypesVersion,
+      required: false,
+    }
+    versionMapping['@types/react-dom'] = {
+      version: targetReactDOMTypesVersion,
+      required: false,
+    }
+  }
+
+  for (const [packageName, { version, required }] of Object.entries(
+    versionMapping
+  )) {
+    if (appPackageJson.devDependencies?.[packageName]) {
+      devDependenciesToInstall.push(`${packageName}@${version}`)
+    } else if (required || appPackageJson.dependencies?.[packageName]) {
+      dependenciesToInstall.push(`${packageName}@${version}`)
+    }
   }
 
   console.log(

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -53,13 +53,12 @@ function endMessage() {
 
 const requiredPackages = new Set(['react', 'react-dom', 'next'])
 
-function addDependencyIfNeeded(
+function addDependency(
   packageName: string,
   version: string,
   appPackageJson: any,
   dependenciesToInstall: string[],
-  devDependenciesToInstall: string[],
-  required: boolean
+  devDependenciesToInstall: string[]
 ) {
   const specifiedDependency = `${packageName}@${version}`
   // First check if it's dev dependencies, then add into dev deps;
@@ -67,9 +66,7 @@ function addDependencyIfNeeded(
   if (appPackageJson.devDependencies?.[packageName]) {
     devDependenciesToInstall.push(specifiedDependency)
   } else {
-    if (required) {
-      dependenciesToInstall.push(specifiedDependency)
-    }
+    dependenciesToInstall.push(specifiedDependency)
   }
 }
 
@@ -206,15 +203,25 @@ export async function runUpgrade(
     'react-is': targetReactVersion,
   }
 
+  const allDependencyKeys = new Set(
+    Object.keys({
+      ...appPackageJson.dependencies,
+      ...appPackageJson.devDependencies,
+    })
+  )
   for (const packageName of Object.keys(corePackageNameVersionMapping)) {
-    addDependencyIfNeeded(
-      packageName,
-      corePackageNameVersionMapping[packageName],
-      appPackageJson,
-      dependenciesToInstall,
-      devDependenciesToInstall,
+    if (
+      allDependencyKeys.has(packageName) ||
       requiredPackages.has(packageName)
-    )
+    ) {
+      addDependency(
+        packageName,
+        corePackageNameVersionMapping[packageName],
+        appPackageJson,
+        dependenciesToInstall,
+        devDependenciesToInstall
+      )
+    }
   }
 
   if (

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -51,20 +51,25 @@ function endMessage() {
   )
 }
 
+const requiredPackages = new Set(['react', 'react-dom', 'next'])
+
 function addDependencyIfNeeded(
   packageName: string,
   version: string,
   appPackageJson: any,
   dependenciesToInstall: string[],
-  devDependenciesToInstall: string[]
+  devDependenciesToInstall: string[],
+  required: boolean
 ) {
   const specifiedDependency = `${packageName}@${version}`
   // First check if it's dev dependencies, then add into dev deps;
   // If it's not, fallback into dependencies.
   if (appPackageJson.devDependencies?.[packageName]) {
     devDependenciesToInstall.push(specifiedDependency)
-  } else if (appPackageJson.dependencies?.[packageName]) {
-    dependenciesToInstall.push(specifiedDependency)
+  } else {
+    if (required) {
+      dependenciesToInstall.push(specifiedDependency)
+    }
   }
 }
 
@@ -193,9 +198,12 @@ export async function runUpgrade(
   const devDependenciesToInstall = []
 
   const corePackageNameVersionMapping = {
+    // required
     react: targetReactVersion,
     'react-dom': targetReactVersion,
     next: targetNextVersion,
+    // optional
+    'react-is': targetReactVersion,
   }
 
   for (const packageName of Object.keys(corePackageNameVersionMapping)) {
@@ -204,7 +212,8 @@ export async function runUpgrade(
       corePackageNameVersionMapping[packageName],
       appPackageJson,
       dependenciesToInstall,
-      devDependenciesToInstall
+      devDependenciesToInstall,
+      requiredPackages.has(packageName)
     )
   }
 


### PR DESCRIPTION
### What

Add `react-is` to the potential upgrade deps
Fixes `@types/` not being installed

#### Test Plan

Running `upgrade` codemod against a app with `react-is@18` in dependency, noticed it's updated to the same version as `react` 