### PR TITLE
feat(turbo-tasks): Implement `IntoFuture` for `&mut Vc` and `&mut ResolvedVc`

### DIFF
--- a/turbopack/crates/turbo-tasks-testing/tests/resolved_vc.rs
+++ b/turbopack/crates/turbo-tasks-testing/tests/resolved_vc.rs
@@ -61,3 +61,19 @@ async fn test_resolved_vc_as_arg() -> Result<()> {
     })
     .await
 }
+
+#[tokio::test]
+async fn test_into_future() -> Result<()> {
+    run(&REGISTRATION, || async {
+        let mut resolved = ResolvedVc::cell(42);
+        let _: ReadRef<u32> = resolved.await?;
+        let _: ReadRef<u32> = (&resolved).await?;
+        let _: ReadRef<u32> = (&mut resolved).await?;
+        let mut unresolved = Vc::cell(42);
+        let _: ReadRef<u32> = unresolved.await?;
+        let _: ReadRef<u32> = (&unresolved).await?;
+        let _: ReadRef<u32> = (&mut unresolved).await?;
+        Ok(())
+    })
+    .await
+}

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -96,6 +96,7 @@ macro_rules! into_future {
 
 into_future!(ResolvedVc<T>);
 into_future!(&ResolvedVc<T>);
+into_future!(&mut ResolvedVc<T>);
 
 impl<T> ResolvedVc<T>
 where


### PR DESCRIPTION
It's not common that you'd have a `&mut Vc` or `&mut ResolvedVc` (because they're `Copy`), but there are some edge cases where you might, and there's no technical reason we can't `impl IntoFuture` for these, so let's do it.

Closes PACK-3464