### PR TITLE
docs(typo): fix typo in `03-multi-zones.mdx`

### DIFF
--- a/docs/02-app/01-building-your-application/10-deploying/03-multi-zones.mdx
+++ b/docs/02-app/01-building-your-application/10-deploying/03-multi-zones.mdx
@@ -100,7 +100,7 @@ Routing requests through [`rewrites`](/docs/app/api-reference/next-config-js/rew
 ```js filename="middleware.js"
 export async function middleware(request) {
   const { pathname, search } = req.nextUrl;
-  if (pathname === '/your-path' && myFeaturFlag.isEnabled()) {
+  if (pathname === '/your-path' && myFeatureFlag.isEnabled()) {
     return NextResponse.rewrite(`${rewriteDomain}${pathname}${search});
   }
 }


### PR DESCRIPTION
### Improving Documentation

This PR fixes a small typo in a code snippet I noticed when reading through the Multi-Zones deployment docs today (https://nextjs.org/docs/app/building-your-application/deploying/multi-zones). ✨ 