### PR TITLE
fix(turbopack): Apply `import_map` option of `swc_emotion` correctly

### DIFF
--- a/test/e2e/app-dir/emotion-js/app/page.js
+++ b/test/e2e/app-dir/emotion-js/app/page.js
@@ -1,7 +1,7 @@
 'use client'
-import { styledCss } from 'import-map-test'
+import { styledJsx } from 'import-map-test'
 
-const red = styledCss({ color: 'red' })
+const red = styledJsx.p({ color: 'red' })
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/emotion-js/app/page.js
+++ b/test/e2e/app-dir/emotion-js/app/page.js
@@ -1,5 +1,13 @@
 'use client'
+import { styledCss } from 'import-map-test'
+
+const red = styledCss({ color: 'red' })
 
 export default function Page() {
-  return <h1 css={{ color: 'blue' }}>Blue</h1>
+  return (
+    <>
+      <h1 css={{ color: 'blue' }}>Blue</h1>
+      <p className={red}>Red</p>
+    </>
+  )
 }

--- a/test/e2e/app-dir/emotion-js/app/page.js
+++ b/test/e2e/app-dir/emotion-js/app/page.js
@@ -1,13 +1,15 @@
 'use client'
-import { styledJsx } from 'import-map-test'
+import { styledCss } from 'import-map-test'
 
-const red = styledJsx.p({ color: 'red' })
+const red = styledCss`
+  color: red;
+`
 
 export default function Page() {
   return (
     <>
       <h1 css={{ color: 'blue' }}>Blue</h1>
-      <p className={red}>Red</p>
+      <p css={red}>Red</p>
     </>
   )
 }

--- a/test/e2e/app-dir/emotion-js/index.test.ts
+++ b/test/e2e/app-dir/emotion-js/index.test.ts
@@ -9,6 +9,19 @@ describe('app dir - emotion-js', () => {
       '@emotion/react': 'latest',
       '@emotion/cache': 'latest',
     },
+    nextConfig: {
+      compiler: {
+        emotion: {
+          importMap: {
+            'import-map-test': {
+              styledCss: {
+                canonicalImport: ['@emotion/react', 'css'],
+              },
+            },
+          },
+        },
+      },
+    },
   })
 
   if (skipped) {
@@ -25,6 +38,16 @@ describe('app dir - emotion-js', () => {
           `window.getComputedStyle(document.querySelector('h1')).color`
         ),
       'rgb(0, 0, 255)'
+    )
+
+    const el2 = browser.elementByCss('p')
+    expect(await el2.text()).toBe('Red')
+    await check(
+      async () =>
+        await browser.eval(
+          `window.getComputedStyle(document.querySelector('p')).color`
+        ),
+      'rgb(255, 0, 0)'
     )
   })
 })

