### PR TITLE
Remove double decoding of encrypted closures 

### DIFF
--- a/packages/next/src/server/app-render/encryption.ts
+++ b/packages/next/src/server/app-render/encryption.ts
@@ -2,15 +2,9 @@
 import 'server-only'
 
 /* eslint-disable import/no-extraneous-dependencies */
-import {
-  renderToReadableStream,
-  decodeReply,
-} from 'react-server-dom-webpack/server.edge'
+import { renderToReadableStream } from 'react-server-dom-webpack/server.edge'
 /* eslint-disable import/no-extraneous-dependencies */
-import {
-  createFromReadableStream,
-  encodeReply,
-} from 'react-server-dom-webpack/client.edge'
+import { createFromReadableStream } from 'react-server-dom-webpack/client.edge'
 
 import { streamToString } from '../stream-utils/node-web-streams-helper'
 import {
@@ -118,17 +112,10 @@ export async function decryptActionBoundArgs(
         moduleMap: isEdgeRuntime
           ? clientReferenceManifestSingleton.edgeRscModuleMapping
           : clientReferenceManifestSingleton.rscModuleMapping,
-        serverModuleMap: null, // getServerModuleMap()
+        serverModuleMap: getServerModuleMap(),
       },
     }
   )
 
-  // This extra step ensures that the server references are recovered.
-  const serverModuleMap = getServerModuleMap()
-  const transformed = await decodeReply(
-    await encodeReply(deserialized),
-    serverModuleMap
-  )
-
-  return transformed
+  return deserialized
 }

--- a/test/e2e/app-dir/actions/app/encryption/page.js
+++ b/test/e2e/app-dir/actions/app/encryption/page.js
@@ -1,12 +1,19 @@
+async function otherAction() {
+  'use server'
+  return 'hi'
+}
 // Test top-level encryption (happens during the module load phase)
-function wrapAction(value) {
+function wrapAction(value, action) {
   return async function () {
     'use server'
-    console.log(value)
+    const v = await action()
+    if (v === 'hi') {
+      console.log(value)
+    }
   }
 }
 
-const action = wrapAction('some-module-level-encryption-value')
+const action = wrapAction('some-module-level-encryption-value', otherAction)
 
 // Test runtime encryption (happens during the rendering phase)
 export default function Page() {
@@ -21,7 +28,9 @@ export default function Page() {
         return 'success'
       }}
     >
-      <button type="submit">Submit</button>
+      <button type="submit" id="submit">
+        Submit
+      </button>
     </form>
   )
 }


### PR DESCRIPTION
Stacked on #71528 

Thanks to the serverModuleMap option added in https://github.com/facebook/react/pull/31300 we don't need to double decode anymore to load server references when parsing the payload.

