### PR TITLE
Allow `"use cache"` functions in server action module (client layer)

### DIFF
--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -149,30 +149,37 @@ impl<C: Comments> ServerActions<C> {
                 self.config.enabled,
             );
 
-            if is_action_fn && !self.config.is_react_server_layer && !self.in_action_file {
-                HANDLER.with(|handler| {
-                    handler
-                        .struct_span_err(
-                            span.unwrap_or(body.span),
-                            "It is not allowed to define inline \"use server\" annotated Server Actions in Client Components.\nTo use Server Actions in a Client Component, you can either export them from a separate file with \"use server\" at the top, or pass them down through props from a Server Component.\n\nRead more: https://nextjs.org/docs/app/api-reference/functions/server-actions#with-client-components\n",
-                        )
-                        .emit()
-                });
-            }
+            if !self.config.is_react_server_layer {
+                if is_action_fn && !self.in_action_file {
+                    HANDLER.with(|handler| {
+                        handler
+                            .struct_span_err(
+                                span.unwrap_or(body.span),
+                                "It is not allowed to define inline \"use server\" annotated \
+                                 Server Actions in Client Components.\nTo use Server Actions in a \
+                                 Client Component, you can either export them from a separate \
+                                 file with \"use server\" at the top, or pass them down through \
+                                 props from a Server Component.\n\n\
+                                 Read more: https://nextjs.org/docs/app/api-reference/functions/server-actions#with-client-components\n",
+                            )
+                            .emit()
+                    });
+                }
 
-            if cache_type.is_some()
-                && !self.config.is_react_server_layer
-                && self.in_cache_file.is_none()
-            {
-                HANDLER.with(|handler| {
-                    handler
-                        .struct_span_err(
-                            span.unwrap_or(body.span),
-                            "It is not allowed to define inline \"use cache\" annotated Cache \
-                             Functions in Client Components.",
-                        )
-                        .emit()
-                });
+                if cache_type.is_some() && self.in_cache_file.is_none() && !self.in_action_file {
+                    HANDLER.with(|handler| {
+                        handler
+                            .struct_span_err(
+                                span.unwrap_or(body.span),
+                                "It is not allowed to define inline \"use cache\" annotated \
+                                 functions in Client Components.\nTo use \"use cache\" functions \
+                                 in a Client Component, you can either export them from a \
+                                 separate file with \"use cache\" or \"use server\" at the top, \
+                                 or pass them down through props from a Server Component.\n",
+                            )
+                            .emit()
+                    });
+                }
             }
         }
 

--- a/crates/next-custom-transforms/tests/errors/server-actions/client-graph/2/input.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/client-graph/2/input.js
@@ -1,0 +1,8 @@
+'use client'
+
+export default function App() {
+  async function fn() {
+    'use cache'
+  }
+  return <div>App</div>
+}

--- a/crates/next-custom-transforms/tests/errors/server-actions/client-graph/2/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/client-graph/2/output.js
@@ -1,0 +1,4 @@
+/* __next_internal_client_entry_do_not_use__ default auto */ export default function App() {
+    async function fn() {}
+    return <div>App</div>;
+}

--- a/crates/next-custom-transforms/tests/errors/server-actions/client-graph/2/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/client-graph/2/output.stderr
@@ -1,0 +1,11 @@
+  x It is not allowed to define inline "use cache" annotated functions in Client Components.
+  | To use "use cache" functions in a Client Component, you can either export them from a separate file with "use cache" or "use server" at the top, or pass them down through props from a Server
+  | Component.
+  | 
+   ,-[input.js:4:1]
+ 3 |     export default function App() {
+ 4 | ,->   async function fn() {
+ 5 | |       'use cache'
+ 6 | `->   }
+ 7 |       return <div>App</div>
+   `----

--- a/crates/next-custom-transforms/tests/fixture/server-actions/client/8/input.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/client/8/input.js
@@ -1,0 +1,5 @@
+'use server'
+
+export async function bar() {
+  'use cache'
+}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/client/8/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/client/8/output.js
@@ -1,0 +1,2 @@
+/* __next_internal_action_entry_do_not_use__ {"ac840dcaf5e8197cb02b7f3a43c119b7a770b272":"bar"} */ import { createServerReference, callServer, findSourceMapURL } from "private-next-rsc-action-client-wrapper";
+export var bar = /*#__PURE__*/ createServerReference("ac840dcaf5e8197cb02b7f3a43c119b7a770b272", callServer, void 0, findSourceMapURL, "bar");


### PR DESCRIPTION
When importing a server action module from a client component, we've already opted into the server layer, so defining inline `"use cache"` annotated functions should be allowed.