### PR TITLE
codemod: only turn function to async when no hooks

### DIFF
--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-24.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-24.input.tsx
@@ -1,0 +1,12 @@
+import { cookies } from 'next/headers'
+
+function useHook() {}
+
+export default function Page() {
+  useHook()
+  const c = cookies();
+}
+
+export function generateMetadata() {
+  cookies()
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-24.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-apis/async-api-24.output.tsx
@@ -1,0 +1,13 @@
+import { use } from "react";
+import { cookies } from 'next/headers'
+
+function useHook() {}
+
+export default function Page() {
+  useHook()
+  const c = use(cookies());
+}
+
+export async function generateMetadata() {
+  await cookies()
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-33.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-33.input.tsx
@@ -1,0 +1,6 @@
+function useHook() {}
+
+export default function Page({ params }: { params: { slug: string } }) {
+  useHook()
+  return <p>child {params.slug}</p>
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-33.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-33.output.tsx
@@ -1,0 +1,8 @@
+import { use } from "react";
+function useHook() {}
+
+export default function Page(props: { params: Promise<{ slug: string }> }) {
+  const params = use(props.params);
+  useHook()
+  return <p>child {params.slug}</p>
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-34.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-34.input.tsx
@@ -1,0 +1,15 @@
+function useHook() {}
+
+function Child() {
+  useHook()
+  return <p>child</p>
+}
+
+export default function Page({ params }: { params: { slug: string } }) {
+  return (
+    <div>
+      <Child />
+      <p>child {params.slug}</p>
+    </div>
+  )
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-34.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-34.input.tsx
@@ -1,15 +1,6 @@
-function useHook() {}
-
-function Child() {
-  useHook()
-  return <p>child</p>
-}
+import React from 'react'
 
 export default function Page({ params }: { params: { slug: string } }) {
-  return (
-    <div>
-      <Child />
-      <p>child {params.slug}</p>
-    </div>
-  )
+  React.use()
+  return <p>child {params.slug}</p>
 }

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-34.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-34.output.tsx
@@ -1,0 +1,16 @@
+function useHook() {}
+
+function Child() {
+  useHook()
+  return <p>child</p>
+}
+
+export default async function Page(props: { params: Promise<{ slug: string }> }) {
+  const params = await props.params;
+  return (
+    <div>
+      <Child />
+      <p>child {params.slug}</p>
+    </div>
+  )
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-34.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-34.output.tsx
@@ -1,16 +1,7 @@
-function useHook() {}
+import React, { use } from 'react';
 
-function Child() {
-  useHook()
-  return <p>child</p>
-}
-
-export default async function Page(props: { params: Promise<{ slug: string }> }) {
-  const params = await props.params;
-  return (
-    <div>
-      <Child />
-      <p>child {params.slug}</p>
-    </div>
-  )
+export default function Page(props: { params: Promise<{ slug: string }> }) {
+  const params = use(props.params);
+  React.use()
+  return <p>child {params.slug}</p>
 }

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-35.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-35.input.tsx
@@ -1,0 +1,15 @@
+function useHook() {}
+
+function Child() {
+  useHook()
+  return <p>child</p>
+}
+
+export default function Page({ params }: { params: { slug: string } }) {
+  return (
+    <div>
+      <Child />
+      <p>child {params.slug}</p>
+    </div>
+  )
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-35.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-35.output.tsx
@@ -1,0 +1,16 @@
+function useHook() {}
+
+function Child() {
+  useHook()
+  return <p>child</p>
+}
+
+export default async function Page(props: { params: Promise<{ slug: string }> }) {
+  const params = await props.params;
+  return (
+    <div>
+      <Child />
+      <p>child {params.slug}</p>
+    </div>
+  )
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-36.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-36.input.tsx
@@ -1,0 +1,4 @@
+export default function Page({ params }: { params: { slug: string } }) {
+  Foo.useFoo()
+  return <p>child {params.slug}</p>
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-36.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-36.output.tsx
@@ -1,0 +1,6 @@
+import { use } from "react";
+export default function Page(props: { params: Promise<{ slug: string }> }) {
+  const params = use(props.params);
+  Foo.useFoo()
+  return <p>child {params.slug}</p>
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-37.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-37.input.tsx
@@ -1,0 +1,4 @@
+export default function Page({ params }: { params: { slug: string } }) {
+  foo.useFakeTimers()
+  return <p>child {params.slug}</p>
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-37.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-37.output.tsx
@@ -1,0 +1,5 @@
+export default async function Page(props: { params: Promise<{ slug: string }> }) {
+  const params = await props.params;
+  foo.useFakeTimers()
+  return <p>child {params.slug}</p>
+}

--- a/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
@@ -13,6 +13,7 @@ import {
   NEXT_CODEMOD_ERROR_PREFIX,
   containsReactHooksCallExpressions,
   isParentUseCallExpression,
+  isReactHookLikeName,
 } from './utils'
 import { createParserFromPath } from '../../../lib/parser'
 
@@ -192,8 +193,10 @@ export function transformDynamicAPI(
             const parentFunction = findClosetParentFunctionScope(path, j)
 
             if (parentFunction) {
-              const parentFunctionName = parentFunction.get().node.id?.name
-              const isParentFunctionHook = parentFunctionName?.startsWith('use')
+              const parentFunctionName =
+                parentFunction.get().node.id?.name || ''
+              const isParentFunctionHook =
+                isReactHookLikeName(parentFunctionName)
               if (isParentFunctionHook && !isParentUseCallExpression(path, j)) {
                 j(path).replaceWith(
                   j.callExpression(j.identifier('use'), [

--- a/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
@@ -11,6 +11,8 @@ import {
   insertCommentOnce,
   NEXTJS_ENTRY_FILES,
   NEXT_CODEMOD_ERROR_PREFIX,
+  containsReactHooksCallExpressions,
+  isParentUseCallExpression,
 } from './utils'
 import { createParserFromPath } from '../../../lib/parser'
 
@@ -151,12 +153,13 @@ export function transformDynamicAPI(
           // check if current path is under the default export function
           if (isEntryFileExport) {
             // if default export function is not async, convert it to async, and await the api call
-            if (!isCallAwaited) {
+            if (!isCallAwaited && isFunctionType(exportFunctionNode.type)) {
+              const hasReactHooksUsage = containsReactHooksCallExpressions(
+                closetScopePath,
+                j
+              )
               // If the scoped function is async function
-              if (
-                isFunctionType(exportFunctionNode.type) &&
-                exportFunctionNode.async === false
-              ) {
+              if (exportFunctionNode.async === false && !hasReactHooksUsage) {
                 canConvertToAsync = true
                 exportFunctionNode.async = true
               }
@@ -170,8 +173,18 @@ export function transformDynamicAPI(
                 )
 
                 turnFunctionReturnTypeToAsync(closetScopePath.node, j)
-
                 modified = true
+              } else {
+                // If it's still sync function that cannot be converted to async, wrap the api call with 'use()' if needed
+                if (!isParentUseCallExpression(path, j)) {
+                  j(path).replaceWith(
+                    j.callExpression(j.identifier('use'), [
+                      j.callExpression(j.identifier(asyncRequestApiName), []),
+                    ])
+                  )
+                  needsReactUseImport = true
+                  modified = true
+                }
               }
             }
           } else {
@@ -181,7 +194,7 @@ export function transformDynamicAPI(
             if (parentFunction) {
               const parentFunctionName = parentFunction.get().node.id?.name
               const isParentFunctionHook = parentFunctionName?.startsWith('use')
-              if (isParentFunctionHook) {
+              if (isParentFunctionHook && !isParentUseCallExpression(path, j)) {
                 j(path).replaceWith(
                   j.callExpression(j.identifier('use'), [
                     j.callExpression(j.identifier(asyncRequestApiName), []),

--- a/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-api.ts
@@ -13,7 +13,7 @@ import {
   NEXT_CODEMOD_ERROR_PREFIX,
   containsReactHooksCallExpressions,
   isParentUseCallExpression,
-  isReactHookLikeName,
+  isReactHookName,
 } from './utils'
 import { createParserFromPath } from '../../../lib/parser'
 
@@ -195,8 +195,7 @@ export function transformDynamicAPI(
             if (parentFunction) {
               const parentFunctionName =
                 parentFunction.get().node.id?.name || ''
-              const isParentFunctionHook =
-                isReactHookLikeName(parentFunctionName)
+              const isParentFunctionHook = isReactHookName(parentFunctionName)
               if (isParentFunctionHook && !isParentUseCallExpression(path, j)) {
                 j(path).replaceWith(
                   j.callExpression(j.identifier('use'), [

--- a/packages/next-codemod/transforms/lib/async-request-api/utils.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/utils.ts
@@ -493,7 +493,7 @@ export function getVariableDeclaratorId(
   return undefined
 }
 
-export function findFunctionBody(path: ASTPath<FunctionScope>) {
+export function findFunctionBody(path: ASTPath<FunctionScope>): null | any[] {
   let functionBody = path.node.body
   if (functionBody && functionBody.type === 'BlockStatement') {
     return functionBody.body

--- a/packages/next-codemod/transforms/lib/async-request-api/utils.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/utils.ts
@@ -501,6 +501,9 @@ export function findFunctionBody(path: ASTPath<FunctionScope>): null | any[] {
   return null
 }
 
+export const isReactHookLikeName = (name: string) =>
+  name.startsWith('use') && name[3] === name[3].toUpperCase()
+
 export function containsReactHooksCallExpressions(
   path: ASTPath<FunctionScope>,
   j: API['jscodeshift']
@@ -512,7 +515,7 @@ export function containsReactHooksCallExpressions(
         // use()
         const isUseCall =
           j.Identifier.check(callPath.value.callee) &&
-          callPath.value.callee.name.startsWith('use')
+          isReactHookLikeName(callPath.value.callee.name)
         // React.use()
         const isReactUseCall =
           j.MemberExpression.check(callPath.value.callee) &&


### PR DESCRIPTION
### What

When there's any react hooks usage in the function body, it will block converting the function into async. Async react components are not available with using with hooks, but hooks should be available called in any children components.

Other changes:

* Moving `isParentUseCallExpression`, `isParentPromiseAllCallExpression` into utils.
* Add new util `containsReactHooksCallExpressions`