### PR TITLE
remove NextCacheHandler from request context

### DIFF
--- a/packages/next/src/server/after/builtin-request-context.ts
+++ b/packages/next/src/server/after/builtin-request-context.ts
@@ -1,5 +1,4 @@
 import { createAsyncLocalStorage } from '../app-render/async-local-storage'
-import type { CacheHandler } from '../lib/incremental-cache'
 
 export function getBuiltinRequestContext():
   | BuiltinRequestContextValue
@@ -36,7 +35,6 @@ export type RunnableBuiltinRequestContext = BuiltinRequestContext & {
 
 export type BuiltinRequestContextValue = {
   waitUntil?: WaitUntil
-  NextCacheHandler?: typeof CacheHandler
 }
 export type WaitUntil = (promise: Promise<any>) => void
 


### PR DESCRIPTION
in #71263, we stopped getting `NextCacheHandler` from the request context and switched to getting it from `@next/cache-handlers`, but it wasn't cleaned up from its original location. I'm assuming we can get rid of it now.