### PR TITLE
Ensure next-dev-server usages can be found

### DIFF
--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -169,7 +169,8 @@ export class NextServer {
   ): Promise<Server> {
     let ServerImplementation: typeof Server
     if (options.dev) {
-      ServerImplementation = require('./dev/next-dev-server').default
+      ServerImplementation = require('./dev/next-dev-server')
+        .default as typeof import('./dev/next-dev-server').default
     } else {
       ServerImplementation = await getServerImpl()
     }


### PR DESCRIPTION

It looked like it was never referenced because we only `require()` it.
Now we import the type to check soundness
and have it appear as referenced.