### PR TITLE
Let cache body execute with hanging inputs

### DIFF
--- a/packages/next/types/$$compiled.internal.d.ts
+++ b/packages/next/types/$$compiled.internal.d.ts
@@ -314,7 +314,10 @@ declare module 'react-server-dom-webpack/client.edge' {
 
   export function encodeReply(
     value: unknown,
-    options?: { temporaryReferences?: TemporaryReferenceSet }
+    options?: {
+      temporaryReferences?: TemporaryReferenceSet
+      signal?: AbortSignal
+    }
   ): Promise<string | FormData>
 }
 

--- a/test/e2e/app-dir/dynamic-io/app/cases/full_cached/page.tsx
+++ b/test/e2e/app-dir/dynamic-io/app/cases/full_cached/page.tsx
@@ -1,0 +1,44 @@
+'use cache'
+
+import { getSentinelValue } from '../../getSentinelValue'
+
+export default async function Page({
+  searchParams: _unused,
+}: {
+  searchParams: Promise<{ n: string }>
+}) {
+  return (
+    <>
+      <p>
+        This page renders two components. Both call a simulated IO function. The
+        whole page is wrapped in "use cache".
+      </p>
+      <p>Niether component is wrapped in a Suspense boundary</p>
+      <p>
+        With PPR this page should be entirely static because all IO is cached.
+      </p>
+      <p>Without PPR this page should be static because all IO is cached.</p>
+      <ComponentOne />
+      <ComponentTwo />
+      <div id="page">{getSentinelValue()}</div>
+    </>
+  )
+}
+
+async function ComponentOne() {
+  return <div>message 1: {await getMessage('hello cached fast', 2)}</div>
+}
+
+async function ComponentTwo() {
+  return (
+    <>
+      <div>message 2: {await getMessage('hello cached fast', 0)}</div>
+      <div>message 3: {await getMessage('hello cached slow', 20)}</div>
+    </>
+  )
+}
+
+async function getMessage(echo, delay) {
+  await new Promise((r) => setTimeout(r, delay))
+  return echo
+}

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.test.ts
@@ -168,6 +168,20 @@ describe('dynamic-io', () => {
     }
   )
 
+  itSkipTurbopack(
+    'should prerender pages that cached the whole page',
+    async () => {
+      const $ = await next.render$('/cases/full_cached', {})
+      if (isNextDev) {
+        expect($('#layout').text()).toBe('at runtime')
+        expect($('#page').text()).toBe('at runtime')
+      } else {
+        expect($('#layout').text()).toBe('at buildtime')
+        expect($('#page').text()).toBe('at buildtime')
+      }
+    }
+  )
+
   if (WITH_PPR) {
     it('should partially prerender pages that do any uncached IO', async () => {
       let $ = await next.render$('/cases/io_mixed', {})


### PR DESCRIPTION
This lets us render deeper into the "use cache" entry as if it wasn't there for the purposes of prerendering.

One such hanging input is the params/searchParams passed to pages.

For now we error if you end up using the dynamic input after a timeout. We could generate a useful partially dynamic output here if we generated a halted RSC payload but for now we just error. Doing this without a timeout is tricky.
