### PR TITLE
fix: next package resolving in dev overlay

### DIFF
--- a/packages/next/src/build/create-compiler-aliases.ts
+++ b/packages/next/src/build/create-compiler-aliases.ts
@@ -14,7 +14,8 @@ import {
 } from '../lib/constants'
 import type { NextConfigComplete } from '../server/config-shared'
 import { defaultOverrides } from '../server/require-hook'
-import { NEXT_PROJECT_ROOT, hasExternalOtelApiPackage } from './webpack-config'
+import { hasExternalOtelApiPackage } from './webpack-config'
+import { NEXT_PROJECT_ROOT } from './next-dir-paths'
 import { WEBPACK_LAYERS } from '../lib/constants'
 import { isWebpackServerOnlyLayer } from './utils'
 

--- a/packages/next/src/build/next-dir-paths.ts
+++ b/packages/next/src/build/next-dir-paths.ts
@@ -1,0 +1,8 @@
+import path from 'path'
+
+export const NEXT_PROJECT_ROOT = path.join(__dirname, '..', '..')
+export const NEXT_PROJECT_ROOT_DIST = path.join(NEXT_PROJECT_ROOT, 'dist')
+export const NEXT_PROJECT_ROOT_DIST_CLIENT = path.join(
+  NEXT_PROJECT_ROOT_DIST,
+  'client'
+)

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -89,6 +89,10 @@ import {
   getReactCompilerLoader,
 } from './get-babel-loader-config'
 import type { NextFlightLoaderOptions } from './webpack/loaders/next-flight-loader'
