### PR TITLE
[dynamicIO] track environment on requestStore 

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1550,6 +1550,7 @@ async function renderToStream(
       renderOpts.experimental.dynamicIO
     ) {
       let environmentName = 'Prerender'
+      requestStore.environment = environmentName
       reactServerResult = new ReactServerResult(
         await workUnitAsyncStorage.run(
           requestStore,
@@ -1565,7 +1566,7 @@ async function renderToStream(
             )
           },
           () => {
-            environmentName = 'Server'
+            environmentName = requestStore.environment = 'Server'
           }
         )
       )

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -51,6 +51,7 @@ export type RequestStore = {
 
   // DEV-only
   usedDynamic?: boolean
+  environment?: string
 } & PhasePartial
 
 /**


### PR DESCRIPTION
Stacked on #71344 

environment is used to contextualize logs. We use the Prerender environment in the first task of a render and Server in the remaining tasks. This was previously implemented using a closed over variable but we actually want to be able to make  error determinations in dev mode using this information so in this change we move this to the requeststore