### PR TITLE
Encode FormData for cache keys using custom algorithm

### DIFF
--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -399,6 +399,40 @@ async function getNthCacheEntry(
   return (await split)[i]
 }
 
+async function encodeFormData(formData: FormData): Promise<string> {
+  let result = ''
+  for (let [key, value] of formData) {
+    // We don't need this key to be serializable but from a security perspective it should not be
+    // possible to generate a string that looks the same from a different structure. To ensure this
+    // we need a delimeter between fields but just using a delimeter is not enough since a string
+    // might contain that delimeter. We use the length of each field as the delimeter to avoid
+    // escaping the values.
+    result += key.length.toString(16) + ':' + key
+    let stringValue
+    if (typeof value === 'string') {
+      stringValue = value
+    } else {
+      // The FormData might contain binary data that is not valid UTF-8 so this cache
+      // key may generate a UCS-2 string. Passing this to another service needs to be
+      // aware that the key might not be compatible.
+      const arrayBuffer = await value.arrayBuffer()
+      if (arrayBuffer.byteLength % 2 === 0) {
+        stringValue = String.fromCodePoint(...new Uint16Array(arrayBuffer))
+      } else {
+        stringValue =
+          String.fromCodePoint(
+            ...new Uint16Array(arrayBuffer, 0, (arrayBuffer.byteLength - 1) / 2)
+          ) +
+          String.fromCodePoint(
+            new Uint8Array(arrayBuffer, arrayBuffer.byteLength - 1, 1)[0]
+          )
+      }
+    }
+    result += stringValue.length.toString(16) + ':' + stringValue
+  }
+  return result
+}
+
 export function cache(kind: string, id: string, fn: any) {
   if (!process.env.__NEXT_DYNAMIC_IO) {
     throw new Error(
@@ -444,14 +478,7 @@ export function cache(kind: string, id: string, fn: any) {
           ? // Fast path for the simple case for simple inputs. We let the CacheHandler
             // Convert it to an ArrayBuffer if it wants to.
             encodedArguments
-          : // The FormData might contain binary data that is not valid UTF-8 so this cache
-            // key may generate a UCS-2 string. Passing this to another service needs to be
-            // aware that the key might not be compatible.
-            String.fromCodePoint(
-              ...new Uint8Array(
-                await new Response(encodedArguments).arrayBuffer()
-              )
-            )
+          : await encodeFormData(encodedArguments)
 
       let stream: undefined | ReadableStream = undefined
 

--- a/test/e2e/app-dir/use-cache/app/complex-args/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/complex-args/page.tsx
@@ -1,0 +1,18 @@
+async function getCached({ p }) {
+  'use cache'
+  const array = await p
+  if (array instanceof Uint8Array) {
+    return array[0].toString(16) + '-' + Math.random()
+  }
+  return 'invalid'
+}
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ n: string }>
+}) {
+  const n = parseInt((await searchParams).n, 16)
+  const p = Promise.resolve(new Uint8Array([n]))
+  return <p id="x">{await getCached({ p })}</p>
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -41,6 +41,31 @@ describe('use-cache', () => {
     expect(await browser.waitForElementByCss('#r').text()).toContain('rnd')
   })
 
+  it('should cache complex args', async () => {
+    // Use two bytes that can't be encoded as UTF-8 to ensure serialization works.
+    const browser = await next.browser('/complex-args?n=a1')
+    const a1a = await browser.waitForElementByCss('#x').text()
+    expect(a1a.slice(0, 2)).toBe('a1')
+
+    await browser.loadPage(new URL('/complex-args?n=e2', next.url).toString())
+    const e2a = await browser.waitForElementByCss('#x').text()
+    expect(e2a.slice(0, 2)).toBe('e2')
+
+    expect(a1a).not.toBe(e2a)
+
+    await browser.loadPage(new URL('/complex-args?n=a1', next.url).toString())
+    const a1b = await browser.waitForElementByCss('#x').text()
+    expect(a1b.slice(0, 2)).toBe('a1')
+
+    await browser.loadPage(new URL('/complex-args?n=e2', next.url).toString())
+    const e2b = await browser.waitForElementByCss('#x').text()
+    expect(e2b.slice(0, 2)).toBe('e2')
+
+    // The two navigations to n=1 should use a cached value.
+    expect(a1a).toBe(a1b)
+    expect(e2a).toBe(e2b)
+  })
+
   it('should dedupe with react cache inside "use cache"', async () => {
     const browser = await next.browser('/react-cache')
     const a = await browser.waitForElementByCss('#a').text()


### PR DESCRIPTION
We need to encode FormData when we generate a complex cache key since that's what RSC uses for encodeReply.

However, using the standard `multipart/form-data` encoding in `new Response().arrayBuffer()` uses a large delimiter that's inefficient but that delimiter is also randomly generated which completely defeats the purpose of using it as a cache key.

Instead, we can use the size of each part as the delimiter.

It is important to something that is not just a character because otherwise it's a potential security hole since someone could carefully tailor input to cause cache poisoning.

E.g. if we used `:` as the delimiter then `[['a', 'b'],['c', 'd']]` would be encoded as `a:b:c:d` but so would `[['a', 'b:c:d']]`.