### PR TITLE
Turbopack: Make UnableToExternalize a warning

### DIFF
--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -472,7 +472,7 @@ struct UnableToExternalize {
 impl Issue for UnableToExternalize {
     #[turbo_tasks::function]
     fn severity(&self) -> Vc<IssueSeverity> {
-        IssueSeverity::Error.cell()
+        IssueSeverity::Warning.cell()
     }
 
     #[turbo_tasks::function]


### PR DESCRIPTION
- Make UnableToExternalize a warning
- Special case that warning so that it's still printed even inside node_modules
- Make sure that it's only printed once