### PR TITLE
Follow up to default cache handler

### DIFF
--- a/packages/next/src/server/lib/cache-handlers/default.ts
+++ b/packages/next/src/server/lib/cache-handlers/default.ts
@@ -28,7 +28,7 @@ type DefaultCacheEntry = CacheEntry & {
 const memoryCache = new LRUCache<DefaultCacheEntry>(50_000_000)
 const pendingSets = new Map<string, Promise<void>>()
 
-export const DefaultCacheHandler: CacheHandler = {
+const DefaultCacheHandler: CacheHandler = {
   async get(cacheKey, softTags) {
     await pendingSets.get(cacheKey)
 
@@ -121,3 +121,5 @@ export const DefaultCacheHandler: CacheHandler = {
     return this.expireTags(...tags)
   },
 }
+
+export default DefaultCacheHandler

--- a/packages/next/src/server/lib/cache-handlers/default.ts
+++ b/packages/next/src/server/lib/cache-handlers/default.ts
@@ -29,10 +29,10 @@ const memoryCache = new LRUCache<DefaultCacheEntry>(50_000_000)
 const pendingSets = new Map<string, Promise<void>>()
 
 export const DefaultCacheHandler: CacheHandler = {
-  get: async function get(cacheKey, softTags) {
+  async get(cacheKey, softTags) {
     await pendingSets.get(cacheKey)
 
-    if (isTagStale(...softTags)) {
+    if (isTagStale(softTags)) {
       return
     }
     const entry = memoryCache.get(cacheKey)
@@ -49,7 +49,7 @@ export const DefaultCacheHandler: CacheHandler = {
       return
     }
 
-    if (isTagStale(...(entry.tags || []))) {
+    if (isTagStale(entry.tags || [])) {
       return
     }
     const [returnStream, newSaved] = entry.value.tee()
@@ -61,7 +61,7 @@ export const DefaultCacheHandler: CacheHandler = {
     }
   },
 
-  set: async function set(cacheKey, entry) {
+  async set(cacheKey, entry) {
     let resolvePending: () => void = () => {}
     const pendingPromise = new Promise<void>((resolve) => {
       resolvePending = resolve
@@ -107,7 +107,7 @@ export const DefaultCacheHandler: CacheHandler = {
     }
   },
 
-  expireTags: async function expireTags(...tags) {
+  async expireTags(tags) {
     for (const tag of tags) {
       if (!tagsManifest.items[tag]) {
         tagsManifest.items[tag] = {}
@@ -117,9 +117,7 @@ export const DefaultCacheHandler: CacheHandler = {
     }
   },
 
-  receiveExpiredTags: async function receiveExpiredTags(
-    ...tags
-  ): Promise<void> {
+  async receiveExpiredTags(tags): Promise<void> {
     return this.expireTags(...tags)
   },
 }

--- a/packages/next/src/server/lib/incremental-cache/tags-manifest.ts
+++ b/packages/next/src/server/lib/incremental-cache/tags-manifest.ts
@@ -8,7 +8,7 @@ export const tagsManifest: TagsManifest = {
   items: {},
 }
 
-export const isTagStale = (...tags: string[]) => {
+export const isTagStale = (tags: string[]) => {
   for (const tag of tags) {
     const tagEntry = tagsManifest.items[tag]
     if (

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -32,7 +32,7 @@ import {
   getServerModuleMap,
 } from '../app-render/encryption-utils'
 import type { CacheScopeStore } from '../async-storage/cache-scope.external'
-import { DefaultCacheHandler } from '../lib/cache-handlers/default'
+import DefaultCacheHandler from '../lib/cache-handlers/default'
 import type { CacheHandler, CacheEntry } from '../lib/cache-handlers/types'
 
 const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'


### PR DESCRIPTION
Some minor optimizations:

- While spreading tags is convenient and is nice if it's inline. It does require some cloning and dynamism. So it's faster if we pass the same array around in internal apis instead of cloning at each level. It also lets us add new options to those APIs later.
- Export the default cache handler as the "default" export since that's what it would look like for third parties if they want to be required. So then it becomes possible to specify the default the same as a third party.
- Use fixed hidden class for cache entries and other fixes
- No need to buffer the chunks. It can add up memory since we have multiple copies in memory at any given time with the current naive stream teeing. We can just GC the copies immediately.
- To avoid hidden class deopts we should avoid optional fields and avoid adding additional fields to existing objects. It also makes it easier to follow and avoid clashes when the same name is added both to the public and private objects.