### PR TITLE
fix global-error styles

### DIFF
--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -311,7 +311,7 @@ impl AppPageLoaderTreeBuilder {
             page,
             default,
             error,
-            global_error: _,
+            global_error,
             layout,
             loading,
             template,
@@ -343,6 +343,8 @@ impl AppPageLoaderTreeBuilder {
         self.write_modules_entry(AppDirModuleType::Page, *page)
             .await?;
         self.write_modules_entry(AppDirModuleType::DefaultPage, *default)
+            .await?;
+        self.write_modules_entry(AppDirModuleType::GlobalError, *global_error)
             .await?;
 
         let modules_code = replace(&mut self.loader_tree_code, temp_loader_tree_code);

--- a/crates/next-core/src/base_loader_tree.rs
+++ b/crates/next-core/src/base_loader_tree.rs
@@ -28,6 +28,7 @@ pub enum AppDirModuleType {
     Loading,
     Template,
     NotFound,
+    GlobalError,
 }
 
 impl AppDirModuleType {
@@ -40,6 +41,7 @@ impl AppDirModuleType {
             AppDirModuleType::Loading => "loading",
             AppDirModuleType::Template => "template",
             AppDirModuleType::NotFound => "not-found",
+            AppDirModuleType::GlobalError => "global-error",
         }
     }
 }

--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -60,6 +60,7 @@ const FILE_TYPES = {
   error: 'error',
   loading: 'loading',
   'not-found': 'not-found',
+  'global-error': 'global-error',
 } as const
 
 const GLOBAL_ERROR_FILE_TYPE = 'global-error'

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -183,7 +183,7 @@ function ServerRoot(): React.ReactNode {
   const router = (
     <AppRouter
       actionQueue={actionQueue}
-      globalErrorComponent={initialRSCPayload.G}
+      globalErrorComponentAndStyles={initialRSCPayload.G}
       assetPrefix={initialRSCPayload.p}
     />
   )

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -622,17 +622,20 @@ function Router({
 
 export default function AppRouter({
   actionQueue,
-  globalErrorComponent,
+  globalErrorComponentAndStyles: [globalErrorComponent, globalErrorStyles],
   assetPrefix,
 }: {
   actionQueue: AppRouterActionQueue
-  globalErrorComponent: ErrorComponent
+  globalErrorComponentAndStyles: [ErrorComponent, React.ReactNode | undefined]
   assetPrefix: string
 }) {
   useNavFailureHandler()
 
   return (
-    <ErrorBoundary errorComponent={globalErrorComponent}>
+    <ErrorBoundary
+      errorComponent={globalErrorComponent}
+      errorStyles={globalErrorStyles}
+    >
       <Router actionQueue={actionQueue} assetPrefix={assetPrefix} />
     </ErrorBoundary>
   )

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -226,7 +226,7 @@ export type InitialRSCPayload = {
   /** missingSlots */
   m: Set<string> | undefined
   /** GlobalError */
-  G: React.ComponentType<any>
+  G: [React.ComponentType<any>, React.ReactNode | undefined]
   /** postponed */
   s: boolean
   /** prerendered */

--- a/test/e2e/app-dir/global-error/with-style-import/app/global-error.tsx
+++ b/test/e2e/app-dir/global-error/with-style-import/app/global-error.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import './global.css'
+
+export default function GlobalError() {
+  return (
+    <html>
+      <body>
+        <h2>Error!</h2>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/global-error/with-style-import/app/global.css
+++ b/test/e2e/app-dir/global-error/with-style-import/app/global.css
@@ -1,0 +1,3 @@
+h2 {
+  color: yellow;
+}

--- a/test/e2e/app-dir/global-error/with-style-import/app/layout.tsx
+++ b/test/e2e/app-dir/global-error/with-style-import/app/layout.tsx
@@ -1,0 +1,12 @@
+// to avoid bailing out of the build
+export const dynamic = 'force-dynamic'
+
+export default function RootLayout({ children }) {
+  throw new Error('Root Layout Error')
+
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/global-error/with-style-import/app/page.tsx
+++ b/test/e2e/app-dir/global-error/with-style-import/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <p>Home</p>
+}

--- a/test/e2e/app-dir/global-error/with-style-import/index.test.ts
+++ b/test/e2e/app-dir/global-error/with-style-import/index.test.ts
@@ -1,0 +1,30 @@
+import { assertHasRedbox, getRedboxHeader } from 'next-test-utils'
+import { nextTestSetup } from 'e2e-utils'
+
+async function testDev(browser, errorRegex) {
+  await assertHasRedbox(browser)
+  expect(await getRedboxHeader(browser)).toMatch(errorRegex)
+}
+
+describe('app dir - global error - with style import', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should render global error with correct styles', async () => {
+    const browser = await next.browser('/')
+
+    if (isNextDev) {
+      await testDev(browser, /Root Layout Error/)
+      return
+    }
+
+    const h2 = await browser.elementByCss('h2')
+    expect(await h2.getComputedCss('color')).toBe('rgb(255, 255, 0)') // yellow
+  })
+})


### PR DESCRIPTION
### What?

Allowing global-error page to apply imported CSS styles

Fixes # https://github.com/vercel/next.js/issues/70553