### PR TITLE
next-upgrade: Only run React 19 codemods when we upgrade to React 19

### DIFF
--- a/packages/next-codemod/bin/__testfixtures__/react-19-installed-mixed-router/README.md
+++ b/packages/next-codemod/bin/__testfixtures__/react-19-installed-mixed-router/README.md
@@ -1,1 +1,2 @@
 Upgrades React without prompt
+Does not apply React 19 codemods

--- a/packages/next-codemod/bin/__testfixtures__/react-19-installed-pure-app-router/README.md
+++ b/packages/next-codemod/bin/__testfixtures__/react-19-installed-pure-app-router/README.md
@@ -1,1 +1,2 @@
 Upgrades React without prompt
+Does not apply React 19 codemods

--- a/packages/next-codemod/bin/__testfixtures__/react-19-installed-pure-pages-router/README.md
+++ b/packages/next-codemod/bin/__testfixtures__/react-19-installed-pure-pages-router/README.md
@@ -1,1 +1,2 @@
 Upgrades React without prompt
+Does not apply React 19 codemods

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -178,7 +178,8 @@ export async function runUpgrade(
   // The following React codemods are for React 19
   if (
     !shouldStayOnReact18 &&
-    compareVersions(targetReactVersion, '19.0.0-beta.0') >= 0
+    compareVersions(targetReactVersion, '18.9999.9999') > 0 &&
+    compareVersions(installedReactVersion, '18.9999.9999') <= 0
   ) {
     shouldRunReactCodemods = await suggestReactCodemods()
     shouldRunReactTypesCodemods = await suggestReactTypesCodemods()


### PR DESCRIPTION
Previously we just checked if the new version was
React 19.
But if you're already on React 19, you would've had
applied the codemod already.
We already do the same for Next.js codemods.