### PR TITLE
Mark revalidate: 0 on fetch or use cache as never resolving promise in Dynamic I/O

### DIFF
--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -116,7 +116,7 @@ export function getFirstDynamicReason(
  */
 export function markCurrentScopeAsDynamic(
   store: WorkStore,
-  workUnitStore: undefined | WorkUnitStore,
+  workUnitStore: undefined | Exclude<WorkUnitStore, PrerenderStoreModern>,
   expression: string
 ): void {
   if (workUnitStore) {
@@ -143,17 +143,7 @@ export function markCurrentScopeAsDynamic(
   }
 
   if (workUnitStore) {
-    if (workUnitStore.type === 'prerender') {
-      // We're prerendering the RSC stream with dynamicIO enabled and we need to abort the
-      // current render because something dynamic is being used.
-      // This won't throw so we still need to fall through to determine if/how we handle
-      // this specific dynamic request.
-      abortAndThrowOnSynchronousDynamicDataAccess(
-        store.route,
-        expression,
-        workUnitStore
-      )
-    } else if (workUnitStore.type === 'prerender-ppr') {
+    if (workUnitStore.type === 'prerender-ppr') {
       postponeWithTracking(
         store.route,
         expression,

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -374,6 +374,19 @@ export function createPatchedFetcher(
             revalidateStore &&
             revalidateStore.revalidate === 0)
 
+        if (
+          hasNoExplicitCacheConfig &&
+          workUnitStore !== undefined &&
+          workUnitStore.type === 'prerender'
+        ) {
+          // If we have no cache config, and we're in Dynamic I/O prerendering, it'll be a dynamic call.
+          // We don't have to issue that dynamic call.
+          return makeHangingPromise<Response>(
+            workUnitStore.renderSignal,
+            'fetch()'
+          )
+        }
+
         switch (pageFetchCacheMode) {
           case 'force-no-store': {
             cacheReason = 'fetchCache = force-no-store'

--- a/packages/next/src/server/web/spec-extension/unstable-no-store.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-no-store.ts
@@ -30,6 +30,10 @@ export function unstable_noStore() {
     return
   } else {
     store.isUnstableNoStore = true
-    markCurrentScopeAsDynamic(store, workUnitStore, callingExpression)
+    if (workUnitStore && workUnitStore.type === 'prerender') {
+      // unstable_noStore() is a noop in Dynamic I/O.
+    } else {
+      markCurrentScopeAsDynamic(store, workUnitStore, callingExpression)
+    }
   }
 }

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.test.ts
@@ -288,33 +288,18 @@ describe('dynamic-io', () => {
     })
   }
 
-  if (WITH_PPR) {
-    it('should partially prerender pages that use `unstable_noStore()`', async () => {
-      let $ = await next.render$('/cases/dynamic_api_no_store', {})
-      if (isNextDev) {
-        expect($('#layout').text()).toBe('at runtime')
-        expect($('#page').text()).toBe('at runtime')
-        expect($('#inner').text()).toBe('at runtime')
-      } else {
-        expect($('#layout').text()).toBe('at buildtime')
-        expect($('#page').text()).toBe('at buildtime')
-        expect($('#inner').text()).toBe('at buildtime')
-      }
-    })
-  } else {
-    it('should not prerender pages that use `unstable_noStore()`', async () => {
-      let $ = await next.render$('/cases/dynamic_api_no_store', {})
-      if (isNextDev) {
-        expect($('#layout').text()).toBe('at runtime')
-        expect($('#page').text()).toBe('at runtime')
-        expect($('#inner').text()).toBe('at runtime')
-      } else {
-        expect($('#layout').text()).toBe('at runtime')
-        expect($('#page').text()).toBe('at runtime')
-        expect($('#inner').text()).toBe('at runtime')
-      }
-    })
-  }
+  it('should fully prerender pages that use `unstable_noStore()`', async () => {
+    let $ = await next.render$('/cases/dynamic_api_no_store', {})
+    if (isNextDev) {
+      expect($('#layout').text()).toBe('at runtime')
+      expect($('#page').text()).toBe('at runtime')
+      expect($('#inner').text()).toBe('at runtime')
+    } else {
+      expect($('#layout').text()).toBe('at buildtime')
+      expect($('#page').text()).toBe('at buildtime')
+      expect($('#inner').text()).toBe('at buildtime')
+    }
+  })
 
   if (WITH_PPR) {
     it('should partially prerender pages that use `searchParams` in Server Components', async () => {
@@ -450,15 +435,9 @@ describe('dynamic-io', () => {
       expect($('#page-slot').text()).toBe('at runtime')
       expect($('#page-children').text()).toBe('at runtime')
     } else {
-      if (WITH_PPR) {
-        expect($('#layout').text()).toBe('at buildtime')
-        expect($('#page-slot').text()).toBe('at runtime')
-        expect($('#page-children').text()).toBe('at buildtime')
-      } else {
-        expect($('#layout').text()).toBe('at runtime')
-        expect($('#page-slot').text()).toBe('at runtime')
-        expect($('#page-children').text()).toBe('at runtime')
-      }
+      expect($('#layout').text()).toBe('at buildtime')
+      expect($('#page-slot').text()).toBe('at buildtime')
+      expect($('#page-children').text()).toBe('at buildtime')
     }
 
     $ = await next.render$('/cases/parallel/cookies', {})


### PR DESCRIPTION
This marks it as dynamic but not "sync abort" since these are not sync APIs.

A new heuristic here is that if the `expire` time is low, then we also treat that as dynamic for the purpose of prerendering since it's not worth including if it's supposed to change frequently but it is still possible to temporarily cache it or client-cache it.