### PR TITLE
feat(turbopack): Add `__turbopack_original__` while tree shaking

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -111,7 +111,7 @@ pub(crate) struct ItemData {
     /// [ItemId].
     ///
     /// Used to optimize `ImportBinding`.
-    pub binding_source: Option<Atom>,
+    pub binding_source: Option<(Atom, ImportSpecifier)>,
 }
 
 impl fmt::Debug for ItemData {
@@ -1045,7 +1045,7 @@ impl DepGraph {
                                     specifiers: vec![s.clone()],
                                     ..item.clone()
                                 })),
-                                binding_source: Some(item.src.value.clone()),
+                                binding_source: Some((item.src.value.clone(), s.clone())),
                                 ..Default::default()
                             },
                         );

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -7,7 +7,6 @@ use petgraph::{
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::{
-    atoms::Atom,
     common::{comments::Comments, util::take::Take, Spanned, SyntaxContext, DUMMY_SP},
     ecma::{
         ast::{
@@ -111,7 +110,7 @@ pub(crate) struct ItemData {
     /// [ItemId].
     ///
     /// Used to optimize `ImportBinding`.
-    pub binding_source: Option<(Atom, ImportSpecifier)>,
+    pub binding_source: Option<(Str, ImportSpecifier)>,
 }
 
 impl fmt::Debug for ItemData {
@@ -512,7 +511,7 @@ impl DepGraph {
                         // Preserve the order of the side effects by importing the
                         // side-effect-import fragment first.
 
-                        if let Some(import_dep) = importer.get(module_specifier) {
+                        if let Some(import_dep) = importer.get(&module_specifier.value) {
                             if *import_dep != ix as u32 {
                                 part_deps
                                     .entry(ix as u32)
@@ -543,11 +542,7 @@ impl DepGraph {
                             .push(ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
                                 span: DUMMY_SP,
                                 specifiers,
-                                src: Box::new(Str {
-                                    span: DUMMY_SP,
-                                    value: module_specifier.clone(),
-                                    raw: None,
-                                }),
+                                src: Box::new(module_specifier.clone()),
                                 type_only: false,
                                 with: None,
                                 phase: Default::default(),
@@ -1105,7 +1100,7 @@ impl DepGraph {
                                     specifiers: vec![s.clone()],
                                     ..item.clone()
                                 })),
-                                binding_source: Some((item.src.value.clone(), s.clone())),
+                                binding_source: Some((*item.src.clone(), s.clone())),
                                 ..Default::default()
                             },
                         );

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -7,6 +7,7 @@ use petgraph::{
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::{
+    atoms::Atom,
     common::{comments::Comments, util::take::Take, Spanned, SyntaxContext, DUMMY_SP},
     ecma::{
         ast::{
@@ -105,6 +106,12 @@ pub(crate) struct ItemData {
     pub content: ModuleItem,
 
     pub export: Option<JsWord>,
+
+    /// This value denotes the module specifier of the [ImportDecl] that declares this
+    /// [ItemId].
+    ///
+    /// Used to optimize `ImportBinding`.
+    pub binding_source: Option<Atom>,
 }
 
 impl fmt::Debug for ItemData {
@@ -136,6 +143,7 @@ impl Default for ItemData {
             content: ModuleItem::dummy(),
             pure: Default::default(),
             export: Default::default(),
+            binding_source: Default::default(),
         }
     }
 }
@@ -1037,6 +1045,7 @@ impl DepGraph {
                                     specifiers: vec![s.clone()],
                                     ..item.clone()
                                 })),
+                                binding_source: Some(item.src.value.clone()),
                                 ..Default::default()
                             },
                         );

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -498,6 +498,10 @@ impl DepGraph {
 
                 let dep_item_ids = groups.graph_ix.get_index(dep as usize).unwrap();
 
+                // Optimization & workaround for `ImportBinding` fragments.
+                // Instead of importing the import binding fragment, we import the original module.
+                // In this way, we can preserve the import statement so that the other code analysis
+                // can work.
                 if dep_item_ids.len() == 1 {
                     let dep_item_id = &dep_item_ids[0];
                     let dep_item_data = data.get(dep_item_id).unwrap();

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/1/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/1/output.md
@@ -593,9 +593,10 @@ foobarCopy += "Unused";
 import { d as foobar } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -7
 };
-import { e as upper } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -6
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
 };
+import { upper } from "module";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
@@ -841,9 +842,10 @@ foobarCopy += "Unused";
 import { d as foobar } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -7
 };
-import { e as upper } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -6
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
 };
+import { upper } from "module";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/1/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/1/output.md
@@ -593,10 +593,10 @@ foobarCopy += "Unused";
 import { d as foobar } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -7
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+import { e as upper } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -6,
+    __turbopack_original__: "module"
 };
-import { upper } from "module";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
@@ -842,10 +842,10 @@ foobarCopy += "Unused";
 import { d as foobar } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -7
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+import { e as upper } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -6,
+    __turbopack_original__: "module"
 };
-import { upper } from "module";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/2/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/2/output.md
@@ -632,9 +632,10 @@ foobarCopy += "Unused";
 import { d as foobar } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -8
 };
-import { f as upper } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -7
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
+import { upper } from "module";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
@@ -888,9 +889,10 @@ foobarCopy += "Unused";
 import { d as foobar } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -8
 };
-import { f as upper } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -7
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
+import { upper } from "module";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/2/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/2/output.md
@@ -632,10 +632,10 @@ foobarCopy += "Unused";
 import { d as foobar } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -8
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { f as upper } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -7,
+    __turbopack_original__: "module"
 };
-import { upper } from "module";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
@@ -889,10 +889,10 @@ foobarCopy += "Unused";
 import { d as foobar } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -8
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { f as upper } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -7,
+    __turbopack_original__: "module"
 };
-import { upper } from "module";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/amphtml-document/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/amphtml-document/output.md
@@ -437,30 +437,38 @@ export { NextScript as i } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 12
 ```js
-import { e as Document } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -7
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
-import { c as _jsxs } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -4
+import Document from "next/document";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
 };
-import { d as _Fragment } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -5
+import { jsxs as _jsxs } from "react/jsx-runtime";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
 };
-import { b as _jsx } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -3
+import { Fragment as _Fragment } from "react/jsx-runtime";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
 };
-import { f as Html } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -8
+import { jsx as _jsx } from "react/jsx-runtime";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
-import { g as Head } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -9
+import { Html } from "next/document";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
-import { h as Main } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -10
+import { Head } from "next/document";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
-import { i as NextScript } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -11
+import { Main } from "next/document";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
+import { NextScript } from "next/document";
 class MyDocument extends Document {
     static async getInitialProps(ctx) {
         const initialProps = await Document.getInitialProps(ctx);
@@ -659,30 +667,38 @@ export { NextScript as i } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 12
 ```js
-import { e as Document } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -7
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
-import { c as _jsxs } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -4
+import Document from "next/document";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
 };
-import { d as _Fragment } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -5
+import { jsxs as _jsxs } from "react/jsx-runtime";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
 };
-import { b as _jsx } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -3
+import { Fragment as _Fragment } from "react/jsx-runtime";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
 };
-import { f as Html } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -8
+import { jsx as _jsx } from "react/jsx-runtime";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
-import { g as Head } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -9
+import { Html } from "next/document";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
-import { h as Main } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -10
+import { Head } from "next/document";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
-import { i as NextScript } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -11
+import { Main } from "next/document";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
+import { NextScript } from "next/document";
 class MyDocument extends Document {
     static async getInitialProps(ctx) {
         const initialProps = await Document.getInitialProps(ctx);

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/amphtml-document/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/amphtml-document/output.md
@@ -437,38 +437,38 @@ export { NextScript as i } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 12
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { e as Document } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -7,
+    __turbopack_original__: 'next/document'
 };
-import Document from "next/document";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+import { c as _jsxs } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -4,
+    __turbopack_original__: "react/jsx-runtime"
 };
-import { jsxs as _jsxs } from "react/jsx-runtime";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+import { d as _Fragment } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -5,
+    __turbopack_original__: "react/jsx-runtime"
 };
-import { Fragment as _Fragment } from "react/jsx-runtime";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+import { b as _jsx } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -3,
+    __turbopack_original__: "react/jsx-runtime"
 };
-import { jsx as _jsx } from "react/jsx-runtime";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { f as Html } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -8,
+    __turbopack_original__: 'next/document'
 };
-import { Html } from "next/document";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { g as Head } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -9,
+    __turbopack_original__: 'next/document'
 };
-import { Head } from "next/document";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { h as Main } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -10,
+    __turbopack_original__: 'next/document'
 };
-import { Main } from "next/document";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { i as NextScript } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -11,
+    __turbopack_original__: 'next/document'
 };
-import { NextScript } from "next/document";
 class MyDocument extends Document {
     static async getInitialProps(ctx) {
         const initialProps = await Document.getInitialProps(ctx);
@@ -667,38 +667,38 @@ export { NextScript as i } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 12
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { e as Document } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -7,
+    __turbopack_original__: 'next/document'
 };
-import Document from "next/document";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+import { c as _jsxs } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -4,
+    __turbopack_original__: "react/jsx-runtime"
 };
-import { jsxs as _jsxs } from "react/jsx-runtime";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+import { d as _Fragment } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -5,
+    __turbopack_original__: "react/jsx-runtime"
 };
-import { Fragment as _Fragment } from "react/jsx-runtime";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+import { b as _jsx } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -3,
+    __turbopack_original__: "react/jsx-runtime"
 };
-import { jsx as _jsx } from "react/jsx-runtime";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { f as Html } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -8,
+    __turbopack_original__: 'next/document'
 };
-import { Html } from "next/document";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { g as Head } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -9,
+    __turbopack_original__: 'next/document'
 };
-import { Head } from "next/document";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { h as Main } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -10,
+    __turbopack_original__: 'next/document'
 };
