### PR TITLE
fix(turbopack): Make `follow_exports` do not go into fragments

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -24,6 +24,7 @@ use turbopack_core::{
     issue::{analyze::AnalyzeIssue, IssueExt, IssueSeverity, StyledString},
     module::Module,
     reference::ModuleReference,
+    resolve::ModulePart,
 };
 
 use super::base::ReferencedAsset;
@@ -31,6 +32,7 @@ use crate::{
     chunk::{EcmascriptChunkPlaceable, EcmascriptExports},
     code_gen::{CodeGenerateable, CodeGeneration, CodeGenerationHoistedStmt},
     magic_identifier,
+    tree_shake::asset::EcmascriptModulePartAsset,
 };
 
 #[derive(Clone, Hash, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs)]
@@ -141,6 +143,23 @@ pub async fn follow_reexports(
     let mut module = module;
     let mut export_name = export_name;
     loop {
+        // Do not go into `internal` fragments. Those modules are private to a single module.
+        if let Some(fragment) =
+            Vc::try_resolve_downcast_type::<EcmascriptModulePartAsset>(module).await?
+        {
+            let part = fragment.await?.part.await?;
+
+            if let ModulePart::Export(export) = *part {
+                if *export.await? == export_name {
+                    return Ok(FollowExportsResult::cell(FollowExportsResult {
+                        module,
+                        export_name: Some(export_name),
+                        ty: FoundExportType::Found,
+                    }));
+                }
+            }
+        }
+
         let exports = module.get_exports().await?;
         let EcmascriptExports::EsmExports(exports) = &*exports else {
             return Ok(FollowExportsResult::cell(FollowExportsResult {


### PR DESCRIPTION
### What?

Improve `follow_exports`. It should not go into private module fragments.

### Why?

Internal module fragments are designed to be module-private, and it can cause problems if it's directly depended by an external module.

### How?

