### PR TITLE
Pass cacheLifeProfiles during static path generation

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1952,6 +1952,7 @@ export default async function build(
               defaultLocale: config.i18n?.defaultLocale,
               nextConfigOutput: config.output,
               pprConfig: config.experimental.ppr,
+              cacheLifeProfiles: config.experimental.cacheLife,
               buildId,
             })
         )
@@ -2176,6 +2177,7 @@ export default async function build(
                             maxMemoryCacheSize: config.cacheMaxMemorySize,
                             nextConfigOutput: config.output,
                             pprConfig: config.experimental.ppr,
+                            cacheLifeProfiles: config.experimental.cacheLife,
                             buildId,
                           })
                         }

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -773,6 +773,7 @@ export default class DevServer extends Server {
           isAppPath,
           requestHeaders,
           cacheHandler: this.nextConfig.cacheHandler,
+          cacheLifeProfiles: this.nextConfig.experimental.cacheLife,
           fetchCacheKeyPrefix: this.nextConfig.experimental.fetchCacheKeyPrefix,
           isrFlushToDisk: this.nextConfig.experimental.isrFlushToDisk,
           maxMemoryCacheSize: this.nextConfig.cacheMaxMemorySize,

--- a/test/e2e/app-dir/use-cache/app/[id]/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/[id]/page.tsx
@@ -1,0 +1,12 @@
+async function getCachedRandom(n: number) {
+  'use cache'
+  return String(Math.ceil(Math.random() * n))
+}
+
+export async function generateStaticParams() {
+  return [{ id: await getCachedRandom(10) }, { id: await getCachedRandom(2) }]
+}
+
+export default async function Page() {
+  return 'hit'
+}


### PR DESCRIPTION
So that you can use cache during generateStaticParams.


