### PR TITLE
Do not log an error if `getSourceMapFromFile` can't find the file

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/get-source-map-from-file.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/get-source-map-from-file.ts
@@ -16,10 +16,10 @@ export async function getSourceMapFromFile(
 
   try {
     fileContents = await fs.readFile(filename, 'utf-8')
-  } catch (error) {
-    throw new Error(`Failed to read file contents of ${filename}.`, {
-      cause: error,
-    })
+  } catch {
+    // We intentionally don't throw if the file does not exist. It might just be
+    // incorrectly source mapped, for example.
+    return undefined
   }
 
   const sourceUrl = getSourceMapUrl(fileContents)


### PR DESCRIPTION
As opposed to the other cases in this function where we do throw an error, this case most likely does not point to a bug in our source map lookup logic, and may just be the result of an incorrectly mapped stack frame leading to a file URL that does not exist.