### PR TITLE
fix: exclude `basePath` in `findSourceMapURL`

### DIFF
--- a/packages/next/src/client/app-find-source-map-url.ts
+++ b/packages/next/src/client/app-find-source-map-url.ts
@@ -8,7 +8,10 @@ export const findSourceMapURL =
 
         url.searchParams.set(
           'filename',
-          filename.replace(new RegExp(`^${document.location.origin}`), '')
+          filename.replace(
+            new RegExp(`^${document.location.origin}${basePath}`),
+            ''
+          )
         )
 
         return url.href


### PR DESCRIPTION
This PR fixes #71706.

When having an error client side and there is a `basePath` defined, the basePath is being used to locate the sourcemap of the given file which results in an error.

With these changes the `basePath` gets removed from the `filename` passed to `findSourceMapURL`

If you have questions, feel free to ask!
