### PR TITLE
[dynamicIO] unify cache filling and lazy-module warming

### DIFF
--- a/packages/next/src/server/app-render/app-render-prerender-utils.ts
+++ b/packages/next/src/server/app-render/app-render-prerender-utils.ts
@@ -77,12 +77,11 @@ export async function createReactServerPrerenderResult(
   while (true) {
     const { done, value } = await reader.read()
     if (done) {
-      break
+      return new ReactServerPrerenderResult(chunks)
     } else {
       chunks.push(value)
     }
   }
-  return new ReactServerPrerenderResult(chunks)
 }
 
 export async function createReactServerPrerenderResultFromRender(

--- a/packages/next/types/react-dom.d.ts
+++ b/packages/next/types/react-dom.d.ts
@@ -17,7 +17,7 @@ declare module 'react-dom/server.edge' {
   export type ResumeOptions = {
     nonce?: string
     signal?: AbortSignal
-    onError?: (error: unknown) => string | undefined
+    onError?: (error: unknown) => string | undefined | void
     onPostpone?: (reason: string) => void
     unstable_externalRuntimeSrc?: string | BootstrapScriptDescriptor
   }
@@ -42,7 +42,10 @@ declare module 'react-dom/server.edge' {
     bootstrapModules?: Array<string | BootstrapScriptDescriptor>
     progressiveChunkSize?: number
     signal?: AbortSignal
-    onError?: (error: unknown, errorInfo: ErrorInfo) => string | undefined
+    onError?: (
+      error: unknown,
+      errorInfo: ErrorInfo
+    ) => string | undefined | void
     onPostpone?: (reason: string) => void
     unstable_externalRuntimeSrc?: string | BootstrapScriptDescriptor
     importMap?: {
@@ -94,7 +97,10 @@ declare module 'react-dom/static.edge' {
     bootstrapModules?: Array<string | BootstrapScriptDescriptor>
     progressiveChunkSize?: number
     signal?: AbortSignal
-    onError?: (error: unknown, errorInfo: ErrorInfo) => string | undefined
+    onError?: (
+      error: unknown,
+      errorInfo: ErrorInfo
+    ) => string | undefined | void
     onPostpone?: (reason: string) => void
     unstable_externalRuntimeSrc?: string | BootstrapScriptDescriptor
     importMap?: {

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.prospective-fallback.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.prospective-fallback.test.ts
@@ -28,7 +28,7 @@ describe(`Dynamic IO Prospective Fallback`, () => {
       }
 
       expect(next.cliOutput).toContain(
-        'In Route "/blog/[slug]" this component accessed data without a fallback UI available somewhere above it using Suspense.'
+        'In Route "/blog/[slug]" this component accessed data without a Suspense boundary above it to provide a fallback UI.'
       )
     })
 
@@ -46,7 +46,7 @@ describe(`Dynamic IO Prospective Fallback`, () => {
       await next.start()
 
       expect(next.cliOutput).not.toContain(
-        'In Route "/blog/[slug]" this component accessed data without a fallback UI available somewhere above it using Suspense.'
+        'In Route "/blog/[slug]" this component accessed data without a Suspense boundary above it to provide a fallback UI.'
       )
     })
   }

--- a/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
+++ b/test/e2e/app-dir/dynamic-io-errors/dynamic-io-errors.test.ts
@@ -322,7 +322,7 @@ function runTests(options: { withMinification: boolean }) {
         const expectError = createExpectError(next.cliOutput)
 
         expectError(
-          'In Route "/" this component accessed data without a fallback UI available somewhere above it using Suspense.',
+          'In Route "/" this component accessed data without a Suspense boundary above it to provide a fallback UI.',
           // Turbopack doesn't support disabling minification yet
           withMinification || isTurbopack ? undefined : 'IndirectionTwo'
         )
@@ -331,7 +331,7 @@ function runTests(options: { withMinification: boolean }) {
           // one task actually reports and error at the moment. We should fix upstream but for now we exclude the second error when PPR is off
           // because we are using canary React and renderToReadableStream rather than experimental React and prerender
           expectError(
-            'In Route "/" this component accessed data without a fallback UI available somewhere above it using Suspense.',
+            'In Route "/" this component accessed data without a Suspense boundary above it to provide a fallback UI.',
             // Turbopack doesn't support disabling minification yet
             withMinification || isTurbopack ? undefined : 'IndirectionThree'
           )


### PR DESCRIPTION
We ended up with up to three prerender passes as we added support for new use cases like lazy module initializaiton. This update refactors the PPR pathway to have at most two renders.

I will follow up with a refactor of the non-ppr pathway next.