### PR TITLE
fix(create-next-app): use web standard error check for URL

### DIFF
--- a/packages/create-next-app/create-app.ts
+++ b/packages/create-next-app/create-app.ts
@@ -64,8 +64,8 @@ export async function createApp({
     try {
       repoUrl = new URL(example)
     } catch (error: unknown) {
-      const err = error as Error & { code: string | undefined }
-      if (err.code !== 'ERR_INVALID_URL') {
+      const err = error as Error
+      if (err instanceof TypeError) {
         console.error(error)
         process.exit(1)
       }

--- a/packages/create-next-app/create-app.ts
+++ b/packages/create-next-app/create-app.ts
@@ -65,7 +65,7 @@ export async function createApp({
       repoUrl = new URL(example)
     } catch (error: unknown) {
       const err = error as Error
-      if (err instanceof TypeError) {
+      if (!(err instanceof TypeError)) {
         console.error(error)
         process.exit(1)
       }

--- a/packages/create-next-app/create-app.ts
+++ b/packages/create-next-app/create-app.ts
@@ -65,6 +65,7 @@ export async function createApp({
       repoUrl = new URL(example)
     } catch (error: unknown) {
       const err = error as Error
+      // TypeError is thrown when the URL is invalid. Equivalent of doing `err.code !== "ERR_INVALID_URL"` in Node.js
       if (!(err instanceof TypeError)) {
         console.error(error)
         process.exit(1)


### PR DESCRIPTION
This patch updates the error check for example URLs in `create-next-app` to use TypeError instead of
`error.code`.

`error.code` is a non-standard property present in Node.js, even for Web APIs like URL.

This fixes `create-next-app -e hello-world` on Deno. Ref https://github.com/denoland/deno/issues/26383
