### PR TITLE
fix: metadata image route normalize path posix for windows

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -76,7 +76,7 @@ async function getStaticAssetRouteCode(
   resourcePath: string,
   fileBaseName: string
 ) {
-  resourcePath &&= path.posix.normalize(resourcePath)
+  resourcePath = path.posix.normalize(resourcePath)
 
   const cache =
     fileBaseName === 'favicon'

--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -76,6 +76,8 @@ async function getStaticAssetRouteCode(
   resourcePath: string,
   fileBaseName: string
 ) {
+  resourcePath &&= path.posix.normalize(resourcePath)
+
   const cache =
     fileBaseName === 'favicon'
       ? 'public, max-age=0, must-revalidate'


### PR DESCRIPTION
### Why?

When handling the opengraph-image size exceeding the limit, we mapped with string literal between Rust and JavaScript. The Rust string literal contains backslashes `\` on Windows, incompatible with JavaScript string syntax.

Following up on #71615.

Fixes #71582