### PR TITLE
next-upgrade: Fix React 19 upgrade not being prompted

### DIFF
--- a/packages/next-codemod/bin/__testfixtures__/react-18-installed-mixed-router/README.md
+++ b/packages/next-codemod/bin/__testfixtures__/react-18-installed-mixed-router/README.md
@@ -1,1 +1,1 @@
-Upgrades React without prompt
+Prompts for React 19 upgrade

--- a/packages/next-codemod/bin/__testfixtures__/react-18-installed-pure-app-router/README.md
+++ b/packages/next-codemod/bin/__testfixtures__/react-18-installed-pure-app-router/README.md
@@ -1,1 +1,1 @@
-Upgrades React without prompt
+Prompts for React 19 upgrade

--- a/packages/next-codemod/bin/__testfixtures__/react-18-installed-pure-pages-router/README.md
+++ b/packages/next-codemod/bin/__testfixtures__/react-18-installed-pure-pages-router/README.md
@@ -1,1 +1,1 @@
-Upgrades React without prompt
+Prompts for React 19 upgrade

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -134,7 +134,7 @@ export async function runUpgrade(
     // we should only let the user stay on React 18 if they are using pure Pages Router.
     // x-ref(PR): https://github.com/vercel/next.js/pull/65058
     // x-ref(release): https://github.com/vercel/next.js/releases/tag/v14.3.0-canary.45
-    compareVersions(installedNextVersion, '14.3.0-canary.45') >= 0 &&
+    compareVersions(targetNextVersion, '14.3.0-canary.45') >= 0 &&
     installedReactVersion.startsWith('18')
   ) {
     const shouldStayOnReact18Res = await prompts(


### PR DESCRIPTION
refiling https://github.com/vercel/next.js/pull/71361 but stacked on https://github.com/vercel/next.js/pull/71377 on to make it clearer what changed.

## test plan

```bash
$ p test:upgrade-fixture bin/__testfixtures__/react-18-installed-mixed-router
? Are you using only the Pages Router (no App Router) and prefer to stay on React 18? › (y/N)
```