### PR TITLE
fix: remove `experimental.ppr` from `CanaryOnlyError` because v14 is supported

### DIFF
--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -71,20 +71,6 @@ describe('loadConfig', () => {
       delete process.env.__NEXT_VERSION
     })
 
-    it('errors when using PPR if not in canary', async () => {
-      await expect(
-        loadConfig('', __dirname, {
-          customConfig: {
-            experimental: {
-              ppr: true,
-            },
-          },
-        })
-      ).rejects.toThrow(
-        /The experimental feature "experimental.ppr" can only be enabled when using the latest canary version of Next.js./
-      )
-    })
-
     it('errors when using dynamicIO if not in canary', async () => {
       await expect(
         loadConfig('', __dirname, {

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -244,9 +244,7 @@ function assignDefaults(
     !process.env.__NEXT_TEST_MODE
   ) {
     // Prevents usage of certain experimental features outside of canary
-    if (result.experimental?.ppr) {
-      throw new CanaryOnlyError('experimental.ppr')
-    } else if (result.experimental?.dynamicIO) {
+    if (result.experimental?.dynamicIO) {
       throw new CanaryOnlyError('experimental.dynamicIO')
     } else if (result.experimental?.turbo?.unstablePersistentCaching) {
       throw new CanaryOnlyError('experimental.turbo.unstablePersistentCaching')


### PR DESCRIPTION
Specifying `expermental.ppr` in Next.js version 15 RC 2 results in an error.

```js
/** @type {import('next').NextConfig} */
const nextConfig = {
  experimental: {
    ppr: true,
  }
}
```

```
% pnpm next dev
/myproject/node_modules/.pnpm/next@15.0.0-rc.1_@opentelemetry+api@1.8.0_react-dom@19.0.0-rc-cd22717c-20241013_react@19.0.0-_2bpi27sy4g7rpow4l3oeki7dqa/node_modules/next/dist/server/config.js:247
            throw new CanaryOnlyError('experimental.ppr');
                  ^

CanaryOnlyError: The experimental feature "experimental.ppr" can only be enabled when using the latest canary version of Next.js.
    at assignDefaults (/myproject/node_modules/.pnpm/next@15.0.0-rc.1_@opentelemetry+api@1.8.0_react-dom@19.0.0-rc-cd22717c-20241013_react@19.0.0-_2bpi27sy4g7rpow4l3oeki7dqa/node_modules/next/dist/server/config.js:247:19)
    at loadConfig (/myproject/node_modules/.pnpm/next@15.0.0-rc.1_@opentelemetry+api@1.8.0_react-dom@19.0.0-rc-cd22717c-20241013_react@19.0.0-_2bpi27sy4g7rpow4l3oeki7dqa/node_modules/next/dist/server/config.js:809:32)
    at async Module.nextDev (/myproject/node_modules/.pnpm/next@15.0.0-rc.1_@opentelemetry+api@1.8.0_react-dom@19.0.0-rc-cd22717c-20241013_react@19.0.0-_2bpi27sy4g7rpow4l3oeki7dqa/node_modules/next/dist/cli/next-dev.js:189:14)
```

This error is probably related to the following commit.

https://github.com/vercel/next.js/commit/786fa613750141c06a227d49f25a90eff8a5b88d#diff-7836d903b56ef6914ef5f3e8d1711c1d353d7b6ae4efefb0d2193897ee4fca85R258

As `experimental.ppr` is available in [version 14](https://nextjs.org/docs/canary/app/api-reference/next-config-js/ppr#enabling-ppr-version-14), it would be strange to throw a `CanaryOnlyError`.