### PR TITLE
codemod(turbopack): Rewrite Vc fields in structs as ResolvedVc (part 4)

### DIFF
--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
@@ -61,7 +61,7 @@ impl Transition for NextEcmascriptClientReferenceTransition {
         let this = self.await?;
 
         let ident = match part {
-            Some(part) => source.ident().with_part(part),
+            Some(part) => source.ident().with_part(*part),
             None => source.ident(),
         };
         let ident_ref = ident.await?;

--- a/turbopack/crates/node-file-trace/src/lib.rs
+++ b/turbopack/crates/node-file-trace/src/lib.rs
@@ -23,8 +23,8 @@ use serde::Deserialize;
 use serde::Serialize;
 use tokio::sync::mpsc::channel;
 use turbo_tasks::{
-    backend::Backend, util::FormatDuration, RcStr, ReadConsistency, TaskId, TransientInstance,
-    TransientValue, TurboTasks, UpdateInfo, Value, Vc,
+    backend::Backend, util::FormatDuration, RcStr, ReadConsistency, ResolvedVc, TaskId,
+    TransientInstance, TransientValue, TurboTasks, UpdateInfo, Value, Vc,
 };
 use turbo_tasks_fs::{
     glob::Glob, DirectoryEntry, DiskFileSystem, FileSystem, FileSystemPath, ReadGlobResult,
@@ -565,7 +565,7 @@ async fn main_operation(
 
 #[turbo_tasks::function]
 async fn create_module_asset(
-    root: Vc<FileSystemPath>,
+    root: ResolvedVc<FileSystemPath>,
     process_cwd: Option<RcStr>,
     module_options: TransientInstance<ModuleOptionsContext>,
     resolve_options: TransientInstance<ResolveOptionsContext>,
@@ -580,14 +580,14 @@ async fn create_module_asset(
     let compile_time_info = CompileTimeInfo::builder(env).cell();
     let glob_mappings = vec![
         (
-            root.to_resolved().await?,
+            root,
             Glob::new("**/*/next/dist/server/next.js".into())
                 .to_resolved()
                 .await?,
             ImportMapping::Ignore.resolved_cell(),
         ),
         (
-            root.to_resolved().await?,
+            root,
             Glob::new("**/*/next/dist/bin/next".into())
                 .to_resolved()
                 .await?,

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -386,7 +386,7 @@ impl ChunkingContext for BrowserChunkingContext {
 
             let mut assets: Vec<Vc<Box<dyn OutputAsset>>> = chunks
                 .iter()
-                .map(|chunk| self.generate_chunk(*chunk))
+                .map(|chunk| self.generate_chunk(**chunk))
                 .collect();
 
             if this.enable_hot_module_replacement {
@@ -455,7 +455,7 @@ impl ChunkingContext for BrowserChunkingContext {
 
             let mut assets: Vec<Vc<Box<dyn OutputAsset>>> = chunks
                 .iter()
-                .map(|chunk| self.generate_chunk(*chunk))
+                .map(|chunk| self.generate_chunk(**chunk))
                 .collect();
 
             let other_assets = Vc::cell(assets.clone());

--- a/turbopack/crates/turbopack-browser/src/ecmascript/merged/update.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/merged/update.rs
@@ -215,7 +215,7 @@ pub(super) async fn update_ecmascript_merged_chunk(
                         if merged_module_map.get(&module_id) != Some(module_hash) {
                             let entry = EcmascriptModuleEntry::from_code(
                                 &module_id,
-                                module_code,
+                                *module_code,
                                 chunk_path,
                             )
                             .await?;
@@ -227,7 +227,7 @@ pub(super) async fn update_ecmascript_merged_chunk(
 
                     for (module_id, module_code) in chunk_partial.modified {
                         let entry =
-                            EcmascriptModuleEntry::from_code(&module_id, module_code, chunk_path)
+                            EcmascriptModuleEntry::from_code(&module_id, *module_code, chunk_path)
                                 .await?;
                         merged_update.entries.insert(module_id, entry);
                     }

--- a/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
@@ -62,7 +62,7 @@ impl RuntimeEntry {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct RuntimeEntries(Vec<Vc<RuntimeEntry>>);
+pub struct RuntimeEntries(Vec<ResolvedVc<RuntimeEntry>>);
 
 #[turbo_tasks::value_impl]
 impl RuntimeEntries {

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -118,7 +118,7 @@ impl TurbopackBuildBuilder {
                     self.entry_requests
                         .iter()
                         .cloned()
-                        .map(EntryRequest::cell)
+                        .map(EntryRequest::resolved_cell) // Changed from cell() to resolved_cell()
                         .collect(),
                 )
                 .cell(),

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -118,7 +118,7 @@ impl TurbopackBuildBuilder {
                     self.entry_requests
                         .iter()
                         .cloned()
-                        .map(EntryRequest::resolved_cell) // Changed from cell() to resolved_cell()
+                        .map(EntryRequest::resolved_cell)
                         .collect(),
                 )
                 .cell(),

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -72,7 +72,8 @@ pub async fn get_client_runtime_entries(
                 request.to_resolved().await?,
                 project_path.join("_".into()).to_resolved().await?,
             )
-            .cell(),
+            .resolved_cell()
+            .into(),
         )
     };
 
@@ -82,7 +83,8 @@ pub async fn get_client_runtime_entries(
                 .to_resolved()
                 .await?,
         ))
-        .cell(),
+        .resolved_cell()
+        .into(),
     );
 
     Ok(Vc::cell(runtime_entries))

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -72,8 +72,7 @@ pub async fn get_client_runtime_entries(
                 request.to_resolved().await?,
                 project_path.join("_".into()).to_resolved().await?,
             )
-            .resolved_cell()
-            .into(),
+            .resolved_cell(),
         )
     };
 
@@ -83,8 +82,7 @@ pub async fn get_client_runtime_entries(
                 .to_resolved()
                 .await?,
         ))
-        .resolved_cell()
-        .into(),
+        .resolved_cell(),
     );
 
     Ok(Vc::cell(runtime_entries))

--- a/turbopack/crates/turbopack-cli/src/util.rs
+++ b/turbopack/crates/turbopack-cli/src/util.rs
@@ -2,11 +2,11 @@ use std::{env::current_dir, path::PathBuf};
 
 use anyhow::{Context, Result};
 use dunce::canonicalize;
-use turbo_tasks::{RcStr, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, Vc};
 use turbo_tasks_fs::{DiskFileSystem, FileSystem};
 
 #[turbo_tasks::value(transparent)]
-pub struct EntryRequests(pub Vec<Vc<EntryRequest>>);
+pub struct EntryRequests(pub Vec<ResolvedVc<EntryRequest>>);
 
 #[turbo_tasks::value(shared)]
 #[derive(Clone)]

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -169,7 +169,6 @@ pub async fn make_chunk_group(
         chunks.extend(async_loader_chunks.iter().copied());
     }
 
-    // Convert chunks to ResolvedVc
     let resolved_chunks = chunks
         .into_iter()
         .map(|chunk| chunk.to_resolved())

--- a/turbopack/crates/turbopack-core/src/chunk/optimize.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/optimize.rs
@@ -4,17 +4,17 @@
 //! their size and eliminating duplicates between them.
 
 use anyhow::Result;
-use turbo_tasks::{TryJoinIterExt, Vc};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 use turbo_tasks_fs::{FileSystemPath, FileSystemPathOption};
 
 use crate::chunk::containment_tree::{ContainmentTree, ContainmentTreeKey};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-struct FileSystemPathKey(Vc<FileSystemPath>);
+struct FileSystemPathKey(ResolvedVc<FileSystemPath>);
 
 impl FileSystemPathKey {
     async fn new(path: Vc<FileSystemPath>) -> Result<Self> {
-        Ok(Self(path.resolve().await?))
+        Ok(Self(path.to_resolved().await?))
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/introspect/output_asset.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/output_asset.rs
@@ -13,15 +13,14 @@ pub struct IntrospectableOutputAsset(ResolvedVc<Box<dyn OutputAsset>>);
 #[turbo_tasks::value_impl]
 impl IntrospectableOutputAsset {
     #[turbo_tasks::function]
-    pub async fn new(asset: Vc<Box<dyn OutputAsset>>) -> Result<Vc<Box<dyn Introspectable>>> {
-        let resolved_asset = asset.to_resolved().await?;
-        Ok(
-            *ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(resolved_asset)
-                .await?
-                .unwrap_or_else(|| {
-                    ResolvedVc::upcast(IntrospectableOutputAsset(resolved_asset).resolved_cell())
-                }),
-        )
+    pub async fn new(
+        asset: ResolvedVc<Box<dyn OutputAsset>>,
+    ) -> Result<Vc<Box<dyn Introspectable>>> {
+        Ok(*ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(asset)
+            .await?
+            .unwrap_or_else(|| {
+                ResolvedVc::upcast(IntrospectableOutputAsset(asset).resolved_cell())
+            }))
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/reference_type.rs
+++ b/turbopack/crates/turbopack-core/src/reference_type.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use anyhow::Result;
-use turbo_tasks::{FxIndexMap, RcStr, Vc};
+use turbo_tasks::{FxIndexMap, RcStr, ResolvedVc, Vc};
 
 use crate::{module::Module, resolve::ModulePart};
 
@@ -42,7 +42,7 @@ pub enum ImportWithType {
 #[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(Debug, Default, Clone, Hash)]
 pub enum EcmaScriptModulesReferenceSubType {
-    ImportPart(Vc<ModulePart>),
+    ImportPart(ResolvedVc<ModulePart>),
     Import,
     ImportWithType(ImportWithType),
     DynamicImport,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1094,9 +1094,7 @@ async fn imports_field(lookup_path: Vc<FileSystemPath>) -> Result<Vc<ImportsFiel
         return Ok(ImportsFieldResult::None.cell());
     };
     match imports.try_into() {
-        Ok(imports) => {
-            Ok(ImportsFieldResult::Some(imports, package_json_path.to_resolved().await?).cell())
-        }
+        Ok(imports) => Ok(ImportsFieldResult::Some(imports, *package_json_path).cell()),
         Err(err) => {
             PackageJsonIssue {
                 path: **package_json_path,
@@ -1138,6 +1136,8 @@ pub async fn find_context_file(
     if refs.is_empty() {
         // Tailcall
         Ok(find_context_file(
+            // Hot codepath optimization: resolve all arguments to avoid an automatically-created
+            // intermediate task
             lookup_path.parent().resolve().await?,
             names,
         ))
@@ -1153,7 +1153,7 @@ pub async fn find_context_file(
                 FindContextFileResult::NotFound(refs)
             }
         }
-        .into())
+        .cell())
     }
 }
 
@@ -1586,16 +1586,16 @@ async fn handle_after_resolve_plugins(
 
 #[turbo_tasks::function]
 async fn resolve_internal(
-    lookup_path: Vc<FileSystemPath>,
-    request: Vc<Request>,
+    lookup_path: ResolvedVc<FileSystemPath>,
+    request: ResolvedVc<Request>,
     options: Vc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
     resolve_internal_inline(lookup_path, request, options).await
 }
 
 async fn resolve_internal_inline(
-    lookup_path: Vc<FileSystemPath>,
-    request: Vc<Request>,
+    lookup_path: ResolvedVc<FileSystemPath>,
+    request: ResolvedVc<Request>,
     options: Vc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
     let span = {
@@ -1616,17 +1616,17 @@ async fn resolve_internal_inline(
         if let Some(import_map) = &options_value.import_map {
             let request_parts = match &*request_value {
                 Request::Alternatives { requests } => requests.as_slice(),
-                _ => &[request],
+                _ => &[*request],
             };
             for request in request_parts {
-                let result = import_map.await?.lookup(lookup_path, *request).await?;
+                let result = import_map.await?.lookup(*lookup_path, *request).await?;
                 if !matches!(result, ImportMapResult::NoEntry) {
                     has_alias = true;
                     let resolved_result = resolve_import_map_result(
                         &result,
                         lookup_path,
                         lookup_path,
-                        *request,
+                        request.to_resolved().await?,
                         options,
                         request.query(),
                     )
@@ -1651,7 +1651,10 @@ async fn resolve_internal_inline(
             Request::Alternatives { requests } => {
                 let results = requests
                     .iter()
-                    .map(|req| Box::pin(resolve_internal_inline(lookup_path, *req, options)))
+                    .map(|req| async {
+                        resolve_internal_inline(lookup_path, req.to_resolved().await?, options)
+                            .await
+                    })
                     .try_join()
                     .await?;
 
@@ -1665,7 +1668,7 @@ async fn resolve_internal_inline(
             } => {
                 let mut results = Vec::new();
                 let matches = read_matches(
-                    lookup_path,
+                    *lookup_path,
                     "".into(),
                     *force_in_lookup_dir,
                     Pattern::new(path.clone()).resolve().await?,
@@ -1766,8 +1769,8 @@ async fn resolve_internal_inline(
                     ResolvingIssue {
                         severity: error_severity(options).await?,
                         request_type: "server relative import: not implemented yet".to_string(),
-                        request,
-                        file_path: lookup_path,
+                        request: *request,
+                        file_path: *lookup_path,
                         resolve_options: options,
                         error_message: Some(
                             "server relative imports are not implemented yet. Please try an \
@@ -1781,8 +1784,8 @@ async fn resolve_internal_inline(
                 }
 
                 Box::pin(resolve_internal_inline(
-                    lookup_path.root().resolve().await?,
-                    relative.resolve().await?,
+                    lookup_path.root().to_resolved().await?,
+                    relative.to_resolved().await?,
                     options,
                 ))
                 .await?
@@ -1796,8 +1799,8 @@ async fn resolve_internal_inline(
                     ResolvingIssue {
                         severity: error_severity(options).await?,
                         request_type: "windows import: not implemented yet".to_string(),
-                        request,
-                        file_path: lookup_path,
+                        request: *request,
+                        file_path: *lookup_path,
                         resolve_options: options,
                         error_message: Some("windows imports are not implemented yet".to_string()),
                         source: None,
@@ -1850,8 +1853,8 @@ async fn resolve_internal_inline(
                     ResolvingIssue {
                         severity: error_severity(options).await?,
                         request_type: format!("unknown import: `{}`", path),
-                        request,
-                        file_path: lookup_path,
+                        request: *request,
+                        file_path: *lookup_path,
                         resolve_options: options,
                         error_message: None,
                         source: None,
@@ -1866,7 +1869,7 @@ async fn resolve_internal_inline(
         // Apply fallback import mappings if provided
         if let Some(import_map) = &options_value.fallback_import_map {
             if *result.is_unresolvable().await? {
-                let result = import_map.await?.lookup(lookup_path, request).await?;
+                let result = import_map.await?.lookup(*lookup_path, *request).await?;
                 let resolved_result = resolve_import_map_result(
                     &result,
                     lookup_path,
@@ -1892,7 +1895,7 @@ async fn resolve_internal_inline(
 
 #[turbo_tasks::function]
 async fn resolve_into_folder(
-    package_path: Vc<FileSystemPath>,
+    package_path: ResolvedVc<FileSystemPath>,
     options: Vc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
     let package_json_path = package_path.join("package.json".into());
@@ -1910,7 +1913,9 @@ async fn resolve_into_folder(
                         {
                             continue;
                         }
-                        let request = Request::parse(Value::new(normalized_request.into()));
+                        let request = Request::parse(Value::new(normalized_request.into()))
+                            .to_resolved()
+                            .await?;
 
                         // main field will always resolve not fully specified
                         let options = if options_value.fully_specified {
@@ -1956,7 +1961,7 @@ async fn resolve_into_folder(
     let request = Request::parse(Value::new(pattern));
 
     Ok(
-        resolve_internal_inline(package_path, request.resolve().await?, options)
+        resolve_internal_inline(package_path, request.to_resolved().await?, options)
             .await?
             .with_request(".".into()),
     )
@@ -1964,8 +1969,8 @@ async fn resolve_into_folder(
 
 #[tracing::instrument(level = Level::TRACE, skip_all)]
 async fn resolve_relative_request(
-    lookup_path: Vc<FileSystemPath>,
-    request: Vc<Request>,
+    lookup_path: ResolvedVc<FileSystemPath>,
+    request: ResolvedVc<Request>,
     options: Vc<ResolveOptions>,
     options_value: &ResolveOptions,
     path_pattern: &Pattern,
@@ -1976,7 +1981,7 @@ async fn resolve_relative_request(
     // Check alias field for aliases first
     let lookup_path_ref = &*lookup_path.await?;
     if let Some(result) = apply_in_package(
-        lookup_path,
+        *lookup_path,
         options,
         options_value,
         |package_path| {
@@ -2063,7 +2068,7 @@ async fn resolve_relative_request(
 
     let mut results = Vec::new();
     let matches = read_matches(
-        lookup_path,
+        *lookup_path,
         "".into(),
         force_in_lookup_dir,
         Pattern::new(new_path).resolve().await?,
@@ -2306,8 +2311,8 @@ async fn find_self_reference(
 
 #[tracing::instrument(level = Level::TRACE, skip_all)]
 async fn resolve_module_request(
-    lookup_path: Vc<FileSystemPath>,
-    request: Vc<Request>,
+    lookup_path: ResolvedVc<FileSystemPath>,
+    request: ResolvedVc<Request>,
     options: Vc<ResolveOptions>,
     options_value: &ResolveOptions,
     module: &str,
@@ -2317,7 +2322,7 @@ async fn resolve_module_request(
 ) -> Result<Vc<ResolveResult>> {
     // Check alias field for module aliases first
     if let Some(result) = apply_in_package(
-        lookup_path,
+        *lookup_path,
         options,
         options_value,
         |_| {
@@ -2336,7 +2341,7 @@ async fn resolve_module_request(
     // module. This should match only using the exports field and no other
     // fields/fallbacks.
     if let FindSelfReferencePackageResult::Found { name, package_path } =
-        &*find_self_reference(lookup_path).await?
+        &*find_self_reference(*lookup_path).await?
     {
         if name == module {
             let result = resolve_into_package(
@@ -2353,7 +2358,7 @@ async fn resolve_module_request(
     }
 
     let result = find_package(
-        lookup_path,
+        *lookup_path,
         module.into(),
         resolve_modules_options(options).resolve().await?,
     )
@@ -2414,13 +2419,11 @@ async fn resolve_module_request(
             RcStr::from("/").into(),
             path.clone(),
         ]);
-        let relative = Request::relative(Value::new(pattern), query, fragment, true);
-        let relative_result = Box::pin(resolve_internal_inline(
-            lookup_path,
-            relative.resolve().await?,
-            options,
-        ))
-        .await?;
+        let relative = Request::relative(Value::new(pattern), query, fragment, true)
+            .to_resolved()
+            .await?;
+        let relative_result =
+            Box::pin(resolve_internal_inline(lookup_path, relative, options)).await?;
         let relative_result = relative_result
             .with_replaced_request_key(module_prefix, Value::new(RequestKey::new(module.into())));
 
@@ -2433,7 +2436,7 @@ async fn resolve_module_request(
 #[turbo_tasks::function]
 async fn resolve_into_package(
     path: Value<Pattern>,
-    package_path: Vc<FileSystemPath>,
+    package_path: ResolvedVc<FileSystemPath>,
     query: Vc<RcStr>,
     fragment: Vc<RcStr>,
     options: Vc<ResolveOptions>,
@@ -2494,7 +2497,7 @@ async fn resolve_into_package(
     // apply main field(s) or fallback to index.js if there's no subpath
     if is_root_match {
         results.push(resolve_into_folder(
-            package_path,
+            *package_path,
             options.with_fully_specified(false),
         ));
     }
@@ -2503,9 +2506,10 @@ async fn resolve_into_package(
         let mut new_pat = path.clone();
         new_pat.push_front(RcStr::from(".").into());
 
-        let relative = Request::relative(Value::new(new_pat), query, fragment, true);
-        results
-            .push(resolve_internal_inline(package_path, relative.resolve().await?, options).await?);
+        let relative = Request::relative(Value::new(new_pat), query, fragment, true)
+            .to_resolved()
+            .await?;
+        results.push(resolve_internal_inline(package_path, relative, options).await?);
     }
 
     Ok(merge_results(results))
@@ -2514,9 +2518,9 @@ async fn resolve_into_package(
 #[tracing::instrument(level = Level::TRACE, skip_all)]
 async fn resolve_import_map_result(
     result: &ImportMapResult,
-    lookup_path: Vc<FileSystemPath>,
-    original_lookup_path: Vc<FileSystemPath>,
-    original_request: Vc<Request>,
+    lookup_path: ResolvedVc<FileSystemPath>,
+    original_lookup_path: ResolvedVc<FileSystemPath>,
+    original_request: ResolvedVc<Request>,
     options: Vc<ResolveOptions>,
     query: Vc<RcStr>,
 ) -> Result<Option<Vc<ResolveResult>>> {
@@ -2525,16 +2529,14 @@ async fn resolve_import_map_result(
         ImportMapResult::Alias(request, alias_lookup_path) => {
             let request = *request;
             let lookup_path = match alias_lookup_path {
-                Some(path) => path,
-                None => &lookup_path.to_resolved().await?,
+                Some(path) => *path,
+                None => lookup_path,
             };
             // We must avoid cycles during resolving
-            if request.resolve().await? == original_request.to_resolved().await?
-                && *lookup_path == original_lookup_path.to_resolved().await?
-            {
+            if request == original_request && lookup_path == original_lookup_path {
                 None
             } else {
-                let result = resolve_internal(**lookup_path, *request, options);
+                let result = resolve_internal(*lookup_path, *request, options);
                 Some(result.with_replaced_request_key_pattern(
                     request.request_pattern(),
                     original_request.request_pattern(),
@@ -2567,8 +2569,8 @@ async fn resolve_import_map_result(
 async fn resolved(
     request_key: RequestKey,
     fs_path: Vc<FileSystemPath>,
-    original_context: Vc<FileSystemPath>,
-    original_request: Vc<Request>,
+    original_context: ResolvedVc<FileSystemPath>,
+    original_request: ResolvedVc<Request>,
     options_value: &ResolveOptions,
     options: Vc<ResolveOptions>,
     query: Vc<RcStr>,
@@ -2593,12 +2595,12 @@ async fn resolved(
 
     if let Some(resolved_map) = options_value.resolved_map {
         let result = resolved_map
-            .lookup(**path, original_context, original_request)
+            .lookup(**path, *original_context, *original_request)
             .await?;
 
         let resolved_result = resolve_import_map_result(
             &result,
-            path.parent(),
+            path.parent().to_resolved().await?,
             original_context,
             original_request,
             options,
@@ -2625,7 +2627,7 @@ async fn resolved(
 }
 
 async fn handle_exports_imports_field(
-    package_path: Vc<FileSystemPath>,
+    package_path: ResolvedVc<FileSystemPath>,
     package_json_path: Vc<FileSystemPath>,
     options: Vc<ResolveOptions>,
     exports_imports_field: &AliasMap<SubpathValue>,
@@ -2662,7 +2664,9 @@ async fn handle_exports_imports_field(
             let request = Request::parse(Value::new(Pattern::Concatenation(vec![
                 Pattern::Constant("./".into()),
                 result_path,
-            ])));
+            ])))
+            .to_resolved()
+            .await?;
 
             let resolve_result =
                 Box::pin(resolve_internal_inline(package_path, request, options)).await?;
@@ -2688,8 +2692,8 @@ async fn handle_exports_imports_field(
 /// static strings or conditions like `import` or `require` to handle ESM/CJS
 /// with differently compiled files.
 async fn resolve_package_internal_with_imports_field(
-    file_path: Vc<FileSystemPath>,
-    request: Vc<Request>,
+    file_path: ResolvedVc<FileSystemPath>,
+    request: ResolvedVc<Request>,
     resolve_options: Vc<ResolveOptions>,
     pattern: &Pattern,
     conditions: &BTreeMap<RcStr, ConditionValue>,
@@ -2702,9 +2706,9 @@ async fn resolve_package_internal_with_imports_field(
     if specifier == "#" || specifier.starts_with("#/") || specifier.ends_with('/') {
         ResolvingIssue {
             severity: error_severity(resolve_options).await?,
-            file_path,
+            file_path: *file_path,
             request_type: format!("package imports request: `{specifier}`"),
-            request,
+            request: *request,
             resolve_options,
             error_message: None,
             source: None,
@@ -2714,15 +2718,15 @@ async fn resolve_package_internal_with_imports_field(
         return Ok(ResolveResult::unresolvable().into());
     }
 
-    let imports_result = imports_field(file_path).await?;
+    let imports_result = imports_field(*file_path).await?;
     let (imports, package_json_path) = match &*imports_result {
-        ImportsFieldResult::Some(i, p) => (i, p),
-        ImportsFieldResult::None => return Ok(ResolveResult::unresolvable().into()),
+        ImportsFieldResult::Some(i, p) => (i, *p),
+        ImportsFieldResult::None => return Ok(ResolveResult::unresolvable().cell()),
     };
 
     handle_exports_imports_field(
-        package_json_path.parent(),
-        **package_json_path,
+        package_json_path.parent().to_resolved().await?,
+        *package_json_path,
         resolve_options,
         imports,
         specifier,

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -324,9 +324,7 @@ async fn import_mapping_to_result(
     request: Vc<Request>,
 ) -> Result<ImportMapResult> {
     Ok(match &*mapping.await? {
-        ReplacedImportMapping::Direct(result) => {
-            ImportMapResult::Result(*result.to_resolved().await?)
-        }
+        ReplacedImportMapping::Direct(result) => ImportMapResult::Result(*result),
         ReplacedImportMapping::External(name, ty) => ImportMapResult::Result(
             *ResolveResult::primary(if let Some(name) = name {
                 ResolveResultItem::External(name.clone(), *ty)
@@ -345,11 +343,11 @@ async fn import_mapping_to_result(
         ),
         ReplacedImportMapping::PrimaryAlternative(name, context) => {
             let request = Request::parse(Value::new(name.clone()));
-            let context = match context {
+            let context_resolved = match context {
                 Some(c) => Some((*c).to_resolved().await?),
                 None => None,
             };
-            ImportMapResult::Alias(request.to_resolved().await?, context)
+            ImportMapResult::Alias(request.to_resolved().await?, context_resolved)
         }
         ReplacedImportMapping::Alternatives(list) => ImportMapResult::Alternatives(
             list.iter()

--- a/turbopack/crates/turbopack-core/src/resolve/pattern.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/pattern.rs
@@ -9,7 +9,7 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use tracing::Instrument;
-use turbo_tasks::{trace::TraceRawVcs, RcStr, Value, ValueToString, Vc};
+use turbo_tasks::{trace::TraceRawVcs, RcStr, ResolvedVc, Value, ValueToString, Vc};
 use turbo_tasks_fs::{
     util::normalize_path, DirectoryContent, DirectoryEntry, FileSystemEntryType, FileSystemPath,
     LinkContent, LinkType,
@@ -1322,7 +1322,7 @@ pub struct PatternMatches(Vec<PatternMatch>);
 /// symlinks when they are interested in that.
 #[turbo_tasks::function]
 pub async fn read_matches(
-    lookup_dir: Vc<FileSystemPath>,
+    lookup_dir: ResolvedVc<FileSystemPath>,
     prefix: RcStr,
     force_in_lookup_dir: bool,
     pattern: Vc<Pattern>,
@@ -1468,17 +1468,17 @@ pub async fn read_matches(
                 if let Some(pos) = pat.match_position(&prefix) {
                     results.push((
                         pos,
-                        PatternMatch::Directory(prefix.clone().into(), lookup_dir),
+                        PatternMatch::Directory(prefix.clone().into(), *lookup_dir),
                     ));
                 }
                 prefix.pop();
             }
             if prefix.is_empty() {
                 if let Some(pos) = pat.match_position("./") {
-                    results.push((pos, PatternMatch::Directory("./".into(), lookup_dir)));
+                    results.push((pos, PatternMatch::Directory("./".into(), *lookup_dir)));
                 }
                 if let Some(pos) = pat.could_match_position("./") {
-                    nested.push((pos, read_matches(lookup_dir, "./".into(), false, pattern)));
+                    nested.push((pos, read_matches(*lookup_dir, "./".into(), false, pattern)));
                 }
             } else {
                 prefix.push('/');
@@ -1486,7 +1486,7 @@ pub async fn read_matches(
                 if let Some(pos) = pat.could_match_position(&prefix) {
                     nested.push((
                         pos,
-                        read_matches(lookup_dir, prefix.to_string().into(), false, pattern),
+                        read_matches(*lookup_dir, prefix.to_string().into(), false, pattern),
                     ));
                 }
                 prefix.pop();
@@ -1495,7 +1495,7 @@ pub async fn read_matches(
                 if let Some(pos) = pat.could_match_position(&prefix) {
                     nested.push((
                         pos,
-                        read_matches(lookup_dir, prefix.to_string().into(), false, pattern),
+                        read_matches(*lookup_dir, prefix.to_string().into(), false, pattern),
                     ));
                 }
                 prefix.pop();

--- a/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
@@ -123,7 +123,7 @@ impl AsyncModule {
                     ReferencedAsset::Some(placeable) => {
                         let chunk_item = placeable
                             .as_chunk_item(Vc::upcast(chunking_context))
-                            .resolve()
+                            .to_resolved()
                             .await?;
                         if async_module_info
                             .referenced_async_modules

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -153,7 +153,7 @@ impl ModuleReference for EsmAssetReference {
         let ty = if matches!(self.annotations.module_type(), Some("json")) {
             EcmaScriptModulesReferenceSubType::ImportWithType(ImportWithType::Json)
         } else if let Some(part) = &self.export_name {
-            EcmaScriptModulesReferenceSubType::ImportPart(**part)
+            EcmaScriptModulesReferenceSubType::ImportPart(part.to_resolved().await?)
         } else {
             EcmaScriptModulesReferenceSubType::Import
         };

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -153,7 +153,7 @@ impl ModuleReference for EsmAssetReference {
         let ty = if matches!(self.annotations.module_type(), Some("json")) {
             EcmaScriptModulesReferenceSubType::ImportWithType(ImportWithType::Json)
         } else if let Some(part) = &self.export_name {
-            EcmaScriptModulesReferenceSubType::ImportPart(part.to_resolved().await?)
+            EcmaScriptModulesReferenceSubType::ImportPart(*part)
         } else {
             EcmaScriptModulesReferenceSubType::Import
         };

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -282,7 +282,7 @@ impl ChunkingContext for NodeJsChunkingContext {
 
             let mut assets: Vec<Vc<Box<dyn OutputAsset>>> = chunks
                 .iter()
-                .map(|chunk| self.generate_chunk(*chunk))
+                .map(|chunk| self.generate_chunk(**chunk))
                 .collect();
 
             // Resolve assets
@@ -333,7 +333,7 @@ impl ChunkingContext for NodeJsChunkingContext {
         let other_chunks: Vec<_> = extra_chunks
             .iter()
             .copied()
-            .chain(chunks.iter().map(|chunk| self.generate_chunk(*chunk)))
+            .chain(chunks.iter().map(|chunk| self.generate_chunk(**chunk)))
             .collect();
 
         let Some(module) = Vc::try_resolve_downcast(module).await? else {

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -484,7 +484,7 @@ async fn process_default_internal(
     let reference_type = reference_type.into_value();
     let part: Option<Vc<ModulePart>> = match &reference_type {
         ReferenceType::EcmaScriptModules(EcmaScriptModulesReferenceSubType::ImportPart(part)) => {
-            Some(*part)
+            Some(**part)
         }
         _ => None,
     };


### PR DESCRIPTION
Generated using a version of https://github.com/vercel/turbopack-resolved-vc-codemod . This uses Anthropic Claude Sonnet 3.5 for more complicated errors we don't have hardcoded logic for.

- Part 1: #70927
- Part 2: #71172
- Part 3: #71665

Closes PACK-3336