### PR TITLE
Avoid server action function indirection in Turbopack

### DIFF
--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -194,9 +194,16 @@ pub struct ActionManifestEntry<'a> {
 }
 
 #[derive(Serialize, Debug)]
-#[serde(rename_all = "camelCase")]
+pub struct ActionManifestWorkerEntry<'a> {
+    #[serde(rename = "moduleId")]
+    pub module_id: ActionManifestModuleId<'a>,
+    #[serde(rename = "async")]
+    pub is_async: bool,
+}
+
+#[derive(Serialize, Debug)]
 #[serde(untagged)]
-pub enum ActionManifestWorkerEntry<'a> {
+pub enum ActionManifestModuleId<'a> {
     String(&'a str),
     Number(f64),
 }

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -55,11 +55,7 @@ const PLUGIN_NAME = 'FlightClientEntryPlugin'
 type Actions = {
   [actionId: string]: {
     workers: {
-      [name: string]:
-        | { moduleId: string | number; async: boolean }
-        // TODO: This is legacy for Turbopack, and needs to be changed to the
-        // object above.
-        | string
+      [name: string]: { moduleId: string | number; async: boolean }
     }
     // Record which layer the action is in (rsc or sc_action), in the specific entry.
     layer: {

--- a/packages/next/src/server/app-render/action-utils.ts
+++ b/packages/next/src/server/app-render/action-utils.ts
@@ -26,7 +26,6 @@ export function createServerModuleMap({
 
         let workerEntry:
           | { moduleId: string | number; async: boolean }
-          | string
           | undefined
 
         if (workStore) {
@@ -44,10 +43,6 @@ export function createServerModuleMap({
 
         if (!workerEntry) {
           return undefined
-        }
-
-        if (typeof workerEntry === 'string') {
-          return { id: workerEntry, name: id, chunks: [] }
         }
 
         const { moduleId, async } = workerEntry

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -679,7 +679,7 @@ export function cache(kind: string, id: string, fn: any) {
         moduleMap: isEdgeRuntime
           ? clientReferenceManifest.edgeRscModuleMapping
           : clientReferenceManifest.rscModuleMapping,
-        serverModuleMap: null,
+        serverModuleMap: getServerModuleMap(),
       }
 
       return createFromReadableStream(stream, {

--- a/test/e2e/app-dir/use-cache/app/with-server-action/form.tsx
+++ b/test/e2e/app-dir/use-cache/app/with-server-action/form.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { ReactNode } from 'react'
+import { useActionState } from 'react'
+
+export function Form({
+  action,
+  children,
+}: {
+  action: () => Promise<string>
+  children: ReactNode
+}) {
+  const [result, formAction] = useActionState(action, 'initial')
+
+  return (
+    <form action={formAction}>
+      <button>Submit</button>
+      <p>{result}</p>
+      {children}
+    </form>
+  )
+}

--- a/test/e2e/app-dir/use-cache/app/with-server-action/layout.tsx
+++ b/test/e2e/app-dir/use-cache/app/with-server-action/layout.tsx
@@ -1,0 +1,14 @@
+import { connection } from 'next/server'
+
+export default async function DynamicLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  // TODO: This is a workaround for Turbopack. Figure out why this fails during
+  // prerendering with:
+  // TypeError: Cannot read properties of undefined (reading 'Form')
+  await connection()
+
+  return children
+}

--- a/test/e2e/app-dir/use-cache/app/with-server-action/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/with-server-action/page.tsx
@@ -1,0 +1,17 @@
+import { Form } from './form'
+
+async function action() {
+  'use server'
+
+  return 'result'
+}
+
+export default async function Page() {
+  'use cache'
+
+  return (
+    <Form action={action}>
+      <p>{Date.now()}</p>
+    </Form>
+  )
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -231,4 +231,19 @@ describe('use-cache', () => {
       expect(meta.headers['x-next-cache-tags']).toContain('a,c,b')
     })
   }
+
+  // TODO: There's a bug with the server actions manifest singleton during next
+  // build that would make this test flaky. Enable the test for isNextStart when
+  // the singleton has been replaced with a proper solution.
+  if (!isNextStart) {
+    it('can reference server actions in "use cache" functions', async () => {
+      const browser = await next.browser('/with-server-action')
+      expect(await browser.elementByCss('p').text()).toBe('initial')
+      await browser.elementByCss('button').click()
+
+      await retry(async () => {
+        expect(await browser.elementByCss('p').text()).toBe('result')
+      })
+    })
+  }
 })

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -232,18 +232,13 @@ describe('use-cache', () => {
     })
   }
 
-  // TODO: There's a bug with the server actions manifest singleton during next
-  // build that would make this test flaky. Enable the test for isNextStart when
-  // the singleton has been replaced with a proper solution.
-  if (!isNextStart) {
-    it('can reference server actions in "use cache" functions', async () => {
-      const browser = await next.browser('/with-server-action')
-      expect(await browser.elementByCss('p').text()).toBe('initial')
-      await browser.elementByCss('button').click()
+  it('can reference server actions in "use cache" functions', async () => {
+    const browser = await next.browser('/with-server-action')
+    expect(await browser.elementByCss('p').text()).toBe('initial')
+    await browser.elementByCss('button').click()
 
-      await retry(async () => {
-        expect(await browser.elementByCss('p').text()).toBe('result')
-      })
+    await retry(async () => {
+      expect(await browser.elementByCss('p').text()).toBe('result')
     })
-  }
+  })
 })


### PR DESCRIPTION
As a follow-up to #71572, this PR replaces the server action function indirection in Turbopack's generated action loader module with a direct re-export of the actions, using the action ID as export name.

The server action identity test that was added in #71572 was not sufficient to uncover that Turbopack was still using the wrapper functions. To fix that, we've added another test here, which uses a combination of `"use server"` and `"use cache"` functions in a page. This test does fail in Turbopack without the loader changes.

In addition, the building of the server reference manifest is adjusted to account for the new structure that expects `{moduleId: string, async: boolean}` instead of `string`. The `async` flag is set based on the loader's chunk item. I believe this is currently always `false` though. However, Turbopack can still resolve the modules just fine, even when there are outgoing async connections.