### PR TITLE
next-upgrade: Stop prompting for React 19 upgrade on pure App Router apps

### DIFF
--- a/packages/next-codemod/bin/__testfixtures__/react-18-installed-mixed-router/README.md
+++ b/packages/next-codemod/bin/__testfixtures__/react-18-installed-mixed-router/README.md
@@ -1,1 +1,1 @@
-Prompts for React 19 upgrade
+Prompts for React 19 upgrade with a recommendation to do so

--- a/packages/next-codemod/bin/__testfixtures__/react-18-installed-mixed-router/package.json
+++ b/packages/next-codemod/bin/__testfixtures__/react-18-installed-mixed-router/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-18-installed-mixed-router",
   "scripts": {
-    "dev": "next dev"
+    "dev": "next dev --turbo"
   },
   "dependencies": {
     "next": "14.3.0-canary.44",

--- a/packages/next-codemod/bin/__testfixtures__/react-18-installed-pure-app-router/README.md
+++ b/packages/next-codemod/bin/__testfixtures__/react-18-installed-pure-app-router/README.md
@@ -1,1 +1,1 @@
-Prompts for React 19 upgrade
+Upgrades to React 19 automatically

--- a/packages/next-codemod/bin/__testfixtures__/react-18-installed-pure-app-router/package.json
+++ b/packages/next-codemod/bin/__testfixtures__/react-18-installed-pure-app-router/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-18-installed-pure-app-router",
   "scripts": {
-    "dev": "next dev"
+    "dev": "next dev --turbo"
   },
   "dependencies": {
     "next": "14.3.0-canary.44",

--- a/packages/next-codemod/bin/__testfixtures__/react-18-installed-pure-pages-router/README.md
+++ b/packages/next-codemod/bin/__testfixtures__/react-18-installed-pure-pages-router/README.md
@@ -1,1 +1,1 @@
-Prompts for React 19 upgrade
+Prompts for React 19 upgrade without any recommendation

--- a/packages/next-codemod/bin/__testfixtures__/react-18-installed-pure-pages-router/package.json
+++ b/packages/next-codemod/bin/__testfixtures__/react-18-installed-pure-pages-router/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-18-installed-pure-pages-router",
   "scripts": {
-    "dev": "next dev"
+    "dev": "next dev --turbo"
   },
   "dependencies": {
     "next": "14.3.0-canary.44",

--- a/packages/next-codemod/bin/__testfixtures__/react-19-installed-mixed-router/package.json
+++ b/packages/next-codemod/bin/__testfixtures__/react-19-installed-mixed-router/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-19-installed-mixed-router",
   "scripts": {
-    "dev": "next dev"
+    "dev": "next dev --turbo"
   },
   "dependencies": {
     "next": "14.3.0-canary.45",

--- a/packages/next-codemod/bin/__testfixtures__/react-19-installed-pure-app-router/package.json
+++ b/packages/next-codemod/bin/__testfixtures__/react-19-installed-pure-app-router/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-19-installed-pure-app-router",
   "scripts": {
-    "dev": "next dev"
+    "dev": "next dev --turbo"
   },
   "dependencies": {
     "next": "14.3.0-canary.45",

--- a/packages/next-codemod/bin/__testfixtures__/react-19-installed-pure-pages-router/package.json
+++ b/packages/next-codemod/bin/__testfixtures__/react-19-installed-pure-pages-router/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-19-installed-pure-pages-router",
   "scripts": {
-    "dev": "next dev"
+    "dev": "next dev --turbo"
   },
   "dependencies": {
     "next": "14.3.0-canary.45",


### PR DESCRIPTION
(when you have 18 installed and the designated Next.js version supports React 19):
```
just app: no prompt
just pages: "Do you prefer to stay on React 18?"
pages+app: "Do you prefer to stay on React 18? Since you're using both pages/ and app/, we recommend upgrading React to use a consistent version throughout your app."
```