### PR TITLE
Fix fetch with no-store inside of use cache

### DIFF
--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -304,16 +304,20 @@ export function createPatchedFetcher(
         if (currentFetchCacheConfig === 'force-cache') {
           currentFetchRevalidate = false
         } else if (
-          currentFetchCacheConfig === 'no-cache' ||
-          currentFetchCacheConfig === 'no-store' ||
-          pageFetchCacheMode === 'force-no-store' ||
-          pageFetchCacheMode === 'only-no-store' ||
-          // If no explicit fetch cache mode is set, but dynamic = `force-dynamic` is set,
-          // we shouldn't consider caching the fetch. This is because the `dynamic` cache
-          // is considered a "top-level" cache mode, whereas something like `fetchCache` is more
-          // fine-grained. Top-level modes are responsible for setting reasonable defaults for the
-          // other configurations.
-          (!pageFetchCacheMode && workStore.forceDynamic)
+          // if we are inside of "use cache"/"unstable_cache"
+          // we shouldn't set the revalidate to 0 as it's overridden
+          // by the cache context
+          workUnitStore?.type !== 'cache' &&
+          (currentFetchCacheConfig === 'no-cache' ||
+            currentFetchCacheConfig === 'no-store' ||
+            pageFetchCacheMode === 'force-no-store' ||
+            pageFetchCacheMode === 'only-no-store' ||
+            // If no explicit fetch cache mode is set, but dynamic = `force-dynamic` is set,
+            // we shouldn't consider caching the fetch. This is because the `dynamic` cache
+            // is considered a "top-level" cache mode, whereas something like `fetchCache` is more
+            // fine-grained. Top-level modes are responsible for setting reasonable defaults for the
+            // other configurations.
+            (!pageFetchCacheMode && workStore.forceDynamic))
         ) {
           currentFetchRevalidate = 0
         }

--- a/test/e2e/app-dir/use-cache/app/cache-fetch-no-store/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/cache-fetch-no-store/page.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+async function getData() {
+  'use cache'
+
+  return fetch('https://next-data-api-endpoint.vercel.app/api/random', {
+    cache: 'no-store',
+  }).then((res) => res.text())
+}
+
+export default async function Page() {
+  return (
+    <>
+      <p>index page</p>
+      <p id="random">{await getData()}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -266,4 +266,13 @@ describe('use-cache', () => {
     // const time4 = await browser.waitForElementByCss('#t').text()
     // expect(time4).toBe(time3);
   })
+
+  it('should override fetch with no-store in use cache properly', async () => {
+    const browser = await next.browser('/cache-fetch-no-store')
+
+    const initialValue = await browser.elementByCss('#random').text()
+    await browser.refresh()
+
+    expect(await browser.elementByCss('#random').text()).toBe(initialValue)
+  })
 })


### PR DESCRIPTION
This ensures if you have a `fetch` with `cache: 'no-store'` inside of `use cache`/`unstable_cache` we don't update the revalidate period to `0` which effectively makes the `use cache` a no-op. This doesn't change the behavior if `revalidate: 0` is defined on a `fetch` inside of `use cache` as that is more explicitly changing the revalidate period similar to `cacheLife()`. 