### PR TITLE
next-lint: Use ESLint v9 by default

### DIFF
--- a/packages/next/src/lib/eslint/runLintCheck.ts
+++ b/packages/next/src/lib/eslint/runLintCheck.ts
@@ -430,13 +430,6 @@ export async function runLintCheck(
           // Check if necessary deps installed, and install any that are missing
           deps = await hasNecessaryDependencies(baseDir, requiredPackages)
           if (deps.missing.length > 0) {
-            deps.missing.forEach((dep) => {
-              if (dep.pkg === 'eslint') {
-                // eslint v9 has breaking changes, so lock to 8 until dependency plugins fully support v9.
-                dep.pkg = 'eslint@^8'
-              }
-            })
-
             await installDependencies(baseDir, deps.missing, true)
           }
 

--- a/packages/next/src/lib/eslint/runLintCheck.ts
+++ b/packages/next/src/lib/eslint/runLintCheck.ts
@@ -430,6 +430,13 @@ export async function runLintCheck(
           // Check if necessary deps installed, and install any that are missing
           deps = await hasNecessaryDependencies(baseDir, requiredPackages)
           if (deps.missing.length > 0) {
+            deps.missing.forEach((dep) => {
+              if (dep.pkg === 'eslint') {
+                // pin to v9 to avoid breaking changes
+                dep.pkg = 'eslint@^9'
+              }
+            })
+
             await installDependencies(baseDir, deps.missing, true)
           }
 


### PR DESCRIPTION
### Why?

Since ESLint v9 was unblocked, we no longer need to pin installing v8 when running `next lint` for the first time.