### PR TITLE
fix(next): eslint v9 not picking up config

### DIFF
--- a/packages/next/src/lib/eslint/runLintCheck.ts
+++ b/packages/next/src/lib/eslint/runLintCheck.ts
@@ -135,9 +135,11 @@ async function lint(
 
     const mod = await Promise.resolve(require(deps.resolved.get('eslint')!))
 
-    const useFlatConfig =
-      // If V9 config was found, use flat config, or else use legacy.
-      eslintrcFile?.startsWith('eslint.config.')
+    // If V9 config was found, use flat config, or else use legacy.
+    const useFlatConfig = eslintrcFile
+      ? // eslintrcFile is absolute path
+        path.basename(eslintrcFile).startsWith('eslint.config.')
+      : false
 
     let ESLint
     // loadESLint is >= 8.57.0
@@ -210,6 +212,15 @@ async function lint(
           ? plugins.includes('@next/next')
           : // in ESLint >= 9, `plugins` value is Record<string, unknown>
             '@next/next' in plugins
+
+      console.log({
+        hasNextPlugin,
+        plugins,
+        completeConfig,
+        configFile,
+        eslint,
+        useFlatConfig,
+      })
 
       if (hasNextPlugin) {
         nextEslintPluginIsEnabled = true

--- a/packages/next/src/lib/eslint/runLintCheck.ts
+++ b/packages/next/src/lib/eslint/runLintCheck.ts
@@ -213,15 +213,6 @@ async function lint(
           : // in ESLint >= 9, `plugins` value is Record<string, unknown>
             '@next/next' in plugins
 
-      console.log({
-        hasNextPlugin,
-        plugins,
-        completeConfig,
-        configFile,
-        eslint,
-        useFlatConfig,
-      })
-
       if (hasNextPlugin) {
         nextEslintPluginIsEnabled = true
         for (const [name, [severity]] of Object.entries(completeConfig.rules)) {


### PR DESCRIPTION
### Why?

We were looking for a config file that starts with `eslint.config.` to enable flat config.
The value for the config file `eslintrcFile` was an absolute path, but we were using `startsWith`

### How?

Used `path.basename` to get the filename.

Fixes #67596