### PR TITLE
fix: set overlay click outside touchstart handler as passive

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/hooks/use-on-click-outside.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/hooks/use-on-click-outside.ts
@@ -20,7 +20,9 @@ export function useOnClickOutside(
 
     const root = el.getRootNode()
     root.addEventListener('mousedown', listener as EventListener)
-    root.addEventListener('touchstart', listener as EventListener)
+    root.addEventListener('touchstart', listener as EventListener, {
+      passive: false,
+    })
     return function () {
       root.removeEventListener('mousedown', listener as EventListener)
       root.removeEventListener('touchstart', listener as EventListener)


### PR DESCRIPTION
Seeing warning showing up while closing the error overlay by clicking outside of the dialog, chrome will show this warning. Explict setting `passive` to `false` now like default

> [Violation] Added non-passive event listener to a scroll-blocking 'touchstart' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952