### PR TITLE
Remove the bottom collapse button in dev overlay

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/index.tsx
@@ -33,30 +33,18 @@ export function RuntimeError({ error }: RuntimeErrorProps) {
       }
     }, [error.frames])
 
-  const [all, setAll] = React.useState(firstFrame == null)
+  const { leadingFramesGroupedByFramework, stackFramesGroupedByFramework } =
+    React.useMemo(() => {
+      const leadingFrames = allLeadingFrames.filter((f) => f.expanded)
 
-  const {
-    canShowMore,
-    leadingFramesGroupedByFramework,
-    stackFramesGroupedByFramework,
-  } = React.useMemo(() => {
-    const leadingFrames = allLeadingFrames.filter((f) => f.expanded || all)
-    const visibleCallStackFrames = allCallStackFrames.filter(
-      (f) => f.expanded || all
-    )
+      return {
+        stackFramesGroupedByFramework:
+          groupStackFramesByFramework(allCallStackFrames),
 
-    return {
-      canShowMore:
-        allCallStackFrames.length !== visibleCallStackFrames.length ||
-        (all && firstFrame != null),
-
-      stackFramesGroupedByFramework:
-        groupStackFramesByFramework(allCallStackFrames),
-
-      leadingFramesGroupedByFramework:
-        groupStackFramesByFramework(leadingFrames),
-    }
-  }, [all, allCallStackFrames, allLeadingFrames, firstFrame])
+        leadingFramesGroupedByFramework:
+          groupStackFramesByFramework(leadingFrames),
+      }
+    }, [allCallStackFrames, allLeadingFrames])
 
   return (
     <React.Fragment>
@@ -82,32 +70,11 @@ export function RuntimeError({ error }: RuntimeErrorProps) {
           />
         </React.Fragment>
       ) : undefined}
-      {canShowMore ? (
-        <React.Fragment>
-          <button
-            tabIndex={10}
-            data-nextjs-data-runtime-error-collapsed-action
-            type="button"
-            onClick={() => setAll(!all)}
-          >
-            {all ? 'Hide' : 'Show'} collapsed frames
-          </button>
-        </React.Fragment>
-      ) : undefined}
     </React.Fragment>
   )
 }
 
 export const styles = css`
-  button[data-nextjs-data-runtime-error-collapsed-action] {
-    background: none;
-    border: none;
-    padding: 0;
-    font-size: var(--size-font-small);
-    line-height: var(--size-font-bigger);
-    color: var(--color-accents-3);
-  }
-
   [data-nextjs-call-stack-frame]:not(:last-child),
   [data-nextjs-component-stack-frame]:not(:last-child) {
     margin-bottom: var(--size-gap-double);

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -803,12 +803,6 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
       expect(source).toContain('app/page.js')
       expect(source).toContain(`throw new Error('Client error')`)
 
-      await expect(
-        browser.hasElementByCssSelector(
-          '[data-nextjs-data-runtime-error-collapsed-action]'
-        )
-      ).resolves.toEqual(false)
-
       const stackFrameElements = await browser.elementsByCss(
         '[data-nextjs-call-stack-frame]'
       )
@@ -843,12 +837,6 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
       const source = await session.getRedboxSource()
       expect(source).toContain('app/page.js')
       expect(source).toContain(`throw new Error('Server error')`)
-
-      await expect(
-        browser.hasElementByCssSelector(
-          '[data-nextjs-data-runtime-error-collapsed-action]'
-        )
-      ).resolves.toEqual(false)
 
       const stackFrameElements = await browser.elementsByCss(
         '[data-nextjs-call-stack-frame]'
@@ -892,12 +880,6 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
       expect(source).toContain(
         `throw new Error("This is an error from an anonymous function")`
       )
-
-      await expect(
-        browser.hasElementByCssSelector(
-          '[data-nextjs-data-runtime-error-collapsed-action]'
-        )
-      ).resolves.toEqual(false)
 
       const stackFrameElements = await browser.elementsByCss(
         '[data-nextjs-call-stack-frame]'
@@ -962,12 +944,6 @@ describe.each(['default', 'turbo'])('ReactRefreshLogBox app %s', () => {
       const source = await session.getRedboxSource()
       expect(source).toContain('app/page.js')
       expect(source).toContain(`new URL("/", "invalid")`)
-
-      await expect(
-        browser.hasElementByCssSelector(
-          '[data-nextjs-data-runtime-error-collapsed-action]'
-        )
-      ).resolves.toEqual(false)
 
       const stackFrameElements = await browser.elementsByCss(
         '[data-nextjs-call-stack-frame]'


### PR DESCRIPTION
### What

The bottom collapse button is actually not useful anymore as the frames are either displayed or grouped within `next` or `react` groups. It would also be weird interaction if it also manages to collase all grouped frames or not.



#### After

<img width="363" alt="image" src="https://github.com/user-attachments/assets/f7e9c056-4698-482e-ac80-dbe2261c8144">

#### Before

There's no frames in the stack, so even you click it, it won't show extra frames

<img width="425" alt="image" src="https://github.com/user-attachments/assets/db86d782-ba0f-4580-89d5-22d98a26b03a">



