### PR TITLE
Ensure workers are cleaned up always

### DIFF
--- a/packages/next/src/lib/worker.ts
+++ b/packages/next/src/lib/worker.ts
@@ -38,6 +38,11 @@ export class Worker {
 
     this._worker = undefined
 
+    // ensure we end workers if they weren't before exit
+    process.on('exit', () => {
+      this.close()
+    })
+
     const createWorker = () => {
       // Get the node options without inspect and also remove the
       // --max-old-space-size flag as it can cause memory issues.


### PR DESCRIPTION
This ensures we properly clean up workers even if an error is thrown before our normal `.end()` call is done. This can be verified currently by building `pnpm next test/e2e/app-dir/dynamic-io` which should encounter an error and fail but the workers were previously being kept and using lots of CPU, now they are properly cleaned up. 