### PR TITLE
chore(next-codemod): remove `@next/font` from optional Next.js packages to install

### DIFF
--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -23,7 +23,6 @@ const optionalNextjsPackages = [
   '@next/codemod',
   '@next/env',
   '@next/eslint-plugin-next',
-  '@next/font',
   '@next/mdx',
   '@next/plugin-storybook',
   '@next/polyfill-module',


### PR DESCRIPTION
### Why?

`@next/font` is deprecated and need to be replaced with `next/font`.