### PR TITLE
Use integrated terminal as console in vscode launch configs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -37,6 +37,7 @@
         "${input:nextCommand}",
         "${input:appDirname}"
       ],
+      "console": "integratedTerminal",
       "skipFiles": ["<node_internals>/**"],
       "sourceMapPathOverrides": {
         "webpack:///./*": "${workspaceFolder}/${input:appDirname}/*",
@@ -70,6 +71,7 @@
         "${input:nextCommand}",
         "${fileDirname}"
       ],
+      "console": "integratedTerminal",
       "skipFiles": ["<node_internals>/**"],
       "sourceMapPathOverrides": {
         "webpack:///./*": "${workspaceFolder}/${fileDirname}/*",


### PR DESCRIPTION
With the default debug console:

<img width="1075" alt="Screenshot 2024-10-15 at 13 22 12" src="https://github.com/user-attachments/assets/5f87b1da-1ac1-4483-bf2e-4903b43b33d9">

With the integrated terminal:

<img width="1075" alt="Screenshot 2024-10-15 at 13 22 20" src="https://github.com/user-attachments/assets/a7cb6b80-c028-46fe-9afc-5f4eceaf172a">
