### PR TITLE
Fix flaky app action test

### DIFF
--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1256,7 +1256,6 @@ describe('app-dir action handling', () => {
         expect(await browser.url()).toBe(`${next.url}/pages-dir`)
         expect(mpaTriggered).toBe(true)
       })
-      // TODO: remove custom duration in case we increase the default.
     }, 5000)
 
     it('should handle revalidatePath', async () => {

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1256,7 +1256,8 @@ describe('app-dir action handling', () => {
         expect(await browser.url()).toBe(`${next.url}/pages-dir`)
         expect(mpaTriggered).toBe(true)
       })
-    })
+      // TODO: remove custom duration in case we increase the default.
+    }, 5000)
 
     it('should handle revalidatePath', async () => {
       const browser = await next.browser('/revalidate')


### PR DESCRIPTION
x-ref: [Flakiness Metrics](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20env%3Aci%20%40git.repository.id%3Agithub.com%2Fvercel%2Fnext.js%20%40test.service%3Anextjs%20%40test.status%3Afail%20%40test.name%3A%22app-dir%20action%20handling%20fetch%20actions%20should%20handle%20redirects%20to%20routes%20that%20provide%20an%20invalid%20RSC%20response%22&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&start=1728463943572&end=1729068743572&paused=false)

In [this example run](https://github.com/vercel/next.js/actions/runs/11360883017/job/31599548914) you can see that the compilation of the redirect target page can take longer than 3 seconds in CI:

```
 GET /client 200 in 69ms
   ○ Compiling /pages-dir ...
   POST /client 303 in 3276ms
   ✓ Compiled /pages-dir in 3.3s (1074 modules)
   GET /pages-dir 200 in 3848ms
```

This exceeds our default `retry` duration, and so the test often fails.

To fix the flakiness, we are increasing the duration from 3 to 5 seconds. We already did this before for a couple of other tests with slow compilation times (e.g. HMR tests). At this point we should probably consider bumping the default to 5 seconds. It won't make the tests that succeed any slower, and it will probably reduce the chances of a slow test failing a job.