### PR TITLE
add dump database

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -613,15 +613,18 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         let snapshot_time = Instant::now();
         drop(snapshot_request);
 
-        let mut counts: HashMap<TaskId, u32> = HashMap::new();
-        for log in persisted_storage_meta_log
-            .iter()
-            .chain(persisted_storage_data_log.iter())
-        {
-            for CachedDataUpdate { task, .. } in log.iter() {
-                *counts.entry(*task).or_default() += 1;
-            }
-        }
+        // TODO track which items are persisting
+        // TODO This is very inefficient, maybe the BackingStorage could compute that since it need
+        // to iterate items anyway.
+        // let mut counts: FxHashMap<TaskId, u32> =
+        // FxHashMap::with_capacity_and_hasher(); for log in persisted_storage_meta_log
+        //     .iter()
+        //     .chain(persisted_storage_data_log.iter())
+        // {
+        //     for CachedDataUpdate { task, .. } in log.iter() {
+        //         *counts.entry(*task).or_default() += 1;
+        //     }
+        // }
 
         let mut new_items = false;
 
@@ -646,12 +649,13 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             }
         }
 
-        for (task_id, count) in counts {
-            self.storage
-                .access_mut(task_id)
-                .persistance_state_mut()
-                .finish_persisting_items(count);
-        }
+        // TODO add when we need to track persisted items
+        // for (task_id, count) in counts {
+        //     self.storage
+        //         .access_mut(task_id)
+        //         .persistance_state_mut()
+        //         .finish_persisting_items(count);
+        // }
 
         Some((snapshot_time, new_items))
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -97,15 +97,20 @@ impl PersistanceState {
     }
 
     pub fn add_persisting_item(&mut self) {
-        self.value += 1;
+        // TODO add when we need to track unpersisted items
+        // self.value += 1;
     }
 
