### PR TITLE
improve typescript autocomplete for cacheLife

### DIFF
--- a/packages/next/src/server/use-cache/cache-life.ts
+++ b/packages/next/src/server/use-cache/cache-life.ts
@@ -28,7 +28,7 @@ type CacheLifeProfiles =
   | 'days'
   | 'weeks'
   | 'max'
-  | string
+  | (string & {})
 
 function validateCacheLife(profile: CacheLife) {
   if (profile.stale !== undefined) {


### PR DESCRIPTION
just applying the good old typescript trick that prevent a `'a' | 'b' | string` union from collapsing into `string`, and thus preserving the autocomplete we'd get for `'a' | 'b'`

before:
<img width="246" alt="Screenshot 2024-10-16 at 21 48 25" src="https://github.com/user-attachments/assets/5bc9c078-fb8a-4aeb-93c5-9ee02854f3f9">
after:
<img width="296" alt="Screenshot 2024-10-16 at 21 47 06" src="https://github.com/user-attachments/assets/6b87cc47-ef2b-4124-9dc4-b628b19a4fe3">
