### PR TITLE
static indicator shouldn't show for force-dynamic

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -921,7 +921,8 @@ async function renderToHTMLOrFlightImpl(
         process.env.NODE_ENV === 'development' &&
         renderOpts.setAppIsrStatus &&
         !isPPR &&
-        !requestStore.usedDynamic
+        !requestStore.usedDynamic &&
+        !workStore.forceDynamic
       ) {
         // only node can be ISR so we only need to update the status here
         const { pathname } = new URL(req.url || '/', 'http://n')

--- a/test/development/app-dir/prerender-indicator/app/force-dynamic/page.tsx
+++ b/test/development/app-dir/prerender-indicator/app/force-dynamic/page.tsx
@@ -1,0 +1,7 @@
+import { WaitForHydration } from './wait-for-hydration'
+
+export const dynamic = 'force-dynamic'
+
+export default function Page() {
+  return <WaitForHydration />
+}

--- a/test/development/app-dir/prerender-indicator/app/force-dynamic/wait-for-hydration.tsx
+++ b/test/development/app-dir/prerender-indicator/app/force-dynamic/wait-for-hydration.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export function WaitForHydration() {
+  const [hydrated, setHydrated] = useState(false)
+
+  useEffect(() => {
+    setHydrated(true)
+  }, [])
+
+  if (hydrated) {
+    return <div id="ready">hydrated</div>
+  }
+
+  return null
+}

--- a/test/development/app-dir/prerender-indicator/prerender-indicator.test.ts
+++ b/test/development/app-dir/prerender-indicator/prerender-indicator.test.ts
@@ -85,4 +85,12 @@ describe('prerender indicator', () => {
       await next.deleteFile('app/page.tsx')
     }
   })
+
+  it('should not have static indicator when using force-dynamic', async () => {
+    const browser = await next.browser('/force-dynamic')
+
+    await browser.waitForElementByCss('#ready')
+
+    expect(await hasStaticIndicator(browser)).toBe(false)
+  })
 })


### PR DESCRIPTION
The static indicator shouldn't show for pages that are opted into dynamic rendering via `export const dynamic = 'force-dynamic'`. 