### PR TITLE
[dynamicIO] Avoid triggering memory leak false positive with makeHangingPromise

### DIFF
--- a/test/e2e/app-dir/dynamic-io/dynamic-io.test.ts
+++ b/test/e2e/app-dir/dynamic-io/dynamic-io.test.ts
@@ -20,6 +20,12 @@ describe('dynamic-io', () => {
     expect(next.cliOutput).not.toMatch('Error occurred prerendering page')
   })
 
+  if (!isNextDev) {
+    it('should not warn about potential memory leak for even listeners on AbortSignal', async () => {
+      expect(next.cliOutput).not.toMatch('MaxListenersExceededWarning')
+    })
+  }
+
   it('should prerender fully static pages', async () => {
     let $ = await next.render$('/cases/static', {})
     if (isNextDev) {


### PR DESCRIPTION
makeHangingPromise returns a promise that rejects when an AbortSignal aborts. If too many are created however Node warns about a possible memory leak. We shouldn't increase the max count becuase this may prevent detection of legitmate memory leaks in user code. As an alternative we delegate aborts through a weakmap and attach only a single listener. This is trivially slower and more memory but safer semantics. This code only runs during revalidate and build so it does not have a perf impact on production streaming use cases.