### PR TITLE
react-sync: Automatically update peer dependencies in libraries

### DIFF
--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -20,8 +20,11 @@ const filesReferencingReactPeerDependencyVersion = [
   'packages/create-next-app/templates/index.ts',
   'test/lib/next-modes/base.ts',
 ]
-const appManifestsInstallingNextjsPeerDependencies = [
+const libraryManifestsSupportingNextjsReact = [
   'packages/third-parties/package.json',
+  'packages/next/package.json',
+]
+const appManifestsInstallingNextjsPeerDependencies = [
   'examples/reproduction-template/package.json',
   'test/.stats-app/package.json',
   // TODO: These should use the usual test helpers that automatically install the right React version
@@ -322,25 +325,6 @@ Or, run this command with no arguments to use the most recently published versio
     }
   }
 
-  const nextjsPackageJsonPath = path.join(
-    process.cwd(),
-    'packages',
-    'next',
-    'package.json'
-  )
-  const nextjsPackageJson = JSON.parse(
-    await fsp.readFile(nextjsPackageJsonPath, 'utf-8')
-  )
-  nextjsPackageJson.peerDependencies.react = `^18.2.0 || ${newVersionStr}`
-  nextjsPackageJson.peerDependencies['react-dom'] =
-    `^18.2.0 || ${newVersionStr}`
-  await fsp.writeFile(
-    nextjsPackageJsonPath,
-    JSON.stringify(nextjsPackageJson, null, 2) +
-      // Prettier would add a newline anyway so do it manually to skip the additional `pnpm prettier-write`
-      '\n'
-  )
-
   for (const fileName of appManifestsInstallingNextjsPeerDependencies) {
     const packageJsonPath = path.join(cwd, fileName)
     const packageJson = await fsp.readFile(packageJsonPath, 'utf-8')
@@ -360,7 +344,29 @@ Or, run this command with no arguments to use the most recently published versio
   }
 
   if (commit) {
-    await commitEverything('Updated peer dependency references')
+    await commitEverything('Updated peer dependency references in apps')
+  }
+
+  for (const fileName of libraryManifestsSupportingNextjsReact) {
+    const packageJsonPath = path.join(cwd, fileName)
+    const packageJson = await fsp.readFile(packageJsonPath, 'utf-8')
+    const manifest = JSON.parse(packageJson)
+    if (manifest.peerDependencies['react']) {
+      manifest.peerDependencies['react'] = `^18.2.0 || ${newVersionStr}`
+    }
+    if (manifest.peerDependencies['react-dom']) {
+      manifest.peerDependencies['react-dom'] = `^18.2.0 || ${newVersionStr}`
+    }
+    await fsp.writeFile(
+      packageJsonPath,
+      JSON.stringify(manifest, null, 2) +
+        // Prettier would add a newline anyway so do it manually to skip the additional `pnpm prettier-write`
+        '\n'
+    )
+  }
+
+  if (commit) {
+    await commitEverything('Updated peer dependency references in libraries')
   }
 
   // Install the updated dependencies and build the vendored React files.


### PR DESCRIPTION
We only updated `dependencies` in apps but didn't
abstract the case for libraries.
`next` was already special cased but we forgot `@next/third-parties`.
Not both go through the same generic logic.

## test plan

Based on an older React sync (e.g. `8a905cf0cb91392627f4b5cb011b7be0ea980038^1`), run `pnpm sync-react --commit`. `Updated peer dependency references in libraries` shows
```diff
diff --git a/packages/next/package.json b/packages/next/package.json
index 8ccee10baf..26f7f91f95 100644
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -107,8 +107,8 @@
     "@opentelemetry/api": "^1.1.0",
     "@playwright/test": "^1.41.2",
     "babel-plugin-react-compiler": "*",
-    "react": "^18.2.0 || 19.0.0-rc-65a56d0e-20241020",
-    "react-dom": "^18.2.0 || 19.0.0-rc-65a56d0e-20241020",
+    "react": "^18.2.0 || 19.0.0-rc-69d4b800-20241021",
+    "react-dom": "^18.2.0 || 19.0.0-rc-69d4b800-20241021",
     "sass": "^1.3.0"
   },
   "peerDependenciesMeta": {
diff --git a/packages/third-parties/package.json b/packages/third-parties/package.json
index 9713549f29..5106c67859 100644
--- a/packages/third-parties/package.json
+++ b/packages/third-parties/package.json
@@ -33,6 +33,6 @@
   },
   "peerDependencies": {
     "next": "^13.0.0 || ^14.0.0 || ^15.0.0",
-    "react": "^18.2.0 || 19.0.0-rc-cd22717c-20241013"
+    "react": "^18.2.0 || 19.0.0-rc-69d4b800-20241021"
   }
 }
```