### PR TITLE
Simplify Server Action entrypoint loader

### DIFF
--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -149,6 +149,7 @@ export function getRSCModuleInformation(
   return {
     type,
     actions,
+    actionIds: parsedActionsMeta,
     clientRefs,
     clientEntryType,
     isClientRef,

--- a/packages/next/src/build/webpack/loaders/next-flight-action-entry-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-action-entry-loader.ts
@@ -30,16 +30,11 @@ ${individualActions
   .join('\n')}
 }
 
-async function endpoint(id, ...args) {
-  const action = await actions[id]()
-  return action.apply(null, args)
-}
-
 // Using CJS to avoid this to be tree-shaken away due to unused exports.
 module.exports = {
 ${individualActions
   .map(([id]) => {
-    return `  '${id}': endpoint.bind(null, '${id}'),`
+    return `  '${id}': actions['${id}'](),`
   })
   .join('\n')}
 }

--- a/packages/next/src/build/webpack/loaders/next-flight-action-entry-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-action-entry-loader.ts
@@ -22,12 +22,15 @@ function nextFlightActionEntryLoader(this: any) {
   return `
 ${individualActions
   .map(([_, path]) => {
+    // This import ensures that the module is always bundled even if there's no
+    // explicit import in the codebase, to avoid the action being DCE'd.
     return `import(/* webpackMode: "eager" */ ${JSON.stringify(path)});`
   })
   .join('\n')}
 
 ${individualActions
   .map(([id, path, name]) => {
+    // Re-export the same functions from the original module path as action IDs.
     return `export { ${name} as "${id}" } from ${JSON.stringify(path)}`
   })
   .join('\n')}

--- a/packages/next/src/build/webpack/loaders/next-flight-action-entry-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-action-entry-loader.ts
@@ -20,24 +20,17 @@ function nextFlightActionEntryLoader(this: any) {
     .flat()
 
   return `
-const actions = {
+${individualActions
+  .map(([_, path]) => {
+    return `import(/* webpackMode: "eager" */ ${JSON.stringify(path)});`
+  })
+  .join('\n')}
+
 ${individualActions
   .map(([id, path, name]) => {
-    return `'${id}': () => import(/* webpackMode: "eager" */ ${JSON.stringify(
-      path
-    )}).then(mod => mod[${JSON.stringify(name)}]),`
+    return `export { ${name} as "${id}" } from ${JSON.stringify(path)}`
   })
   .join('\n')}
-}
-
-// Using CJS to avoid this to be tree-shaken away due to unused exports.
-module.exports = {
-${individualActions
-  .map(([id]) => {
-    return `  '${id}': actions['${id}'](),`
-  })
-  .join('\n')}
-}
 `
 }
 

--- a/packages/next/src/build/webpack/loaders/utils.ts
+++ b/packages/next/src/build/webpack/loaders/utils.ts
@@ -51,6 +51,13 @@ export function getActionsFromBuildInfo(mod: {
   return mod.buildInfo?.rsc?.actions
 }
 
+export function getActionIdMappingsFromBuildInfo(mod: {
+  resource: string
+  buildInfo?: any
+}): undefined | Record<string, string> {
+  return mod.buildInfo?.rsc?.actionIds
+}
+
 export function generateActionId(
   hashSalt: string,
   filePath: string,

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -870,7 +870,7 @@ export async function handleAction({
         }
       }
 
-      const actionHandler = (
+      const actionHandler = await (
         await ComponentMod.__next_app__.require(actionModId)
       )[
         // `actionId` must exist if we got here, as otherwise we would have thrown an error above

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -870,7 +870,7 @@ export async function handleAction({
         }
       }
 
-      const actionHandler = await (
+      const actionHandler = (
         await ComponentMod.__next_app__.require(actionModId)
       )[
         // `actionId` must exist if we got here, as otherwise we would have thrown an error above

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -828,6 +828,21 @@ describe('app-dir action handling', () => {
     ).toBe(true)
   })
 
+  it('should keep action instances identical', async () => {
+    const logs: string[] = []
+    next.on('stdout', (log) => {
+      logs.push(log)
+    })
+
+    const browser = await next.browser('/identity')
+
+    await browser.elementByCss('button').click()
+
+    await retry(() => {
+      expect(logs.join('')).toContain('result: true')
+    })
+  })
+
   it.each(['node', 'edge'])(
     'should forward action request to a worker that contains the action handler (%s)',
     async (runtime) => {

--- a/test/e2e/app-dir/actions/app/identity/client.js
+++ b/test/e2e/app-dir/actions/app/identity/client.js
@@ -1,0 +1,13 @@
+'use client'
+
+export function Client({ foo, b }) {
+  return (
+    <button
+      onClick={() => {
+        foo(b)
+      }}
+    >
+      Trigger
+    </button>
+  )
+}

--- a/test/e2e/app-dir/actions/app/identity/page.js
+++ b/test/e2e/app-dir/actions/app/identity/page.js
@@ -1,0 +1,14 @@
+import { Client } from './client'
+
+export default async function Page() {
+  async function b() {
+    'use server'
+  }
+
+  async function foo(a) {
+    'use server'
+    console.log('result:', a === b)
+  }
+
+  return <Client foo={foo} b={b} />
+}


### PR DESCRIPTION
This PR removes the extra wrapper functions and `.bind()` calls from the entrypoint loader, but only re-exporting them from the original module. This ensures that same action instance will always remain identical.