### PR TITLE
chore(docs): fix typo in image.mdx docs

### DIFF
--- a/docs/02-app/02-api-reference/01-components/image.mdx
+++ b/docs/02-app/02-api-reference/01-components/image.mdx
@@ -93,7 +93,7 @@ When using the default [loader](#loader), also consider the following for source
 
 - When src is an external URL, you must also configure [remotePatterns](#remotepatterns)
 - When src is [animated](#animated-images) or not a known format (JPEG, PNG, WebP, AVIF, GIF, TIFF) the image will be served as-is
-- When src is SVG format, it will be blocked unless [`unoptimized`](#unoptimized)` or [`dangerouslyAllowSVG`](#dangerouslyallowsvg) is enabled
+- When src is SVG format, it will be blocked unless [`unoptimized`](#unoptimized) or [`dangerouslyAllowSVG`](#dangerouslyallowsvg) is enabled
 
 ### `width`
 


### PR DESCRIPTION
There was an extra backtick causing a format error.

https://nextjs.org/docs/app/api-reference/components/image#src

<img width="664" alt="image" src="https://github.com/user-attachments/assets/2792e71b-f3a7-4790-80a0-eecb5210753a">
