### PR TITLE
DX improvements for `"use cache"` functions

### DIFF
--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/33/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/33/output.js
@@ -5,6 +5,10 @@ const v = 'world';
 export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "3128060c414d59f8552e4788b846c0d2b7f74743", async function fn() {
     return 'hello, ' + v;
 });
+Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+    "value": "fn",
+    "writable": false
+});
 var fn = registerServerReference($$RSC_SERVER_CACHE_0, "3128060c414d59f8552e4788b846c0d2b7f74743", null);
 export async function Component() {
     const data = await fn();

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/34/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/34/output.js
@@ -1,26 +1,42 @@
-/* __next_internal_action_entry_do_not_use__ {"12a8d21b6362b4cc8f5b15560525095bc48dba80":"$$RSC_SERVER_CACHE_3","3128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0","4acc55633206134002149ce873fe498be64a6fef":"$$RSC_SERVER_CACHE_4","951c375b4a6a6e89d67b743ec5808127cfde405d":"$$RSC_SERVER_CACHE_1"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+/* __next_internal_action_entry_do_not_use__ {"12a8d21b6362b4cc8f5b15560525095bc48dba80":"$$RSC_SERVER_CACHE_3","3128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0","69348c79fce073bae2f70f139565a2fda1c74c74":"$$RSC_SERVER_CACHE_2","951c375b4a6a6e89d67b743ec5808127cfde405d":"$$RSC_SERVER_CACHE_1"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "3128060c414d59f8552e4788b846c0d2b7f74743", async function() {
     return 'foo';
+});
+Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+    "value": "foo",
+    "writable": false
 });
 const foo = registerServerReference($$RSC_SERVER_CACHE_0, "3128060c414d59f8552e4788b846c0d2b7f74743", null);
 export { bar };
 export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "951c375b4a6a6e89d67b743ec5808127cfde405d", async function bar() {
     return 'bar';
 });
+Object.defineProperty($$RSC_SERVER_CACHE_1, "name", {
+    "value": "bar",
+    "writable": false
+});
 var bar = registerServerReference($$RSC_SERVER_CACHE_1, "951c375b4a6a6e89d67b743ec5808127cfde405d", null);
 // Should not be wrapped in $$cache__.
 const qux = async function qux() {
     return 'qux';
 };
-export var $$RSC_SERVER_CACHE_3 = $$cache__("default", "12a8d21b6362b4cc8f5b15560525095bc48dba80", async function $$RSC_SERVER_CACHE_2() {
+export var $$RSC_SERVER_CACHE_2 = $$cache__("default", "69348c79fce073bae2f70f139565a2fda1c74c74", async function baz() {
     return qux() + 'baz';
 });
-const baz = registerServerReference($$RSC_SERVER_CACHE_3, "12a8d21b6362b4cc8f5b15560525095bc48dba80", null);
-export var $$RSC_SERVER_CACHE_4 = $$cache__("default", "4acc55633206134002149ce873fe498be64a6fef", async function() {
+Object.defineProperty($$RSC_SERVER_CACHE_2, "name", {
+    "value": "baz",
+    "writable": false
+});
+const baz = registerServerReference($$RSC_SERVER_CACHE_2, "69348c79fce073bae2f70f139565a2fda1c74c74", null);
+export var $$RSC_SERVER_CACHE_3 = $$cache__("default", "12a8d21b6362b4cc8f5b15560525095bc48dba80", async function() {
     return 'quux';
 });
-const quux = registerServerReference($$RSC_SERVER_CACHE_4, "4acc55633206134002149ce873fe498be64a6fef", null);
+Object.defineProperty($$RSC_SERVER_CACHE_3, "name", {
+    "value": "quux",
+    "writable": false
+});
+const quux = registerServerReference($$RSC_SERVER_CACHE_3, "12a8d21b6362b4cc8f5b15560525095bc48dba80", null);
 export { foo, baz };
 export default quux;

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/35/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/35/output.js
@@ -4,4 +4,8 @@ import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "3128060c414d59f8552e4788b846c0d2b7f74743", async function() {
     return 'data';
 });
+Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+    "value": "my_fn",
+    "writable": false
+});
 export const my_fn = registerServerReference($$RSC_SERVER_CACHE_0, "3128060c414d59f8552e4788b846c0d2b7f74743", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/36/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/36/output.js
@@ -1,19 +1,35 @@
-/* __next_internal_action_entry_do_not_use__ {"3128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0","4acc55633206134002149ce873fe498be64a6fef":"$$RSC_SERVER_CACHE_4","69348c79fce073bae2f70f139565a2fda1c74c74":"$$RSC_SERVER_CACHE_2","951c375b4a6a6e89d67b743ec5808127cfde405d":"$$RSC_SERVER_CACHE_1"} */ import { registerServerReference } from "private-next-rsc-server-reference";
+/* __next_internal_action_entry_do_not_use__ {"12a8d21b6362b4cc8f5b15560525095bc48dba80":"$$RSC_SERVER_CACHE_3","3128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0","69348c79fce073bae2f70f139565a2fda1c74c74":"$$RSC_SERVER_CACHE_2","951c375b4a6a6e89d67b743ec5808127cfde405d":"$$RSC_SERVER_CACHE_1"} */ import { registerServerReference } from "private-next-rsc-server-reference";
 import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
 import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "3128060c414d59f8552e4788b846c0d2b7f74743", async function foo() {
     return 'data A';
 });
+Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+    "value": "foo",
+    "writable": false
+});
 export var foo = registerServerReference($$RSC_SERVER_CACHE_0, "3128060c414d59f8552e4788b846c0d2b7f74743", null);
 export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "951c375b4a6a6e89d67b743ec5808127cfde405d", async function bar() {
     return 'data B';
+});
+Object.defineProperty($$RSC_SERVER_CACHE_1, "name", {
+    "value": "bar",
+    "writable": false
 });
 export var bar = registerServerReference($$RSC_SERVER_CACHE_1, "951c375b4a6a6e89d67b743ec5808127cfde405d", null);
 export var $$RSC_SERVER_CACHE_2 = $$cache__("default", "69348c79fce073bae2f70f139565a2fda1c74c74", async function Cached({ children }) {
     return children;
 });
+Object.defineProperty($$RSC_SERVER_CACHE_2, "name", {
+    "value": "Cached",
+    "writable": false
+});
 export default registerServerReference($$RSC_SERVER_CACHE_2, "69348c79fce073bae2f70f139565a2fda1c74c74", null);
-export var $$RSC_SERVER_CACHE_4 = $$cache__("default", "4acc55633206134002149ce873fe498be64a6fef", async function $$RSC_SERVER_CACHE_3() {
+export var $$RSC_SERVER_CACHE_3 = $$cache__("default", "12a8d21b6362b4cc8f5b15560525095bc48dba80", async function baz() {
     return 'data C';
 });
-export const baz = registerServerReference($$RSC_SERVER_CACHE_4, "4acc55633206134002149ce873fe498be64a6fef", null);
+Object.defineProperty($$RSC_SERVER_CACHE_3, "name", {
+    "value": "baz",
+    "writable": false
+});
+export const baz = registerServerReference($$RSC_SERVER_CACHE_3, "12a8d21b6362b4cc8f5b15560525095bc48dba80", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/37/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/37/output.js
@@ -4,6 +4,10 @@ import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "3128060c414d59f8552e4788b846c0d2b7f74743", async function fn() {
     return 'foo';
 });
+Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+    "value": "fn",
+    "writable": false
+});
 var fn = registerServerReference($$RSC_SERVER_CACHE_0, "3128060c414d59f8552e4788b846c0d2b7f74743", null);
 async function Component() {
     const data = await fn();

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/38/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/38/output.js
@@ -4,4 +4,8 @@ import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 export var $$RSC_SERVER_CACHE_0 = $$cache__("x", "3128060c414d59f8552e4788b846c0d2b7f74743", async function foo() {
     return 'data';
 });
+Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+    "value": "foo",
+    "writable": false
+});
 export var foo = registerServerReference($$RSC_SERVER_CACHE_0, "3128060c414d59f8552e4788b846c0d2b7f74743", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/39/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/39/output.js
@@ -8,6 +8,10 @@ export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "3128060c414d59f8552e4788
         foo: $$ACTION_ARG_1
     };
 });
+Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+    "value": "fn",
+    "writable": false
+});
 async function Component({ foo }) {
     const a = 123;
     var fn = $$RSC_SERVER_REF_1.bind(null, encryptActionBoundArgs("3128060c414d59f8552e4788b846c0d2b7f74743", [

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/40/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/40/output.js
@@ -11,6 +11,10 @@ export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "3128060c414d59f8552e4788
         }
     ];
 });
+Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+    "value": "cache",
+    "writable": false
+});
 export const $$RSC_SERVER_ACTION_2 = async function action($$ACTION_CLOSURE_BOUND, c) {
     var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("1c36b06e398c97abe5d5d7ae8c672bfddf4e1b91", $$ACTION_CLOSURE_BOUND);
     const d = $$ACTION_ARG_0 + $$ACTION_ARG_1 + c;

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/41/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/41/output.js
@@ -17,4 +17,8 @@ export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "951c375b4a6a6e89d67b743e
     const data = await fn();
     return <div>{data}</div>;
 });
+Object.defineProperty($$RSC_SERVER_CACHE_1, "name", {
+    "value": "Component",
+    "writable": false
+});
 export var Component = registerServerReference($$RSC_SERVER_CACHE_1, "951c375b4a6a6e89d67b743ec5808127cfde405d", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/43/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/43/output.js
@@ -17,4 +17,8 @@ export var $$RSC_SERVER_CACHE_1 = $$cache__("default", "951c375b4a6a6e89d67b743e
         r: children
     };
 });
