### PR TITLE
Increase timeout for deploy tests from 120 (default) to 240 seconds

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -368,7 +368,7 @@ jobs:
 
     uses: ./.github/workflows/build_reusable.yml
     with:
-      afterBuild: node scripts/test-new-tests.mjs --mode deploy --group ${{ matrix.group }}
+      afterBuild: NEXT_E2E_TEST_TIMEOUT=240000 node scripts/test-new-tests.mjs --mode deploy --group ${{ matrix.group }}
       stepName: 'test-new-tests-deploy-${{matrix.group}}'
 
     secrets: inherit

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         group: [1/5, 2/5, 3/5, 4/5, 5/5, 6/6]
     with:
-      afterBuild: NEXT_TEST_MODE=deploy NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" node run-tests.js --timings -g ${{ matrix.group }} -c 2 --type e2e
+      afterBuild: NEXT_E2E_TEST_TIMEOUT=240000 NEXT_TEST_MODE=deploy NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" node run-tests.js --timings -g ${{ matrix.group }} -c 2 --type e2e
       skipNativeBuild: 'yes'
       skipNativeInstall: 'no'
       stepName: 'test-deploy-${{ matrix.group }}'


### PR DESCRIPTION
When running deploy tests, the deployments are done in the `beforeAll` hook of a test. For some more complex test apps the deployment may take a while to complete which can result in the test timing out after 120 seconds. To mitigate this, we increase the timeout to 240 seconds.

x-ref: [example run with a timeout](https://github.com/vercel/next.js/actions/runs/11385828170/job/31678217067)