+import {
+  NEXT_PROJECT_ROOT,
+  NEXT_PROJECT_ROOT_DIST_CLIENT,
+} from './next-dir-paths'
 
 type ExcludesFalse = <T>(x: T | false) => x is T
 type ClientEntries = {
@@ -100,13 +104,6 @@ const EXTERNAL_PACKAGES =
 
 const DEFAULT_TRANSPILED_PACKAGES =
   require('../lib/default-transpiled-packages.json') as string[]
-
-export const NEXT_PROJECT_ROOT = path.join(__dirname, '..', '..')
-export const NEXT_PROJECT_ROOT_DIST = path.join(NEXT_PROJECT_ROOT, 'dist')
-const NEXT_PROJECT_ROOT_DIST_CLIENT = path.join(
-  NEXT_PROJECT_ROOT_DIST,
-  'client'
-)
 
 if (parseInt(React.version) < 18) {
   throw new Error('Next.js requires react >= 18.2.0 to be installed.')

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/CallStackFrame.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/CallStackFrame.tsx
@@ -24,10 +24,14 @@ export const CallStackFrame: React.FC<{
       : undefined
   )
 
+  // Format method to strip out the webpack layer prefix.
+  // e.g. (app-pages-browser)/./app/page.tsx -> ./app/page.tsx
+  const formattedMethod = f.methodName.replace(/^\([\w-]+\)\//, '')
+
   return (
     <div data-nextjs-call-stack-frame>
       <h3 data-nextjs-frame-expanded={Boolean(frame.expanded)}>
-        <HotlinkedText text={f.methodName} />
+        <HotlinkedText text={formattedMethod} />
       </h3>
       <div
         data-has-source={hasSource ? 'true' : undefined}

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
@@ -104,14 +104,14 @@ export function getOriginalStackFrames(
 }
 
 const webpackRegExes = [
-  /^(rsc:\/\/React\/[^/]+\/)?webpack-internal:\/\/\/(\.)?(\((\w+)\))?/,
-  /^(webpack:\/\/\/(\.)?|webpack:\/\/(_N_E\/)?)(\((\w+)\))?/,
+  /^(rsc:\/\/React\/[^/]+\/)?webpack-internal:\/\/\/(\([\w-]+\)\/)?/,
+  /^(webpack:\/\/\/|webpack:\/\/(_N_E\/)?)(\((\w+)\))?/,
 ]
 
 const replacementRegExes = [
   /^(rsc:\/\/React\/[^/]+\/)/,
-  /^webpack-internal:\/\/\/(\.)?(\((\w+)\))?/,
-  /^(webpack:\/\/\/(\.)?|webpack:\/\/(_N_E\/)?)(\((\w+)\))?/,
+  /^webpack-internal:\/\/\/(\([\w-]+\)\/)?/,
+  /^(webpack:\/\/\/|webpack:\/\/(_N_E\/)?)(\([\w-]+\)\/)?/,
   /\?\d+$/, // React's fakeFunctionIdx query param
 ]
 
@@ -129,7 +129,7 @@ function isWebpackBundled(file: string) {
  *
  * <anonymous> => ''
  */
-function formatFrameSourceFile(file: string) {
+export function formatFrameSourceFile(file: string) {
   if (file === '<anonymous>') return ''
 
   for (const regex of replacementRegExes) {

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stack-frame.ts
@@ -1,6 +1,6 @@
 import type { StackFrame } from 'next/dist/compiled/stacktrace-parser'
 import type { OriginalStackFrameResponse } from '../../server/shared'
-
+import { isWebpackBundled, formatFrameSourceFile } from './webpack-module-path'
 export interface OriginalStackFrame extends OriginalStackFrameResponse {
   error: boolean
   reason: string | null
@@ -101,42 +101,6 @@ export function getOriginalStackFrames(
       getOriginalStackFrame(frame, type, isAppDir, errorMessage)
     )
   )
-}
-
-const webpackRegExes = [
-  /^(rsc:\/\/React\/[^/]+\/)?webpack-internal:\/\/\/(\([\w-]+\)\/)?/,
-  /^(webpack:\/\/\/|webpack:\/\/(_N_E\/)?)(\((\w+)\))?/,
-]
-
-const replacementRegExes = [
-  /^(rsc:\/\/React\/[^/]+\/)/,
-  /^webpack-internal:\/\/\/(\([\w-]+\)\/)?/,
-  /^(webpack:\/\/\/|webpack:\/\/(_N_E\/)?)(\([\w-]+\)\/)?/,
-  /\?\d+$/, // React's fakeFunctionIdx query param
-]
-
-function isWebpackBundled(file: string) {
-  return webpackRegExes.some((regEx) => regEx.test(file))
-}
-
-/**
- * Format the webpack internal id to original file path
- * webpack-internal:///./src/hello.tsx => ./src/hello.tsx
- * rsc://React/Server/webpack-internal:///(rsc)/./src/hello.tsx?42 => ./src/hello.tsx
- * webpack://_N_E/./src/hello.tsx => ./src/hello.tsx
- * webpack://./src/hello.tsx => ./src/hello.tsx
- * webpack:///./src/hello.tsx => ./src/hello.tsx
- *
- * <anonymous> => ''
- */
-export function formatFrameSourceFile(file: string) {
-  if (file === '<anonymous>') return ''
-
-  for (const regex of replacementRegExes) {
-    file = file.replace(regex, '')
-  }
-
-  return file
 }
 
 export function getFrameSource(frame: StackFrame): string {

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/webpack-module-path.test.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/webpack-module-path.test.ts
@@ -14,6 +14,11 @@ describe('webpack-module-path', () => {
           'rsc://React/Server/webpack:///(rsc)/./src/hello.tsx?42'
         )
       ).toBe(true)
+      expect(
+        isWebpackBundled(
+          'rsc://React/Server/webpack:///(app-pages-browser)/./src/hello.tsx?42'
+        )
+      ).toBe(true)
       expect(isWebpackBundled('webpack://_N_E/./src/hello.tsx')).toBe(true)
       expect(isWebpackBundled('webpack://./src/hello.tsx')).toBe(true)
       expect(isWebpackBundled('webpack:///./src/hello.tsx')).toBe(true)
@@ -38,6 +43,11 @@ describe('webpack-module-path', () => {
       expect(
         formatFrameSourceFile(
           'rsc://React/Server/webpack:///(rsc)/./src/hello.tsx?42'
+        )
+      ).toBe('./src/hello.tsx')
+      expect(
+        formatFrameSourceFile(
+          'rsc://React/Server/webpack:///(app-pages-browser)/./src/hello.tsx?42'
         )
       ).toBe('./src/hello.tsx')
       expect(formatFrameSourceFile('webpack://_N_E/./src/hello.tsx')).toBe(

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/webpack-module-path.test.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/webpack-module-path.test.ts
@@ -1,0 +1,58 @@
+import { formatFrameSourceFile, isWebpackBundled } from './webpack-module-path'
+
+describe('webpack-module-path', () => {
+  describe('isWebpackBundled', () => {
+    it('should return true for webpack-internal paths', () => {
+      expect(isWebpackBundled('webpack-internal:///./src/hello.tsx')).toBe(true)
+      expect(
+        isWebpackBundled(
+          'rsc://React/Server/webpack-internal:///(rsc)/./src/hello.tsx?42'
+        )
+      ).toBe(true)
+      expect(
+        isWebpackBundled(
+          'rsc://React/Server/webpack:///(rsc)/./src/hello.tsx?42'
+        )
+      ).toBe(true)
+      expect(isWebpackBundled('webpack://_N_E/./src/hello.tsx')).toBe(true)
+      expect(isWebpackBundled('webpack://./src/hello.tsx')).toBe(true)
+      expect(isWebpackBundled('webpack:///./src/hello.tsx')).toBe(true)
+    })
+
+    it('should return false for non-webpack-internal paths', () => {
+      expect(isWebpackBundled('<anonymous>')).toBe(false)
+      expect(isWebpackBundled('file:///src/hello.tsx')).toBe(false)
+    })
+  })
+
+  describe('formatFrameSourceFile', () => {
+    it('should return the original file path', () => {
+      expect(formatFrameSourceFile('webpack-internal:///./src/hello.tsx')).toBe(
+        './src/hello.tsx'
+      )
+      expect(
+        formatFrameSourceFile(
+          'rsc://React/Server/webpack-internal:///(rsc)/./src/hello.tsx?42'
+        )
+      ).toBe('./src/hello.tsx')
+      expect(
+        formatFrameSourceFile(
+          'rsc://React/Server/webpack:///(rsc)/./src/hello.tsx?42'
+        )
+      ).toBe('./src/hello.tsx')
+      expect(formatFrameSourceFile('webpack://_N_E/./src/hello.tsx')).toBe(
+        './src/hello.tsx'
+      )
+      expect(formatFrameSourceFile('webpack://./src/hello.tsx')).toBe(
+        './src/hello.tsx'
+      )
+      expect(formatFrameSourceFile('webpack:///./src/hello.tsx')).toBe(
+        './src/hello.tsx'
+      )
+    })
+
+    it('should return an empty string for <anonymous> file paths', () => {
+      expect(formatFrameSourceFile('<anonymous>')).toBe('')
+    })
+  })
+})

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/webpack-module-path.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/webpack-module-path.ts
@@ -1,0 +1,36 @@
+const replacementRegExes = [
+  /^(rsc:\/\/React\/[^/]+\/)/,
+  /^webpack-internal:\/\/\/(\([\w-]+\)\/)?/,
+  /^(webpack:\/\/\/|webpack:\/\/(_N_E\/)?)(\([\w-]+\)\/)?/,
+  /\?\d+$/, // React's fakeFunctionIdx query param
+]
+
+export function isWebpackBundled(file: string) {
+  for (const regex of replacementRegExes) {
+    if (regex.test(file)) return true
+
+    file = file.replace(regex, '')
+  }
+
+  return false
+}
+
+/**
+ * Format the webpack internal id to original file path
+ * webpack-internal:///./src/hello.tsx => ./src/hello.tsx
+ * rsc://React/Server/webpack-internal:///(rsc)/./src/hello.tsx?42 => ./src/hello.tsx
+ * webpack://_N_E/./src/hello.tsx => ./src/hello.tsx
+ * webpack://./src/hello.tsx => ./src/hello.tsx
+ * webpack:///./src/hello.tsx => ./src/hello.tsx
+ *
+ * <anonymous> => ''
+ */
+export function formatFrameSourceFile(file: string) {
+  if (file === '<anonymous>') return ''
+
+  for (const regex of replacementRegExes) {
+    file = file.replace(regex, '')
+  }
+
+  return file
+}

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware.ts
@@ -13,6 +13,7 @@ import {
   noContent,
   type OriginalStackFrameResponse,
 } from './shared'
+import { NEXT_PROJECT_ROOT } from '../../../../build/webpack-config'
 export { getServerError } from '../internal/helpers/node-stack-frames'
 export { parseStack } from '../internal/helpers/parse-stack'
 export { getSourceMapFromFile }
@@ -20,6 +21,7 @@ export { getSourceMapFromFile }
 import type { IncomingMessage, ServerResponse } from 'http'
 import type webpack from 'webpack'
 import type { RawSourceMap } from 'next/dist/compiled/source-map08'
+import { formatFrameSourceFile } from '../internal/helpers/stack-frame'
 
 type Source =
   | {
@@ -149,10 +151,12 @@ export async function createOriginalStackFrame({
     )
   )
 
+  const resolvedFilePath = sourceContent
+    ? path.relative(rootDirectory, filePath)
+    : sourcePosition.source
+
   const traced = {
-    file: sourceContent
-      ? path.relative(rootDirectory, filePath)
-      : sourcePosition.source,
+    file: resolvedFilePath,
     lineNumber: sourcePosition.line,
     column: (sourcePosition.column ?? 0) + 1,
     methodName:
@@ -286,7 +290,16 @@ export function getOverlayMiddleware(options: {
         return badRequest(res)
       }
 
+      const formattedFilePath = formatFrameSourceFile(frame.file)
+      const filePath = path.join(rootDirectory, formattedFilePath)
+      const isNextjsSource = filePath.startsWith(NEXT_PROJECT_ROOT)
+
       let source: Source | undefined
+
+      if (isNextjsSource) {
+        sourcePackage = 'next'
+        return json(res, { sourcePackage })
+      }
 
       try {
         source = await getSource(frame.file, {

--- a/packages/next/src/client/components/react-dev-overlay/server/middleware.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware.ts
@@ -13,7 +13,7 @@ import {
   noContent,
   type OriginalStackFrameResponse,
 } from './shared'
-import { NEXT_PROJECT_ROOT } from '../../../../build/webpack-config'
+import { NEXT_PROJECT_ROOT } from '../../../../build/next-dir-paths'
 export { getServerError } from '../internal/helpers/node-stack-frames'
 export { parseStack } from '../internal/helpers/parse-stack'
 export { getSourceMapFromFile }
@@ -21,7 +21,7 @@ export { getSourceMapFromFile }
 import type { IncomingMessage, ServerResponse } from 'http'
 import type webpack from 'webpack'
 import type { RawSourceMap } from 'next/dist/compiled/source-map08'
-import { formatFrameSourceFile } from '../internal/helpers/stack-frame'
+import { formatFrameSourceFile } from '../internal/helpers/webpack-module-path'
 
 type Source =
   | {

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -1288,7 +1288,7 @@ export default function Home() {
       expect(stack).toMatchInlineSnapshot(`
         "app/utils.ts (1:7) @ eval
         ---
-        (app-pages-browser)/./app/utils.ts
+        ./app/utils.ts
         file://TEST_DIR/.next/static/chunks/app/page.js (39:1)
         ---
         Next.js
@@ -1300,8 +1300,7 @@ export default function Home() {
         file://TEST_DIR/.next/static/chunks/app/page.js (28:1)
         ---
         Next.js
-        ---
-        React"
+        "
       `)
     }
 

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -1288,19 +1288,18 @@ export default function Home() {
       expect(stack).toMatchInlineSnapshot(`
         "app/utils.ts (1:7) @ eval
         ---
-        ./app/utils.ts
+        (app-pages-browser)/./app/utils.ts
         file://TEST_DIR/.next/static/chunks/app/page.js (39:1)
         ---
         Next.js
         ---
         eval
-        (app-pages-browser)/./app/page.js
+        ./app/page.js
         ---
         (app-pages-browser)/./app/page.js
         file://TEST_DIR/.next/static/chunks/app/page.js (28:1)
         ---
-        Next.js
-        "
+        Next.js"
       `)
     }
 

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -1288,7 +1288,7 @@ export default function Home() {
       expect(stack).toMatchInlineSnapshot(`
         "app/utils.ts (1:7) @ eval
         ---
-        (app-pages-browser)/./app/utils.ts
+        ./app/utils.ts
         file://TEST_DIR/.next/static/chunks/app/page.js (39:1)
         ---
         Next.js
@@ -1296,7 +1296,7 @@ export default function Home() {
         eval
         ./app/page.js
         ---
-        (app-pages-browser)/./app/page.js
+        ./app/page.js
         file://TEST_DIR/.next/static/chunks/app/page.js (28:1)
         ---
         Next.js"


### PR DESCRIPTION
### What

Ensure during the local development, the file paths from `next` can be properly determined as `next` package files, instead of being treated as source file and being incorrectly joined with project directory and trying to search the modules in webpack compilation.

This will help owner stack work in #70393 to move the `next` stacks into the collapsed view.

Also fixed a small formatting thing for method name, as it could be webpack modueId in some case for client errors, we ensure to strip the webpack layer prefix