### PR TITLE
Remove SourceMap wrapper providing Send+Sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6147,8 +6147,7 @@ dependencies = [
 [[package]]
 name = "sourcemap"
 version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab08a862c70980b8e23698b507e272317ae52a608a164a844111f5372374f1f"
+source = "git+https://github.com/wbinnssmith/rust-sourcemap?branch=wbinnssmith%2Fdecoded-serde#bc90cfd4c30a12cb901c1e03221e399c33d85d87"
 dependencies = [
  "base64-simd",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,3 +216,6 @@ unsize = "1.1.0"
 url = "2.2.2"
 urlencoding = "2.1.2"
 webbrowser = "0.8.7"
+
+[patch.crates-io]
+sourcemap = { git = "https://github.com/wbinnssmith/rust-sourcemap", branch = "wbinnssmith/decoded-serde" }

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -29,7 +29,7 @@ use turbopack_core::{
     error::PrettyPrintError,
     issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
     source::Source,
-    source_map::{GenerateSourceMap, OptionSourceMap, SourceMap},
+    source_map::{as_regular_source_map, GenerateSourceMap, OptionSourceMap, SourceMap},
     SOURCE_MAP_PREFIX,
 };
 use turbopack_swc_utils::emitter::IssueEmitter;
@@ -119,7 +119,7 @@ impl GenerateSourceMap for ParseResultSourceMap {
             None
         };
         let input_map = if let Some(map) = original_src_map.as_ref() {
-            map.as_regular_source_map()
+            as_regular_source_map(map)
         } else {
             None
         };


### PR DESCRIPTION
Previously, the sourcemap crate did not implement Send+Sync on `DecodedMap`, so we created unsafe wrappers around it and avoided unsafe behavior. Since https://github.com/getsentry/rust-sourcemap/pull/80, this is no longer necessary.

Test Plan: CI


Closes PACK-3956