### PR TITLE
chore(next): `next lint` - generate eslint flat config with flat

### DIFF
--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -10,6 +10,7 @@
   },
   "homepage": "https://nextjs.org/docs/app/building-your-application/configuring/eslint#eslint-config",
   "dependencies": {
+    "@babel/eslint-parser": "7.24.5",
     "@next/eslint-plugin-next": "15.0.1-canary.1",
     "@rushstack/eslint-patch": "^1.10.3",
     "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",

--- a/packages/eslint-config-next/parser.js
+++ b/packages/eslint-config-next/parser.js
@@ -1,7 +1,4 @@
-const {
-  parse,
-  parseForESLint,
-} = require('next/dist/compiled/babel/eslint-parser')
+const { parse, parseForESLint } = require('@babel/eslint-parser')
 
 module.exports = {
   parse,

--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -249,7 +249,7 @@ program
   )
   .option(
     '--strict',
-    'Creates a `.eslintrc.json` file using the Next.js strict configuration.'
+    'Creates a ESLint configuration file using the Next.js strict configuration.'
   )
   .option(
     '--rulesdir, <rulesdir...>',

--- a/packages/next/src/lib/eslint/getESLintPromptValues.ts
+++ b/packages/next/src/lib/eslint/getESLintPromptValues.ts
@@ -7,10 +7,15 @@ import { FlatCompat } from '@eslint/eslintrc';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+
 const compat = new FlatCompat({
   baseDirectory: __dirname,
 });
-const eslintConfig = [...compat.extends(${compatExtendsStr})];
+
+const eslintConfig = [
+  ...compat.extends(${compatExtendsStr}),
+];
+
 export default eslintConfig;`
 }
 

--- a/packages/next/src/lib/eslint/runLintCheck.ts
+++ b/packages/next/src/lib/eslint/runLintCheck.ts
@@ -454,7 +454,12 @@ export async function runLintCheck(
               existsSync(path.join(baseDir, dir))
             )
           ) {
-            await writeDefaultConfig(baseDir, config, selectedConfig)
+            await writeDefaultConfig(
+              baseDir,
+              config,
+              selectedConfig,
+              eslintrcFile
+            )
           }
         }
 

--- a/packages/next/src/lib/eslint/writeDefaultConfig.ts
+++ b/packages/next/src/lib/eslint/writeDefaultConfig.ts
@@ -52,14 +52,14 @@ export async function writeDefaultConfig(
     )
   } else if (!exists) {
     await fs.writeFile(
-      path.join(baseDir, '.eslintrc.json'),
-      CommentJson.stringify(selectedConfig, null, 2) + os.EOL
+      path.join(baseDir, 'eslint.config.mjs'),
+      selectedConfig + os.EOL
     )
 
     console.log(
       green(
         `We created the ${bold(
-          '.eslintrc.json'
+          'eslint.config.mjs'
         )} file for you and included your selected configuration.`
       )
     )

--- a/packages/next/src/lib/eslint/writeDefaultConfig.ts
+++ b/packages/next/src/lib/eslint/writeDefaultConfig.ts
@@ -1,67 +1,54 @@
 import { promises as fs } from 'fs'
-import { bold, green } from '../picocolors'
+import { bold } from '../picocolors'
 import os from 'os'
 import path from 'path'
 import * as CommentJson from 'next/dist/compiled/comment-json'
 import type { ConfigAvailable } from './hasEslintConfiguration'
 
-import * as Log from '../../build/output/log'
+import { info } from '../../build/output/log'
 
 export async function writeDefaultConfig(
   baseDir: string,
-  { exists, emptyEslintrc, emptyPkgJsonConfig }: ConfigAvailable,
+  { exists, emptyEslintrc }: ConfigAvailable,
   selectedConfig: any,
-  eslintrcFile: string | null,
-  pkgJsonPath: string | null,
-  packageJsonConfig: { eslintConfig: any } | null
+  eslintrcFile: string | null
 ) {
-  if (!exists && emptyEslintrc && eslintrcFile) {
-    const ext = path.extname(eslintrcFile)
+  if (!exists) {
+    const isLegacyConfig = eslintrcFile && eslintrcFile.startsWith('.eslintrc')
 
-    let newFileContent
-    if (ext === '.yaml' || ext === '.yml') {
-      newFileContent = "extends: 'next'"
-    } else {
-      newFileContent = CommentJson.stringify(selectedConfig, null, 2)
+    if (emptyEslintrc && isLegacyConfig) {
+      const ext = path.extname(eslintrcFile)
 
-      if (ext === '.js') {
-        newFileContent = 'module.exports = ' + newFileContent
+      let newFileContent
+      if (ext === '.yaml' || ext === '.yml') {
+        newFileContent = "extends: 'next'"
+      } else {
+        newFileContent = CommentJson.stringify(selectedConfig, null, 2)
+
+        if (ext === '.js') {
+          newFileContent = 'module.exports = ' + newFileContent
+        }
       }
+
+      await fs.writeFile(eslintrcFile, newFileContent + os.EOL)
+
+      info(
+        `We detected an empty ESLint configuration file (${bold(
+          path.basename(eslintrcFile)
+        )}) and updated it for you!`
+      )
+      return
     }
 
-    await fs.writeFile(eslintrcFile, newFileContent + os.EOL)
-
-    Log.info(
-      `We detected an empty ESLint configuration file (${bold(
-        path.basename(eslintrcFile)
-      )}) and updated it for you!`
-    )
-  } else if (!exists && emptyPkgJsonConfig && packageJsonConfig) {
-    packageJsonConfig.eslintConfig = selectedConfig
-
-    if (pkgJsonPath)
-      await fs.writeFile(
-        pkgJsonPath,
-        CommentJson.stringify(packageJsonConfig, null, 2) + os.EOL
-      )
-
-    Log.info(
-      `We detected an empty ${bold(
-        'eslintConfig'
-      )} field in package.json and updated it for you!`
-    )
-  } else if (!exists) {
     await fs.writeFile(
       path.join(baseDir, 'eslint.config.mjs'),
       selectedConfig + os.EOL
     )
 
-    console.log(
-      green(
-        `We created the ${bold(
-          'eslint.config.mjs'
-        )} file for you and included your selected configuration.`
-      )
+    info(
+      `We created the ${bold(
+        'eslint.config.mjs'
+      )} file for you and included your selected configuration.`
     )
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -794,6 +794,9 @@ importers:
 
   packages/eslint-config-next:
     dependencies:
+      '@babel/eslint-parser':
+        specifier: 7.24.5
+        version: 7.24.5(@babel/core@7.22.5)(eslint@9.12.0)
       '@next/eslint-plugin-next':
         specifier: 15.0.1-canary.1
         version: link:../eslint-plugin-next
@@ -1897,6 +1900,13 @@ packages:
     peerDependencies:
       '@babel/core': 7.22.5
       eslint: ^7.5.0 || ^8.0.0
+
+  '@babel/eslint-parser@7.24.5':
+    resolution: {integrity: sha512-gsUcqS/fPlgAw1kOtpss7uhY6E9SFFANQ6EFX5GTvzUwaV0+sGaZWk6xq22MOdeT9wfxyokW3ceCUvOiRtZciQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
+    peerDependencies:
+      '@babel/core': 7.22.5
+      eslint: ^7.5.0 || ^8.0.0 || ^9.0.0
 
   '@babel/generator@7.18.0':
     resolution: {integrity: sha512-81YO9gGx6voPXlvYdZBliFXAZU8vZ9AZ6z+CjlmcnaeOcYSFbMTpdeDUO9xD9dh/68Vq03I8ZspfUTPfitcDHg==}
@@ -12679,6 +12689,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.11.0:
@@ -15442,6 +15453,14 @@ snapshots:
       - supports-color
 
   '@babel/eslint-parser@7.22.5(@babel/core@7.22.5)(eslint@9.12.0)':
+    dependencies:
+      '@babel/core': 7.22.5
+      '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
+      eslint: 9.12.0
+      eslint-visitor-keys: 2.1.0
+      semver: 6.3.1
+
+  '@babel/eslint-parser@7.24.5(@babel/core@7.22.5)(eslint@9.12.0)':
     dependencies:
       '@babel/core': 7.22.5
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1

--- a/test/integration/eslint/first-time-setup/.eslintrc.json
+++ b/test/integration/eslint/first-time-setup/.eslintrc.json
@@ -1,1 +1,0 @@
-{ "extends": "next", "root": true }

--- a/test/production/eslint/test/next-build-and-lint.test.ts
+++ b/test/production/eslint/test/next-build-and-lint.test.ts
@@ -105,8 +105,8 @@ describe('Next Build', () => {
         })
 
         try {
-          const eslintrcJsonPath = join(next.testDir, '.eslintrc.json')
-          await fs.writeFile(eslintrcJsonPath, '')
+          const eslintConfigPath = join(next.testDir, 'eslint.config.mjs')
+          await fs.writeFile(eslintConfigPath, '')
 
           const nextBuildCommand = await next.build()
           const buildOutput = nextBuildCommand.cliOutput
@@ -126,7 +126,7 @@ describe('Next Build', () => {
           const eslintConfigAfterSetupJSON = execSync(
             // TODO(jiwon): remove `ESLINT_USE_FLAT_CONFIG=false` when we create the config for ESLint 9.
             // https://eslint.org/docs/latest/use/migrate-to-9.0.0#-new-default-config-format-eslintconfigjs
-            `ESLINT_USE_FLAT_CONFIG=false pnpm eslint --print-config pages/index.js`,
+            `pnpm eslint --print-config pages/index.js`,
             {
               cwd: next.testDir,
               encoding: 'utf8',
@@ -269,8 +269,8 @@ describe('Next Build', () => {
         })
 
         try {
-          const eslintrcJsonPath = join(next.testDir, '.eslintrc.json')
-          await fs.writeFile(eslintrcJsonPath, '')
+          const eslintConfigPath = join(next.testDir, 'eslint.config.mjs')
+          await fs.writeFile(eslintConfigPath, '')
 
           const nextBuildCommand = await next.build()
           const buildOutput = nextBuildCommand.cliOutput


### PR DESCRIPTION
### Why?

Since ESLint v9 was unblocked and v8 is deprecated, it is good to generate as flat config for the users when running `next lint` for the first time.