--- a/test/e2e/app-dir/emotion-js/index.test.ts
+++ b/test/e2e/app-dir/emotion-js/index.test.ts
@@ -9,19 +9,6 @@ describe('app dir - emotion-js', () => {
       '@emotion/react': 'latest',
       '@emotion/cache': 'latest',
     },
-    nextConfig: {
-      compiler: {
-        emotion: {
-          importMap: {
-            'import-map-test': {
-              styledCss: {
-                canonicalImport: ['@emotion/react', 'css'],
-              },
-            },
-          },
-        },
-      },
-    },
   })
 
   if (skipped) {

--- a/test/e2e/app-dir/emotion-js/next.config.js
+++ b/test/e2e/app-dir/emotion-js/next.config.js
@@ -6,8 +6,8 @@ module.exports = {
       emotion: {
         importMap: {
           'import-map-test': {
-            styledCss: {
-              canonicalImport: ['@emotion/react', 'css'],
+            styledJsx: {
+              canonicalImport: ['@emotion/react', 'jsx'],
             },
           },
         },

--- a/test/e2e/app-dir/emotion-js/next.config.js
+++ b/test/e2e/app-dir/emotion-js/next.config.js
@@ -3,7 +3,6 @@ module.exports = {
   reactStrictMode: true,
   compiler: {
     emotion: {
-      enabled: true,
       importMap: {
         'import-map-test': {
           styledCss: {

--- a/test/e2e/app-dir/emotion-js/next.config.js
+++ b/test/e2e/app-dir/emotion-js/next.config.js
@@ -2,6 +2,16 @@
 module.exports = {
   reactStrictMode: true,
   compiler: {
-    emotion: true,
+    compiler: {
+      emotion: {
+        importMap: {
+          'import-map-test': {
+            styledCss: {
+              canonicalImport: ['@emotion/react', 'css'],
+            },
+          },
+        },
+      },
+    },
   },
 }

--- a/test/e2e/app-dir/emotion-js/next.config.js
+++ b/test/e2e/app-dir/emotion-js/next.config.js
@@ -2,13 +2,12 @@
 module.exports = {
   reactStrictMode: true,
   compiler: {
-    compiler: {
-      emotion: {
-        importMap: {
-          'import-map-test': {
-            styledJsx: {
-              canonicalImport: ['@emotion/react', 'jsx'],
-            },
+    emotion: {
+      enabled: true,
+      importMap: {
+        'import-map-test': {
+          styledCss: {
+            canonicalImport: ['@emotion/react', 'css'],
           },
         },
       },

--- a/test/e2e/app-dir/emotion-js/node_modules/import-map-test/index.js
+++ b/test/e2e/app-dir/emotion-js/node_modules/import-map-test/index.js
@@ -1,0 +1,1 @@
+exports.styledCss = (css) => css

--- a/test/e2e/app-dir/emotion-js/node_modules/import-map-test/index.js
+++ b/test/e2e/app-dir/emotion-js/node_modules/import-map-test/index.js
@@ -1,1 +1,1 @@
-exports.styledCss = (css) => css
+export { jsx as styledJsx } from '@emotion/react'

--- a/test/e2e/app-dir/emotion-js/node_modules/import-map-test/index.js
+++ b/test/e2e/app-dir/emotion-js/node_modules/import-map-test/index.js
@@ -1,1 +1,1 @@
-export { jsx as styledJsx } from '@emotion/react'
+export { css as styledCss } from '@emotion/react'

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/emotion.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/emotion.rs
@@ -35,6 +35,7 @@ pub enum EmotionLabelKind {
 #[derive(
     Clone, PartialEq, Eq, Debug, TraceRawVcs, Serialize, Deserialize, NonLocalValue, OperationValue,
 )]
+#[serde(rename_all = "camelCase")]
 pub struct EmotionImportItemConfig {
     pub canonical_import: EmotionItemSpecifier,
     pub styled_base_import: Option<EmotionItemSpecifier>,

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/emotion.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/emotion.rs
@@ -28,8 +28,6 @@ pub enum EmotionLabelKind {
     Never,
 }
 
-//[TODO]: need to support importmap, there are type mismatch between
-//next.config.js to swc's emotion options
 #[turbo_tasks::value(shared, operation)]
 #[derive(Default, Clone, Debug)]
 #[serde(rename_all = "camelCase")]

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/emotion.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/emotion.rs
@@ -6,15 +6,19 @@ use std::{
 
 use anyhow::Result;
 use async_trait::async_trait;
-use rustc_hash::FxHasher;
+use indexmap::IndexMap;
+use rustc_hash::{FxBuildHasher, FxHasher};
 use serde::{Deserialize, Serialize};
 use swc_core::{
+    atoms::Atom,
     common::util::take::Take,
     ecma::{
         ast::{Module, Program},
         visit::FoldWith,
     },
 };
+use swc_emotion::ImportMap;
+use turbo_rcstr::RcStr;
 use turbo_tasks::{trace::TraceRawVcs, NonLocalValue, OperationValue, ValueDefault, Vc};
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
 
@@ -28,6 +32,36 @@ pub enum EmotionLabelKind {
     Never,
 }
 
+#[derive(
+    Clone, PartialEq, Eq, Debug, TraceRawVcs, Serialize, Deserialize, NonLocalValue, OperationValue,
+)]
+pub struct EmotionImportItemConfig {
+    pub canonical_import: EmotionItemSpecifier,
+    pub styled_base_import: Option<EmotionItemSpecifier>,
+}
+
+impl From<&EmotionImportItemConfig> for swc_emotion::ImportItemConfig {
+    fn from(value: &EmotionImportItemConfig) -> Self {
+        swc_emotion::ImportItemConfig {
+            canonical_import: From::from(&value.canonical_import),
+            styled_base_import: value.styled_base_import.as_ref().map(From::from),
+        }
+    }
+}
+
+#[derive(
+    Clone, PartialEq, Eq, Debug, TraceRawVcs, Serialize, Deserialize, NonLocalValue, OperationValue,
+)]
+pub struct EmotionItemSpecifier(pub RcStr, pub RcStr);
+
+impl From<&EmotionItemSpecifier> for swc_emotion::ItemSpecifier {
+    fn from(value: &EmotionItemSpecifier) -> Self {
+        swc_emotion::ItemSpecifier(value.0.as_str().into(), value.1.as_str().into())
+    }
+}
+
+pub type EmotionImportMapValue = IndexMap<RcStr, EmotionImportItemConfig, FxBuildHasher>;
+
 #[turbo_tasks::value(shared, operation)]
 #[derive(Default, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -35,6 +69,7 @@ pub struct EmotionTransformConfig {
     pub sourcemap: Option<bool>,
     pub label_format: Option<String>,
     pub auto_label: Option<EmotionLabelKind>,
+    pub import_map: Option<IndexMap<RcStr, EmotionImportMapValue, FxBuildHasher>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -76,7 +111,18 @@ impl EmotionTransformer {
             } else {
                 None
             },
-            ..Default::default()
+            import_map: config.import_map.as_ref().map(|map| {
+                map.iter()
+                    .map(|(k, v)| {
+                        (
+                            k.as_str().into(),
+                            swc_emotion::ImportMapValue::from_iter(v.iter().map(|(k, v)| {
+                                (k.as_str().into(), swc_emotion::ImportItemConfig::from(v))
+                            })),
+                        )
+                    })
+                    .collect()
+            }),
         };
 
         Some(EmotionTransformer { config })


### PR DESCRIPTION
### What?

Preserve `import_map` config specified by the user

### Why?

The default mode (webpack mode) supports `import_map` config, so turbopack should also support it.

### How?

Closes https://github.com/vercel/next.js/issues/71408


Closes PACK-4287