### PR TITLE
[dynamicIO] Implement a warmup prefetch render in dev

### DIFF
--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -171,6 +171,7 @@ export interface RenderOptsPartial {
   }
   params?: ParsedUrlQuery
   isPrefetch?: boolean
+  isDevWarmup?: boolean
   experimental: {
     /**
      * When true, it indicates that the current page supports partial

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2390,12 +2390,21 @@ export default abstract class Server<
        * The unknown route params for this render.
        */
       fallbackRouteParams: FallbackRouteParams | null
+
+      /**
+       * Whether or not this render is a warmup render for dev mode.
+       */
+      isDevWarmup?: boolean
     }
     type Renderer = (
       context: RendererContext
     ) => Promise<ResponseCacheEntry | null>
 
-    const doRender: Renderer = async ({ postponed, fallbackRouteParams }) => {
+    const doRender: Renderer = async ({
+      postponed,
+      fallbackRouteParams,
+      isDevWarmup,
+    }) => {
       // In development, we always want to generate dynamic HTML.
       let supportsDynamicResponse: boolean =
         // If we're in development, we always support dynamic HTML, unless it's
@@ -2468,6 +2477,7 @@ export default abstract class Server<
         isOnDemandRevalidate,
         isDraftMode: isPreviewMode,
         isServerAction,
+        isDevWarmup,
         postponed,
         waitUntil: this.getWaitUntil(),
         onClose: res.onClose.bind(res),
@@ -2788,6 +2798,7 @@ export default abstract class Server<
       hasResolved,
       previousCacheEntry,
       isRevalidating,
+      isDevWarmup,
     }): Promise<ResponseCacheEntry | null> => {
       const isProduction = !this.renderOpts.dev
       const didRespond = hasResolved || res.sent
@@ -3026,6 +3037,7 @@ export default abstract class Server<
       const result = await doRender({
         postponed,
         fallbackRouteParams,
+        isDevWarmup,
       })
       if (!result) return null
 
@@ -3039,7 +3051,7 @@ export default abstract class Server<
       const originalResponseGenerator = responseGenerator
 
       responseGenerator = async (
-        ...args: Parameters<typeof responseGenerator>
+        state: Parameters<ResponseGenerator>[0]
       ): ReturnType<typeof responseGenerator> => {
         if (this.renderOpts.dev) {
           let cache = this.prefetchCacheScopesDev.get(urlPathname)
@@ -3053,23 +3065,17 @@ export default abstract class Server<
             routeModule?.definition.kind === RouteKind.APP_PAGE &&
             !isServerAction
           ) {
-            req.headers[RSC_HEADER] = '1'
-            req.headers[NEXT_ROUTER_PREFETCH_HEADER] = '1'
-
             cache = new Map()
 
             await runWithCacheScope({ cache }, () =>
-              originalResponseGenerator(...args)
+              originalResponseGenerator({ ...state, isDevWarmup: true })
             )
             this.prefetchCacheScopesDev.set(urlPathname, cache)
-
-            delete req.headers[RSC_HEADER]
-            delete req.headers[NEXT_ROUTER_PREFETCH_HEADER]
           }
 
           if (cache) {
             return runWithCacheScope({ cache }, () =>
-              originalResponseGenerator(...args)
+              originalResponseGenerator(state)
             ).finally(() => {
               if (isPrefetchRSCRequest) {
                 this.prefetchCacheScopesDev.set(urlPathname, cache)
@@ -3080,7 +3086,7 @@ export default abstract class Server<
           }
         }
 
-        return originalResponseGenerator(...args)
+        return originalResponseGenerator(state)
       }
     }
 

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -399,6 +399,25 @@ export class IncrementalCache implements IncrementalCacheType {
       isFallback: boolean | undefined
     }
   ): Promise<IncrementalCacheEntry | null> {
+    // unlike other caches if we have a cacheScope we use it even if
+    // testmode would normally disable it or if requestHeaders say 'no-cache'.
+    if (this.hasDynamicIO && ctx.kind === IncrementalCacheKind.FETCH) {
+      const cacheScope = cacheScopeAsyncLocalStorage.getStore()
+
+      if (cacheScope) {
+        const memoryCacheData = cacheScope.cache.get(cacheKey)
+
+        if (memoryCacheData?.kind === CachedRouteKind.FETCH) {
+          return {
+            isStale: false,
+            value: memoryCacheData,
+            revalidateAfter: false,
+            isFallback: false,
+          }
+        }
+      }
+    }
+
     // we don't leverage the prerender cache in dev mode
     // so that getStaticProps is always called for easier debugging
     if (
@@ -418,23 +437,6 @@ export class IncrementalCache implements IncrementalCacheType {
     )
     let entry: IncrementalCacheEntry | null = null
     let revalidate = ctx.revalidate
-
-    if (this.hasDynamicIO && ctx.kind === IncrementalCacheKind.FETCH) {
-      const cacheScope = cacheScopeAsyncLocalStorage.getStore()
-
-      if (cacheScope) {
-        const memoryCacheData = cacheScope.cache.get(cacheKey)
-
-        if (memoryCacheData?.kind === CachedRouteKind.FETCH) {
-          return {
-            isStale: false,
-            value: memoryCacheData,
-            revalidateAfter: false,
-            isFallback: false,
-          }
-        }
-      }
-    }
 
     const cacheData = await this.cacheHandler?.get(cacheKey, ctx)
 
@@ -539,10 +541,10 @@ export class IncrementalCache implements IncrementalCacheType {
       isFallback?: boolean
     }
   ) {
-    if (this.disableForTestmode || (this.dev && !ctx.fetchCache)) return
-
-    pathname = this._getPathname(pathname, ctx.fetchCache)
-
+    // Even if we otherwise disable caching for testMode or if no fetchCache is configured
+    // we still always stash results in the cacheScope if one exists. This is because this
+    // is a transient in memory cache that populates caches ahead of a dynamic render in dev mode
+    // to allow the RSC debug info to have the right environment associated to it.
     if (this.hasDynamicIO && data?.kind === CachedRouteKind.FETCH) {
       const cacheScope = cacheScopeAsyncLocalStorage.getStore()
 
@@ -550,6 +552,10 @@ export class IncrementalCache implements IncrementalCacheType {
         cacheScope.cache.set(pathname, data)
       }
     }
+
+    if (this.disableForTestmode || (this.dev && !ctx.fetchCache)) return
+
+    pathname = this._getPathname(pathname, ctx.fetchCache)
 
     // FetchCache has upper limit of 2MB per-entry currently
     const itemSize = JSON.stringify(data).length

--- a/packages/next/src/server/response-cache/types.ts
+++ b/packages/next/src/server/response-cache/types.ts
@@ -172,6 +172,7 @@ export type ResponseGenerator = (state: {
   hasResolved: boolean
   previousCacheEntry?: IncrementalCacheItem
   isRevalidating?: boolean
+  isDevWarmup?: boolean
 }) => Promise<ResponseCacheEntry | null>
 
 export type IncrementalCacheItem = {

--- a/test/development/app-dir/dynamic-io-dev-warmup/app/data-fetching.ts
+++ b/test/development/app-dir/dynamic-io-dev-warmup/app/data-fetching.ts
@@ -1,0 +1,10 @@
+export async function fetchCached(url: string) {
+  const response = await fetch(url, { cache: 'force-cache' })
+  return response.text()
+}
+
+export async function getCachedData(_key: string) {
+  'use cache'
+  await new Promise((r) => setTimeout(r))
+  return Math.random()
+}

--- a/test/development/app-dir/dynamic-io-dev-warmup/app/layout.tsx
+++ b/test/development/app-dir/dynamic-io-dev-warmup/app/layout.tsx
@@ -1,0 +1,62 @@
+import { fetchCached, getCachedData } from './data-fetching'
+
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        {children}
+        <section>
+          <h1>Layout</h1>
+          <p>This data is from the root layout</p>
+          <FetchingComponent />
+          <CachedFetchingComponent />
+          <CachedDataComponent />
+        </section>
+      </body>
+    </html>
+  )
+}
+
+async function CachedFetchingComponent() {
+  const data = await fetchCached(
+    'https://next-data-api-endpoint.vercel.app/api/random?key=cachedlayout'
+  )
+  console.log('after cached layout fetch')
+  return (
+    <dl>
+      <dt>
+        Cached Fetch
+        (https://next-data-api-endpoint.vercel.app/api/random?key=cachedlayout)
+      </dt>
+      <dd>{data}</dd>
+    </dl>
+  )
+}
+
+async function FetchingComponent() {
+  const response = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?key=uncachedlayout'
+  )
+  console.log('after uncached layout fetch')
+  const data = await response.text()
+  return (
+    <dl>
+      <dt>
+        Uncached Fetch
+        (https://next-data-api-endpoint.vercel.app/api/random?key=uncachedlayout)
+      </dt>
+      <dd>{data}</dd>
+    </dl>
+  )
+}
+
+async function CachedDataComponent() {
+  const data = await getCachedData('layout')
+  console.log('after layout cache read')
+  return (
+    <dl>
+      <dt>Cached Data</dt>
+      <dd>{data}</dd>
+    </dl>
+  )
+}

--- a/test/development/app-dir/dynamic-io-dev-warmup/app/loading.tsx
+++ b/test/development/app-dir/dynamic-io-dev-warmup/app/loading.tsx
@@ -1,0 +1,9 @@
+import { fetchCached, getCachedData } from './data-fetching'
+
+export default async function Loading() {
+  await fetchCached(
+    'https://next-data-api-endpoint.vercel.app/api/random?key=cachedpage'
+  )
+  await getCachedData('page')
+  return <main>loading...</main>
+}

--- a/test/development/app-dir/dynamic-io-dev-warmup/app/page.tsx
+++ b/test/development/app-dir/dynamic-io-dev-warmup/app/page.tsx
@@ -1,0 +1,63 @@
+import { fetchCached, getCachedData } from './data-fetching'
+
+export default async function Page() {
+  return (
+    <main>
+      <h1>Warmup Dev Renders</h1>
+      <p>
+        In Dev when dynamicIO is enabled requests are preceded by a cache
+        warming prerender. Without PPR this prerender only includes up to the
+        nearest Loading boundary (loading.tsx) and will never include the Page
+        itself. When PPR is enabled it will include everything that is
+        prerenderable including the page if appropriate.
+      </p>
+      <FetchingComponent />
+      <CachedFetchingComponent />
+      <CachedDataComponent />
+    </main>
+  )
+}
+
+async function CachedFetchingComponent() {
+  const data = await fetchCached(
+    'https://next-data-api-endpoint.vercel.app/api/random?key=cachedpage'
+  )
+  console.log('after cached page fetch')
+  return (
+    <dl>
+      <dt>
+        Cached Fetch
+        (https://next-data-api-endpoint.vercel.app/api/random?key=cachedpage)
+      </dt>
+      <dd>{data}</dd>
+    </dl>
+  )
+}
+
+async function FetchingComponent() {
+  const response = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?key=uncachedpage'
+  )
+  console.log('after uncached page fetch')
+  const data = await response.text()
+  return (
+    <dl>
+      <dt>
+        Uncached Fetch
+        (https://next-data-api-endpoint.vercel.app/api/random?key=uncachedpage)
+      </dt>
+      <dd>{data}</dd>
+    </dl>
+  )
+}
+
+async function CachedDataComponent() {
+  const data = await getCachedData('page')
+  console.log('after page cache read')
+  return (
+    <dl>
+      <dt>Cached Data (Page)</dt>
+      <dd>{data}</dd>
+    </dl>
+  )
+}

--- a/test/development/app-dir/dynamic-io-dev-warmup/dynamic-io.warnings.test.ts
+++ b/test/development/app-dir/dynamic-io-dev-warmup/dynamic-io.warnings.test.ts
@@ -1,0 +1,39 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('dynamic-io-dev-warmup', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  function assertLog(
+    logs: Array<{ source: string; message: string }>,
+    message: string,
+    environment: string
+  ) {
+    expect(logs.map((l) => l.message)).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(
+          new RegExp(`^(?=.*\\b${message}\\b)(?=.*\\b${environment}\\b).*`)
+        ),
+      ])
+    )
+  }
+
+  it('logs with Prerender or Server environment depending based on whether the timing of when the log runs relative to this environment boundary', async () => {
+    let browser = await next.browser('/')
+    // At the moment this second render is required for the logs to resolves in the expected environment
+    // This doesn't reproduce locally but I suspect some kind of lazy initialization during dev that leads the initial render
+    // to not resolve in a microtask on the first render.
+    await browser.close()
+    browser = await next.browser('/')
+
+    const logs = await browser.log()
+
+    assertLog(logs, 'after layout cache read', 'Prerender')
+    assertLog(logs, 'after page cache read', 'Prerender')
+    assertLog(logs, 'after cached layout fetch', 'Prerender')
+    assertLog(logs, 'after cached page fetch', 'Prerender')
+    assertLog(logs, 'after uncached layout fetch', 'Server')
+    assertLog(logs, 'after uncached page fetch', 'Server')
+  })
+})

--- a/test/development/app-dir/dynamic-io-dev-warmup/next.config.js
+++ b/test/development/app-dir/dynamic-io-dev-warmup/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    dynamicIO: true,
+  },
+}


### PR DESCRIPTION
To seed caches in dev mode we implemented a prefetch if one had not been done in the recent past. The implementation isn't quite working b/c it doesn't match the prefetch header properly but the mechanics are there. One problem however is the prefetch streams so we end up starting the regular render before the prefetch render is complete.

The ideal cache warmup is to only render until there are no more caches to fill in the prefetch. Additionally we can disable certain things like dynamic Request apis and fetches so they stall forever too. This suggests that there is enough of a difference in the needs of the prefetch for cache warming that we ought to implement it as it's own request type. This change implements the mechanics of triggering the warmup prefetch but does not yet implement the changes to things like the request or fetch apis behavior. I will follow up with further changes on top of this commit.