### PR TITLE
fixes: 71131 - i18n causes 500 with backslashes

### DIFF
--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -13,7 +13,7 @@ import path from 'path'
 import loadConfig from '../config'
 import { serveStatic } from '../serve-static'
 import setupDebug from 'next/dist/compiled/debug'
-import { DecodeError } from '../../shared/lib/utils'
+import { DecodeError, normalizeRepeatedSlashes } from '../../shared/lib/utils'
 import { findPagesDir } from '../../lib/find-pages-dir'
 import { setupFsCheck } from './router-utils/filesystem'
 import { proxyRequest } from './router-utils/proxy-request'
@@ -191,7 +191,7 @@ export async function initialize(opts: {
       const { getLocaleRedirect } =
         require('../../shared/lib/i18n/get-locale-redirect') as typeof import('../../shared/lib/i18n/get-locale-redirect')
 
-      const parsedUrl = parseUrlUtil((req.url || '')?.replace(/^\/+/, '/'))
+      const parsedUrl = parseUrlUtil(normalizeRepeatedSlashes(req.url || ''))
 
       const redirect = getLocaleRedirect({
         defaultLocale,


### PR DESCRIPTION
### What?

Normalize repeated slashes while deciding if we should redirect to locale URL when i18n is activated.

Test plan described in issue.

- Fixes #71131
- Forum link : https://nextjs-forum.com/post/1293815757494288404

### Test plan

1. Create a new next app
2. Enable i18n
```javascript
/** @type {import('next').NextConfig} */
const nextConfig = {
  reactStrictMode: true,
  i18n: {
    locales: ["en-US"],
    defaultLocale: "en-US",
  },
};

export default nextConfig;
```

3. Start the server: `next dev`.
4. Run: `curl -k http://localhost:3000/\\\\\\%20../%20../%20../%20../%20../%20../foobar`

It should return a 308 redirect.


