### PR TITLE
make failed fetch calls session dependent

### DIFF
--- a/turbopack/crates/turbo-tasks-fetch/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fetch/src/lib.rs
@@ -3,7 +3,7 @@
 #![feature(arbitrary_self_types_pointers)]
 
 use anyhow::Result;
-use turbo_tasks::{RcStr, Vc};
+use turbo_tasks::{mark_session_dependent, RcStr, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::issue::{Issue, IssueSeverity, IssueStage, OptionStyledString, StyledString};
 
@@ -83,9 +83,12 @@ pub async fn fetch(
             }
             .cell())))
         }
-        Err(err) => Ok(Vc::cell(Err(
-            FetchError::from_reqwest_error(&err, url).cell()
-        ))),
+        Err(err) => {
+            mark_session_dependent();
+            Ok(Vc::cell(Err(
+                FetchError::from_reqwest_error(&err, url).cell()
+            )))
+        }
     }
 }
 


### PR DESCRIPTION
### What?

When fetch fails we don't want to cache that persistently, but only for the session.

Closes PACK-3487