### PR TITLE
enhance: polish hydration error layout to separate error link

### DIFF
--- a/packages/next/src/client/components/is-hydration-error.ts
+++ b/packages/next/src/client/components/is-hydration-error.ts
@@ -8,10 +8,7 @@ const reactUnifiedMismatchWarning = `Hydration failed because the server rendere
 const reactHydrationErrorDocLink = 'https://react.dev/link/hydration-mismatch'
 
 export const getDefaultHydrationErrorMessage = () => {
-  return (
-    reactUnifiedMismatchWarning +
-    '\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error'
-  )
+  return reactUnifiedMismatchWarning
 }
 
 export function isHydrationError(error: unknown): boolean {

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/Errors.tsx
@@ -345,6 +345,14 @@ export function Errors({
                 </p>
               </>
             ) : null}
+            {hydrationWarning ? (
+              <p
+                id="nextjs__container_errors__link"
+                className="nextjs__container_errors__link"
+              >
+                <HotlinkedText text="See more info here: https://nextjs.org/docs/messages/react-hydration-error" />
+              </p>
+            ) : null}
 
             {hydrationWarning &&
             (activeError.componentStackFrames?.length ||
@@ -411,6 +419,12 @@ export const styles = css`
     font-weight: bold;
     color: var(--color-text-color-red-1);
     background-color: var(--color-text-background-red-1);
+  }
+  p.nextjs__container_errors__link {
+    margin: var(--size-gap-double) auto;
+    color: var(--color-text-color-red-1);
+    font-weight: 600;
+    font-size: 15px;
   }
   p.nextjs__container_errors__notes {
     margin: var(--size-gap-double) auto;

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/attach-hydration-error-state.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/attach-hydration-error-state.ts
@@ -40,8 +40,6 @@ export function attachHydrationErrorState(error: Error) {
           ...hydrationErrorState,
         }
       }
-      error.message +=
-        '\nSee more info here: https://nextjs.org/docs/messages/react-hydration-error'
     }
     ;(error as any).details = parsedHydrationErrorState
   }

--- a/test/development/acceptance-app/error-message-url.test.ts
+++ b/test/development/acceptance-app/error-message-url.test.ts
@@ -52,7 +52,7 @@ describe('Error overlay - error message urls', () => {
 
     await session.waitForAndOpenRuntimeError()
 
-    const link = await browser.elementByCss('#nextjs__container_errors_desc a')
+    const link = await browser.elementByCss('#nextjs__container_errors__link a')
     const text = await link.text()
     const href = await link.getAttribute('href')
     expect(text).toEqual(

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -76,10 +76,9 @@ describe('Error overlay for hydration errors in App router', () => {
     await session.assertHasRedbox()
     expect(await getRedboxTotalErrorCount(browser)).toBe(1)
 
-    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
-      "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
-      See more info here: https://nextjs.org/docs/messages/react-hydration-error"
-    `)
+    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+      `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
+    )
 
     expect(await session.getRedboxDescriptionWarning()).toMatchInlineSnapshot(`
       "- A server/client branch \`if (typeof window !== 'undefined')\`.
@@ -90,6 +89,10 @@ describe('Error overlay for hydration errors in App router', () => {
 
       It can also happen if the client has a browser extension installed which messes with the HTML before React loaded."
     `)
+
+    expect(await session.getRedboxErrorLink()).toMatchInlineSnapshot(
+      `"See more info here: https://nextjs.org/docs/messages/react-hydration-error"`
+    )
 
     const pseudoHtml = await session.getRedboxComponentStack()
 
@@ -173,10 +176,9 @@ describe('Error overlay for hydration errors in App router', () => {
       `)
     }
 
-    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
-      "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
-      See more info here: https://nextjs.org/docs/messages/react-hydration-error"
-    `)
+    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+      `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
+    )
 
     await cleanup()
   })
@@ -227,10 +229,9 @@ describe('Error overlay for hydration errors in App router', () => {
       `)
     }
 
-    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
-      "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
-      See more info here: https://nextjs.org/docs/messages/react-hydration-error"
-    `)
+    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+      `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
+    )
 
     await cleanup()
   })
@@ -276,10 +277,9 @@ describe('Error overlay for hydration errors in App router', () => {
       `)
     }
 
-    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
-      "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
-      See more info here: https://nextjs.org/docs/messages/react-hydration-error"
-    `)
+    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+      `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
+    )
 
     await cleanup()
   })
@@ -306,10 +306,9 @@ describe('Error overlay for hydration errors in App router', () => {
     await session.assertHasRedbox()
     expect(await getRedboxTotalErrorCount(browser)).toBe(1)
 
-    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
-      "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
-      See more info here: https://nextjs.org/docs/messages/react-hydration-error"
-    `)
+    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+      `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
+    )
 
     const pseudoHtml = await session.getRedboxComponentStack()
 
@@ -358,10 +357,9 @@ describe('Error overlay for hydration errors in App router', () => {
     expect(await getRedboxTotalErrorCount(browser)).toBe(2)
 
     // FIXME: Should also have "text nodes cannot be a child of tr"
-    expect(await session.getRedboxDescription()).toEqual(outdent`
-      Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
-      See more info here: https://nextjs.org/docs/messages/react-hydration-error
-    `)
+    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+      `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
+    )
 
     const pseudoHtml = await session.getRedboxComponentStack()
     if (isTurbopack) {
@@ -490,10 +488,9 @@ describe('Error overlay for hydration errors in App router', () => {
     `)
     }
 
-    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
-      "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
-      See more info here: https://nextjs.org/docs/messages/react-hydration-error"
-    `)
+    expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+      `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
+    )
 
     await cleanup()
   })
@@ -834,7 +831,6 @@ describe('Error overlay for hydration errors in App router', () => {
               return (
                 <p>
                   <span>
-                    
                     hello {isServer ? 'server' : 'client'}
                   </span>
                 </p>

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -81,10 +81,9 @@ describe('Error overlay for hydration errors in Pages router', () => {
         `"Text content did not match. Server: "server" Client: "client""`
       )
     } else {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
-        "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
-        See more info here: https://nextjs.org/docs/messages/react-hydration-error"
-      `)
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+        `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
+      )
     }
 
     if (isReact18) {
@@ -103,6 +102,9 @@ describe('Error overlay for hydration errors in Pages router', () => {
           It can also happen if the client has a browser extension installed which messes with the HTML before React loaded."
         `)
     }