-import { Main } from "next/document";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { i as NextScript } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -11,
+    __turbopack_original__: 'next/document'
 };
-import { NextScript } from "next/document";
 class MyDocument extends Document {
     static async getInitialProps(ctx) {
         const initialProps = await Document.getInitialProps(ctx);

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/app-route/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/app-route/output.md
@@ -524,15 +524,18 @@ export { userland as j } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 15
 ```js
-import { g as AppRouteRouteModule } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -8
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
 };
-import { h as RouteKind } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -10
+import { AppRouteRouteModule } from "../../server/future/route-modules/app-route/module.compiled";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
 };
-import { j as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -14
+import { RouteKind } from "../../server/future/route-kind";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
@@ -586,9 +589,10 @@ export { originalPathname as a } from "__TURBOPACK_VAR__" assert {
 import { f as workAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -16
 };
-import { i as _patchFetch } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -12
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
 };
+import { patchFetch as _patchFetch } from "../../server/lib/patch-fetch";
 import { e as serverHooks } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -16
 };
@@ -799,15 +803,18 @@ export { userland as j } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 15
 ```js
-import { g as AppRouteRouteModule } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -8
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
 };
-import { h as RouteKind } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -10
+import { AppRouteRouteModule } from "../../server/future/route-modules/app-route/module.compiled";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
 };
-import { j as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -14
+import { RouteKind } from "../../server/future/route-kind";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
@@ -858,9 +865,10 @@ export { originalPathname as a } from "__TURBOPACK_VAR__" assert {
 import { f as workAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -16
 };
-import { i as _patchFetch } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -12
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
 };
+import { patchFetch as _patchFetch } from "../../server/lib/patch-fetch";
 import { e as serverHooks } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -16
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/app-route/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/app-route/output.md
@@ -524,18 +524,18 @@ export { userland as j } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 15
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
+import { g as AppRouteRouteModule } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -8,
+    __turbopack_original__: '../../server/future/route-modules/app-route/module.compiled'
 };
-import { AppRouteRouteModule } from "../../server/future/route-modules/app-route/module.compiled";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
+import { h as RouteKind } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -10,
+    __turbopack_original__: '../../server/future/route-kind'
 };
-import { RouteKind } from "../../server/future/route-kind";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
+import { j as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -14,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
@@ -589,10 +589,10 @@ export { originalPathname as a } from "__TURBOPACK_VAR__" assert {
 import { f as workAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -16
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
+import { i as _patchFetch } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -12,
+    __turbopack_original__: '../../server/lib/patch-fetch'
 };
-import { patchFetch as _patchFetch } from "../../server/lib/patch-fetch";
 import { e as serverHooks } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -16
 };
@@ -803,18 +803,18 @@ export { userland as j } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 15
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
+import { g as AppRouteRouteModule } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -8,
+    __turbopack_original__: '../../server/future/route-modules/app-route/module.compiled'
 };
-import { AppRouteRouteModule } from "../../server/future/route-modules/app-route/module.compiled";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
+import { h as RouteKind } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -10,
+    __turbopack_original__: '../../server/future/route-kind'
 };
-import { RouteKind } from "../../server/future/route-kind";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
+import { j as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -14,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 13
 };
@@ -865,10 +865,10 @@ export { originalPathname as a } from "__TURBOPACK_VAR__" assert {
 import { f as workAsyncStorage } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -16
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
+import { i as _patchFetch } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -12,
+    __turbopack_original__: '../../server/lib/patch-fetch'
 };
-import { patchFetch as _patchFetch } from "../../server/lib/patch-fetch";
 import { e as serverHooks } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -16
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/dce/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/dce/output.md
@@ -125,9 +125,10 @@ export { baz as a } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 3
 ```js
-import { a as baz } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -2
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
 };
+import { baz } from "./module";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
@@ -185,9 +186,10 @@ export { baz as a } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 3
 ```js
-import { a as baz } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -2
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 1
 };
+import { baz } from "./module";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/dce/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/dce/output.md
@@ -125,10 +125,10 @@ export { baz as a } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 3
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+import { a as baz } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -2,
+    __turbopack_original__: './module'
 };
-import { baz } from "./module";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };
@@ -186,10 +186,10 @@ export { baz as a } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 3
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 1
+import { a as baz } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -2,
+    __turbopack_original__: './module'
 };
-import { baz } from "./module";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 1
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-2/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-2/output.md
@@ -794,9 +794,10 @@ export { getPathname as l } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 17
 ```js
-import { i as React } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -10
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
 };
+import React from "react";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 15
 };
@@ -850,15 +851,18 @@ export { createPrerenderState as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 19
 ```js
-import { j as DynamicServerError } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -12
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
 };
-import { l as getPathname } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -16
+import { DynamicServerError } from "../../client/components/hooks-server-context";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
 };
-import { k as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -14
+import { getPathname } from "../../lib/url";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
 };
+import { StaticGenBailoutError } from "../../client/components/static-generation-bailout";
 import { n as postponeWithTracking } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -17
 };
@@ -887,15 +891,18 @@ export { markCurrentScopeAsDynamic as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 20
 ```js
-import { j as DynamicServerError } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -12
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
 };
-import { l as getPathname } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -16
+import { DynamicServerError } from "../../client/components/hooks-server-context";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
 };
-import { k as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -14
+import { getPathname } from "../../lib/url";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
 };
+import { StaticGenBailoutError } from "../../client/components/static-generation-bailout";
 import { n as postponeWithTracking } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -17
 };
@@ -985,9 +992,10 @@ export { formatDynamicAPIAccesses as d } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 25
 ```js
-import { i as React } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -10
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
 };
+import React from "react";
 import { o as assertPostpone } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -17
 };
@@ -1224,9 +1232,10 @@ export { getPathname as l } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 17
 ```js
-import { i as React } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -10
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
 };
+import React from "react";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 15
 };
@@ -1251,15 +1260,18 @@ export { createPrerenderState as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 19
 ```js
-import { j as DynamicServerError } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -12
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
 };
-import { l as getPathname } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -16
+import { DynamicServerError } from "../../client/components/hooks-server-context";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
 };
-import { k as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -14
+import { getPathname } from "../../lib/url";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
 };
+import { StaticGenBailoutError } from "../../client/components/static-generation-bailout";
 import { n as postponeWithTracking } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -23
 };
@@ -1288,15 +1300,18 @@ export { markCurrentScopeAsDynamic as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 20
 ```js
-import { j as DynamicServerError } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -12
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
 };
-import { l as getPathname } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -16
+import { DynamicServerError } from "../../client/components/hooks-server-context";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
 };
-import { k as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -14
+import { getPathname } from "../../lib/url";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
 };
+import { StaticGenBailoutError } from "../../client/components/static-generation-bailout";
 import { n as postponeWithTracking } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -23
 };
@@ -1352,9 +1367,10 @@ export { trackDynamicFetch as g } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 23
 ```js
-import { i as React } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -10
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
 };
+import React from "react";
 import { o as assertPostpone } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -26
 };
@@ -1426,9 +1442,10 @@ export { assertPostpone as o } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 27
 ```js
-import { i as React } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -10
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
 };
+import React from "react";
 import { o as assertPostpone } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -26
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-2/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-2/output.md
@@ -794,10 +794,10 @@ export { getPathname as l } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 17
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
+import { i as React } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -10,
+    __turbopack_original__: 'react'
 };
-import React from "react";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 15
 };
@@ -851,18 +851,18 @@ export { createPrerenderState as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 19
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
+import { j as DynamicServerError } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -12,
+    __turbopack_original__: '../../client/components/hooks-server-context'
 };
-import { DynamicServerError } from "../../client/components/hooks-server-context";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
+import { l as getPathname } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -16,
+    __turbopack_original__: '../../lib/url'
 };
-import { getPathname } from "../../lib/url";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
+import { k as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -14,
+    __turbopack_original__: '../../client/components/static-generation-bailout'
 };
-import { StaticGenBailoutError } from "../../client/components/static-generation-bailout";
 import { n as postponeWithTracking } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -17
 };
@@ -891,18 +891,18 @@ export { markCurrentScopeAsDynamic as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 20
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
+import { j as DynamicServerError } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -12,
+    __turbopack_original__: '../../client/components/hooks-server-context'
 };
-import { DynamicServerError } from "../../client/components/hooks-server-context";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
+import { l as getPathname } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -16,
+    __turbopack_original__: '../../lib/url'
 };
-import { getPathname } from "../../lib/url";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
+import { k as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -14,
+    __turbopack_original__: '../../client/components/static-generation-bailout'
 };
-import { StaticGenBailoutError } from "../../client/components/static-generation-bailout";
 import { n as postponeWithTracking } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -17
 };
@@ -992,10 +992,10 @@ export { formatDynamicAPIAccesses as d } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 25
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
+import { i as React } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -10,
+    __turbopack_original__: 'react'
 };
-import React from "react";
 import { o as assertPostpone } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -17
 };
@@ -1232,10 +1232,10 @@ export { getPathname as l } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 17
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
+import { i as React } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -10,
+    __turbopack_original__: 'react'
 };
-import React from "react";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 15
 };
@@ -1260,18 +1260,18 @@ export { createPrerenderState as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 19
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
+import { j as DynamicServerError } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -12,
+    __turbopack_original__: '../../client/components/hooks-server-context'
 };
-import { DynamicServerError } from "../../client/components/hooks-server-context";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
+import { l as getPathname } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -16,
+    __turbopack_original__: '../../lib/url'
 };
-import { getPathname } from "../../lib/url";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
+import { k as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -14,
+    __turbopack_original__: '../../client/components/static-generation-bailout'
 };
-import { StaticGenBailoutError } from "../../client/components/static-generation-bailout";
 import { n as postponeWithTracking } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -23
 };
@@ -1300,18 +1300,18 @@ export { markCurrentScopeAsDynamic as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 20
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
+import { j as DynamicServerError } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -12,
+    __turbopack_original__: '../../client/components/hooks-server-context'
 };
-import { DynamicServerError } from "../../client/components/hooks-server-context";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
+import { l as getPathname } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -16,
+    __turbopack_original__: '../../lib/url'
 };
-import { getPathname } from "../../lib/url";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
+import { k as StaticGenBailoutError } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -14,
+    __turbopack_original__: '../../client/components/static-generation-bailout'
 };
-import { StaticGenBailoutError } from "../../client/components/static-generation-bailout";
 import { n as postponeWithTracking } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -23
 };
@@ -1367,10 +1367,10 @@ export { trackDynamicFetch as g } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 23
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
+import { i as React } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -10,
+    __turbopack_original__: 'react'
 };
-import React from "react";
 import { o as assertPostpone } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -26
 };
@@ -1442,10 +1442,10 @@ export { assertPostpone as o } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 27
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
+import { i as React } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -10,
+    __turbopack_original__: 'react'
 };
-import React from "react";
 import { o as assertPostpone } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -26
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-3/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-3/output.md
@@ -1225,12 +1225,14 @@ export { getProperError as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 9
 ```js
