### PR TITLE
fix(after): broken error handling for unstable_after(promise)

### DIFF
--- a/test/e2e/app-dir/next-after-app-static/build-time-error/app/page-throws-in-after/callback/page.tsx
+++ b/test/e2e/app-dir/next-after-app-static/build-time-error/app/page-throws-in-after/callback/page.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react'
+import { unstable_after as after } from 'next/server'
+import { setTimeout } from 'timers/promises'
+
+export const dynamic = 'error'
+
+export default function Index() {
+  after(async () => {
+    await setTimeout(500)
+    throw new Error(
+      'My cool error thrown inside unstable_after on route "/page-throws-in-after/callback"'
+    )
+  })
+  return <div>Page with after()</div>
+}

--- a/test/e2e/app-dir/next-after-app-static/build-time-error/app/page-throws-in-after/promise/page.tsx
+++ b/test/e2e/app-dir/next-after-app-static/build-time-error/app/page-throws-in-after/promise/page.tsx
@@ -5,9 +5,12 @@ import { setTimeout } from 'timers/promises'
 export const dynamic = 'error'
 
 export default function Index() {
-  after(async () => {
+  const promise = (async () => {
     await setTimeout(500)
-    throw new Error('Error thrown from unstable_after: /page-throws-in-after')
-  })
+    throw new Error(
+      'My cool error thrown inside unstable_after on route "/page-throws-in-after/promise"'
+    )
+  })()
+  after(promise)
   return <div>Page with after()</div>
 }

--- a/test/e2e/app-dir/next-after-app-static/build-time-error/app/route-throws-in-after/callback/route.ts
+++ b/test/e2e/app-dir/next-after-app-static/build-time-error/app/route-throws-in-after/callback/route.ts
@@ -6,7 +6,9 @@ export const dynamic = 'error'
 export async function GET() {
   after(async () => {
     await setTimeout(500)
-    throw new Error('Error thrown from unstable_after: /route-throws-in-after')
+    throw new Error(
+      'My cool error thrown inside unstable_after on route "/route-throws-in-after/callback"'
+    )
   })
   return new Response()
 }

--- a/test/e2e/app-dir/next-after-app-static/build-time-error/app/route-throws-in-after/promise/route.ts
+++ b/test/e2e/app-dir/next-after-app-static/build-time-error/app/route-throws-in-after/promise/route.ts
@@ -1,0 +1,15 @@
+import { unstable_after as after } from 'next/server'
+import { setTimeout } from 'timers/promises'
+
+export const dynamic = 'error'
+
+export async function GET() {
+  const promise = (async () => {
+    await setTimeout(500)
+    throw new Error(
+      'My cool error thrown inside unstable_after on route "/route-throws-in-after/promise"'
+    )
+  })()
+  after(promise)
+  return new Response()
+}

--- a/test/e2e/app-dir/next-after-app-static/build-time-error/build-time-error.test.ts
+++ b/test/e2e/app-dir/next-after-app-static/build-time-error/build-time-error.test.ts
@@ -17,11 +17,44 @@ _describe('unstable_after() in static pages - thrown errors', () => {
     const buildResult = await next.build()
     expect(buildResult?.exitCode).toBe(1)
 
-    expect(next.cliOutput).toContain(
-      'Error thrown from unstable_after: /page-throws-in-after'
-    )
-    expect(next.cliOutput).toContain(
-      'Error thrown from unstable_after: /route-throws-in-after'
-    )
+    {
+      const path = '/page-throws-in-after/callback'
+      expect(next.cliOutput).toContain(
+        `Error occurred prerendering page "${path}"`
+      )
+      expect(next.cliOutput).toContain(
+        `My cool error thrown inside unstable_after on route "${path}"`
+      )
+    }
+
+    {
+      const path = '/page-throws-in-after/promise'
+      expect(next.cliOutput).toContain(
+        `Error occurred prerendering page "${path}"`
+      )
+      expect(next.cliOutput).toContain(
+        `My cool error thrown inside unstable_after on route "${path}"`
+      )
+    }
+
+    {
+      const path = '/route-throws-in-after/callback'
+      expect(next.cliOutput).toContain(
+        `Error occurred prerendering page "${path}"`
+      )
+      expect(next.cliOutput).toContain(
+        `My cool error thrown inside unstable_after on route "${path}"`
+      )
+    }
+
+    {
+      const path = '/route-throws-in-after/promise'
+      expect(next.cliOutput).toContain(
+        `Error occurred prerendering page "${path}"`
+      )
+      expect(next.cliOutput).toContain(
+        `My cool error thrown inside unstable_after on route "${path}"`
+      )
+    }
   })
 })


### PR DESCRIPTION
In #71231 we've added `onAfterTaskError`, which is intended for handling errors that happened within `unstable_after` (currently only used to fail the build if anything is thrown during prerendering). It was being called correctly for the callback form, `unstable_after(() => { ... })`, but we missed the fact that `unstable_after(promise)` is also valid, and weren't calling it for rejected promises.

(Apparently we also weren't printing any kind of error message for those, and it's been that way since the start. my bad.)

This PR unifies the error handling for callbacks and promises.