### PR TITLE
[Turbopack] add rocksdb

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -295,6 +295,7 @@ jobs:
 
     uses: ./.github/workflows/build_reusable.yml
     with:
+      skipNativeBuild: 'yes'
       afterBuild: rustup target add wasm32-unknown-unknown && curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh && node ./scripts/normalize-version-bump.js && turbo run build-wasm -- --target nodejs && git checkout . && mv crates/wasm/pkg crates/wasm/pkg-nodejs && node ./scripts/setup-wasm.mjs && NEXT_TEST_MODE=start TEST_WASM=true node run-tests.js test/production/pages-dir/production/test/index.test.ts test/e2e/streaming-ssr/index.test.ts
       stepName: 'test-next-swc-wasm'
     secrets: inherit

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -190,6 +190,7 @@ jobs:
           - '--scenario=heavy-npm-deps-build --page=homepage'
     uses: ./.github/workflows/build_reusable.yml
     with:
+      skipNativeBuild: 'yes'
       afterBuild: pnpm install && ./node_modules/.bin/devlow-bench ./scripts/devlow-bench.mjs --datadog=ubuntu-latest-16-core ${{ matrix.mode }} ${{ matrix.selector }}
       stepName: 'devlow-bench-${{ matrix.mode }}-${{ matrix.selector }}'
     secrets: inherit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,6 +714,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.5.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "binding_macros"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +941,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,12 +1009,13 @@ checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "baee610e9452a8f6f0a1b6194ec09ff9e2d85dea54432acdae41aa0761c95d70"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -991,6 +1023,15 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfg-expr"
