### PR TITLE
Fix docs for configuring Turbopack

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/turbo.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/turbo.mdx
@@ -126,11 +126,19 @@ To configure resolve extensions, use the `resolveExtensions` field in `next.conf
 
 ```js filename="next.config.js"
 module.exports = {
-    experimental: {
-      turbo: {
-        resolveExtensions: ['.mdx', '.tsx', '.ts', '.jsx', '.js', '.mjs', '.json'],
-      },
+  experimental: {
+    turbo: {
+      resolveExtensions: [
+        '.mdx',
+        '.tsx',
+        '.ts',
+        '.jsx',
+        '.js',
+        '.mjs',
+        '.json',
+      ],
     },
+  },
 }
 ```
 
@@ -161,6 +169,6 @@ module.exports = {
 
 ## Version History
 
-| Version     | Changes                                           |
-| ----------- | ------------------------------------------------- |
-| `13.0.0`    | `experimental.turbo` introduced.                  |
+| Version  | Changes                          |
+| -------- | -------------------------------- |
+| `13.0.0` | `experimental.turbo` introduced. |

--- a/docs/02-app/02-api-reference/05-next-config-js/turbo.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/turbo.mdx
@@ -11,8 +11,10 @@ The `turbo` option lets you customize [Turbopack](/docs/architecture/turbopack) 
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
-  turbo: {
-    // ...
+  experimental: {
+    turbo: {
+      // ...
+    },
   },
 }
 
@@ -22,8 +24,10 @@ export default nextConfig
 ```js filename="next.config.js" switcher
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  turbo: {
-    // ...
+  experimental: {
+    turbo: {
+      // ...
+    },
   },
 }
 
@@ -76,11 +80,13 @@ To configure loaders, add the names of the loaders you've installed and any opti
 
 ```js filename="next.config.js"
 module.exports = {
-  turbo: {
-    rules: {
-      '*.svg': {
-        loaders: ['@svgr/webpack'],
-        as: '*.js',
+  experimental: {
+    turbo: {
+      rules: {
+        '*.svg': {
+          loaders: ['@svgr/webpack'],
+          as: '*.js',
+        },
       },
     },
   },
@@ -97,10 +103,12 @@ To configure resolve aliases, map imported patterns to their new destination in 
 
 ```js filename="next.config.js"
 module.exports = {
-  turbo: {
-    resolveAlias: {
-      underscore: 'lodash',
-      mocha: { browser: 'mocha/browser-entry.js' },
+  experimental: {
+    turbo: {
+      resolveAlias: {
+        underscore: 'lodash',
+        mocha: { browser: 'mocha/browser-entry.js' },
+      },
     },
   },
 }
@@ -118,9 +126,11 @@ To configure resolve extensions, use the `resolveExtensions` field in `next.conf
 
 ```js filename="next.config.js"
 module.exports = {
-  turbo: {
-    resolveExtensions: ['.mdx', '.tsx', '.ts', '.jsx', '.js', '.mjs', '.json'],
-  },
+    experimental: {
+      turbo: {
+        resolveExtensions: ['.mdx', '.tsx', '.ts', '.jsx', '.js', '.mjs', '.json'],
+      },
+    },
 }
 ```
 
@@ -141,8 +151,10 @@ To configure the module IDs strategy, use the `moduleIdStrategy` field in `next.
 
 ```js filename="next.config.js"
 module.exports = {
-  turbo: {
-    moduleIdStrategy: 'deterministic',
+  experimental: {
+    turbo: {
+      moduleIdStrategy: 'deterministic',
+    },
   },
 }
 ```

--- a/docs/02-app/02-api-reference/05-next-config-js/turbo.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/turbo.mdx
@@ -163,5 +163,4 @@ module.exports = {
 
 | Version     | Changes                                           |
 | ----------- | ------------------------------------------------- |
-| `15.0.0-RC` | `turbo` is now stable and no longer experimental. |
 | `13.0.0`    | `experimental.turbo` introduced.                  |


### PR DESCRIPTION
### What?
Fixes code examples for configuring Turbopack. Turbopack Dev is stable, but we're keeping the configuration options under `experimental` until Turbopack Build is stable as well. Most of these options will not change, but we didn't want a combination of experimental and stable options. 


Closes PACK-3324