### PR TITLE
misc(next-upgrade): reuse process.cwd() value

### DIFF
--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -72,12 +72,14 @@ function endMessage() {
   )
 }
 
+const CWD = process.cwd()
+
 export async function runUpgrade(
   revision: string | undefined,
   options: { verbose: boolean }
 ): Promise<void> {
   const { verbose } = options
-  const appPackageJsonPath = path.resolve(process.cwd(), 'package.json')
+  const appPackageJsonPath = path.resolve(CWD, 'package.json')
   let appPackageJson = JSON.parse(fs.readFileSync(appPackageJsonPath, 'utf8'))
 
   let targetNextPackageJson: {
@@ -126,8 +128,8 @@ export async function runUpgrade(
   console.log(`  - Next.js: v${installedNextVersion}`)
   let shouldStayOnReact18 = false
 
-  const usesAppDir = isUsingAppDir(process.cwd())
-  const usesPagesDir = isUsingPagesDir(process.cwd())
+  const usesAppDir = isUsingAppDir(CWD)
+  const usesPagesDir = isUsingPagesDir(CWD)
 
   const isPureAppRouter = usesAppDir && !usesPagesDir
   const isMixedApp = usesPagesDir && usesAppDir
@@ -183,7 +185,7 @@ export async function runUpgrade(
     installedNextVersion,
     targetNextVersion
   )
-  const packageManager: PackageManager = getPkgManager(process.cwd())
+  const packageManager: PackageManager = getPkgManager(CWD)
 
   let shouldRunReactCodemods = false
   let shouldRunReactTypesCodemods = false
@@ -321,7 +323,7 @@ export async function runUpgrade(
   runInstallation(packageManager)
 
   for (const codemod of codemods) {
-    await runTransform(codemod, process.cwd(), { force: true, verbose })
+    await runTransform(codemod, CWD, { force: true, verbose })
   }
 
   // To reduce user-side burden of selecting which codemods to run as it needs additional
@@ -355,12 +357,12 @@ function getInstalledNextVersion(): string {
   try {
     return require(
       require.resolve('next/package.json', {
-        paths: [process.cwd()],
+        paths: [CWD],
       })
     ).version
   } catch (error) {
     throw new BadInput(
-      `Failed to get the installed Next.js version at "${process.cwd()}".\nIf you're using a monorepo, please run this command from the Next.js app directory.`,
+      `Failed to get the installed Next.js version at "${CWD}".\nIf you're using a monorepo, please run this command from the Next.js app directory.`,
       {
         cause: error,
       }
@@ -372,12 +374,12 @@ function getInstalledReactVersion(): string {
   try {
     return require(
       require.resolve('react/package.json', {
-        paths: [process.cwd()],
+        paths: [CWD],
       })
     ).version
   } catch (error) {
     throw new BadInput(
-      `Failed to detect the installed React version in "${process.cwd()}".\nIf you're working in a monorepo, please run this command from the Next.js app directory.`,
+      `Failed to detect the installed React version in "${CWD}".\nIf you're working in a monorepo, please run this command from the Next.js app directory.`,
       {
         cause: error,
       }

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -72,14 +72,14 @@ function endMessage() {
   )
 }
 
-const CWD = process.cwd()
+const cwd = process.cwd()
 
 export async function runUpgrade(
   revision: string | undefined,
   options: { verbose: boolean }
 ): Promise<void> {
   const { verbose } = options
-  const appPackageJsonPath = path.resolve(CWD, 'package.json')
+  const appPackageJsonPath = path.resolve(cwd, 'package.json')
   let appPackageJson = JSON.parse(fs.readFileSync(appPackageJsonPath, 'utf8'))
 
   let targetNextPackageJson: {
@@ -128,8 +128,8 @@ export async function runUpgrade(
   console.log(`  - Next.js: v${installedNextVersion}`)
   let shouldStayOnReact18 = false
 
-  const usesAppDir = isUsingAppDir(CWD)
-  const usesPagesDir = isUsingPagesDir(CWD)
+  const usesAppDir = isUsingAppDir(cwd)
+  const usesPagesDir = isUsingPagesDir(cwd)
 
   const isPureAppRouter = usesAppDir && !usesPagesDir
   const isMixedApp = usesPagesDir && usesAppDir
@@ -185,7 +185,7 @@ export async function runUpgrade(
     installedNextVersion,
     targetNextVersion
   )
-  const packageManager: PackageManager = getPkgManager(CWD)
+  const packageManager: PackageManager = getPkgManager(cwd)
 
   let shouldRunReactCodemods = false
   let shouldRunReactTypesCodemods = false
@@ -323,7 +323,7 @@ export async function runUpgrade(
   runInstallation(packageManager)
 
   for (const codemod of codemods) {
-    await runTransform(codemod, CWD, { force: true, verbose })
+    await runTransform(codemod, cwd, { force: true, verbose })
   }
 
   // To reduce user-side burden of selecting which codemods to run as it needs additional
@@ -357,12 +357,12 @@ function getInstalledNextVersion(): string {
   try {
     return require(
       require.resolve('next/package.json', {
-        paths: [CWD],
+        paths: [cwd],
       })
     ).version
   } catch (error) {
     throw new BadInput(
-      `Failed to get the installed Next.js version at "${CWD}".\nIf you're using a monorepo, please run this command from the Next.js app directory.`,
+      `Failed to get the installed Next.js version at "${cwd}".\nIf you're using a monorepo, please run this command from the Next.js app directory.`,
       {
         cause: error,
       }
@@ -374,12 +374,12 @@ function getInstalledReactVersion(): string {
   try {
     return require(
       require.resolve('react/package.json', {
-        paths: [CWD],
+        paths: [cwd],
       })
     ).version
   } catch (error) {
     throw new BadInput(
-      `Failed to detect the installed React version in "${CWD}".\nIf you're working in a monorepo, please run this command from the Next.js app directory.`,
+      `Failed to detect the installed React version in "${cwd}".\nIf you're working in a monorepo, please run this command from the Next.js app directory.`,
       {
         cause: error,
       }

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -513,12 +513,10 @@ async function suggestCodemods(
 async function suggestReactCodemods(): Promise<boolean> {
   const { runReactCodemod } = await prompts(
     {
-      type: 'toggle',
+      type: 'confirm',
       name: 'runReactCodemod',
       message: 'Would you like to run the React 19 upgrade codemod?',
       initial: true,
-      active: 'Yes',
-      inactive: 'No',
     },
     { onCancel }
   )
@@ -529,12 +527,10 @@ async function suggestReactCodemods(): Promise<boolean> {
 async function suggestReactTypesCodemods(): Promise<boolean> {
   const { runReactTypesCodemod } = await prompts(
     {
-      type: 'toggle',
+      type: 'confirm',
       name: 'runReactTypesCodemod',
       message: 'Would you like to run the React 19 Types upgrade codemod?',
       initial: true,
-      active: 'Yes',
-      inactive: 'No',
     },
     { onCancel }
   )


### PR DESCRIPTION
### Why?

Reuse `process.cwd` value. This is good for slight perf and future extensible when we add `cwd` option.