### PR TITLE
docs(route-groups): add an example about opting loading skeletons to a specific route

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/08-route-groups.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/08-route-groups.mdx
@@ -13,7 +13,7 @@ Route groups are useful for:
 - Enabling [nested layouts](/docs/app/building-your-application/routing/layouts-and-templates) in the same route segment level:
   - [Creating multiple nested layouts in the same segment, including multiple root layouts](#creating-multiple-root-layouts)
   - [Adding a layout to a subset of routes in a common segment](#opting-specific-segments-into-a-layout)
-- [Adding a loading skeleton to specific route in a common segment](#opting-loading-skeletons-to-a-specific-route)
+- [Adding a loading skeleton to specific route in a common segment](#opting-for-loading-skeletons-on-a-specific-route)
 
 ## Convention
 

--- a/docs/02-app/01-building-your-application/01-routing/08-route-groups.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/08-route-groups.mdx
@@ -67,7 +67,7 @@ To apply a [loading skeleton](/docs/app/building-your-application/routing/loadin
   height="444"
 />
 
-Now, the `loading.tsx` file will only apply to your dashboard → overview page instead of all your dashboard pages.
+Now, the `loading.tsx` file will only apply to your dashboard → overview page instead of all your dashboard pages without affecting the URL path structure.
 
 ### Creating multiple root layouts
 

--- a/docs/02-app/01-building-your-application/01-routing/08-route-groups.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/08-route-groups.mdx
@@ -13,6 +13,7 @@ Route groups are useful for:
 - Enabling [nested layouts](/docs/app/building-your-application/routing/layouts-and-templates) in the same route segment level:
   - [Creating multiple nested layouts in the same segment, including multiple root layouts](#creating-multiple-root-layouts)
   - [Adding a layout to a subset of routes in a common segment](#opting-specific-segments-into-a-layout)
+- [Adding a loading skeleton to specific route in a common segment](#opting-loading-skeletons-to-a-specific-route)
 
 ## Convention
 
@@ -53,6 +54,20 @@ To opt specific routes into a layout, create a new route group (e.g. `(shop)`) a
   width="1600"
   height="930"
 />
+
+### Opting for loading skeletons on a specific route
+
+To apply a [loading skeleton](/docs/app/building-your-application/routing/loading-ui-and-streaming) via a `loading.js` file to a specific route, create a new route group (e.g., `/(overview)`) and then move your `loading.tsx` inside that route group.
+
+<Image
+  alt="Folder structure showing a loading.tsx and a page.tsx inside the route group"
+  srcLight="/docs/light/route-group-loading.png"
+  srcDark="/docs/dark/route-group-loading.png"
+  width="1600"
+  height="444"
+/>
+
+Now, the `loading.tsx` file will only apply to your dashboard → overview page instead of all your dashboard pages.
 
 ### Creating multiple root layouts
 


### PR DESCRIPTION
## Why?

Add an additional example that highlights using Route Groups to opt a loading skeleton to a specific route.

- Fixes: https://github.com/vercel/next.js/issues/71321