### PR TITLE
feat(turbopack): Enable tree shaking for modules with dynamic imports

### DIFF
--- a/test/integration/telemetry/pages/warning.skip
+++ b/test/integration/telemetry/pages/warning.skip
@@ -1,7 +1,7 @@
-function a(v) {
-  return v
-}
 ;['index.js'].forEach(async f => {
+  function a(v) {
+    return v
+  }
   await import(a('./dynamic-file-imports/' + f))
 })
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/util.rs
@@ -490,16 +490,6 @@ impl Visit for ShouldSkip {
         n.visit_children_with(self);
     }
 
-    fn visit_callee(&mut self, n: &Callee) {
-        // TOOD(PACK-3231): Tree shaking work with dynamic imports
-        if matches!(n, Callee::Import(..)) {
-            self.skip = true;
-            return;
-        }
-
-        n.visit_children_with(self);
-    }
-
     fn visit_expr(&mut self, n: &Expr) {
         if self.skip {
             return;


### PR DESCRIPTION
### What?

We can now enable tree shaking for modules that imports `next/dynamic`.

### Why?

The bug is now fixed.

### How?

Closes PACK-3231
