### PR TITLE
Check tag staleness against the timestamp of the entry

### DIFF
--- a/packages/next/src/server/lib/cache-handlers/default.ts
+++ b/packages/next/src/server/lib/cache-handlers/default.ts
@@ -34,9 +34,6 @@ const DefaultCacheHandler: CacheHandler = {
   async get(cacheKey, softTags) {
     await pendingSets.get(cacheKey)
 
-    if (isTagStale(softTags)) {
-      return
-    }
     const privateEntry = memoryCache.get(cacheKey)
 
     if (!privateEntry) {
@@ -50,11 +47,14 @@ const DefaultCacheHandler: CacheHandler = {
     ) {
       // In memory caches should expire after revalidate time because it is unlikely that
       // a new entry will be able to be used before it is dropped from the cache.
-      return
+      return undefined
     }
 
-    if (isTagStale(entry.tags || [])) {
-      return
+    if (
+      isTagStale(entry.tags, entry.timestamp) ||
+      isTagStale(softTags, entry.timestamp)
+    ) {
+      return undefined
     }
     const [returnStream, newSaved] = entry.value.tee()
     entry.value = newSaved

--- a/packages/next/src/server/lib/incremental-cache/tags-manifest.ts
+++ b/packages/next/src/server/lib/incremental-cache/tags-manifest.ts
@@ -8,13 +8,13 @@ export const tagsManifest: TagsManifest = {
   items: {},
 }
 
-export const isTagStale = (tags: string[]) => {
+export const isTagStale = (tags: string[], timestamp: number) => {
   for (const tag of tags) {
     const tagEntry = tagsManifest.items[tag]
     if (
       typeof tagEntry?.revalidatedAt === 'number' &&
       // TODO: use performance.now and update file-system-cache?
-      tagEntry.revalidatedAt >= Date.now()
+      tagEntry.revalidatedAt >= timestamp
     ) {
       return true
     }


### PR DESCRIPTION
Not current time. `revalidatedAt` should always be lower than the current time. Otherwise it's some kind of drift or bug.