### PR TITLE
Fix handling of local functions in `"use cache"` modules

### DIFF
--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/34/input.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/34/input.js
@@ -1,5 +1,22 @@
 'use cache'
 
-export async function foo() {}
-const bar = async () => {}
+const foo = async () => {
+  return 'foo'
+}
+
 export { bar }
+
+async function bar() {
+  return 'bar'
+}
+
+// Should not be wrapped in $$cache__.
+const qux = async function qux() {
+  return 'qux'
+}
+
+const baz = async function () {
+  return qux() + 'baz'
+}
+
+export { foo, baz }

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/34/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/34/output.js
@@ -1,8 +1,21 @@
-/* __next_internal_action_entry_do_not_use__ {"3128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0","951c375b4a6a6e89d67b743ec5808127cfde405d":"$$RSC_SERVER_CACHE_1"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+/* __next_internal_action_entry_do_not_use__ {"12a8d21b6362b4cc8f5b15560525095bc48dba80":"$$RSC_SERVER_CACHE_3","3128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0","951c375b4a6a6e89d67b743ec5808127cfde405d":"$$RSC_SERVER_CACHE_1"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "3128060c414d59f8552e4788b846c0d2b7f74743", async function foo() {});
-export var foo = registerServerReference($$RSC_SERVER_CACHE_0, "3128060c414d59f8552e4788b846c0d2b7f74743", null);
-export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "951c375b4a6a6e89d67b743ec5808127cfde405d", async function() {});
-const bar = registerServerReference($$RSC_SERVER_CACHE_1, "951c375b4a6a6e89d67b743ec5808127cfde405d", null);
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "3128060c414d59f8552e4788b846c0d2b7f74743", async function() {
+    return 'foo';
+});
+const foo = registerServerReference($$RSC_SERVER_CACHE_0, "3128060c414d59f8552e4788b846c0d2b7f74743", null);
 export { bar };
+export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "951c375b4a6a6e89d67b743ec5808127cfde405d", async function bar() {
+    return 'bar';
+});
+var bar = registerServerReference($$RSC_SERVER_CACHE_1, "951c375b4a6a6e89d67b743ec5808127cfde405d", null);
+// Should not be wrapped in $$cache__.
+const qux = async function qux() {
+    return 'qux';
+};
+export var $$RSC_SERVER_CACHE_3 = $$cache__("default", "12a8d21b6362b4cc8f5b15560525095bc48dba80", async function $$RSC_SERVER_CACHE_2() {
+    return qux() + 'baz';
+});
+const baz = registerServerReference($$RSC_SERVER_CACHE_3, "12a8d21b6362b4cc8f5b15560525095bc48dba80", null);
+export { foo, baz };

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/45/input.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/45/input.js
@@ -1,0 +1,12 @@
+'use cache'
+
+// Expect no error here, this is allowed to be sync because it's not exported.
+function Foo() {
+  const v = Math.random()
+  console.log(v)
+  return v
+}
+
+export async function bar() {
+  return <Foo />
+}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/45/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/45/output.js
@@ -1,0 +1,13 @@
+/* __next_internal_action_entry_do_not_use__ {"3128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
+// Expect no error here, this is allowed to be sync because it's not exported.
+function Foo() {
+    const v = Math.random();
+    console.log(v);
+    return v;
+}
+export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "3128060c414d59f8552e4788b846c0d2b7f74743", async function bar() {
+    return <Foo/>;
+});
+export var bar = registerServerReference($$RSC_SERVER_CACHE_0, "3128060c414d59f8552e4788b846c0d2b7f74743", null);


### PR DESCRIPTION
This fixes two issues in the server function transforms:

### 1) Do not wrap unexported functions in `cache`

In #71401, we added support for decoupled export statements:

```ts
'use cache'

function Foo() {}

export { Foo }
```

However, this was done in a rather naïve way by wrapping all functions in a `"use cache"` module with the `cache` wrapper.

With this PR, we are constraining this to the functions that are actually exported, by first collecting all exported identifiers in a pre-pass.

### 2) Do not fail for local sync functions

Consider the following example:

```ts
"use cache"

function Foo() {
  const v = Math.random();
  console.log(v)
  return v;
}

export async function bar() {
  return <Foo />
}
```

Previously, this file would have yielded an error during compilation because the function `Foo` was wrongly required to be async. This requirement is only true for exported functions in a `"use cache"` module. This has now been fixed, and the module above compiles without errors.

Due to the first mentioned fix, `Foo` is also not wrapped in the `cache` wrapper.