-    pub fn add_persisting_items(&mut self, count: u32) {
-        self.value += count;
+    pub fn add_persisting_items(&mut self, _count: u32) {
+        // TODO add when we need to track unpersisted items
+        // self.value += count;
     }
 
-    pub fn finish_persisting_items(&mut self, count: u32) {
-        self.value -= count;
+    // TODO remove when we need to track unpersisted items
+    #[allow(dead_code)]
+    pub fn finish_persisting_items(&mut self, _count: u32) {
+        // TODO add when we need to track unpersisted items
+        // self.value -= count;
     }
 
     pub fn is_restored(&self, category: TaskDataCategory) -> bool {

--- a/turbopack/crates/turbo-tasks-backend/src/database/by_key_space.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/by_key_space.rs
@@ -1,0 +1,52 @@
+use crate::database::key_value_database::KeySpace;
+
+pub struct ByKeySpace<T> {
+    infra: T,
+    task_meta: T,
+    task_data: T,
+    forward_task_cache: T,
+    reverse_task_cache: T,
+}
+
+impl<T> ByKeySpace<T> {
+    pub fn new(mut factory: impl FnMut(KeySpace) -> T) -> Self {
+        Self {
+            infra: factory(KeySpace::Infra),
+            task_meta: factory(KeySpace::TaskMeta),
+            task_data: factory(KeySpace::TaskData),
+            forward_task_cache: factory(KeySpace::ForwardTaskCache),
+            reverse_task_cache: factory(KeySpace::ReverseTaskCache),
+        }
+    }
+
+    pub fn get(&self, key_space: KeySpace) -> &T {
+        match key_space {
+            KeySpace::Infra => &self.infra,
+            KeySpace::TaskMeta => &self.task_meta,
+            KeySpace::TaskData => &self.task_data,
+            KeySpace::ForwardTaskCache => &self.forward_task_cache,
+            KeySpace::ReverseTaskCache => &self.reverse_task_cache,
+        }
+    }
+
+    pub fn get_mut(&mut self, key_space: KeySpace) -> &mut T {
+        match key_space {
+            KeySpace::Infra => &mut self.infra,
+            KeySpace::TaskMeta => &mut self.task_meta,
+            KeySpace::TaskData => &mut self.task_data,
+            KeySpace::ForwardTaskCache => &mut self.forward_task_cache,
+            KeySpace::ReverseTaskCache => &mut self.reverse_task_cache,
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (KeySpace, &T)> {
+        [
+            (KeySpace::Infra, &self.infra),
+            (KeySpace::TaskMeta, &self.task_meta),
+            (KeySpace::TaskData, &self.task_data),
+            (KeySpace::ForwardTaskCache, &self.forward_task_cache),
+            (KeySpace::ReverseTaskCache, &self.reverse_task_cache),
+        ]
+        .into_iter()
+    }
+}

--- a/turbopack/crates/turbo-tasks-backend/src/database/dump_db/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/dump_db/mod.rs
@@ -1,0 +1,121 @@
+use std::{
+    borrow::Cow,
+    fs::{create_dir_all, File},
+    io::BufWriter,
+    path::PathBuf,
+};
+
+use anyhow::{Context, Result};
+
+use crate::database::{
+    key_value_database::{KeySpace, KeyValueDatabase, WriteBatch},
+    rw_pair::{write_key_value_pair, PAIR_HEADER_SIZE},
+};
+
+pub struct DumpKeyValueDatabase {
+    path: PathBuf,
+}
+
+impl DumpKeyValueDatabase {
+    pub fn new(path: PathBuf) -> Result<Self> {
+        create_dir_all(&path).context("Creating database directory failed")?;
+
+        Ok(Self { path })
+    }
+}
+
+impl KeyValueDatabase for DumpKeyValueDatabase {
+    type ReadTransaction<'l>
+        = ()
+    where
+        Self: 'l;
+
+    fn lower_read_transaction<'l: 'i + 'r, 'i: 'r, 'r>(
+        tx: &'r Self::ReadTransaction<'l>,
+    ) -> &'r Self::ReadTransaction<'i> {
+        tx
+    }
+
+    fn begin_read_transaction(&self) -> Result<Self::ReadTransaction<'_>> {
+        Ok(())
+    }
+
+    type ValueBuffer<'l>
+        = &'l [u8]
+    where
+        Self: 'l;
+
+    fn get<'l, 'db: 'l>(
+        &'l self,
+        _transaction: &'l Self::ReadTransaction<'db>,
+        _key_space: KeySpace,
+        _key: &[u8],
+    ) -> Result<Option<Self::ValueBuffer<'l>>> {
+        Ok(None)
+    }
+
+    type WriteBatch<'l>
+        = DumpWriteBatch<'l>
+    where
+        Self: 'l;
+
+    fn write_batch(&self) -> Result<Self::WriteBatch<'_>> {
+        Ok(DumpWriteBatch {
+            current_file: BufWriter::new(File::create(&self.path.join("0"))?),
+            current_file_size: 0,
+            current_file_index: 0,
+            _this: self,
+        })
+    }
+}
+
+const MAX_FILE_SIZE: usize = 100 * 1024 * 1024;
+
+pub struct DumpWriteBatch<'a> {
+    current_file: BufWriter<File>,
+    current_file_size: usize,
+    current_file_index: usize,
+    _this: &'a DumpKeyValueDatabase,
+}
+
+impl<'a> DumpWriteBatch<'a> {
+    fn reserve_size(&mut self, size: usize) -> Result<()> {
+        self.current_file_size += size;
+        if self.current_file_size > MAX_FILE_SIZE {
+            self.current_file_index += 1;
+            self.current_file = BufWriter::new(File::create(&self.current_file_index.to_string())?);
+            self.current_file_size = size;
+        }
+        Ok(())
+    }
+}
+
+impl<'a> WriteBatch<'a> for DumpWriteBatch<'a> {
+    type ValueBuffer<'l>
+        = &'l [u8]
+    where
+        Self: 'l;
+
+    fn get<'l>(&'l self, _key_space: KeySpace, _key: &[u8]) -> Result<Option<Self::ValueBuffer<'l>>>
+    where
+        'a: 'l,
+    {
+        Ok(None)
+    }
+
+    fn put(&mut self, key_space: KeySpace, key: Cow<[u8]>, value: Cow<[u8]>) -> Result<()> {
+        self.reserve_size(key.len() + value.len() + PAIR_HEADER_SIZE)?;
+        write_key_value_pair(&mut self.current_file, key_space, &key, &value)?;
+        Ok(())
+    }
+
+    fn delete(&mut self, key_space: KeySpace, key: Cow<[u8]>) -> Result<()> {
+        self.reserve_size(key.len() + PAIR_HEADER_SIZE)?;
+        write_key_value_pair(&mut self.current_file, key_space, &key, &[])?;
+        Ok(())
+    }
+
+    fn commit(self) -> Result<()> {
+        Ok(())
+    }
+}

