### PR TITLE
[dynamicIO] warn for disallowed dynamic in dev

### DIFF
--- a/packages/next/src/client/components/client-page.tsx
+++ b/packages/next/src/client/components/client-page.tsx
@@ -40,27 +40,13 @@ export function ClientPageRoot({
       )
     }
 
-    if (store.isStaticGeneration) {
-      // We are in a prerender context
-      const { createPrerenderSearchParamsFromClient } =
-        require('../../server/request/search-params') as typeof import('../../server/request/search-params')
-      clientSearchParams = createPrerenderSearchParamsFromClient(store)
+    const { createSearchParamsFromClient } =
+      require('../../server/request/search-params') as typeof import('../../server/request/search-params')
+    clientSearchParams = createSearchParamsFromClient(searchParams, store)
 
-      const { createPrerenderParamsFromClient } =
-        require('../../server/request/params') as typeof import('../../server/request/params')
-
-      clientParams = createPrerenderParamsFromClient(params, store)
-    } else {
-      const { createRenderSearchParamsFromClient } =
-        require('../../server/request/search-params') as typeof import('../../server/request/search-params')
-      clientSearchParams = createRenderSearchParamsFromClient(
-        searchParams,
-        store
-      )
-      const { createRenderParamsFromClient } =
-        require('../../server/request/params') as typeof import('../../server/request/params')
-      clientParams = createRenderParamsFromClient(params, store)
-    }
+    const { createParamsFromClient } =
+      require('../../server/request/params') as typeof import('../../server/request/params')
+    clientParams = createParamsFromClient(params, store)
 
     return <Component params={clientParams} searchParams={clientSearchParams} />
   } else {

--- a/packages/next/src/client/components/client-segment.tsx
+++ b/packages/next/src/client/components/client-segment.tsx
@@ -38,16 +38,10 @@ export function ClientSegmentRoot({
       )
     }
 
-    const { createPrerenderParamsFromClient } =
+    const { createParamsFromClient } =
       require('../../server/request/params') as typeof import('../../server/request/params')
+    clientParams = createParamsFromClient(params, store)
 
-    if (store.isStaticGeneration) {
-      clientParams = createPrerenderParamsFromClient(params, store)
-    } else {
-      const { createRenderParamsFromClient } =
-        require('../../server/request/params') as typeof import('../../server/request/params')
-      clientParams = createRenderParamsFromClient(params, store)
-    }
     return <Component {...slots} params={clientParams} />
   } else {
     const { createRenderParamsFromClient } =

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -21,18 +21,19 @@
  */
 
 import type { WorkStore } from '../app-render/work-async-storage.external'
-import type { WorkUnitStore } from '../app-render/work-unit-async-storage.external'
+import type {
+  WorkUnitStore,
+  RequestStore,
+  PrerenderStoreLegacy,
+  PrerenderStoreModern,
+} from '../app-render/work-unit-async-storage.external'
 
 // Once postpone is in stable we should switch to importing the postpone export directly
 import React from 'react'
 
 import { DynamicServerError } from '../../client/components/hooks-server-context'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
-import {
-  workUnitAsyncStorage,
-  type PrerenderStoreLegacy,
-  type PrerenderStoreModern,
-} from './work-unit-async-storage.external'
+import { workUnitAsyncStorage } from './work-unit-async-storage.external'
 import { workAsyncStorage } from '../app-render/work-async-storage.external'
 import { makeHangingPromise } from '../dynamic-rendering-utils'
 import {
@@ -78,7 +79,7 @@ export type DynamicValidationState = {
   hasSuspendedDynamic: boolean
   hasDynamicMetadata: boolean
   hasDynamicViewport: boolean
-  syncDynamicErrors: Array<Error>
+  hasSyncDynamicErrors: boolean
   dynamicErrors: Array<Error>
 }
 
@@ -98,7 +99,7 @@ export function createDynamicValidationState(): DynamicValidationState {
     hasSuspendedDynamic: false,
     hasDynamicMetadata: false,
     hasDynamicViewport: false,
-    syncDynamicErrors: [],
+    hasSyncDynamicErrors: false,
     dynamicErrors: [],
   }
 }
@@ -295,6 +296,22 @@ export function abortOnSynchronousPlatformIOAccess(
   return abortOnSynchronousDynamicDataAccess(route, expression, prerenderStore)
 }
 
+export function trackSynchronousPlatformIOAccessInDev(
+  expression: string,
+  errorWithStack: Error,
+  requestStore: RequestStore,
+  dynamicTracking: DynamicTrackingState
+): void {
+  if (dynamicTracking.syncDynamicErrorWithStack === null) {
+    dynamicTracking.syncDynamicExpression = expression
+    dynamicTracking.syncDynamicErrorWithStack = errorWithStack
+  }
+  // We don't actually have a controller to abort but we do the semantic equivalent by
+  // advancing the request store out of prerender mode
+  console.log('SETTING prerenderPhase to false')
+  requestStore.prerenderPhase = false
+}
+
 /**
  * use this function when prerendering with dynamicIO. If we are doing a
  * prospective prerender we don't actually abort because we want to discover
@@ -323,6 +340,10 @@ export function abortAndThrowOnSynchronousRequestDataAccess(
     `Route ${route} needs to bail out of prerendering at this point because it used ${expression}.`
   )
 }
+
+// For now these implementations are the same so we just reexport
+export const trackSynchronousRequestDataAccessInDev =
+  trackSynchronousPlatformIOAccessInDev
 
 /**
  * This component will call `React.postpone` that throws the postponed error.
@@ -578,15 +599,11 @@ export function trackAllowedDynamicAccess(
   } else if (hasSuspenseRegex.test(componentStack)) {
     dynamicValidation.hasSuspendedDynamic = true
     return
-  } else if (typeof serverDynamic.syncDynamicExpression === 'string') {
-    const message = `In Route "${route}" this parent component stack may help you locate where ${serverDynamic.syncDynamicExpression} was used.`
-    const error = createErrorWithComponentStack(message, componentStack)
-    dynamicValidation.syncDynamicErrors.push(error)
-    return
-  } else if (typeof clientDynamic.syncDynamicExpression === 'string') {
-    const message = `In Route "${route}" this parent component stack may help you locate where ${clientDynamic.syncDynamicExpression} was used.`
-    const error = createErrorWithComponentStack(message, componentStack)
-    dynamicValidation.syncDynamicErrors.push(error)
+  } else if (
+    serverDynamic.syncDynamicErrorWithStack ||
+    clientDynamic.syncDynamicErrorWithStack
+  ) {
+    dynamicValidation.hasSyncDynamicErrors = true
     return
   } else {
     // The thrownValue must have been the RENDER_COMPLETE abortReason because the only kinds of errors tracked here are
@@ -608,17 +625,16 @@ function createErrorWithComponentStack(
 }
 
 export function throwIfDisallowedDynamic(
-  workStore: WorkStore,
+  route: string,
   dynamicValidation: DynamicValidationState,
   serverDynamic: DynamicTrackingState,
   clientDynamic: DynamicTrackingState
 ): void {
-  const syncDynamicErrors = dynamicValidation.syncDynamicErrors
   let syncError: null | Error, syncExpression: undefined | string
-  if (serverDynamic.syncDynamicExpression) {
+  if (serverDynamic.syncDynamicErrorWithStack) {
     syncError = serverDynamic.syncDynamicErrorWithStack
     syncExpression = serverDynamic.syncDynamicExpression!
-  } else if (clientDynamic.syncDynamicExpression) {
+  } else if (clientDynamic.syncDynamicErrorWithStack) {
     syncError = clientDynamic.syncDynamicErrorWithStack
     syncExpression = clientDynamic.syncDynamicExpression!
   } else {
@@ -626,15 +642,11 @@ export function throwIfDisallowedDynamic(
     syncExpression = undefined
   }
 
-  if (syncDynamicErrors.length && syncError) {
+  if (syncError) {
     console.error(syncError)
 
-    for (let i = 0; i < syncDynamicErrors.length; i++) {
-      console.error(syncDynamicErrors[i])
-    }
-
     throw new StaticGenBailoutError(
-      `Route "${workStore.route}" could not be prerendered.`
+      `Route "${route}" could not be prerendered.`
     )
   }
 
@@ -645,7 +657,7 @@ export function throwIfDisallowedDynamic(
     }
 
     throw new StaticGenBailoutError(
-      `Route "${workStore.route}" could not be prerendered.`
+      `Route "${route}" could not be prerendered.`
     )
   }
 
@@ -654,21 +666,21 @@ export function throwIfDisallowedDynamic(
       if (syncError) {
         console.error(syncError)
         throw new StaticGenBailoutError(
-          `Route "${workStore.route}" has a \`generateMetadata\` that could not finish rendering before ${syncExpression} was used. Follow the instructions in the error for this expression to resolve.`
+          `Route "${route}" has a \`generateMetadata\` that could not finish rendering before ${syncExpression} was used. Follow the instructions in the error for this expression to resolve.`
         )
       }
       throw new StaticGenBailoutError(
-        `Route "${workStore.route}" has a \`generateMetadata\` that depends on Request data (\`cookies()\`, etc...) or external data (\`fetch(...)\`, etc...) but the rest of the route was static or only used cached data (\`"use cache"\`). If you expected this route to be prerenderable update your \`generateMetadata\` to not use Request data and only use cached external data. Otherwise, add \`await connection()\` somewhere within this route to indicate explicitly it should not be prerendered.`
+        `Route "${route}" has a \`generateMetadata\` that depends on Request data (\`cookies()\`, etc...) or external data (\`fetch(...)\`, etc...) but the rest of the route was static or only used cached data (\`"use cache"\`). If you expected this route to be prerenderable update your \`generateMetadata\` to not use Request data and only use cached external data. Otherwise, add \`await connection()\` somewhere within this route to indicate explicitly it should not be prerendered.`
       )
     } else if (dynamicValidation.hasDynamicViewport) {
       if (syncError) {
         console.error(syncError)
         throw new StaticGenBailoutError(
-          `Route "${workStore.route}" has a \`generateViewport\` that could not finish rendering before ${syncExpression} was used. Follow the instructions in the error for this expression to resolve.`
+          `Route "${route}" has a \`generateViewport\` that could not finish rendering before ${syncExpression} was used. Follow the instructions in the error for this expression to resolve.`
         )
       }
       throw new StaticGenBailoutError(
-        `Route "${workStore.route}" has a \`generateViewport\` that depends on Request data (\`cookies()\`, etc...) or external data (\`fetch(...)\`, etc...) but the rest of the route was static or only used cached data (\`"use cache"\`). If you expected this route to be prerenderable update your \`generateViewport\` to not use Request data and only use cached external data. Otherwise, add \`await connection()\` somewhere within this route to indicate explicitly it should not be prerendered.`
+        `Route "${route}" has a \`generateViewport\` that depends on Request data (\`cookies()\`, etc...) or external data (\`fetch(...)\`, etc...) but the rest of the route was static or only used cached data (\`"use cache"\`). If you expected this route to be prerenderable update your \`generateViewport\` to not use Request data and only use cached external data. Otherwise, add \`await connection()\` somewhere within this route to indicate explicitly it should not be prerendered.`
       )
     }
   }

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -51,7 +51,9 @@ export type RequestStore = {
 
   // DEV-only
   usedDynamic?: boolean
-  environment?: 'Prerender' | 'Server'
+  dynamicTracking?: DynamicTrackingState
+  prerenderPhase?: boolean
+  prospectiveRender?: boolean
 } & PhasePartial
 
 /**

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -51,9 +51,7 @@ export type RequestStore = {
 
   // DEV-only
   usedDynamic?: boolean
-  dynamicTracking?: DynamicTrackingState
   prerenderPhase?: boolean
-  prospectiveRender?: boolean
 } & PhasePartial
 
 /**
@@ -96,6 +94,12 @@ export type PrerenderStoreModern = {
   expire: number // server expiration time
   stale: number // client expiration time
   tags: null | string[]
+
+  // DEV ONLY
+  // When used this flag informs certain APIs to skip logging because we're
+  // not part of the primary render path and are just prerendering to produce
+  // validation results
+  validating?: boolean
 } & PhasePartial
 
 export type PrerenderStorePPR = {

--- a/packages/next/src/server/create-deduped-by-callsite-server-error-loger.ts
+++ b/packages/next/src/server/create-deduped-by-callsite-server-error-loger.ts
@@ -33,8 +33,7 @@ const flushCurrentErrorIfNew = cache(
  * @returns
  */
 export function createDedupedByCallsiteServerErrorLoggerDev<Args extends any[]>(
-  getMessage: (...args: Args) => Error,
-  indirections: number = 0
+  getMessage: (...args: Args) => Error
 ) {
   return function logDedupedError(...args: Args) {
     const message = getMessage(...args)
@@ -49,7 +48,7 @@ export function createDedupedByCallsiteServerErrorLoggerDev<Args extends any[]>(
         //   asyncApiBeingAccessedSynchronously
         //   <userland callsite>
         // TODO: This breaks if sourcemaps with ignore lists are enabled.
-        const key = callStackFrames[3 + indirections]
+        const key = callStackFrames[4]
         errorRef.current = message
         flushCurrentErrorIfNew(key)
       }

--- a/packages/next/src/server/create-deduped-by-callsite-server-error-loger.ts
+++ b/packages/next/src/server/create-deduped-by-callsite-server-error-loger.ts
@@ -33,7 +33,8 @@ const flushCurrentErrorIfNew = cache(
  * @returns
  */
 export function createDedupedByCallsiteServerErrorLoggerDev<Args extends any[]>(
-  getMessage: (...args: Args) => Error
+  getMessage: (...args: Args) => Error,
+  indirections: number = 0
 ) {
   return function logDedupedError(...args: Args) {
     const message = getMessage(...args)
@@ -48,7 +49,7 @@ export function createDedupedByCallsiteServerErrorLoggerDev<Args extends any[]>(
         //   asyncApiBeingAccessedSynchronously
         //   <userland callsite>
         // TODO: This breaks if sourcemaps with ignore lists are enabled.
-        const key = callStackFrames[3]
+        const key = callStackFrames[3 + indirections]
         errorRef.current = message
         flushCurrentErrorIfNew(key)
       }

--- a/packages/next/src/server/node-environment-extensions/utils.tsx
+++ b/packages/next/src/server/node-environment-extensions/utils.tsx
@@ -1,6 +1,9 @@
 import { workAsyncStorage } from '../app-render/work-async-storage.external'
 import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
-import { abortOnSynchronousPlatformIOAccess } from '../app-render/dynamic-rendering'
+import {
+  abortOnSynchronousPlatformIOAccess,
+  trackSynchronousPlatformIOAccessInDev,
+} from '../app-render/dynamic-rendering'
 import { InvariantError } from '../../shared/lib/invariant-error'
 
 type ApiType = 'time' | 'random' | 'crypto'
@@ -34,6 +37,38 @@ export function io(expression: string, type: ApiType) {
           expression,
           errorWithStack,
           workUnitStore
+        )
+      }
+    } else if (
+      workUnitStore.type === 'request' &&
+      workUnitStore.prerenderPhase === true &&
+      workUnitStore.dynamicTracking
+    ) {
+      const workStore = workAsyncStorage.getStore()
+      if (workStore) {
+        let message: string
+        switch (type) {
+          case 'time':
+            message = `Route "${workStore.route}" used ${expression} instead of using \`performance\` or without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time`
+            break
+          case 'random':
+            message = `Route "${workStore.route}" used ${expression} outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random`
+            break
+          case 'crypto':
+            message = `Route "${workStore.route}" used ${expression} outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-crypto`
+            break
+          default:
+            throw new InvariantError(
+              'Unknown expression type in abortOnSynchronousPlatformIOAccess.'
+            )
+        }
+        const errorWithStack = new Error(message)
+
+        trackSynchronousPlatformIOAccessInDev(
+          expression,
+          errorWithStack,
+          workUnitStore,
+          workUnitStore.dynamicTracking
         )
       }
     }

--- a/packages/next/src/server/node-environment-extensions/utils.tsx
+++ b/packages/next/src/server/node-environment-extensions/utils.tsx
@@ -41,36 +41,10 @@ export function io(expression: string, type: ApiType) {
       }
     } else if (
       workUnitStore.type === 'request' &&
-      workUnitStore.prerenderPhase === true &&
-      workUnitStore.dynamicTracking
+      workUnitStore.prerenderPhase === true
     ) {
-      const workStore = workAsyncStorage.getStore()
-      if (workStore) {
-        let message: string
-        switch (type) {
-          case 'time':
-            message = `Route "${workStore.route}" used ${expression} instead of using \`performance\` or without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time`
-            break
-          case 'random':
-            message = `Route "${workStore.route}" used ${expression} outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random`
-            break
-          case 'crypto':
-            message = `Route "${workStore.route}" used ${expression} outside of \`"use cache"\` and without explicitly calling \`await connection()\` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-crypto`
-            break
-          default:
-            throw new InvariantError(
-              'Unknown expression type in abortOnSynchronousPlatformIOAccess.'
-            )
-        }
-        const errorWithStack = new Error(message)
-
-        trackSynchronousPlatformIOAccessInDev(
-          expression,
-          errorWithStack,
-          workUnitStore,
-          workUnitStore.dynamicTracking
-        )
-      }
+      const requestStore = workUnitStore
+      trackSynchronousPlatformIOAccessInDev(requestStore)
     }
   }
 }

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -167,8 +167,8 @@ function makeDynamicallyTrackedExoticCookies(
   Object.defineProperties(promise, {
     [Symbol.iterator]: {
       value: function () {
-        const expression = 'cookies()[Symbol.iterator]()'
-        const error = createSyncCookiesError(route, expression)
+        const expression = '`cookies()[Symbol.iterator]()`'
+        const error = createCookiesAccessError(route, expression)
         abortAndThrowOnSynchronousRequestDataAccess(
           route,
           expression,
@@ -179,8 +179,8 @@ function makeDynamicallyTrackedExoticCookies(
     },
     size: {
       get() {
-        const expression = `cookies().size`
-        const error = createSyncCookiesError(route, expression)
+        const expression = '`cookies().size`'
+        const error = createCookiesAccessError(route, expression)
         abortAndThrowOnSynchronousRequestDataAccess(
           route,
           expression,
@@ -193,11 +193,11 @@ function makeDynamicallyTrackedExoticCookies(
       value: function get() {
         let expression: string
         if (arguments.length === 0) {
-          expression = 'cookies().get()'
+          expression = '`cookies().get()`'
         } else {
-          expression = `cookies().get(${describeNameArg(arguments[0])})`
+          expression = `\`cookies().get(${describeNameArg(arguments[0])})\``
         }
-        const error = createSyncCookiesError(route, expression)
+        const error = createCookiesAccessError(route, expression)
         abortAndThrowOnSynchronousRequestDataAccess(
           route,
           expression,
@@ -210,11 +210,11 @@ function makeDynamicallyTrackedExoticCookies(
       value: function getAll() {
         let expression: string
         if (arguments.length === 0) {
-          expression = `cookies().getAll()`
+          expression = '`cookies().getAll()`'
         } else {
-          expression = `cookies().getAll(${describeNameArg(arguments[0])})`
+          expression = `\`cookies().getAll(${describeNameArg(arguments[0])})\``
         }
-        const error = createSyncCookiesError(route, expression)
+        const error = createCookiesAccessError(route, expression)
         abortAndThrowOnSynchronousRequestDataAccess(
           route,
           expression,
@@ -227,11 +227,11 @@ function makeDynamicallyTrackedExoticCookies(
       value: function has() {
         let expression: string
         if (arguments.length === 0) {
-          expression = `cookies().has()`
+          expression = '`cookies().has()`'
         } else {
-          expression = `cookies().has(${describeNameArg(arguments[0])})`
+          expression = `\`cookies().has(${describeNameArg(arguments[0])})\``
         }
-        const error = createSyncCookiesError(route, expression)
+        const error = createCookiesAccessError(route, expression)
         abortAndThrowOnSynchronousRequestDataAccess(
           route,
           expression,
@@ -244,16 +244,16 @@ function makeDynamicallyTrackedExoticCookies(
       value: function set() {
         let expression: string
         if (arguments.length === 0) {
-          expression = 'cookies().set()'
+          expression = '`cookies().set()`'
         } else {
           const arg = arguments[0]
           if (arg) {
-            expression = `cookies().set(${describeNameArg(arg)}, ...)`
+            expression = `\`cookies().set(${describeNameArg(arg)}, ...)\``
           } else {
-            expression = `cookies().set(...)`
+            expression = '`cookies().set(...)`'
           }
         }
-        const error = createSyncCookiesError(route, expression)
+        const error = createCookiesAccessError(route, expression)
         abortAndThrowOnSynchronousRequestDataAccess(
           route,
           expression,
@@ -266,13 +266,13 @@ function makeDynamicallyTrackedExoticCookies(
       value: function () {
         let expression: string
         if (arguments.length === 0) {
-          expression = `cookies().delete()`
+          expression = '`cookies().delete()`'
         } else if (arguments.length === 1) {
-          expression = `cookies().delete(${describeNameArg(arguments[0])})`
+          expression = `\`cookies().delete(${describeNameArg(arguments[0])})\``
         } else {
-          expression = `cookies().delete(${describeNameArg(arguments[0])}, ...)`
+          expression = `\`cookies().delete(${describeNameArg(arguments[0])}, ...)\``
         }
-        const error = createSyncCookiesError(route, expression)
+        const error = createCookiesAccessError(route, expression)
         abortAndThrowOnSynchronousRequestDataAccess(
           route,
           expression,
@@ -283,8 +283,8 @@ function makeDynamicallyTrackedExoticCookies(
     },
     clear: {
       value: function clear() {
-        const expression = 'cookies().clear()'
-        const error = createSyncCookiesError(route, expression)
+        const expression = '`cookies().clear()`'
+        const error = createCookiesAccessError(route, expression)
         abortAndThrowOnSynchronousRequestDataAccess(
           route,
           expression,
@@ -295,8 +295,8 @@ function makeDynamicallyTrackedExoticCookies(
     },
     toString: {
       value: function toString() {
-        const expression = 'cookies().toString()'
-        const error = createSyncCookiesError(route, expression)
+        const expression = '`cookies().toString()`'
+        const error = createCookiesAccessError(route, expression)
         abortAndThrowOnSynchronousRequestDataAccess(
           route,
           expression,
@@ -382,23 +382,14 @@ function makeUntrackedExoticCookiesWithDevWarnings(
     return cachedCookies
   }
 
-  const promise = new Promise<ReadonlyRequestCookies>((resolve) => {
-    scheduleImmediate(() =>
-      // @TODO the fact that we need to wait two ticks tells us that there
-      // is something not quite right about how we cut off the RSC stream
-      // for validating dynamic rendering in dynamicIO. This is fine for now
-      // for dev b/c it helps surface what will be build issues but we may
-      // need to just do a clean prerender to avoid subtle timing issues that
-      // require workarounds like this double schedule
-      scheduleImmediate(() => resolve(underlyingCookies))
-    )
-  })
+  const promise = new Promise<ReadonlyRequestCookies>((resolve) =>
+    scheduleImmediate(() => resolve(underlyingCookies))
+  )
   CachedCookies.set(underlyingCookies, promise)
 
   Object.defineProperties(promise, {
     [Symbol.iterator]: {
       value: function () {
-        console.log('here')
         const expression = '`...cookies()` or similar iteration'
         syncIODev(route, expression)
         return underlyingCookies[Symbol.iterator]
@@ -519,7 +510,7 @@ function makeUntrackedExoticCookiesWithDevWarnings(
     },
     toString: {
       value: function toString() {
-        const expression = '`cookies().toString()` or implicit casting.'
+        const expression = '`cookies().toString()` or implicit casting'
         syncIODev(route, expression)
         return underlyingCookies.toString.apply(
           underlyingCookies,
@@ -545,43 +536,31 @@ function describeNameArg(arg: unknown) {
 
 function syncIODev(route: string | undefined, expression: string) {
   const workUnitStore = workUnitAsyncStorage.getStore()
-  if (workUnitStore && workUnitStore.type === 'request') {
+  if (
+    workUnitStore &&
+    workUnitStore.type === 'request' &&
+    workUnitStore.prerenderPhase === true
+  ) {
+    // When we're rendering dynamically in dev we need to advance out of the
+    // Prerender environment when we read Request data synchronously
     const requestStore = workUnitStore
-    const dynamicTracking = requestStore.dynamicTracking
-    if (dynamicTracking) {
-      // We are in a dynamic IO dev render context
-      if (
-        !dynamicTracking.syncDynamicErrorWithStack &&
-        requestStore.prerenderPhase === true
-      ) {
-        const errorWithStack = createCookiesAccessError(route, expression)
-        trackSynchronousRequestDataAccessInDev(
-          expression,
-          errorWithStack,
-          requestStore,
-          dynamicTracking
-        )
-      } else if (requestStore.prospectiveRender !== true) {
-        warnForSyncAccess(route, expression)
-      }
-    } else {
-      // We are in a legacy dev render context
-      warnForSyncAccess(route, expression)
-    }
+    trackSynchronousRequestDataAccessInDev(requestStore)
   }
+  // In all cases we warn normally
+  warnForSyncAccess(route, expression)
 }
 
 const noop = () => {}
 
 const warnForSyncAccess = process.env.__NEXT_DISABLE_SYNC_DYNAMIC_API_WARNINGS
   ? noop
-  : createDedupedByCallsiteServerErrorLoggerDev(createCookiesAccessError, 1)
+  : createDedupedByCallsiteServerErrorLoggerDev(createCookiesAccessError)
 
 function createCookiesAccessError(
   route: string | undefined,
   expression: string
 ) {
-  const prefix = route ? ` Route "${route}" ` : 'This route '
+  const prefix = route ? `Route "${route}" ` : 'This route '
   return new Error(
     `${prefix}used ${expression}. ` +
       `\`cookies()\` should be awaited before using its value. ` +
@@ -609,10 +588,4 @@ function polyfilledResponseCookiesClear(
 
 type CookieExtensions = {
   [K in keyof ReadonlyRequestCookies | 'clear']: unknown
-}
-
-function createSyncCookiesError(route: string, expression: string) {
-  return new Error(
-    `Route "${route}" used ${expression}. \`cookies()\` now returns a Promise and should be \`awaited\` before using it's value. See more info here: https://nextjs.org/docs/messages/next-prerender-sync-headers`
-  )
 }

--- a/packages/next/src/server/request/utils.ts
+++ b/packages/next/src/server/request/utils.ts
@@ -1,19 +1,5 @@
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 
-/**
- * React annotates Promises with extra properties to make unwrapping them synchronous
- * after they have resolved. We sometimes create promises that are compatible with this
- * internal implementation detail when we want to construct a promise that is already resolved.
- *
- * @internal
- */
-export function makeResolvedReactPromise<T>(value: T): Promise<T> {
-  const promise = Promise.resolve(value)
-  ;(promise as any).status = 'fulfilled'
-  ;(promise as any).value = value
-  return promise
-}
-
 // This regex will have fast negatives meaning valid identifiers may not pass
 // this test. However this is only used during static generation to provide hints
 // about why a page bailed out of some or all prerendering and we can use bracket notation

--- a/packages/next/src/server/request/utils.ts
+++ b/packages/next/src/server/request/utils.ts
@@ -58,6 +58,9 @@ export const wellKnownProperties = new Set([
   // fallthrough
   'status',
 
+  // React introspection
+  'displayName',
+
   // Common tested properties
   // fallthrough
   'toJSON',

--- a/test/development/app-dir/async-request-warnings/async-request-warnings.test.ts
+++ b/test/development/app-dir/async-request-warnings/async-request-warnings.test.ts
@@ -16,36 +16,20 @@ describe('dynamic-requests warnings', () => {
       .map((log) => log.message)
     const terminalOutput = next.cliOutput.slice(nextDevBootstrapOutputIndex)
     const terminalCookieErrors = terminalOutput.split('\n').filter((line) => {
-      return line.includes('In route /request/cookies')
+      return line.includes('Route "/request/cookies')
     })
     expect({ browserConsoleErrors, terminalCookieErrors }).toEqual({
       browserConsoleErrors: [
-        expect.stringContaining(
-          "In route /request/cookies a cookie property was accessed directly with `cookies().get('page')`."
-        ),
-        expect.stringContaining(
-          "In route /request/cookies a cookie property was accessed directly with `cookies().get('component')`."
-        ),
-        expect.stringContaining(
-          "In route /request/cookies a cookie property was accessed directly with `cookies().has('component')`."
-        ),
-        expect.stringContaining(
-          'In route /request/cookies cookies were iterated over'
-        ),
+        expect.stringContaining("`cookies().get('page')`."),
+        expect.stringContaining("`cookies().get('component')`."),
+        expect.stringContaining("`cookies().has('component')`."),
+        expect.stringContaining('`...cookies()` or similar iteration'),
       ],
       terminalCookieErrors: [
-        expect.stringContaining(
-          "In route /request/cookies a cookie property was accessed directly with `cookies().get('page')`."
-        ),
-        expect.stringContaining(
-          "In route /request/cookies a cookie property was accessed directly with `cookies().get('component')`."
-        ),
-        expect.stringContaining(
-          "In route /request/cookies a cookie property was accessed directly with `cookies().has('component')`."
-        ),
-        expect.stringContaining(
-          'In route /request/cookies cookies were iterated over'
-        ),
+        expect.stringContaining("`cookies().get('page')`."),
+        expect.stringContaining("`cookies().get('component')`."),
+        expect.stringContaining("`cookies().has('component')`."),
+        expect.stringContaining('`...cookies()` or similar iteration'),
       ],
     })
   })
@@ -61,36 +45,20 @@ describe('dynamic-requests warnings', () => {
       .map((log) => log.message)
     const terminalOutput = next.cliOutput.slice(nextDevBootstrapOutputIndex)
     const terminalCookieErrors = terminalOutput.split('\n').filter((line) => {
-      return line.includes('In route /request/draftMode')
+      return line.includes('Route "/request/draftMode')
     })
     expect({ browserConsoleErrors, terminalCookieErrors }).toEqual({
       browserConsoleErrors: [
-        expect.stringContaining(
-          'In route /request/draftMode a `draftMode()` property was accessed directly with `draftMode().isEnabled`.'
-        ),
-        expect.stringContaining(
-          'In route /request/draftMode a `draftMode()` property was accessed directly with `draftMode().isEnabled`.'
-        ),
-        expect.stringContaining(
-          'In route /request/draftMode a `draftMode()` property was accessed directly with `draftMode().enable()`.'
-        ),
-        expect.stringContaining(
-          'In route /request/draftMode a `draftMode()` property was accessed directly with `draftMode().isEnabled`.'
-        ),
+        expect.stringContaining('`draftMode().isEnabled`.'),
+        expect.stringContaining('`draftMode().isEnabled`.'),
+        expect.stringContaining('`draftMode().enable()`.'),
+        expect.stringContaining('`draftMode().isEnabled`.'),
       ],
       terminalCookieErrors: [
-        expect.stringContaining(
-          'In route /request/draftMode a `draftMode()` property was accessed directly with `draftMode().isEnabled`.'
-        ),
-        expect.stringContaining(
-          'In route /request/draftMode a `draftMode()` property was accessed directly with `draftMode().isEnabled`.'
-        ),
-        expect.stringContaining(
-          'In route /request/draftMode a `draftMode()` property was accessed directly with `draftMode().enable()`.'
-        ),
-        expect.stringContaining(
-          'In route /request/draftMode a `draftMode()` property was accessed directly with `draftMode().isEnabled`.'
-        ),
+        expect.stringContaining('`draftMode().isEnabled`.'),
+        expect.stringContaining('`draftMode().isEnabled`.'),
+        expect.stringContaining('`draftMode().enable()`.'),
+        expect.stringContaining('`draftMode().isEnabled`.'),
       ],
     })
   })
@@ -106,36 +74,20 @@ describe('dynamic-requests warnings', () => {
       .map((log) => log.message)
     const terminalOutput = next.cliOutput.slice(nextDevBootstrapOutputIndex)
     const terminalCookieErrors = terminalOutput.split('\n').filter((line) => {
-      return line.includes('In route /request/headers')
+      return line.includes('Route "/request/headers')
     })
     expect({ browserConsoleErrors, terminalCookieErrors }).toEqual({
       browserConsoleErrors: [
-        expect.stringContaining(
-          "In route /request/headers a header property was accessed directly with `headers().get('page')`."
-        ),
-        expect.stringContaining(
-          "In route /request/headers a header property was accessed directly with `headers().get('component')`."
-        ),
-        expect.stringContaining(
-          "In route /request/headers a header property was accessed directly with `headers().has('component')`."
-        ),
-        expect.stringContaining(
-          'In route /request/headers headers were iterated over'
-        ),
+        expect.stringContaining("`headers().get('page')`."),
+        expect.stringContaining("`headers().get('component')`."),
+        expect.stringContaining("`headers().has('component')`."),
+        expect.stringContaining('`...headers()` or similar iteration'),
       ],
       terminalCookieErrors: [
-        expect.stringContaining(
-          "In route /request/headers a header property was accessed directly with `headers().get('page')`."
-        ),
-        expect.stringContaining(
-          "In route /request/headers a header property was accessed directly with `headers().get('component')`."
-        ),
-        expect.stringContaining(
-          "In route /request/headers a header property was accessed directly with `headers().has('component')`."
-        ),
-        expect.stringContaining(
-          'In route /request/headers headers were iterated over'
-        ),
+        expect.stringContaining("`headers().get('page')`."),
+        expect.stringContaining("`headers().get('component')`."),
+        expect.stringContaining("`headers().has('component')`."),
+        expect.stringContaining('`...headers()` or similar iteration'),
       ],
     })
   })
@@ -151,36 +103,20 @@ describe('dynamic-requests warnings', () => {
       .map((log) => log.message)
     const terminalOutput = next.cliOutput.slice(nextDevBootstrapOutputIndex)
     const terminalCookieErrors = terminalOutput.split('\n').filter((line) => {
-      return line.includes('In route /request/params/[slug]')
+      return line.includes('Route "/request/params/[slug]')
     })
     expect({ browserConsoleErrors, terminalCookieErrors }).toEqual({
       browserConsoleErrors: [
-        expect.stringContaining(
-          'In route /request/params/[slug] a param property was accessed directly with `params.slug`.'
-        ),
-        expect.stringContaining(
-          'In route /request/params/[slug] a param property was accessed directly with `params.slug`.'
-        ),
-        expect.stringContaining(
-          'In route /request/params/[slug] a param property was accessed directly with `params.slug`.'
-        ),
-        expect.stringContaining(
-          'In route /request/params/[slug] params are being enumerated'
-        ),
+        expect.stringContaining('`params.slug`.'),
+        expect.stringContaining('`params.slug`.'),
+        expect.stringContaining('`params.slug`.'),
+        expect.stringContaining('`...params` or similar expression'),
       ],
       terminalCookieErrors: [
-        expect.stringContaining(
-          'In route /request/params/[slug] a param property was accessed directly with `params.slug`.'
-        ),
-        expect.stringContaining(
-          'In route /request/params/[slug] a param property was accessed directly with `params.slug`.'
-        ),
-        expect.stringContaining(
-          'In route /request/params/[slug] a param property was accessed directly with `params.slug`.'
-        ),
-        expect.stringContaining(
-          'In route /request/params/[slug] params are being enumerated'
-        ),
+        expect.stringContaining('`params.slug`.'),
+        expect.stringContaining('`params.slug`.'),
+        expect.stringContaining('`params.slug`.'),
+        expect.stringContaining('`...params` or similar expression'),
       ],
     })
   })
@@ -196,36 +132,20 @@ describe('dynamic-requests warnings', () => {
       .map((log) => log.message)
     const terminalOutput = next.cliOutput.slice(nextDevBootstrapOutputIndex)
     const terminalCookieErrors = terminalOutput.split('\n').filter((line) => {
-      return line.includes('In route /request/searchParams')
+      return line.includes('Route "/request/searchParams')
     })
     expect({ browserConsoleErrors, terminalCookieErrors }).toEqual({
       browserConsoleErrors: [
-        expect.stringContaining(
-          'In route /request/searchParams a searchParam property was accessed directly with `searchParams.slug`.'
-        ),
-        expect.stringContaining(
-          'In route /request/searchParams a searchParam property was accessed directly with `searchParams.slug`.'
-        ),
-        expect.stringContaining(
-          'In route /request/searchParams a searchParam property was accessed directly with `searchParams.slug`.'
-        ),
-        expect.stringContaining(
-          'In route /request/searchParams searchParams are being enumerated'
-        ),
+        expect.stringContaining('`searchParams.slug`.'),
+        expect.stringContaining('`searchParams.slug`.'),
+        expect.stringContaining('`searchParams.slug`.'),
+        expect.stringContaining('`Object.keys(searchParams)` or similar'),
       ],
       terminalCookieErrors: [
-        expect.stringContaining(
-          'In route /request/searchParams a searchParam property was accessed directly with `searchParams.slug`.'
-        ),
-        expect.stringContaining(
-          'In route /request/searchParams a searchParam property was accessed directly with `searchParams.slug`.'
-        ),
-        expect.stringContaining(
-          'In route /request/searchParams a searchParam property was accessed directly with `searchParams.slug`.'
-        ),
-        expect.stringContaining(
-          'In route /request/searchParams searchParams are being enumerated'
-        ),
+        expect.stringContaining('`searchParams.slug`.'),
+        expect.stringContaining('`searchParams.slug`.'),
+        expect.stringContaining('`searchParams.slug`.'),
+        expect.stringContaining('`Object.keys(searchParams)` or similar'),
       ],
     })
   })

--- a/test/e2e/app-dir/dynamic-data/dynamic-data.test.ts
+++ b/test/e2e/app-dir/dynamic-data/dynamic-data.test.ts
@@ -28,20 +28,14 @@ describe('dynamic-data', () => {
       // in dev we expect the entire page to be rendered at runtime
       expect($('#layout').text()).toBe('at runtime')
       expect($('#page').text()).toBe('at runtime')
-      // we expect there to be no suspense boundary in fallback state
-      expect($('#boundary').html()).toBeNull()
     } else if (process.env.__NEXT_EXPERIMENTAL_PPR) {
       // in PPR we expect the shell to be rendered at build and the page to be rendered at runtime
       expect($('#layout').text()).toBe('at buildtime')
       expect($('#page').text()).toBe('at runtime')
-      // we expect there to be a suspense boundary in fallback state
-      expect($('#boundary').html()).not.toBeNull()
     } else {
       // in static generation we expect the entire page to be rendered at runtime
       expect($('#layout').text()).toBe('at runtime')
       expect($('#page').text()).toBe('at runtime')
-      // we expect there to be no suspense boundary in fallback state
-      expect($('#boundary').html()).toBeNull()
     }
 
     expect($('#headers .fooheader').text()).toBe('foo header value')
@@ -64,21 +58,15 @@ describe('dynamic-data', () => {
       // in dev we expect the entire page to be rendered at runtime
       expect($('#layout').text()).toBe('at runtime')
       expect($('#page').text()).toBe('at runtime')
-      // we expect there to be no suspense boundary in fallback state
-      expect($('#boundary').html()).toBeNull()
     } else if (process.env.__NEXT_EXPERIMENTAL_PPR) {
       // @TODO this should actually be build but there is a bug in how we do segment level dynamic in PPR at the moment
       // see note in create-component-tree
       expect($('#layout').text()).toBe('at runtime')
       expect($('#page').text()).toBe('at runtime')
-      // we expect there to be a suspense boundary in fallback state
-      expect($('#boundary').html()).toBeNull()
     } else {
       // in static generation we expect the entire page to be rendered at runtime
       expect($('#layout').text()).toBe('at runtime')
       expect($('#page').text()).toBe('at runtime')
-      // we expect there to be no suspense boundary in fallback state
-      expect($('#boundary').html()).toBeNull()
     }
 
     expect($('#headers .fooheader').text()).toBe('foo header value')

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.platform-dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.platform-dynamic.test.ts
@@ -39,7 +39,6 @@ function createExpectError(cliOutput: string) {
 }
 
 function runTests(options: { withMinification: boolean }) {
-  const isTurbopack = !!process.env.TURBOPACK
   const { withMinification } = options
   describe(`Dynamic IO Errors - ${withMinification ? 'With Minification' : 'Without Minification'}`, () => {
     describe('Sync Dynamic - With Fallback - Math.random()', () => {
@@ -125,11 +124,6 @@ function runTests(options: { withMinification: boolean }) {
 
         expectError(
           'Error: Route "/" used `Math.random()` outside of `"use cache"` and without explicitly calling `await connection()` beforehand. See more info here: https://nextjs.org/docs/messages/next-prerender-random'
-        )
-        expectError(
-          'Error: In Route "/" this parent component stack may help you locate where `Math.random()` was used.',
-          // Turbopack doesn't support disabling minification yet
-          withMinification || isTurbopack ? undefined : 'IndirectionTwo'
         )
         expectError('Error occurred prerendering page "/"')
         expectError('Error: Route "/" could not be prerendered.')

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.sync-dynamic.test.ts
@@ -39,7 +39,6 @@ function createExpectError(cliOutput: string) {
 }
 
 function runTests(options: { withMinification: boolean }) {
-  const isTurbopack = !!process.env.TURBOPACK
   const { withMinification } = options
   describe(`Dynamic IO Errors - ${withMinification ? 'With Minification' : 'Without Minification'}`, () => {
     describe('Sync Dynamic - With Fallback - client searchParams', () => {
@@ -123,14 +122,7 @@ function runTests(options: { withMinification: boolean }) {
         }
         const expectError = createExpectError(next.cliOutput)
 
-        expectError(
-          'Error: Route "/" used `searchParams.foo`. `searchParams` is now a Promise and should be `awaited` before accessing search param values. See more info here: https://nextjs.org/docs/messages/next-prerender-sync-params'
-        )
-        expectError(
-          'Error: In Route "/" this parent component stack may help you locate where `searchParams.foo` was used.',
-          // Turbopack doesn't support disabling minification yet
-          withMinification || isTurbopack ? undefined : 'IndirectionTwo'
-        )
+        expectError('Route "/" used `searchParams.foo`')
         expectError('Error occurred prerendering page "/"')
         expectError('Error: Route "/" could not be prerendered.')
         expectError('exiting the build.')
@@ -218,14 +210,7 @@ function runTests(options: { withMinification: boolean }) {
         }
         const expectError = createExpectError(next.cliOutput)
 
-        expectError(
-          'Error: Route "/" used `searchParams.foo`. `searchParams` is now a Promise and should be `awaited` before accessing search param values. See more info here: https://nextjs.org/docs/messages/next-prerender-sync-params'
-        )
-        expectError(
-          'Error: In Route "/" this parent component stack may help you locate where `searchParams.foo` was used.',
-          // Turbopack doesn't support disabling minification yet
-          withMinification || isTurbopack ? undefined : 'IndirectionTwo'
-        )
+        expectError('Route "/" used `searchParams.foo`')
         expectError('Error occurred prerendering page "/"')
         expectError('Error: Route "/" could not be prerendered.')
         expectError('exiting the build.')
@@ -313,14 +298,7 @@ function runTests(options: { withMinification: boolean }) {
         }
         const expectError = createExpectError(next.cliOutput)
 
-        expectError(
-          "Error: Route \"/\" used cookies().get('token'). `cookies()` now returns a Promise and should be `awaited` before using it's value. See more info here: https://nextjs.org/docs/messages/next-prerender-sync-headers"
-        )
-        expectError(
-          'Error: In Route "/" this parent component stack may help you locate where cookies().get(\'token\') was used.',
-          // Turbopack doesn't support disabling minification yet
-          withMinification || isTurbopack ? undefined : 'IndirectionTwo'
-        )
+        expectError('Route "/" used `cookies().get(\'token\')`')
         expectError('Error occurred prerendering page "/"')
         expectError('Route "/" could not be prerendered.')
         expectError('exiting the build.')

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/[dyn]/build-id.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/[dyn]/build-id.tsx
@@ -1,0 +1,10 @@
+export async function BuildID() {
+  const buildID = require('./lazy-id').buildID
+  await 1
+  return (
+    <dl>
+      <dt>Build ID</dt>
+      <dd id="id">{buildID}</dd>
+    </dl>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/[dyn]/lazy-id.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/[dyn]/lazy-id.ts
@@ -1,0 +1,1 @@
+export const buildID = Date.now() + Math.random()

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/[dyn]/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/[dyn]/page.tsx
@@ -1,6 +1,6 @@
 import { BuildID } from './build-id'
 
-export default async function Page({ searchParams }) {
+export default async function Page({ params }) {
   return (
     <>
       <p>

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/client-page/build-id.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/client-page/build-id.tsx
@@ -1,0 +1,11 @@
+export function BuildID() {
+  const buildID = require('./lazy-id').buildID
+  return (
+    <dl>
+      <dt>Build ID</dt>
+      <dd id="id" suppressHydrationWarning={true}>
+        {buildID}
+      </dd>
+    </dl>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/client-page/lazy-id.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/client-page/lazy-id.ts
@@ -1,0 +1,1 @@
+export const buildID = Date.now() + Math.random()

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/client-page/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/client-page/page.tsx
@@ -1,6 +1,8 @@
+'use client'
+
 import { BuildID } from './build-id'
 
-export default async function Page() {
+export default function Page() {
   return (
     <>
       <p>

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/client/build-id.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/client/build-id.tsx
@@ -5,7 +5,9 @@ export function BuildID() {
   return (
     <dl>
       <dt>Build ID</dt>
-      <dd id="id">{buildID}</dd>
+      <dd id="id" suppressHydrationWarning={true}>
+        {buildID}
+      </dd>
     </dl>
   )
 }

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/layout.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/layout.tsx
@@ -1,8 +1,13 @@
+// import { Suspense } from 'react'
+
 export default function Root({ children }: { children: React.ReactNode }) {
   return (
     <html>
       <body>
         <main>{children}</main>
+        {/* <main>
+          <Suspense>{children}</Suspense>
+        </main> */}
       </body>
     </html>
   )

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/layout.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/layout.tsx
@@ -1,13 +1,8 @@
-// import { Suspense } from 'react'
-
 export default function Root({ children }: { children: React.ReactNode }) {
   return (
     <html>
       <body>
         <main>{children}</main>
-        {/* <main>
-          <Suspense>{children}</Suspense>
-        </main> */}
       </body>
     </html>
   )

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/server/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/lazy-module-init/app/server/page.tsx
@@ -1,6 +1,6 @@
 import { BuildID } from './build-id'
 
-export default async function Page({ searchParams }) {
+export default async function Page() {
   return (
     <>
       <p>

--- a/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-client-search-without-fallback/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-errors/fixtures/sync-client-search-without-fallback/app/page.tsx
@@ -6,15 +6,13 @@ import { type UnsafeUnwrappedSearchParams } from 'next/server'
 import { IndirectionOne, IndirectionTwo, IndirectionThree } from './indirection'
 
 type SearchParams = { foo: string | string[] | undefined }
-export default async function Page(props: {
-  searchParams: Promise<SearchParams>
-}) {
+export default function Page(props: { searchParams: Promise<SearchParams> }) {
   return (
     <>
       <p>
-        This page accesses searchParams synchronously but it does so late enough
-        in the render that all unfinished sub-trees have a defined Suspense
-        boundary. This is fine and doesn't need to error the build.
+        This page accesses searchParams synchronously and it does it early
+        enough that some sibling component trees are not finished and they do
+        not have a parent Suspense boundary above them.
       </p>
       <Suspense fallback={<Fallback />}>
         <IndirectionOne>

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.cookies.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.cookies.test.ts
@@ -237,7 +237,12 @@ describe('dynamic-io', () => {
     }
 
     if (isNextDev) {
-      expect(i).toBe(cookieWarnings.length)
+      // TODO currently we double render in RSC during dev to account for
+      // flushing out module scope dynamic errors. This is leading the server logs to be doubled
+      // The client logs aren't doubled because we only send the second render to the client.
+      // We should fix this by not logging in the prospective render. But We will land that fix
+      // later and separately
+      expect(i * 2).toBe(cookieWarnings.length)
     }
   })
 })

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.cookies.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.cookies.test.ts
@@ -83,7 +83,7 @@ describe('dynamic-io', () => {
     let $ = await next.render$('/cookies/exercise/async', {})
     let cookieWarnings = next.cliOutput
       .split('\n')
-      .filter((l) => l.includes('In route /cookies/exercise'))
+      .filter((l) => l.includes('Route "/cookies/exercise'))
 
     expect(cookieWarnings).toHaveLength(0)
 
@@ -143,7 +143,7 @@ describe('dynamic-io', () => {
     let $ = await next.render$('/cookies/exercise/sync', {})
     let cookieWarnings = next.cliOutput
       .split('\n')
-      .filter((l) => l.includes('In route /cookies/exercise'))
+      .filter((l) => l.includes('Route "/cookies/exercise'))
 
     if (!isNextDev) {
       expect(cookieWarnings).toHaveLength(0)
@@ -157,7 +157,9 @@ describe('dynamic-io', () => {
     )
     expect($('#for-of-x-sentinel-rand').text()).toContain('x-sentinel-rand')
     if (isNextDev) {
-      expect(cookieWarnings[i++]).toContain('cookies were iterated over')
+      expect(cookieWarnings[i++]).toContain(
+        '`...cookies()` or similar iteration.'
+      )
     }
 
     // ...spread iteration
@@ -167,13 +169,15 @@ describe('dynamic-io', () => {
     )
     expect($('#spread-x-sentinel-rand').text()).toContain('x-sentinel-rand')
     if (isNextDev) {
-      expect(cookieWarnings[i++]).toContain('cookies were iterated over')
+      expect(cookieWarnings[i++]).toContain(
+        '`...cookies()` or similar iteration.'
+      )
     }
 
     // cookies().size
     expect(parseInt($('#size-cookies').text())).toBeGreaterThanOrEqual(3)
     if (isNextDev) {
-      expect(cookieWarnings[i++]).toContain('cookies().size')
+      expect(cookieWarnings[i++]).toContain('`cookies().size`')
     }
 
     // cookies().get('...') && cookies().getAll('...')
@@ -181,10 +185,12 @@ describe('dynamic-io', () => {
     expect($('#get-x-sentinel-path').text()).toContain('/cookies/exercise/sync')
     expect($('#get-x-sentinel-rand').text()).toContain('x-sentinel-rand')
     if (isNextDev) {
-      expect(cookieWarnings[i++]).toContain("cookies().get('x-sentinel')")
-      expect(cookieWarnings[i++]).toContain("cookies().get('x-sentinel-path')")
+      expect(cookieWarnings[i++]).toContain("`cookies().get('x-sentinel')`")
       expect(cookieWarnings[i++]).toContain(
-        "cookies().getAll('x-sentinel-rand')"
+        "`cookies().get('x-sentinel-path')`"
+      )
+      expect(cookieWarnings[i++]).toContain(
+        "`cookies().getAll('x-sentinel-rand')`"
       )
     }
 
@@ -192,9 +198,9 @@ describe('dynamic-io', () => {
     expect($('#has-x-sentinel').text()).toContain('true')
     expect($('#has-x-sentinel-foobar').text()).toContain('false')
     if (isNextDev) {
-      expect(cookieWarnings[i++]).toContain("cookies().has('x-sentinel')")
+      expect(cookieWarnings[i++]).toContain("`cookies().has('x-sentinel')`")
       expect(cookieWarnings[i++]).toContain(
-        "cookies().has('x-sentinel-foobar')"
+        "`cookies().has('x-sentinel-foobar')`"
       )
     }
 
@@ -204,8 +210,10 @@ describe('dynamic-io', () => {
     )
     expect($('#set-value-x-sentinel').text()).toContain('hello')
     if (isNextDev) {
-      expect(cookieWarnings[i++]).toContain("cookies().set('x-sentinel', ...)")
-      expect(cookieWarnings[i++]).toContain("cookies().get('x-sentinel')")
+      expect(cookieWarnings[i++]).toContain(
+        "`cookies().set('x-sentinel', ...)`"
+      )
+      expect(cookieWarnings[i++]).toContain("`cookies().get('x-sentinel')`")
     }
 
     // cookies().delete('...', '...')
@@ -214,8 +222,8 @@ describe('dynamic-io', () => {
     )
     expect($('#delete-value-x-sentinel').text()).toContain('hello')
     if (isNextDev) {
-      expect(cookieWarnings[i++]).toContain("cookies().delete('x-sentinel')")
-      expect(cookieWarnings[i++]).toContain("cookies().get('x-sentinel')")
+      expect(cookieWarnings[i++]).toContain("`cookies().delete('x-sentinel')`")
+      expect(cookieWarnings[i++]).toContain("`cookies().get('x-sentinel')`")
     }
 
     // cookies().clear()
@@ -224,8 +232,8 @@ describe('dynamic-io', () => {
     )
     expect($('#clear-value-x-sentinel').text()).toContain('hello')
     if (isNextDev) {
-      expect(cookieWarnings[i++]).toContain('cookies().clear()')
-      expect(cookieWarnings[i++]).toContain("cookies().get('x-sentinel')")
+      expect(cookieWarnings[i++]).toContain('`cookies().clear()`')
+      expect(cookieWarnings[i++]).toContain("`cookies().get('x-sentinel')`")
     }
 
     // cookies().toString()
@@ -233,16 +241,13 @@ describe('dynamic-io', () => {
     expect($('#toString').text()).toContain('x-sentinel-path')
     expect($('#toString').text()).toContain('x-sentinel-rand=')
     if (isNextDev) {
-      expect(cookieWarnings[i++]).toContain('cookies().toString()')
+      expect(cookieWarnings[i++]).toContain(
+        '`cookies().toString()` or implicit casting'
+      )
     }
 
     if (isNextDev) {
-      // TODO currently we double render in RSC during dev to account for
-      // flushing out module scope dynamic errors. This is leading the server logs to be doubled
-      // The client logs aren't doubled because we only send the second render to the client.
-      // We should fix this by not logging in the prospective render. But We will land that fix
-      // later and separately
-      expect(i * 2).toBe(cookieWarnings.length)
+      expect(i).toBe(cookieWarnings.length)
     }
   })
 })

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.date.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.date.test.ts
@@ -13,7 +13,7 @@ describe('dynamic-io', () => {
   }
 
   it('should not have route specific errors', async () => {
-    expect(next.cliOutput).not.toMatch('Error: Route /')
+    expect(next.cliOutput).not.toMatch('Error: Route "/')
     expect(next.cliOutput).not.toMatch('Error occurred prerendering page')
   })
 

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.draft-mode.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.draft-mode.test.ts
@@ -25,18 +25,18 @@ describe('dynamic-io', () => {
   }
 
   it('should fully prerender pages that use draftMode', async () => {
-    expect(getLines('In route /draftmode')).toEqual([])
+    expect(getLines('Route "/draftmode')).toEqual([])
     let $ = await next.render$('/draftmode/async', {})
     if (isNextDev) {
       expect($('#layout').text()).toBe('at runtime')
       expect($('#page').text()).toBe('at runtime')
       expect($('#draft-mode').text()).toBe('false')
-      expect(getLines('In route /draftmode')).toEqual([])
+      expect(getLines('Route "/draftmode')).toEqual([])
     } else {
       expect($('#layout').text()).toBe('at buildtime')
       expect($('#page').text()).toBe('at buildtime')
       expect($('#draft-mode').text()).toBe('false')
-      expect(getLines('In route /draftmode')).toEqual([])
+      expect(getLines('Route "/draftmode')).toEqual([])
     }
 
     $ = await next.render$('/draftmode/sync', {})
@@ -44,16 +44,16 @@ describe('dynamic-io', () => {
       expect($('#layout').text()).toBe('at runtime')
       expect($('#page').text()).toBe('at runtime')
       expect($('#draft-mode').text()).toBe('false')
-      expect(getLines('In route /draftmode')).toEqual([
-        expect.stringContaining(
-          'a `draftMode()` property was accessed directly with `draftMode().isEnabled`.'
-        ),
+      expect(getLines('Route "/draftmode')).toEqual([
+        expect.stringContaining('`draftMode().isEnabled`'),
+        // TODO need to figure out why deduping isn't working here
+        expect.stringContaining('`draftMode().isEnabled`'),
       ])
     } else {
       expect($('#layout').text()).toBe('at buildtime')
       expect($('#page').text()).toBe('at buildtime')
       expect($('#draft-mode').text()).toBe('false')
-      expect(getLines('In route /draftmode')).toEqual([])
+      expect(getLines('Route "/draftmode')).toEqual([])
     }
   })
 })

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.headers.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.headers.test.ts
@@ -284,7 +284,12 @@ describe('dynamic-io', () => {
     }
 
     if (isNextDev) {
-      expect(i).toBe(headerWarnings.length)
+      // TODO currently we double render in RSC during dev to account for
+      // flushing out module scope dynamic errors. This is leading the server logs to be doubled
+      // The client logs aren't doubled because we only send the second render to the client.
+      // We should fix this by not logging in the prospective render. But We will land that fix
+      // later and separately
+      expect(i * 2).toBe(headerWarnings.length)
     }
   })
 })

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.headers.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.headers.test.ts
@@ -83,7 +83,7 @@ describe('dynamic-io', () => {
     let $ = await next.render$('/headers/exercise/async', {})
     let cookieWarnings = next.cliOutput
       .split('\n')
-      .filter((l) => l.includes('In route /headers/exercise'))
+      .filter((l) => l.includes('Route "/headers/exercise'))
 
     expect(cookieWarnings).toHaveLength(0)
 
@@ -162,7 +162,7 @@ describe('dynamic-io', () => {
     let $ = await next.render$('/headers/exercise/sync', {})
     let headerWarnings = next.cliOutput
       .split('\n')
-      .filter((l) => l.includes('In route /headers/exercise'))
+      .filter((l) => l.includes('Route "/headers/exercise'))
 
     if (!isNextDev) {
       expect(headerWarnings).toHaveLength(0)
@@ -176,9 +176,9 @@ describe('dynamic-io', () => {
     expect($('#append-value-x-sentinel').text()).toContain('hello')
     if (isNextDev) {
       expect(headerWarnings[i++]).toContain(
-        "headers().append('x-sentinel', ...)"
+        "`headers().append('x-sentinel', ...)`"
       )
-      expect(headerWarnings[i++]).toContain("headers().get('x-sentinel')")
+      expect(headerWarnings[i++]).toContain("`headers().get('x-sentinel')`")
     }
 
     // headers().delete('...')
@@ -187,23 +187,23 @@ describe('dynamic-io', () => {
     )
     expect($('#delete-value-x-sentinel').text()).toContain('hello')
     if (isNextDev) {
-      expect(headerWarnings[i++]).toContain("headers().delete('x-sentinel')")
-      expect(headerWarnings[i++]).toContain("headers().get('x-sentinel')")
+      expect(headerWarnings[i++]).toContain("`headers().delete('x-sentinel')`")
+      expect(headerWarnings[i++]).toContain("`headers().get('x-sentinel')`")
     }
 
     // headers().get('...')
     expect($('#get-x-sentinel').text()).toContain('hello')
     if (isNextDev) {
-      expect(headerWarnings[i++]).toContain("headers().get('x-sentinel')")
+      expect(headerWarnings[i++]).toContain("`headers().get('x-sentinel')`")
     }
 
     // cookies().has('...')
     expect($('#has-x-sentinel').text()).toContain('true')
     expect($('#has-x-sentinel-foobar').text()).toContain('false')
     if (isNextDev) {
-      expect(headerWarnings[i++]).toContain("headers().has('x-sentinel')")
+      expect(headerWarnings[i++]).toContain("`headers().has('x-sentinel')`")
       expect(headerWarnings[i++]).toContain(
-        "headers().has('x-sentinel-foobar')"
+        "`headers().has('x-sentinel-foobar')`"
       )
     }
 
@@ -213,8 +213,10 @@ describe('dynamic-io', () => {
     )
     expect($('#set-value-x-sentinel').text()).toContain('hello')
     if (isNextDev) {
-      expect(headerWarnings[i++]).toContain("headers().set('x-sentinel', ...)")
-      expect(headerWarnings[i++]).toContain("headers().get('x-sentinel')")
+      expect(headerWarnings[i++]).toContain(
+        "`headers().set('x-sentinel', ...)`"
+      )
+      expect(headerWarnings[i++]).toContain("`headers().get('x-sentinel')`")
     }
 
     // headers().getSetCookie()
@@ -222,7 +224,7 @@ describe('dynamic-io', () => {
     // not response headers and is not mutable.
     expect($('#get-set-cookie').text()).toEqual('[]')
     if (isNextDev) {
-      expect(headerWarnings[i++]).toContain('headers().getSetCookie()')
+      expect(headerWarnings[i++]).toContain('`headers().getSetCookie()`')
     }
 
     // headers().forEach(...)
@@ -232,7 +234,7 @@ describe('dynamic-io', () => {
     )
     expect($('#for-each-x-sentinel-rand').length).toBe(1)
     if (isNextDev) {
-      expect(headerWarnings[i++]).toContain('headers().forEach(...)')
+      expect(headerWarnings[i++]).toContain('`headers().forEach(...)`')
     }
 
     // headers().keys(...)
@@ -240,7 +242,7 @@ describe('dynamic-io', () => {
     expect($('#keys-x-sentinel-path').text()).toContain('x-sentinel-path')
     expect($('#keys-x-sentinel-rand').text()).toContain('x-sentinel-rand')
     if (isNextDev) {
-      expect(headerWarnings[i++]).toContain('headers().keys()')
+      expect(headerWarnings[i++]).toContain('`headers().keys()`')
     }
 
     // headers().values(...)
@@ -250,7 +252,7 @@ describe('dynamic-io', () => {
     )
     expect($('[data-class="values"]').length).toBe(3)
     if (isNextDev) {
-      expect(headerWarnings[i++]).toContain('headers().values()')
+      expect(headerWarnings[i++]).toContain('`headers().values()`')
     }
 
     // headers().entries(...)
@@ -260,7 +262,7 @@ describe('dynamic-io', () => {
     )
     expect($('#entries-x-sentinel-rand').length).toBe(1)
     if (isNextDev) {
-      expect(headerWarnings[i++]).toContain('headers().entries()')
+      expect(headerWarnings[i++]).toContain('`headers().entries()`')
     }
 
     // for...of headers()
@@ -270,7 +272,9 @@ describe('dynamic-io', () => {
     )
     expect($('#for-of-x-sentinel-rand').length).toBe(1)
     if (isNextDev) {
-      expect(headerWarnings[i++]).toContain('headers were iterated over.')
+      expect(headerWarnings[i++]).toContain(
+        '`...headers()` or similar iteration'
+      )
     }
 
     // ...headers()
@@ -280,16 +284,13 @@ describe('dynamic-io', () => {
     )
     expect($('#spread-x-sentinel-rand').length).toBe(1)
     if (isNextDev) {
-      expect(headerWarnings[i++]).toContain('headers were iterated over.')
+      expect(headerWarnings[i++]).toContain(
+        '`...headers()` or similar iteration'
+      )
     }
 
     if (isNextDev) {
-      // TODO currently we double render in RSC during dev to account for
-      // flushing out module scope dynamic errors. This is leading the server logs to be doubled
-      // The client logs aren't doubled because we only send the second render to the client.
-      // We should fix this by not logging in the prospective render. But We will land that fix
-      // later and separately
-      expect(i * 2).toBe(headerWarnings.length)
+      expect(i).toBe(headerWarnings.length)
     }
   })
 })

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.node-crypto.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.node-crypto.test.ts
@@ -13,7 +13,7 @@ describe('dynamic-io', () => {
   }
 
   it('should not have route specific errors', async () => {
-    expect(next.cliOutput).not.toMatch('Error: Route /')
+    expect(next.cliOutput).not.toMatch('Error: Route "/')
     expect(next.cliOutput).not.toMatch('Error occurred prerendering page')
   })
 

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.params.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.params.test.ts
@@ -30,7 +30,7 @@ describe('dynamic-io', () => {
   describe('Async Params', () => {
     if (WITH_PPR) {
       it('should partially prerender pages that await params in a server components', async () => {
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
 
         let $ = await next.render$(
           '/params/semantics/one/build/async/layout-access/server'
@@ -43,7 +43,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
           expect($('#lowcard').text()).toBe('at buildtime')
@@ -64,7 +64,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
           expect($('#lowcard').text()).toBe('at buildtime')
@@ -75,7 +75,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -89,7 +89,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
           expect($('#lowcard').text()).toBe('at buildtime')
@@ -97,7 +97,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at buildtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -111,7 +111,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
           expect($('#lowcard').text()).toBe('at buildtime')
@@ -122,12 +122,12 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       })
 
       it('should partially prerender pages that use params in a client components', async () => {
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
 
         let $ = await next.render$(
           '/params/semantics/one/build/async/layout-access/client'
@@ -139,7 +139,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
           expect($('#lowcard').text()).toBe('at buildtime')
@@ -147,7 +147,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at buildtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -161,7 +161,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
           expect($('#lowcard').text()).toBe('at buildtime')
@@ -172,7 +172,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -185,7 +185,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
           expect($('#lowcard').text()).toBe('at buildtime')
@@ -193,7 +193,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at buildtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -206,7 +206,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
           expect($('#lowcard').text()).toBe('at buildtime')
@@ -217,12 +217,12 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       })
     } else {
       it('should prerender pages that await params in a server component when prebuilt', async () => {
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
         let $ = await next.render$(
           '/params/semantics/one/build/async/layout-access/server'
         )
@@ -233,7 +233,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
           expect($('#lowcard').text()).toBe('at buildtime')
@@ -241,7 +241,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at buildtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -254,7 +254,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
           expect($('#lowcard').text()).toBe('at buildtime')
@@ -262,12 +262,12 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at buildtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       })
 
       it('should prerender pages that `use` params in a client component when prebuilt', async () => {
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
         let $ = await next.render$(
           '/params/semantics/one/build/async/layout-access/client'
         )
@@ -278,7 +278,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
           expect($('#lowcard').text()).toBe('at buildtime')
@@ -286,7 +286,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at buildtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -299,7 +299,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           // TODO at the moment pages receive searchParams which are not know at build time
           // and always dynamic. We have to pessimistically assume they are accessed and thus
@@ -310,12 +310,12 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       })
 
       it('should render pages that await params in a server component when not prebuilt', async () => {
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
         let $ = await next.render$(
           '/params/semantics/one/run/async/layout-access/server'
         )
@@ -326,7 +326,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at runtime')
           expect($('#lowcard').text()).toBe('at runtime')
@@ -334,7 +334,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -347,7 +347,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at runtime')
           expect($('#lowcard').text()).toBe('at runtime')
@@ -355,12 +355,12 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       })
 
       it('should render pages that `use` params in a client component when not prebuilt', async () => {
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
         let $ = await next.render$(
           '/params/semantics/one/run/async/layout-access/client'
         )
@@ -371,7 +371,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at runtime')
           expect($('#lowcard').text()).toBe('at runtime')
@@ -379,7 +379,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -392,7 +392,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at runtime')
           expect($('#lowcard').text()).toBe('at runtime')
@@ -400,13 +400,13 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       })
     }
 
     it('should fully prerender pages that check individual param keys after awaiting params in a server component', async () => {
-      expect(getLines('In route /params')).toEqual([])
+      expect(getLines('Route "/params')).toEqual([])
       let $ = await next.render$(
         '/params/semantics/one/build/async/layout-has/server'
       )
@@ -418,7 +418,7 @@ describe('dynamic-io', () => {
         expect($('#param-has-lowcard').text()).toBe('true')
         expect($('#param-has-highcard').text()).toBe('true')
         expect($('#param-has-foo').text()).toBe('false')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       } else {
         expect($('#layout').text()).toBe('at buildtime')
         expect($('#lowcard').text()).toBe('at buildtime')
@@ -427,7 +427,7 @@ describe('dynamic-io', () => {
         expect($('#param-has-lowcard').text()).toBe('true')
         expect($('#param-has-highcard').text()).toBe('true')
         expect($('#param-has-foo').text()).toBe('false')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       }
 
       $ = await next.render$(
@@ -441,7 +441,7 @@ describe('dynamic-io', () => {
         expect($('#param-has-lowcard').text()).toBe('true')
         expect($('#param-has-highcard').text()).toBe('true')
         expect($('#param-has-foo').text()).toBe('false')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       } else {
         expect($('#layout').text()).toBe('at buildtime')
         expect($('#lowcard').text()).toBe('at buildtime')
@@ -450,7 +450,7 @@ describe('dynamic-io', () => {
         expect($('#param-has-lowcard').text()).toBe('true')
         expect($('#param-has-highcard').text()).toBe('true')
         expect($('#param-has-foo').text()).toBe('false')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       }
 
       $ = await next.render$(
@@ -464,7 +464,7 @@ describe('dynamic-io', () => {
         expect($('#param-has-lowcard').text()).toBe('true')
         expect($('#param-has-highcard').text()).toBe('true')
         expect($('#param-has-foo').text()).toBe('false')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       } else {
         if (WITH_PPR) {
           // With PPR fallbacks the first visit is still partially prerendered
@@ -478,7 +478,7 @@ describe('dynamic-io', () => {
           expect($('#param-has-lowcard').text()).toBe('true')
           expect($('#param-has-highcard').text()).toBe('true')
           expect($('#param-has-foo').text()).toBe('false')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           // without PPR the first visit is dynamic
           expect($('#layout').text()).toBe('at runtime')
@@ -488,7 +488,7 @@ describe('dynamic-io', () => {
           expect($('#param-has-lowcard').text()).toBe('true')
           expect($('#param-has-highcard').text()).toBe('true')
           expect($('#param-has-foo').text()).toBe('false')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       }
 
@@ -501,7 +501,7 @@ describe('dynamic-io', () => {
         expect($('#param-has-lowcard').text()).toBe('true')
         expect($('#param-has-highcard').text()).toBe('true')
         expect($('#param-has-foo').text()).toBe('false')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       } else {
         if (WITH_PPR) {
           // With PPR fallbacks the first visit is still partially prerendered
@@ -515,7 +515,7 @@ describe('dynamic-io', () => {
           expect($('#param-has-lowcard').text()).toBe('true')
           expect($('#param-has-highcard').text()).toBe('true')
           expect($('#param-has-foo').text()).toBe('false')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           // without PPR the first visit is dynamic
           expect($('#layout').text()).toBe('at runtime')
@@ -525,13 +525,13 @@ describe('dynamic-io', () => {
           expect($('#param-has-lowcard').text()).toBe('true')
           expect($('#param-has-highcard').text()).toBe('true')
           expect($('#param-has-foo').text()).toBe('false')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       }
     })
 
     it('should fully prerender pages that check individual param keys after `use`ing params in a client component', async () => {
-      expect(getLines('In route /params')).toEqual([])
+      expect(getLines('Route "/params')).toEqual([])
       let $ = await next.render$(
         '/params/semantics/one/build/async/layout-has/client'
       )
@@ -543,7 +543,7 @@ describe('dynamic-io', () => {
         expect($('#param-has-lowcard').text()).toBe('true')
         expect($('#param-has-highcard').text()).toBe('true')
         expect($('#param-has-foo').text()).toBe('false')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       } else {
         expect($('#layout').text()).toBe('at buildtime')
         expect($('#lowcard').text()).toBe('at buildtime')
@@ -552,7 +552,7 @@ describe('dynamic-io', () => {
         expect($('#param-has-lowcard').text()).toBe('true')
         expect($('#param-has-highcard').text()).toBe('true')
         expect($('#param-has-foo').text()).toBe('false')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       }
 
       $ = await next.render$(
@@ -566,7 +566,7 @@ describe('dynamic-io', () => {
         expect($('#param-has-lowcard').text()).toBe('true')
         expect($('#param-has-highcard').text()).toBe('true')
         expect($('#param-has-foo').text()).toBe('false')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       } else {
         if (WITH_PPR) {
           expect($('#layout').text()).toBe('at buildtime')
@@ -576,7 +576,7 @@ describe('dynamic-io', () => {
           expect($('#param-has-lowcard').text()).toBe('true')
           expect($('#param-has-highcard').text()).toBe('true')
           expect($('#param-has-foo').text()).toBe('false')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           // When dynamicIO is on and PPR is off the search params passed to a client page
           // are enough to mark the whole route as dynamic. This is because we can't know if
@@ -591,7 +591,7 @@ describe('dynamic-io', () => {
           expect($('#param-has-lowcard').text()).toBe('true')
           expect($('#param-has-highcard').text()).toBe('true')
           expect($('#param-has-foo').text()).toBe('false')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       }
 
@@ -606,7 +606,7 @@ describe('dynamic-io', () => {
         expect($('#param-has-lowcard').text()).toBe('true')
         expect($('#param-has-highcard').text()).toBe('true')
         expect($('#param-has-foo').text()).toBe('false')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       } else {
         if (WITH_PPR) {
           // With PPR fallbacks the first visit is still partially prerendered
@@ -620,7 +620,7 @@ describe('dynamic-io', () => {
           expect($('#param-has-lowcard').text()).toBe('true')
           expect($('#param-has-highcard').text()).toBe('true')
           expect($('#param-has-foo').text()).toBe('false')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           // without PPR the first visit is dynamic
           expect($('#layout').text()).toBe('at runtime')
@@ -630,7 +630,7 @@ describe('dynamic-io', () => {
           expect($('#param-has-lowcard').text()).toBe('true')
           expect($('#param-has-highcard').text()).toBe('true')
           expect($('#param-has-foo').text()).toBe('false')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       }
 
@@ -643,7 +643,7 @@ describe('dynamic-io', () => {
         expect($('#param-has-lowcard').text()).toBe('true')
         expect($('#param-has-highcard').text()).toBe('true')
         expect($('#param-has-foo').text()).toBe('false')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       } else {
         if (WITH_PPR) {
           // With PPR fallbacks the first visit is still partially prerendered
@@ -657,7 +657,7 @@ describe('dynamic-io', () => {
           expect($('#param-has-lowcard').text()).toBe('true')
           expect($('#param-has-highcard').text()).toBe('true')
           expect($('#param-has-foo').text()).toBe('false')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           // When dynamicIO is on and PPR is off the search params passed to a client page
           // are enough to mark the whole route as dynamic. This is because we can't know if
@@ -672,14 +672,14 @@ describe('dynamic-io', () => {
           expect($('#param-has-lowcard').text()).toBe('true')
           expect($('#param-has-highcard').text()).toBe('true')
           expect($('#param-has-foo').text()).toBe('false')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       }
     })
 
     if (WITH_PPR) {
       it('should partially prerender pages that spread awaited params in a server component', async () => {
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
         let $ = await next.render$(
           '/params/semantics/one/build/async/layout-spread/server'
         )
@@ -691,7 +691,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
           expect($('#lowcard').text()).toBe('at buildtime')
@@ -700,7 +700,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -714,7 +714,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
           expect($('#lowcard').text()).toBe('at buildtime')
@@ -723,7 +723,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -737,7 +737,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
           expect($('#lowcard').text()).toBe('at buildtime')
@@ -749,7 +749,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -763,7 +763,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
           expect($('#lowcard').text()).toBe('at buildtime')
@@ -775,12 +775,12 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       })
 
       it('should partially prerender pages that spread `use`ed params in a client component', async () => {
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
         let $ = await next.render$(
           '/params/semantics/one/build/async/layout-spread/client'
         )
@@ -792,7 +792,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
           expect($('#lowcard').text()).toBe('at buildtime')
@@ -801,7 +801,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -815,7 +815,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
           expect($('#lowcard').text()).toBe('at buildtime')
@@ -824,7 +824,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -838,7 +838,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
           expect($('#lowcard').text()).toBe('at buildtime')
@@ -850,7 +850,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -864,7 +864,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
           expect($('#lowcard').text()).toBe('at buildtime')
@@ -876,12 +876,12 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       })
     } else {
       it('should prerender pages that spread awaited params in a server component when prebuilt', async () => {
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
         let $ = await next.render$(
           '/params/semantics/one/build/async/layout-spread/server'
         )
@@ -893,7 +893,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
           expect($('#lowcard').text()).toBe('at buildtime')
@@ -902,7 +902,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -916,7 +916,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
           expect($('#lowcard').text()).toBe('at buildtime')
@@ -925,12 +925,12 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       })
 
       it('should prerender pages that spread `use`ed params in a client component when prebuilt', async () => {
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
         let $ = await next.render$(
           '/params/semantics/one/build/async/layout-spread/client'
         )
@@ -942,7 +942,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
           expect($('#lowcard').text()).toBe('at buildtime')
@@ -951,7 +951,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -965,7 +965,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           // TODO at the moment pages receive searchParams which are not know at build time
           // and always dynamic. We have to pessimistically assume they are accessed and thus
@@ -977,7 +977,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       })
 
@@ -1076,7 +1076,7 @@ describe('dynamic-io', () => {
   describe('Synchronous Params access', () => {
     if (WITH_PPR) {
       it('should partially prerender pages that access params synchronously in a server components', async () => {
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
 
         let $ = await next.render$(
           '/params/semantics/one/build/sync/layout-access/server'
@@ -1088,9 +1088,9 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1112,9 +1112,9 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1126,7 +1126,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -1139,9 +1139,9 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1150,7 +1150,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at buildtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -1164,9 +1164,9 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1178,12 +1178,12 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       })
 
       it('should partially prerender pages that access params synchronously in a client components', async () => {
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
 
         let $ = await next.render$(
           '/params/semantics/one/build/sync/layout-access/client'
@@ -1195,9 +1195,9 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1206,7 +1206,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at buildtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -1220,9 +1220,9 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1234,7 +1234,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -1248,9 +1248,9 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1259,7 +1259,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at buildtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -1273,9 +1273,9 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1287,12 +1287,12 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       })
     } else {
       it('should prerender pages that access params synchronously in a server component when prebuilt', async () => {
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
         let $ = await next.render$(
           '/params/semantics/one/build/sync/layout-access/server'
         )
@@ -1303,9 +1303,9 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1314,7 +1314,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at buildtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -1327,9 +1327,9 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1338,12 +1338,12 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at buildtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       })
 
       it('should prerender pages that access params synchronously in a client component when prebuilt', async () => {
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
         let $ = await next.render$(
           '/params/semantics/one/build/sync/layout-access/client'
         )
@@ -1354,9 +1354,9 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1365,7 +1365,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at buildtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -1378,9 +1378,9 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           // TODO at the moment pages receive searchParams which are not know at build time
@@ -1392,12 +1392,12 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('build')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       })
 
       it('should render pages that access params synchronously in a server component when not prebuilt', async () => {
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
         let $ = await next.render$(
           '/params/semantics/one/run/sync/layout-access/server'
         )
@@ -1408,9 +1408,9 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at runtime')
@@ -1419,7 +1419,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -1432,9 +1432,9 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at runtime')
@@ -1443,12 +1443,12 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       })
 
       it('should render pages that access params synchronously in a client component when not prebuilt', async () => {
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
         let $ = await next.render$(
           '/params/semantics/one/run/sync/layout-access/client'
         )
@@ -1459,9 +1459,9 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at runtime')
@@ -1470,7 +1470,7 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -1483,9 +1483,9 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at runtime')
@@ -1494,13 +1494,13 @@ describe('dynamic-io', () => {
           expect($('#page').text()).toBe('at runtime')
           expect($('#param-lowcard').text()).toBe('one')
           expect($('#param-highcard').text()).toBe('run')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       })
     }
 
     it('should fully prerender pages that check individual param keys directly on the params prop in a server component', async () => {
-      expect(getLines('In route /params')).toEqual([])
+      expect(getLines('Route "/params')).toEqual([])
       let $ = await next.render$(
         '/params/semantics/one/build/sync/layout-has/server'
       )
@@ -1512,7 +1512,7 @@ describe('dynamic-io', () => {
         expect($('#param-has-lowcard').text()).toBe('true')
         expect($('#param-has-highcard').text()).toBe('true')
         expect($('#param-has-foo').text()).toBe('false')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       } else {
         expect($('#layout').text()).toBe('at buildtime')
         expect($('#lowcard').text()).toBe('at buildtime')
@@ -1521,7 +1521,7 @@ describe('dynamic-io', () => {
         expect($('#param-has-lowcard').text()).toBe('true')
         expect($('#param-has-highcard').text()).toBe('true')
         expect($('#param-has-foo').text()).toBe('false')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       }
 
       $ = await next.render$('/params/semantics/one/build/sync/page-has/server')
@@ -1533,7 +1533,7 @@ describe('dynamic-io', () => {
         expect($('#param-has-lowcard').text()).toBe('true')
         expect($('#param-has-highcard').text()).toBe('true')
         expect($('#param-has-foo').text()).toBe('false')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       } else {
         expect($('#layout').text()).toBe('at buildtime')
         expect($('#lowcard').text()).toBe('at buildtime')
@@ -1542,7 +1542,7 @@ describe('dynamic-io', () => {
         expect($('#param-has-lowcard').text()).toBe('true')
         expect($('#param-has-highcard').text()).toBe('true')
         expect($('#param-has-foo').text()).toBe('false')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       }
 
       $ = await next.render$('/params/semantics/one/run/sync/layout-has/server')
@@ -1554,7 +1554,7 @@ describe('dynamic-io', () => {
         expect($('#param-has-lowcard').text()).toBe('true')
         expect($('#param-has-highcard').text()).toBe('true')
         expect($('#param-has-foo').text()).toBe('false')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       } else {
         if (WITH_PPR) {
           // With PPR fallbacks the first visit is fully prerendered
@@ -1566,7 +1566,7 @@ describe('dynamic-io', () => {
           expect($('#param-has-lowcard').text()).toBe('true')
           expect($('#param-has-highcard').text()).toBe('true')
           expect($('#param-has-foo').text()).toBe('false')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           // without PPR the first visit is dynamic
           expect($('#layout').text()).toBe('at runtime')
@@ -1576,7 +1576,7 @@ describe('dynamic-io', () => {
           expect($('#param-has-lowcard').text()).toBe('true')
           expect($('#param-has-highcard').text()).toBe('true')
           expect($('#param-has-foo').text()).toBe('false')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       }
 
@@ -1589,7 +1589,7 @@ describe('dynamic-io', () => {
         expect($('#param-has-lowcard').text()).toBe('true')
         expect($('#param-has-highcard').text()).toBe('true')
         expect($('#param-has-foo').text()).toBe('false')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       } else {
         if (WITH_PPR) {
           // With PPR fallbacks the first visit is fully prerendered
@@ -1601,7 +1601,7 @@ describe('dynamic-io', () => {
           expect($('#param-has-lowcard').text()).toBe('true')
           expect($('#param-has-highcard').text()).toBe('true')
           expect($('#param-has-foo').text()).toBe('false')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           // without PPR the first visit is dynamic
           expect($('#layout').text()).toBe('at runtime')
@@ -1611,13 +1611,13 @@ describe('dynamic-io', () => {
           expect($('#param-has-lowcard').text()).toBe('true')
           expect($('#param-has-highcard').text()).toBe('true')
           expect($('#param-has-foo').text()).toBe('false')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       }
     })
 
     it('should fully prerender pages that check individual param keys directly on the params prop in a client component', async () => {
-      expect(getLines('In route /params')).toEqual([])
+      expect(getLines('Route "/params')).toEqual([])
       let $ = await next.render$(
         '/params/semantics/one/build/sync/layout-has/client'
       )
@@ -1629,7 +1629,7 @@ describe('dynamic-io', () => {
         expect($('#param-has-lowcard').text()).toBe('true')
         expect($('#param-has-highcard').text()).toBe('true')
         expect($('#param-has-foo').text()).toBe('false')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       } else {
         expect($('#layout').text()).toBe('at buildtime')
         expect($('#lowcard').text()).toBe('at buildtime')
@@ -1638,7 +1638,7 @@ describe('dynamic-io', () => {
         expect($('#param-has-lowcard').text()).toBe('true')
         expect($('#param-has-highcard').text()).toBe('true')
         expect($('#param-has-foo').text()).toBe('false')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       }
 
       $ = await next.render$('/params/semantics/one/build/sync/page-has/client')
@@ -1650,7 +1650,7 @@ describe('dynamic-io', () => {
         expect($('#param-has-lowcard').text()).toBe('true')
         expect($('#param-has-highcard').text()).toBe('true')
         expect($('#param-has-foo').text()).toBe('false')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       } else {
         if (WITH_PPR) {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1660,7 +1660,7 @@ describe('dynamic-io', () => {
           expect($('#param-has-lowcard').text()).toBe('true')
           expect($('#param-has-highcard').text()).toBe('true')
           expect($('#param-has-foo').text()).toBe('false')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           // When dynamicIO is on and PPR is off the search params passed to a client page
           // are enough to mark the whole route as dynamic. This is because we can't know if
@@ -1675,7 +1675,7 @@ describe('dynamic-io', () => {
           expect($('#param-has-lowcard').text()).toBe('true')
           expect($('#param-has-highcard').text()).toBe('true')
           expect($('#param-has-foo').text()).toBe('false')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       }
 
@@ -1688,7 +1688,7 @@ describe('dynamic-io', () => {
         expect($('#param-has-lowcard').text()).toBe('true')
         expect($('#param-has-highcard').text()).toBe('true')
         expect($('#param-has-foo').text()).toBe('false')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       } else {
         if (WITH_PPR) {
           // With PPR fallbacks the first visit is fully prerendered
@@ -1700,7 +1700,7 @@ describe('dynamic-io', () => {
           expect($('#param-has-lowcard').text()).toBe('true')
           expect($('#param-has-highcard').text()).toBe('true')
           expect($('#param-has-foo').text()).toBe('false')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           // without PPR the first visit is dynamic
           expect($('#layout').text()).toBe('at runtime')
@@ -1710,7 +1710,7 @@ describe('dynamic-io', () => {
           expect($('#param-has-lowcard').text()).toBe('true')
           expect($('#param-has-highcard').text()).toBe('true')
           expect($('#param-has-foo').text()).toBe('false')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       }
 
@@ -1723,7 +1723,7 @@ describe('dynamic-io', () => {
         expect($('#param-has-lowcard').text()).toBe('true')
         expect($('#param-has-highcard').text()).toBe('true')
         expect($('#param-has-foo').text()).toBe('false')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       } else {
         if (WITH_PPR) {
           // With PPR fallbacks the first visit is still fully prerendered
@@ -1737,7 +1737,7 @@ describe('dynamic-io', () => {
           expect($('#param-has-lowcard').text()).toBe('true')
           expect($('#param-has-highcard').text()).toBe('true')
           expect($('#param-has-foo').text()).toBe('false')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         } else {
           // When dynamicIO is on and PPR is off the search params passed to a client page
           // are enough to mark the whole route as dynamic. This is because we can't know if
@@ -1752,14 +1752,14 @@ describe('dynamic-io', () => {
           expect($('#param-has-lowcard').text()).toBe('true')
           expect($('#param-has-highcard').text()).toBe('true')
           expect($('#param-has-foo').text()).toBe('false')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       }
     })
 
     if (WITH_PPR) {
       it('should partially prerender pages that spread params without awaiting first in a server component', async () => {
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
         let $ = await next.render$(
           '/params/semantics/one/build/sync/layout-spread/server'
         )
@@ -1771,8 +1771,8 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('params are being enumerated.'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`...params` or similar expression'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1782,7 +1782,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -1796,8 +1796,8 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('params are being enumerated.'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`...params` or similar expression'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1807,7 +1807,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -1821,8 +1821,8 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('params are being enumerated.'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`...params` or similar expression'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1835,7 +1835,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -1849,8 +1849,8 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('params are being enumerated.'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`...params` or similar expression'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1863,12 +1863,12 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       })
 
       it('should partially prerender pages that spread params without `use`ing them first in a client component', async () => {
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
         let $ = await next.render$(
           '/params/semantics/one/build/sync/layout-spread/client'
         )
@@ -1880,10 +1880,10 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('params are being enumerated.'),
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`...params` or similar expression'),
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1893,7 +1893,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -1907,10 +1907,10 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('params are being enumerated.'),
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`...params` or similar expression'),
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1920,7 +1920,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -1934,10 +1934,10 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('params are being enumerated.'),
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`...params` or similar expression'),
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1950,7 +1950,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -1964,10 +1964,10 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('params are being enumerated.'),
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`...params` or similar expression'),
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -1980,12 +1980,12 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       })
     } else {
       it('should prerender pages that spread params without awaiting first in a server component when prebuilt', async () => {
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
         let $ = await next.render$(
           '/params/semantics/one/build/sync/layout-spread/server'
         )
@@ -1997,8 +1997,8 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('params are being enumerated.'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`...params` or similar expression'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -2008,7 +2008,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -2022,8 +2022,8 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('params are being enumerated.'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`...params` or similar expression'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -2033,12 +2033,12 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       })
 
       it('should prerender pages that spread params without `use`ing first in a client component when prebuilt', async () => {
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
         let $ = await next.render$(
           '/params/semantics/one/build/sync/layout-spread/client'
         )
@@ -2050,10 +2050,10 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('params are being enumerated.'),
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`...params` or similar expression'),
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at buildtime')
@@ -2063,7 +2063,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -2077,10 +2077,10 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('params are being enumerated.'),
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`...params` or similar expression'),
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           // TODO at the moment pages receive searchParams which are not know at build time
@@ -2093,12 +2093,12 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('build')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       })
 
       it('should prerender pages that spread params without awaiting first in a server component when not prebuilt', async () => {
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
         let $ = await next.render$(
           '/params/semantics/one/run/sync/layout-spread/server'
         )
@@ -2110,8 +2110,8 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('params are being enumerated.'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`...params` or similar expression'),
           ])
         } else {
           expect($('#layout').text()).toBe('at runtime')
@@ -2122,7 +2122,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -2136,8 +2136,8 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('params are being enumerated.'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`...params` or similar expression'),
           ])
         } else {
           expect($('#layout').text()).toBe('at runtime')
@@ -2148,12 +2148,12 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       })
 
       it('should prerender pages that spread params without `use`ing first in a client component when not prebuilt', async () => {
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
         let $ = await next.render$(
           '/params/semantics/one/run/sync/layout-spread/client'
         )
@@ -2165,10 +2165,10 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('params are being enumerated.'),
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`...params` or similar expression'),
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at runtime')
@@ -2179,7 +2179,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
 
         $ = await next.render$(
@@ -2193,10 +2193,10 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([
-            expect.stringContaining('params are being enumerated.'),
-            expect.stringContaining('accessed directly with `params.lowcard`'),
-            expect.stringContaining('accessed directly with `params.highcard`'),
+          expect(getLines('Route "/params')).toEqual([
+            expect.stringContaining('`...params` or similar expression'),
+            expect.stringContaining('`params.lowcard`'),
+            expect.stringContaining('`params.highcard`'),
           ])
         } else {
           expect($('#layout').text()).toBe('at runtime')
@@ -2206,7 +2206,7 @@ describe('dynamic-io', () => {
           expect($('#param-copied-lowcard').text()).toBe('one')
           expect($('#param-copied-highcard').text()).toBe('run')
           expect($('#param-key-count').text()).toBe('2')
-          expect(getLines('In route /params')).toEqual([])
+          expect(getLines('Route "/params')).toEqual([])
         }
       })
     }
@@ -2214,7 +2214,7 @@ describe('dynamic-io', () => {
 
   describe('Param Shadowing', () => {
     it('should correctly allow param names like then, value, and status when awaiting params in a server component', async () => {
-      expect(getLines('In route /params')).toEqual([])
+      expect(getLines('Route "/params')).toEqual([])
       let $ = await next.render$(
         '/params/shadowing/foo/bar/baz/qux/async/layout/server'
       )
@@ -2225,7 +2225,7 @@ describe('dynamic-io', () => {
         expect($('#param-then').text()).toBe('bar')
         expect($('#param-value').text()).toBe('baz')
         expect($('#param-status').text()).toBe('qux')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       } else {
         if (WITH_PPR) {
           expect($('#layout').text()).toBe('at buildtime')
@@ -2237,7 +2237,7 @@ describe('dynamic-io', () => {
         expect($('#param-then').text()).toBe('bar')
         expect($('#param-value').text()).toBe('baz')
         expect($('#param-status').text()).toBe('qux')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       }
 
       $ = await next.render$(
@@ -2250,7 +2250,7 @@ describe('dynamic-io', () => {
         expect($('#param-then').text()).toBe('bar')
         expect($('#param-value').text()).toBe('baz')
         expect($('#param-status').text()).toBe('qux')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       } else {
         if (WITH_PPR) {
           expect($('#layout').text()).toBe('at buildtime')
@@ -2262,12 +2262,12 @@ describe('dynamic-io', () => {
         expect($('#param-then').text()).toBe('bar')
         expect($('#param-value').text()).toBe('baz')
         expect($('#param-status').text()).toBe('qux')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       }
     })
 
     it('should correctly allow param names like then, value, and status when `use`ing params in a client component', async () => {
-      expect(getLines('In route /params')).toEqual([])
+      expect(getLines('Route "/params')).toEqual([])
       let $ = await next.render$(
         '/params/shadowing/foo/bar/baz/qux/async/layout/client'
       )
@@ -2278,7 +2278,7 @@ describe('dynamic-io', () => {
         expect($('#param-then').text()).toBe('bar')
         expect($('#param-value').text()).toBe('baz')
         expect($('#param-status').text()).toBe('qux')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       } else {
         if (WITH_PPR) {
           expect($('#layout').text()).toBe('at buildtime')
@@ -2290,7 +2290,7 @@ describe('dynamic-io', () => {
         expect($('#param-then').text()).toBe('bar')
         expect($('#param-value').text()).toBe('baz')
         expect($('#param-status').text()).toBe('qux')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       }
 
       $ = await next.render$(
@@ -2303,7 +2303,7 @@ describe('dynamic-io', () => {
         expect($('#param-then').text()).toBe('bar')
         expect($('#param-value').text()).toBe('baz')
         expect($('#param-status').text()).toBe('qux')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       } else {
         if (WITH_PPR) {
           expect($('#layout').text()).toBe('at buildtime')
@@ -2315,12 +2315,12 @@ describe('dynamic-io', () => {
         expect($('#param-then').text()).toBe('bar')
         expect($('#param-value').text()).toBe('baz')
         expect($('#param-status').text()).toBe('qux')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       }
     })
 
     it('should not allow param names like then and status when accessing params directly in a server component', async () => {
-      expect(getLines('In route /params')).toEqual([])
+      expect(getLines('Route "/params')).toEqual([])
       let $ = await next.render$(
         '/params/shadowing/foo/bar/baz/qux/sync/layout/server'
       )
@@ -2333,12 +2333,10 @@ describe('dynamic-io', () => {
         )
         expect($('#param-value').text()).toBe('baz')
         expect($('#param-status').text()).toBe('undefined')
-        expect(getLines('In route /params')).toEqual([
-          expect.stringContaining(
-            'missing these properties: `then` and `status`.'
-          ),
-          expect.stringContaining('accessed directly with `params.dyn`'),
-          expect.stringContaining('accessed directly with `params.value`'),
+        expect(getLines('Route "/params')).toEqual([
+          expect.stringContaining('`then` and `status`'),
+          expect.stringContaining('`params.dyn`'),
+          expect.stringContaining('`params.value`'),
         ])
       } else {
         if (WITH_PPR) {
@@ -2353,7 +2351,7 @@ describe('dynamic-io', () => {
         )
         expect($('#param-value').text()).toBe('baz')
         expect($('#param-status').text()).toBe('undefined')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       }
 
       $ = await next.render$(
@@ -2368,12 +2366,10 @@ describe('dynamic-io', () => {
         )
         expect($('#param-value').text()).toBe('baz')
         expect($('#param-status').text()).toBe('undefined')
-        expect(getLines('In route /params')).toEqual([
-          expect.stringContaining(
-            'missing these properties: `then` and `status`.'
-          ),
-          expect.stringContaining('accessed directly with `params.dyn`'),
-          expect.stringContaining('accessed directly with `params.value`'),
+        expect(getLines('Route "/params')).toEqual([
+          expect.stringContaining('`then` and `status`'),
+          expect.stringContaining('`params.dyn`'),
+          expect.stringContaining('`params.value`'),
         ])
       } else {
         if (WITH_PPR) {
@@ -2388,12 +2384,12 @@ describe('dynamic-io', () => {
         )
         expect($('#param-value').text()).toBe('baz')
         expect($('#param-status').text()).toBe('undefined')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       }
     })
 
     it('should not allow param names like then and status when accessing params directly in a client component', async () => {
-      expect(getLines('In route /params')).toEqual([])
+      expect(getLines('Route "/params')).toEqual([])
       let $ = await next.render$(
         '/params/shadowing/foo/bar/baz/qux/sync/layout/client'
       )
@@ -2406,14 +2402,12 @@ describe('dynamic-io', () => {
         )
         expect($('#param-value').text()).toBe('baz')
         expect($('#param-status').text()).toBe('undefined')
-        expect(getLines('In route /params')).toEqual([
-          expect.stringContaining(
-            'missing these properties: `then` and `status`.'
-          ),
-          expect.stringContaining('accessed directly with `params.dyn`'),
-          expect.stringContaining('accessed directly with `params.value`'),
-          expect.stringContaining('accessed directly with `params.dyn`'),
-          expect.stringContaining('accessed directly with `params.value`'),
+        expect(getLines('Route "/params')).toEqual([
+          expect.stringContaining('`then` and `status`'),
+          expect.stringContaining('`params.dyn`'),
+          expect.stringContaining('`params.value`'),
+          expect.stringContaining('`params.dyn`'),
+          expect.stringContaining('`params.value`'),
         ])
       } else {
         if (WITH_PPR) {
@@ -2428,7 +2422,7 @@ describe('dynamic-io', () => {
         )
         expect($('#param-value').text()).toBe('baz')
         expect($('#param-status').text()).toBe('undefined')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       }
 
       $ = await next.render$(
@@ -2443,14 +2437,12 @@ describe('dynamic-io', () => {
         )
         expect($('#param-value').text()).toBe('baz')
         expect($('#param-status').text()).toBe('undefined')
-        expect(getLines('In route /params')).toEqual([
-          expect.stringContaining(
-            'missing these properties: `then` and `status`.'
-          ),
-          expect.stringContaining('accessed directly with `params.dyn`'),
-          expect.stringContaining('accessed directly with `params.value`'),
-          expect.stringContaining('accessed directly with `params.dyn`'),
-          expect.stringContaining('accessed directly with `params.value`'),
+        expect(getLines('Route "/params')).toEqual([
+          expect.stringContaining('`then` and `status`'),
+          expect.stringContaining('`params.dyn`'),
+          expect.stringContaining('`params.value`'),
+          expect.stringContaining('`params.dyn`'),
+          expect.stringContaining('`params.value`'),
         ])
       } else {
         if (WITH_PPR) {
@@ -2465,7 +2457,7 @@ describe('dynamic-io', () => {
         )
         expect($('#param-value').text()).toBe('baz')
         expect($('#param-status').text()).toBe('undefined')
-        expect(getLines('In route /params')).toEqual([])
+        expect(getLines('Route "/params')).toEqual([])
       }
     })
   })

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.random.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.random.test.ts
@@ -13,7 +13,7 @@ describe('dynamic-io', () => {
   }
 
   it('should not have route specific errors', async () => {
-    expect(next.cliOutput).not.toMatch('Error: Route /')
+    expect(next.cliOutput).not.toMatch('Error: Route "/')
     expect(next.cliOutput).not.toMatch('Error occurred prerendering page')
   })
 

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.routes.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.routes.test.ts
@@ -247,7 +247,7 @@ describe('dynamic-io', () => {
   })
 
   it('should prerender GET route handlers when accessing awaited params', async () => {
-    expect(getLines('In route /routes/[dyn]')).toEqual([])
+    expect(getLines('Route "/routes/[dyn]')).toEqual([])
     let str = await next.render('/routes/1/async', {})
     let json = JSON.parse(str)
 
@@ -255,12 +255,12 @@ describe('dynamic-io', () => {
       expect(json.value).toEqual('at runtime')
       expect(json.type).toBe('dynamic params')
       expect(json.param).toBe('1')
-      expect(getLines('In route /routes/[dyn]')).toEqual([])
+      expect(getLines('Route "/routes/[dyn]')).toEqual([])
     } else {
       expect(json.value).toEqual('at buildtime')
       expect(json.type).toBe('dynamic params')
       expect(json.param).toBe('1')
-      expect(getLines('In route /routes/[dyn]')).toEqual([])
+      expect(getLines('Route "/routes/[dyn]')).toEqual([])
     }
 
     str = await next.render('/routes/2/async', {})
@@ -270,17 +270,17 @@ describe('dynamic-io', () => {
       expect(json.value).toEqual('at runtime')
       expect(json.type).toBe('dynamic params')
       expect(json.param).toBe('2')
-      expect(getLines('In route /routes/[dyn]')).toEqual([])
+      expect(getLines('Route "/routes/[dyn]')).toEqual([])
     } else {
       expect(json.value).toEqual('at runtime')
       expect(json.type).toBe('dynamic params')
       expect(json.param).toBe('2')
-      expect(getLines('In route /routes/[dyn]')).toEqual([])
+      expect(getLines('Route "/routes/[dyn]')).toEqual([])
     }
   })
 
   it('should prerender GET route handlers when accessing params without awaiting first', async () => {
-    expect(getLines('In route /routes/[dyn]')).toEqual([])
+    expect(getLines('Route "/routes/[dyn]')).toEqual([])
     let str = await next.render('/routes/1/sync', {})
     let json = JSON.parse(str)
 
@@ -288,16 +288,14 @@ describe('dynamic-io', () => {
       expect(json.value).toEqual('at runtime')
       expect(json.type).toBe('dynamic params')
       expect(json.param).toBe('1')
-      expect(getLines('In route /routes/[dyn]')).toEqual([
-        expect.stringContaining(
-          'a param property was accessed directly with `params.dyn`.'
-        ),
+      expect(getLines('Route "/routes/[dyn]')).toEqual([
+        expect.stringContaining('`params.dyn`.'),
       ])
     } else {
       expect(json.value).toEqual('at buildtime')
       expect(json.type).toBe('dynamic params')
       expect(json.param).toBe('1')
-      expect(getLines('In route /routes/[dyn]')).toEqual([])
+      expect(getLines('Route "/routes/[dyn]')).toEqual([])
     }
 
     str = await next.render('/routes/2/sync', {})
@@ -307,16 +305,14 @@ describe('dynamic-io', () => {
       expect(json.value).toEqual('at runtime')
       expect(json.type).toBe('dynamic params')
       expect(json.param).toBe('2')
-      expect(getLines('In route /routes/[dyn]')).toEqual([
-        expect.stringContaining(
-          'a param property was accessed directly with `params.dyn`.'
-        ),
+      expect(getLines('Route "/routes/[dyn]')).toEqual([
+        expect.stringContaining('`params.dyn`.'),
       ])
     } else {
       expect(json.value).toEqual('at runtime')
       expect(json.type).toBe('dynamic params')
       expect(json.param).toBe('2')
-      expect(getLines('In route /routes/[dyn]')).toEqual([])
+      expect(getLines('Route "/routes/[dyn]')).toEqual([])
     }
   })
 })

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.search.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.search.test.ts
@@ -124,6 +124,9 @@ describe('dynamic-io', () => {
           expect.stringContaining(
             'searchParam property was accessed directly with `searchParams.sentinel`'
           ),
+          expect.stringContaining(
+            'Route "/search/sync/server/access" used `searchParams.sentinel`. `search` is a Promise and must be awaited'
+          ),
         ])
       } else {
         expect(searchWarnings).toHaveLength(0)

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.search.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.search.test.ts
@@ -115,18 +115,13 @@ describe('dynamic-io', () => {
   if (WITH_PPR) {
     it('should partially prerender pages that access a searchParam property synchronously in a server component', async () => {
       let $ = await next.render$('/search/sync/server/access?sentinel=hello')
-      let searchWarnings = getLines('In route /search')
+      let searchWarnings = getLines('Route "/search')
       if (isNextDev) {
         expect($('#layout').text()).toBe('at runtime')
         expect($('#value').text()).toBe('hello')
         expect($('#page').text()).toBe('at runtime')
         expect(searchWarnings).toEqual([
-          expect.stringContaining(
-            'searchParam property was accessed directly with `searchParams.sentinel`'
-          ),
-          expect.stringContaining(
-            'Route "/search/sync/server/access" used `searchParams.sentinel`. `search` is a Promise and must be awaited'
-          ),
+          expect.stringContaining('`searchParams.sentinel`'),
         ])
       } else {
         expect(searchWarnings).toHaveLength(0)
@@ -142,15 +137,13 @@ describe('dynamic-io', () => {
 
     it('should partially prerender pages that access a searchParam property synchronously in a client component', async () => {
       let $ = await next.render$('/search/sync/client/access?sentinel=hello')
-      let searchWarnings = getLines('In route /search')
+      let searchWarnings = getLines('Route "/search')
       if (isNextDev) {
         expect($('#layout').text()).toBe('at runtime')
         expect($('#value').text()).toBe('hello')
         expect($('#page').text()).toBe('at runtime')
         expect(searchWarnings).toEqual([
-          expect.stringContaining(
-            'searchParam property was accessed directly with `searchParams.sentinel`'
-          ),
+          expect.stringContaining('`searchParams.sentinel`'),
         ])
       } else {
         expect(searchWarnings).toHaveLength(0)
@@ -164,7 +157,7 @@ describe('dynamic-io', () => {
 
     it('should partially prerender pages that checks for the existence of a searchParam property synchronously in a server component', async () => {
       let $ = await next.render$('/search/sync/server/has?sentinel=hello')
-      let searchWarnings = getLines('In route /search')
+      let searchWarnings = getLines('Route "/search')
       if (isNextDev) {
         expect($('#layout').text()).toBe('at runtime')
         expect($('#has-sentinel').text()).toBe('true')
@@ -193,7 +186,7 @@ describe('dynamic-io', () => {
 
     it('should partially prerender pages that checks for the existence of a searchParam property synchronously in a client component', async () => {
       let $ = await next.render$('/search/sync/client/has?sentinel=hello')
-      let searchWarnings = getLines('In route /search')
+      let searchWarnings = getLines('Route "/search')
       if (isNextDev) {
         expect($('#layout').text()).toBe('at runtime')
         expect($('#has-sentinel').text()).toBe('true')
@@ -222,7 +215,7 @@ describe('dynamic-io', () => {
       let $ = await next.render$(
         '/search/sync/server/spread?sentinel=hello&foo=foo&then=bar&value=baz'
       )
-      let searchWarnings = getLines('In route /search')
+      let searchWarnings = getLines('Route "/search')
       if (isNextDev) {
         expect($('#layout').text()).toBe('at runtime')
         expect($('[data-value]').length).toBe(3)
@@ -232,7 +225,7 @@ describe('dynamic-io', () => {
         expect($('#page').text()).toBe('at runtime')
         expect(searchWarnings).toEqual([
           expect.stringContaining(
-            'searchParams are being enumerated incompletely'
+            'conflict with builtin or well-known property names: `then`'
           ),
         ])
       } else {
@@ -254,7 +247,7 @@ describe('dynamic-io', () => {
       let $ = await next.render$(
         '/search/sync/client/spread?sentinel=hello&foo=foo&then=bar&value=baz'
       )
-      let searchWarnings = getLines('In route /search')
+      let searchWarnings = getLines('Route "/search')
       if (isNextDev) {
         expect($('#layout').text()).toBe('at runtime')
         expect($('[data-value]').length).toBe(3)
@@ -264,15 +257,11 @@ describe('dynamic-io', () => {
         expect($('#page').text()).toBe('at runtime')
         expect(searchWarnings).toEqual([
           expect.stringContaining(
-            'searchParams are being enumerated incompletely'
+            'conflict with builtin or well-known property names: `then`'
           ),
-          expect.stringContaining(
-            'accessed directly with `searchParams.sentinel`'
-          ),
-          expect.stringContaining('accessed directly with `searchParams.foo`'),
-          expect.stringContaining(
-            'accessed directly with `searchParams.value`'
-          ),
+          expect.stringContaining('`searchParams.sentinel`'),
+          expect.stringContaining('`searchParams.foo`'),
+          expect.stringContaining('`searchParams.value`'),
         ])
       } else {
         expect(searchWarnings).toHaveLength(0)
@@ -289,15 +278,13 @@ describe('dynamic-io', () => {
   } else {
     it('should not prerender a page that accesses a searchParam property synchronously in a server component', async () => {
       let $ = await next.render$('/search/sync/server/access?sentinel=hello')
-      let searchWarnings = getLines('In route /search')
+      let searchWarnings = getLines('Route "/search')
       if (isNextDev) {
         expect($('#layout').text()).toBe('at runtime')
         expect($('#value').text()).toBe('hello')
         expect($('#page').text()).toBe('at runtime')
         expect(searchWarnings).toEqual([
-          expect.stringContaining(
-            'searchParam property was accessed directly with `searchParams.sentinel`'
-          ),
+          expect.stringContaining('`searchParams.sentinel`'),
         ])
       } else {
         expect(searchWarnings).toHaveLength(0)
@@ -309,15 +296,13 @@ describe('dynamic-io', () => {
 
     it('should not prerender a page that accesses a searchParam property synchronously in a client component', async () => {
       let $ = await next.render$('/search/sync/client/access?sentinel=hello')
-      let searchWarnings = getLines('In route /search')
+      let searchWarnings = getLines('Route "/search')
       if (isNextDev) {
         expect($('#layout').text()).toBe('at runtime')
         expect($('#value').text()).toBe('hello')
         expect($('#page').text()).toBe('at runtime')
         expect(searchWarnings).toEqual([
-          expect.stringContaining(
-            'searchParam property was accessed directly with `searchParams.sentinel`'
-          ),
+          expect.stringContaining('`searchParams.sentinel`'),
         ])
       } else {
         expect(searchWarnings).toHaveLength(0)
@@ -329,7 +314,7 @@ describe('dynamic-io', () => {
 
     it('should not prerender a page that checks for the existence of a searchParam property synchronously in a server component', async () => {
       let $ = await next.render$('/search/sync/server/has?sentinel=hello')
-      let searchWarnings = getLines('In route /search')
+      let searchWarnings = getLines('Route "/search')
       if (isNextDev) {
         expect($('#layout').text()).toBe('at runtime')
         expect($('#has-sentinel').text()).toBe('true')
@@ -337,10 +322,10 @@ describe('dynamic-io', () => {
         expect($('#page').text()).toBe('at runtime')
         expect(searchWarnings).toEqual([
           expect.stringContaining(
-            '`Reflect.has(searchParams, "sentinel")`, `"sentinel" in searchParams`, or similar.'
+            '`Reflect.has(searchParams, "sentinel")`, `"sentinel" in searchParams`, or similar'
           ),
           expect.stringContaining(
-            'Reflect.has(searchParams, "foo")`, `"foo" in searchParams`, or similar.'
+            '`Reflect.has(searchParams, "foo")`, `"foo" in searchParams`, or similar'
           ),
         ])
       } else {
@@ -354,7 +339,7 @@ describe('dynamic-io', () => {
 
     it('should not prerender a page that checks for the existence of a searchParam property synchronously in a client component', async () => {
       let $ = await next.render$('/search/sync/client/has?sentinel=hello')
-      let searchWarnings = getLines('In route /search')
+      let searchWarnings = getLines('Route "/search')
       if (isNextDev) {
         expect($('#layout').text()).toBe('at runtime')
         expect($('#has-sentinel').text()).toBe('true')
@@ -362,10 +347,10 @@ describe('dynamic-io', () => {
         expect($('#page').text()).toBe('at runtime')
         expect(searchWarnings).toEqual([
           expect.stringContaining(
-            '`Reflect.has(searchParams, "sentinel")`, `"sentinel" in searchParams`, or similar.'
+            '`Reflect.has(searchParams, "sentinel")`, `"sentinel" in searchParams`, or similar'
           ),
           expect.stringContaining(
-            'Reflect.has(searchParams, "foo")`, `"foo" in searchParams`, or similar.'
+            '`Reflect.has(searchParams, "foo")`, `"foo" in searchParams`, or similar'
           ),
         ])
       } else {
@@ -381,7 +366,7 @@ describe('dynamic-io', () => {
       let $ = await next.render$(
         '/search/sync/server/spread?sentinel=hello&foo=foo&then=bar&value=baz'
       )
-      let searchWarnings = getLines('In route /search')
+      let searchWarnings = getLines('Route "/search')
       if (isNextDev) {
         expect($('#layout').text()).toBe('at runtime')
         expect($('[data-value]').length).toBe(3)
@@ -391,7 +376,7 @@ describe('dynamic-io', () => {
         expect($('#page').text()).toBe('at runtime')
         expect(searchWarnings).toEqual([
           expect.stringContaining(
-            'searchParams are being enumerated incompletely'
+            'conflict with builtin or well-known property names: `then`'
           ),
         ])
       } else {
@@ -409,7 +394,7 @@ describe('dynamic-io', () => {
       let $ = await next.render$(
         '/search/sync/client/spread?sentinel=hello&foo=foo&then=bar&value=baz'
       )
-      let searchWarnings = getLines('In route /search')
+      let searchWarnings = getLines('Route "/search')
       if (isNextDev) {
         expect($('#layout').text()).toBe('at runtime')
         expect($('[data-value]').length).toBe(3)
@@ -419,15 +404,11 @@ describe('dynamic-io', () => {
         expect($('#page').text()).toBe('at runtime')
         expect(searchWarnings).toEqual([
           expect.stringContaining(
-            'searchParams are being enumerated incompletely'
+            'conflict with builtin or well-known property names: `then`'
           ),
-          expect.stringContaining(
-            'accessed directly with `searchParams.sentinel`'
-          ),
-          expect.stringContaining('accessed directly with `searchParams.foo`'),
-          expect.stringContaining(
-            'accessed directly with `searchParams.value`'
-          ),
+          expect.stringContaining('`searchParams.sentinel`'),
+          expect.stringContaining('`searchParams.foo`'),
+          expect.stringContaining('`searchParams.value`'),
         ])
       } else {
         expect(searchWarnings).toHaveLength(0)

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.test.ts
@@ -16,7 +16,7 @@ describe('dynamic-io', () => {
   const itSkipTurbopack = isTurbopack ? it.skip : it
 
   it('should not have route specific errors', async () => {
-    expect(next.cliOutput).not.toMatch('Error: Route /')
+    expect(next.cliOutput).not.toMatch('Error: Route "/')
     expect(next.cliOutput).not.toMatch('Error occurred prerendering page')
   })
 

--- a/test/e2e/app-dir/dynamic-io/dynamic-io.web-crypto.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.web-crypto.test.ts
@@ -13,7 +13,7 @@ describe('dynamic-io', () => {
   }
 
   it('should not have route specific errors', async () => {
-    expect(next.cliOutput).not.toMatch('Error: Route /')
+    expect(next.cliOutput).not.toMatch('Error: Route "/')
     expect(next.cliOutput).not.toMatch('Error occurred prerendering page')
   })
 

--- a/test/e2e/app-dir/ppr/ppr.test.ts
+++ b/test/e2e/app-dir/ppr/ppr.test.ts
@@ -59,7 +59,10 @@ describe('ppr', () => {
     if (isNextDev) {
       it('should have the dynamic part', async () => {
         let $ = await next.render$(pathname)
-        let dynamic = $('#container > #dynamic > #state')
+        // asserting this flushes in a single pass in dev is not reliable
+        // so we just assert that the nodes are somewhere in the document
+        // even if they aren't in position
+        let dynamic = $('#dynamic > #state')
 
         expect(dynamic.length).toBe(1)
         expect(dynamic.text()).toBe('Not Signed In')
@@ -73,7 +76,7 @@ describe('ppr', () => {
             },
           }
         )
-        dynamic = $('#container > #dynamic > #state')
+        dynamic = $('#dynamic > #state')
         expect(dynamic.length).toBe(1)
         expect(dynamic.text()).toBe('Signed In')
       })


### PR DESCRIPTION
Previously our rules for allowed dynamic were only enforced in builds. This is not tenable for serious adoption because you can't spend all day working on your site and then find out its broken when you build / deploy.

To address this I've added a simulated prerendering during dev that should enforce the same rules for rendered routes in dev that would apply during a build. There is no way to avoid doing additional work to implement this feature because we need the abort mechanism of SSR to actually find the dynamic holes that should be disallowed. I was able to avoid completely duplicating the RSC render however by capturing the stream chunks available before the first task completes and stashing them away as a simulated halted RSC payload.

I did have to introduce prospective renders to the RSC render and the validating SSR render however to work around issues of lazy module initialization where functions like Math.random and new Date() in module scope would incorrectly trigger dynamic validation when you would not expect them to.