### PR TITLE
next-codemod(upgrade): warn peer dependencies not met

### DIFF
--- a/packages/next-codemod/bin/__testfixtures__/peer-dep-out-of-range/README.md
+++ b/packages/next-codemod/bin/__testfixtures__/peer-dep-out-of-range/README.md
@@ -2,19 +2,6 @@ default should print
 
 ```bash
 ⚠ Found 2 dependencies that seem incompatible with the upgraded package versions.
-You may have to update these packages to their latest version or file an issue ask for support of the upgraded libraries.
-unmet-prerelease 0.0.1
-  ├── incompatible with react@19.0.0-rc-7c8e5e7a-20241101
-  └── incompatible with react-dom@19.0.0-rc-7c8e5e7a-20241101
-unmet-range 0.0.1
-  ├── incompatible with react@19.0.0-rc-7c8e5e7a-20241101
-  └── incompatible with react-dom@19.0.0-rc-7c8e5e7a-20241101
-```
-
-`--verbose` should print
-
-```bash
-⚠ Found 2 dependencies that seem incompatible with the upgraded package versions.
 You may have to update these packages to their latest version or file an issue to ask for support of the upgraded libraries.
 unmet-prerelease 0.0.1
   ├── ✕ unmet peer react@"^18.2.0 || 19.0.0-rc-aaaaaaaa-20240101": found 19.0.0-rc-7c8e5e7a-20241101

--- a/packages/next-codemod/bin/__testfixtures__/peer-dep-out-of-range/README.md
+++ b/packages/next-codemod/bin/__testfixtures__/peer-dep-out-of-range/README.md
@@ -1,0 +1,25 @@
+default should print
+
+```bash
+⚠ Found 2 dependencies that seem incompatible with the upgraded package versions.
+You may have to update these packages to their latest version or file an issue ask for support of the upgraded libraries.
+unmet-prerelease 0.0.1
+  ├── incompatible with react@19.0.0-rc-7c8e5e7a-20241101
+  └── incompatible with react-dom@19.0.0-rc-7c8e5e7a-20241101
+unmet-range 0.0.1
+  ├── incompatible with react@19.0.0-rc-7c8e5e7a-20241101
+  └── incompatible with react-dom@19.0.0-rc-7c8e5e7a-20241101
+```
+
+`--verbose` should print
+
+```bash
+⚠ Found 2 dependencies that seem incompatible with the upgraded package versions.
+You may have to update these packages to their latest version or file an issue to ask for support of the upgraded libraries.
+unmet-prerelease 0.0.1
+  ├── ✕ unmet peer react@"^18.2.0 || 19.0.0-rc-aaaaaaaa-20240101": found 19.0.0-rc-7c8e5e7a-20241101
+  └── ✕ unmet peer react-dom@"^18.2.0 || 19.0.0-rc-aaaaaaaa-20240101": found 19.0.0-rc-7c8e5e7a-20241101
+unmet-range 0.0.1
+  ├── ✕ unmet peer react@"^18.0.0 || ^19.0.0": found 19.0.0-rc-7c8e5e7a-20241101
+  └── ✕ unmet peer react-dom@"< 19": found 19.0.0-rc-7c8e5e7a-20241101
+```

--- a/packages/next-codemod/bin/__testfixtures__/peer-dep-out-of-range/met-range/package.json
+++ b/packages/next-codemod/bin/__testfixtures__/peer-dep-out-of-range/met-range/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "met-range",
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0-rc.0",
+    "react-dom": "^19.0.0-rc.0"
+  }
+}

--- a/packages/next-codemod/bin/__testfixtures__/peer-dep-out-of-range/package.json
+++ b/packages/next-codemod/bin/__testfixtures__/peer-dep-out-of-range/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "peer-dep-out-of-range",
+  "scripts": {
+    "dev": "next dev --turbopack"
+  },
+  "dependencies": {
+    "next": "15.0.0-canary.0",
+    "react": "19.0.0-rc-f994737d14-20240522",
+    "react-dom": "19.0.0-rc-f994737d14-20240522",
+    "unmet-prerelease": "file:./unmet-prerelease",
+    "unmet-range": "file:./unmet-range"
+  }
+}

--- a/packages/next-codemod/bin/__testfixtures__/peer-dep-out-of-range/unmet-prerelease/package.json
+++ b/packages/next-codemod/bin/__testfixtures__/peer-dep-out-of-range/unmet-prerelease/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "unmet-prerelease",
+  "version": "0.0.1",
+  "peerDependencies": {
+    "react": "^18.2.0 || 19.0.0-rc-aaaaaaaa-20240101",
+    "react-dom": "^18.2.0 || 19.0.0-rc-aaaaaaaa-20240101"
+  }
+}

--- a/packages/next-codemod/bin/__testfixtures__/peer-dep-out-of-range/unmet-range/package.json
+++ b/packages/next-codemod/bin/__testfixtures__/peer-dep-out-of-range/unmet-range/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "unmet-range",
+  "version": "0.0.1",
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "< 19"
+  }
+}

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -2,7 +2,7 @@ import * as os from 'os'
 import prompts from 'prompts'
 import fs from 'fs'
 import {
-  satisfies as semverSatisfies,
+  satisfies as satisfiesVersionRange,
   compare as compareVersions,
 } from 'semver'
 import { execSync } from 'child_process'
@@ -678,7 +678,7 @@ function warnDependenciesOutOfRange(
         const expectedVersionRange = peerDeps[depName]
         const { version: currentVersion } = versionMapping[depName]
         if (
-          !semverSatisfies(currentVersion, expectedVersionRange, {
+          !satisfiesVersionRange(currentVersion, expectedVersionRange, {
             includePrerelease: true,
           })
         ) {

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -357,7 +357,7 @@ export async function runUpgrade(
     console.log(`${pc.green('✔')} Codemods have been applied successfully.`)
   }
 
-  warnDependenciesOutOfRange(appPackageJson, versionMapping, { verbose })
+  warnDependenciesOutOfRange(appPackageJson, versionMapping)
 
   endMessage()
 }
@@ -642,10 +642,8 @@ function writeOverridesField(
 
 function warnDependenciesOutOfRange(
   appPackageJson: any,
-  versionMapping: Record<string, { version: string; required: boolean }>,
-  options: { verbose: boolean }
+  versionMapping: Record<string, { version: string; required: boolean }>
 ) {
-  const { verbose } = options
   const allDirectDependencies = {
     ...appPackageJson.dependencies,
     ...appPackageJson.devDependencies,
@@ -727,15 +725,9 @@ function warnDependenciesOutOfRange(
       )
       Object.entries(deps).forEach(([depName, value], index, depsArray) => {
         const prefix = index === depsArray.length - 1 ? '  └── ' : '  ├── '
-        if (verbose) {
-          console.log(
-            `${prefix}${pc.yellow('✕ unmet peer')} ${depName}@"${value.expectedVersionRange}": found ${value.currentVersion}`
-          )
-        } else {
-          console.log(
-            `${prefix}incompatible with ${depName}@${value.currentVersion}`
-          )
-        }
+        console.log(
+          `${prefix}${pc.yellow('✕ unmet peer')} ${depName}@"${value.expectedVersionRange}": found ${value.currentVersion}`
+        )
       })
     })
   }

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -702,22 +702,20 @@ function getDependenciesOutOfRange(
       peerDepsKeys.includes(versionMappingKey)
     )
 
-    if (commonKeys.length > 0) {
-      for (const key of commonKeys) {
-        const peerDepVersion = peerDeps[key]
-        const { version } = versionMapping[key]
+    for (const key of commonKeys) {
+      const peerDepVersion = peerDeps[key]
+      const { version } = versionMapping[key]
 
-        if (
-          !semverSatisfies(version, peerDepVersion, {
-            includePrerelease: true,
-          })
-        ) {
-          dependenciesOutOfRange.set(key, {
-            current: version,
-            expected: peerDepVersion,
-            from: key,
-          })
-        }
+      if (
+        !semverSatisfies(version, peerDepVersion, {
+          includePrerelease: true,
+        })
+      ) {
+        dependenciesOutOfRange.set(key, {
+          current: version,
+          expected: peerDepVersion,
+          from: key,
+        })
       }
     }
   }
@@ -738,22 +736,20 @@ function getDependenciesOutOfRange(
         peerDepsKeys.includes(versionMappingKey)
       )
 
-      if (commonKeys.length > 0) {
-        for (const key of commonKeys) {
-          const peerDepVersion = peerDeps[key]
-          const { version } = versionMapping[key]
+      for (const key of commonKeys) {
+        const peerDepVersion = peerDeps[key]
+        const { version } = versionMapping[key]
 
-          if (
-            !semverSatisfies(version, peerDepVersion, {
-              includePrerelease: true,
-            })
-          ) {
-            dependenciesOutOfRange.set(key, {
-              current: version,
-              expected: peerDepVersion,
-              from: dependency,
-            })
-          }
+        if (
+          !semverSatisfies(version, peerDepVersion, {
+            includePrerelease: true,
+          })
+        ) {
+          dependenciesOutOfRange.set(key, {
+            current: version,
+            expected: peerDepVersion,
+            from: dependency,
+          })
         }
       }
     }

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -371,39 +371,6 @@ export async function runUpgrade(
   warnDependenciesOutOfRange(dependenciesOutOfRange, allDependenciesToInstall)
 
   endMessage()
-
-  if (dry) {
-    console.log() // new line
-    console.log(pc.bold('Dry-run Output:'))
-    console.log() // new line
-    console.log(
-      JSON.stringify(
-        {
-          revision,
-          verbose,
-          installedNextVersion,
-          installedReactVersion,
-          targetNextVersion,
-          targetReactVersion,
-          packageManager,
-          usesAppDir,
-          usesPagesDir,
-          isPureAppRouter,
-          isMixedApp,
-          shouldStayOnReact18,
-          codemods,
-          shouldRunReactCodemods,
-          shouldRunReactTypesCodemods,
-          execCommand,
-          dependenciesToInstall,
-          devDependenciesToInstall,
-          dependenciesOutOfRange: Object.fromEntries(dependenciesOutOfRange),
-        },
-        null,
-        2
-      )
-    )
-  }
 }
 
 function getInstalledNextVersion(): string {

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -357,7 +357,7 @@ export async function runUpgrade(
     console.log(`${pc.green('✔')} Codemods have been applied successfully.`)
   }
 
-  warnDependenciesOutOfRange(appPackageJson, versionMapping)
+  warnDependenciesOutOfRange(appPackageJson, versionMapping, { verbose })
 
   endMessage()
 }
@@ -642,8 +642,10 @@ function writeOverridesField(
 
 function warnDependenciesOutOfRange(
   appPackageJson: any,
-  versionMapping: Record<string, { version: string; required: boolean }>
+  versionMapping: Record<string, { version: string; required: boolean }>,
+  options: { verbose: boolean }
 ) {
+  const { verbose } = options
   const allDependenciesToInstall = {
     ...appPackageJson.dependencies,
     ...appPackageJson.devDependencies,
@@ -720,7 +722,8 @@ function warnDependenciesOutOfRange(
     console.log(
       `${pc.yellow('⚠')} Found ${size} ${
         size === 1 ? 'dependency' : 'dependencies'
-      } out of range from their peer dependencies.`
+      } that seem incompatible with the upgraded package versions.\n` +
+        'You may have to update these packages to their latest version or file an issue to ask for support of the upgraded libraries.'
     )
     dependenciesOutOfRange.forEach((deps, packageName) => {
       console.log(
@@ -728,9 +731,15 @@ function warnDependenciesOutOfRange(
       )
       Object.entries(deps).forEach(([depName, value], index, depsArray) => {
         const prefix = index === depsArray.length - 1 ? '  └── ' : '  ├── '
-        console.log(
-          `${prefix}${pc.yellow('✕ unmet peer')} ${depName}@"${value.expectedVersionRange}": found ${value.currentVersion}`
-        )
+        if (verbose) {
+          console.log(
+            `${prefix}${pc.yellow('✕ unmet peer')} ${depName}@"${value.expectedVersionRange}": found ${value.currentVersion}`
+          )
+        } else {
+          console.log(
+            `${prefix}incompatible with ${depName}@${value.currentVersion}`
+          )
+        }
       })
     })
   }

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -667,12 +667,22 @@ function warnDependenciesOutOfRange(
       )
     } catch (error) {
       if (error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
-        pkgJson = JSON.parse(
-          fs.readFileSync(
-            path.join(cwd, 'node_modules', dependency, 'package.json'),
-            'utf8'
+        let pkgJsonFromNodeModules
+        try {
+          pkgJsonFromNodeModules = path.join(
+            cwd,
+            'node_modules',
+            dependency,
+            'package.json'
           )
-        )
+
+          pkgJson = JSON.parse(fs.readFileSync(pkgJsonFromNodeModules, 'utf8'))
+        } catch {
+          console.warn(
+            `${pc.yellow('⚠')} Could not find package.json for dependency "${dependency}" at "${pkgJsonFromNodeModules}". This may affect peer dependency checks.`
+          )
+          continue
+        }
       } else {
         throw error
       }

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -660,12 +660,23 @@ function warnDependenciesOutOfRange(
   >()
 
   for (const dependency of Object.keys(allDependenciesToInstall)) {
-    const pkgJson = JSON.parse(
-      fs.readFileSync(
-        path.join(cwd, 'node_modules', dependency, 'package.json'),
-        'utf8'
+    let pkgJson
+    try {
+      pkgJson = require(
+        require.resolve(`${dependency}/package.json`, { paths: [cwd] })
       )
-    )
+    } catch (error) {
+      if (error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
+        pkgJson = JSON.parse(
+          fs.readFileSync(
+            path.join(cwd, 'node_modules', dependency, 'package.json'),
+            'utf8'
+          )
+        )
+      } else {
+        throw error
+      }
+    }
 
     if ('peerDependencies' in pkgJson) {
       const peerDeps = pkgJson.peerDependencies

--- a/packages/next-codemod/lib/handle-package.ts
+++ b/packages/next-codemod/lib/handle-package.ts
@@ -107,9 +107,13 @@ export function installPackages(
   }
 }
 
-export function runInstallation(packageManager: PackageManager) {
+export function runInstallation(
+  packageManager: PackageManager,
+  options: { cwd: string }
+) {
   try {
     execa.sync(packageManager, ['install'], {
+      cwd: options.cwd,
       stdio: 'inherit',
       shell: true,
     })


### PR DESCRIPTION
### Why?

After the upgrade, there might be an incompatibility with the `peerDependencies` of the existing dependencies. Therefore, we run a check for it to warn the user at the end of the upgrade.

## Testing Plan

### Unmet Peer Dependencies with Range and Prerelease

```
pnpm test:upgrade-fixture bin/__testfixtures__/peer-dep-out-of-range
```

CLI output includes:
```
⚠ Found 2 dependencies that seem incompatible with the upgraded package versions.
You may have to update these packages to their latest version or file an issue to ask for support of the upgraded libraries.
unmet-prerelease 0.0.1
  ├── incompatible with react@19.0.0-rc-7c8e5e7a-20241101
  └── incompatible with react-dom@19.0.0-rc-7c8e5e7a-20241101
unmet-range 0.0.1
  ├── incompatible with react@19.0.0-rc-7c8e5e7a-20241101
  └── incompatible with react-dom@19.0.0-rc-7c8e5e7a-20241101
```

Closes NDX-382