### PR TITLE
codemod(turbopack): Rewrite Vc fields in structs as ResolvedVc (part 5)

### DIFF
--- a/turbopack/crates/node-file-trace/src/lib.rs
+++ b/turbopack/crates/node-file-trace/src/lib.rs
@@ -576,8 +576,10 @@ async fn create_module_asset(
             ..Default::default()
         }
         .into(),
-    )));
-    let compile_time_info = CompileTimeInfo::builder(env).cell();
+    )))
+    .to_resolved()
+    .await?;
+    let compile_time_info = CompileTimeInfo::builder(*env).cell();
     let glob_mappings = vec![
         (
             root,

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -17,7 +17,7 @@ pub struct AssetIdent {
     /// The fragment of the asset (e.g. `#foo`)
     pub fragment: Option<ResolvedVc<RcStr>>,
     /// The assets that are nested in this asset
-    pub assets: Vec<(Vc<RcStr>, Vc<AssetIdent>)>,
+    pub assets: Vec<(ResolvedVc<RcStr>, ResolvedVc<AssetIdent>)>,
     /// The modifiers of this asset (e.g. `client chunks`)
     pub modifiers: Vec<Vc<RcStr>>,
     /// The part of the asset that is a (ECMAScript) module
@@ -31,7 +31,7 @@ impl AssetIdent {
         self.modifiers.push(modifier);
     }
 
-    pub fn add_asset(&mut self, key: Vc<RcStr>, asset: Vc<AssetIdent>) {
+    pub fn add_asset(&mut self, key: ResolvedVc<RcStr>, asset: ResolvedVc<AssetIdent>) {
         self.assets.push((key, asset));
     }
 

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -286,7 +286,7 @@ impl OutputAsset for CssChunk {
             } else {
                 *ServerFileSystem::new().root().to_resolved().await?
             },
-            query: *Vc::<RcStr>::default().to_resolved().await?,
+            query: Vc::<RcStr>::default(),
             fragment: None,
             assets,
             modifiers: Vec::new(),

--- a/turbopack/crates/turbopack-dev-server/src/source/resolve.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/resolve.rs
@@ -107,7 +107,7 @@ pub async fn resolve_source_request(
                     }
                     ContentSourceContent::Static(static_content) => {
                         return Ok(ResolveSourceRequestResult::Static(
-                            static_content.to_resolved().await?,
+                            *static_content,
                             HeaderList::new(response_header_overwrites)
                                 .to_resolved()
                                 .await?,

--- a/turbopack/crates/turbopack-dev-server/src/source/resolve.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/resolve.rs
@@ -24,7 +24,7 @@ use super::{
 #[turbo_tasks::value(serialization = "none")]
 pub enum ResolveSourceRequestResult {
     NotFound,
-    Static(Vc<StaticContent>, ResolvedVc<HeaderList>),
+    Static(ResolvedVc<StaticContent>, ResolvedVc<HeaderList>),
     HttpProxy(Vc<ProxyResult>),
 }
 
@@ -107,7 +107,7 @@ pub async fn resolve_source_request(
                     }
                     ContentSourceContent::Static(static_content) => {
                         return Ok(ResolveSourceRequestResult::Static(
-                            **static_content,
+                            static_content.to_resolved().await?,
                             HeaderList::new(response_header_overwrites)
                                 .to_resolved()
                                 .await?,

--- a/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
@@ -334,7 +334,7 @@ impl RouteTree {
             match selector_segment {
                 BaseSegment::Static(value) => Ok(RouteTree {
                     base,
-                    static_segments: fxindexmap! { value => *inner.resolved_cell() },
+                    static_segments: fxindexmap! { value => inner.cell() },
                     ..Default::default()
                 }
                 .cell()),
@@ -380,9 +380,8 @@ impl RouteTree {
         for s in not_found_sources.iter_mut() {
             *s = mapper.map_get_content(*s);
         }
-
         for r in static_segments.values_mut() {
-            *r = *r.map_routes(mapper).to_resolved().await?;
+            *r = r.map_routes(mapper);
         }
         for r in dynamic_segments.iter_mut() {
             *r = r.map_routes(mapper).to_resolved().await?;

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -78,7 +78,7 @@ impl Chunk for EcmascriptChunk {
 
         let EcmascriptChunkContent { chunk_items, .. } = &*self.content.await?;
         let mut common_path = if let Some((chunk_item, _)) = chunk_items.first() {
-            let path = chunk_item.asset_ident().path().resolve().await?;
+            let path = chunk_item.asset_ident().path().to_resolved().await?;
             Some((path, path.await?))
         } else {
             None
@@ -90,7 +90,7 @@ impl Chunk for EcmascriptChunk {
             if let Some((common_path_vc, common_path_ref)) = common_path.as_mut() {
                 let path = chunk_item.asset_ident().path().await?;
                 while !path.is_inside_or_equal_ref(common_path_ref) {
-                    let parent = common_path_vc.parent().resolve().await?;
+                    let parent = common_path_vc.parent().to_resolved().await?;
                     if parent == *common_path_vc {
                         common_path = None;
                         break;
@@ -99,21 +99,21 @@ impl Chunk for EcmascriptChunk {
                     *common_path_ref = (*common_path_vc).await?;
                 }
             }
-            assets.push((chunk_item_key, chunk_item.content_ident()));
+            assets.push((
+                chunk_item_key.to_resolved().await?,
+                chunk_item.content_ident().to_resolved().await?,
+            ));
         }
 
-        // Make sure the idents are resolved
-        for (_, ident) in assets.iter_mut() {
-            *ident = ident.resolve().await?;
-        }
+        // The previous resolve loop is no longer needed since we're already using ResolvedVc
 
         let ident = AssetIdent {
             path: if let Some((common_path, _)) = common_path {
-                common_path
+                *common_path
             } else {
-                ServerFileSystem::new().root()
+                *ServerFileSystem::new().root().to_resolved().await?
             },
-            query: Vc::<RcStr>::default(),
+            query: *Vc::<RcStr>::default().to_resolved().await?,
             fragment: None,
             assets,
             modifiers: Vec::new(),

--- a/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
@@ -3,7 +3,7 @@ use swc_core::ecma::{
     ast::Stmt,
     visit::{AstParentKind, VisitMut},
 };
-use turbo_tasks::{debug::ValueDebugFormat, trace::TraceRawVcs, RcStr, Vc};
+use turbo_tasks::{debug::ValueDebugFormat, trace::TraceRawVcs, RcStr, ResolvedVc, Vc};
 use turbopack_core::chunk::{AsyncModuleInfo, ChunkingContext};
 
 /// impl of code generation inferred from a ModuleReference.
@@ -108,7 +108,7 @@ pub trait CodeGenerateableWithAsyncModuleInfo {
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat)]
 pub enum CodeGen {
     CodeGenerateable(Vc<Box<dyn CodeGenerateable>>),
-    CodeGenerateableWithAsyncModuleInfo(Vc<Box<dyn CodeGenerateableWithAsyncModuleInfo>>),
+    CodeGenerateableWithAsyncModuleInfo(ResolvedVc<Box<dyn CodeGenerateableWithAsyncModuleInfo>>),
 }
 
 #[turbo_tasks::value(transparent)]

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -523,7 +523,10 @@ impl Module for EcmascriptModuleAsset {
         if let Some(inner_assets) = self.inner_assets {
             let mut ident = self.source.ident().await?.clone_value();
             for (name, asset) in inner_assets.await?.iter() {
-                ident.add_asset(Vc::cell(name.to_string().into()), asset.ident());
+                ident.add_asset(
+                    ResolvedVc::cell(name.to_string().into()),
+                    asset.ident().to_resolved().await?,
+                );
             }
             ident.add_modifier(modifier());
             ident.layer = Some(self.asset_context.layer().to_resolved().await?);

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -14,7 +14,9 @@ use swc_core::{
     },
     quote, quote_expr,
 };
-use turbo_tasks::{trace::TraceRawVcs, FxIndexMap, RcStr, TryFlatJoinIterExt, ValueToString, Vc};
+use turbo_tasks::{
+    trace::TraceRawVcs, FxIndexMap, RcStr, ResolvedVc, TryFlatJoinIterExt, ValueToString, Vc,
+};
 use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
     chunk::ChunkingContext,
@@ -425,7 +427,7 @@ pub struct EsmExports {
 pub struct ExpandedExports {
     pub exports: BTreeMap<RcStr, EsmExport>,
     /// Modules we couldn't analyse all exports of.
-    pub dynamic_exports: Vec<Vc<Box<dyn EcmascriptChunkPlaceable>>>,
+    pub dynamic_exports: Vec<ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -456,7 +458,7 @@ impl EsmExports {
             }
 
             if export_info.has_dynamic_exports {
-                dynamic_exports.push(**asset);
+                dynamic_exports.push((**asset).to_resolved().await?);
             }
         }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -458,7 +458,7 @@ impl EsmExports {
             }
 
             if export_info.has_dynamic_exports {
-                dynamic_exports.push((**asset).to_resolved().await?);
+                dynamic_exports.push(*asset);
             }
         }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -240,14 +240,14 @@ impl AnalyzeEcmascriptModuleResultBuilder {
 
     /// Adds a codegen to the analysis result.
     #[allow(dead_code)]
-    pub fn add_code_gen_with_availability_info<C>(&mut self, code_gen: Vc<C>)
+    pub fn add_code_gen_with_availability_info<C>(&mut self, code_gen: ResolvedVc<C>)
     where
         C: Upcast<Box<dyn CodeGenerateableWithAsyncModuleInfo>>,
     {
         self.code_gens
-            .push(CodeGen::CodeGenerateableWithAsyncModuleInfo(Vc::upcast(
-                code_gen,
-            )));
+            .push(CodeGen::CodeGenerateableWithAsyncModuleInfo(
+                ResolvedVc::upcast(code_gen),
+            ));
     }
 
     pub fn add_binding(&mut self, binding: EsmBinding) {
@@ -316,10 +316,10 @@ impl AnalyzeEcmascriptModuleResultBuilder {
         for c in self.code_gens.iter_mut() {
             match c {
                 CodeGen::CodeGenerateable(c) => {
-                    *c = c.resolve().await?;
+                    *c = *c.to_resolved().await?;
                 }
                 CodeGen::CodeGenerateableWithAsyncModuleInfo(c) => {
-                    *c = c.resolve().await?;
+                    *c = c.to_resolved().await?;
                 }
             }
         }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -316,7 +316,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
         for c in self.code_gens.iter_mut() {
             match c {
                 CodeGen::CodeGenerateable(c) => {
-                    *c = *c.to_resolved().await?;
+                    *c = c.resolve().await?;
                 }
                 CodeGen::CodeGenerateableWithAsyncModuleInfo(c) => {
                     *c = c.to_resolved().await?;

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -83,10 +83,7 @@ impl DirList {
                 DirectoryEntry::File(path) => {
                     if let Some(relative_path) = root_val.get_relative_path_to(&*path.await?) {
                         if regex.is_match(&relative_path) {
-                            list.insert(
-                                relative_path,
-                                DirListEntry::File(path.to_resolved().await?),
-                            );
+                            list.insert(relative_path, DirListEntry::File(*path));
                         }
                     }
                 }
@@ -124,8 +121,7 @@ impl DirList {
             for (k, entry) in &*dir {
                 match entry {
                     DirListEntry::File(path) => {
-                        // Don't dereference the path, store it as a Vc
-                        list.insert(k.clone(), path.resolve().await?);
+                        list.insert(k.clone(), **path);
                     }
                     DirListEntry::Dir(d) => {
                         queue.push_back(d.await?);

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -12,7 +12,7 @@ use swc_core::{
     },
     quote, quote_expr,
 };
-use turbo_tasks::{primitives::Regex, FxIndexMap, RcStr, Value, ValueToString, Vc};
+use turbo_tasks::{primitives::Regex, FxIndexMap, RcStr, ResolvedVc, Value, ValueToString, Vc};
 use turbo_tasks_fs::{DirectoryContent, DirectoryEntry, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -46,8 +46,8 @@ use crate::{
 #[turbo_tasks::value]
 #[derive(Debug)]
 pub(crate) enum DirListEntry {
-    File(Vc<FileSystemPath>),
-    Dir(Vc<DirList>),
+    File(ResolvedVc<FileSystemPath>),
+    Dir(ResolvedVc<DirList>),
 }
 
 #[turbo_tasks::value(transparent)]
@@ -83,7 +83,10 @@ impl DirList {
                 DirectoryEntry::File(path) => {
                     if let Some(relative_path) = root_val.get_relative_path_to(&*path.await?) {
                         if regex.is_match(&relative_path) {
-                            list.insert(relative_path, DirListEntry::File(**path));
+                            list.insert(
+                                relative_path,
+                                DirListEntry::File(path.to_resolved().await?),
+                            );
                         }
                     }
                 }
@@ -91,9 +94,11 @@ impl DirList {
                     if let Some(relative_path) = root_val.get_relative_path_to(&*path.await?) {
                         list.insert(
                             relative_path,
-                            DirListEntry::Dir(DirList::read_internal(
-                                root, **path, recursive, filter,
-                            )),
+                            DirListEntry::Dir(
+                                DirList::read_internal(root, **path, recursive, filter)
+                                    .to_resolved()
+                                    .await?,
+                            ),
                         );
                     }
                 }
@@ -119,7 +124,8 @@ impl DirList {
             for (k, entry) in &*dir {
                 match entry {
                     DirListEntry::File(path) => {
-                        list.insert(k.clone(), *path);
+                        // Don't dereference the path, store it as a Vc
+                        list.insert(k.clone(), path.resolve().await?);
                     }
                     DirListEntry::Dir(d) => {
                         queue.push_back(d.await?);

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -127,7 +127,7 @@ pub async fn external_asset_entrypoints(
 /// assets.
 #[turbo_tasks::function]
 async fn separate_assets(
-    intermediate_asset: Vc<Box<dyn OutputAsset>>,
+    intermediate_asset: ResolvedVc<Box<dyn OutputAsset>>,
     intermediate_output_path: Vc<FileSystemPath>,
 ) -> Result<Vc<SeparatedAssets>> {
     let intermediate_output_path = &*intermediate_output_path.await?;
@@ -166,10 +166,7 @@ async fn separate_assets(
 
     let graph = AdjacencyMap::new()
         .skip_duplicates()
-        .visit(
-            once(Type::Internal(intermediate_asset.to_resolved().await?)),
-            get_asset_children,
-        )
+        .visit(once(Type::Internal(intermediate_asset)), get_asset_children)
         .await
         .completed()?
         .into_inner();

--- a/turbopack/crates/turbopack-node/src/render/render_static.rs
+++ b/turbopack/crates/turbopack-node/src/render/render_static.rs
@@ -317,7 +317,9 @@ async fn render_stream_internal(
             RenderStaticIncomingMessage::Headers { data } => yield RenderItem::Headers(data),
             RenderStaticIncomingMessage::Rewrite { path } => {
                 drop(guard);
-                yield RenderItem::Response(StaticResult::rewrite(RewriteBuilder::new(path).build()).to_resolved().await?);
+                yield RenderItem::Response(
+                    StaticResult::rewrite(RewriteBuilder::new(path).build()).to_resolved().await?
+                );
                 return;
             }
             RenderStaticIncomingMessage::Response {

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -511,16 +511,9 @@ impl PostCssTransformedAsset {
 
         // TODO handle SourceMap
         let file = File::from(processed_css.css);
-        let mut resolved_assets = Vec::new();
-        for asset in emitted_assets_to_virtual_sources(processed_css.assets) {
-            resolved_assets.push(asset.to_resolved().await?);
-        }
-        let content = AssetContent::File(*FileContent::Content(file).resolved_cell()).cell();
-        Ok(ProcessPostCssResult {
-            content,
-            assets: resolved_assets,
-        }
-        .cell())
+        let assets = emitted_assets_to_virtual_sources(processed_css.assets).await?;
+        let content = AssetContent::File(FileContent::Content(file).cell()).cell();
+        Ok(ProcessPostCssResult { content, assets }.cell())
     }
 }
 

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -268,7 +268,11 @@ impl WebpackLoadersProcessedAsset {
             Either::Left(str) => File::from(str),
             Either::Right(bytes) => File::from(bytes.binary),
         };
-        let assets = emitted_assets_to_virtual_sources(processed.assets);
+        let assets = emitted_assets_to_virtual_sources(processed.assets)
+            .await?
+            .into_iter()
+            .map(|asset| *asset)
+            .collect();
         let content = AssetContent::File(FileContent::Content(file).cell()).cell();
         Ok(ProcessWebpackLoadersResult {
             content,

--- a/turbopack/crates/turbopack-resolve/src/resolve_options_context.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve_options_context.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{RcStr, ValueDefault, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, ValueDefault, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     condition::ContextCondition,
@@ -14,7 +14,7 @@ use turbopack_core::{
 #[derive(Default, Clone)]
 pub struct ResolveOptionsContext {
     #[serde(default)]
-    pub emulate_environment: Option<Vc<Environment>>,
+    pub emulate_environment: Option<ResolvedVc<Environment>>,
     #[serde(default)]
     pub enable_types: bool,
     #[serde(default)]

--- a/turbopack/crates/turbopack/benches/node_file_trace.rs
+++ b/turbopack/crates/turbopack/benches/node_file_trace.rs
@@ -98,7 +98,9 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
                     }
                     .cell(),
                     ResolveOptionsContext {
-                        emulate_environment: Some(compile_time_info.environment().resolve().await?),
+                        emulate_environment: Some(
+                            compile_time_info.environment().to_resolved().await?,
+                        ),
                         ..Default::default()
                     }
                     .cell(),

--- a/turbopack/crates/turbopack/src/graph/mod.rs
+++ b/turbopack/crates/turbopack/src/graph/mod.rs
@@ -96,13 +96,12 @@ impl AggregatedGraph {
             .collect::<Vec<_>>()
         {
             let cost = cost.await?.0;
-            let resolved_reference = reference.to_resolved().await?;
             if cost == 0 {
-                inner.insert(resolved_reference);
+                inner.insert(reference);
             } else if cost > self_cost {
-                references.insert(resolved_reference);
+                references.insert(reference);
             } else {
-                outer.insert(resolved_reference);
+                outer.insert(reference);
             }
         }
         Ok(AggregatedGraphsValuedReferences {


### PR DESCRIPTION
Generated using a version of https://github.com/vercel/turbopack-resolved-vc-codemod . This uses Anthropic Claude Sonnet 3.5 for more complicated errors we don't have hardcoded logic for.

- Part 1: #70927
- Part 2: #71172
- Part 3: #71665
- Part 4: #71804

Closes PACK-3339