### PR TITLE
Don't filter out <anonymous> source location frames through RSC

### DIFF
--- a/packages/next/src/client/app-find-source-map-url.ts
+++ b/packages/next/src/client/app-find-source-map-url.ts
@@ -4,6 +4,10 @@ const pathname = `${basePath}/__nextjs_source-map`
 export const findSourceMapURL =
   process.env.NODE_ENV === 'development'
     ? function findSourceMapURL(filename: string): string | null {
+        if (filename === '') {
+          return null
+        }
+
         const url = new URL(pathname, document.location.origin)
 
         url.searchParams.set(

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1592,6 +1592,12 @@ async function renderToStream(
               onError: serverComponentsErrorHandler,
               environmentName: () =>
                 requestStore.prerenderPhase === true ? 'Prerender' : 'Server',
+              filterStackFrame(url: string, _functionName: string): boolean {
+                // The default implementation filters out <anonymous> stack frames
+                // but we want to retain them because current Server Components and
+                // built-in Components in parent stacks don't have source location.
+                return !url.startsWith('node:') && !url.includes('node_modules')
+              },
             }
           )
         },


### PR DESCRIPTION
This lets us show Server Components (and Host Components) in the Parent Stack passed to errors.

<img width="1039" alt="Screenshot 2024-10-23 at 12 51 10 PM" src="https://github.com/user-attachments/assets/5912e750-b544-403d-8d5a-bce91c01b3a8">
