### PR TITLE
docs(dynamic-routes): add async await to params in docs example

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/10-dynamic-routes.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/10-dynamic-routes.mdx
@@ -22,14 +22,22 @@ Dynamic Segments are passed as the `params` prop to [`layout`](/docs/app/api-ref
 For example, a blog could include the following route `app/blog/[slug]/page.js` where `[slug]` is the Dynamic Segment for blog posts.
 
 ```tsx filename="app/blog/[slug]/page.tsx" switcher
-export default function Page({ params }: { params: { slug: string } }) {
-  return <div>My Post: {params.slug}</div>
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const slug = (await params).slug
+
+  return <div>My Post: {slug}</div>
 }
 ```
 
 ```jsx filename="app/blog/[slug]/page.js" switcher
-export default function Page({ params }) {
-  return <div>My Post: {params.slug}</div>
+export default async function Page({ params }) {
+  const slug = (await params).slug
+
+  return <div>My Post: {slug}</div>
 }
 ```
 


### PR DESCRIPTION
## Why?

We're missing `async` and `await` in this example → https://nextjs.org/docs/app/building-your-application/routing/dynamic-routes#example.

## How?

We can do something like this → https://nextjs.org/docs/app/api-reference/file-conventions/page#props.

- x-ref: https://github.com/vercel/next.js/issues/71603#issuecomment-2430389506