### PR TITLE
next-upgrade: Reduce formatting artifacts when overrides are added

### DIFF
--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -1,3 +1,4 @@
+import * as os from 'os'
 import prompts from 'prompts'
 import fs from 'fs'
 import semver from 'semver'
@@ -296,7 +297,12 @@ export async function runUpgrade(
     addPackageDependency(appPackageJson, dep, version, true)
   }
 
-  fs.writeFileSync(appPackageJsonPath, JSON.stringify(appPackageJson, null, 2))
+  fs.writeFileSync(
+    appPackageJsonPath,
+    JSON.stringify(appPackageJson, null, 2) +
+      // Common IDE formatters would add a newline as well.
+      os.EOL
+  )
 
   runInstallation(packageManager)
 


### PR DESCRIPTION
JSON formatters usually add a newline so we can just add one ourselves to make git-diffs cleaner. I think IDEs even do that for just about any file in version control so that adding a line only creates a oneline diff instead of two-line (actual added line and EOL on the previousone).

Correct thing to do would be to check if there's an EOL and only then add it but lazy.