### PR TITLE
codemod(turbopack): Rewrite Vc fields in structs as ResolvedVc (part 3)

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -989,7 +989,7 @@ impl Project {
         let FindContextFileResult::Found(fs_path, _) = *middleware.await? else {
             return Ok(Vc::upcast(EmptyEndpoint::new()));
         };
-        let source = Vc::upcast(FileSource::new(fs_path));
+        let source = Vc::upcast(FileSource::new(*fs_path));
         let app_dir = *find_app_dir(self.project_path()).await?;
         let ecmascript_client_reference_transition_name = (*self.app_project().await?)
             .as_ref()
@@ -1123,7 +1123,7 @@ impl Project {
         let FindContextFileResult::Found(fs_path, _) = *instrumentation.await? else {
             return Ok(Vc::upcast(EmptyEndpoint::new()));
         };
-        let source = Vc::upcast(FileSource::new(fs_path));
+        let source = Vc::upcast(FileSource::new(*fs_path));
         let app_dir = *find_app_dir(self.project_path()).await?;
         let ecmascript_client_reference_transition_name = (*self.app_project().await?)
             .as_ref()

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -172,7 +172,8 @@ impl VersionedContentMap {
         };
 
         if let Some(generate_source_map) =
-            Vc::try_resolve_sidecast::<Box<dyn GenerateSourceMap>>(*asset).await?
+            Vc::try_resolve_sidecast::<Box<dyn GenerateSourceMap>>(*asset.to_resolved().await?)
+                .await?
         {
             Ok(if let Some(section) = section {
                 generate_source_map.by_section(section)
@@ -200,7 +201,7 @@ impl VersionedContentMap {
             side_effects.await?;
 
             if let Some(asset) = path_to_asset.get(&path) {
-                return Ok(Vc::cell(Some(*asset)));
+                return Ok(Vc::cell(Some(asset.to_resolved().await?)));
             } else {
                 let path = path.to_string().await?;
                 bail!(

--- a/crates/next-core/src/transform_options.rs
+++ b/crates/next-core/src/transform_options.rs
@@ -25,7 +25,7 @@ async fn get_typescript_options(
         FindContextFileResult::Found(path, _) => Some(
             read_tsconfigs(
                 path.read(),
-                Vc::upcast(FileSource::new(path)),
+                Vc::upcast(FileSource::new(*path)),
                 node_cjs_resolve_options(path.root()),
             )
             .await

--- a/turbopack/crates/turbo-tasks-testing/tests/all_in_one.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/all_in_one.rs
@@ -17,7 +17,7 @@ async fn all_in_one() {
         let a: Vc<MyTransparentValue> = Vc::cell(4242);
         assert_eq!(*a.await?, 4242);
 
-        let b = MyEnumValue::cell(MyEnumValue::More(MyEnumValue::Yeah(42).into()));
+        let b = MyEnumValue::cell(MyEnumValue::More(MyEnumValue::Yeah(42).resolved_cell()));
         assert_eq!(*b.to_string().await?, "42");
 
         let c = MyStructValue {
@@ -71,7 +71,7 @@ struct MyTransparentValue(u32);
 enum MyEnumValue {
     Yeah(u32),
     Nah,
-    More(Vc<MyEnumValue>),
+    More(ResolvedVc<MyEnumValue>),
 }
 
 #[turbo_tasks::value_impl]
@@ -80,7 +80,7 @@ impl MyEnumValue {
     pub async fn get_last(self: Vc<Self>) -> Result<Vc<Self>> {
         let mut current = self;
         while let MyEnumValue::More(more) = &*current.await? {
-            current = *more;
+            current = **more;
         }
         Ok(current)
     }

--- a/turbopack/crates/turbo-tasks-testing/tests/debug.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/debug.rs
@@ -47,7 +47,7 @@ async fn enum_none_debug() {
 #[tokio::test]
 async fn enum_transparent_debug() {
     run(&REGISTRATION, || async {
-        let a: Vc<Enum> = Enum::Transparent(Transparent(42).cell()).cell();
+        let a: Vc<Enum> = Enum::Transparent(Transparent(42).resolved_cell()).cell();
         assert_eq!(
             format!("{:?}", a.dbg().await?),
             r#"Enum :: Transparent(
@@ -63,7 +63,7 @@ async fn enum_transparent_debug() {
 #[tokio::test]
 async fn enum_inner_vc_debug() {
     run(&REGISTRATION, || async {
-        let a: Vc<Enum> = Enum::Enum(Enum::None.cell()).cell();
+        let a: Vc<Enum> = Enum::Enum(Enum::None.resolved_cell()).cell();
         assert_eq!(
             format!("{:?}", a.dbg().await?),
             r#"Enum :: Enum(
@@ -118,7 +118,7 @@ async fn struct_vec_debug() {
         );
 
         let b: Vc<StructWithVec> = StructWithVec {
-            vec: vec![Transparent(42).cell()],
+            vec: vec![Transparent(42).resolved_cell()],
         }
         .cell();
         assert_eq!(
@@ -163,8 +163,8 @@ struct Transparent(u32);
 #[turbo_tasks::value(shared)]
 enum Enum {
     None,
-    Transparent(Vc<Transparent>),
-    Enum(Vc<Enum>),
+    Transparent(ResolvedVc<Transparent>),
+    Enum(ResolvedVc<Enum>),
 }
 
 #[turbo_tasks::value(shared)]
@@ -182,7 +182,7 @@ struct StructWithOption {
 
 #[turbo_tasks::value(shared)]
 struct StructWithVec {
-    vec: Vec<Vc<Transparent>>,
+    vec: Vec<ResolvedVc<Transparent>>,
 }
 
 #[turbo_tasks::value(shared, eq = "manual")]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
@@ -47,12 +47,12 @@ impl ValueToString for EcmascriptDevChunk {
 #[turbo_tasks::value_impl]
 impl OutputChunk for EcmascriptDevChunk {
     #[turbo_tasks::function]
-    fn runtime_info(&self) -> Vc<OutputChunkRuntimeInfo> {
-        OutputChunkRuntimeInfo {
-            included_ids: Some(self.chunk.entry_ids()),
+    async fn runtime_info(&self) -> Result<Vc<OutputChunkRuntimeInfo>> {
+        Ok(OutputChunkRuntimeInfo {
+            included_ids: Some(self.chunk.entry_ids().to_resolved().await?),
             ..Default::default()
         }
-        .cell()
+        .cell())
     }
 }
 

--- a/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
@@ -14,7 +14,7 @@ use turbopack_resolve::ecmascript::cjs_resolve;
 pub enum RuntimeEntry {
     Request(ResolvedVc<Request>, ResolvedVc<FileSystemPath>),
     Evaluatable(ResolvedVc<Box<dyn EvaluatableAsset>>),
-    Source(Vc<Box<dyn Source>>),
+    Source(ResolvedVc<Box<dyn Source>>),
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -76,9 +76,11 @@ pub async fn get_client_runtime_entries(
     };
 
     runtime_entries.push(
-        RuntimeEntry::Source(Vc::upcast(FileSource::new(embed_file_path(
-            "entry/bootstrap.ts".into(),
-        ))))
+        RuntimeEntry::Source(ResolvedVc::upcast(
+            FileSource::new(embed_file_path("entry/bootstrap.ts".into()))
+                .to_resolved()
+                .await?,
+        ))
         .cell(),
     );
 

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -168,7 +168,7 @@ pub struct CompileTimeDefines(pub FxIndexMap<Vec<DefineableNameSegment>, Compile
 #[turbo_tasks::value(transparent)]
 #[derive(Debug, Clone)]
 pub struct CompileTimeDefinesIndividual(
-    pub FxIndexMap<Vec<DefineableNameSegment>, Vc<CompileTimeDefineValue>>,
+    pub FxIndexMap<Vec<DefineableNameSegment>, ResolvedVc<CompileTimeDefineValue>>,
 );
 
 impl IntoIterator for CompileTimeDefines {
@@ -192,7 +192,7 @@ impl CompileTimeDefines {
         Vc::cell(
             self.0
                 .iter()
-                .map(|(key, value)| (key.clone(), value.clone().cell()))
+                .map(|(key, value)| (key.clone(), value.clone().resolved_cell()))
                 .collect(),
         )
     }
@@ -241,7 +241,7 @@ pub struct FreeVarReferences(pub FxIndexMap<Vec<DefineableNameSegment>, FreeVarR
 #[turbo_tasks::value(transparent)]
 #[derive(Debug, Clone)]
 pub struct FreeVarReferencesIndividual(
-    pub FxIndexMap<Vec<DefineableNameSegment>, Vc<FreeVarReference>>,
+    pub FxIndexMap<Vec<DefineableNameSegment>, ResolvedVc<FreeVarReference>>,
 );
 
 #[turbo_tasks::value_impl]
@@ -256,7 +256,7 @@ impl FreeVarReferences {
         Vc::cell(
             self.0
                 .iter()
-                .map(|(key, value)| (key.clone(), value.clone().cell()))
+                .map(|(key, value)| (key.clone(), value.clone().resolved_cell()))
                 .collect(),
         )
     }

--- a/turbopack/crates/turbopack-core/src/output.rs
+++ b/turbopack/crates/turbopack-core/src/output.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
-use turbo_tasks::{FxIndexSet, Vc};
+use turbo_tasks::{FxIndexSet, ResolvedVc, Vc};
 
 use crate::{asset::Asset, ident::AssetIdent};
 
 #[turbo_tasks::value(transparent)]
-pub struct OptionOutputAsset(Option<Vc<Box<dyn OutputAsset>>>);
+pub struct OptionOutputAsset(Option<ResolvedVc<Box<dyn OutputAsset>>>);
 
 /// An asset that should be outputted, e. g. written to disk or served from a
 /// server.

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -214,8 +214,8 @@ impl OutputChunk for CssChunk {
             .map(|item| Vc::upcast(SingleItemCssChunk::new(self.chunking_context, *item)))
             .collect();
         Ok(OutputChunkRuntimeInfo {
-            included_ids: Some(Vc::cell(included_ids)),
-            module_chunks: Some(Vc::cell(module_chunks)),
+            included_ids: Some(ResolvedVc::cell(included_ids)),
+            module_chunks: Some(ResolvedVc::cell(module_chunks)),
             ..Default::default()
         }
         .cell())

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -170,7 +170,7 @@ pub async fn is_marked_as_side_effect_free(
     let find_package_json = find_context_file(path.parent(), package_json()).await?;
 
     if let FindContextFileResult::Found(package_json, _) = *find_package_json {
-        match *side_effects_from_package_json(package_json).await? {
+        match *side_effects_from_package_json(*package_json).await? {
             SideEffectsValue::None => {}
             SideEffectsValue::Constant(side_effects) => return Ok(Vc::cell(!side_effects)),
             SideEffectsValue::Glob(glob) => {

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -504,14 +504,14 @@ impl EcmascriptModuleAsset {
                         Some("commonjs") => SpecifiedModuleType::CommonJs,
                         _ => SpecifiedModuleType::Automatic,
                     },
-                    package_json,
+                    *package_json,
                 ));
             }
         }
 
         Ok(ModuleTypeResult::new_with_package_json(
             SpecifiedModuleType::Automatic,
-            package_json,
+            *package_json,
         ))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -466,7 +466,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
     if analyze_types {
         match &*find_context_file(path.parent(), tsconfig()).await? {
             FindContextFileResult::Found(tsconfig, _) => {
-                analysis.add_reference(TsConfigReference::new(origin, *tsconfig));
+                analysis.add_reference(TsConfigReference::new(origin, **tsconfig));
             }
             FindContextFileResult::NotFound(_) => {}
         };

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -391,7 +391,7 @@ async fn find_config_in_location(
     )
     .await?
     {
-        return Ok(Some(config_path));
+        return Ok(Some(*config_path));
     }
 
     if matches!(location, PostCssConfigLocation::ProjectPathOrLocalPath) {
@@ -402,7 +402,7 @@ async fn find_config_in_location(
         )
         .await?
         {
-            return Ok(Some(config_path));
+            return Ok(Some(*config_path));
         }
     }
 

--- a/turbopack/crates/turbopack-resolve/src/resolve.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve.rs
@@ -292,7 +292,7 @@ pub async fn resolve_options(
         let tsconfig = find_context_file(resolve_path, tsconfig()).await?;
         match *tsconfig {
             FindContextFileResult::Found(path, _) => {
-                apply_tsconfig_resolve_options(resolve_options, tsconfig_resolve_options(path))
+                apply_tsconfig_resolve_options(resolve_options, tsconfig_resolve_options(*path))
             }
             FindContextFileResult::NotFound(_) => resolve_options,
         }


### PR DESCRIPTION
Generated using a version of https://github.com/vercel/turbopack-resolved-vc-codemod using Anthropic Claude Sonnet 3.5 (`claude-3-5-sonnet-20241022`) for more complicated errors we don't have hardcoded logic for.

- Part 1: #70927
- Part 2: #71172

I kept running the script until I ran out of tokens (the tier 1 rate limit is 1M input tokens). I'll keep improving how I'm calling the LLM (there's still a lot of room for improvement from my side), and try running it again tomorrow to fix more things.

This fixes 13 struct field types. There are still 271 struct fields remaining that need to be codemodded.

Closes PACK-3453