### PR TITLE
Turbopack unhandled errors: ask for a description

### DIFF
--- a/crates/napi/src/util.rs
+++ b/crates/napi/src/util.rs
@@ -121,7 +121,7 @@ pub fn log_internal_error_and_inform(err_info: &str) {
         .unwrap_or_else(|_| panic!("Failed to open {}", PANIC_LOG.to_string_lossy()));
 
     writeln!(log_file, "{}\n{}", LOG_DIVIDER, err_info).unwrap();
-    eprintln!("{}: An unexpected Turbopack error occurred. Please report the content of {} to https://github.com/vercel/next.js/issues/new", "FATAL".red().bold(), PANIC_LOG.to_string_lossy());
+    eprintln!("{}: An unexpected Turbopack error occurred. Please report the content of {}, along with a description of what you were doing when the error occurred, to https://github.com/vercel/next.js/issues/new", "FATAL".red().bold(), PANIC_LOG.to_string_lossy());
 }
 
 #[napi]


### PR DESCRIPTION
This instructs users to provide a written description of what they were doing when filing an issue.


Closes PACK-3503