### PR TITLE
codemod: modify props types when arg is prop

### DIFF
--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-38.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-38.input.tsx
@@ -1,0 +1,8 @@
+type PageProps = {
+  params: { slug: string }
+}
+
+export default function Page(props: PageProps) {
+  const params = props.params
+  return <p>child {params.slug}</p>
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-38.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-38.output.tsx
@@ -1,0 +1,8 @@
+type PageProps = {
+  params: { slug: string }
+}
+
+export default async function Page(props: PageProps) {
+  const params = (await props.params)
+  return <p>child {params.slug}</p>
+}

--- a/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-prop.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-prop.ts
@@ -414,6 +414,10 @@ export function transformDynamicProps(
           modified ||= awaited
         }
 
+        if (modified) {
+          modifyTypes(currentParam.typeAnnotation, propsIdentifier, root, j)
+        }
+
         // cases of passing down `props` into any function
         // Page(props) { callback(props) }
 


### PR DESCRIPTION
### What

When `Page()` is taking `props` as argument without desctrution, the type should also be changed if possible