### PR TITLE
fix: metadata image route Windows path escaping

### DIFF
--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -168,7 +168,7 @@ async fn static_route_source(
             if ({is_twitter} || {is_open_graph}) {{
                 const fileSizeInMB = buffer.byteLength / 1024 / 1024
                 if (fileSizeInMB > {file_size_limit}) {{
-                    throw new Error('File size for {img_name} image "{path}" exceeds {file_size_limit}MB. ' +
+                    throw new Error('File size for {img_name} image {path} exceeds {file_size_limit}MB. ' +
                     `(Current: ${{fileSizeInMB.toFixed(2)}}MB)\n` +
                     'Read more: https://nextjs.org/docs/app/api-reference/file-conventions/metadata/opengraph-image#image-files-jpg-png-gif'
                     )

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -193,7 +193,7 @@ async fn static_route_source(
         is_open_graph = is_open_graph,
         file_size_limit = file_size_limit,
         img_name = img_name,
-        path = path.to_string().await?,
+        path = StringifyJs(&path.to_string().await?.replace("\\", "\\\\")),
     };
 
     let file = File::from(code);

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -193,7 +193,7 @@ async fn static_route_source(
         is_open_graph = is_open_graph,
         file_size_limit = file_size_limit,
         img_name = img_name,
-        path = StringifyJs(&path.to_string().await?.replace("\\", "\\\\")),
+        path = StringifyJs(&path.to_string().await?),
     };
 
     let file = File::from(code);

--- a/test/production/app-dir/metadata-img-too-large/opengraph-image/index.test.ts
+++ b/test/production/app-dir/metadata-img-too-large/opengraph-image/index.test.ts
@@ -2,7 +2,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { generatePNG } from '../generate-image'
 
 describe('app-dir - metadata-img-too-large opengraph-image', () => {
-  const { next } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
   })
@@ -11,11 +11,13 @@ describe('app-dir - metadata-img-too-large opengraph-image', () => {
 
   it('should throw when opengraph-image file size exceeds 8MB', async () => {
     await next.patchFile('app/opengraph-image.png', pngFile as any)
-
     await next.build()
-    const { cliOutput } = next
-    expect(cliOutput).toMatch(
-      /Error: File size for Open Graph image ".*\/app\/opengraph-image\.png" exceeds 8MB/
-    )
+
+    const regex = isTurbopack
+      ? // in Turbopack, the path is simplified as [project]/...
+        /Error: File size for Open Graph image "\[project\]\/app\/opengraph-image\.png" exceeds 8MB/
+      : /Error: File size for Open Graph image ".*\/app\/opengraph-image\.png" exceeds 8MB/
+
+    expect(next.cliOutput).toMatch(regex)
   })
 })

--- a/test/production/app-dir/metadata-img-too-large/twitter-image/index.test.ts
+++ b/test/production/app-dir/metadata-img-too-large/twitter-image/index.test.ts
@@ -1,21 +1,23 @@
 import { nextTestSetup } from 'e2e-utils'
 import { generatePNG } from '../generate-image'
 
-describe('metadata-img-too-large twitter-image', () => {
-  const { next } = nextTestSetup({
+describe('app-dir - metadata-img-too-large twitter-image', () => {
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
   })
 
-  const pngFile = generatePNG(6)
+  const pngFile = generatePNG(5)
 
   it('should throw when twitter-image file size exceeds 5MB', async () => {
     await next.patchFile('app/twitter-image.png', pngFile as any)
-
     await next.build()
-    const { cliOutput } = next
-    expect(cliOutput).toMatch(
-      /Error: File size for Twitter image ".*\/app\/twitter-image\.png" exceeds 5MB/
-    )
+
+    const regex = isTurbopack
+      ? // in Turbopack, the path is simplified as [project]/...
+        /Error: File size for Twitter image "\[project\]\/app\/twitter-image\.png" exceeds 5MB/
+      : /Error: File size for Twitter image ".*\/app\/twitter-image\.png" exceeds 5MB/
+
+    expect(next.cliOutput).toMatch(regex)
   })
 })


### PR DESCRIPTION
### Why?

When handling the `opengraph-image` size exceeding the limit, we mapped with string literal between Rust and JavaScript. The Rust string literal contains backslashes `\` on Windows, incompatible with JavaScript string syntax.

Fixes #71582