+Object.defineProperty($$RSC_SERVER_CACHE_1, "name", {
+    "value": "getCachedRandom",
+    "writable": false
+});
 var getCachedRandom = registerServerReference($$RSC_SERVER_CACHE_1, "951c375b4a6a6e89d67b743ec5808127cfde405d", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server/45/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server/45/output.js
@@ -10,4 +10,8 @@ function Foo() {
 export var $$RSC_SERVER_CACHE_0 = $$cache__("default", "3128060c414d59f8552e4788b846c0d2b7f74743", async function bar() {
     return <Foo/>;
 });
+Object.defineProperty($$RSC_SERVER_CACHE_0, "name", {
+    "value": "bar",
+    "writable": false
+});
 export var bar = registerServerReference($$RSC_SERVER_CACHE_0, "3128060c414d59f8552e4788b846c0d2b7f74743", null);

--- a/test/e2e/app-dir/use-cache/app/form.tsx
+++ b/test/e2e/app-dir/use-cache/app/form.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { useActionState } from 'react'
+
+export function Form({
+  foo,
+  bar,
+  baz,
+}: {
+  foo: () => Promise<number>
+  bar: () => Promise<number>
+  baz: () => Promise<number>
+}) {
+  const [result, dispatch] = useActionState<
+    [number, number, number],
+    'submit' | 'reset'
+  >(
+    async (_state, event) => {
+      if (event === 'reset') {
+        return [0, 0, 0]
+      }
+
+      return [await foo(), await bar(), await baz()]
+    },
+    [0, 0, 0]
+  )
+
+  return (
+    <form action={() => dispatch('submit')}>
+      <button id="submit-button">Submit</button>{' '}
+      <button id="reset-button" formAction={() => dispatch('reset')}>
+        Reset
+      </button>
+      <p>
+        {result[0]} {result[1]} {result[2]}
+      </p>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/use-cache/app/imported-from-client/cached.ts
+++ b/test/e2e/app-dir/use-cache/app/imported-from-client/cached.ts
@@ -1,15 +1,21 @@
 'use cache'
 
-export async function bar() {
+function getRandomValue() {
   const v = Math.random()
   console.log(v)
   return v
 }
 
+export async function foo() {
+  return getRandomValue()
+}
+
+export const bar = async function () {
+  return getRandomValue()
+}
+
 const baz = async () => {
-  const v = Math.random()
-  console.log(v)
-  return v
+  return getRandomValue()
 }
 
 export { baz }

--- a/test/e2e/app-dir/use-cache/app/imported-from-client/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/imported-from-client/page.tsx
@@ -1,32 +1,8 @@
 'use client'
 
-import { useActionState } from 'react'
-import { bar, baz } from './cached'
+import { foo, bar, baz } from './cached'
+import { Form } from '../form'
 
 export default function Page() {
-  const [result, dispatch] = useActionState<
-    [number, number],
-    'submit' | 'reset'
-  >(
-    async (_state, event) => {
-      if (event === 'reset') {
-        return [0, 0]
-      }
-
-      return [await bar(), await baz()]
-    },
-    [0, 0]
-  )
-
-  return (
-    <form action={() => dispatch('submit')}>
-      <button id="submit-button">Click me</button>
-      <p>
-        {result[0]} {result[1]}
-      </p>
-      <button id="reset-button" formAction={() => dispatch('reset')}>
-        Reset
-      </button>
-    </form>
-  )
+  return <Form foo={foo} bar={bar} baz={baz} />
 }

--- a/test/e2e/app-dir/use-cache/app/passed-to-client/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/passed-to-client/page.tsx
@@ -1,0 +1,26 @@
+import { Form } from '../form'
+
+function getRandomValue() {
+  const v = Math.random()
+  console.log(v)
+  return v
+}
+
+export default function Page() {
+  return (
+    <Form
+      foo={async function fooNamed() {
+        'use cache'
+        return getRandomValue()
+      }}
+      bar={async function () {
+        'use cache'
+        return getRandomValue()
+      }}
+      baz={async () => {
+        'use cache'
+        return getRandomValue()
+      }}
+    />
+  )
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -133,23 +133,45 @@ describe('use-cache', () => {
 
   it('should cache results for cached funtions imported from client components', async () => {
     const browser = await next.browser('/imported-from-client')
-    expect(await browser.elementByCss('p').text()).toBe('0 0')
+    expect(await browser.elementByCss('p').text()).toBe('0 0 0')
     await browser.elementById('submit-button').click()
 
-    let twoRandomValues: string
+    let threeRandomValues: string
 
     await retry(async () => {
-      twoRandomValues = await browser.elementByCss('p').text()
-      expect(twoRandomValues).toMatch(/\d\.\d+ \d\.\d+/)
+      threeRandomValues = await browser.elementByCss('p').text()
+      expect(threeRandomValues).toMatch(/\d\.\d+ \d\.\d+/)
     })
 
     await browser.elementById('reset-button').click()
-    expect(await browser.elementByCss('p').text()).toBe('0 0')
+    expect(await browser.elementByCss('p').text()).toBe('0 0 0')
 
     await browser.elementById('submit-button').click()
 
     await retry(async () => {
-      expect(await browser.elementByCss('p').text()).toBe(twoRandomValues)
+      expect(await browser.elementByCss('p').text()).toBe(threeRandomValues)
+    })
+  })
+
+  it('should cache results for cached funtions passed client components', async () => {
+    const browser = await next.browser('/passed-to-client')
+    expect(await browser.elementByCss('p').text()).toBe('0 0 0')
+    await browser.elementById('submit-button').click()
+
+    let threeRandomValues: string
+
+    await retry(async () => {
+      threeRandomValues = await browser.elementByCss('p').text()
+      expect(threeRandomValues).toMatch(/\d\.\d+ \d\.\d+/)
+    })
+
+    await browser.elementById('reset-button').click()
+    expect(await browser.elementByCss('p').text()).toBe('0 0 0')
+
+    await browser.elementById('submit-button').click()
+
+    await retry(async () => {
+      expect(await browser.elementByCss('p').text()).toBe(threeRandomValues)
     })
   })
 


### PR DESCRIPTION
With this PR, we're assigning names to the transformed `"use cache"` functions, using the same rules as in #71478. Since we can't use named function expressions here, we're using `Object.defineProperty` instead, which we already used  in #71478 for server actions with default export expressions.

In addition, this PR fixes source mapping of `"use cache"` functions, which was slightly off before, due to the wrong spans being assigned to the new expressions.

**Before:**

<img width="943" alt="before" src="https://github.com/user-attachments/assets/f7cf674c-32d4-4f0d-a304-d5de5637a6a1">

**After:**

<img width="943" alt="after" src="https://github.com/user-attachments/assets/8edda482-a666-4431-bfad-7e21987331eb">
