### PR TITLE
fix: add test helper back

### DIFF
--- a/test/e2e/app-dir/dynamic-io/dynamic-io.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.test.ts
@@ -1,9 +1,10 @@
+/* eslint-disable jest/no-standalone-expect */
 import { nextTestSetup } from 'e2e-utils'
 
 const WITH_PPR = !!process.env.__NEXT_EXPERIMENTAL_PPR
 
 describe('dynamic-io', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
   })
@@ -11,6 +12,8 @@ describe('dynamic-io', () => {
   if (skipped) {
     return
   }
+
+  const itSkipTurbopack = isTurbopack ? it.skip : it
 
   it('should not have route specific errors', async () => {
     expect(next.cliOutput).not.toMatch('Error: Route /')


### PR DESCRIPTION
A test helper was recently deleted that caused a failure for tests:

https://github.com/vercel/next.js/pull/71326/files#diff-89f3ffc2ba61402d4e283e83323169b7b567967666b03b1e3eabca8d87fbcf20L16

This adds the test helper back.
