### PR TITLE
react-sync: Ignore update notices from npm

### DIFF
--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -211,7 +211,7 @@ async function main() {
   ) {
     const { stdout, stderr } = await execa(
       'npm',
-      ['view', 'react@canary', 'version'],
+      ['--silent', 'view', 'react@canary', 'version'],
       {
         // Avoid "Usage Error: This project is configured to use pnpm".
         cwd: '/tmp',


### PR DESCRIPTION
`npm view` prints a notice when a new update is available
to `stderr` tricking us into thinking there was an error.
```
npm notice
npm notice New minor version of npm available! 10.7.0 -> 10.9.0
npm notice Changelog: https://github.com/npm/cli/releases/tag/v10.9.0
npm notice To update run: npm install -g npm@10.9.0
npm notice
```

Running with `--silent` avoids these unrelated warnings (see https://github.com/npm/npm/issues/2040#issuecomment-3504495).

## Test plan

https://github.com/vercel/next.js/pull/71718