### PR TITLE
perf(turbopack): Do not store export star in internal fragments

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use anyhow::{bail, Result};
-use turbo_tasks::Vc;
+use turbo_tasks::{ValueToString, Vc};
 use turbo_tasks_fs::{glob::Glob, File, FileContent};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -61,10 +61,10 @@ impl EcmascriptModuleFacadeModule {
 #[turbo_tasks::value_impl]
 impl Module for EcmascriptModuleFacadeModule {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
         let inner = self.module.ident();
 
-        inner.with_part(self.ty)
+        Ok(inner.with_modifier(self.ty.to_string()))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -1,17 +1,16 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use turbo_tasks::Vc;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{AsyncModuleInfo, ChunkableModule, ChunkingContext, EvaluatableAsset},
     ident::AssetIdent,
     module::Module,
-    reference::{ModuleReference, ModuleReferences, SingleModuleReference},
+    reference::ModuleReferences,
     resolve::ModulePart,
 };
 
 use super::{
-    chunk_item::EcmascriptModulePartChunkItem, get_part_id, part_of_module, split, split_module,
-    PartId, SplitResult,
+    chunk_item::EcmascriptModulePartChunkItem, part_of_module, split, split_module, SplitResult,
 };
 use crate::{
     chunk::{EcmascriptChunkPlaceable, EcmascriptExports},
@@ -123,60 +122,9 @@ impl Module for EcmascriptModulePartAsset {
 
     #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<ModuleReferences>> {
-        let split_data = split_module(self.full_module).await?;
-
         let analyze = analyze(self.full_module, self.part).await?;
 
-        let deps = match &*split_data {
-            SplitResult::Ok { deps, .. } => deps,
-            SplitResult::Failed { .. } => return Ok(analyze.references),
-        };
-
-        let part_dep = |part: Vc<ModulePart>| -> Vc<Box<dyn ModuleReference>> {
-            Vc::upcast(SingleModuleReference::new(
-                Vc::upcast(EcmascriptModulePartAsset::new(self.full_module, part)),
-                Vc::cell("ecmascript module part".into()),
-            ))
-        };
-
-        let mut references = analyze.references.await?.to_vec();
-
-        // Facade depends on evaluation and re-exports
-        if matches!(&*self.part.await?, ModulePart::Facade) {
-            references.push(part_dep(ModulePart::evaluation()));
-            references.push(part_dep(ModulePart::exports()));
-            return Ok(Vc::cell(references));
-        }
-
-        let deps = {
-            let part_id = get_part_id(&split_data, self.part)
-                .await
-                .with_context(|| format!("part {:?} is not found in the module", self.part))?;
-
-            match deps.get(&part_id) {
-                Some(v) => &**v,
-                None => &[],
-            }
-        };
-
-        references.extend(
-            deps.iter()
-                .filter_map(|part_id| {
-                    Some(part_dep(match part_id {
-                        // This is an internal part that is not for evaluation, so we don't need to
-                        // force-add it.
-                        PartId::Internal(.., false) => return None,
-                        PartId::Internal(part_id, true) => ModulePart::internal(*part_id),
-                        PartId::Export(name) => ModulePart::export(name.clone()),
-                        _ => unreachable!(
-                            "PartId other than Internal and Export should not be used here"
-                        ),
-                    }))
-                })
-                .collect::<Vec<_>>(),
-        );
-
-        Ok(Vc::cell(references))
+        Ok(analyze.references)
     }
 }
 

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export/issues/__l_Export __c_Abc__ doesn't exist in target modul-66918a.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export/issues/__l_Export __c_Abc__ doesn't exist in target modul-66918a.txt
@@ -8,7 +8,7 @@ error - [bindings] [project]/turbopack/crates/turbopack-tests/tests/execution/tu
        4 | import * as X from "./module";
        5 | 
   
-  The export Abc was not found in module [project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export/input/invalid-export/module.js [test] (ecmascript) <exports>.
+  The export Abc was not found in module [project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export/input/invalid-export/module.js [test] (ecmascript, exports).
   
   Did you mean to import Abd?
   


### PR DESCRIPTION
### What?

Do not store `export *` in internal fragments.

### Why?

It results in large number of fragments.

### How?

Closes PACK-3264