### PR TITLE
Run with `--enable-source-maps` by default in `next dev`

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "lint-staged": "lint-staged",
     "next-with-deps": "./scripts/next-with-deps.sh",
     "next": "cross-env NEXT_TELEMETRY_DISABLED=1 node --trace-deprecation --enable-source-maps packages/next/dist/bin/next",
-    "next-no-sourcemaps": "cross-env NEXT_TELEMETRY_DISABLED=1 node --trace-deprecation packages/next/dist/bin/next",
+    "next-no-sourcemaps": "echo 'No longer supported. Use `pnpm next --disable-source-maps` instead'; exit 1;",
     "clean-trace-jaeger": "node scripts/rm.mjs test/integration/basic/.next && TRACE_TARGET=JAEGER pnpm next build test/integration/basic",
     "debug": "cross-env NEXT_TELEMETRY_DISABLED=1 node --inspect --trace-deprecation --enable-source-maps packages/next/dist/bin/next",
     "postinstall": "node scripts/git-configure.mjs && node scripts/install-native.mjs",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "prepublishOnly": "turbo run build",
     "lint-staged": "lint-staged",
     "next-with-deps": "./scripts/next-with-deps.sh",
-    "next": "cross-env NEXT_TELEMETRY_DISABLED=1 node --trace-deprecation --enable-source-maps packages/next/dist/bin/next",
+    "next": "cross-env NEXT_TELEMETRY_DISABLED=1 NODE_OPTIONS=\"--trace-deprecation --enable-source-maps\" next",
     "next-no-sourcemaps": "echo 'No longer supported. Use `pnpm next --disable-source-maps` instead'; exit 1;",
     "clean-trace-jaeger": "node scripts/rm.mjs test/integration/basic/.next && TRACE_TARGET=JAEGER pnpm next build test/integration/basic",
     "debug": "cross-env NEXT_TELEMETRY_DISABLED=1 node --inspect --trace-deprecation --enable-source-maps packages/next/dist/bin/next",

--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -173,6 +173,11 @@ program
     'Specify a hostname on which to start the application (default: 0.0.0.0).'
   )
   .option(
+    '--disable-source-maps',
+    "Don't start the Dev server with `--enable-source-maps`.",
+    false
+  )
+  .option(
     '--experimental-https',
     'Starts the server with HTTPS and generates a self-signed certificate.'
   )

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -268,7 +268,9 @@ const nextDev = async (
         delete nodeOptions['max_old_space_size']
       }
 