-import { d as parseStackTrace } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -6
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
 };
-import { e as getProperError } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -8
+import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
 };
+import { getProperError } from "./error";
 function structuredError(e) {
     e = getProperError(e);
     return {
@@ -1249,9 +1251,10 @@ export { structuredError as b } from "__TURBOPACK_VAR__" assert {
 import { b as structuredError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -9
 };
-import { c as createConnection } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -4
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
+import { createConnection } from "node:net";
 function createIpc(port) {
     const socket = createConnection(port, "127.0.0.1");
     const packetQueue = [];
@@ -1973,12 +1976,14 @@ export { getProperError as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 9
 ```js
-import { d as parseStackTrace } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -6
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
 };
-import { e as getProperError } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -8
+import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
 };
+import { getProperError } from "./error";
 function structuredError(e) {
     e = getProperError(e);
     return {
@@ -1997,9 +2002,10 @@ export { structuredError as b } from "__TURBOPACK_VAR__" assert {
 import { b as structuredError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -9
 };
-import { c as createConnection } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -4
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
+import { createConnection } from "node:net";
 function createIpc(port) {
     const socket = createConnection(port, "127.0.0.1");
     const packetQueue = [];

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-3/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-3/output.md
@@ -1225,14 +1225,14 @@ export { getProperError as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 9
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+import { d as parseStackTrace } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -6,
+    __turbopack_original__: "../compiled/stacktrace-parser"
 };
-import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
+import { e as getProperError } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -8,
+    __turbopack_original__: "./error"
 };
-import { getProperError } from "./error";
 function structuredError(e) {
     e = getProperError(e);
     return {
@@ -1251,10 +1251,10 @@ export { structuredError as b } from "__TURBOPACK_VAR__" assert {
 import { b as structuredError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -9
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+import { c as createConnection } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -4,
+    __turbopack_original__: "node:net"
 };
-import { createConnection } from "node:net";
 function createIpc(port) {
     const socket = createConnection(port, "127.0.0.1");
     const packetQueue = [];
@@ -1976,14 +1976,14 @@ export { getProperError as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 9
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+import { d as parseStackTrace } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -6,
+    __turbopack_original__: "../compiled/stacktrace-parser"
 };
-import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
+import { e as getProperError } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -8,
+    __turbopack_original__: "./error"
 };
-import { getProperError } from "./error";
 function structuredError(e) {
     e = getProperError(e);
     return {
@@ -2002,10 +2002,10 @@ export { structuredError as b } from "__TURBOPACK_VAR__" assert {
 import { b as structuredError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -9
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+import { c as createConnection } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -4,
+    __turbopack_original__: "node:net"
 };
-import { createConnection } from "node:net";
 function createIpc(port) {
     const socket = createConnection(port, "127.0.0.1");
     const packetQueue = [];

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/ipc-evaluate/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/ipc-evaluate/output.md
@@ -278,9 +278,10 @@ export { IPC as b } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 4
 ```js
-import { b as IPC } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -3
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
 };
+import { IPC } from "./index";
 const ipc = IPC;
 export { ipc as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -465,9 +466,10 @@ export { IPC as b } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 4
 ```js
-import { b as IPC } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -3
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
 };
+import { IPC } from "./index";
 const ipc = IPC;
 export { ipc as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/ipc-evaluate/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/ipc-evaluate/output.md
@@ -278,10 +278,10 @@ export { IPC as b } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 4
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+import { b as IPC } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -3,
+    __turbopack_original__: "./index"
 };
-import { IPC } from "./index";
 const ipc = IPC;
 export { ipc as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
@@ -466,10 +466,10 @@ export { IPC as b } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 4
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+import { b as IPC } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -3,
+    __turbopack_original__: "./index"
 };
-import { IPC } from "./index";
 const ipc = IPC;
 export { ipc as c } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/ipc-index/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/ipc-index/output.md
@@ -1225,12 +1225,14 @@ export { getProperError as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 9
 ```js
-import { d as parseStackTrace } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -6
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
 };
-import { e as getProperError } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -8
+import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
 };
+import { getProperError } from "./error";
 function structuredError(e) {
     e = getProperError(e);
     return {
@@ -1249,9 +1251,10 @@ export { structuredError as b } from "__TURBOPACK_VAR__" assert {
 import { b as structuredError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -9
 };
-import { c as createConnection } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -4
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
+import { createConnection } from "node:net";
 function createIpc(port) {
     const socket = createConnection(port, "127.0.0.1");
     const packetQueue = [];
@@ -1973,12 +1976,14 @@ export { getProperError as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 9
 ```js
-import { d as parseStackTrace } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -6
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
 };
-import { e as getProperError } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -8
+import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 7
 };
+import { getProperError } from "./error";
 function structuredError(e) {
     e = getProperError(e);
     return {
@@ -1997,9 +2002,10 @@ export { structuredError as b } from "__TURBOPACK_VAR__" assert {
 import { b as structuredError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -9
 };
-import { c as createConnection } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -4
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
+import { createConnection } from "node:net";
 function createIpc(port) {
     const socket = createConnection(port, "127.0.0.1");
     const packetQueue = [];

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/ipc-index/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/ipc-index/output.md
@@ -1225,14 +1225,14 @@ export { getProperError as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 9
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+import { d as parseStackTrace } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -6,
+    __turbopack_original__: "../compiled/stacktrace-parser"
 };
-import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
+import { e as getProperError } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -8,
+    __turbopack_original__: "./error"
 };
-import { getProperError } from "./error";
 function structuredError(e) {
     e = getProperError(e);
     return {
@@ -1251,10 +1251,10 @@ export { structuredError as b } from "__TURBOPACK_VAR__" assert {
 import { b as structuredError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -9
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+import { c as createConnection } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -4,
+    __turbopack_original__: "node:net"
 };
-import { createConnection } from "node:net";
 function createIpc(port) {
     const socket = createConnection(port, "127.0.0.1");
     const packetQueue = [];
@@ -1976,14 +1976,14 @@ export { getProperError as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 9
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+import { d as parseStackTrace } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -6,
+    __turbopack_original__: "../compiled/stacktrace-parser"
 };
-import { parse as parseStackTrace } from "../compiled/stacktrace-parser";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 7
+import { e as getProperError } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -8,
+    __turbopack_original__: "./error"
 };
-import { getProperError } from "./error";
 function structuredError(e) {
     e = getProperError(e);
     return {
@@ -2002,10 +2002,10 @@ export { structuredError as b } from "__TURBOPACK_VAR__" assert {
 import { b as structuredError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -9
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+import { c as createConnection } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -4,
+    __turbopack_original__: "node:net"
 };
-import { createConnection } from "node:net";
 function createIpc(port) {
     const socket = createConnection(port, "127.0.0.1");
     const packetQueue = [];

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/mui-sys/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/mui-sys/output.md
@@ -1299,15 +1299,18 @@ export { responsivePropType as s } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 25
 ```js
-import { p as createUnaryUnit } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -19
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
 };
-import { q as getValue } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -20
+import { createUnaryUnit } from "./spacing";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
 };
-import { r as handleBreakpoints } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -22
+import { getValue } from "./spacing";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
 };
+import { handleBreakpoints } from "./breakpoints";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 23
 };
@@ -1331,9 +1334,10 @@ export { gap as c } from "__TURBOPACK_VAR__" assert {
 import { c as gap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -25
 };
-import { s as responsivePropType } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import responsivePropType from "./responsivePropType";
 gap.propTypes = process.env.NODE_ENV !== 'production' ? {
     gap: responsivePropType
 } : {};
@@ -1354,15 +1358,18 @@ gap.filterProps = [
 ```
 ## Part 28
 ```js
-import { p as createUnaryUnit } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -19
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
 };
-import { q as getValue } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -20
+import { createUnaryUnit } from "./spacing";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
 };
-import { r as handleBreakpoints } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -22
+import { getValue } from "./spacing";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
 };
+import { handleBreakpoints } from "./breakpoints";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 26
 };
@@ -1386,9 +1393,10 @@ export { columnGap as b } from "__TURBOPACK_VAR__" assert {
 import { b as columnGap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -28
 };
-import { s as responsivePropType } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import responsivePropType from "./responsivePropType";
 columnGap.propTypes = process.env.NODE_ENV !== 'production' ? {
     columnGap: responsivePropType
 } : {};
@@ -1409,15 +1417,18 @@ columnGap.filterProps = [
 ```
 ## Part 31
 ```js
-import { p as createUnaryUnit } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -19
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
 };
-import { q as getValue } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -20
+import { createUnaryUnit } from "./spacing";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
 };
-import { r as handleBreakpoints } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -22
+import { getValue } from "./spacing";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
 };
+import { handleBreakpoints } from "./breakpoints";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 29
 };
