### PR TITLE
Show all diff when uncollapse

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/component-stack-pseudo-html.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/RuntimeError/component-stack-pseudo-html.tsx
@@ -85,7 +85,7 @@ export function PseudoHtmlDiff({
       reactComponentDiffLines.forEach((line, index) => {
         let trimmedLine = line.trim()
         const isDiffLine = trimmedLine[0] === '+' || trimmedLine[0] === '-'
-        const spaces = ' '.repeat(componentStacks.length * 2)
+        const spaces = ' '.repeat(Math.max(componentStacks.length * 2, 1))
 
         if (isDiffLine) {
           const sign = trimmedLine[0]
@@ -126,6 +126,15 @@ export function PseudoHtmlDiff({
               </span>
             )
           }
+        } else if (!isHtmlCollapsed) {
+          // In general, if it's not collapsed, show the whole diff
+          componentStacks.push(
+            <span key={'comp-diff' + index}>
+              {spaces}
+              {trimmedLine}
+              {'\n'}
+            </span>
+          )
         }
       })
       return componentStacks.concat(diffHtmlStack)

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -212,7 +212,7 @@ describe('Error overlay for hydration errors in App router', () => {
     expect(await getRedboxTotalErrorCount(browser)).toBe(1)
 
     const pseudoHtml = await session.getRedboxComponentStack()
-    expect(pseudoHtml).toMatchInlineSnapshot(`"-className="server-html""`)
+    expect(pseudoHtml).toMatchInlineSnapshot(`"- className="server-html""`)
 
     expect(await session.getRedboxDescription()).toMatchInlineSnapshot(
       `"Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used"`
@@ -960,6 +960,7 @@ describe('Error overlay for hydration errors in App router', () => {
                               <Mismatch>
                                 <p>
                                   <span>
+                                    ...
         +                            client
         -                            server"
       `)

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -1277,6 +1277,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
                           <Mismatch>
                             <p>
                               <span>
+                                ...
           +                      client
           -                      server"
         `)


### PR DESCRIPTION
### What

When uncollapse the diff view, show all the component diff in the diff view.

Minor improvement: add at least one space between `+/-` sign and the code

x-ref: [slack thread](https://vercel.slack.com/archives/C078NFQQZ0B/p1729701586302299)


https://github.com/user-attachments/assets/fa35b588-f7d5-4729-ae5c-e0d362372164

