### PR TITLE
fix: make "Release stats" use the correct artifact name

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -597,7 +597,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          pattern: next-swc-binaries
+          pattern: next-swc-binaries-*
           merge-multiple: true
           path: packages/next-swc/native
 


### PR DESCRIPTION
There's no artifact called `next-swc-binaries`, all the other places use `next-swc-binaries-*`
The name's coming from here: https://github.com/vercel/next.js/blob/bc309364d09c11cc6c149e643fa012c4d88dcb6c/.github/workflows/build_and_deploy.yml#L377

Example failing run: https://github.com/vercel/next.js/actions/runs/11352776677/job/31576710878
It's failing because `download-artifact` didn't download anything (because of the incorrect name), and the `native` directory no longer exists (it used to have a .gitkeep inside, but we removed that a while ago), so it just crashes