@@ -1441,9 +1452,10 @@ export { rowGap as m } from "__TURBOPACK_VAR__" assert {
 import { m as rowGap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -31
 };
-import { s as responsivePropType } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import responsivePropType from "./responsivePropType";
 rowGap.propTypes = process.env.NODE_ENV !== 'production' ? {
     rowGap: responsivePropType
 } : {};
@@ -1464,9 +1476,10 @@ rowGap.filterProps = [
 ```
 ## Part 34
 ```js
-import { n as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -15
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
 };
+import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 32
 };
@@ -1480,9 +1493,10 @@ export { gridColumn as h } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 35
 ```js
-import { n as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -15
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
 };
+import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 34
 };
@@ -1496,9 +1510,10 @@ export { gridRow as i } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 36
 ```js
-import { n as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -15
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
 };
+import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 35
 };
@@ -1512,9 +1527,10 @@ export { gridAutoFlow as f } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 37
 ```js
-import { n as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -15
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
 };
+import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 36
 };
@@ -1528,9 +1544,10 @@ export { gridAutoColumns as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 38
 ```js
-import { n as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -15
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
 };
+import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 37
 };
@@ -1544,9 +1561,10 @@ export { gridAutoRows as g } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 39
 ```js
-import { n as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -15
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
 };
+import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 38
 };
@@ -1560,9 +1578,10 @@ export { gridTemplateColumns as k } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 40
 ```js
-import { n as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -15
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
 };
+import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 39
 };
@@ -1576,9 +1595,10 @@ export { gridTemplateRows as l } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 41
 ```js
-import { n as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -15
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
 };
+import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 40
 };
@@ -1592,9 +1612,10 @@ export { gridTemplateAreas as j } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 42
 ```js
-import { n as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -15
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
 };
+import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 41
 };
@@ -1608,9 +1629,10 @@ export { gridArea as d } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 43
 ```js
-import { o as compose } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -17
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
 };
+import compose from "./compose";
 import { c as gap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -25
 };
@@ -2000,15 +2022,18 @@ export { responsivePropType as s } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 25
 ```js
-import { p as createUnaryUnit } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -19
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
 };
-import { q as getValue } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -20
+import { createUnaryUnit } from "./spacing";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
 };
-import { r as handleBreakpoints } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -22
+import { getValue } from "./spacing";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
 };
+import { handleBreakpoints } from "./breakpoints";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 23
 };
@@ -2032,9 +2057,10 @@ export { gap as c } from "__TURBOPACK_VAR__" assert {
 import { c as gap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -25
 };
-import { s as responsivePropType } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import responsivePropType from "./responsivePropType";
 gap.propTypes = process.env.NODE_ENV !== 'production' ? {
     gap: responsivePropType
 } : {};
@@ -2055,15 +2081,18 @@ gap.filterProps = [
 ```
 ## Part 28
 ```js
-import { p as createUnaryUnit } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -19
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
 };
-import { q as getValue } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -20
+import { createUnaryUnit } from "./spacing";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
 };
-import { r as handleBreakpoints } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -22
+import { getValue } from "./spacing";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
 };
+import { handleBreakpoints } from "./breakpoints";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 26
 };
@@ -2087,9 +2116,10 @@ export { columnGap as b } from "__TURBOPACK_VAR__" assert {
 import { b as columnGap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -28
 };
-import { s as responsivePropType } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import responsivePropType from "./responsivePropType";
 columnGap.propTypes = process.env.NODE_ENV !== 'production' ? {
     columnGap: responsivePropType
 } : {};
@@ -2110,15 +2140,18 @@ columnGap.filterProps = [
 ```
 ## Part 31
 ```js
-import { p as createUnaryUnit } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -19
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
 };
-import { q as getValue } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -20
+import { createUnaryUnit } from "./spacing";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 18
 };
-import { r as handleBreakpoints } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -22
+import { getValue } from "./spacing";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
 };
+import { handleBreakpoints } from "./breakpoints";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 29
 };
@@ -2142,9 +2175,10 @@ export { rowGap as m } from "__TURBOPACK_VAR__" assert {
 import { m as rowGap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -31
 };
-import { s as responsivePropType } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import responsivePropType from "./responsivePropType";
 rowGap.propTypes = process.env.NODE_ENV !== 'production' ? {
     rowGap: responsivePropType
 } : {};
@@ -2165,9 +2199,10 @@ rowGap.filterProps = [
 ```
 ## Part 34
 ```js
-import { n as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -15
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
 };
+import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 32
 };
@@ -2181,9 +2216,10 @@ export { gridColumn as h } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 35
 ```js
-import { n as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -15
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
 };
+import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 34
 };
@@ -2197,9 +2233,10 @@ export { gridRow as i } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 36
 ```js
-import { n as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -15
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
 };
+import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 35
 };
@@ -2213,9 +2250,10 @@ export { gridAutoFlow as f } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 37
 ```js
-import { n as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -15
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
 };
+import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 36
 };
@@ -2229,9 +2267,10 @@ export { gridAutoColumns as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 38
 ```js
-import { n as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -15
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
 };
+import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 37
 };
@@ -2245,9 +2284,10 @@ export { gridAutoRows as g } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 39
 ```js
-import { n as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -15
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
 };
+import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 38
 };
@@ -2261,9 +2301,10 @@ export { gridTemplateColumns as k } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 40
 ```js
-import { n as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -15
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
 };
+import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 39
 };
@@ -2277,9 +2318,10 @@ export { gridTemplateRows as l } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 41
 ```js
-import { n as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -15
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
 };
+import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 40
 };
@@ -2293,9 +2335,10 @@ export { gridTemplateAreas as j } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 42
 ```js
-import { n as style } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -15
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 14
 };
+import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 41
 };
@@ -2309,9 +2352,10 @@ export { gridArea as d } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 43
 ```js
-import { o as compose } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -17
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 16
 };
+import compose from "./compose";
 import { c as gap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -25
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/mui-sys/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/mui-sys/output.md
@@ -1299,18 +1299,18 @@ export { responsivePropType as s } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 25
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+import { p as createUnaryUnit } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -19,
+    __turbopack_original__: './spacing'
 };
-import { createUnaryUnit } from "./spacing";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+import { q as getValue } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -20,
+    __turbopack_original__: './spacing'
 };
-import { getValue } from "./spacing";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+import { r as handleBreakpoints } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -22,
+    __turbopack_original__: './breakpoints'
 };
-import { handleBreakpoints } from "./breakpoints";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 23
 };
@@ -1334,10 +1334,10 @@ export { gap as c } from "__TURBOPACK_VAR__" assert {
 import { c as gap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -25
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { s as responsivePropType } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: './responsivePropType'
 };
-import responsivePropType from "./responsivePropType";
 gap.propTypes = process.env.NODE_ENV !== 'production' ? {
     gap: responsivePropType
 } : {};
@@ -1358,18 +1358,18 @@ gap.filterProps = [
 ```
 ## Part 28
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+import { p as createUnaryUnit } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -19,
+    __turbopack_original__: './spacing'
 };
-import { createUnaryUnit } from "./spacing";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+import { q as getValue } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -20,
+    __turbopack_original__: './spacing'
 };
-import { getValue } from "./spacing";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+import { r as handleBreakpoints } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -22,
+    __turbopack_original__: './breakpoints'
 };
-import { handleBreakpoints } from "./breakpoints";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 26
 };
@@ -1393,10 +1393,10 @@ export { columnGap as b } from "__TURBOPACK_VAR__" assert {
 import { b as columnGap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -28
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { s as responsivePropType } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: './responsivePropType'
 };
-import responsivePropType from "./responsivePropType";
 columnGap.propTypes = process.env.NODE_ENV !== 'production' ? {
     columnGap: responsivePropType
 } : {};
@@ -1417,18 +1417,18 @@ columnGap.filterProps = [
 ```
 ## Part 31
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+import { p as createUnaryUnit } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -19,
+    __turbopack_original__: './spacing'
 };
-import { createUnaryUnit } from "./spacing";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+import { q as getValue } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -20,
+    __turbopack_original__: './spacing'
 };
-import { getValue } from "./spacing";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+import { r as handleBreakpoints } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -22,
+    __turbopack_original__: './breakpoints'
 };
-import { handleBreakpoints } from "./breakpoints";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 29
 };
@@ -1452,10 +1452,10 @@ export { rowGap as m } from "__TURBOPACK_VAR__" assert {
 import { m as rowGap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -31
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { s as responsivePropType } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: './responsivePropType'
 };
-import responsivePropType from "./responsivePropType";
 rowGap.propTypes = process.env.NODE_ENV !== 'production' ? {
     rowGap: responsivePropType
 } : {};
@@ -1476,10 +1476,10 @@ rowGap.filterProps = [
 ```
 ## Part 34
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+import { n as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -15,
+    __turbopack_original__: './style'
 };
-import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 32
 };
@@ -1493,10 +1493,10 @@ export { gridColumn as h } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 35
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+import { n as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -15,
+    __turbopack_original__: './style'
 };
-import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 34
 };
@@ -1510,10 +1510,10 @@ export { gridRow as i } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 36
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+import { n as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -15,
+    __turbopack_original__: './style'
 };
-import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 35
 };
@@ -1527,10 +1527,10 @@ export { gridAutoFlow as f } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 37
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+import { n as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -15,
+    __turbopack_original__: './style'
 };
-import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 36
 };
@@ -1544,10 +1544,10 @@ export { gridAutoColumns as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 38
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+import { n as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -15,
+    __turbopack_original__: './style'
 };
-import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 37
 };
@@ -1561,10 +1561,10 @@ export { gridAutoRows as g } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 39
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+import { n as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -15,
+    __turbopack_original__: './style'
 };
-import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 38
 };
@@ -1578,10 +1578,10 @@ export { gridTemplateColumns as k } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 40
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+import { n as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -15,
+    __turbopack_original__: './style'
 };
