### PR TITLE
remove usage of "@vercel/request-context"

### DIFF
--- a/packages/next/src/server/after/builtin-request-context.ts
+++ b/packages/next/src/server/after/builtin-request-context.ts
@@ -4,23 +4,15 @@ export function getBuiltinRequestContext():
   | BuiltinRequestContextValue
   | undefined {
   const _globalThis = globalThis as GlobalThisWithRequestContext
-  const ctx =
-    _globalThis[NEXT_REQUEST_CONTEXT_SYMBOL] ??
-    _globalThis[VERCEL_REQUEST_CONTEXT_SYMBOL]
+  const ctx = _globalThis[NEXT_REQUEST_CONTEXT_SYMBOL]
   return ctx?.get()
 }
 
 /** This should be considered unstable until `unstable_after` is stablized. */
 const NEXT_REQUEST_CONTEXT_SYMBOL = Symbol.for('@next/request-context')
 
-// TODO(after): this is a temporary workaround.
-// Remove this when vercel builder is updated to provide '@next/request-context'.
-const VERCEL_REQUEST_CONTEXT_SYMBOL = Symbol.for('@vercel/request-context')
-
 type GlobalThisWithRequestContext = typeof globalThis & {
   [NEXT_REQUEST_CONTEXT_SYMBOL]?: BuiltinRequestContext
-  /** @deprecated */
-  [VERCEL_REQUEST_CONTEXT_SYMBOL]?: BuiltinRequestContext
 }
 
 /** A request context provided by the platform.


### PR DESCRIPTION
Removes usage of `@vercel/request-context`, because now we have `@next/request-context` and can get `waitUntil` from there instead.

Dependent on builder changes from https://github.com/vercel/vercel/pull/12286, which were [released in `vercel@39.1.2` / `@vercel/next@4.4.0`](https://github.com/vercel/vercel/pull/12648)

### Testing

We can verify that, when using an older builder (which doesn't provide `@next/request-context`), the deploy tests for `after` fail, because they can't access `waitUntil`:
```
# these will fail, except some edge runtime tests
# because they can use FetchEventResult.waitUntil as a fallback
VERCEL_CLI_VERSION='vercel@39.1.1' \
  NEXT_TEST_VERSION='https://vercel-packages.vercel.app/next/commits/b1b97b8bbaa2f9d400de42957869d138a54da304/next' \
  pnpm test-deploy test/e2e/app-dir/next-after-app-deploy
```
To see the errors, need to inspect the logs and look for this error message: https://github.com/vercel/next.js/blob/d1e554be4c0bac8bf28c84a05065c230cb6f9d80/packages/next/src/server/after/after-context.ts#L145

But using `39.1.2`, they will pass, because `@next/request-context` is present:
```
# these will pass
VERCEL_CLI_VERSION='vercel@39.1.2' \
  NEXT_TEST_VERSION='https://vercel-packages.vercel.app/next/commits/b1b97b8bbaa2f9d400de42957869d138a54da304/next' \
  pnpm test-deploy test/e2e/app-dir/next-after-app-deploy
```