### PR TITLE
Avoid server action `endpoint` function indirection

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-flight-action-entry-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-action-entry-loader.ts
@@ -23,10 +23,7 @@ function nextFlightActionEntryLoader(this: any) {
 ${individualActions
   .map(([id, path, name]) => {
     // Re-export the same functions from the original module path as action IDs.
-    return `
-    const { ${name}: _${id} } = await import(${JSON.stringify(path)});
-    export { _${id} as "${id}" };
-`
+    return `export { ${name} as "${id}" } from ${JSON.stringify(path)}`
   })
   .join('\n')}
 `

--- a/packages/next/src/build/webpack/loaders/next-flight-action-entry-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-action-entry-loader.ts
@@ -30,16 +30,11 @@ ${individualActions
   .join('\n')}
 }
 
-async function endpoint(id, ...args) {
-  const action = await actions[id]()
-  return action.apply(null, args)
-}
-
 // Using CJS to avoid this to be tree-shaken away due to unused exports.
 module.exports = {
 ${individualActions
   .map(([id]) => {
-    return `  '${id}': endpoint.bind(null, '${id}'),`
+    return `  '${id}': actions['${id}'](),`
   })
   .join('\n')}
 }

--- a/packages/next/src/build/webpack/loaders/next-flight-action-entry-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-action-entry-loader.ts
@@ -21,17 +21,12 @@ function nextFlightActionEntryLoader(this: any) {
 
   return `
 ${individualActions
-  .map(([_, path]) => {
-    // This import ensures that the module is always bundled even if there's no
-    // explicit import in the codebase, to avoid the action being DCE'd.
-    return `import(/* webpackMode: "eager" */ ${JSON.stringify(path)});`
-  })
-  .join('\n')}
-
-${individualActions
   .map(([id, path, name]) => {
     // Re-export the same functions from the original module path as action IDs.
-    return `export { ${name} as "${id}" } from ${JSON.stringify(path)}`
+    return `
+    const { ${name}: _${id} } = await import(${JSON.stringify(path)});
+    export { _${id} as "${id}" };
+`
   })
   .join('\n')}
 `

--- a/packages/next/src/build/webpack/loaders/next-flight-action-entry-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-action-entry-loader.ts
@@ -22,12 +22,15 @@ function nextFlightActionEntryLoader(this: any) {
   return `
 ${individualActions
   .map(([_, path]) => {
+    // This import ensures that the module is always bundled even if there's no
+    // explicit import in the codebase, to avoid the action being DCE'd.
     return `import(/* webpackMode: "eager" */ ${JSON.stringify(path)});`
   })
   .join('\n')}
 
 ${individualActions
   .map(([id, path, name]) => {
+    // Re-export the same functions from the original module path as action IDs.
     return `export { ${name} as "${id}" } from ${JSON.stringify(path)}`
   })
   .join('\n')}

--- a/packages/next/src/build/webpack/loaders/next-flight-action-entry-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-action-entry-loader.ts
@@ -20,24 +20,17 @@ function nextFlightActionEntryLoader(this: any) {
     .flat()
 
   return `
-const actions = {
+${individualActions
+  .map(([_, path]) => {
+    return `import(/* webpackMode: "eager" */ ${JSON.stringify(path)});`
+  })
+  .join('\n')}
+
 ${individualActions
   .map(([id, path, name]) => {
-    return `'${id}': () => import(/* webpackMode: "eager" */ ${JSON.stringify(
-      path
-    )}).then(mod => mod[${JSON.stringify(name)}]),`
+    return `export { ${name} as "${id}" } from ${JSON.stringify(path)}`
   })
   .join('\n')}
-}
-
-// Using CJS to avoid this to be tree-shaken away due to unused exports.
-module.exports = {
-${individualActions
-  .map(([id]) => {
-    return `  '${id}': actions['${id}'](),`
-  })
-  .join('\n')}
-}
 `
 }
 

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -928,6 +928,13 @@ export class FlightClientEntryPlugin {
           }
 
           compilation.hooks.succeedEntry.call(dependency, options, module)
+
+          compilation.moduleGraph
+            .getExportsInfo(module)
+            .setUsedInUnknownWay(
+              this.isEdgeServer ? EDGE_RUNTIME_WEBPACK : DEFAULT_RUNTIME_WEBPACK
+            )
+
           return resolve(module)
         }
       )

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -55,7 +55,7 @@ const PLUGIN_NAME = 'FlightClientEntryPlugin'
 type Actions = {
   [actionId: string]: {
     workers: {
-      [name: string]: string | number
+      [name: string]: { moduleId: string | number; async: boolean }
     }
     // Record which layer the action is in (rsc or sc_action), in the specific entry.
     layer: {
@@ -79,15 +79,15 @@ const pluginState = getProxiedPluginState({
   actionModServerId: {} as Record<
     string,
     {
-      server?: string | number
-      client?: string | number
+      server?: { moduleId: string | number; async: boolean }
+      client?: { moduleId: string | number; async: boolean }
     }
   >,
   actionModEdgeServerId: {} as Record<
     string,
     {
-      server?: string | number
-      client?: string | number
+      server?: { moduleId: string | number; async: boolean }
+      client?: { moduleId: string | number; async: boolean }
     }
   >,
 
@@ -879,7 +879,11 @@ export class FlightClientEntryPlugin {
             layer: {},
           }
         }
-        currentCompilerServerActions[id].workers[bundlePath] = ''
+        currentCompilerServerActions[id].workers[bundlePath] = {
+          moduleId: '', // TODO: What's the meaning of this?
+          async: false,
+        }
+
         currentCompilerServerActions[id].layer[bundlePath] = fromClient
           ? WEBPACK_LAYERS.actionBrowser
           : WEBPACK_LAYERS.reactServerComponents
@@ -965,7 +969,10 @@ export class FlightClientEntryPlugin {
         if (!mapping[chunkGroup.name]) {
           mapping[chunkGroup.name] = {}
         }
-        mapping[chunkGroup.name][fromClient ? 'client' : 'server'] = modId
+        mapping[chunkGroup.name][fromClient ? 'client' : 'server'] = {
+          moduleId: modId,
+          async: compilation.moduleGraph.isAsync(mod),
+        }
       }
     })
 

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -55,7 +55,11 @@ const PLUGIN_NAME = 'FlightClientEntryPlugin'
 type Actions = {
   [actionId: string]: {
     workers: {
-      [name: string]: { moduleId: string | number; async: boolean }
+      [name: string]:
+        | { moduleId: string | number; async: boolean }
+        // TODO: This is legacy for Turbopack, and needs to be changed to the
+        // object above.
+        | string
     }
     // Record which layer the action is in (rsc or sc_action), in the specific entry.
     layer: {

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -870,7 +870,7 @@ export async function handleAction({
         }
       }
 
-      const actionHandler = (
+      const actionHandler = await (
         await ComponentMod.__next_app__.require(actionModId)
       )[
         // `actionId` must exist if we got here, as otherwise we would have thrown an error above

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -870,7 +870,7 @@ export async function handleAction({
         }
       }
 
-      const actionHandler = await (
+      const actionHandler = (
         await ComponentMod.__next_app__.require(actionModId)
       )[
         // `actionId` must exist if we got here, as otherwise we would have thrown an error above

--- a/packages/next/src/server/app-render/action-utils.ts
+++ b/packages/next/src/server/app-render/action-utils.ts
@@ -18,10 +18,16 @@ export function createServerModuleMap({
     {},
     {
       get: (_, id: string) => {
-        const { moduleId, async } =
+        const workerEntry =
           serverActionsManifest[
             process.env.NEXT_RUNTIME === 'edge' ? 'edge' : 'node'
           ][id].workers[normalizeWorkerPageName(pageName)]
+
+        if (typeof workerEntry === 'string') {
+          return { id: workerEntry, name: id, chunks: [] }
+        }
+
+        const { moduleId, async } = workerEntry
 
         return { id: moduleId, name: id, chunks: [], async }
       },

--- a/packages/next/src/server/app-render/action-utils.ts
+++ b/packages/next/src/server/app-render/action-utils.ts
@@ -18,17 +18,12 @@ export function createServerModuleMap({
     {},
     {
       get: (_, id: string) => {
-        return {
-          id: serverActionsManifest[
+        const { moduleId, async } =
+          serverActionsManifest[
             process.env.NEXT_RUNTIME === 'edge' ? 'edge' : 'node'
-          ][id].workers[normalizeWorkerPageName(pageName)],
-          name: id,
-          chunks: [],
-          // Because of how next-flight-action-entry-loader creates the action
-          // entry modules, we know that these become async. So we set the flag
-          // accordingly.
-          async: true,
-        }
+          ][id].workers[normalizeWorkerPageName(pageName)]
+
+        return { id: moduleId, name: id, chunks: [], async }
       },
     }
   )

--- a/packages/next/src/server/app-render/action-utils.ts
+++ b/packages/next/src/server/app-render/action-utils.ts
@@ -24,6 +24,10 @@ export function createServerModuleMap({
           ][id].workers[normalizeWorkerPageName(pageName)],
           name: id,
           chunks: [],
+          // Because of how next-flight-action-entry-loader creates the action
+          // entry modules, we know that these become async. So we set the flag
+          // accordingly.
+          async: true,
         }
       },
     }

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -828,6 +828,21 @@ describe('app-dir action handling', () => {
     ).toBe(true)
   })
 
+  it('should keep action instances identical', async () => {
+    const logs: string[] = []
+    next.on('stdout', (log) => {
+      logs.push(log)
+    })
+
+    const browser = await next.browser('/identity')
+
+    await browser.elementByCss('button').click()
+
+    await retry(() => {
+      expect(logs.join('')).toContain('result: true')
+    })
+  })
+
   it.each(['node', 'edge'])(
     'should forward action request to a worker that contains the action handler (%s)',
     async (runtime) => {

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -828,20 +828,23 @@ describe('app-dir action handling', () => {
     ).toBe(true)
   })
 
-  it('should keep action instances identical', async () => {
-    const logs: string[] = []
-    next.on('stdout', (log) => {
-      logs.push(log)
+  // we don't have access to runtime logs on deploy
+  if (!isNextDeploy) {
+    it('should keep action instances identical', async () => {
+      const logs: string[] = []
+      next.on('stdout', (log) => {
+        logs.push(log)
+      })
+
+      const browser = await next.browser('/identity')
+
+      await browser.elementByCss('button').click()
+
+      await retry(() => {
+        expect(logs.join('')).toContain('result: true')
+      })
     })
-
-    const browser = await next.browser('/identity')
-
-    await browser.elementByCss('button').click()
-
-    await retry(() => {
-      expect(logs.join('')).toContain('result: true')
-    })
-  })
+  }
 
   it.each(['node', 'edge'])(
     'should forward action request to a worker that contains the action handler (%s)',

--- a/test/e2e/app-dir/actions/app/identity/client.js
+++ b/test/e2e/app-dir/actions/app/identity/client.js
@@ -1,0 +1,13 @@
+'use client'
+
+export function Client({ foo, b }) {
+  return (
+    <button
+      onClick={() => {
+        foo(b)
+      }}
+    >
+      Trigger
+    </button>
+  )
+}

--- a/test/e2e/app-dir/actions/app/identity/page.js
+++ b/test/e2e/app-dir/actions/app/identity/page.js
@@ -1,0 +1,14 @@
+import { Client } from './client'
+
+export default async function Page() {
+  async function b() {
+    'use server'
+  }
+
+  async function foo(a) {
+    'use server'
+    console.log('result:', a === b)
+  }
+
+  return <Client foo={foo} b={b} />
+}


### PR DESCRIPTION
This PR removes the extra wrapper functions and `.bind()` calls from the action entrypoint loader. Instead, the loader module now only re-exports the actions from the original module using the IDs as export names. This ensures that the same action instance will always remain identical. It also unblocks the combined usage of `"use cache"` and `"use server"` functions.