-import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 39
 };
@@ -1595,10 +1595,10 @@ export { gridTemplateRows as l } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 41
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+import { n as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -15,
+    __turbopack_original__: './style'
 };
-import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 40
 };
@@ -1612,10 +1612,10 @@ export { gridTemplateAreas as j } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 42
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+import { n as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -15,
+    __turbopack_original__: './style'
 };
-import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 41
 };
@@ -1629,10 +1629,10 @@ export { gridArea as d } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 43
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
+import { o as compose } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -17,
+    __turbopack_original__: './compose'
 };
-import compose from "./compose";
 import { c as gap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -25
 };
@@ -2022,18 +2022,18 @@ export { responsivePropType as s } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 25
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+import { p as createUnaryUnit } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -19,
+    __turbopack_original__: './spacing'
 };
-import { createUnaryUnit } from "./spacing";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+import { q as getValue } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -20,
+    __turbopack_original__: './spacing'
 };
-import { getValue } from "./spacing";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+import { r as handleBreakpoints } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -22,
+    __turbopack_original__: './breakpoints'
 };
-import { handleBreakpoints } from "./breakpoints";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 23
 };
@@ -2057,10 +2057,10 @@ export { gap as c } from "__TURBOPACK_VAR__" assert {
 import { c as gap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -25
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { s as responsivePropType } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: './responsivePropType'
 };
-import responsivePropType from "./responsivePropType";
 gap.propTypes = process.env.NODE_ENV !== 'production' ? {
     gap: responsivePropType
 } : {};
@@ -2081,18 +2081,18 @@ gap.filterProps = [
 ```
 ## Part 28
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+import { p as createUnaryUnit } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -19,
+    __turbopack_original__: './spacing'
 };
-import { createUnaryUnit } from "./spacing";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+import { q as getValue } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -20,
+    __turbopack_original__: './spacing'
 };
-import { getValue } from "./spacing";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+import { r as handleBreakpoints } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -22,
+    __turbopack_original__: './breakpoints'
 };
-import { handleBreakpoints } from "./breakpoints";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 26
 };
@@ -2116,10 +2116,10 @@ export { columnGap as b } from "__TURBOPACK_VAR__" assert {
 import { b as columnGap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -28
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { s as responsivePropType } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: './responsivePropType'
 };
-import responsivePropType from "./responsivePropType";
 columnGap.propTypes = process.env.NODE_ENV !== 'production' ? {
     columnGap: responsivePropType
 } : {};
@@ -2140,18 +2140,18 @@ columnGap.filterProps = [
 ```
 ## Part 31
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+import { p as createUnaryUnit } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -19,
+    __turbopack_original__: './spacing'
 };
-import { createUnaryUnit } from "./spacing";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 18
+import { q as getValue } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -20,
+    __turbopack_original__: './spacing'
 };
-import { getValue } from "./spacing";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+import { r as handleBreakpoints } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -22,
+    __turbopack_original__: './breakpoints'
 };
-import { handleBreakpoints } from "./breakpoints";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 29
 };
@@ -2175,10 +2175,10 @@ export { rowGap as m } from "__TURBOPACK_VAR__" assert {
 import { m as rowGap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -31
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { s as responsivePropType } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: './responsivePropType'
 };
-import responsivePropType from "./responsivePropType";
 rowGap.propTypes = process.env.NODE_ENV !== 'production' ? {
     rowGap: responsivePropType
 } : {};
@@ -2199,10 +2199,10 @@ rowGap.filterProps = [
 ```
 ## Part 34
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+import { n as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -15,
+    __turbopack_original__: './style'
 };
-import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 32
 };
@@ -2216,10 +2216,10 @@ export { gridColumn as h } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 35
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+import { n as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -15,
+    __turbopack_original__: './style'
 };
-import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 34
 };
@@ -2233,10 +2233,10 @@ export { gridRow as i } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 36
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+import { n as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -15,
+    __turbopack_original__: './style'
 };
-import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 35
 };
@@ -2250,10 +2250,10 @@ export { gridAutoFlow as f } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 37
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+import { n as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -15,
+    __turbopack_original__: './style'
 };
-import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 36
 };
@@ -2267,10 +2267,10 @@ export { gridAutoColumns as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 38
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+import { n as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -15,
+    __turbopack_original__: './style'
 };
-import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 37
 };
@@ -2284,10 +2284,10 @@ export { gridAutoRows as g } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 39
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+import { n as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -15,
+    __turbopack_original__: './style'
 };
-import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 38
 };
@@ -2301,10 +2301,10 @@ export { gridTemplateColumns as k } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 40
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+import { n as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -15,
+    __turbopack_original__: './style'
 };
-import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 39
 };
@@ -2318,10 +2318,10 @@ export { gridTemplateRows as l } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 41
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+import { n as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -15,
+    __turbopack_original__: './style'
 };
-import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 40
 };
@@ -2335,10 +2335,10 @@ export { gridTemplateAreas as j } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 42
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 14
+import { n as style } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -15,
+    __turbopack_original__: './style'
 };
-import style from "./style";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 41
 };
@@ -2352,10 +2352,10 @@ export { gridArea as d } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 43
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 16
+import { o as compose } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -17,
+    __turbopack_original__: './compose'
 };
-import compose from "./compose";
 import { c as gap } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -25
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nanoid/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nanoid/output.md
@@ -459,9 +459,10 @@ export { random };
 ```
 ## Part 5
 ```js
-import { e as urlAlphabet } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -9
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
 };
+import { urlAlphabet } from "./url-alphabet/index.js";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 17
 };
@@ -479,7 +480,7 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
 import crypto from 'crypto';
-export { crypto as f } from "__TURBOPACK_VAR__" assert {
+export { crypto as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -498,7 +499,7 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
 import { urlAlphabet } from './url-alphabet/index.js';
-export { urlAlphabet as e } from "__TURBOPACK_VAR__" assert {
+export { urlAlphabet as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -535,9 +536,10 @@ import { h as pool } from "__TURBOPACK_PART__" assert {
 import { g as POOL_SIZE_MULTIPLIER } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -10
 };
-import { f as crypto } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -7
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
+import crypto from "crypto";
 import { i as poolOffset } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -12
 };
@@ -627,9 +629,10 @@ import { j as fillPool } from "__TURBOPACK_PART__" assert {
 import { i as poolOffset } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -12
 };
-import { e as urlAlphabet } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -9
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
 };
+import { urlAlphabet } from "./url-alphabet/index.js";
 import { h as pool } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -11
 };
@@ -744,9 +747,10 @@ export { random };
 ```
 ## Part 5
 ```js
-import { e as urlAlphabet } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -9
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
 };
+import { urlAlphabet } from "./url-alphabet/index.js";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 17
 };
@@ -764,7 +768,7 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
 import crypto from 'crypto';
-export { crypto as f } from "__TURBOPACK_VAR__" assert {
+export { crypto as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -783,7 +787,7 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
 import { urlAlphabet } from './url-alphabet/index.js';
-export { urlAlphabet as e } from "__TURBOPACK_VAR__" assert {
+export { urlAlphabet as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -820,9 +824,10 @@ import { h as pool } from "__TURBOPACK_PART__" assert {
 import { g as POOL_SIZE_MULTIPLIER } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -10
 };
-import { f as crypto } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -7
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
+import crypto from "crypto";
 import { i as poolOffset } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -12
 };
@@ -912,9 +917,10 @@ import { j as fillPool } from "__TURBOPACK_PART__" assert {
 import { i as poolOffset } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -12
 };
-import { e as urlAlphabet } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -9
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 8
 };
+import { urlAlphabet } from "./url-alphabet/index.js";
 import { h as pool } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -11
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nanoid/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nanoid/output.md
@@ -459,10 +459,10 @@ export { random };
 ```
 ## Part 5
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
+import { e as urlAlphabet } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -9,
+    __turbopack_original__: './url-alphabet/index.js'
 };
-import { urlAlphabet } from "./url-alphabet/index.js";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 17
 };
@@ -480,7 +480,7 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
 import crypto from 'crypto';
-export { crypto as e } from "__TURBOPACK_VAR__" assert {
+export { crypto as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -499,7 +499,7 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
 import { urlAlphabet } from './url-alphabet/index.js';
-export { urlAlphabet as f } from "__TURBOPACK_VAR__" assert {
+export { urlAlphabet as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -536,10 +536,10 @@ import { h as pool } from "__TURBOPACK_PART__" assert {
 import { g as POOL_SIZE_MULTIPLIER } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -10
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { f as crypto } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -7,
+    __turbopack_original__: 'crypto'
 };
-import crypto from "crypto";
 import { i as poolOffset } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -12
 };
@@ -629,10 +629,10 @@ import { j as fillPool } from "__TURBOPACK_PART__" assert {
 import { i as poolOffset } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -12
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
+import { e as urlAlphabet } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -9,
+    __turbopack_original__: './url-alphabet/index.js'
 };
-import { urlAlphabet } from "./url-alphabet/index.js";
 import { h as pool } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -11
 };
@@ -747,10 +747,10 @@ export { random };
 ```
 ## Part 5
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
+import { e as urlAlphabet } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -9,
+    __turbopack_original__: './url-alphabet/index.js'
 };
-import { urlAlphabet } from "./url-alphabet/index.js";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 17
 };
@@ -768,7 +768,7 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 6
 };
 import crypto from 'crypto';
-export { crypto as e } from "__TURBOPACK_VAR__" assert {
+export { crypto as f } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -787,7 +787,7 @@ import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 8
 };
 import { urlAlphabet } from './url-alphabet/index.js';
-export { urlAlphabet as f } from "__TURBOPACK_VAR__" assert {
+export { urlAlphabet as e } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
@@ -824,10 +824,10 @@ import { h as pool } from "__TURBOPACK_PART__" assert {
 import { g as POOL_SIZE_MULTIPLIER } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -10
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { f as crypto } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -7,
+    __turbopack_original__: 'crypto'
 };
-import crypto from "crypto";
 import { i as poolOffset } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -12
 };
@@ -917,10 +917,10 @@ import { j as fillPool } from "__TURBOPACK_PART__" assert {
 import { i as poolOffset } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -12
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 8
+import { e as urlAlphabet } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -9,
+    __turbopack_original__: './url-alphabet/index.js'
 };
-import { urlAlphabet } from "./url-alphabet/index.js";
 import { h as pool } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -11
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/next-response/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/next-response/output.md
@@ -629,30 +629,36 @@ export { handleMiddlewareField as j } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 16
 ```js
-import { g as ResponseCookies } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -12
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
 };
-import { b as stringifyCookie } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -3
+import { ResponseCookies } from "./cookies";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
 };
