### PR TITLE
Include sourceframe in errors logged in the terminal during development

### DIFF
--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -157,7 +157,7 @@ function parseAndSourceMap(error: Error): string {
         if (
           process.env.NODE_ENV !== 'production' &&
           sourcemappedFrame.code !== null &&
-          sourceFrameDEV !== null
+          sourceFrameDEV === null
         ) {
           sourceFrameDEV = sourcemappedFrame.code
         }


### PR DESCRIPTION
This matches how we special case certain errors already. Since we only special case certain erros in dev, we only include the codeframe in dev for all logged errors now. This will allow us to replace the special casing in dev and just use `console.error`.

Example (ignore the wrong method name. Investigating that separately since it's related to the stack not codeframe):
```
Error: test
    at indirection (webpack:///app/some-module.ts:2:15)
    at indirection (webpack:///app/some-module.ts:6:2)
    at logError (webpack:///app/page.tsx:5:10)
  1 | function indirection() {
> 2 |   console.warn(new Error('test'))
    |               ^
  3 | }
  4 |
  5 | export function logError() {
```