### PR TITLE
Turbopack: Fix `module_resolution: "nodenext"` with `mjs` or `cjs`

### DIFF
--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -2019,14 +2019,14 @@ async fn resolve_relative_request(
                     base,
                     vec![
                         Pattern::Constant(".mts".into()),
-                        Pattern::Constant(".js".into()),
+                        Pattern::Constant(".mjs".into()),
                     ],
                 ),
                 Some((base, "cjs")) => (
                     base,
                     vec![
                         Pattern::Constant(".cts".into()),
-                        Pattern::Constant(".js".into()),
+                        Pattern::Constant(".cjs".into()),
                     ],
                 ),
                 _ => {

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -2006,41 +2006,41 @@ async fn resolve_relative_request(
 
     if options_value.enable_typescript_with_output_extension {
         new_path.replace_final_constants(&|c: &RcStr| -> Option<Pattern> {
-            let result = match c.rsplit_once(".") {
-                Some((base, "js")) => Some((
+            let (base, replacement) = match c.rsplit_once(".") {
+                Some((base, "js")) => (
                     base,
                     vec![
                         Pattern::Constant(".ts".into()),
                         Pattern::Constant(".tsx".into()),
                         Pattern::Constant(".js".into()),
                     ],
-                )),
-                Some((base, "mjs")) => Some((
+                ),
+                Some((base, "mjs")) => (
                     base,
                     vec![
                         Pattern::Constant(".mts".into()),
                         Pattern::Constant(".js".into()),
                     ],
-                )),
-                Some((base, "cjs")) => Some((
+                ),
+                Some((base, "cjs")) => (
                     base,
                     vec![
                         Pattern::Constant(".cts".into()),
                         Pattern::Constant(".js".into()),
                     ],
-                )),
-                _ => None,
-            };
-            result.map(|(base, replacement)| {
-                if base.is_empty() {
-                    Pattern::Alternatives(replacement)
-                } else {
-                    Pattern::Concatenation(vec![
-                        Pattern::Constant(base.into()),
-                        Pattern::Alternatives(replacement),
-                    ])
+                ),
+                _ => {
+                    return None;
                 }
-            })
+            };
+            if base.is_empty() {
+                Some(Pattern::Alternatives(replacement))
+            } else {
+                Some(Pattern::Concatenation(vec![
+                    Pattern::Constant(base.into()),
+                    Pattern::Alternatives(replacement),
+                ]))
+            }
         });
         new_path.normalize();
     }

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/index.js
@@ -1,11 +1,21 @@
 import foo from "./src/foo.js";
-import bar from "./src/bar.js";
-import fooEsm from "./src/foo-esm.mjs";
-import fooCjs from "./src/foo-cjs.cjs";
+import fileTsx from "./src/file-tsx.js";
+import fileMts from "./src/file-mts.mjs";
+import fileCts from "./src/file-cts.cjs";
+import fileMjs from "./src/file-mjs.mjs";
+import fileCjs from "./src/file-cjs.cjs";
 
 it("should correctly resolve explicit extensions with nodenext", () => {
-  expect(foo).toBe("foo");
-  expect(bar).toBe("bar");
-  expect(fooEsm).toBe("fooEsm");
-  expect(fooCjs).toBe("fooCjs");
+  expect(foo).toBe("foo.ts");
+  expect(fileTsx).toBe("file-tsx");
+  expect(fileMts).toBe("file-mts");
+  expect(fileCts).toBe("file-cts");
+  expect(fileMjs).toBe("file-mjs");
+  expect(fileCjs).toBe("file-cjs");
 });
+
+// import fooButton from "foo/button";
+
+// it("should correctly resolve explicit extensions with nodenext", () => {
+//   expect(fooButton).toBe("button");
+// });

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/node_modules/foo/package.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/node_modules/foo/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "foo",
+  "exports": {
+    "./button": "./source.mjs"
+  }
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/node_modules/foo/source.mjs
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/node_modules/foo/source.mjs
@@ -1,0 +1,1 @@
+export default 'button'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/src/bar.tsx
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/src/bar.tsx
@@ -1,1 +1,0 @@
-export default "bar";

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/src/file-cjs.cjs
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/src/file-cjs.cjs
@@ -1,0 +1,1 @@
+module.exports = 'file-cjs'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/src/file-cts.cts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/src/file-cts.cts
@@ -1,0 +1,1 @@
+module.exports = "file-cts";

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/src/file-mjs.mjs
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/src/file-mjs.mjs
@@ -1,0 +1,1 @@
+export default 'file-mjs'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/src/file-mts.mts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/src/file-mts.mts
@@ -1,0 +1,1 @@
+export default "file-mts";

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/src/file-tsx.tsx
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/src/file-tsx.tsx
@@ -1,0 +1,1 @@
+export default "file-tsx";

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/src/foo-cjs.cts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/src/foo-cjs.cts
@@ -1,1 +1,0 @@
-module.exports = "fooCjs";

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/src/foo-esm.mts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/src/foo-esm.mts
@@ -1,1 +1,0 @@
-export default "fooEsm";

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/src/foo.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/src/foo.ts
@@ -1,1 +1,1 @@
-export default "foo";
+export default "foo.ts";

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/tsconfig.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-nodenext/input/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "compilerOptions": {
     "module": "NodeNext",
-    "moduleResolution": "NodeNext"
-  }
+    "moduleResolution": "NodeNext",
+    "allowJs": true,
+    "outDir": "dist"
+  },
+  "include": ["index.js"],
 }


### PR DESCRIPTION
A regression from https://github.com/vercel/turborepo/pull/8748

Closes PACK-3312

Previously, it treated imports to `something.mjs` as importing `something.mts` with a fallback to `something.js`.

But it should obviously instead fallback to the original extension `mjs`, which is also what tsc does:

```
Found 'package.json' at 'input/package.json'.
======== Resolving module './src/foo.mjs' from 'input/index.js'. ========
Explicitly specified module resolution kind: 'NodeNext'.
Resolving in CJS mode with conditions 'require', 'types', 'node'.
Loading module as file / folder, candidate module location 'input/src/foo.mjs', target file types: TypeScript, JavaScript, Declaration.
File name 'input/src/foo.mjs' has a '.mjs' extension - stripping it.
File 'input/src/foo.mts' does not exist.
File 'input/src/foo.d.mts' does not exist.
File 'input/src/foo.mjs' does not exist.
File 'input/src/foo.mjs.ts' does not exist.
File 'input/src/foo.mjs.tsx' does not exist.
File 'input/src/foo.mjs.d.ts' does not exist.
File 'input/src/foo.mjs.js' does not exist.
File 'input/src/foo.mjs.jsx' does not exist.
Directory 'input/src/foo.mjs' does not exist, skipping all lookups in it.
======== Module name './src/foo.mjs' was not resolved. ========
```