### PR TITLE
Update start-server.ts

### DIFF
--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -296,7 +296,7 @@ export async function startServer(
         })
         process.on('uncaughtException', exception)
         process.on('unhandledRejection', exception)
-
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
         const initResult = await getRequestHandlers({
           dir,
           port,


### PR DESCRIPTION
* ignore this warning


warning ..\..\package.json: No license field
TypeError: fetch failed
    at node:internal/deps/undici/undici:12618:11
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async getVersionInfo (C:\Users\maqingbo\Desktop\software-sharing\node_modules\next\dist\server\dev\hot-reloader-webpack.js:215:21)
    at async createHotReloaderTurbopack (C:\Users\maqingbo\Desktop\software-sharing\node_modules\next\dist\server\dev\hot-reloader-turbopack.js:395:25)
    at async startWatcher (C:\Users\maqingbo\Desktop\software-sharing\node_modules\next\dist\server\lib\router-utils\setup-dev-bundler.js:145:38)
    at async setupDevBundler (C:\Users\maqingbo\Desktop\software-sharing\node_modules\next\dist\server\lib\router-utils\setup-dev-bundler.js:775:20)
    at async Span.traceAsyncFn (C:\Users\maqingbo\Desktop\software-sharing\node_modules\next\dist\trace\trace.js:154:20)
    at async initialize (C:\Users\maqingbo\Desktop\software-sharing\node_modules\next\dist\server\lib\router-server.js:78:30)
    at async Server.<anonymous> (C:\Users\maqingbo\Desktop\software-sharing\node_modules\next\dist\server\lib\start-server.js:249:36) {
  cause: Error: certificate has expired
      at TLSSocket.onConnectSecure (node:_tls_wrap:1674:34)
      at TLSSocket.emit (node:events:518:28)
      at TLSSocket._finishInit (node:_tls_wrap:1085:8)
      at ssl.onhandshakedone (node:_tls_wrap:871:12) {
    code: 'CERT_HAS_EXPIRED'
  }
}