### PR TITLE
Fix flaky app action test, take 2

### DIFF
--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1255,8 +1255,8 @@ describe('app-dir action handling', () => {
         )
         expect(await browser.url()).toBe(`${next.url}/pages-dir`)
         expect(mpaTriggered).toBe(true)
-      })
-    }, 5000)
+      }, 5000)
+    })
 
     it('should handle revalidatePath', async () => {
       const browser = await next.browser('/revalidate')


### PR DESCRIPTION
In #71360, I accidentally changed the jest test timeout value instead of increasing the `retry` duration.