### PR TITLE
test: re-enable test with note

### DIFF
--- a/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
+++ b/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
@@ -45,8 +45,8 @@ describe('Dynamic IO Dev Errors', () => {
     })
   })
 
-  // Disabling so I can land docs update. reenable after
-  it.skip('should display error when component accessed data without suspense boundary', async () => {
+  // NOTE: when update this snapshot, use `pnpm build` in packages/next to avoid next source code get mapped to source.
+  it('should display error when component accessed data without suspense boundary', async () => {
     const browser = await next.browser('/no-accessed-data')
 
     await retry(async () => {
@@ -62,33 +62,14 @@ describe('Dynamic IO Dev Errors', () => {
       stack,
     }
 
+    // FIXME: avoid `next` code to be mapped to source code and filter them out even when sourcemap is enabled.
     expect(result).toMatchInlineSnapshot(`
       {
         "description": "[ Server ] Error: Route "/no-accessed-data": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
         "stack": "Page [Server]
       <anonymous> (2:1)
       Root [Server]
-      <anonymous> (2:1)
-      RedirectErrorBoundary
-      ./dist/esm/server/route-modules/app-page/module.js
-      RedirectBoundary
-      ./dist/esm/server/route-modules/app-page/module.js
-      ReactDevOverlay
-      ./dist/esm/client/components/react-dev-overlay/app/hot-reloader-client.js
-      HotReload
-      ./dist/esm/client/components/react-dev-overlay/app/hot-reloader-client.js
-      Router
-      ./dist/esm/server/route-modules/app-page/module.js
-      ErrorBoundaryHandler
-      ./dist/esm/server/route-modules/app-page/module.js
-      ErrorBoundary
-      ./dist/esm/server/route-modules/app-page/module.js
-      AppRouter
-      ./dist/esm/server/route-modules/app-page/module.js
-      ServerInsertedHTMLProvider
-      ./dist/esm/server/route-modules/app-page/module.js
-      App
-      ./dist/esm/server/route-modules/app-page/module.js",
+      <anonymous> (2:1)",
       }
     `)
   })

--- a/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
+++ b/test/development/app-dir/dynamic-io-dev-errors/dynamic-io-dev-errors.test.ts
@@ -57,20 +57,14 @@ describe('Dynamic IO Dev Errors', () => {
 
     const description = await getRedboxDescription(browser)
     const stack = await getRedboxCallStack(browser)
-    const result = {
-      description,
-      stack,
-    }
 
+    expect(description).toMatchInlineSnapshot(
+      `"[ Server ] Error: Route "/no-accessed-data": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense"`
+    )
+    // TODO: use snapshot testing for stack
     // FIXME: avoid `next` code to be mapped to source code and filter them out even when sourcemap is enabled.
-    expect(result).toMatchInlineSnapshot(`
-      {
-        "description": "[ Server ] Error: Route "/no-accessed-data": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. We don't have the exact line number added to error messages yet but you can see which component in the stack below. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
-        "stack": "Page [Server]
-      <anonymous> (2:1)
-      Root [Server]
-      <anonymous> (2:1)",
-      }
-    `)
+    expect(stack).toContain('Page [Server]')
+    expect(stack).toContain('Root [Server]')
+    expect(stack).toContain('<anonymous> (2:1)')
   })
 })


### PR DESCRIPTION
The test requires `next` be treated as external package and without using eval source mapped, added a note and re-enabled it.

Workaround a bit on the test to only check the necessary lines due, will properly fix it once we can exclude the sourcemapped `next` code as external module paths