### PR TITLE
Add test for fetch with auth in use cache

### DIFF
--- a/test/e2e/app-dir/use-cache/app/cache-fetch-auth-header/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/cache-fetch-auth-header/page.tsx
@@ -1,0 +1,25 @@
+import { cookies } from 'next/headers'
+import React from 'react'
+
+async function getData() {
+  'use cache'
+
+  return fetch('https://next-data-api-endpoint.vercel.app/api/random', {
+    headers: {
+      Authorization: `Bearer ${process.env.MY_TOKEN}`,
+    },
+  }).then((res) => res.text())
+}
+
+export default async function Page() {
+  const myCookies = await cookies()
+  const id = myCookies.get('id')?.value
+
+  return (
+    <>
+      <p>index page</p>
+      <p id="random">{await getData()}</p>
+      <p id="my-id">{id || ''}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -275,4 +275,13 @@ describe('use-cache', () => {
 
     expect(await browser.elementByCss('#random').text()).toBe(initialValue)
   })
+
+  it('should override fetch with cookies/auth in use cache properly', async () => {
+    const browser = await next.browser('/cache-fetch-auth-header')
+
+    const initialValue = await browser.elementByCss('#random').text()
+    await browser.refresh()
+
+    expect(await browser.elementByCss('#random').text()).toBe(initialValue)
+  })
 })


### PR DESCRIPTION
This ensures we are properly caching fetch inside of use cache even if it uses `Authorzation` and comes after cookies() access. 