+import { stringifyCookie } from "../../web/spec-extension/cookies";
 import { j as handleMiddlewareField } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -15
 };
-import { f as ReflectAdapter } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -10
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
 };
+import { ReflectAdapter } from "./adapters/reflect";
 import { h as INTERNALS } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -13
 };
-import { c as NextURL } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -5
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
 };
-import { d as toNodeOutgoingHttpHeaders } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -7
+import { NextURL } from "../next-url";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
-import { e as validateURL } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -8
+import { toNodeOutgoingHttpHeaders } from "../utils";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
+import { validateURL } from "../utils";
 import { i as REDIRECTS } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -14
 };
@@ -948,30 +954,36 @@ export { handleMiddlewareField as j } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 16
 ```js
-import { g as ResponseCookies } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -12
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 11
 };
-import { b as stringifyCookie } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -3
+import { ResponseCookies } from "./cookies";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
 };
+import { stringifyCookie } from "../../web/spec-extension/cookies";
 import { j as handleMiddlewareField } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -15
 };
-import { f as ReflectAdapter } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -10
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 9
 };
+import { ReflectAdapter } from "./adapters/reflect";
 import { h as INTERNALS } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -13
 };
-import { c as NextURL } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -5
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
 };
-import { d as toNodeOutgoingHttpHeaders } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -7
+import { NextURL } from "../next-url";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
-import { e as validateURL } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -8
+import { toNodeOutgoingHttpHeaders } from "../utils";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
+import { validateURL } from "../utils";
 import { i as REDIRECTS } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -14
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/next-response/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/next-response/output.md
@@ -629,36 +629,36 @@ export { handleMiddlewareField as j } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 16
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
+import { g as ResponseCookies } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -12,
+    __turbopack_original__: './cookies'
 };
-import { ResponseCookies } from "./cookies";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+import { b as stringifyCookie } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -3,
+    __turbopack_original__: '../../web/spec-extension/cookies'
 };
-import { stringifyCookie } from "../../web/spec-extension/cookies";
 import { j as handleMiddlewareField } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -15
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
+import { f as ReflectAdapter } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -10,
+    __turbopack_original__: './adapters/reflect'
 };
-import { ReflectAdapter } from "./adapters/reflect";
 import { h as INTERNALS } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -13
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+import { c as NextURL } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -5,
+    __turbopack_original__: '../next-url'
 };
-import { NextURL } from "../next-url";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { d as toNodeOutgoingHttpHeaders } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -7,
+    __turbopack_original__: '../utils'
 };
-import { toNodeOutgoingHttpHeaders } from "../utils";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { e as validateURL } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -8,
+    __turbopack_original__: '../utils'
 };
-import { validateURL } from "../utils";
 import { i as REDIRECTS } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -14
 };
@@ -954,36 +954,36 @@ export { handleMiddlewareField as j } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 16
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 11
+import { g as ResponseCookies } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -12,
+    __turbopack_original__: './cookies'
 };
-import { ResponseCookies } from "./cookies";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+import { b as stringifyCookie } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -3,
+    __turbopack_original__: '../../web/spec-extension/cookies'
 };
-import { stringifyCookie } from "../../web/spec-extension/cookies";
 import { j as handleMiddlewareField } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -15
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 9
+import { f as ReflectAdapter } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -10,
+    __turbopack_original__: './adapters/reflect'
 };
-import { ReflectAdapter } from "./adapters/reflect";
 import { h as INTERNALS } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -13
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+import { c as NextURL } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -5,
+    __turbopack_original__: '../next-url'
 };
-import { NextURL } from "../next-url";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { d as toNodeOutgoingHttpHeaders } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -7,
+    __turbopack_original__: '../utils'
 };
-import { toNodeOutgoingHttpHeaders } from "../utils";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { e as validateURL } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -8,
+    __turbopack_original__: '../utils'
 };
-import { validateURL } from "../utils";
 import { i as REDIRECTS } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -14
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nextjs-tracer/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nextjs-tracer/output.md
@@ -964,9 +964,10 @@ import { j as propagation } from "__TURBOPACK_PART__" assert {
 import { s as clientTraceDataSetter } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -20
 };
-import { g as NextVanillaSpanAllowlist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -8
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
+import { NextVanillaSpanAllowlist } from "./constants";
 import { l as ROOT_CONTEXT } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -11
 };
@@ -979,9 +980,10 @@ import { p as rootSpanIdKey } from "__TURBOPACK_PART__" assert {
 import { o as rootSpanAttributesStore } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -16
 };
-import { f as LogSpanAllowList } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -7
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
+import { LogSpanAllowList } from "./constants";
 import { n as closeSpanWithError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -15
 };
@@ -1479,9 +1481,10 @@ import { j as propagation } from "__TURBOPACK_PART__" assert {
 import { s as clientTraceDataSetter } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -20
 };
-import { g as NextVanillaSpanAllowlist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -8
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
+import { NextVanillaSpanAllowlist } from "./constants";
 import { l as ROOT_CONTEXT } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -11
 };
@@ -1494,9 +1497,10 @@ import { p as rootSpanIdKey } from "__TURBOPACK_PART__" assert {
 import { o as rootSpanAttributesStore } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -16
 };
-import { f as LogSpanAllowList } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -7
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
+import { LogSpanAllowList } from "./constants";
 import { n as closeSpanWithError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -15
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nextjs-tracer/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/nextjs-tracer/output.md
@@ -964,10 +964,10 @@ import { j as propagation } from "__TURBOPACK_PART__" assert {
 import { s as clientTraceDataSetter } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -20
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { g as NextVanillaSpanAllowlist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -8,
+    __turbopack_original__: './constants'
 };
-import { NextVanillaSpanAllowlist } from "./constants";
 import { l as ROOT_CONTEXT } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -11
 };
@@ -980,10 +980,10 @@ import { p as rootSpanIdKey } from "__TURBOPACK_PART__" assert {
 import { o as rootSpanAttributesStore } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -16
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { f as LogSpanAllowList } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -7,
+    __turbopack_original__: './constants'
 };
-import { LogSpanAllowList } from "./constants";
 import { n as closeSpanWithError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -15
 };
@@ -1481,10 +1481,10 @@ import { j as propagation } from "__TURBOPACK_PART__" assert {
 import { s as clientTraceDataSetter } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -20
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { g as NextVanillaSpanAllowlist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -8,
+    __turbopack_original__: './constants'
 };
-import { NextVanillaSpanAllowlist } from "./constants";
 import { l as ROOT_CONTEXT } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -11
 };
@@ -1497,10 +1497,10 @@ import { p as rootSpanIdKey } from "__TURBOPACK_PART__" assert {
 import { o as rootSpanAttributesStore } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -16
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { f as LogSpanAllowList } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -7,
+    __turbopack_original__: './constants'
 };
-import { LogSpanAllowList } from "./constants";
 import { n as closeSpanWithError } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -15
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/node-fetch/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/node-fetch/output.md
@@ -190,9 +190,10 @@ export { Stream as b } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 4
 ```js
-import { b as Stream } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -3
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
 };
+import Stream from "node:stream";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
@@ -287,9 +288,10 @@ export { Stream as b } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 4
 ```js
-import { b as Stream } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -3
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
 };
+import Stream from "node:stream";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/node-fetch/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/node-fetch/output.md
@@ -190,10 +190,10 @@ export { Stream as b } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 4
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+import { b as Stream } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -3,
+    __turbopack_original__: 'node:stream'
 };
-import Stream from "node:stream";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };
@@ -288,10 +288,10 @@ export { Stream as b } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 4
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+import { b as Stream } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -3,
+    __turbopack_original__: 'node:stream'
 };
-import Stream from "node:stream";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 2
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/otel-core/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/otel-core/output.md
@@ -282,15 +282,18 @@ export { _globalThis as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
-import { c as DEFAULT_ENVIRONMENT } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -4
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
-import { d as parseEnvironment } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -5
+import { DEFAULT_ENVIRONMENT } from "../../utils/environment";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
-import { e as _globalThis } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -7
+import { parseEnvironment } from "../../utils/environment";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
+import { _globalThis } from "./globalThis";
 function getEnv() {
     var globalEnv = parseEnvironment(_globalThis);
     return Object.assign({}, DEFAULT_ENVIRONMENT, globalEnv);
@@ -302,12 +305,14 @@ export { getEnv as a } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 9
 ```js
-import { e as _globalThis } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -7
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
-import { d as parseEnvironment } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -5
+import { _globalThis } from "./globalThis";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
+import { parseEnvironment } from "../../utils/environment";
 function getEnvWithoutDefaults() {
     return parseEnvironment(_globalThis);
 }
