### PR TITLE
docs(turbo): add experimental icon to turbo config section

### DIFF
--- a/docs/02-app/02-api-reference/05-next-config-js/turbo.mdx
+++ b/docs/02-app/02-api-reference/05-next-config-js/turbo.mdx
@@ -1,6 +1,7 @@
 ---
 title: turbo
 description: Configure Next.js with Turbopack-specific options
+version: experimental
 ---
 
 {/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}


### PR DESCRIPTION
## Why?

The `turbo` config is still experimental in v15.

- Fixes https://github.com/vercel/next.js/issues/71750
- Related PR: https://github.com/vercel/next.js/pull/71755