### PR TITLE
[dynamicIO] Do not warn on arbitrary param access in browser

### DIFF
--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -639,11 +639,19 @@ function makeDynamicallyTrackedExoticSearchParamsWithDevWarnings(
     },
     has(target, prop) {
       if (typeof prop === 'string') {
-        const expression = describeHasCheckingStringProperty(
-          'searchParams',
-          prop
-        )
-        warnForSyncAccess(store.route, expression)
+        if (
+          !wellKnownProperties.has(prop) &&
+          (proxiedProperties.has(prop) ||
+            // We are accessing a property that doesn't exist on the promise nor
+            // the underlying searchParams.
+            Reflect.has(target, prop) === false)
+        ) {
+          const expression = describeHasCheckingStringProperty(
+            'searchParams',
+            prop
+          )
+          warnForSyncAccess(store.route, expression)
+        }
       }
       return Reflect.has(target, prop)
     },

--- a/test/development/app-dir/async-request-warnings/app/no-access/mismatch/page.js
+++ b/test/development/app-dir/async-request-warnings/app/no-access/mismatch/page.js
@@ -1,0 +1,5 @@
+'use client'
+
+export default function Page() {
+  return typeof window === 'undefined' ? 'server' : 'client'
+}

--- a/test/development/app-dir/async-request-warnings/app/no-access/normal/page.js
+++ b/test/development/app-dir/async-request-warnings/app/no-access/normal/page.js
@@ -1,0 +1,5 @@
+'use client'
+
+export default function Page() {
+  return 'normal'
+}

--- a/test/development/app-dir/async-request-warnings/async-request-warnings.test.ts
+++ b/test/development/app-dir/async-request-warnings/async-request-warnings.test.ts
@@ -229,4 +229,40 @@ describe('dynamic-requests warnings', () => {
       ],
     })
   })
+
+  describe('no warnings', () => {
+    it('should have no warnings on normal rsc page without accessing params', async () => {
+      const browser = await next.browser('/no-access/normal')
+      const browserLogItems = await browser.log()
+      const browserConsoleErrors = browserLogItems
+        .filter((log) => log.source === 'error')
+        .map((log) => log.message)
+
+      expect(browserConsoleErrors.length).toBe(0)
+    })
+
+    it('should only have hydration warnings on hydration mismatch page without accessing params', async () => {
+      const browser = await next.browser('/no-access/mismatch')
+      const browserLogItems = await browser.log()
+      console.log('browserLogItems', browserLogItems)
+      const browserConsoleErrors = browserLogItems
+        .filter((log) => log.source === 'error')
+        .map((log) => log.message)
+
+      // We assert there are zero logged errors but first we assert specific strings b/c we want a better
+      // failure message if these do appear
+      expect(browserConsoleErrors).toEqual(
+        expect.not.arrayContaining([
+          expect.stringContaining('param property was accessed directly with'),
+          expect.stringContaining(
+            'searchParam property was accessed directly with'
+          ),
+        ])
+      )
+
+      // Even though there is a hydration error it does show up in the logs list b/c it is an
+      // uncaught Error not a console.error. We expect there to be no logged errors
+      expect(browserConsoleErrors.length).toBe(0)
+    })
+  })
 })


### PR DESCRIPTION
params and searchParams have implementations for the browser that avoid pulling in server code like asyncLocalStorage and largely don't actually implement dynamic behavior. However they can still warn when you access properties synchronously and the exotic objects still need to have equivalent sync access supported.

This update unifies the implementations of server and client params and searchParams to uniformly use wellKnownProperties to exclude sync access for well know properties. It also no longer warns for arbitrary param reads in the params client implementation. It also uniformly does not instrument the ReactPromise properties for consistency of spread behavior.