### PR TITLE
[dynamicIO] track suspense boundaries only after excluding metadata and other boundaries

### DIFF
--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -609,10 +609,7 @@ export function trackAllowedDynamicAccess(
   dynamicTracking: DynamicTrackingState
 ) {
   const disallowedDynamic = dynamicTracking.disallowedDynamic
-  if (hasSuspenseRegex.test(componentStack)) {
-    disallowedDynamic.hasSuspendedDynamic = true
-    return
-  } else if (hasOutletRegex.test(componentStack)) {
+  if (hasOutletRegex.test(componentStack)) {
     // We don't need to track that this is dynamic. It is only so when something else is also dynamic.
     return
   } else if (hasMetadataRegex.test(componentStack)) {
@@ -621,6 +618,9 @@ export function trackAllowedDynamicAccess(
     return
   } else if (hasViewportRegex.test(componentStack)) {
     disallowedDynamic.hasDynamicViewport = true
+    return
+  } else if (hasSuspenseRegex.test(componentStack)) {
+    disallowedDynamic.hasSuspendedDynamic = true
     return
   } else if (isPrerenderInterruptedError(thrownValue)) {
     const syncDynamicExpression = disallowedDynamic.syncDynamicExpression

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
@@ -83,6 +83,47 @@ function runTests(options: { withMinification: boolean }) {
         )
       })
     })
+    describe('Dynamic Metadata - Static Route With Suspense', () => {
+      const { next, isNextDev, skipped } = nextTestSetup({
+        files: __dirname + '/fixtures/dynamic-metadata-static-with-suspense',
+        skipStart: true,
+        skipDeployment: true,
+      })
+
+      if (skipped) {
+        return
+      }
+
+      if (isNextDev) {
+        it('does not run in dev', () => {})
+        return
+      }
+
+      beforeEach(async () => {
+        if (!withMinification) {
+          await next.patchFile('next.config.js', (content) =>
+            content.replace(
+              'serverMinification: true,',
+              'serverMinification: false,'
+            )
+          )
+        }
+      })
+
+      it('should error the build if generateMetadata is dynamic', async () => {
+        try {
+          await next.start()
+        } catch {
+          // we expect the build to fail
+        }
+        const expectError = createExpectError(next.cliOutput)
+
+        expectError('Error occurred prerendering page "/"')
+        expectError(
+          'Error: Route / has a dynamic `generateMetadata` but nothing else is dynamic.'
+        )
+      })
+    })
 
     describe('Dynamic Metadata - Dynamic Route', () => {
       const { next, isNextDev, skipped } = nextTestSetup({

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-static-with-suspense/app/layout.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-static-with-suspense/app/layout.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from 'react'
+
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>
+          <Suspense>{children}</Suspense>
+        </main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-static-with-suspense/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-static-with-suspense/app/page.tsx
@@ -1,0 +1,17 @@
+export async function generateMetadata() {
+  await new Promise((r) => setTimeout(r, 0))
+  return { title: 'Dynamic Metadata' }
+}
+
+export default async function Page() {
+  return (
+    <>
+      <p>
+        This page is static except for generateMetadata which does some IO. This
+        is a build error because metadata is not wrapped in a Suspense boundary.
+        We expect that if you intended for your metadata to be dynamic you will
+        ensure your page is dynamic too
+      </p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-static-with-suspense/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/dynamic-metadata-static-with-suspense/next.config.js
@@ -1,0 +1,13 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    ppr: process.env.__NEXT_EXPERIMENTAL_PPR === 'true',
+    pprFallbacks: process.env.__NEXT_EXPERIMENTAL_PPR === 'true',
+    dynamicIO: true,
+    serverMinification: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/dynamic-io/app/cookies/exercise/sync/page.tsx
+++ b/test/e2e/app-dir/dynamic-io/app/cookies/exercise/sync/page.tsx
@@ -4,6 +4,7 @@ import { getSentinelValue } from '../../../getSentinelValue'
 import { AllComponents } from '../components'
 
 export default async function Page() {
+  await new Promise((r) => process.nextTick(r))
   const allCookies = cookies() as unknown as UnsafeUnwrappedCookies
   return (
     <>

--- a/test/e2e/app-dir/dynamic-io/app/headers/exercise/sync/page.tsx
+++ b/test/e2e/app-dir/dynamic-io/app/headers/exercise/sync/page.tsx
@@ -4,6 +4,7 @@ import { getSentinelValue } from '../../../getSentinelValue'
 import { AllComponents } from '../components'
 
 export default async function Page() {
+  await new Promise((r) => process.nextTick(r))
   const xSentinelValues = new Set<string>()
   // We use the async form here to avoid triggering dev warnings. this is not direclty being
   // aserted, it just helps us do assertions in our AllComponents


### PR DESCRIPTION
When we determine if a dynamicIO error representing a dynamic hold is allowed we use the parent component stack of the erroring component. Certain components have special marker components int heir stack that allow us to make intelligent erroring and messaging decisions, in particular Metadata and related APIs. There was a bug in the current implementation where if there was a Suspense boundary parent of the metadata outlet it would be categorized as having something dynamic inside a Suspense boundary. This is erroneous because the MetaataOutlet should be ignored for dynamic purposes given it only throws if metadata itself was dynamic.

This change fixes the order, prioritizing Suspense behind the special case boundaries.
