### PR TITLE
[dynamicIO] implement dynamic check using AbortSignal

### DIFF
--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -471,10 +471,6 @@ export function isPrerenderInterruptedError(
   )
 }
 
-export function isRenderInterruptedReason(reason: string) {
-  return reason === NEXT_PRERENDER_INTERRUPTED
-}
-
 export function accessedDynamicData(
   dynamicTracking: DynamicTrackingState
 ): boolean {
@@ -616,7 +612,6 @@ export function trackAllowedDynamicAccess(
     // We don't need to track that this is dynamic. It is only so when something else is also dynamic.
     return
   } else if (hasMetadataRegex.test(componentStack)) {
-    //
     disallowedDynamic.hasDynamicMetadata = true
     return
   } else if (hasViewportRegex.test(componentStack)) {


### PR DESCRIPTION
Reimplements the logic of determining if we are dynamic by reading the AbortController's signal when handling errors. This is more robust than checking error identity because it's not guaranteed that the error we receive is literally the instance that was passed to the abort call.