### PR TITLE
Adjust transforms for cached functions imported from client components

### DIFF
--- a/crates/next-custom-transforms/tests/fixture/server-actions/client/6/input.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/client/6/input.js
@@ -1,3 +1,5 @@
 'use cache'
 
 export async function foo() {}
+const bar = async () => {}
+export { bar }

--- a/crates/next-custom-transforms/tests/fixture/server-actions/client/6/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/client/6/output.js
@@ -1,2 +1,3 @@
-/* __next_internal_action_entry_do_not_use__ {"3128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { createServerReference, callServer, findSourceMapURL } from "private-next-rsc-action-client-wrapper";
+/* __next_internal_action_entry_do_not_use__ {"ab21efdafbe611287bc25c0462b1e0510d13e48b":"foo","ac840dcaf5e8197cb02b7f3a43c119b7a770b272":"bar"} */ import { createServerReference, callServer, findSourceMapURL } from "private-next-rsc-action-client-wrapper";
 export var foo = /*#__PURE__*/ createServerReference("ab21efdafbe611287bc25c0462b1e0510d13e48b", callServer, void 0, findSourceMapURL, "foo");
+export var bar = /*#__PURE__*/ createServerReference("ac840dcaf5e8197cb02b7f3a43c119b7a770b272", callServer, void 0, findSourceMapURL, "bar");

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/34/input.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/34/input.js
@@ -1,5 +1,5 @@
 'use cache'
 
-export async function foo() {
-  return 'data'
-}
+export async function foo() {}
+const bar = async () => {}
+export { bar }

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/34/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/34/output.js
@@ -1,7 +1,8 @@
-/* __next_internal_action_entry_do_not_use__ {"3128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+/* __next_internal_action_entry_do_not_use__ {"3128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0","951c375b4a6a6e89d67b743ec5808127cfde405d":"$$RSC_SERVER_CACHE_1"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "3128060c414d59f8552e4788b846c0d2b7f74743", async function foo() {
-    return 'data';
-});
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "3128060c414d59f8552e4788b846c0d2b7f74743", async function foo() {});
 export var foo = registerServerReference($$RSC_SERVER_CACHE_0, "3128060c414d59f8552e4788b846c0d2b7f74743", null);
+export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "951c375b4a6a6e89d67b743ec5808127cfde405d", async function() {});
+const bar = registerServerReference($$RSC_SERVER_CACHE_1, "951c375b4a6a6e89d67b743ec5808127cfde405d", null);
+export { bar };

--- a/test/e2e/app-dir/use-cache/app/imported-from-client/cached.ts
+++ b/test/e2e/app-dir/use-cache/app/imported-from-client/cached.ts
@@ -1,0 +1,15 @@
+'use cache'
+
+export async function bar() {
+  const v = Math.random()
+  console.log(v)
+  return v
+}
+
+const baz = async () => {
+  const v = Math.random()
+  console.log(v)
+  return v
+}
+
+export { baz }

--- a/test/e2e/app-dir/use-cache/app/imported-from-client/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/imported-from-client/page.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useActionState } from 'react'
+import { bar, baz } from './cached'
+
+export default function Page() {
+  const [result, dispatch] = useActionState<
+    [number, number],
+    'submit' | 'reset'
+  >(
+    async (_state, event) => {
+      if (event === 'reset') {
+        return [0, 0]
+      }
+
+      return [await bar(), await baz()]
+    },
+    [0, 0]
+  )
+
+  return (
+    <form action={() => dispatch('submit')}>
+      <button id="submit-button">Click me</button>
+      <p>
+        {result[0]} {result[1]}
+      </p>
+      <button id="reset-button" formAction={() => dispatch('reset')}>
+        Reset
+      </button>
+    </form>
+  )
+}


### PR DESCRIPTION
This fixes the server reference ID generation in client modules so that they can be imported and called from client components. In addition, support for cached functions with decoupled export declarations is added.