@@ -423,15 +428,18 @@ export { _globalThis as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
-import { c as DEFAULT_ENVIRONMENT } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -4
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
-import { d as parseEnvironment } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -5
+import { DEFAULT_ENVIRONMENT } from "../../utils/environment";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
-import { e as _globalThis } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -7
+import { parseEnvironment } from "../../utils/environment";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
+import { _globalThis } from "./globalThis";
 function getEnv() {
     var globalEnv = parseEnvironment(_globalThis);
     return Object.assign({}, DEFAULT_ENVIRONMENT, globalEnv);
@@ -443,12 +451,14 @@ export { getEnv as a } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 9
 ```js
-import { e as _globalThis } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -7
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
-import { d as parseEnvironment } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -5
+import { _globalThis } from "./globalThis";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
+import { parseEnvironment } from "../../utils/environment";
 function getEnvWithoutDefaults() {
     return parseEnvironment(_globalThis);
 }

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/otel-core/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/otel-core/output.md
@@ -282,18 +282,18 @@ export { _globalThis as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+import { c as DEFAULT_ENVIRONMENT } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -4,
+    __turbopack_original__: '../../utils/environment'
 };
-import { DEFAULT_ENVIRONMENT } from "../../utils/environment";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+import { d as parseEnvironment } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -5,
+    __turbopack_original__: '../../utils/environment'
 };
-import { parseEnvironment } from "../../utils/environment";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { e as _globalThis } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -7,
+    __turbopack_original__: './globalThis'
 };
-import { _globalThis } from "./globalThis";
 function getEnv() {
     var globalEnv = parseEnvironment(_globalThis);
     return Object.assign({}, DEFAULT_ENVIRONMENT, globalEnv);
@@ -305,14 +305,14 @@ export { getEnv as a } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 9
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { e as _globalThis } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -7,
+    __turbopack_original__: './globalThis'
 };
-import { _globalThis } from "./globalThis";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+import { d as parseEnvironment } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -5,
+    __turbopack_original__: '../../utils/environment'
 };
-import { parseEnvironment } from "../../utils/environment";
 function getEnvWithoutDefaults() {
     return parseEnvironment(_globalThis);
 }
@@ -428,18 +428,18 @@ export { _globalThis as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+import { c as DEFAULT_ENVIRONMENT } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -4,
+    __turbopack_original__: '../../utils/environment'
 };
-import { DEFAULT_ENVIRONMENT } from "../../utils/environment";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+import { d as parseEnvironment } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -5,
+    __turbopack_original__: '../../utils/environment'
 };
-import { parseEnvironment } from "../../utils/environment";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { e as _globalThis } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -7,
+    __turbopack_original__: './globalThis'
 };
-import { _globalThis } from "./globalThis";
 function getEnv() {
     var globalEnv = parseEnvironment(_globalThis);
     return Object.assign({}, DEFAULT_ENVIRONMENT, globalEnv);
@@ -451,14 +451,14 @@ export { getEnv as a } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 9
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { e as _globalThis } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -7,
+    __turbopack_original__: './globalThis'
 };
-import { _globalThis } from "./globalThis";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+import { d as parseEnvironment } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -5,
+    __turbopack_original__: '../../utils/environment'
 };
-import { parseEnvironment } from "../../utils/environment";
 function getEnvWithoutDefaults() {
     return parseEnvironment(_globalThis);
 }

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/route-handler/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/route-handler/output.md
@@ -187,9 +187,10 @@ export { NextResponse as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 5
 ```js
-import { c as NextResponse } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -4
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
+import { NextResponse } from "next/server";
 const GET = (req)=>{
     return NextResponse.json({
         pathname: req.nextUrl.pathname
@@ -285,9 +286,10 @@ export { NextResponse as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 5
 ```js
-import { c as NextResponse } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -4
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 3
 };
+import { NextResponse } from "next/server";
 const GET = (req)=>{
     return NextResponse.json({
         pathname: req.nextUrl.pathname

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/route-handler/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/route-handler/output.md
@@ -187,10 +187,10 @@ export { NextResponse as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 5
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+import { c as NextResponse } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -4,
+    __turbopack_original__: "next/server"
 };
-import { NextResponse } from "next/server";
 const GET = (req)=>{
     return NextResponse.json({
         pathname: req.nextUrl.pathname
@@ -286,10 +286,10 @@ export { NextResponse as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 5
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 3
+import { c as NextResponse } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -4,
+    __turbopack_original__: "next/server"
 };
-import { NextResponse } from "next/server";
 const GET = (req)=>{
     return NextResponse.json({
         pathname: req.nextUrl.pathname

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/template-pages/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/template-pages/output.md
@@ -1031,12 +1031,14 @@ export { userland as r } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 25
 ```js
-import { o as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -18
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import { hoist } from "./helpers";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 23
 };
@@ -1048,12 +1050,14 @@ export { __TURBOPACK__default__export__ as a } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 26
 ```js
-import { o as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -18
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import { hoist } from "./helpers";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 25
 };
@@ -1065,12 +1069,14 @@ export { getStaticProps as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 27
 ```js
-import { o as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -18
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import { hoist } from "./helpers";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 26
 };
@@ -1082,12 +1088,14 @@ export { getStaticPaths as d } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 28
 ```js
-import { o as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -18
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import { hoist } from "./helpers";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 27
 };
@@ -1099,12 +1107,14 @@ export { getServerSideProps as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 29
 ```js
-import { o as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -18
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import { hoist } from "./helpers";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 28
 };
@@ -1116,12 +1126,14 @@ export { config as b } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 30
 ```js
-import { o as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -18
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import { hoist } from "./helpers";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 29
 };
@@ -1133,12 +1145,14 @@ export { reportWebVitals as f } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 31
 ```js
-import { o as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -18
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import { hoist } from "./helpers";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 30
 };
@@ -1150,12 +1164,14 @@ export { unstable_getStaticProps as l } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 32
 ```js
-import { o as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -18
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import { hoist } from "./helpers";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 31
 };
@@ -1167,12 +1183,14 @@ export { unstable_getStaticPaths as k } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 33
 ```js
-import { o as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -18
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import { hoist } from "./helpers";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 32
 };
@@ -1184,12 +1202,14 @@ export { unstable_getStaticParams as j } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 34
 ```js
-import { o as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -18
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import { hoist } from "./helpers";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 33
 };
@@ -1201,12 +1221,14 @@ export { unstable_getServerProps as h } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 35
 ```js
-import { o as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -18
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import { hoist } from "./helpers";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 34
 };
@@ -1218,21 +1240,26 @@ export { unstable_getServerSideProps as i } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 36
 ```js
-import { m as PagesRouteModule } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -14
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
 };
-import { n as RouteKind } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -16
+import { PagesRouteModule } from "../../server/future/route-modules/pages/module.compiled";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
 };
-import { q as App } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -22
+import { RouteKind } from "../../server/future/route-kind";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
 };
-import { p as Document } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -20
+import App from "VAR_MODULE_APP";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import Document from "VAR_MODULE_DOCUMENT";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 35
 };
@@ -1567,12 +1594,14 @@ export { userland as r } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 25
 ```js
-import { o as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -18
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import { hoist } from "./helpers";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 23
 };
@@ -1584,12 +1613,14 @@ export { __TURBOPACK__default__export__ as a } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 26
 ```js
-import { o as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -18
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import { hoist } from "./helpers";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 25
 };
@@ -1601,12 +1632,14 @@ export { getStaticProps as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 27
 ```js
-import { o as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -18
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import { hoist } from "./helpers";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 26
 };
@@ -1618,12 +1651,14 @@ export { getStaticPaths as d } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 28
 ```js
-import { o as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -18
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import { hoist } from "./helpers";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 27
 };
@@ -1635,12 +1670,14 @@ export { getServerSideProps as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 29
 ```js
-import { o as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -18
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import { hoist } from "./helpers";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 28
 };
@@ -1652,12 +1689,14 @@ export { config as b } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 30
 ```js
-import { o as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -18
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import { hoist } from "./helpers";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 29
 };
@@ -1669,12 +1708,14 @@ export { reportWebVitals as f } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 31
 ```js
-import { o as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -18
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import { hoist } from "./helpers";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 30
 };
@@ -1686,12 +1727,14 @@ export { unstable_getStaticProps as l } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 32
 ```js
-import { o as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -18
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import { hoist } from "./helpers";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 31
 };
@@ -1703,12 +1746,14 @@ export { unstable_getStaticPaths as k } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 33
 ```js
-import { o as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -18
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import { hoist } from "./helpers";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 32
 };
@@ -1720,12 +1765,14 @@ export { unstable_getStaticParams as j } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 34
 ```js
-import { o as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -18
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import { hoist } from "./helpers";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 33
 };
@@ -1737,12 +1784,14 @@ export { unstable_getServerProps as h } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 35
 ```js
-import { o as hoist } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -18
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 17
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import { hoist } from "./helpers";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 34
 };
@@ -1754,21 +1803,26 @@ export { unstable_getServerSideProps as i } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 36
 ```js
-import { m as PagesRouteModule } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -14
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 13
 };
-import { n as RouteKind } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -16
+import { PagesRouteModule } from "../../server/future/route-modules/pages/module.compiled";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 15
 };
-import { q as App } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -22
+import { RouteKind } from "../../server/future/route-kind";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 21
 };
-import { p as Document } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -20
+import App from "VAR_MODULE_APP";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 19
 };
-import { r as userland } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -24
+import Document from "VAR_MODULE_DOCUMENT";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 23
 };
+import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 35
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/template-pages/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/template-pages/output.md
@@ -1031,14 +1031,14 @@ export { userland as r } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 25
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+import { o as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -18,
+    __turbopack_original__: './helpers'
 };
-import { hoist } from "./helpers";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 23
 };
@@ -1050,14 +1050,14 @@ export { __TURBOPACK__default__export__ as a } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 26
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+import { o as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -18,
+    __turbopack_original__: './helpers'
 };
-import { hoist } from "./helpers";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 25
 };
@@ -1069,14 +1069,14 @@ export { getStaticProps as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 27
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+import { o as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -18,
+    __turbopack_original__: './helpers'
 };
-import { hoist } from "./helpers";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 26
 };
@@ -1088,14 +1088,14 @@ export { getStaticPaths as d } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 28
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+import { o as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -18,
+    __turbopack_original__: './helpers'
 };
-import { hoist } from "./helpers";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 27
 };
@@ -1107,14 +1107,14 @@ export { getServerSideProps as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 29
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+import { o as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -18,
+    __turbopack_original__: './helpers'
 };
-import { hoist } from "./helpers";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 28
 };
@@ -1126,14 +1126,14 @@ export { config as b } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 30
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+import { o as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -18,
+    __turbopack_original__: './helpers'
 };
-import { hoist } from "./helpers";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 29
 };
@@ -1145,14 +1145,14 @@ export { reportWebVitals as f } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 31
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+import { o as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -18,
+    __turbopack_original__: './helpers'
 };
-import { hoist } from "./helpers";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 30
 };
@@ -1164,14 +1164,14 @@ export { unstable_getStaticProps as l } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 32
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+import { o as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -18,
+    __turbopack_original__: './helpers'
 };
-import { hoist } from "./helpers";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 31
 };
@@ -1183,14 +1183,14 @@ export { unstable_getStaticPaths as k } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 33
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+import { o as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -18,
+    __turbopack_original__: './helpers'
 };
-import { hoist } from "./helpers";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 32
 };
@@ -1202,14 +1202,14 @@ export { unstable_getStaticParams as j } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 34
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+import { o as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -18,
+    __turbopack_original__: './helpers'
 };
-import { hoist } from "./helpers";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 33
 };
@@ -1221,14 +1221,14 @@ export { unstable_getServerProps as h } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 35
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+import { o as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -18,
+    __turbopack_original__: './helpers'
 };
-import { hoist } from "./helpers";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 34
 };
@@ -1240,26 +1240,26 @@ export { unstable_getServerSideProps as i } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 36
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
+import { m as PagesRouteModule } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -14,
+    __turbopack_original__: '../../server/future/route-modules/pages/module.compiled'
 };
-import { PagesRouteModule } from "../../server/future/route-modules/pages/module.compiled";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
+import { n as RouteKind } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -16,
+    __turbopack_original__: '../../server/future/route-kind'
 };
-import { RouteKind } from "../../server/future/route-kind";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+import { q as App } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -22,
+    __turbopack_original__: 'VAR_MODULE_APP'
 };
-import App from "VAR_MODULE_APP";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 19
+import { p as Document } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -20,
+    __turbopack_original__: 'VAR_MODULE_DOCUMENT'
 };
-import Document from "VAR_MODULE_DOCUMENT";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 35
 };
@@ -1594,14 +1594,14 @@ export { userland as r } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 25
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+import { o as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -18,
+    __turbopack_original__: './helpers'
 };
-import { hoist } from "./helpers";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 23
 };
@@ -1613,14 +1613,14 @@ export { __TURBOPACK__default__export__ as a } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 26
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+import { o as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -18,
+    __turbopack_original__: './helpers'
 };
-import { hoist } from "./helpers";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 25
 };
@@ -1632,14 +1632,14 @@ export { getStaticProps as e } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 27
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+import { o as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -18,
+    __turbopack_original__: './helpers'
 };
-import { hoist } from "./helpers";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 26
 };
@@ -1651,14 +1651,14 @@ export { getStaticPaths as d } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 28
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+import { o as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -18,
+    __turbopack_original__: './helpers'
 };
-import { hoist } from "./helpers";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 27
 };
@@ -1670,14 +1670,14 @@ export { getServerSideProps as c } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 29
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+import { o as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -18,
+    __turbopack_original__: './helpers'
 };
-import { hoist } from "./helpers";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 28
 };
@@ -1689,14 +1689,14 @@ export { config as b } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 30
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+import { o as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -18,
+    __turbopack_original__: './helpers'
 };
-import { hoist } from "./helpers";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 29
 };
@@ -1708,14 +1708,14 @@ export { reportWebVitals as f } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 31
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+import { o as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -18,
+    __turbopack_original__: './helpers'
 };
-import { hoist } from "./helpers";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 30
 };
@@ -1727,14 +1727,14 @@ export { unstable_getStaticProps as l } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 32
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+import { o as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -18,
+    __turbopack_original__: './helpers'
 };
-import { hoist } from "./helpers";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 31
 };
@@ -1746,14 +1746,14 @@ export { unstable_getStaticPaths as k } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 33
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+import { o as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -18,
+    __turbopack_original__: './helpers'
 };
-import { hoist } from "./helpers";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 32
 };
@@ -1765,14 +1765,14 @@ export { unstable_getStaticParams as j } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 34
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+import { o as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -18,
+    __turbopack_original__: './helpers'
 };
-import { hoist } from "./helpers";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 33
 };
@@ -1784,14 +1784,14 @@ export { unstable_getServerProps as h } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 35
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 17
+import { o as hoist } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -18,
+    __turbopack_original__: './helpers'
 };
-import { hoist } from "./helpers";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 34
 };
@@ -1803,26 +1803,26 @@ export { unstable_getServerSideProps as i } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 36
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 13
+import { m as PagesRouteModule } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -14,
+    __turbopack_original__: '../../server/future/route-modules/pages/module.compiled'
 };
-import { PagesRouteModule } from "../../server/future/route-modules/pages/module.compiled";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 15
+import { n as RouteKind } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -16,
+    __turbopack_original__: '../../server/future/route-kind'
 };
-import { RouteKind } from "../../server/future/route-kind";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 21
+import { q as App } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -22,
+    __turbopack_original__: 'VAR_MODULE_APP'
 };
-import App from "VAR_MODULE_APP";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 19
+import { p as Document } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -20,
+    __turbopack_original__: 'VAR_MODULE_DOCUMENT'
 };
-import Document from "VAR_MODULE_DOCUMENT";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 23
+import { r as userland } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -24,
+    __turbopack_original__: 'VAR_USERLAND'
 };
-import * as userland from "VAR_USERLAND";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 35
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/test-config-1/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/test-config-1/output.md
@@ -593,9 +593,10 @@ foobarCopy += "Unused";
 import { d as foobar } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -7
 };
-import { e as upper } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -6
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
 };
+import { upper } from "module";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
@@ -841,9 +842,10 @@ foobarCopy += "Unused";
 import { d as foobar } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -7
 };
-import { e as upper } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -6
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 5
 };
+import { upper } from "module";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/test-config-1/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/test-config-1/output.md
@@ -593,10 +593,10 @@ foobarCopy += "Unused";
 import { d as foobar } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -7
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+import { e as upper } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -6,
+    __turbopack_original__: "module"
 };
-import { upper } from "module";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };
@@ -842,10 +842,10 @@ foobarCopy += "Unused";
 import { d as foobar } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -7
 };
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 5
+import { e as upper } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -6,
+    __turbopack_original__: "module"
 };
-import { upper } from "module";
 import "__TURBOPACK_PART__" assert {
     __turbopack_part__: 12
 };

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/typeof-1/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/typeof-1/output.md
@@ -264,15 +264,18 @@ export { MyModuleClientComponent as d } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
-import { d as MyModuleClientComponent } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -7
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
-import { b as NextResponse } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -3
+import { MyModuleClientComponent } from "my-module/MyModuleClientComponent";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
 };
-import { c as ClientComponent } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -5
+import { NextResponse } from "next/server";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
 };
+import { ClientComponent } from "../../ClientComponent";
 function GET() {
     return NextResponse.json({
         clientComponent: typeof ClientComponent,
@@ -385,15 +388,18 @@ export { MyModuleClientComponent as d } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
-import { d as MyModuleClientComponent } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -7
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 6
 };
-import { b as NextResponse } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -3
+import { MyModuleClientComponent } from "my-module/MyModuleClientComponent";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 2
 };
-import { c as ClientComponent } from "__TURBOPACK_PART__" assert {
-    __turbopack_part__: -5
+import { NextResponse } from "next/server";
+import "__TURBOPACK_PART__" assert {
+    __turbopack_part__: 4
 };
+import { ClientComponent } from "../../ClientComponent";
 function GET() {
     return NextResponse.json({
         clientComponent: typeof ClientComponent,

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/typeof-1/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/typeof-1/output.md
@@ -264,18 +264,18 @@ export { MyModuleClientComponent as d } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { d as MyModuleClientComponent } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -7,
+    __turbopack_original__: 'my-module/MyModuleClientComponent'
 };
-import { MyModuleClientComponent } from "my-module/MyModuleClientComponent";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+import { b as NextResponse } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -3,
+    __turbopack_original__: 'next/server'
 };
-import { NextResponse } from "next/server";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+import { c as ClientComponent } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -5,
+    __turbopack_original__: '../../ClientComponent'
 };
-import { ClientComponent } from "../../ClientComponent";
 function GET() {
     return NextResponse.json({
         clientComponent: typeof ClientComponent,
@@ -388,18 +388,18 @@ export { MyModuleClientComponent as d } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 8
 ```js
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 6
+import { d as MyModuleClientComponent } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -7,
+    __turbopack_original__: 'my-module/MyModuleClientComponent'
 };
-import { MyModuleClientComponent } from "my-module/MyModuleClientComponent";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 2
+import { b as NextResponse } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -3,
+    __turbopack_original__: 'next/server'
 };
-import { NextResponse } from "next/server";
-import "__TURBOPACK_PART__" assert {
-    __turbopack_part__: 4
+import { c as ClientComponent } from "__TURBOPACK_PART__" assert {
+    __turbopack_part__: -5,
+    __turbopack_original__: '../../ClientComponent'
 };
-import { ClientComponent } from "../../ClientComponent";
 function GET() {
     return NextResponse.json({
         clientComponent: typeof ClientComponent,


### PR DESCRIPTION
### What?

Preserve the original import specifier when tree shaking, so the import analyzers after tree shaking can work.

### Why?

This is required for `next/dynamic`.

### How?

Closes PACK-3307
