### PR TITLE
docs: remove the canary note on instrumentation

### DIFF
--- a/docs/02-app/02-api-reference/02-file-conventions/instrumentation.mdx
+++ b/docs/02-app/02-api-reference/02-file-conventions/instrumentation.mdx
@@ -35,8 +35,6 @@ export function register() {
 
 ### `onRequestError` (optional)
 
-> This API is available in Next.js canary.
-
 You can optionally export an `onRequestError` function to track **server** errors to any custom observability provider.
 
 - If you're running any async tasks in `onRequestError`, make sure they're awaited. `onRequestError` will be triggered when the Next.js server captures the error.


### PR DESCRIPTION
The note of `onRequestError` API is outdated, it's available on v15 stable now

Fixes #71634 