### PR TITLE
docs(next-config): remove mention of appIsrStatus is on canary

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/devIndicators.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/devIndicators.mdx
@@ -22,8 +22,6 @@ description: Optimized pages include an indicator to let you know if it's being 
 
 ## `appIsrStatus` (Static Indicator)
 
-> This option is available in Next.js canary.
-
 Next.js displays a static indicator in the bottom corner of the screen that signals if a route will be prerendered at build time. This makes it easier to understand whether a route is static or dynamic, and for you to identify if a route [opts out of static rendering](#static-route-not-showing-the-indicator).
 
 <Image


### PR DESCRIPTION
## Why?

[`appIsrStatus`](https://nextjs.org/docs/canary/app/api-reference/next-config-js/devIndicators#appisrstatus-static-indicator) is stable now, so this note is no longer necessary.