### PR TITLE
`next/dynamic`: compat with @typescript-eslint/naming-convention

### DIFF
--- a/packages/next/src/shared/lib/dynamic.tsx
+++ b/packages/next/src/shared/lib/dynamic.tsx
@@ -79,7 +79,7 @@ export function noSSR<P = {}>(
 export default function dynamic<P = {}>(
   dynamicOptions: DynamicOptions<P> | Loader<P>,
   options?: DynamicOptions<P>
-): React.ComponentType<P> {
+): React.FunctionComponent<P> {
   let loadableFn = Loadable as LoadableFn<P>
 
   let loadableOptions: LoadableOptions<P> = {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

This PR is mostly to start the discussion around using `React.FunctionComponent` instead of `React.ComponentType` with `next/dynamic` - it does not yet contain full code changes.

The very noticeable surface-level downside of this is that using `React.FunctionComponent` is actually \*not accurate\* for libraries like `react-player`, which actually use a class component internally.

So maybe the suggestion will be to do [the type assertion workaround](https://github.com/vercel/next.js/pull/71627#issuecomment-2429119021) for these cases instead of making a change to the Next.js types.

cc @eps1lon 

### What?

Make `dynamic()` compatible with [`@typescript-eslint/naming-convention`](https://typescript-eslint.io/rules/naming-convention), without overly permissive rules.

### Why?

The `React.ComponentType` type is not compatible with `@typescript-eslint/naming-convention`:

```ts
import dynamic from 'next/dynamic'

// 💥 Variable name `ReactPlayer` must match one of the following formats: camelCase eslint @typescript-eslint/naming-convention
const ReactPlayer = dynamic(() => import('react-player'))
```

![Screenshot 2024-10-22 at 13 44 03](https://github.com/user-attachments/assets/c83040ac-48cb-4fca-868a-7556b1b953d3)

But the `React.FunctionComponent` type has no problems:

```ts
import dynamic from 'next/dynamic'
import { FunctionComponent } from 'react'

// ✅ No errors
const ReactPlayer = dynamic(() => import('react-player')) as FunctionComponent
```

But the downside with the type assertion workaround above is that [you need to type the props](https://github.com/vercel/next.js/pull/71627#issuecomment-2429119021), which is more code and a bit annoying.

This is because of these closed / rejected issues, which would have introduced a new "constructable" type:

- https://github.com/typescript-eslint/typescript-eslint/issues/1484
- https://github.com/typescript-eslint/typescript-eslint/issues/1485

---

Another example, with the `typescript-eslint` Playground:

[Playground](https://typescript-eslint.io/play/#ts=5.6.2&fileType=.ts&code=JYWwDg9gTgLgBAbzgYQuCA7AphmAVATzCwBo4AxAVwwGMZhNV1tc4BfOAMyjTgHIoWAIZ0%2BAbgBQEmpgDO8JpBYwAjHAC8iDkNko0SnPiJZJUs9LkL9mQwCYNWuDorU6DDIpu5TAeh9wAVVksOAA3IShgIQAjABssXRgIOEEAE0oaEIwIYGCLDFkIeIA6WIgAcwAKT2UVMhq7AEpJIA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6JgQwFtmBzWsgHsmAN0QtKw9GADa4bDkTRog6JAA08ha1ZgAIogBmHBPmRhDKrmAIlyVGvWSMWrBszrF4sXsy3YdMAALfHxiZDQdX3wg2AAjADohLlYiUmQKajp3VzT7LKcXNjj4QTjWLg5kfCVWYg4yAGsOXhQ3Zw9aLx9mVgATQTJkVjgkYc4eJn4hUXF8SSYErj6AYkEaBeR-CCwFbEhkRCQyfFVpSD6jE3h8DW39w1VK24w5Pb3IMm4jgGEqxEg9wgAF1NO8cEgOH0%2BABVJiXaAZVQAjCQDjwUoAdzu4Kg%2BGgHEoLl4cIRSOgKKg6KxgPeAF8wXtdu8DkdECczqiRBwqBwSgDGSy8qhXkD9nFBIJIUwcbioNUqFNZbjIExYFw4kpleC0coOIRaeDQWLII9oM9pG85Z9vvA-odtSyYQAFZ0AUQASgB9H4AQQAym7De9jSrIdCpqSlOTKWiMYJsYKPvjCcSo4ihBTztSE8HsAz7syPodjqc1Ki8gAZSiNAUms0W0VyqDOqpfO3-PMKYH3AvvQK%2B%2BOYsCtjLo%2B2ICyqCywJgnTZgAAUHsQDXwYGSxGEc2QAEpCyaS%2Byy%2BdDLP51IkwpTU8OC9ZGKcF8uL9O1ePqP2xOu9hQzrw7C8LRpmsY5tivbvkW15Hhy5ZQNyvL8o6%2BzCpaj5QGec7zFIYp-iyDZ3mhzY2i%2BHYOu%2B16fuOna4RRUAAZGQEZsi2ZDj%2BdL%2BD2EAcXSQA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false)

```ts
import { ComponentType, FunctionComponent } from 'react';

// 💥 Variable name `Component1` must match one of the following formats: camelCase ESLint @typescript-eslint/naming-convention
const Component1 = {} as ComponentType;
// ✅ No errors
const Component2 = {} as FunctionComponent;

// Use variables to reduce noise
console.log(Component1, Component2);
```

### How?

Use the `React.FunctionComponent` instead of `React.ComponentType` in the `dynamic()` return type