### PR TITLE
Enable source maps for `pnpm debug`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "next": "cross-env NEXT_TELEMETRY_DISABLED=1 node --trace-deprecation --enable-source-maps packages/next/dist/bin/next",
     "next-no-sourcemaps": "cross-env NEXT_TELEMETRY_DISABLED=1 node --trace-deprecation packages/next/dist/bin/next",
     "clean-trace-jaeger": "node scripts/rm.mjs test/integration/basic/.next && TRACE_TARGET=JAEGER pnpm next build test/integration/basic",
-    "debug": "cross-env NEXT_TELEMETRY_DISABLED=1 node --inspect packages/next/dist/bin/next",
+    "debug": "cross-env NEXT_TELEMETRY_DISABLED=1 node --inspect --trace-deprecation --enable-source-maps packages/next/dist/bin/next",
     "postinstall": "node scripts/git-configure.mjs && node scripts/install-native.mjs",
     "version": "pnpm install --no-frozen-lockfile && IS_PUBLISH=yes ./scripts/check-pre-compiled.sh && git add .",
     "prepare": "husky",


### PR DESCRIPTION
Now `pnpm debug` is like `pnpm next` with `NODE_OPTIONS=--inspect`