### PR TITLE
Ensure custom cache handlers are traced

### DIFF
--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -244,6 +244,7 @@ export async function collectBuildTraces({
       ]
 
       const { cacheHandler } = config
+      const { cacheHandlers } = config.experimental
 
       // ensure we trace any dependencies needed for custom
       // incremental cache handler
@@ -255,6 +256,20 @@ export async function collectBuildTraces({
               : path.join(dir, cacheHandler)
           )
         )
+      }
+
+      if (cacheHandlers) {
+        for (const handlerPath of Object.values(cacheHandlers)) {
+          if (handlerPath) {
+            sharedEntriesSet.push(
+              require.resolve(
+                path.isAbsolute(handlerPath)
+                  ? handlerPath
+                  : path.join(dir, handlerPath)
+              )
+            )
+          }
+        }
       }
 
       const serverEntries = [


### PR DESCRIPTION
This ensures we properly include this in our traces for output standalone. 

x-ref: https://github.com/vercel/next.js/actions/runs/11418733317/attempts/2