### PR TITLE
Add built-in set of cacheLife profiles

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1031,8 +1031,38 @@ export const defaultConfig: NextConfig = {
     cacheLife: {
       default: {
         stale: undefined, // defaults to staleTimes.static
-        revalidate: 900,
+        revalidate: 60 * 15, // 15 minutes
         expire: INFINITE_CACHE,
+      },
+      seconds: {
+        stale: undefined, // defaults to staleTimes.dynamic
+        revalidate: 1, // 1 second
+        expire: 1, // 1 minute
+      },
+      minutes: {
+        stale: 60 * 5, // 5 minutes
+        revalidate: 60, // 1 minute
+        expire: 60 * 60, // 1 hour
+      },
+      hours: {
+        stale: 60 * 5, // 5 minutes
+        revalidate: 60 * 60, // 1 hour
+        expire: 60 * 60 * 24, // 1 day
+      },
+      days: {
+        stale: 60 * 5, // 5 minutes
+        revalidate: 60 * 60 * 24, // 1 day
+        expire: 60 * 60 * 24 * 7, // 1 week
+      },
+      weeks: {
+        stale: 60 * 5, // 5 minutes
+        revalidate: 60 * 60 * 24 * 7, // 1 week
+        expire: 60 * 60 * 24 * 30, // 1 month
+      },
+      max: {
+        stale: 60 * 5, // 5 minutes
+        revalidate: 60 * 60 * 24 * 30, // 1 month
+        expire: INFINITE_CACHE, // Unbounded.
       },
     },
     multiZoneDraftMode: false,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -848,6 +848,18 @@ function assignDefaults(
           result.expireTime ?? defaultDefault.expire
       }
     }
+    // This is the most dynamic cache life profile.
+    const secondsCacheLifeProfile = result.experimental.cacheLife['seconds']
+    if (
+      secondsCacheLifeProfile &&
+      secondsCacheLifeProfile.stale === undefined
+    ) {
+      // We default this to whatever stale time you had configured for dynamic content.
+      // Since this is basically a dynamic cache life profile.
+      const dynamicStaleTime = result.experimental.staleTimes?.dynamic
+      secondsCacheLifeProfile.stale =
+        dynamicStaleTime ?? defaultConfig.experimental?.staleTimes?.dynamic
+    }
   }
 
   const userProvidedModularizeImports = result.modularizeImports

--- a/packages/next/src/server/use-cache/cache-life.ts
+++ b/packages/next/src/server/use-cache/cache-life.ts
@@ -19,7 +19,16 @@ export type CacheLife = {
 // The default revalidates relatively frequently but doesn't expire to ensure it's always
 // able to serve fast results but by default doesn't hang.
 
-type CacheLifeProfiles = string // This gets overridden by the next-types-plugin
+// This gets overridden by the next-types-plugin
+type CacheLifeProfiles =
+  | 'default'
+  | 'seconds'
+  | 'minutes'
+  | 'hours'
+  | 'days'
+  | 'weeks'
+  | 'max'
+  | string
 
 function validateCacheLife(profile: CacheLife) {
   if (profile.stale !== undefined) {


### PR DESCRIPTION
```
cacheLife: {
  "seconds": {
    stale: 30, // 30 seconds
    revalidate: 1, // 1 second
    expire: 1, // 1 minute
  },
  "minutes": {
    stale: 60 * 5, // 5 minutes
    revalidate: 60, // 1 minute
    expire: 60 * 60, // 1 hour
  },
  "hours": {
    stale: 60 * 5, // 5 minutes
    revalidate: 60 * 60, // 1 hour
    expire: 60 * 60 * 24, // 1 day
  },
  "days": {
    stale: 60 * 5, // 5 minutes
    revalidate: 60 * 60 * 24, // 1 day
    expire: 60 * 60 * 24 * 7, // 1 week
  },
  "weeks": {
    stale: 60 * 5, // 5 minutes
    revalidate: 60 * 60 * 24 * 7, // 1 week
    expire: 60 * 60 * 24 * 30, // 1 month
  },
  "max": {
    stale: 60 * 5, // 5 minutes
    revalidate: 60 * 60 * 24 * 30, // 1 month
    expire: Infinity, // Unbounded. Whatever max your host stores.
  }
}
```

The stale time is either 30 seconds or 5 minutes which correspond to our existing default for dynamic/static data. If you have overridden the `staleTimes` options, we default for those. `"seconds"` means basically dynamic.

The revalidate time is the beginning of the range and the expire is the end of that range. So `"days"` refreshes somewhere after 1 day and before 1 week.