### PR TITLE
Add handling for custom cache handlers

### DIFF
--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -441,6 +441,7 @@ export function getEdgeServerEntry(opts: {
       JSON.stringify(opts.middlewareConfig || {})
     ).toString('base64'),
     serverActions: opts.config.experimental.serverActions,
+    cacheHandlers: JSON.stringify(opts.config.experimental.cacheHandlers || {}),
   }
 
   return {

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2171,6 +2171,7 @@ export default async function build(
                             pageType,
                             dynamicIO: Boolean(config.experimental.dynamicIO),
                             cacheHandler: config.cacheHandler,
+                            cacheHandlers: config.experimental.cacheHandlers,
                             isrFlushToDisk: ciEnvironment.hasNextSupport
                               ? false
                               : config.experimental.isrFlushToDisk,

--- a/packages/next/src/build/load-entrypoint.ts
+++ b/packages/next/src/build/load-entrypoint.ts
@@ -36,13 +36,36 @@ export async function loadEntrypoint(
     | 'pages-api',
   replacements: Record<`VAR_${string}`, string>,
   injections?: Record<string, string>,
-  imports?: Record<string, string | null>
+  imports?: Record<string, string | null>,
+  importMaps?: Record<string, Record<string, string>>
 ): Promise<string> {
   const filepath = path.resolve(
     path.join(TEMPLATES_ESM_FOLDER, `${entrypoint}.js`)
   )
 
   let file = await fs.readFile(filepath, 'utf8')
+
+  const importMapItems: Record<string, Record<string, string>> = {}
+
+  for (const key of Object.keys(importMaps || {})) {
+    importMapItems[key] = {}
+
+    for (const [innerKey, importPath] of Object.entries(
+      importMaps?.[key] || {}
+    )) {
+      file = `import ${key}_${innerKey} from "${importPath}"\n${file}`
+      importMapItems[key][innerKey] = `${key}_${innerKey}`
+    }
+  }
+
+  file = file.replace(
+    new RegExp(`cacheHandlers = {}`),
+    `cacheHandlers = {\n${Object.entries(importMapItems['cacheHandlers'] || {})
+      .map(([key, value]) => {
+        return `${key}: ${value}`
+      })
+      .join(',')}\n}`
+  )
 
   // Update the relative imports to be absolute. This will update any relative
   // imports to be relative to the root of the `next` package.

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -19,8 +19,8 @@ declare const incrementalCacheHandler: any
 
 const cacheHandlers = {}
 
-if (!(globalThis as any).nextCacheHandlers) {
-  ;(globalThis as any).nextCacheHandlers = cacheHandlers
+if (!(globalThis as any).__nextCacheHandlers) {
+  ;(globalThis as any).__nextCacheHandlers = cacheHandlers
 }
 
 const Document: DocumentType = null!

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -17,6 +17,12 @@ import { createServerModuleMap } from '../../server/app-render/action-utils'
 declare const incrementalCacheHandler: any
 // OPTIONAL_IMPORT:incrementalCacheHandler
 
+const cacheHandlers = {}
+
+if (!(globalThis as any).nextCacheHandlers) {
+  ;(globalThis as any).nextCacheHandlers = cacheHandlers
+}
+
 const Document: DocumentType = null!
 const appMod = null
 const errorMod = null

--- a/packages/next/src/build/templates/edge-ssr.ts
+++ b/packages/next/src/build/templates/edge-ssr.ts
@@ -42,8 +42,8 @@ declare const user500RouteModuleOptions: any
 
 const cacheHandlers = {}
 
-if (!(globalThis as any).nextCacheHandlers) {
-  ;(globalThis as any).nextCacheHandlers = cacheHandlers
+if (!(globalThis as any).__nextCacheHandlers) {
+  ;(globalThis as any).__nextCacheHandlers = cacheHandlers
 }
 
 const pageMod = {

--- a/packages/next/src/build/templates/edge-ssr.ts
+++ b/packages/next/src/build/templates/edge-ssr.ts
@@ -40,6 +40,12 @@ declare const user500RouteModuleOptions: any
 // INJECT:errorRouteModuleOptions
 // INJECT:user500RouteModuleOptions
 
+const cacheHandlers = {}
+
+if (!(globalThis as any).nextCacheHandlers) {
+  ;(globalThis as any).nextCacheHandlers = cacheHandlers
+}
+
 const pageMod = {
   ...userlandPage,
   routeModule: new RouteModule({

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -99,6 +99,7 @@ import type { OutgoingHttpHeaders } from 'http'
 import type { AppSegmentConfig } from './segment-config/app/app-segment-config'
 import type { AppSegment } from './segment-config/app/app-segments'
 import { collectSegments } from './segment-config/app/app-segments'
+import { createIncrementalCache } from '../export/helpers/create-incremental-cache'
 
 export type ROUTER_TYPE = 'pages' | 'app'
 
@@ -1490,6 +1491,7 @@ export async function isPageStatic({
   maxMemoryCacheSize,
   nextConfigOutput,
   cacheHandler,
+  cacheHandlers,
   cacheLifeProfiles,
   pprConfig,
   buildId,
@@ -1511,6 +1513,7 @@ export async function isPageStatic({
   isrFlushToDisk?: boolean
   maxMemoryCacheSize?: number
   cacheHandler?: string
+  cacheHandlers?: Record<string, string | undefined>
   cacheLifeProfiles?: {
     [profile: string]: import('../server/use-cache/cache-life').CacheLife
   }
@@ -1518,6 +1521,16 @@ export async function isPageStatic({
   pprConfig: ExperimentalPPRConfig | undefined
   buildId: string
 }): Promise<PageIsStaticResult> {
+  await createIncrementalCache({
+    cacheHandler,
+    cacheHandlers,
+    distDir,
+    dir,
+    dynamicIO,
+    flushToDisk: isrFlushToDisk,
+    cacheMaxMemorySize: maxMemoryCacheSize,
+  })
+
   const isPageStaticSpan = trace('is-page-static-utils', parentId)
   return isPageStaticSpan
     .traceAsyncFn(async (): Promise<PageIsStaticResult> => {

--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
@@ -24,6 +24,7 @@ export type EdgeSSRLoaderQuery = {
   pagesType: PAGE_TYPES
   sriEnabled: boolean
   cacheHandler?: string
+  cacheHandlers?: string
   preferredRegion: string | string[] | undefined
   middlewareConfig: string
   serverActions?: {
@@ -75,10 +76,13 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
       pagesType,
       sriEnabled,
       cacheHandler,
+      cacheHandlers: cacheHandlersStringified,
       preferredRegion,
       middlewareConfig: middlewareConfigBase64,
       serverActions,
     } = this.getOptions()
+
+    const cacheHandlers = JSON.parse(cacheHandlersStringified || '{}')
 
     const middlewareConfig: MiddlewareConfig = JSON.parse(
       Buffer.from(middlewareConfigBase64, 'base64').toString()
@@ -156,6 +160,9 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
         },
         {
           incrementalCacheHandler: cacheHandler ?? null,
+        },
+        {
+          cacheHandlers: cacheHandlers ?? {},
         }
       )
     } else {
@@ -184,6 +191,9 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
         {
           userland500Page: userland500Path,
           incrementalCacheHandler: cacheHandler ?? null,
+        },
+        {
+          cacheHandlers: cacheHandlers || {},
         }
       )
     }

--- a/packages/next/src/export/helpers/create-incremental-cache.ts
+++ b/packages/next/src/export/helpers/create-incremental-cache.ts
@@ -34,12 +34,12 @@ export async function createIncrementalCache({
     )
   }
 
-  if (!(globalThis as any).nextCacheHandlers && cacheHandlers) {
-    ;(globalThis as any).nextCacheHandlers = {}
+  if (!(globalThis as any).__nextCacheHandlers && cacheHandlers) {
+    ;(globalThis as any).__nextCacheHandlers = {}
 
     for (const key of Object.keys(cacheHandlers)) {
       if (cacheHandlers[key]) {
-        ;(globalThis as any).nextCacheHandlers[key] = interopDefault(
+        ;(globalThis as any).__nextCacheHandlers[key] = interopDefault(
           await import(formatDynamicImportPath(dir, cacheHandlers[key])).then(
             (mod) => mod.default || mod
           )

--- a/packages/next/src/export/helpers/create-incremental-cache.ts
+++ b/packages/next/src/export/helpers/create-incremental-cache.ts
@@ -38,11 +38,13 @@ export async function createIncrementalCache({
     ;(globalThis as any).nextCacheHandlers = {}
 
     for (const key of Object.keys(cacheHandlers)) {
-      ;(globalThis as any).nextCacheHandlers[key] = interopDefault(
-        await import(
-          formatDynamicImportPath(dir, cacheHandlers[key] || '')
-        ).then((mod) => mod.default || mod)
-      )
+      if (cacheHandlers[key]) {
+        ;(globalThis as any).nextCacheHandlers[key] = interopDefault(
+          await import(formatDynamicImportPath(dir, cacheHandlers[key])).then(
+            (mod) => mod.default || mod
+          )
+        )
+      }
     }
   }
 

--- a/packages/next/src/export/helpers/create-incremental-cache.ts
+++ b/packages/next/src/export/helpers/create-incremental-cache.ts
@@ -13,6 +13,7 @@ export async function createIncrementalCache({
   distDir,
   dir,
   flushToDisk,
+  cacheHandlers,
 }: {
   dynamicIO: boolean
   cacheHandler?: string
@@ -21,6 +22,7 @@ export async function createIncrementalCache({
   distDir: string
   dir: string
   flushToDisk?: boolean
+  cacheHandlers?: Record<string, string | undefined>
 }) {
   // Custom cache handler overrides.
   let CacheHandler: any
@@ -30,6 +32,18 @@ export async function createIncrementalCache({
         (mod) => mod.default || mod
       )
     )
+  }
+
+  if (!(globalThis as any).nextCacheHandlers && cacheHandlers) {
+    ;(globalThis as any).nextCacheHandlers = {}
+
+    for (const key of Object.keys(cacheHandlers)) {
+      ;(globalThis as any).nextCacheHandlers[key] = interopDefault(
+        await import(
+          formatDynamicImportPath(dir, cacheHandlers[key] || '')
+        ).then((mod) => mod.default || mod)
+      )
+    }
   }
 
   const incrementalCache = new IncrementalCache({

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -358,6 +358,7 @@ export async function exportPages(
     // skip writing to disk in minimal mode for now, pending some
     // changes to better support it
     flushToDisk: !hasNextSupport,
+    cacheHandlers: nextConfig.experimental.cacheHandlers,
   })
 
   renderOpts.incrementalCache = incrementalCache

--- a/packages/next/src/server/lib/cache-handlers/remote.ts
+++ b/packages/next/src/server/lib/cache-handlers/remote.ts
@@ -1,4 +1,0 @@
-/*
-  This is the remote "use cache" handler it defaults
-  to a no-op unless customized
-*/

--- a/packages/next/src/server/lib/cache-handlers/static.ts
+++ b/packages/next/src/server/lib/cache-handlers/static.ts
@@ -1,4 +1,0 @@
-/*
-  This is the static "use cache" handler it defaults
-  to a filesystem cache unless customized
-*/

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -363,6 +363,20 @@ export default class NextNodeServer extends BaseServer<
       )
     }
 
+    const { cacheHandlers } = this.nextConfig.experimental
+
+    if (!(globalThis as any).nextCacheHandlers && cacheHandlers) {
+      ;(globalThis as any).nextCacheHandlers = {}
+
+      for (const key of Object.keys(cacheHandlers)) {
+        ;(globalThis as any).nextCacheHandlers[key] = interopDefault(
+          await dynamicImportEsmDefault(
+            formatDynamicImportPath(this.distDir, cacheHandlers[key] || '')
+          )
+        )
+      }
+    }
+
     // incremental-cache is request specific
     // although can have shared caches in module scope
     // per-cache handler

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -369,11 +369,13 @@ export default class NextNodeServer extends BaseServer<
       ;(globalThis as any).nextCacheHandlers = {}
 
       for (const key of Object.keys(cacheHandlers)) {
-        ;(globalThis as any).nextCacheHandlers[key] = interopDefault(
-          await dynamicImportEsmDefault(
-            formatDynamicImportPath(this.distDir, cacheHandlers[key] || '')
+        if (cacheHandlers[key]) {
+          ;(globalThis as any).nextCacheHandlers[key] = interopDefault(
+            await dynamicImportEsmDefault(
+              formatDynamicImportPath(this.distDir, cacheHandlers[key])
+            )
           )
-        )
+        }
       }
     }
 

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -365,12 +365,12 @@ export default class NextNodeServer extends BaseServer<
 
     const { cacheHandlers } = this.nextConfig.experimental
 
-    if (!(globalThis as any).nextCacheHandlers && cacheHandlers) {
-      ;(globalThis as any).nextCacheHandlers = {}
+    if (!(globalThis as any).__nextCacheHandlers && cacheHandlers) {
+      ;(globalThis as any).__nextCacheHandlers = {}
 
       for (const key of Object.keys(cacheHandlers)) {
         if (cacheHandlers[key]) {
-          ;(globalThis as any).nextCacheHandlers[key] = interopDefault(
+          ;(globalThis as any).__nextCacheHandlers[key] = interopDefault(
             await dynamicImportEsmDefault(
               formatDynamicImportPath(this.distDir, cacheHandlers[key])
             )

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -44,11 +44,15 @@ const cacheHandlersSymbol = Symbol.for('@next/cache-handlers')
 const _globalThis: typeof globalThis & {
   [cacheHandlersSymbol]?: {
     RemoteCache?: CacheHandler
+    DefaultCache?: CacheHandler
   }
 } = globalThis
 
 const cacheHandlerMap: Map<string, CacheHandler> = new Map([
-  ['default', DefaultCacheHandler],
+  [
+    'default',
+    _globalThis[cacheHandlersSymbol]?.DefaultCache || DefaultCacheHandler,
+  ],
   [
     'remote',
     // in dev remote maps to default handler

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -62,7 +62,7 @@ const cacheHandlerMap: Map<string, CacheHandler> = new Map([
 ])
 
 for (const [key, value] of Object.entries(
-  (globalThis as any).nextCacheHandlers
+  (globalThis as any).__nextCacheHandlers
 ) || {}) {
   cacheHandlerMap.set(key, value as CacheHandler)
 }

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -46,6 +46,7 @@ const _globalThis: typeof globalThis & {
     RemoteCache?: CacheHandler
     DefaultCache?: CacheHandler
   }
+  __nextCacheHandlers?: Record<string, CacheHandler>
 } = globalThis
 
 const cacheHandlerMap: Map<string, CacheHandler> = new Map([
@@ -60,12 +61,6 @@ const cacheHandlerMap: Map<string, CacheHandler> = new Map([
     _globalThis[cacheHandlersSymbol]?.RemoteCache || DefaultCacheHandler,
   ],
 ])
-
-for (const [key, value] of Object.entries(
-  (globalThis as any).__nextCacheHandlers || {}
-)) {
-  cacheHandlerMap.set(key, value as CacheHandler)
-}
 
 function generateCacheEntry(
   workStore: WorkStore,
@@ -435,6 +430,11 @@ export function cache(kind: string, id: string, fn: any) {
     throw new Error(
       '"use cache" is only available with the experimental.dynamicIO config.'
     )
+  }
+  for (const [key, value] of Object.entries(
+    _globalThis.__nextCacheHandlers || {}
+  )) {
+    cacheHandlerMap.set(key, value as CacheHandler)
   }
   const cacheHandler = cacheHandlerMap.get(kind)
 

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -62,8 +62,8 @@ const cacheHandlerMap: Map<string, CacheHandler> = new Map([
 ])
 
 for (const [key, value] of Object.entries(
-  (globalThis as any).__nextCacheHandlers
-) || {}) {
+  (globalThis as any).__nextCacheHandlers || {}
+)) {
   cacheHandlerMap.set(key, value as CacheHandler)
 }
 

--- a/test/e2e/app-dir/use-cache/app/custom-handler/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/custom-handler/page.tsx
@@ -1,11 +1,8 @@
-import { Foo } from '../client'
-
 async function getCachedRandom(x: number, children: React.ReactNode) {
   'use cache: custom'
   return {
     x,
     y: Math.random(),
-    z: <Foo />,
     r: children,
   }
 }
@@ -24,7 +21,6 @@ export default async function Page({
     <>
       <p id="x">{values.x}</p>
       <p id="y">{values.y}</p>
-      <p id="z">{values.z}</p>
       {values.r}
     </>
   )

--- a/test/e2e/app-dir/use-cache/app/custom-handler/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/custom-handler/page.tsx
@@ -1,0 +1,31 @@
+import { Foo } from '../client'
+
+async function getCachedRandom(x: number, children: React.ReactNode) {
+  'use cache: custom'
+  return {
+    x,
+    y: Math.random(),
+    z: <Foo />,
+    r: children,
+  }
+}
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ n: string }>
+}) {
+  const n = +(await searchParams).n
+  const values = await getCachedRandom(
+    n,
+    <p id="r">rnd{Math.random()}</p> // This should not invalidate the cache
+  )
+  return (
+    <>
+      <p id="x">{values.x}</p>
+      <p id="y">{values.y}</p>
+      <p id="z">{values.z}</p>
+      {values.r}
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-cache/next.config.js
+++ b/test/e2e/app-dir/use-cache/next.config.js
@@ -10,6 +10,9 @@ const nextConfig = {
         revalidate: 100,
       },
     },
+    cacheHandlers: {
+      custom: require.resolve('next/dist/server/lib/cache-handlers/default'),
+    },
   },
 }
 

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -9,36 +9,56 @@ describe('use-cache', () => {
     files: __dirname,
   })
 
-  it.each([{ path: '/' }, { path: '/custom-handler' }])(
-    'should cache results',
-    async ({ path }) => {
-      const browser = await next.browser(`${path}?n=1`)
-      expect(await browser.waitForElementByCss('#x').text()).toBe('1')
-      const random1a = await browser.waitForElementByCss('#y').text()
+  it('should cache results', async () => {
+    const browser = await next.browser(`/?n=1`)
+    expect(await browser.waitForElementByCss('#x').text()).toBe('1')
+    const random1a = await browser.waitForElementByCss('#y').text()
 
-      await browser.loadPage(new URL(`${path}?n=2`, next.url).toString())
-      expect(await browser.waitForElementByCss('#x').text()).toBe('2')
-      const random2 = await browser.waitForElementByCss('#y').text()
+    await browser.loadPage(new URL(`/?n=2`, next.url).toString())
+    expect(await browser.waitForElementByCss('#x').text()).toBe('2')
+    const random2 = await browser.waitForElementByCss('#y').text()
 
-      await browser.loadPage(
-        new URL(`${path}?n=1&unrelated`, next.url).toString()
-      )
-      expect(await browser.waitForElementByCss('#x').text()).toBe('1')
-      const random1b = await browser.waitForElementByCss('#y').text()
+    await browser.loadPage(new URL(`/?n=1&unrelated`, next.url).toString())
+    expect(await browser.waitForElementByCss('#x').text()).toBe('1')
+    const random1b = await browser.waitForElementByCss('#y').text()
 
-      // The two navigations to n=1 should use a cached value.
-      expect(random1a).toBe(random1b)
+    // The two navigations to n=1 should use a cached value.
+    expect(random1a).toBe(random1b)
 
-      // The navigation to n=2 should be some other random value.
-      expect(random1a).not.toBe(random2)
+    // The navigation to n=2 should be some other random value.
+    expect(random1a).not.toBe(random2)
 
-      // Client component should have rendered.
-      expect(await browser.waitForElementByCss('#z').text()).toBe('foo')
+    // Client component should have rendered.
+    expect(await browser.waitForElementByCss('#z').text()).toBe('foo')
 
-      // Client component child should have rendered but not invalidated the cache.
-      expect(await browser.waitForElementByCss('#r').text()).toContain('rnd')
-    }
-  )
+    // Client component child should have rendered but not invalidated the cache.
+    expect(await browser.waitForElementByCss('#r').text()).toContain('rnd')
+  })
+
+  it('should cache results custom handler', async () => {
+    const browser = await next.browser(`/custom-handler?n=1`)
+    expect(await browser.waitForElementByCss('#x').text()).toBe('1')
+    const random1a = await browser.waitForElementByCss('#y').text()
+
+    await browser.loadPage(new URL(`/custom-handler?n=2`, next.url).toString())
+    expect(await browser.waitForElementByCss('#x').text()).toBe('2')
+    const random2 = await browser.waitForElementByCss('#y').text()
+
+    await browser.loadPage(
+      new URL(`/custom-handler?n=1&unrelated`, next.url).toString()
+    )
+    expect(await browser.waitForElementByCss('#x').text()).toBe('1')
+    const random1b = await browser.waitForElementByCss('#y').text()
+
+    // The two navigations to n=1 should use a cached value.
+    expect(random1a).toBe(random1b)
+
+    // The navigation to n=2 should be some other random value.
+    expect(random1a).not.toBe(random2)
+
+    // Client component child should have rendered but not invalidated the cache.
+    expect(await browser.waitForElementByCss('#r').text()).toContain('rnd')
+  })
 
   it('should cache complex args', async () => {
     // Use two bytes that can't be encoded as UTF-8 to ensure serialization works.

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -35,30 +35,34 @@ describe('use-cache', () => {
     expect(await browser.waitForElementByCss('#r').text()).toContain('rnd')
   })
 
-  it('should cache results custom handler', async () => {
-    const browser = await next.browser(`/custom-handler?n=1`)
-    expect(await browser.waitForElementByCss('#x').text()).toBe('1')
-    const random1a = await browser.waitForElementByCss('#y').text()
+  if (!process.env.TURBOPACK_BUILD) {
+    it('should cache results custom handler', async () => {
+      const browser = await next.browser(`/custom-handler?n=1`)
+      expect(await browser.waitForElementByCss('#x').text()).toBe('1')
+      const random1a = await browser.waitForElementByCss('#y').text()
 
-    await browser.loadPage(new URL(`/custom-handler?n=2`, next.url).toString())
-    expect(await browser.waitForElementByCss('#x').text()).toBe('2')
-    const random2 = await browser.waitForElementByCss('#y').text()
+      await browser.loadPage(
+        new URL(`/custom-handler?n=2`, next.url).toString()
+      )
+      expect(await browser.waitForElementByCss('#x').text()).toBe('2')
+      const random2 = await browser.waitForElementByCss('#y').text()
 
-    await browser.loadPage(
-      new URL(`/custom-handler?n=1&unrelated`, next.url).toString()
-    )
-    expect(await browser.waitForElementByCss('#x').text()).toBe('1')
-    const random1b = await browser.waitForElementByCss('#y').text()
+      await browser.loadPage(
+        new URL(`/custom-handler?n=1&unrelated`, next.url).toString()
+      )
+      expect(await browser.waitForElementByCss('#x').text()).toBe('1')
+      const random1b = await browser.waitForElementByCss('#y').text()
 
-    // The two navigations to n=1 should use a cached value.
-    expect(random1a).toBe(random1b)
+      // The two navigations to n=1 should use a cached value.
+      expect(random1a).toBe(random1b)
 
-    // The navigation to n=2 should be some other random value.
-    expect(random1a).not.toBe(random2)
+      // The navigation to n=2 should be some other random value.
+      expect(random1a).not.toBe(random2)
 
-    // Client component child should have rendered but not invalidated the cache.
-    expect(await browser.waitForElementByCss('#r').text()).toContain('rnd')
-  })
+      // Client component child should have rendered but not invalidated the cache.
+      expect(await browser.waitForElementByCss('#r').text()).toContain('rnd')
+    })
+  }
 
   it('should cache complex args', async () => {
     // Use two bytes that can't be encoded as UTF-8 to ensure serialization works.

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -9,31 +9,36 @@ describe('use-cache', () => {
     files: __dirname,
   })
 
-  it('should cache results', async () => {
-    const browser = await next.browser('/?n=1')
-    expect(await browser.waitForElementByCss('#x').text()).toBe('1')
-    const random1a = await browser.waitForElementByCss('#y').text()
+  it.each([{ path: '/' }, { path: '/custom-handler' }])(
+    'should cache results',
+    async ({ path }) => {
+      const browser = await next.browser(`${path}?n=1`)
+      expect(await browser.waitForElementByCss('#x').text()).toBe('1')
+      const random1a = await browser.waitForElementByCss('#y').text()
 
-    await browser.loadPage(new URL('/?n=2', next.url).toString())
-    expect(await browser.waitForElementByCss('#x').text()).toBe('2')
-    const random2 = await browser.waitForElementByCss('#y').text()
+      await browser.loadPage(new URL(`${path}?n=2`, next.url).toString())
+      expect(await browser.waitForElementByCss('#x').text()).toBe('2')
+      const random2 = await browser.waitForElementByCss('#y').text()
 
-    await browser.loadPage(new URL('/?n=1&unrelated', next.url).toString())
-    expect(await browser.waitForElementByCss('#x').text()).toBe('1')
-    const random1b = await browser.waitForElementByCss('#y').text()
+      await browser.loadPage(
+        new URL(`${path}?n=1&unrelated`, next.url).toString()
+      )
+      expect(await browser.waitForElementByCss('#x').text()).toBe('1')
+      const random1b = await browser.waitForElementByCss('#y').text()
 
-    // The two navigations to n=1 should use a cached value.
-    expect(random1a).toBe(random1b)
+      // The two navigations to n=1 should use a cached value.
+      expect(random1a).toBe(random1b)
 
-    // The navigation to n=2 should be some other random value.
-    expect(random1a).not.toBe(random2)
+      // The navigation to n=2 should be some other random value.
+      expect(random1a).not.toBe(random2)
 
-    // Client component should have rendered.
-    expect(await browser.waitForElementByCss('#z').text()).toBe('foo')
+      // Client component should have rendered.
+      expect(await browser.waitForElementByCss('#z').text()).toBe('foo')
 
-    // Client component child should have rendered but not invalidated the cache.
-    expect(await browser.waitForElementByCss('#r').text()).toContain('rnd')
-  })
+      // Client component child should have rendered but not invalidated the cache.
+      expect(await browser.waitForElementByCss('#r').text()).toContain('rnd')
+    }
+  )
 
   it('should cache complex args', async () => {
     // Use two bytes that can't be encoded as UTF-8 to ensure serialization works.


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/71455 this adds wiring up for the cache handlers config and exposing it to use-cache-wrapper. Also adds mapping of remote -> default cache handler for dev.  