### PR TITLE
Set Next-Router-Stale-Time header from collected stale times

### DIFF
--- a/packages/next/src/client/components/app-router-headers.ts
+++ b/packages/next/src/client/components/app-router-headers.ts
@@ -11,7 +11,6 @@ export const NEXT_ROUTER_PREFETCH_HEADER = 'Next-Router-Prefetch' as const
 // be merged into a single enum.
 export const NEXT_ROUTER_SEGMENT_PREFETCH_HEADER =
   'Next-Router-Segment-Prefetch' as const
-export const NEXT_ROUTER_STALE_TIME_HEADER = 'Next-Router-Stale-Time' as const
 export const NEXT_HMR_REFRESH_HEADER = 'Next-HMR-Refresh' as const
 export const NEXT_URL = 'Next-Url' as const
 export const RSC_CONTENT_TYPE_HEADER = 'text/x-component' as const
@@ -26,5 +25,6 @@ export const FLIGHT_HEADERS = [
 
 export const NEXT_RSC_UNION_QUERY = '_rsc' as const
 
+export const NEXT_ROUTER_STALE_TIME_HEADER = 'x-nextjs-stale-time' as const
 export const NEXT_DID_POSTPONE_HEADER = 'x-nextjs-postponed' as const
 export const NEXT_IS_PRERENDER_HEADER = 'x-nextjs-prerender' as const

--- a/packages/next/src/client/components/app-router-headers.ts
+++ b/packages/next/src/client/components/app-router-headers.ts
@@ -11,6 +11,7 @@ export const NEXT_ROUTER_PREFETCH_HEADER = 'Next-Router-Prefetch' as const
 // be merged into a single enum.
 export const NEXT_ROUTER_SEGMENT_PREFETCH_HEADER =
   'Next-Router-Segment-Prefetch' as const
+export const NEXT_ROUTER_STALE_TIME_HEADER = 'Next-Router-Stale-Time' as const
 export const NEXT_HMR_REFRESH_HEADER = 'Next-HMR-Refresh' as const
 export const NEXT_URL = 'Next-Url' as const
 export const RSC_CONTENT_TYPE_HEADER = 'text/x-component' as const

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -43,6 +43,7 @@ import {
   NEXT_HMR_REFRESH_HEADER,
   NEXT_ROUTER_PREFETCH_HEADER,
   NEXT_ROUTER_STATE_TREE_HEADER,
+  NEXT_ROUTER_STALE_TIME_HEADER,
   NEXT_URL,
   RSC_HEADER,
 } from '../../client/components/app-router-headers'
@@ -1113,6 +1114,12 @@ async function renderToHTMLOrFlightImpl(
     if (response.collectedTags) {
       metadata.fetchTags = response.collectedTags.join(',')
     }
+
+    // Let the client router know how long to keep the cached entry around.
+    const staleHeader = String(response.collectedStale)
+    res.setHeader(NEXT_ROUTER_STALE_TIME_HEADER, staleHeader)
+    metadata.headers ??= {}
+    metadata.headers[NEXT_ROUTER_STALE_TIME_HEADER] = staleHeader
 
     // If force static is specifically set to false, we should not revalidate
     // the page.

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -188,6 +188,7 @@ function generateCacheEntryWithCacheContext(
       'A default cacheLife profile must always be provided. This is a bug in Next.js.'
     )
   }
+
   // Initialize the Store for this Cache entry.
   const cacheStore: UseCacheStore = {
     type: 'cache',
@@ -239,8 +240,14 @@ function propagateCacheLifeAndTags(
         outerTags.push(tag)
       }
     }
+    if (workUnitStore.stale > entry.stale) {
+      workUnitStore.stale = entry.stale
+    }
     if (workUnitStore.revalidate > entry.revalidate) {
       workUnitStore.revalidate = entry.revalidate
+    }
+    if (workUnitStore.expire > entry.expire) {
+      workUnitStore.expire = entry.expire
     }
   }
 }

--- a/test/e2e/app-dir/use-cache/next.config.js
+++ b/test/e2e/app-dir/use-cache/next.config.js
@@ -6,6 +6,7 @@ const nextConfig = {
     dynamicIO: true,
     cacheLife: {
       frequent: {
+        stale: 19,
         revalidate: 100,
       },
     },

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -99,6 +99,16 @@ describe('use-cache', () => {
     )
 
     itSkipTurbopack(
+      'should match the expected stale config in the page header',
+      async () => {
+        const meta = JSON.parse(
+          await next.readFile('.next/server/app/cache-tag.meta')
+        )
+        expect(meta.headers['Next-Router-Stale-Time']).toBe('19')
+      }
+    )
+
+    itSkipTurbopack(
       'should propagate unstable_cache tags correctly',
       async () => {
         const meta = JSON.parse(

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -102,7 +102,7 @@ describe('use-cache', () => {
       'should match the expected stale config in the page header',
       async () => {
         const meta = JSON.parse(
-          await next.readFile('.next/server/app/cache-tag.meta')
+          await next.readFile('.next/server/app/cache-life.meta')
         )
         expect(meta.headers['x-nextjs-stale-time']).toBe('19')
       }

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -104,7 +104,7 @@ describe('use-cache', () => {
         const meta = JSON.parse(
           await next.readFile('.next/server/app/cache-tag.meta')
         )
-        expect(meta.headers['Next-Router-Stale-Time']).toBe('19')
+        expect(meta.headers['x-nextjs-stale-time']).toBe('19')
       }
     )
 


### PR DESCRIPTION
That way the client router can use it to inform its cache.

This is only done during prerender which is typically the only things we prefetch (other than loading.tsx).

I add it to `.meta` but this applies to both the RSC and HTML payloads I believe. I'm not sure if there's away to only add it to the RSC payload.

For static parts of the HTML document we need a different strategy than the head so this doesn't work for initial load.