### PR TITLE
misc: update source map paths for bundled Next.js runtime

### DIFF
--- a/packages/next/webpack.config.js
+++ b/packages/next/webpack.config.js
@@ -154,6 +154,7 @@ module.exports = ({ dev, turbo, bundleType, experimental }) => {
         experimental ? '-experimental' : ''
       }.runtime.${dev ? 'dev' : 'prod'}.js`,
       libraryTarget: 'commonjs2',
+      devtoolModuleFilenameTemplate: './[resource-path]',
     },
     devtool: process.env.NEXT_SERVER_EVAL_SOURCE_MAPS
       ? 'eval-source-map'


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

This changes the generated source map to not do the "webpack://next/dist/<file>" and instead use the relative path. this allows us to use the vanilla ignoreList "node_modules" config to also also ignore those files

![CleanShot 2024-10-23 at 22 41 37@2x](https://github.com/user-attachments/assets/387bdf1e-c507-459c-8740-8e9587ebb0ca)

![CleanShot 2024-10-23 at 22 42 03@2x](https://github.com/user-attachments/assets/5fc45209-292b-4f53-8e86-541def464286)

