### PR TITLE
test: fix flaky react 18 tests

### DIFF
--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -197,9 +197,10 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    const errorCount = await getRedboxTotalErrorCount(browser)
     await retry(async () => {
-      await expect(errorCount).toBe(isReact18 ? 3 : 1)
+      await expect(await getRedboxTotalErrorCount(browser)).toBe(
+        isReact18 ? 3 : 1
+      )
     })
 
     const pseudoHtml = await session.getRedboxComponentStack()
@@ -284,9 +285,10 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    const errorCount = await getRedboxTotalErrorCount(browser)
     await retry(async () => {
-      await expect(errorCount).toBe(isReact18 ? 3 : 1)
+      await expect(await getRedboxTotalErrorCount(browser)).toBe(
+        isReact18 ? 3 : 1
+      )
     })
 
     const pseudoHtml = await session.getRedboxComponentStack()
@@ -525,9 +527,8 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     await session.assertHasRedbox()
 
-    const errorCount = await getRedboxTotalErrorCount(browser)
     await retry(async () => {
-      await expect(errorCount).toBe(
+      await expect(await getRedboxTotalErrorCount(browser)).toBe(
         isReact18
           ? 3
           : // FIXME: Should be 2
@@ -773,9 +774,8 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    const errorCount = await getRedboxTotalErrorCount(browser)
     await retry(async () => {
-      await expect(errorCount).toBe(isReact18 ? 3 : 1)
+      expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
     })
 
     const description = await session.getRedboxDescription()
@@ -862,9 +862,8 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    const errorCount = await getRedboxTotalErrorCount(browser)
     await retry(async () => {
-      await expect(errorCount).toBe(isReact18 ? 3 : 1)
+      expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
     })
 
     const description = await session.getRedboxDescription()
@@ -920,9 +919,8 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    const errorCount = await getRedboxTotalErrorCount(browser)
     await retry(async () => {
-      await expect(errorCount).toBe(isReact18 ? 3 : 1)
+      expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
     })
 
     const description = await session.getRedboxDescription()
@@ -1003,9 +1001,8 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    const errorCount = await getRedboxTotalErrorCount(browser)
     await retry(async () => {
-      await expect(errorCount).toBe(isReact18 ? 3 : 1)
+      expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
     })
 
     const description = await session.getRedboxDescription()
@@ -1156,9 +1153,10 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    const errorCount = await getRedboxTotalErrorCount(browser)
     await retry(async () => {
-      await expect(errorCount).toBe(isReact18 ? 3 : 1)
+      await expect(await getRedboxTotalErrorCount(browser)).toBe(
+        isReact18 ? 3 : 1
+      )
     })
 
     const pseudoHtml = await session.getRedboxComponentStack()

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -526,7 +526,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     expect(await getRedboxTotalErrorCount(browser)).toBe(
       isReact18
-        ? 3
+        ? 2
         : // FIXME: Should be 2
           1
     )
@@ -855,7 +855,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
+    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 2 : 1)
 
     const description = await session.getRedboxDescription()
     if (isReact18) {
@@ -990,7 +990,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
+    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 2 : 1)
 
     const description = await session.getRedboxDescription()
     if (isReact18) {

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -3,7 +3,7 @@ import { sandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import { outdent } from 'outdent'
-import { getRedboxTotalErrorCount } from 'next-test-utils'
+import { getRedboxTotalErrorCount, retry } from 'next-test-utils'
 
 const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 // https://github.com/facebook/react/blob/main/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js used as a reference
@@ -197,12 +197,10 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    const totalAmount = await getRedboxTotalErrorCount(browser)
-    if (isReact18) {
-      expect(totalAmount).toBeGreaterThanOrEqual(2)
-    } else {
-      expect(totalAmount).toBe(1)
-    }
+    const errorCount = await getRedboxTotalErrorCount(browser)
+    await retry(async () => {
+      await expect(errorCount).toBe(isReact18 ? 3 : 1)
+    })
 
     const pseudoHtml = await session.getRedboxComponentStack()
     if (isTurbopack) {
@@ -287,11 +285,9 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     await session.assertHasRedbox()
     const errorCount = await getRedboxTotalErrorCount(browser)
-    if (isReact18) {
-      expect(errorCount).toBeGreaterThanOrEqual(2)
-    } else {
-      expect(errorCount).toBe(1)
-    }
+    await retry(async () => {
+      await expect(errorCount).toBe(isReact18 ? 3 : 1)
+    })
 
     const pseudoHtml = await session.getRedboxComponentStack()
     if (isTurbopack) {
@@ -530,12 +526,14 @@ describe('Error overlay for hydration errors in Pages router', () => {
     await session.assertHasRedbox()
 
     const errorCount = await getRedboxTotalErrorCount(browser)
-    if (isReact18) {
-      expect(errorCount).toBeGreaterThanOrEqual(2)
-    } else {
-      // FIXME: Should be 2
-      expect(errorCount).toBe(1)
-    }
+    await retry(async () => {
+      await expect(errorCount).toBe(
+        isReact18
+          ? 3
+          : // FIXME: Should be 2
+            1
+      )
+    })
 
     // FIXME: Should also have "text nodes cannot be a child of tr"
     if (isReact18) {
@@ -776,11 +774,9 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     await session.assertHasRedbox()
     const errorCount = await getRedboxTotalErrorCount(browser)
-    if (isReact18) {
-      expect(errorCount).toBeGreaterThanOrEqual(2)
-    } else {
-      expect(errorCount).toBe(1)
-    }
+    await retry(async () => {
+      await expect(errorCount).toBe(isReact18 ? 3 : 1)
+    })
 
     const description = await session.getRedboxDescription()
     if (isReact18) {
@@ -867,11 +863,9 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     await session.assertHasRedbox()
     const errorCount = await getRedboxTotalErrorCount(browser)
-    if (isReact18) {
-      expect(errorCount).toBeGreaterThanOrEqual(2)
-    } else {
-      expect(errorCount).toBe(1)
-    }
+    await retry(async () => {
+      await expect(errorCount).toBe(isReact18 ? 3 : 1)
+    })
 
     const description = await session.getRedboxDescription()
     if (isReact18) {
@@ -927,11 +921,9 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     await session.assertHasRedbox()
     const errorCount = await getRedboxTotalErrorCount(browser)
-    if (isReact18) {
-      expect(errorCount).toBeGreaterThanOrEqual(2)
-    } else {
-      expect(errorCount).toBe(1)
-    }
+    await retry(async () => {
+      await expect(errorCount).toBe(isReact18 ? 3 : 1)
+    })
 
     const description = await session.getRedboxDescription()
     if (isReact18) {
@@ -1012,11 +1004,9 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     await session.assertHasRedbox()
     const errorCount = await getRedboxTotalErrorCount(browser)
-    if (isReact18) {
-      expect(errorCount).toBeGreaterThanOrEqual(2)
-    } else {
-      expect(errorCount).toBe(1)
-    }
+    await retry(async () => {
+      await expect(errorCount).toBe(isReact18 ? 3 : 1)
+    })
 
     const description = await session.getRedboxDescription()
     if (isReact18) {
@@ -1166,7 +1156,10 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 2 : 1)
+    const errorCount = await getRedboxTotalErrorCount(browser)
+    await retry(async () => {
+      await expect(errorCount).toBe(isReact18 ? 3 : 1)
+    })
 
     const pseudoHtml = await session.getRedboxComponentStack()
     if (isTurbopack) {

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -286,7 +286,12 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
+    const errorCount = await getRedboxTotalErrorCount(browser)
+    if (isReact18) {
+      expect(errorCount).toBeGreaterThanOrEqual(2)
+    } else {
+      expect(errorCount).toBe(1)
+    }
 
     const pseudoHtml = await session.getRedboxComponentStack()
     if (isTurbopack) {
@@ -770,7 +775,12 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
+    const errorCount = await getRedboxTotalErrorCount(browser)
+    if (isReact18) {
+      expect(errorCount).toBeGreaterThanOrEqual(2)
+    } else {
+      expect(errorCount).toBe(1)
+    }
 
     const description = await session.getRedboxDescription()
     if (isReact18) {
@@ -916,7 +926,12 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 3 : 1)
+    const errorCount = await getRedboxTotalErrorCount(browser)
+    if (isReact18) {
+      expect(errorCount).toBeGreaterThanOrEqual(2)
+    } else {
+      expect(errorCount).toBe(1)
+    }
 
     const description = await session.getRedboxDescription()
     if (isReact18) {

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -524,12 +524,13 @@ describe('Error overlay for hydration errors in Pages router', () => {
 
     await session.assertHasRedbox()
 
-    expect(await getRedboxTotalErrorCount(browser)).toBe(
-      isReact18
-        ? 2
-        : // FIXME: Should be 2
-          1
-    )
+    const errorCount = await getRedboxTotalErrorCount(browser)
+    if (isReact18) {
+      expect(errorCount).toBeGreaterThanOrEqual(2)
+    } else {
+      // FIXME: Should be 2
+      expect(errorCount).toBe(1)
+    }
 
     // FIXME: Should also have "text nodes cannot be a child of tr"
     if (isReact18) {
@@ -855,7 +856,12 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 2 : 1)
+    const errorCount = await getRedboxTotalErrorCount(browser)
+    if (isReact18) {
+      expect(errorCount).toBeGreaterThanOrEqual(2)
+    } else {
+      expect(errorCount).toBe(1)
+    }
 
     const description = await session.getRedboxDescription()
     if (isReact18) {
@@ -990,7 +996,12 @@ describe('Error overlay for hydration errors in Pages router', () => {
     )
 
     await session.assertHasRedbox()
-    expect(await getRedboxTotalErrorCount(browser)).toBe(isReact18 ? 2 : 1)
+    const errorCount = await getRedboxTotalErrorCount(browser)
+    if (isReact18) {
+      expect(errorCount).toBeGreaterThanOrEqual(2)
+    } else {
+      expect(errorCount).toBe(1)
+    }
 
     const description = await session.getRedboxDescription()
     if (isReact18) {


### PR DESCRIPTION
### What

CI is flaky with the result is `2`, the actual error count is 3 but is added incrementally. Adding a `retry` waiting for the actual error count is reached then go to the rest checking.

x-ref: https://github.com/vercel/next.js/actions/runs/11374743288/job/31644936928
x-ref: https://github.com/vercel/next.js/actions/runs/11352508279/job/31577008340