### PR TITLE
fix: handle terminal color in chrome console

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -653,7 +653,6 @@ export function createStaticWorker(
     run: () => void
     clear: () => void
   }
-  // onActivity?: () => void
 ): StaticWorker {
   return new Worker(staticWorkerPath, {
     logger: Log,

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -649,12 +649,21 @@ const staticWorkerExposedMethods = [
 type StaticWorker = typeof import('./worker') & Worker
 export function createStaticWorker(
   config: NextConfigComplete,
-  onActivity?: () => void
+  progress?: {
+    run: () => void
+    clear: () => void
+  }
+  // onActivity?: () => void
 ): StaticWorker {
   return new Worker(staticWorkerPath, {
     logger: Log,
     numWorkers: getNumberOfWorkers(config),
-    onActivity,
+    onActivity: () => {
+      progress?.run()
+    },
+    onActivityAbort: () => {
+      progress?.clear()
+    },
     forkOptions: {
       env: process.env,
     },
@@ -1516,7 +1525,7 @@ export default async function build(
                   remainingRampup--
                   sema.release()
                 }
-                progress()
+                progress.run()
               }
             })()
           )

--- a/packages/next/src/build/progress.ts
+++ b/packages/next/src/build/progress.ts
@@ -47,7 +47,7 @@ export const createProgress = (total: number, label: string) => {
     },
   })
 
-  return () => {
+  const run = () => {
     curProgress++
 
     // Make sure we only log once
@@ -79,5 +79,23 @@ export const createProgress = (total: number, label: string) => {
         Log.info(`${message} ${process.stdout.isTTY ? '\n' : '\r'}`)
       }
     }
+  }
+
+  const clear = () => {
+    if (
+      progressSpinner &&
+      // Ensure only reset and clear once to avoid set operation overflow in ora
+      progressSpinner.isSpinning
+    ) {
+      progressSpinner.prefixText = '\r'
+      progressSpinner.text = '\r'
+      progressSpinner.clear()
+      progressSpinner.stop()
+    }
+  }
+
+  return {
+    run,
+    clear,
   }
 }

--- a/packages/next/src/build/spinner.ts
+++ b/packages/next/src/build/spinner.ts
@@ -34,6 +34,9 @@ export default function createSpinner(
 
     const logHandle = (method: any, args: any[]) => {
       origStop()
+      // Enter a new line before logging new message, to avoid
+      // the new message shows up right after the spinner in the saem line.
+      console.log()
       method(...args)
       spinner!.start()
     }

--- a/packages/next/src/build/spinner.ts
+++ b/packages/next/src/build/spinner.ts
@@ -34,9 +34,10 @@ export default function createSpinner(
 
     const logHandle = (method: any, args: any[]) => {
       // Enter a new line before logging new message, to avoid
-      // the new message shows up right after the spinner in the saem line.
+      // the new message shows up right after the spinner in the same line.
       const isInProgress = spinner?.isSpinning
       if (spinner && isInProgress) {
+        // Reset the current running spinner to empty line by `\r`
         spinner.prefixText = '\r'
         spinner.text = '\r'
         spinner.clear()
@@ -44,7 +45,7 @@ export default function createSpinner(
       }
       method(...args)
       if (spinner && isInProgress) {
-        spinner!.start()
+        spinner.start()
       }
     }
 

--- a/packages/next/src/build/spinner.ts
+++ b/packages/next/src/build/spinner.ts
@@ -33,12 +33,19 @@ export default function createSpinner(
     const origStopAndPersist = spinner.stopAndPersist.bind(spinner)
 
     const logHandle = (method: any, args: any[]) => {
-      origStop()
       // Enter a new line before logging new message, to avoid
       // the new message shows up right after the spinner in the saem line.
-      console.log()
+      const isInProgress = spinner?.isSpinning
+      if (spinner && isInProgress) {
+        spinner.prefixText = '\r'
+        spinner.text = '\r'
+        spinner.clear()
+        origStop()
+      }
       method(...args)
-      spinner!.start()
+      if (spinner && isInProgress) {
+        spinner!.start()
+      }
     }
 
     console.log = (...args: any) => logHandle(origLog, args)

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -537,7 +537,7 @@ async function exportPage(
     }
   } catch (err) {
     console.error(
-      `\nError occurred prerendering page "${input.path}". Read more: https://nextjs.org/docs/messages/prerender-error\n`
+      `Error occurred prerendering page "${input.path}". Read more: https://nextjs.org/docs/messages/prerender-error`
     )
 
     if (!isBailoutToCSRError(err)) {

--- a/packages/next/src/lib/worker.ts
+++ b/packages/next/src/lib/worker.ts
@@ -4,6 +4,8 @@ import {
   getParsedNodeOptionsWithoutInspect,
   formatNodeOptions,
 } from '../server/lib/utils'
+import { Transform } from 'stream'
+
 type FarmOptions = ConstructorParameters<typeof JestWorker>[1]
 
 const RESTARTED = Symbol('restarted')
@@ -24,6 +26,7 @@ export class Worker {
     options: FarmOptions & {
       timeout?: number
       onActivity?: () => void
+      onActivityAbort?: () => void
       onRestart?: (method: string, args: any[], attempts: number) => void
       logger?: Pick<typeof console, 'error' | 'info' | 'warn'>
       exposedMethods: ReadonlyArray<string>
@@ -106,6 +109,26 @@ export class Worker {
         }
       }
 
+      let aborted = false
+      const onActivityAbort = () => {
+        if (!aborted) {
+          options.onActivityAbort?.()
+          aborted = true
+        }
+      }
+
+      // Listen to the worker's stdout and stderr, if there's any thing logged, abort the activity first
+      const abortActivityStreamOnLog = new Transform({
+        transform(_chunk, _encoding, callback) {
+          onActivityAbort()
+          callback()
+        },
+      })
+      // Stop the activity if there's any output from the worker
+      this._worker.getStdout().pipe(abortActivityStreamOnLog)
+      this._worker.getStderr().pipe(abortActivityStreamOnLog)
+
+      // Pipe the worker's stdout and stderr to the parent process
       this._worker.getStdout().pipe(process.stdout)
       this._worker.getStderr().pipe(process.stderr)
     }


### PR DESCRIPTION
# What

Improve the log with spinner in build, when new log shows up we just break into a new line then log the new message to avoid messages showing up right after the spinner line.

We're also using a Transform stream listening to the stdout and stderr change, when the worker child process is going to be piped into current process, we clear the current line of spinner. We're adding a new API `clear()` to the `progress` to rest the current line by `\r`, and also do the same for `spinner` when there's new output emitted from stdout / stderr.


### After

```
   Generating static pages (0/4)  [  ==]Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error

Error: Route "/" has a `generateViewport` that depends on Request data (`cookies()`, etc...) or external data (`fetch(.
..)`, etc...) but the rest of the route was static or only used cached data (`"use cache"`). If you expected this route
 to be prerenderable update your `generateViewport` to not use Request data and only use cached external data. Otherwis
e, add `await connection()` somewhere within this route to indicate explicitly it should not be prerendered.
```

### Before

```
 ✓ Linting and checking validity of types
 ✓ Collecting page data
Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
Error: Route "/" has a `generateViewport` that depends on Request data (`cookies()`, etc...) or external data (`fetch(...)`, etc...) but the rest of the route was static or only used ca
ched data (`"use cache"`). If you expected this route to be prerenderable update your `generateViewport` to not use Request data and only use cached external data. Otherwise, add `await
```