### PR TITLE
Don't error asking for prebuilt bundles

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
+++ b/packages/next/src/client/components/react-dev-overlay/server/middleware-turbopack.ts
@@ -169,6 +169,10 @@ export function getSourceMapMiddleware(project: Project, distDir: string) {
       return badRequest(res)
     }
 
+    if (filename.startsWith('webpack://next/')) {
+      return noContent(res)
+    }
+
     try {
       if (filename.startsWith('/_next/static')) {
         filename = path.join(


### PR DESCRIPTION
Turbopack doesn't recognize webpack:// and so errors otherwise.

We don't need source maps for internals.

<img width="774" alt="Screenshot 2024-10-23 at 10 13 02 PM" src="https://github.com/user-attachments/assets/72ec2ecc-7fbb-4a2a-9978-8d8c365ab966">
