### PR TITLE
next-upgrade: Consistent version comparison to codemod decisions

### DIFF
--- a/packages/next-codemod/bin/__testfixtures__/next-14-installed/README.md
+++ b/packages/next-codemod/bin/__testfixtures__/next-14-installed/README.md
@@ -1,0 +1,1 @@
+suggests `next-dynamic-access-named-export` transform

--- a/packages/next-codemod/bin/__testfixtures__/next-14-installed/package.json
+++ b/packages/next-codemod/bin/__testfixtures__/next-14-installed/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "next-14-installed",
+  "scripts": {
+    "dev": "next dev"
+  },
+  "dependencies": {
+    "next": "14.3.0-canary.44",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/packages/next-codemod/bin/__testfixtures__/next-15-canary-43-installed/README.md
+++ b/packages/next-codemod/bin/__testfixtures__/next-15-canary-43-installed/README.md
@@ -1,0 +1,1 @@
+suggests `next-dynamic-access-named-export` transform

--- a/packages/next-codemod/bin/__testfixtures__/next-15-canary-43-installed/package.json
+++ b/packages/next-codemod/bin/__testfixtures__/next-15-canary-43-installed/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "next-15-canary-43-installed",
+  "scripts": {
+    "dev": "next dev"
+  },
+  "dependencies": {
+    "next": "15.0.0-canary.43",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/packages/next-codemod/bin/__testfixtures__/next-15-canary-44-installed/README.md
+++ b/packages/next-codemod/bin/__testfixtures__/next-15-canary-44-installed/README.md
@@ -1,0 +1,1 @@
+suggests `next-dynamic-access-named-export` transform

--- a/packages/next-codemod/bin/__testfixtures__/next-15-canary-44-installed/README.md
+++ b/packages/next-codemod/bin/__testfixtures__/next-15-canary-44-installed/README.md
@@ -1,1 +1,1 @@
-suggests `next-dynamic-access-named-export` transform
+does not suggest `next-dynamic-access-named-export` transform

--- a/packages/next-codemod/bin/__testfixtures__/next-15-canary-44-installed/package.json
+++ b/packages/next-codemod/bin/__testfixtures__/next-15-canary-44-installed/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "next-15-canary-44-installed",
+  "scripts": {
+    "dev": "next dev"
+  },
+  "dependencies": {
+    "next": "15.0.0-canary.44",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -1,7 +1,6 @@
 import * as os from 'os'
 import prompts from 'prompts'
 import fs from 'fs'
-import semver from 'semver'
 import compareVersions from 'semver/functions/compare'
 import { execSync } from 'child_process'
 import path from 'path'
@@ -178,8 +177,8 @@ export async function runUpgrade(
   // The following React codemods are for React 19
   if (
     !shouldStayOnReact18 &&
-    compareVersions(targetReactVersion, '18.9999.9999') > 0 &&
-    compareVersions(installedReactVersion, '18.9999.9999') <= 0
+    compareVersions(targetReactVersion, '19.0.0-0') >= 0 &&
+    compareVersions(installedReactVersion, '19.0.0-0') < 0
   ) {
     shouldRunReactCodemods = await suggestReactCodemods()
     shouldRunReactTypesCodemods = await suggestReactTypesCodemods()
@@ -431,37 +430,26 @@ async function suggestCodemods(
   initialNextVersion: string,
   targetNextVersion: string
 ): Promise<string[]> {
-  // Here we suggest pre-released codemods by their "stable" version.
-  // It is because if we suggest by the version range (installed ~ target),
-  // pre-released codemods for the target version are not suggested when upgrading.
-
-  // Let's say we have a codemod for v15.0.0-canary.x, and we're upgrading from
-  // v15.x -> v15.x. Our initial version is higher than the codemod's version,
-  // so the codemod will not be suggested.
-
-  // This is not ideal as the codemods for pre-releases are also targeting the major version.
-  // Also, when the user attempts to run the upgrade command twice, and have installed the
-  // target version, the behavior must be idempotent and suggest the codemods including the
-  // pre-releases of the target version.
-  const initial = semver.parse(initialNextVersion)
+  // example:
+  // codemod version: 15.0.0-canary.45
+  // 14.3             -> 15.0.0-canary.45: apply
+  // 14.3             -> 15.0.0-canary.44: don't apply
+  // 15.0.0-canary.44 -> 15.0.0-canary.45: apply
+  // 15.0.0-canary.45 -> 15.0.0-canary.46: don't apply
+  // 15.0.0-canary.45 -> 15.0.0          : don't apply
+  // 15.0.0-canary.44 -> 15.0.0          : apply
   const initialVersionIndex = TRANSFORMER_INQUIRER_CHOICES.findIndex(
-    (versionCodemods) => {
-      const codemod = semver.parse(versionCodemods.version)
-      return (
-        compareVersions(
-          `${codemod.major}.${codemod.minor}.${codemod.patch}`,
-          `${initial.major}.${initial.minor}.${initial.patch}`
-        ) >= 0
-      )
+    (codemod) => {
+      return compareVersions(codemod.version, initialNextVersion) > 0
     }
   )
   if (initialVersionIndex === -1) {
     return []
   }
 
+  // findLastIndex(compareVersions(versionCodemods.version, targetNextVersion) <= 0)
   let targetVersionIndex = TRANSFORMER_INQUIRER_CHOICES.findIndex(
-    (versionCodemods) =>
-      compareVersions(versionCodemods.version, targetNextVersion) > 0
+    (codemod) => compareVersions(codemod.version, targetNextVersion) > 0
   )
   if (targetVersionIndex === -1) {
     targetVersionIndex = TRANSFORMER_INQUIRER_CHOICES.length

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -447,7 +447,6 @@ async function suggestCodemods(
     return []
   }
 
-  // findLastIndex(compareVersions(versionCodemods.version, targetNextVersion) <= 0)
   let targetVersionIndex = TRANSFORMER_INQUIRER_CHOICES.findIndex(
     (codemod) => compareVersions(codemod.version, targetNextVersion) > 0
   )


### PR DESCRIPTION
Decide on consistent application of codemods dependending on the version the codemod got introduced.

codemod version: 15.0.0-canary.45:
```
14.3             -> 15.0.0-canary.45: apply
14.3             -> 15.0.0-canary.44: don't apply
15.0.0-canary.44 -> 15.0.0-canary.45: apply
15.0.0-canary.45 -> 15.0.0-canary.46: don't apply
15.0.0-canary.45 -> 15.0.0          : don't apply
15.0.0-canary.44 -> 15.0.0          : apply
```

## test plan

New fixtures and also verified the other react-* fixtures didn't change