### PR TITLE
refactor: types for collected cache info in route modules

### DIFF
--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -126,13 +126,13 @@ export async function exportAppRoute(
     await afterRunner.executeAfter()
 
     const revalidate =
-      typeof (context.renderOpts as any).collectedRevalidate === 'undefined' ||
-      (context.renderOpts as any).collectedRevalidate >= INFINITE_CACHE
+      typeof context.renderOpts.collectedRevalidate === 'undefined' ||
+      context.renderOpts.collectedRevalidate >= INFINITE_CACHE
         ? false
-        : (context.renderOpts as any).collectedRevalidate
+        : context.renderOpts.collectedRevalidate
 
     const headers = toNodeOutgoingHttpHeaders(response.headers)
-    const cacheTags = (context.renderOpts as any).collectedTags
+    const cacheTags = context.renderOpts.collectedTags
 
     if (cacheTags) {
       headers[NEXT_CACHE_TAGS_HEADER] = cacheTags

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2506,7 +2506,7 @@ export default abstract class Server<
               context.renderOpts as any
             ).fetchMetrics
 
-            const cacheTags = (context.renderOpts as any).collectedTags
+            const cacheTags = context.renderOpts.collectedTags
 
             // If the request is for a static response, we can cache it so long
             // as it's not edge.
@@ -2525,12 +2525,10 @@ export default abstract class Server<
               }
 
               const revalidate =
-                typeof (context.renderOpts as any).collectedRevalidate ===
-                  'undefined' ||
-                (context.renderOpts as any).collectedRevalidate >=
-                  INFINITE_CACHE
+                typeof context.renderOpts.collectedRevalidate === 'undefined' ||
+                context.renderOpts.collectedRevalidate >= INFINITE_CACHE
                   ? false
-                  : (context.renderOpts as any).collectedRevalidate
+                  : context.renderOpts.collectedRevalidate
 
               // Create the cache entry for the response.
               const cacheEntry: ResponseCacheEntry = {

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -100,8 +100,16 @@ export type AppRouteModule = typeof import('../../../build/templates/app-route')
  */
 export interface AppRouteRouteHandlerContext extends RouteModuleHandleContext {
   renderOpts: WorkStoreContext['renderOpts'] &
-    Pick<RenderOptsPartial, 'onInstrumentationRequestError'>
+    Pick<RenderOptsPartial, 'onInstrumentationRequestError'> &
+    CollectedCacheInfo
   prerenderManifest: DeepReadonly<PrerenderManifest>
+}
+
+type CollectedCacheInfo = {
+  collectedTags?: string
+  collectedRevalidate?: number
+  collectedExpire?: number
+  collectedStale?: number
 }
 
 /**
@@ -590,12 +598,10 @@ export class AppRouteRouteModule extends RouteModule<
     ])
 
     if (prerenderStore) {
-      ;(context.renderOpts as any).collectedTags =
-        prerenderStore.tags?.join(',')
-      ;(context.renderOpts as any).collectedRevalidate =
-        prerenderStore.revalidate
-      ;(context.renderOpts as any).collectedExpire = prerenderStore.expire
-      ;(context.renderOpts as any).collectedStale = prerenderStore.stale
+      context.renderOpts.collectedTags = prerenderStore.tags?.join(',')
+      context.renderOpts.collectedRevalidate = prerenderStore.revalidate
+      context.renderOpts.collectedExpire = prerenderStore.expire
+      context.renderOpts.collectedStale = prerenderStore.stale
     }
 
     // It's possible cookies were set in the handler, so we need


### PR DESCRIPTION
adds types for `renderOpts.collectedRevalidate` & friends (only used in route modules). nicer than doing `(context.renderOpts as any)` everywhere