### PR TITLE
chore: remove experimental warning for next-config-ts

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1034,9 +1034,6 @@ export default async function loadConfig(
           nextConfigPath: path,
           cwd: dir,
         })
-        curLog.warn(
-          `Configuration with ${configFileName} is currently an experimental feature, use with caution.`
-        )
       } else {
         userConfigModule = await import(pathToFileURL(path).href)
       }


### PR DESCRIPTION
### Why?

Is not experimental, but has some restrictions (module resolution to CJS, incompatible with ESM-only packages or syntax).