### PR TITLE
fix: stack frame text color in dark mode

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
@@ -149,6 +149,7 @@ export const styles = css`
     margin-bottom: var(--size-gap);
     font-family: var(--font-stack-monospace);
     font-size: var(--size-font);
+    color: #666;
   }
   [data-nextjs-call-stack-frame] > h3[data-nextjs-frame-expanded='false'] {
     color: #666;

--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
@@ -149,7 +149,6 @@ export const styles = css`
     margin-bottom: var(--size-gap);
     font-family: var(--font-stack-monospace);
     font-size: var(--size-font);
-    color: #222;
   }
   [data-nextjs-call-stack-frame] > h3[data-nextjs-frame-expanded='false'] {
     color: #666;


### PR DESCRIPTION
The color of stack frame `h3` in dark mode is too dimmed that almost not visible

#### After 

![image](https://github.com/user-attachments/assets/46db8050-f72e-4cf6-8b2f-baa08951ba7e)




#### Before

![image](https://github.com/user-attachments/assets/11e4b47c-4be9-4bb7-b84a-ca3a52e9c975)

