### PR TITLE
Implement cacheScope by caching a Promise<CacheEntry>

### DIFF
--- a/test/e2e/app-dir/use-cache-route-handler-only/app/route.ts
+++ b/test/e2e/app-dir/use-cache-route-handler-only/app/route.ts
@@ -5,8 +5,6 @@ async function getCachedRandom() {
 
 export async function GET() {
   const rand1 = await getCachedRandom()
-  // TODO: Remove this extra micro task when bug in use cache wrapper is fixed.
-  await Promise.resolve()
   const rand2 = await getCachedRandom()
 
   const response = JSON.stringify({ rand1, rand2 })

--- a/test/e2e/app-dir/use-cache/app/api/route.ts
+++ b/test/e2e/app-dir/use-cache/app/api/route.ts
@@ -5,8 +5,6 @@ async function getCachedRandom() {
 
 export async function GET() {
   const rand1 = await getCachedRandom()
-  // TODO: Remove this extra micro task when bug in use cache wrapper is fixed.
-  await Promise.resolve()
   const rand2 = await getCachedRandom()
 
   const response = JSON.stringify({ rand1, rand2 })


### PR DESCRIPTION
The cacheScope needs to contain the full CacheEntry, not just the stream, so that it can transfer tag/life to the parent scope when it's used.

I needed to do some refactoring. The tricky bit is that we want to store a Promise into both the cacheHandler and the cacheScope as early as possible to ensure they can dedupe and future requests while it's still pending.