-      if (!options.disableSourceMaps) {
+      if (options.disableSourceMaps) {
+        delete nodeOptions['enable-source-maps']
+      } else {
         nodeOptions['enable-source-maps'] = true
       }
 

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -267,6 +267,8 @@ const nextDev = async (
         delete nodeOptions['max_old_space_size']
       }
 
+      nodeOptions['enable-source-maps'] = true
+
       if (nodeDebugType) {
         const address = getParsedDebugAddress()
         address.port = address.port + 1

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -40,6 +40,7 @@ import { flushAllTraces, trace } from '../trace'
 import { traceId } from '../trace/shared'
 
 export type NextDevOptions = {
+  disableSourceMaps: boolean
   turbo?: boolean
   turbopack?: boolean
   port: number
@@ -267,7 +268,9 @@ const nextDev = async (
         delete nodeOptions['max_old_space_size']
       }
 
-      nodeOptions['enable-source-maps'] = true
+      if (!options.disableSourceMaps) {
+        nodeOptions['enable-source-maps'] = true
+      }
 
       if (nodeDebugType) {
         const address = getParsedDebugAddress()

--- a/run-tests.js
+++ b/run-tests.js
@@ -480,6 +480,10 @@ ${ENDGROUP}`)
         // unset CI env so CI behavior is only explicitly
         // tested when enabled
         CI: '',
+        // But some tests need to fork based on machine? CI? behavior differences
+        // Only use read this in tests.
+        // For implementation forks, use `process.env.CI` instead
+        NEXT_TEST_CI: process.env.CI,
 
         ...(options.local
           ? {}

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/.gitignore
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+pnpm-lock.yaml

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/app/rsc-error-log-ignore-listed/page.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/app/rsc-error-log-ignore-listed/page.js
@@ -1,0 +1,11 @@
+import { run } from 'internal-pkg'
+
+function logError() {
+  const error = new Error('Boom')
+  console.error(error)
+}
+
+export default function Page() {
+  run(() => logError())
+  return null
+}

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/app/ssr-error-log-ignore-listed/page.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/app/ssr-error-log-ignore-listed/page.js
@@ -1,0 +1,12 @@
+'use client'
+import { run } from 'internal-pkg'
+
+function logError() {
+  const error = new Error('Boom')
+  console.error(error)
+}
+
+export default function Page() {
+  run(() => logError())
+  return null
+}

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/app/ssr-error-log/page.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/app/ssr-error-log/page.js
@@ -1,0 +1,11 @@
+'use client'
+
+function logError() {
+  const error = new Error('Boom')
+  console.error(error)
+}
+
+export default function Page() {
+  logError()
+  return null
+}

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/index.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/index.js
@@ -1,0 +1,3 @@
+export function run(fn) {
+  return fn()
+}

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/package.json
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "internal-pkg",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "default": "./index.js"
+    }
+  }
+}

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/package.json
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "internal-pkg": "file:./internal-pkg"
+  }
+}

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -1,8 +1,53 @@
+/* eslint-disable jest/no-standalone-expect */
 import * as path from 'path'
 import { nextTestSetup } from 'e2e-utils'
+import stripAnsi from 'strip-ansi'
+import { retry } from 'next-test-utils'
+
+/**
+ * TODO: Remove this function once we log the file name on disk by adjusting `moduleFileNameTemplate`.
+ * in: webpack:///app/ssr-error-log-ignore-listed/page.js?1234:5:16
+ * out: webpack:///app/ssr-error-log-ignore-listed/page.js?[search]:5:16
+ */
+function normalizeWebpackLocation(frame: string) {
+  const webpackQueryStringtMatch = frame.match(/\?\w+:(\d+):(\d+)\)$/)
+  if (webpackQueryStringtMatch === null) {
+    return frame
+  }
+
+  return frame.replace(
+    webpackQueryStringtMatch[0],
+    `?[search]:${webpackQueryStringtMatch[1]}:${webpackQueryStringtMatch[2]})`
+  )
+}
+
+function normalizeCliOutput(output: string) {
+  return stripAnsi(output)
+    .split('\n')
+    .map((line) => {
+      return (
+        normalizeWebpackLocation(line)
+          .replaceAll(
+            path.join(__dirname, 'fixtures/default'),
+            '[fixture-root]'
+          )
+          //  in: webpack://[fixture-root]/node_modules/.pnpm/internal-pkg@file+internal-pkg/node_modules/internal-pkg/index.js?[search]:2:0
+          // out: webpack://[fixture-root]/node_modules/[pnpm]/internal-pkg/index.js?[search]:2:0
+          .replace(/\/.pnpm\/[^/]+\/node_modules/g, '/[pnpm]')
+      )
+    })
+    .join('\n')
+}
 
 describe('app-dir - server source maps', () => {
-  const { skipped, next, isNextDev } = nextTestSetup({
+  const dependencies =
+    // 'link:' is not suitable for this test since this makes internal-pkg
+    // not appear in node_modules.
+    {
+      'internal-pkg': `file:${path.resolve(__dirname, 'fixtures/default/internal-pkg')}`,
+    }
+  const { skipped, next, isNextDev, isTurbopack } = nextTestSetup({
+    dependencies,
     files: path.join(__dirname, 'fixtures/default'),
     // Deploy tests don't have access to runtime logs.
     // Manually verify that the runtime logs match.
@@ -12,12 +57,152 @@ describe('app-dir - server source maps', () => {
   if (skipped) return
 
   it('logged errors have a sourcemapped stack with a codeframe', async () => {
-    // TODO: Write test once we run with `--enable-source-maps` when `experimental.serverSourceMaps` is set
+    await next.render('/rsc-error-log')
+
+    if (isNextDev) {
+      await retry(() => {
+        expect(normalizeCliOutput(next.cliOutput)).toContain(
+          isTurbopack
+            ? '\nError: Boom' +
+                '\n    at logError (turbopack://[project]/app/rsc-error-log/page.js:2:16)' +
+                '\n    at Page (turbopack://[project]/app/rsc-error-log/page.js:7:2)' +
+                '\n  1 | function logError() {' +
+                "\n> 2 |   const error = new Error('Boom')" +
+                '\n    |                ^' +
+                '\n  3 |   console.error(error)' +
+                '\n  4 | }' +
+                '\n  5 |' +
+                '\n'
+            : '\nError: Boom' +
+                '\n    at logError (webpack:///app/rsc-error-log/page.js?[search]:2:16)' +
+                // FIXME: Method name should be "Page"
+                '\n    at logError (webpack:///app/rsc-error-log/page.js?[search]:7:2)' +
+                '\n  1 | function logError() {' +
+                "\n> 2 |   const error = new Error('Boom')" +
+                '\n    |                ^' +
+                '\n  3 |   console.error(error)' +
+                '\n  4 | }' +
+                '\n  5 |' +
+                '\n'
+        )
+      })
+    } else {
+      // TODO: Test `next build` with `--enable-source-maps`.
+    }
   })
 
   it('logged errors have a sourcemapped `cause`', async () => {
-    // TODO: Write test once we run with `--enable-source-maps` when `experimental.serverSourceMaps` is set
+    await next.render('/rsc-error-log-cause')
+
+    if (isNextDev) {
+      await retry(() => {
+        expect(normalizeCliOutput(next.cliOutput)).toContain(
+          isTurbopack
+            ? '\nError: Boom' +
+                '\n    at logError (turbopack://[project]/app/rsc-error-log-cause/page.js:2:16)' +
+                '\n    at Page (turbopack://[project]/app/rsc-error-log-cause/page.js:8:2)' +
+                '\n  1 | function logError(cause) {' +
+                "\n> 2 |   const error = new Error('Boom', { cause })" +
+                '\n    |                ^' +
+                '\n  3 |   console.error(error)' +
+                '\n  4 | }' +
+                '\n  5 | {' +
+                '\n  [cause]: Error: Boom' +
+                '\n      at Page (turbopack://[project]/app/rsc-error-log-cause/page.js:7:16)' +
+                '\n     5 |' +
+                '\n     6 | export default function Page() {' +
+                "\n  >  7 |   const error = new Error('Boom')" +
+                '\n       |                ^' +
+                '\n     8 |   logError(error)' +
+                '\n     9 |   return null' +
+                '\n    10 | }' +
+                '\n'
+            : '\nError: Boom' +
+                '\n    at logError (webpack:///app/rsc-error-log-cause/page.js?[search]:2:16)' +
+                // FIXME: Method name should be "Page"
+                '\n    at logError (webpack:///app/rsc-error-log-cause/page.js?[search]:8:2)' +
+                '\n  1 | function logError(cause) {' +
+                "\n> 2 |   const error = new Error('Boom', { cause })" +
+                '\n    |                ^' +
+                '\n  3 |   console.error(error)' +
+                '\n  4 | }' +
+                '\n  5 | {' +
+                '\n  [cause]: Error: Boom' +
+                '\n      at Page (webpack:///app/rsc-error-log-cause/page.js?[search]:7:16)' +
+                '\n     5 |' +
+                '\n     6 | export default function Page() {' +
+                "\n  >  7 |   const error = new Error('Boom')" +
+                '\n       |                ^' +
+                '\n     8 |   logError(error)' +
+                '\n     9 |   return null' +
+                '\n    10 | }' +
+                '\n'
+        )
+      })
+    } else {
+      // TODO: Test `next build` with `--enable-source-maps`.
+    }
   })
+
+  // FIXME: Turbopack resolver bug
+  // FIXME: Turbopack build? bugs taint the whole dev server
+  ;(isTurbopack ? it.skip : it)(
+    'stack frames are not ignore-listed in ssr',
+    async () => {
+      await next.render('/ssr-error-log-ignore-listed')
+
+      if (isNextDev) {
+        await retry(() => {
+          expect(normalizeCliOutput(next.cliOutput)).toContain(
+            isTurbopack
+              ? // FIXME: Turbopack resolver bug
+                "Module not found: Can't resolve 'internal-pkg'"
+              : '\nError: Boom' +
+                  '\n    at logError (webpack:///app/ssr-error-log-ignore-listed/page.js?[search]:5:16)' +
+                  // FIXME: Method name should be "Page"
+                  '\n    at logError (webpack:///app/ssr-error-log-ignore-listed/page.js?[search]:10:12)' +
+                  (process.env.NEXT_TEST_CI
+                    ? '\n    at run (webpack:///node_modules/[pnpm]/internal-pkg/index.js?[search]:2:0)'
+                    : '\n    at run (webpack://[fixture-root]/node_modules/[pnpm]/internal-pkg/index.js?[search]:2:0)') +
+                  '\n    at Page (webpack:///app/ssr-error-log-ignore-listed/page.js?[search]:10:6)' +
+                  '\n  3 |'
+          )
+        })
+      } else {
+        // TODO: Test `next build` with `--enable-source-maps`.
+      }
+    }
+  )
+
+  // FIXME: Turbopack resolver bug
+  // FIXME: Turbopack build? bugs taint the whole dev server
+  ;(isTurbopack ? it.skip : it)(
+    'stack frames are not ignore-listed in rsc',
+    async () => {
+      await next.render('/rsc-error-log-ignore-listed')
+
+      if (isNextDev) {
+        await retry(() => {
+          expect(normalizeCliOutput(next.cliOutput)).toContain(
+            isTurbopack
+              ? // FIXME: Turbopack resolver bug
+                "Module not found: Can't resolve 'internal-pkg'"
+              : '\nError: Boom' +
+                  '\n    at logError (webpack:///app/rsc-error-log-ignore-listed/page.js?[search]:4:16)' +
+                  // FIXME: Method name should be "Page"
+                  '\n    at logError (webpack:///app/rsc-error-log-ignore-listed/page.js?[search]:9:12)' +
+                  (process.env.NEXT_TEST_CI
+                    ? '\n    at run (webpack:///node_modules/[pnpm]/internal-pkg/index.js?[search]:2:0)'
+                    : '\n    at run (webpack://[fixture-root]/node_modules/[pnpm]/internal-pkg/index.js?[search]:2:0)') +
+                  '\n    at Page (webpack:///app/rsc-error-log-ignore-listed/page.js?[search]:9:6)' +
+                  '\n  2 |'
+          )
+        })
+      } else {
+        // TODO: Test `next build` with `--enable-source-maps`.
+      }
+    }
+  )
 
   it('logged errors preserve their name', async () => {
     await next.render('/rsc-error-log-custom-name')


### PR DESCRIPTION
We already create server source maps in dev by default,
so we should make use of them.

To opt-out, run `next dev --disable-source-maps` instead.

Our internal `next-no-sourcemaps` script is now defunct. 