### PR TITLE
Fix fetch caching inside of `"use cache"`

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -3103,9 +3103,15 @@ export default abstract class Server<
             )
           }
 
-          return runWithCacheScope({ cache }, () =>
+          const response = runWithCacheScope({ cache }, () =>
             originalResponseGenerator(state)
           )
+
+          // Clear the prefetch cache to ensure a clean slate for the next
+          // request.
+          this.prefetchCacheScopesDev.del(urlPathname)
+
+          return response
         }
 
         return originalResponseGenerator(state)

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -278,11 +278,15 @@ export function createPatchedFetcher(
             ? []
             : workUnitStore.implicitTags
 
-        // Inside unstable-cache we treat it the same as force-no-store on the page.
+        // Inside unstable-cache or "use cache", we treat it the same as
+        // force-no-store on the page.
         const pageFetchCacheMode =
-          workUnitStore && workUnitStore.type === 'unstable-cache'
+          workUnitStore &&
+          (workUnitStore.type === 'unstable-cache' ||
+            workUnitStore.type === 'cache')
             ? 'force-no-store'
             : workStore.fetchCache
+
         const isUsingNoStore = !!workStore.isUnstableNoStore
 
         let currentFetchCacheConfig = getRequestMeta('cache')

--- a/test/e2e/app-dir/use-cache/app/cache-fetch/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/cache-fetch/page.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+async function getData() {
+  'use cache'
+
+  return fetch('https://next-data-api-endpoint.vercel.app/api/random').then(
+    (res) => res.text()
+  )
+}
+
+export default async function Page() {
+  return (
+    <>
+      <p>index page</p>
+      <p id="random">{await getData()}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-cache/app/fetch-revalidate/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/fetch-revalidate/page.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+async function getData() {
+  'use cache'
+
+  return fetch('https://next-data-api-endpoint.vercel.app/api/random', {
+    next: { revalidate: 0 },
+  }).then((res) => res.text())
+}
+
+export default async function Page() {
+  return (
+    <>
+      <p>index page</p>
+      <p id="random">{await getData()}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -267,6 +267,24 @@ describe('use-cache', () => {
     // expect(time4).toBe(time3);
   })
 
+  it('should use revalidate config in fetch', async () => {
+    const browser = await next.browser('/fetch-revalidate')
+
+    const initialValue = await browser.elementByCss('#random').text()
+    await browser.refresh()
+
+    expect(await browser.elementByCss('#random').text()).not.toBe(initialValue)
+  })
+
+  it('should cache fetch without no-store', async () => {
+    const browser = await next.browser('/cache-fetch')
+
+    const initialValue = await browser.elementByCss('#random').text()
+    await browser.refresh()
+
+    expect(await browser.elementByCss('#random').text()).toBe(initialValue)
+  })
+
   it('should override fetch with no-store in use cache properly', async () => {
     const browser = await next.browser('/cache-fetch-no-store')
 


### PR DESCRIPTION
Follow-up to #71754:

> This ensures if you have a `fetch` with `cache: 'no-store'` inside of `use cache`/`unstable_cache` we don't update the revalidate period to `0` which effectively makes the `use cache` a no-op. This doesn't  change the behavior if `revalidate: 0` is defined on a `fetch` inside of `use cache` as that is more explicitly changing the revalidate period similar to `cacheLife()`.

This PR follows this logic and ensures that we also cache fetches inside of `"use cache"` if `cache: 'no-store'` is not specified.

It also adds a test to ensure that `revalidate: 0` inside of `"use cache"` is still considered. To make sure that this also works in dev mode, we need to clear the prefetch cache after generating a response, to not affect subsequent requests.