### PR TITLE
Re-add canary gates for certain experimental features

### DIFF
--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -61,4 +61,58 @@ describe('loadConfig', () => {
       expect(result.images.remotePatterns.length).toBe(1)
     })
   })
+
+  describe('canary-only features', () => {
+    beforeAll(() => {
+      process.env.__NEXT_VERSION = '14.2.0'
+    })
+
+    afterAll(() => {
+      delete process.env.__NEXT_VERSION
+    })
+
+    it('errors when using PPR if not in canary', async () => {
+      await expect(
+        loadConfig('', __dirname, {
+          customConfig: {
+            experimental: {
+              ppr: true,
+            },
+          },
+        })
+      ).rejects.toThrow(
+        /The experimental feature "experimental.ppr" can only be enabled when using the latest canary version of Next.js./
+      )
+    })
+
+    it('errors when using dynamicIO if not in canary', async () => {
+      await expect(
+        loadConfig('', __dirname, {
+          customConfig: {
+            experimental: {
+              dynamicIO: true,
+            },
+          },
+        })
+      ).rejects.toThrow(
+        /The experimental feature "experimental.dynamicIO" can only be enabled when using the latest canary version of Next.js./
+      )
+    })
+
+    it('errors when using persistentCaching if not in canary', async () => {
+      await expect(
+        loadConfig('', __dirname, {
+          customConfig: {
+            experimental: {
+              turbo: {
+                unstablePersistentCaching: true,
+              },
+            },
+          },
+        })
+      ).rejects.toThrow(
+        /The experimental feature "experimental.turbo.unstablePersistentCaching" can only be enabled when using the latest canary version of Next.js./
+      )
+    })
+  })
 })

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -250,6 +250,20 @@ function assignDefaults(
     )
   }
 
+  if (
+    !process.env.__NEXT_VERSION?.includes('canary') &&
+    !process.env.__NEXT_TEST_MODE
+  ) {
+    // Prevents usage of certain experimental features outside of canary
+    if (result.experimental?.ppr) {
+      throw new CanaryOnlyError('experimental.ppr')
+    } else if (result.experimental?.dynamicIO) {
+      throw new CanaryOnlyError('experimental.dynamicIO')
+    } else if (result.experimental?.turbo?.unstablePersistentCaching) {
+      throw new CanaryOnlyError('experimental.turbo.unstablePersistentCaching')
+    }
+  }
+
   if (result.output === 'export') {
     if (result.i18n) {
       throw new Error(
@@ -1220,4 +1234,12 @@ export function getEnabledExperimentalFeatures(
     }
   }
   return enabledExperiments
+}
+
+class CanaryOnlyError extends Error {
+  constructor(feature: string) {
+    super(
+      `The experimental feature "${feature}" can only be enabled when using the latest canary version of Next.js.`
+    )
+  }
 }


### PR DESCRIPTION
This re-adds the gate that verifies canary is being used before allowing certain experimental features to be enabled. This is because these features are undergoing frequent changes where we want to make sure that the latest iterations are being validated.