--- a/turbopack/crates/turbo-tasks-backend/src/database/dump_db/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/dump_db/mod.rs
@@ -64,7 +64,7 @@ impl KeyValueDatabase for DumpKeyValueDatabase {
             current_file: BufWriter::new(File::create(&self.path.join("0"))?),
             current_file_size: 0,
             current_file_index: 0,
-            _this: self,
+            path: &self.path,
         })
     }
 }
@@ -75,7 +75,7 @@ pub struct DumpWriteBatch<'a> {
     current_file: BufWriter<File>,
     current_file_size: usize,
     current_file_index: usize,
-    _this: &'a DumpKeyValueDatabase,
+    path: &'a Path,
 }
 
 impl<'a> DumpWriteBatch<'a> {
@@ -83,7 +83,9 @@ impl<'a> DumpWriteBatch<'a> {
         self.current_file_size += size;
         if self.current_file_size > MAX_FILE_SIZE {
             self.current_file_index += 1;
-            self.current_file = BufWriter::new(File::create(&self.current_file_index.to_string())?);
+            self.current_file = BufWriter::new(File::create(
+                &self.path.join(self.current_file_index.to_string()),
+            )?);
             self.current_file_size = size;
         }
         Ok(())

--- a/turbopack/crates/turbo-tasks-backend/src/database/dump_db/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/dump_db/mod.rs
@@ -2,7 +2,7 @@ use std::{
     borrow::Cow,
     fs::{create_dir_all, File},
     io::BufWriter,
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 use anyhow::{Context, Result};

--- a/turbopack/crates/turbo-tasks-backend/src/database/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/mod.rs
@@ -4,9 +4,11 @@ pub mod key_value_database;
 pub mod lmdb;
 pub mod noop_kv;
 pub mod read_transaction_cache;
+mod startup_cache;
 
 pub use db_versioning::handle_db_versioning;
 pub use fresh_db_optimization::{is_fresh, FreshDbOptimization};
 #[allow(unused_imports)]
 pub use noop_kv::NoopKvDb;
 pub use read_transaction_cache::ReadTransactionCache;
+pub use startup_cache::StartupCacheLayer;

--- a/turbopack/crates/turbo-tasks-backend/src/database/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/mod.rs
@@ -1,3 +1,4 @@
+mod by_key_space;
 pub mod db_versioning;
 pub mod fresh_db_optimization;
 pub mod key_value_database;

--- a/turbopack/crates/turbo-tasks-backend/src/database/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/mod.rs
@@ -1,13 +1,16 @@
 mod by_key_space;
 pub mod db_versioning;
+mod dump_db;
 pub mod fresh_db_optimization;
 pub mod key_value_database;
 pub mod lmdb;
 pub mod noop_kv;
 pub mod read_transaction_cache;
+mod rw_pair;
 mod startup_cache;
 
 pub use db_versioning::handle_db_versioning;
+pub use dump_db::DumpKeyValueDatabase;
 pub use fresh_db_optimization::{is_fresh, FreshDbOptimization};
 #[allow(unused_imports)]
 pub use noop_kv::NoopKvDb;

--- a/turbopack/crates/turbo-tasks-backend/src/database/rw_pair.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/rw_pair.rs
@@ -1,0 +1,57 @@
+use std::{
+    fs::File,
+    io::{BufWriter, Write},
+};
+
+use anyhow::Result;
+use byteorder::WriteBytesExt;
+
+use crate::database::key_value_database::KeySpace;
+
+pub const PAIR_HEADER_SIZE: usize = 9;
+
+pub fn write_key_value_pair(
+    writer: &mut BufWriter<File>,
+    key_space: KeySpace,
+    key: &[u8],
+    value: &[u8],
+) -> Result<usize> {
+    writer.write_u8(match key_space {
+        KeySpace::Infra => 0,
+        KeySpace::TaskMeta => 1,
+        KeySpace::TaskData => 2,
+        KeySpace::ForwardTaskCache => 3,
+        KeySpace::ReverseTaskCache => 4,
+    })?;
+    let key_len = key.len();
+    writer.write_all(&(key_len as u32).to_be_bytes())?;
+    let value_len = value.len();
+    writer.write_all(&(value_len as u32).to_be_bytes())?;
+    writer.write_all(key)?;
+    writer.write_all(value)?;
+    Ok(9 + key_len + value_len)
+}
+
+pub fn read_key_value_pair<'l>(
+    buffer: &'l [u8],
+    pos: &mut usize,
+) -> Result<(KeySpace, &'l [u8], &'l [u8])> {
+    let key_space = match buffer[*pos] {
+        0 => KeySpace::Infra,
+        1 => KeySpace::TaskMeta,
+        2 => KeySpace::TaskData,
+        3 => KeySpace::ForwardTaskCache,
+        4 => KeySpace::ReverseTaskCache,
+        _ => return Err(anyhow::anyhow!("Invalid key space")),
+    };
+    *pos += 1;
+    let key_len = u32::from_be_bytes(buffer[*pos..*pos + 4].try_into()?);
+    *pos += 4;
+    let value_len = u32::from_be_bytes(buffer[*pos..*pos + 4].try_into()?);
+    *pos += 4;
+    let key = &buffer[*pos..*pos + key_len as usize];
+    *pos += key_len as usize;
+    let value = &buffer[*pos..*pos + value_len as usize];
+    *pos += value_len as usize;
+    Ok((key_space, key, value))
+}

--- a/turbopack/crates/turbo-tasks-backend/src/database/startup_cache.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/startup_cache.rs
@@ -95,7 +95,8 @@ pub struct StartupCacheLayer<T: KeyValueDatabase> {
     cache_size: AtomicUsize,
     cache: Cache,
     restored_map: ByKeySpace<FxHashMap<&'static [u8], &'static [u8]>>,
-    restored: Vec<u8>,
+    // Need to be kept around to keep the restored_map reference alive
+    _restored: Vec<u8>,
 }
 
 impl<T: KeyValueDatabase> StartupCacheLayer<T> {
@@ -138,7 +139,7 @@ impl<T: KeyValueDatabase> StartupCacheLayer<T> {
                     Default::default(),
                 )
             }),
-            restored,
+            _restored: restored,
             restored_map,
         })
     }

