### PR TITLE
docs: small updates for canary docs

### DIFF
--- a/docs/02-app/01-building-your-application/02-data-fetching/03-server-actions-and-mutations.mdx
+++ b/docs/02-app/01-building-your-application/02-data-fetching/03-server-actions-and-mutations.mdx
@@ -880,8 +880,8 @@ and should be treated with the same security assumptions and authorization check
 
 To improve security, Next.js has the following built-in features:
 
-- **Dead code elimination:** Unused Server Actions won’t have their IDs exposed to the client-side JavaScript bundle, reducing bundle size and improving performance.
-- **Secure action IDs:** Next.js creates unguessable, non-deterministic IDs to allow the client to reference and call the Server Action. These IDs are periodically recalculated for enhanced security.
+- **Secure action IDs:** Next.js creates unguessable, non-deterministic IDs to allow the client to reference and call the Server Action. These IDs are periodically recalculated between builds for enhanced security.
+- **Dead code elimination:** Unused Server Actions (referenced by their IDs) are automatically removed.
 
 ```jsx
 // app/actions.js

--- a/docs/02-app/01-building-your-application/03-rendering/01-server-components.mdx
+++ b/docs/02-app/01-building-your-application/03-rendering/01-server-components.mdx
@@ -99,13 +99,13 @@ As a developer, you do not need to choose between static and dynamic rendering a
 
 Dynamic APIs rely on information that can only be known at request time (and not ahead of time during prerendering). Using any of these APIs signals the developer's intention and will opt the whole route into dynamic rendering at the request time. These APIs include:
 
-- [`cookies`](https://www.notion.so/docs/app/api-reference/functions/cookies)
-- [`headers`](https://www.notion.so/docs/app/api-reference/functions/headers)
-- [`unstable_noStore`](https://www.notion.so/docs/app/api-reference/functions/unstable_noStore)
-- [`unstable_after`](https://www.notion.so/docs/app/api-reference/functions/unstable_after)
-- [`connection`](https://www.notion.so/docs/app/api-reference/functions/connection)
-- [`draftMode`](https://www.notion.so/docs/app/api-reference/functions/draft-mode)
-- [`searchParams` prop](https://www.notion.so/docs/app/api-reference/file-conventions/page#searchparams-optional)
+- [`cookies`](/docs/app/api-reference/functions/cookies)
+- [`headers`](/docs/app/api-reference/functions/headers)
+- [`connection`](/docs/app/api-reference/functions/connection)
+- [`draftMode`](/docs/app/api-reference/functions/draft-mode)
+- [`searchParams` prop](/docs/app/api-reference/file-conventions/page#searchparams-optional)
+- [`unstable_noStore`](/docs/app/api-reference/functions/unstable_noStore)
+- [`unstable_after`](/docs/app/api-reference/functions/unstable_after)
 
 ### Streaming
 


### PR DESCRIPTION
- Rework bullet points from blog post
- Fix relative links mentioning Notion from copy/pasta
- Move the unstable APIs to the bottom of the list