### PR TITLE
Fix missing `await` of `params` when metadata is used with an image file

### DIFF
--- a/packages/next/src/build/webpack/loaders/metadata/discover.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/discover.ts
@@ -114,7 +114,7 @@ export async function createStaticMetadataFromRoute(
           // WEBPACK_RESOURCE_QUERIES.metadata query here only for filtering out applying to image loader
         )}!${filepath}?${WEBPACK_RESOURCE_QUERIES.metadata}`
 
-        const imageModule = `(async (props) => (await import(/* webpackMode: "eager" */ ${JSON.stringify(
+        const imageModule = `(async (props) => await (await import(/* webpackMode: "eager" */ ${JSON.stringify(
           imageModuleImportSource
         )})).default(props))`
         hasStaticMetadataFiles = true

--- a/packages/next/src/build/webpack/loaders/metadata/discover.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/discover.ts
@@ -114,7 +114,7 @@ export async function createStaticMetadataFromRoute(
           // WEBPACK_RESOURCE_QUERIES.metadata query here only for filtering out applying to image loader
         )}!${filepath}?${WEBPACK_RESOURCE_QUERIES.metadata}`
 
-        const imageModule = `(async (props) => await (await import(/* webpackMode: "eager" */ ${JSON.stringify(
+        const imageModule = `(async (props) => (await import(/* webpackMode: "eager" */ ${JSON.stringify(
           imageModuleImportSource
         )})).default(props))`
         hasStaticMetadataFiles = true

--- a/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
@@ -172,7 +172,7 @@ async function nextMetadataImageLoader(
     const imageData = ${JSON.stringify(imageData)}
     const imageUrl = fillMetadataSegment(${JSON.stringify(
       pathnamePrefix
-    )}, props.params, ${JSON.stringify(pageSegment)})
+    )}, await props.params, ${JSON.stringify(pageSegment)})
 
     return [{
       ...imageData,

--- a/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
@@ -168,7 +168,7 @@ async function nextMetadataImageLoader(
   return `\
   import { fillMetadataSegment } from 'next/dist/lib/metadata/get-metadata-route'
 
-  export default (props) => {
+  export default async (props) => {
     const imageData = ${JSON.stringify(imageData)}
     const imageUrl = fillMetadataSegment(${JSON.stringify(
       pathnamePrefix


### PR DESCRIPTION
### Fixing a bug
Like #70698 but for the case where we add an image `/app/[locale]/my-page/opengraph-image.jpg`

### Stacktrace of an error triggered by this
```
Error: Route "/[locale]/my-page" used `params.locale`. `params` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis      
    at createParamsAccessError (webpack-internal:///(rsc)/./node_modules/next/dist/server/request/params.js:321:12)
    at logDedupedError (webpack-internal:///(rsc)/./node_modules/next/dist/server/create-deduped-by-callsite-server-error-loger.js:69:25)
    at syncIODev (webpack-internal:///(rsc)/./node_modules/next/dist/server/request/params.js:313:9)
    at Object.get (webpack-internal:///(rsc)/./node_modules/next/dist/server/request/params.js:281:21)
    at interpolateDynamicPath (webpack-internal:///(rsc)/./node_modules/next/dist/server/server-utils.js:60:29)
    at fillMetadataSegment (webpack-internal:///(rsc)/./node_modules/next/dist/lib/metadata/get-metadata-route.js:52:59)
    at Module.__WEBPACK_DEFAULT_EXPORT__ (webpack-internal:///(rsc)/./node_modules/next/dist/build/webpack/loaders/next-metadata-image-loader.js?type=openGraph&segment=%2F%5Blocale%5D%2Fmy-page&basePath=&pageExtensions=tsx&pageExtensions=ts&pageExtensions=jsx&pageExtensions=js!./app/[locale]/my-page/opengraph-image.jpg?__next_metadata__:11:116)
    at tree.children.children.children.children.metadata.openGraph (webpack-internal:///(rsc)/./node_modules/next/dist/build/webpack/loaders/next-app-loader/index.js?name=app%2F%5Blocale%5D%2Fmy-page%2Fpage&page=%2F%5Blocale%5D%2Fmy-page%2Fpage&appPaths=%2F%5Blocale%5D%2Fmy-page%2Fpage&pagePath=private-next-app-dir%2F%5Blocale%5D%2Fmy-page%2Fpage.tsx&appDir=REDACTED&pageExtensions=tsx&pageExtensions=ts&pageExtensions=jsx&pageExtensions=js&rootDir=REDACTED&isDev=true&tsconfigPath=tsconfig.json&basePath=&assetPrefix=&nextConfigOutput=&preferredRegion=&middlewareConfig=e30%3D!:45:677)
    at async eval (webpack-internal:///(rsc)/./node_modules/next/dist/lib/metadata/resolve-metadata.js:264:102)
    at async Promise.all (index 0)
    at async collectStaticImagesFiles (webpack-internal:///(rsc)/./node_modules/next/dist/lib/metadata/resolve-metadata.js:265:81)
    at async Promise.all (index 2)
    at async resolveStaticMetadata (webpack-internal:///(rsc)/./node_modules/next/dist/lib/metadata/resolve-metadata.js:270:47)
    at async collectMetadata (webpack-internal:///(rsc)/./node_modules/next/dist/lib/metadata/resolve-metadata.js:301:33)
    at async resolveMetadataItemsImpl (webpack-internal:///(rsc)/./node_modules/next/dist/lib/metadata/resolve-metadata.js:370:5)
    at async resolveMetadataItemsImpl (webpack-internal:///(rsc)/./node_modules/next/dist/lib/metadata/resolve-metadata.js:381:9)
    at async resolveMetadataItemsImpl (webpack-internal:///(rsc)/./node_modules/next/dist/lib/metadata/resolve-metadata.js:381:9)
    at async resolveMetadataItemsImpl (webpack-internal:///(rsc)/./node_modules/next/dist/lib/metadata/resolve-metadata.js:381:9)
```