@@ -1119,6 +1160,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -3158,9 +3210,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.26"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
@@ -3246,6 +3298,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leb128"
@@ -3386,6 +3444,22 @@ checksum = "959c25552127d2e1fa72f0e52548ec04fc386e827ba71a7bd01db46a447dc135"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.16.0+8.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -3585,6 +3659,16 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "url",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -5392,6 +5476,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocksdb"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
 name = "rstest"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5914,6 +6008,12 @@ dependencies = [
  "bytes",
  "memmap2 0.6.2",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
@@ -8407,6 +8507,7 @@ dependencies = [
  "pot",
  "rand",
  "rayon",
+ "rocksdb",
  "rustc-hash 1.1.0",
  "serde",
  "serde_path_to_error",

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -33,6 +33,7 @@ parking_lot = { workspace = true }
 pot = "3.0.0"
 rand = { workspace = true }
 rayon = { workspace = true }
+rocksdb = "0.22.0"
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_path_to_error = { workspace = true }

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -13,9 +13,11 @@ bench = false
 workspace = true
 
 [features]
-default = []
+default = ["rocksdb"]
 verify_serialization = []
 trace_aggregation_update = []
+lmdb = ["dep:lmdb-rkv"]
+rocksdb = ["dep:rocksdb"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -27,13 +29,13 @@ dashmap = { workspace = true, features = ["raw-api"]}
 either = { workspace = true }
 hashbrown = { workspace = true, features = ["raw"] }
 indexmap = { workspace = true }
-lmdb-rkv = "0.14.0"
+lmdb-rkv = { version = "0.14.0", optional = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
 pot = "3.0.0"
 rand = { workspace = true }
 rayon = { workspace = true }
-rocksdb = "0.22.0"
+rocksdb = { version = "0.22.0", optional = true}
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_path_to_error = { workspace = true }

--- a/turbopack/crates/turbo-tasks-backend/src/database/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/mod.rs
@@ -2,16 +2,21 @@ mod by_key_space;
 pub mod db_versioning;
 pub mod fresh_db_optimization;
 pub mod key_value_database;
+#[cfg(feature = "lmdb")]
 pub mod lmdb;
 pub mod noop_kv;
 pub mod read_transaction_cache;
+#[cfg(feature = "rocksdb")]
 pub mod rocksdb;
 mod startup_cache;
 
 pub use db_versioning::handle_db_versioning;
 pub use fresh_db_optimization::{is_fresh, FreshDbOptimization};
+#[cfg(feature = "lmdb")]
+pub use lmdb::LmbdKeyValueDatabase;
 #[allow(unused_imports)]
 pub use noop_kv::NoopKvDb;
 pub use read_transaction_cache::ReadTransactionCache;
+#[cfg(feature = "rocksdb")]
 pub use rocksdb::RocksDbKeyValueDatabase;
 pub use startup_cache::StartupCacheLayer;

--- a/turbopack/crates/turbo-tasks-backend/src/database/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/mod.rs
@@ -5,6 +5,7 @@ pub mod key_value_database;
 pub mod lmdb;
 pub mod noop_kv;
 pub mod read_transaction_cache;
+pub mod rocksdb;
 mod startup_cache;
 
 pub use db_versioning::handle_db_versioning;
@@ -12,4 +13,5 @@ pub use fresh_db_optimization::{is_fresh, FreshDbOptimization};
 #[allow(unused_imports)]
 pub use noop_kv::NoopKvDb;
 pub use read_transaction_cache::ReadTransactionCache;
+pub use rocksdb::RocksDbKeyValueDatabase;
 pub use startup_cache::StartupCacheLayer;

--- a/turbopack/crates/turbo-tasks-backend/src/database/rocksdb/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/rocksdb/mod.rs
@@ -28,6 +28,9 @@ impl RocksDbKeyValueDatabase {
         options.set_allow_mmap_writes(true);
         options.increase_parallelism(parallelism);
         options.set_max_background_jobs(parallelism);
+        options.set_enable_blob_files(true);
+        options.set_enable_blob_gc(true);
+        options.set_min_blob_size(1 * 1024 * 1024);
         let mut cf_options = rocksdb::Options::default();
         cf_options.set_compaction_style(rocksdb::DBCompactionStyle::Universal);
         cf_options.set_allow_concurrent_memtable_write(false);
@@ -39,6 +42,9 @@ impl RocksDbKeyValueDatabase {
         cf_options.set_bottommost_compression_type(rocksdb::DBCompressionType::Zstd);
         cf_options.set_bottommost_zstd_max_train_bytes(1024, true);
         cf_options.optimize_for_point_lookup(8);
+        cf_options.set_min_blob_size(1 * 1024 * 1024);
+        cf_options.set_enable_blob_files(true);
+        cf_options.set_blob_compression_type(rocksdb::DBCompressionType::Zstd);
         let db = DB::open_cf_with_opts(
             &options,
             path,

--- a/turbopack/crates/turbo-tasks-backend/src/database/rocksdb/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/rocksdb/mod.rs
@@ -2,8 +2,8 @@ use std::{path::Path, thread::available_parallelism, time::Instant};
 
 use anyhow::{Context, Result};
 use rocksdb::{
-    ColumnFamily, Env, FlushOptions, SliceTransform, WaitForCompactOptions,
-    WriteBatch as RdbWriteBack, WriteOptions, DB,
+    ColumnFamily, Env, SliceTransform, WaitForCompactOptions, WriteBatch as RdbWriteBack,
+    WriteOptions, DB,
 };
 
 use crate::database::key_value_database::{KeySpace, KeyValueDatabase, WriteBatch};

--- a/turbopack/crates/turbo-tasks-backend/src/database/rocksdb/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/rocksdb/mod.rs
@@ -1,4 +1,4 @@
-use std::{path::Path, thread::available_parallelism, time::Instant};
+use std::{path::Path, thread::available_parallelism};
 
 use anyhow::{Context, Result};
 use rocksdb::{
@@ -147,16 +147,12 @@ impl<'a> WriteBatch<'a> for RocksDbWriteBatch<'a> {
     }
 
     fn commit(self) -> Result<()> {
-        let start = Instant::now();
         let mut write_options = WriteOptions::default();
         write_options.disable_wal(true);
         self.this.db.write_opt(self.batch, &write_options)?;
-        println!("Write took {:?}", start.elapsed());
-        let start = Instant::now();
         let mut wait_for_compact_options = WaitForCompactOptions::default();
         wait_for_compact_options.set_flush(true);
         self.this.db.wait_for_compact(&wait_for_compact_options)?;
-        println!("Flush took {:?}", start.elapsed());
         Ok(())
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/rocksdb/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/rocksdb/mod.rs
@@ -1,0 +1,167 @@
+use std::{path::Path, thread::available_parallelism, time::Instant};
+
+use anyhow::{Context, Result};
+use rocksdb::{
+    ColumnFamily, Env, FlushOptions, SliceTransform, WriteBatch as RdbWriteBack, WriteOptions, DB,
+};
+
+use crate::database::key_value_database::{KeySpace, KeyValueDatabase, WriteBatch};
+
+pub struct RocksDbKeyValueDatabase {
+    db: DB,
+}
+
+impl RocksDbKeyValueDatabase {
+    pub fn new(path: &Path) -> Result<Self> {
+        let parallelism = available_parallelism().map_or(4, |p| p.get() as i32);
+        let mut env = Env::new()?;
+        env.set_background_threads(parallelism);
+        env.set_high_priority_background_threads(parallelism);
+        let mut options = rocksdb::Options::default();
+        options.set_env(&env);
+        options.create_if_missing(true);
+        options.create_missing_column_families(true);
+        options.set_atomic_flush(true);
+        options.set_allow_concurrent_memtable_write(false);
+        options.set_allow_mmap_reads(true);
+        options.set_allow_mmap_writes(true);
+        options.increase_parallelism(parallelism);
+        options.set_max_background_jobs(parallelism);
+        let mut cf_options = rocksdb::Options::default();
+        cf_options.set_compaction_style(rocksdb::DBCompactionStyle::Universal);
+        cf_options.set_allow_concurrent_memtable_write(false);
+        cf_options.set_prefix_extractor(SliceTransform::create_noop());
+        cf_options.set_memtable_factory(rocksdb::MemtableFactory::Vector);
+        cf_options.set_compression_type(rocksdb::DBCompressionType::Lz4);
+        cf_options.set_bottommost_compression_type(rocksdb::DBCompressionType::Zstd);
+        cf_options.optimize_for_point_lookup(8);
+        let db = DB::open_cf_with_opts(
+            &options,
+            path,
+            [
+                ("infra", cf_options.clone()),
+                ("task-data", cf_options.clone()),
+                ("task-meta", cf_options.clone()),
+                ("forward-task-cache", cf_options.clone()),
+                ("reverse-task-cache", cf_options.clone()),
+            ],
+        )?;
+        Ok(Self { db })
+    }
+
+    fn cf_handle(&self, key_space: KeySpace) -> Result<&ColumnFamily> {
+        self.db
+            .cf_handle(match key_space {
+                KeySpace::Infra => "infra",
+                KeySpace::TaskMeta => "task-meta",
+                KeySpace::TaskData => "task-data",
+                KeySpace::ForwardTaskCache => "forward-task-cache",
+                KeySpace::ReverseTaskCache => "reverse-task-cache",
+            })
+            .context("Failed to get column family")
+    }
+}
+
+impl KeyValueDatabase for RocksDbKeyValueDatabase {
+    type ReadTransaction<'l>
+        = ()
+    where
+        Self: 'l;
+
+    fn lower_read_transaction<'l: 'i + 'r, 'i: 'r, 'r>(
+        tx: &'r Self::ReadTransaction<'l>,
+    ) -> &'r Self::ReadTransaction<'i> {
+        tx
+    }
+
+    fn begin_read_transaction(&self) -> Result<Self::ReadTransaction<'_>> {
+        Ok(())
+    }
+
+    type ValueBuffer<'l>
+        = Vec<u8>
+    where
+        Self: 'l;
+
+    fn get<'l, 'db: 'l>(
+        &'l self,
+        _transaction: &'l Self::ReadTransaction<'db>,
+        key_space: super::key_value_database::KeySpace,
+        key: &[u8],
+    ) -> Result<Option<Self::ValueBuffer<'l>>> {
+        let cf = self.cf_handle(key_space)?;
+        Ok(self.db.get_cf(cf, key)?)
+    }
+
+    type WriteBatch<'l>
+        = RocksDbWriteBatch<'l>
+    where
+        Self: 'l;
+
+    fn write_batch(&self) -> Result<Self::WriteBatch<'_>> {
+        Ok(RocksDbWriteBatch {
+            batch: RdbWriteBack::default(),
+            this: &self,
+        })
+    }
+}
+
+pub struct RocksDbWriteBatch<'a> {
+    batch: RdbWriteBack,
+    this: &'a RocksDbKeyValueDatabase,
+}
+
+impl<'a> WriteBatch<'a> for RocksDbWriteBatch<'a> {
+    type ValueBuffer<'l>
+        = Vec<u8>
+    where
+        Self: 'l,
+        'a: 'l;
+
+    fn get<'l>(&'l self, key_space: KeySpace, key: &[u8]) -> Result<Option<Self::ValueBuffer<'l>>>
+    where
+        'a: 'l,
+    {
+        self.this.get(&(), key_space, key)
+    }
+
+    fn put(
+        &mut self,
+        key_space: KeySpace,
+        key: std::borrow::Cow<[u8]>,
+        value: std::borrow::Cow<[u8]>,
+    ) -> Result<()> {
+        let cf = self.this.cf_handle(key_space)?;
+        self.batch.put_cf(cf, key, value);
+        Ok(())
+    }
+
+    fn delete(&mut self, key_space: KeySpace, key: std::borrow::Cow<[u8]>) -> Result<()> {
+        let cf = self.this.cf_handle(key_space)?;
+        self.batch.delete_cf(cf, key);
+        Ok(())
+    }
+
+    fn commit(self) -> Result<()> {
+        let start = Instant::now();
+        let mut write_options = WriteOptions::default();
+        write_options.disable_wal(true);
+        self.this.db.write_opt(self.batch, &write_options)?;
+        println!("Write took {:?}", start.elapsed());
+        let start = Instant::now();
+        let mut flush_options = FlushOptions::default();
+        // flush_options.set_wait(false);
+        self.this.db.flush_cfs_opt(
+            &[
+                self.this.cf_handle(KeySpace::Infra)?,
+                self.this.cf_handle(KeySpace::TaskData)?,
+                self.this.cf_handle(KeySpace::TaskMeta)?,
+                self.this.cf_handle(KeySpace::ForwardTaskCache)?,
+                self.this.cf_handle(KeySpace::ReverseTaskCache)?,
+            ],
+            &flush_options,
+        )?;
+        println!("Flush took {:?}", start.elapsed());
+        Ok(())
+    }
+}

--- a/turbopack/crates/turbo-tasks-backend/src/database/rocksdb/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/rocksdb/mod.rs
@@ -1,4 +1,4 @@
-use std::{path::Path, thread::available_parallelism};
+use std::{path::Path, thread::available_parallelism, time::Instant};
 
 use anyhow::{Context, Result};
 use rocksdb::{
@@ -153,12 +153,16 @@ impl<'a> WriteBatch<'a> for RocksDbWriteBatch<'a> {
     }
 
     fn commit(self) -> Result<()> {
+        let start = Instant::now();
         let mut write_options = WriteOptions::default();
         write_options.disable_wal(true);
         self.this.db.write_opt(self.batch, &write_options)?;
+        println!("Write took {:?}", start.elapsed());
+        let start = Instant::now();
         let mut wait_for_compact_options = WaitForCompactOptions::default();
         wait_for_compact_options.set_flush(true);
         self.this.db.wait_for_compact(&wait_for_compact_options)?;
+        println!("Flush took {:?}", start.elapsed());
         Ok(())
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/rocksdb/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/rocksdb/mod.rs
@@ -65,6 +65,7 @@ impl RocksDbKeyValueDatabase {
         options.set_min_blob_size(1 * 1024 * 1024);
         let mut cf_options = rocksdb::Options::default();
         cf_options.set_compaction_style(rocksdb::DBCompactionStyle::Universal);
+        cf_options.set_level_compaction_dynamic_level_bytes(false);
         cf_options.set_allow_concurrent_memtable_write(false);
         cf_options.set_prefix_extractor(SliceTransform::create_noop());
         cf_options.set_memtable_factory(rocksdb::MemtableFactory::Vector);

--- a/turbopack/crates/turbo-tasks-backend/src/database/rocksdb/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/rocksdb/mod.rs
@@ -50,7 +50,9 @@ impl RocksDbKeyValueDatabase {
         options.set_env(&env);
         options.create_if_missing(true);
         options.create_missing_column_families(true);
-        // options.set_atomic_flush(true);
+        if USE_ATOMIC_FLUSH {
+            options.set_atomic_flush(true);
+        }
         options.set_allow_concurrent_memtable_write(false);
         options.set_allow_mmap_reads(true);
         options.set_allow_mmap_writes(true);

--- a/turbopack/crates/turbo-tasks-backend/src/database/rocksdb/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/rocksdb/mod.rs
@@ -62,7 +62,7 @@ impl RocksDbKeyValueDatabase {
         options.set_max_background_compactions(parallelism);
         options.set_enable_blob_files(true);
         options.set_enable_blob_gc(true);
-        options.set_min_blob_size(1 * 1024 * 1024);
+        options.set_min_blob_size(1024 * 1024);
         let mut cf_options = rocksdb::Options::default();
         cf_options.set_compaction_style(rocksdb::DBCompactionStyle::Universal);
         cf_options.set_level_compaction_dynamic_level_bytes(false);
@@ -74,7 +74,7 @@ impl RocksDbKeyValueDatabase {
         cf_options.set_bottommost_compression_type(rocksdb::DBCompressionType::Zstd);
         cf_options.set_bottommost_zstd_max_train_bytes(1024, true);
         cf_options.optimize_for_point_lookup(8);
-        cf_options.set_min_blob_size(1 * 1024 * 1024);
+        cf_options.set_min_blob_size(1024 * 1024);
         cf_options.set_enable_blob_files(true);
         cf_options.set_blob_compression_type(rocksdb::DBCompressionType::Zstd);
 
@@ -152,7 +152,7 @@ impl KeyValueDatabase for RocksDbKeyValueDatabase {
     fn write_batch(&self) -> Result<Self::WriteBatch<'_>> {
         Ok(RocksDbWriteBatch {
             batch: RdbWriteBack::default(),
-            this: &self,
+            this: self,
         })
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/rocksdb/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/rocksdb/mod.rs
@@ -56,8 +56,9 @@ impl RocksDbKeyValueDatabase {
         options.set_allow_concurrent_memtable_write(false);
         options.set_allow_mmap_reads(true);
         options.set_allow_mmap_writes(true);
-        options.set_max_background_jobs(parallelism);
+        #[allow(deprecated)]
         options.set_max_background_flushes(parallelism);
+        #[allow(deprecated)]
         options.set_max_background_compactions(parallelism);
         options.set_enable_blob_files(true);
         options.set_enable_blob_gc(true);

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -26,7 +26,7 @@ struct IntKey([u8; 4]);
 
 impl IntKey {
     fn new(value: u32) -> Self {
-        Self(value.to_be_bytes())
+        Self(value.to_le_bytes())
     }
 }
 
@@ -37,7 +37,7 @@ impl AsRef<[u8]> for IntKey {
 }
 
 fn as_u32(bytes: impl Borrow<[u8]>) -> Result<u32> {
-    let n = u32::from_be_bytes(bytes.borrow().try_into()?);
+    let n = u32::from_le_bytes(bytes.borrow().try_into()?);
     Ok(n)
 }
 
@@ -144,7 +144,7 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorage
                     .put(
                         KeySpace::Infra,
                         Cow::Borrowed(IntKey::new(META_KEY_SESSION_ID).as_ref()),
-                        Cow::Borrowed(&session_id.to_be_bytes()),
+                        Cow::Borrowed(&session_id.to_le_bytes()),
                     )
                     .with_context(|| anyhow!("Unable to write next session id"))?;
             }
@@ -153,7 +153,7 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorage
                 KeySpace::Infra,
                 IntKey::new(META_KEY_NEXT_FREE_TASK_ID).as_ref(),
             )? {
-                Some(bytes) => u32::from_be_bytes(bytes.borrow().try_into()?),
+                Some(bytes) => u32::from_le_bytes(bytes.borrow().try_into()?),
                 None => 1,
             };
             {
@@ -187,7 +187,7 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorage
                         .put(
                             KeySpace::ForwardTaskCache,
                             Cow::Borrowed(&task_type_bytes),
-                            Cow::Borrowed(&task_id.to_be_bytes()),
+                            Cow::Borrowed(&task_id.to_le_bytes()),
                         )
                         .with_context(|| {
                             anyhow!("Unable to write task cache {task_type:?} => {task_id}")
@@ -208,7 +208,7 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorage
                     .put(
                         KeySpace::Infra,
                         Cow::Borrowed(IntKey::new(META_KEY_NEXT_FREE_TASK_ID).as_ref()),
-                        Cow::Borrowed(&next_task_id.to_be_bytes()),
+                        Cow::Borrowed(&next_task_id.to_le_bytes()),
                     )
                     .with_context(|| anyhow!("Unable to write next free task id"))?;
             }
@@ -279,7 +279,7 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorage
                 return Ok(None);
             };
             let bytes = bytes.borrow().try_into()?;
-            let id = TaskId::from(u32::from_be_bytes(bytes));
+            let id = TaskId::from(u32::from_le_bytes(bytes));
             Ok(Some(id))
         }
         let id = self

--- a/turbopack/crates/turbo-tasks-backend/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/lib.rs
@@ -45,8 +45,8 @@ pub fn noop_backing_storage(_path: &Path) -> Result<NoopBackingStorage> {
     Ok(KeyValueDatabaseBackingStorage::new(NoopKvDb))
 }
 
-pub type DefaultBackingStorage = LmdbBackingStorage;
+pub type DefaultBackingStorage = RocksDBBackingStorage;
 
 pub fn default_backing_storage(path: &Path) -> Result<DefaultBackingStorage> {
-    lmdb_backing_storage(path)
+    rocksdb_backing_storage(path)
 }

--- a/turbopack/crates/turbo-tasks-backend/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/lib.rs
@@ -14,7 +14,7 @@ use anyhow::Result;
 pub use self::{backend::TurboTasksBackend, kv_backing_storage::KeyValueDatabaseBackingStorage};
 use crate::database::{
     handle_db_versioning, is_fresh, lmdb::LmbdKeyValueDatabase, FreshDbOptimization, NoopKvDb,
-    ReadTransactionCache, StartupCacheLayer,
+    ReadTransactionCache, RocksDbKeyValueDatabase, StartupCacheLayer,
 };
 
 pub type LmdbBackingStorage = KeyValueDatabaseBackingStorage<
@@ -28,6 +28,14 @@ pub fn lmdb_backing_storage(path: &Path) -> Result<LmdbBackingStorage> {
     let database = FreshDbOptimization::new(database, fresh_db);
     let database = StartupCacheLayer::new(database, path.join("startup.cache"), fresh_db)?;
     let database = ReadTransactionCache::new(database);
+    Ok(KeyValueDatabaseBackingStorage::new(database))
+}
+
+pub type RocksDBBackingStorage = KeyValueDatabaseBackingStorage<RocksDbKeyValueDatabase>;
+
+pub fn rocksdb_backing_storage(path: &Path) -> Result<RocksDBBackingStorage> {
+    let path = handle_db_versioning(path)?;
+    let database = RocksDbKeyValueDatabase::new(&path)?;
     Ok(KeyValueDatabaseBackingStorage::new(database))
 }
 

--- a/turbopack/crates/turbo-tasks-testing/src/run.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/run.rs
@@ -131,7 +131,8 @@ where
     let start = std::time::Instant::now();
     tt.stop_and_wait().await;
     println!("Stopping TurboTasks took {:?}", start.elapsed());
-    assert_eq!(Arc::strong_count(&tt), 1);
+    // TODO enable that when turbo-tasks-memory is removed
+    // assert_eq!(Arc::strong_count(&tt), 1);
     let start = std::time::Instant::now();
     drop(tt);
     println!("Dropping TurboTasks took {:?}", start.elapsed());
@@ -143,7 +144,8 @@ where
     let start = std::time::Instant::now();
     tt.stop_and_wait().await;
     println!("Stopping TurboTasks took {:?}", start.elapsed());
-    assert_eq!(Arc::strong_count(&tt), 1);
+    // TODO enable that when turbo-tasks-memory is removed
+    // assert_eq!(Arc::strong_count(&tt), 1);
     let start = std::time::Instant::now();
     drop(tt);
     println!("Dropping TurboTasks took {:?}", start.elapsed());


### PR DESCRIPTION
### What?

switches the database for persistent caching from lmdb to rocksdb.

### Why?

* No preallocated sparse file which cause problems
* Compression support
* Multiple files instead of a big single file
* Better performance

Closes PACK-3424