### PR TITLE
refactor(turbopack): Simplify `EcmascriptModulePartAsset::ident`

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -117,14 +117,8 @@ impl EcmascriptModulePartAsset {
 #[turbo_tasks::value_impl]
 impl Module for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
-    async fn ident(&self) -> Result<Vc<AssetIdent>> {
-        let inner = self.full_module.ident();
-        let result = split_module(self.full_module);
-
-        match &*result.await? {
-            SplitResult::Ok { .. } => Ok(inner.with_part(self.part)),
-            SplitResult::Failed { .. } => Ok(inner),
-        }
+    fn ident(&self) -> Vc<AssetIdent> {
+        self.full_module.ident().with_part(self.part)
     }
 
     #[turbo_tasks::function]


### PR DESCRIPTION
### What?

Simplify `ident` implementation of `EcmascriptModulePartAsset`.

### Why?

`EcmascriptModulePartAsset` is not created if a module is not splitted.

### How?
