### PR TITLE
docs: remove `"use cache"` on before code snippet

### DIFF
--- a/errors/next-prerender-current-time.md
+++ b/errors/next-prerender-current-time.md
@@ -49,7 +49,6 @@ Before:
 
 ```jsx filename="app/page.js"
 async function InformationTable() {
-  "use cache"
   const data = await fetch(...)
   return (
     <section>


### PR DESCRIPTION
Removed `"use cache"` directive on the before example of the code snippet.