+    expect(await session.getRedboxErrorLink()).toMatchInlineSnapshot(
+      `"See more info here: https://nextjs.org/docs/messages/react-hydration-error"`
+    )
 
     const pseudoHtml = await session.getRedboxComponentStack()
 
@@ -253,10 +255,9 @@ describe('Error overlay for hydration errors in Pages router', () => {
         `"Expected server HTML to contain a matching <main> in <div>."`
       )
     } else {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
-        "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
-        See more info here: https://nextjs.org/docs/messages/react-hydration-error"
-      `)
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+        `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
+      )
     }
 
     await cleanup()
@@ -343,10 +344,9 @@ describe('Error overlay for hydration errors in Pages router', () => {
         `"Expected server HTML to contain a matching text node for "second" in <div>."`
       )
     } else {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
-        "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
-        See more info here: https://nextjs.org/docs/messages/react-hydration-error"
-      `)
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+        `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
+      )
     }
 
     await cleanup()
@@ -416,10 +416,9 @@ describe('Error overlay for hydration errors in Pages router', () => {
         `"Did not expect server HTML to contain a <main> in <div>."`
       )
     } else {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
-        "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
-        See more info here: https://nextjs.org/docs/messages/react-hydration-error"
-      `)
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+        `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
+      )
     }
 
     await cleanup()
@@ -449,10 +448,9 @@ describe('Error overlay for hydration errors in Pages router', () => {
         `"Did not expect server HTML to contain the text node "only" in <div>."`
       )
     } else {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
-        "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
-        See more info here: https://nextjs.org/docs/messages/react-hydration-error"
-      `)
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+        `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
+      )
     }
 
     const pseudoHtml = await session.getRedboxComponentStack()
@@ -542,10 +540,9 @@ describe('Error overlay for hydration errors in Pages router', () => {
         `"Expected server HTML to contain a matching <table> in <div>."`
       )
     } else {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
-        "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
-        See more info here: https://nextjs.org/docs/messages/react-hydration-error"
-      `)
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+        `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
+      )
     }
 
     const pseudoHtml = await session.getRedboxComponentStack()
@@ -706,10 +703,9 @@ describe('Error overlay for hydration errors in Pages router', () => {
         `"Expected server HTML to contain a matching <main> in <div>."`
       )
     } else {
-      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(`
-        "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used
-        See more info here: https://nextjs.org/docs/messages/react-hydration-error"
-      `)
+      expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
+        `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
+      )
     }
 
     await cleanup()

--- a/test/lib/development-sandbox.ts
+++ b/test/lib/development-sandbox.ts
@@ -11,6 +11,7 @@ import {
   waitForAndOpenRuntimeError,
   getRedboxDescriptionWarning,
   toggleCollapseComponentStack,
+  getRedboxErrorLink,
 } from './next-test-utils'
 import webdriver, { WebdriverOptions } from './next-webdriver'
 import { NextInstance } from './next-modes/base'
@@ -130,6 +131,9 @@ export async function sandbox(
       },
       async getRedboxDescriptionWarning() {
         return getRedboxDescriptionWarning(browser)
+      },
+      async getRedboxErrorLink() {
+        return getRedboxErrorLink(browser)
       },
       async getRedboxSource(includeHeader = false) {
         const header = includeHeader ? await getRedboxHeader(browser) : ''

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -985,6 +985,29 @@ export async function getRedboxDescriptionWarning(browser: BrowserInterface) {
   )
 }
 
+export async function getRedboxErrorLink(
+  browser: BrowserInterface
+): Promise<string | undefined> {
+  return retry(
+    () =>
+      evaluate(browser, () => {
+        const portal = [].slice
+          .call(document.querySelectorAll('nextjs-portal'))
+          .find((p) =>
+            p.shadowRoot.querySelector('[data-nextjs-dialog-header]')
+          )
+        const root = portal.shadowRoot
+        const text = root.querySelector(
+          '#nextjs__container_errors__link'
+        )?.innerText
+        return text
+      }),
+    3000,
+    500,
+    'getRedboxDescriptionWarning'
+  )
+}
+
 export function getBrowserBodyText(browser: BrowserInterface) {
   return browser.eval('document.getElementsByTagName("body")[0].innerText')
 }


### PR DESCRIPTION
### What

Move the "See more: <link>" below the extra message, this is a change that make the description still able to continuous read the message but not interrupted by the link in the middle. We were also thinking to move the link outside the message to become an additional section. Ideally in the future we can extra other `"See more"` from error message into this separate section as visually independent.

<img width="777" alt="image" src="https://github.com/user-attachments/assets/db67f1d2-c4ee-4f24-ba79-264d77f40793">


<details>
  <summary>After</summary>
  <img width="865" alt="image" src="https://github.com/user-attachments/assets/c124abba-11c3-4042-99c7-719befef40d6">
</details>

<details>
  <summary>Before</summary>
<img width="865" alt="image" src="https://github.com/user-attachments/assets/cd3c32ba-1d3a-45d8-a30a-b2a77f4181f5">
</details>

Closes NEXT-3728