--- a/turbopack/crates/turbo-tasks-backend/src/database/startup_cache.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/startup_cache.rs
@@ -13,61 +13,13 @@ use byteorder::WriteBytesExt;
 use dashmap::DashMap;
 use rustc_hash::{FxHashMap, FxHasher};
 
-use crate::database::key_value_database::{KeySpace, KeyValueDatabase, WriteBatch};
+use crate::database::{
+    by_key_space::ByKeySpace,
+    key_value_database::{KeySpace, KeyValueDatabase, WriteBatch},
+};
 
 const CACHE_SIZE_LIMIT: usize = 100 * 1024 * 1024;
 const PAIR_HEADER_SIZE: usize = 9;
-
-pub struct ByKeySpace<T> {
-    infra: T,
-    task_meta: T,
-    task_data: T,
-    forward_task_cache: T,
-    reverse_task_cache: T,
-}
-
-impl<T> ByKeySpace<T> {
-    pub fn new(mut factory: impl FnMut(KeySpace) -> T) -> Self {
-        Self {
-            infra: factory(KeySpace::Infra),
-            task_meta: factory(KeySpace::TaskMeta),
-            task_data: factory(KeySpace::TaskData),
-            forward_task_cache: factory(KeySpace::ForwardTaskCache),
-            reverse_task_cache: factory(KeySpace::ReverseTaskCache),
-        }
-    }
-
-    pub fn get(&self, key_space: KeySpace) -> &T {
-        match key_space {
-            KeySpace::Infra => &self.infra,
-            KeySpace::TaskMeta => &self.task_meta,
-            KeySpace::TaskData => &self.task_data,
-            KeySpace::ForwardTaskCache => &self.forward_task_cache,
-            KeySpace::ReverseTaskCache => &self.reverse_task_cache,
-        }
-    }
-
-    pub fn get_mut(&mut self, key_space: KeySpace) -> &mut T {
-        match key_space {
-            KeySpace::Infra => &mut self.infra,
-            KeySpace::TaskMeta => &mut self.task_meta,
-            KeySpace::TaskData => &mut self.task_data,
-            KeySpace::ForwardTaskCache => &mut self.forward_task_cache,
-            KeySpace::ReverseTaskCache => &mut self.reverse_task_cache,
-        }
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (KeySpace, &T)> {
-        [
-            (KeySpace::Infra, &self.infra),
-            (KeySpace::TaskMeta, &self.task_meta),
-            (KeySpace::TaskData, &self.task_data),
-            (KeySpace::ForwardTaskCache, &self.forward_task_cache),
-            (KeySpace::ReverseTaskCache, &self.reverse_task_cache),
-        ]
-        .into_iter()
-    }
-}
 
 pub enum ValueBuffer<'l, T: KeyValueDatabase>
 where

--- a/turbopack/crates/turbo-tasks-backend/src/database/startup_cache.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/startup_cache.rs
@@ -1,0 +1,351 @@
+use std::{
+    borrow::{Borrow, Cow},
+    fs::{self, File},
+    hash::BuildHasherDefault,
+    io::{BufWriter, Read, Write},
+    mem::transmute,
+    path::PathBuf,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use anyhow::{Ok, Result};
+use byteorder::WriteBytesExt;
+use dashmap::DashMap;
+use rustc_hash::{FxHashMap, FxHasher};
+
+use crate::database::key_value_database::{KeySpace, KeyValueDatabase, WriteBatch};
+
+const CACHE_SIZE_LIMIT: usize = 100 * 1024 * 1024;
+const PAIR_HEADER_SIZE: usize = 9;
+
+pub struct ByKeySpace<T> {
+    infra: T,
+    task_meta: T,
+    task_data: T,
+    forward_task_cache: T,
+    reverse_task_cache: T,
+}
+
+impl<T> ByKeySpace<T> {
+    pub fn new(mut factory: impl FnMut(KeySpace) -> T) -> Self {
+        Self {
+            infra: factory(KeySpace::Infra),
+            task_meta: factory(KeySpace::TaskMeta),
+            task_data: factory(KeySpace::TaskData),
+            forward_task_cache: factory(KeySpace::ForwardTaskCache),
+            reverse_task_cache: factory(KeySpace::ReverseTaskCache),
+        }
+    }
+
+    pub fn get(&self, key_space: KeySpace) -> &T {
+        match key_space {
+            KeySpace::Infra => &self.infra,
+            KeySpace::TaskMeta => &self.task_meta,
+            KeySpace::TaskData => &self.task_data,
+            KeySpace::ForwardTaskCache => &self.forward_task_cache,
+            KeySpace::ReverseTaskCache => &self.reverse_task_cache,
+        }
+    }
+
+    pub fn get_mut(&mut self, key_space: KeySpace) -> &mut T {
+        match key_space {
+            KeySpace::Infra => &mut self.infra,
+            KeySpace::TaskMeta => &mut self.task_meta,
+            KeySpace::TaskData => &mut self.task_data,
+            KeySpace::ForwardTaskCache => &mut self.forward_task_cache,
+            KeySpace::ReverseTaskCache => &mut self.reverse_task_cache,
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (KeySpace, &T)> {
+        [
+            (KeySpace::Infra, &self.infra),
+            (KeySpace::TaskMeta, &self.task_meta),
+            (KeySpace::TaskData, &self.task_data),
+            (KeySpace::ForwardTaskCache, &self.forward_task_cache),
+            (KeySpace::ReverseTaskCache, &self.reverse_task_cache),
+        ]
+        .into_iter()
+    }
+}
+
+pub enum ValueBuffer<'l, T: KeyValueDatabase>
+where
+    T: 'l,
+{
+    Database(T::ValueBuffer<'l>),
+    Cached(&'l [u8]),
+}
+
+impl<T: KeyValueDatabase> Borrow<[u8]> for ValueBuffer<'_, T> {
+    fn borrow(&self) -> &[u8] {
+        match self {
+            ValueBuffer::Database(value) => value.borrow(),
+            ValueBuffer::Cached(value) => value,
+        }
+    }
+}
+
+pub struct StartupCacheLayer<T: KeyValueDatabase> {
+    database: T,
+    path: PathBuf,
+    fresh_db: bool,
+    cache_size: AtomicUsize,
+    cache: ByKeySpace<DashMap<Vec<u8>, Option<Vec<u8>>, BuildHasherDefault<FxHasher>>>,
+    restored_map: ByKeySpace<FxHashMap<&'static [u8], &'static [u8]>>,
+    restored: Vec<u8>,
+}
+
+impl<T: KeyValueDatabase> StartupCacheLayer<T> {
+    pub fn new(database: T, path: PathBuf, fresh_db: bool) -> Result<Self> {
+        let mut restored = Vec::new();
+        let mut restored_map = ByKeySpace::new(|_| FxHashMap::default());
+        if !fresh_db {
+            if let Result::Ok(mut cache_file) = File::open(&path) {
+                cache_file.read_to_end(&mut restored)?;
+                drop(cache_file);
+                let mut pos = 0;
+                while pos < restored.len() {
+                    let (key_space, key, value) = read_key_value_pair(&restored, &mut pos)?;
+                    let map = restored_map.get_mut(key_space);
+                    unsafe {
+                        // Safety: This is a self reference, it's valid as long the `restored`
+                        // buffer is alive
+                        map.insert(
+                            transmute::<&'_ [u8], &'static [u8]>(key),
+                            transmute::<&'_ [u8], &'static [u8]>(value),
+                        );
+                    }
+                }
+            }
+        }
+        Ok(Self {
+            database,
+            path,
+            fresh_db,
+            cache_size: AtomicUsize::new(0),
+            cache: ByKeySpace::new(|key_space| {
+                DashMap::with_capacity_and_hasher(
+                    match key_space {
+                        KeySpace::Infra => 8,
+                        KeySpace::TaskMeta => 1024 * 1024,
+                        KeySpace::TaskData => 1024 * 1024,
+                        KeySpace::ForwardTaskCache => 1024 * 1024,
+                        KeySpace::ReverseTaskCache => 1024 * 1024,
+                    },
+                    Default::default(),
+                )
+            }),
+            restored,
+            restored_map,
+        })
+    }
+}
+
+impl<T: KeyValueDatabase> KeyValueDatabase for StartupCacheLayer<T> {
+    type ReadTransaction<'l>
+        = T::ReadTransaction<'l>
+    where
+        Self: 'l;
+
+    fn lower_read_transaction<'l: 'i + 'r, 'i: 'r, 'r>(
+        tx: &'r Self::ReadTransaction<'l>,
+    ) -> &'r Self::ReadTransaction<'i> {
+        T::lower_read_transaction(tx)
+    }
+
+    fn begin_read_transaction<'l>(&'l self) -> Result<Self::ReadTransaction<'l>> {
+        self.database.begin_read_transaction()
+    }
+
+    type ValueBuffer<'l>
+        = ValueBuffer<'l, T>
+    where
+        Self: 'l;
+
+    fn get<'l, 'db: 'l>(
+        &'l self,
+        transaction: &'l Self::ReadTransaction<'db>,
+        key_space: KeySpace,
+        key: &[u8],
+    ) -> Result<Option<Self::ValueBuffer<'l>>> {
+        if self.fresh_db {
+            return Ok(self
+                .database
+                .get(transaction, key_space, key)?
+                .map(ValueBuffer::Database));
+        }
+        let value = {
+            if let Some(value) = self.restored_map.get(key_space).get(key) {
+                Some(ValueBuffer::Cached(*value))
+            } else {
+                self.database
+                    .get(transaction, key_space, key)?
+                    .map(ValueBuffer::Database)
+            }
+        };
+        if let Some(value) = value.as_ref() {
+            let value: &[u8] = value.borrow();
+            let size = self.cache_size.fetch_add(
+                key.len() + value.len() + PAIR_HEADER_SIZE,
+                Ordering::Relaxed,
+            );
+            if size < CACHE_SIZE_LIMIT {
+                self.cache
+                    .get(key_space)
+                    .entry(key.to_vec())
+                    .or_insert_with(|| Some(value.to_vec()));
+            }
+        }
+        Ok(value)
+    }
+
+    type WriteBatch<'l>
+        = StartupCacheWriteBatch<'l, T>
+    where
+        Self: 'l;
+
+    fn write_batch(&self) -> Result<Self::WriteBatch<'_>> {
+        Ok(StartupCacheWriteBatch {
+            batch: self.database.write_batch()?,
+            this: self,
+        })
+    }
+}
+
+pub struct StartupCacheWriteBatch<'a, T: KeyValueDatabase> {
+    batch: T::WriteBatch<'a>,
+    this: &'a StartupCacheLayer<T>,
+}
+
+impl<'a, T: KeyValueDatabase> WriteBatch<'a> for StartupCacheWriteBatch<'a, T> {
+    fn put(&mut self, key_space: KeySpace, key: Cow<[u8]>, value: Cow<[u8]>) -> Result<()> {
+        if !self.this.fresh_db {
+            let cache = self.this.cache.get(key_space);
+            cache.insert(key.to_vec(), Some(value.to_vec()));
+        }
+        self.batch.put(key_space, key, value)
+    }
+
+    type ValueBuffer<'l>
+        = <T::WriteBatch<'a> as WriteBatch<'a>>::ValueBuffer<'l>
+    where
+        Self: 'l,
+        'a: 'l;
+
+    fn get<'l>(&'l self, key_space: KeySpace, key: &[u8]) -> Result<Option<Self::ValueBuffer<'l>>>
+    where
+        'a: 'l,
+    {
+        self.batch.get(key_space, key)
+    }
+
+    fn delete(&mut self, key_space: KeySpace, key: Cow<[u8]>) -> Result<()> {
+        if !self.this.fresh_db {
+            let cache = self.this.cache.get(key_space);
+            cache.insert(key.to_vec(), None);
+        }
+        self.batch.delete(key_space, key)
+    }
+
+    fn commit(self) -> Result<()> {
+        if !self.this.fresh_db {
+            // Remove file before writing the new snapshot to database to avoid inconsistency
+            let _ = fs::remove_file(&self.this.path);
+        }
+        self.batch.commit()?;
+        if !self.this.fresh_db {
+            // write cache to a temp file to avoid corrupted file
+            let temp_path = self.this.path.with_extension("cache.tmp");
+            let mut writer = BufWriter::new(File::create(&temp_path)?);
+            let mut size_buffer = [0u8; 4];
+            let mut pos = 0;
+            for (key_space, cache) in self.this.cache.iter() {
+                for entry in cache.iter() {
+                    if let (key, Some(value)) = entry.pair() {
+                        pos += write_key_value_pair(
+                            &mut writer,
+                            key_space,
+                            key,
+                            value,
+                            &mut size_buffer,
+                        )?;
+                    }
+                }
+            }
+            for (key_space, map) in self.this.restored_map.iter() {
+                let cache = self.this.cache.get(key_space);
+                for (key, value) in map.iter() {
+                    if !cache.contains_key(*key) {
+                        let size = key.len() + value.len() + PAIR_HEADER_SIZE;
+                        if pos + size < CACHE_SIZE_LIMIT {
+                            pos += write_key_value_pair(
+                                &mut writer,
+                                key_space,
+                                *key,
+                                *value,
+                                &mut size_buffer,
+                            )?;
+                            if pos + 24 >= CACHE_SIZE_LIMIT {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // move temp file to the final location
+            fs::rename(temp_path, &self.this.path)?;
+        }
+        Ok(())
+    }
+}
+
+fn write_key_value_pair(
+    writer: &mut BufWriter<File>,
+    key_space: KeySpace,
+    key: &[u8],
+    value: &[u8],
+    size_buffer: &mut [u8; 4],
+) -> Result<usize> {
+    writer.write_u8(match key_space {
+        KeySpace::Infra => 0,
+        KeySpace::TaskMeta => 1,
+        KeySpace::TaskData => 2,
+        KeySpace::ForwardTaskCache => 3,
+        KeySpace::ReverseTaskCache => 4,
+    })?;
+    let key_len = key.len();
+    size_buffer.copy_from_slice(&(key_len as u32).to_be_bytes());
+    writer.write_all(&*size_buffer)?;
+    let value_len = value.len();
+    size_buffer.copy_from_slice(&(value_len as u32).to_be_bytes());
+    writer.write_all(&*size_buffer)?;
+    writer.write_all(&key)?;
+    writer.write_all(&value)?;
+    Ok(9 + key_len + value_len)
+}
+
+fn read_key_value_pair<'l>(
+    buffer: &'l [u8],
+    pos: &mut usize,
+) -> Result<(KeySpace, &'l [u8], &'l [u8])> {
+    let key_space = match buffer[*pos] {
+        0 => KeySpace::Infra,
+        1 => KeySpace::TaskMeta,
+        2 => KeySpace::TaskData,
+        3 => KeySpace::ForwardTaskCache,
+        4 => KeySpace::ReverseTaskCache,
+        _ => return Err(anyhow::anyhow!("Invalid key space")),
+    };
+    *pos += 1;
+    let key_len = u32::from_be_bytes(buffer[*pos..*pos + 4].try_into()?);
+    *pos += 4;
+    let value_len = u32::from_be_bytes(buffer[*pos..*pos + 4].try_into()?);
+    *pos += 4;
+    let key = &buffer[*pos..*pos + key_len as usize];
+    *pos += key_len as usize;
+    let value = &buffer[*pos..*pos + value_len as usize];
+    *pos += value_len as usize;
+    Ok((key_space, key, value))
+}

--- a/turbopack/crates/turbo-tasks-backend/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/lib.rs
@@ -13,8 +13,8 @@ use anyhow::Result;
 
 pub use self::{backend::TurboTasksBackend, kv_backing_storage::KeyValueDatabaseBackingStorage};
 use crate::database::{
-    handle_db_versioning, is_fresh, lmdb::LmbdKeyValueDatabase, FreshDbOptimization, NoopKvDb,
-    ReadTransactionCache, StartupCacheLayer,
+    handle_db_versioning, is_fresh, lmdb::LmbdKeyValueDatabase, DumpKeyValueDatabase,
+    FreshDbOptimization, NoopKvDb, ReadTransactionCache, StartupCacheLayer,
 };
 
 pub type LmdbBackingStorage = KeyValueDatabaseBackingStorage<
@@ -37,7 +37,13 @@ pub fn noop_backing_storage(_path: &Path) -> Result<NoopBackingStorage> {
     Ok(KeyValueDatabaseBackingStorage::new(NoopKvDb))
 }
 
-pub type DefaultBackingStorage = LmdbBackingStorage;
+pub type DumpBackingStorage = KeyValueDatabaseBackingStorage<DumpKeyValueDatabase>;
+
+pub fn dump_backing_storage(path: &Path) -> Result<DumpBackingStorage> {
+    let path = handle_db_versioning(path)?;
+    let database = DumpKeyValueDatabase::new(path)?;
+    Ok(KeyValueDatabaseBackingStorage::new(database))
+}
 
 pub fn default_backing_storage(path: &Path) -> Result<DefaultBackingStorage> {
     lmdb_backing_storage(path)

--- a/turbopack/crates/turbo-tasks-backend/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/lib.rs
@@ -45,6 +45,8 @@ pub fn dump_backing_storage(path: &Path) -> Result<DumpBackingStorage> {
     Ok(KeyValueDatabaseBackingStorage::new(database))
 }
 
+pub type DefaultBackingStorage = DumpBackingStorage;
+
 pub fn default_backing_storage(path: &Path) -> Result<DefaultBackingStorage> {
-    lmdb_backing_storage(path)
+    dump_backing_storage(path)
 }


### PR DESCRIPTION
### What?

Adds adatabase which just dumps data to disk. It could technically be read again, but that's not implemented yet. 

To make that somewhat usable:

* needs a AQMF to avoid scanning all files. They need to be in a separate file.
* needs a page cache to cache read files
* need to reorganize data automatically to move frequently accessed data into fewer files
* for consistency it needs a file pointing to the maximum committed file index 
* need a way to remove data from files again in a crash safe way