### PR TITLE
Turbopack: Support resolving to index.js with fully_specified

### DIFF
--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -2485,7 +2485,10 @@ async fn resolve_into_package(
 
     // apply main field(s) or fallback to index.js if there's no subpath
     if is_root_match {
-        results.push(resolve_into_folder(package_path, options));
+        results.push(resolve_into_folder(
+            package_path,
+            options.with_fully_specified(false),
+        ));
     }
 
     if could_match_others {


### PR DESCRIPTION
Closes PACK-3303 

`next-mdx-remote` has no `main` field, only the fallback `next-mdx-remote/index.js` entry.
This failed when using `fully_specified: true` because internally
- `resolve_module_request("next-md-remote", "")` calls
- `resolve_into_package(".../node_modules/next-mdx-remote")` calls
- `resolve_into_folder(".../node_modules/next-mdx-remote")`.

This codepath via `resolve_into_package` should work however even when `fully_specified`, as `await import("next-mdx-remote")` is also allowed by Node.js.


Unfortunately we have no way to test this right now.
`fully_specified` isn't exposed in `ModuleOptionsContext`, should that be in there? @sokra