### PR TITLE
fix: log the error instance modified extra location info

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stitched-error.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stitched-error.ts
@@ -6,10 +6,7 @@ const REACT_ERROR_STACK_BOTTOM_FRAME_REGEX = new RegExp(
   `(at ${REACT_ERROR_STACK_BOTTOM_FRAME} )|(${REACT_ERROR_STACK_BOTTOM_FRAME}\\@)`
 )
 
-export function getReactStitchedError<T = unknown>(
-  err: T,
-  locationInfo?: string
-): Error | T {
+export function getReactStitchedError<T = unknown>(err: T): Error | T {
   if (typeof (React as any).captureOwnerStack !== 'function') {
     return err
   }
@@ -34,14 +31,9 @@ export function getReactStitchedError<T = unknown>(
   const ownerStack = (React as any).captureOwnerStack()
   if (ownerStack && newStack.endsWith(ownerStack) === false) {
     newStack += ownerStack
+    // Override stack
+    newError.stack = newStack
   }
-
-  if (locationInfo) {
-    newStack += `\n\n${locationInfo}`
-  }
-
-  // Override stack
-  newError.stack = newStack
 
   return newError
 }

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stitched-error.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stitched-error.ts
@@ -6,7 +6,10 @@ const REACT_ERROR_STACK_BOTTOM_FRAME_REGEX = new RegExp(
   `(at ${REACT_ERROR_STACK_BOTTOM_FRAME} )|(${REACT_ERROR_STACK_BOTTOM_FRAME}\\@)`
 )
 
-export function getReactStitchedError<T = unknown>(err: T): Error | T {
+export function getReactStitchedError<T = unknown>(
+  err: T,
+  locationInfo?: string
+): Error | T {
   if (typeof (React as any).captureOwnerStack !== 'function') {
     return err
   }
@@ -26,15 +29,19 @@ export function getReactStitchedError<T = unknown>(err: T): Error | T {
   const newError = new Error(originMessage)
   // Copy all enumerable properties, e.g. digest
   Object.assign(newError, err)
-  newError.stack = newStack
 
   // Avoid duplicate overriding stack frames
   const ownerStack = (React as any).captureOwnerStack()
   if (ownerStack && newStack.endsWith(ownerStack) === false) {
     newStack += ownerStack
-    // Override stack
-    newError.stack = newStack
   }
+
+  if (locationInfo) {
+    newStack += `\n\n${locationInfo}`
+  }
+
+  // Override stack
+  newError.stack = newStack
 
   return newError
 }

--- a/packages/next/src/client/components/react-dev-overlay/internal/helpers/stitched-error.ts
+++ b/packages/next/src/client/components/react-dev-overlay/internal/helpers/stitched-error.ts
@@ -26,6 +26,7 @@ export function getReactStitchedError<T = unknown>(err: T): Error | T {
   const newError = new Error(originMessage)
   // Copy all enumerable properties, e.g. digest
   Object.assign(newError, err)
+  newError.stack = newStack
 
   // Avoid duplicate overriding stack frames
   const ownerStack = (React as any).captureOwnerStack()

--- a/packages/next/src/client/react-client-callbacks/app-router.ts
+++ b/packages/next/src/client/react-client-callbacks/app-router.ts
@@ -49,7 +49,7 @@ export const onCaughtError: HydrationOptions['onCaughtError'] = (
     }
 
     // Log and report the error with location but without modifying the error stack
-    originConsoleError('%o\n\n%s', stitchedError, errorLocation)
+    originConsoleError('%o\n\n%s', err, errorLocation)
 
     handleClientError(stitchedError, [])
   } else {
@@ -85,7 +85,7 @@ export const onUncaughtError: HydrationOptions['onUncaughtError'] = (
     }
 
     // Log and report the error with location but without modifying the error stack
-    originConsoleError('%o\n\n%s', stitchedError, errorLocation)
+    originConsoleError('%o\n\n%s', err, errorLocation)
     reportGlobalError(stitchedError)
   } else {
     reportGlobalError(err)

--- a/packages/next/src/client/react-client-callbacks/app-router.ts
+++ b/packages/next/src/client/react-client-callbacks/app-router.ts
@@ -6,7 +6,6 @@ import { handleClientError } from '../components/react-dev-overlay/internal/help
 import { isNextRouterError } from '../components/is-next-router-error'
 import { isBailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
 import { reportGlobalError } from './report-global-error'
-import isError from '../../lib/is-error'
 import { originConsoleError } from '../components/globals/intercept-console-error'
 
 export const onCaughtError: HydrationOptions['onCaughtError'] = (
@@ -16,9 +15,7 @@ export const onCaughtError: HydrationOptions['onCaughtError'] = (
   // Skip certain custom errors which are not expected to be reported on client
   if (isBailoutToCSRError(err) || isNextRouterError(err)) return
 
-  const stitchedError = getReactStitchedError(err)
-
-  if (process.env.NODE_ENV === 'development') {
+  if (process.env.NODE_ENV !== 'production') {
     const errorBoundaryComponent = errorInfo?.errorBoundary?.constructor
     const errorBoundaryName =
       // read react component displayName
@@ -36,11 +33,6 @@ export const onCaughtError: HydrationOptions['onCaughtError'] = (
       componentThatErroredFrame?.match(/\s+at (\w+)\s+|(\w+)@/) ?? []
     const componentThatErroredName = matches[1] || matches[2] || 'Unknown'
 
-    // In development mode, pass along the component stack to the error
-    if (process.env.NODE_ENV === 'development' && errorInfo.componentStack) {
-      ;(stitchedError as any)._componentStack = errorInfo.componentStack
-    }
-
     // Create error location with errored component and error boundary, to match the behavior of default React onCaughtError handler.
     const errorBoundaryMessage = `It was handled by the <${errorBoundaryName}> error boundary.`
     const componentErrorMessage = componentThatErroredName
@@ -49,10 +41,16 @@ export const onCaughtError: HydrationOptions['onCaughtError'] = (
 
     const errorLocation = `${componentErrorMessage} ${errorBoundaryMessage}`
 
-    const originErrorStack = isError(err) ? err.stack || '' : ''
+    const stitchedError = getReactStitchedError(err, errorLocation)
+    // TODO: change to passing down errorInfo later
+    // In development mode, pass along the component stack to the error
+    if (errorInfo.componentStack) {
+      ;(stitchedError as any)._componentStack = errorInfo.componentStack
+    }
 
-    // Log the modified error message with stack so without being intercepted again.
-    originConsoleError(originErrorStack + '\n\n' + errorLocation)
+    // Log the error
+    originConsoleError(stitchedError)
+
     handleClientError(stitchedError, [])
   } else {
     originConsoleError(err)
@@ -66,9 +64,7 @@ export const onUncaughtError: HydrationOptions['onUncaughtError'] = (
   // Skip certain custom errors which are not expected to be reported on client
   if (isBailoutToCSRError(err) || isNextRouterError(err)) return
 
-  const stitchedError = getReactStitchedError(err)
-
-  if (process.env.NODE_ENV === 'development') {
+  if (process.env.NODE_ENV !== 'production') {
     const componentThatErroredFrame = errorInfo?.componentStack?.split('\n')[1]
 
     // Match chrome or safari stack trace
@@ -76,19 +72,20 @@ export const onUncaughtError: HydrationOptions['onUncaughtError'] = (
       componentThatErroredFrame?.match(/\s+at (\w+)\s+|(\w+)@/) ?? []
     const componentThatErroredName = matches[1] || matches[2] || 'Unknown'
 
-    // In development mode, pass along the component stack to the error
-    if (process.env.NODE_ENV === 'development' && errorInfo.componentStack) {
-      ;(stitchedError as any)._componentStack = errorInfo.componentStack
-    }
-
     // Create error location with errored component and error boundary, to match the behavior of default React onCaughtError handler.
     const errorLocation = componentThatErroredName
       ? `The above error occurred in the <${componentThatErroredName}> component.`
       : `The above error occurred in one of your components.`
 
-    const errStack = (stitchedError as any).stack || ''
-    // Log the modified error message with stack so without being intercepted again.
-    originConsoleError(errStack + '\n\n' + errorLocation)
+    const stitchedError = getReactStitchedError(err, errorLocation)
+    // TODO: change to passing down errorInfo later
+    // In development mode, pass along the component stack to the error
+    if (errorInfo.componentStack) {
+      ;(stitchedError as any)._componentStack = errorInfo.componentStack
+    }
+
+    // Log and report the error
+    originConsoleError(stitchedError)
     reportGlobalError(stitchedError)
   } else {
     reportGlobalError(err)

--- a/packages/next/src/client/react-client-callbacks/app-router.ts
+++ b/packages/next/src/client/react-client-callbacks/app-router.ts
@@ -41,15 +41,15 @@ export const onCaughtError: HydrationOptions['onCaughtError'] = (
 
     const errorLocation = `${componentErrorMessage} ${errorBoundaryMessage}`
 
-    const stitchedError = getReactStitchedError(err, errorLocation)
+    const stitchedError = getReactStitchedError(err)
     // TODO: change to passing down errorInfo later
     // In development mode, pass along the component stack to the error
     if (errorInfo.componentStack) {
       ;(stitchedError as any)._componentStack = errorInfo.componentStack
     }
 
-    // Log the error
-    originConsoleError(stitchedError)
+    // Log and report the error with location but without modifying the error stack
+    originConsoleError('%o\n\n%s', stitchedError, errorLocation)
 
     handleClientError(stitchedError, [])
   } else {
@@ -77,15 +77,15 @@ export const onUncaughtError: HydrationOptions['onUncaughtError'] = (
       ? `The above error occurred in the <${componentThatErroredName}> component.`
       : `The above error occurred in one of your components.`
 
-    const stitchedError = getReactStitchedError(err, errorLocation)
+    const stitchedError = getReactStitchedError(err)
     // TODO: change to passing down errorInfo later
     // In development mode, pass along the component stack to the error
     if (errorInfo.componentStack) {
       ;(stitchedError as any)._componentStack = errorInfo.componentStack
     }
 
-    // Log and report the error
-    originConsoleError(stitchedError)
+    // Log and report the error with location but without modifying the error stack
+    originConsoleError('%o\n\n%s', stitchedError, errorLocation)
     reportGlobalError(stitchedError)
   } else {
     reportGlobalError(err)

--- a/test/development/app-dir/owner-stack/owner-stack.test.ts
+++ b/test/development/app-dir/owner-stack/owner-stack.test.ts
@@ -79,11 +79,17 @@ describe('app-dir - owner-stack', () => {
         at useThrowError 
         at useErrorHook 
         at Page 
-        at NotFoundBoundary 
-        at DevRootNotFoundBoundary 
-        at Router 
-        at AppRouter 
-        at ServerRoot  The above error occurred in the <Page> component. It was handled by the <ReactDevOverlay> error boundary."
+        at react-stack-bottom-frame 
+        at renderWithHooks 
+        at updateFunctionComponent 
+        at beginWork 
+        at runWithFiberInDEV 
+        at performUnitOfWork 
+        at workLoopSync 
+        at renderRootSync 
+        at performWorkOnRoot 
+        at performWorkOnRootViaSchedulerTask 
+        at MessagePort.performWorkUntilDeadline  The above error occurred in the <Page> component. It was handled by the <ReactDevOverlay> error boundary."
       `)
     } else {
       expect(normalizeStackTrace(errorLog)).toMatchInlineSnapshot(`
@@ -92,11 +98,17 @@ describe('app-dir - owner-stack', () => {
         at useThrowError 
         at useErrorHook 
         at Page 
-        at NotFoundBoundary 
-        at DevRootNotFoundBoundary 
-        at Router 
-        at AppRouter 
-        at ServerRoot  The above error occurred in the <Page> component. It was handled by the <ReactDevOverlay> error boundary."
+        at react-stack-bottom-frame 
+        at renderWithHooks 
+        at updateFunctionComponent 
+        at beginWork 
+        at runWithFiberInDEV 
+        at performUnitOfWork 
+        at workLoopSync 
+        at renderRootSync 
+        at performWorkOnRoot 
+        at performWorkOnRootViaSchedulerTask 
+        at MessagePort.performWorkUntilDeadline  The above error occurred in the <Page> component. It was handled by the <ReactDevOverlay> error boundary."
       `)
     }
   })
@@ -137,9 +149,17 @@ describe('app-dir - owner-stack', () => {
       at useThrowError 
       at useErrorHook 
       at Thrower 
-      at Inner 
-      at Page 
-      at ClientPageRoot  The above error occurred in the <Thrower> component. It was handled by the <MyErrorBoundary> error boundary."
+      at react-stack-bottom-frame 
+      at renderWithHooks 
+      at updateFunctionComponent 
+      at beginWork 
+      at runWithFiberInDEV 
+      at performUnitOfWork 
+      at workLoopSync 
+      at renderRootSync 
+      at performWorkOnRoot 
+      at performWorkOnRootViaSchedulerTask 
+      at MessagePort.performWorkUntilDeadline  The above error occurred in the <Thrower> component. It was handled by the <MyErrorBoundary> error boundary."
     `)
   })
 
@@ -172,11 +192,17 @@ describe('app-dir - owner-stack', () => {
       at useThrowError 
       at useErrorHook 
       at Page 
-      at NotFoundBoundary 
-      at DevRootNotFoundBoundary 
-      at Router 
-      at AppRouter 
-      at ServerRoot  The above error occurred in the <Page> component. It was handled by the <ReactDevOverlay> error boundary."
+      at react-stack-bottom-frame 
+      at renderWithHooks 
+      at updateFunctionComponent 
+      at beginWork 
+      at runWithFiberInDEV 
+      at performUnitOfWork 
+      at workLoopSync 
+      at renderRootSync 
+      at performWorkOnRoot 
+      at performWorkOnRootViaSchedulerTask 
+      at MessagePort.performWorkUntilDeadline  The above error occurred in the <Page> component. It was handled by the <ReactDevOverlay> error boundary."
     `)
   })
 

--- a/test/development/app-dir/owner-stack/owner-stack.test.ts
+++ b/test/development/app-dir/owner-stack/owner-stack.test.ts
@@ -78,17 +78,11 @@ describe('app-dir - owner-stack', () => {
         at useThrowError 
         at useErrorHook 
         at Page 
-        at react-stack-bottom-frame 
-        at renderWithHooks 
-        at updateFunctionComponent 
-        at beginWork 
-        at runWithFiberInDEV 
-        at performUnitOfWork 
-        at workLoopSync 
-        at renderRootSync 
-        at performWorkOnRoot 
-        at performWorkOnRootViaSchedulerTask 
-        at MessagePort.performWorkUntilDeadline 
+        at NotFoundBoundary 
+        at DevRootNotFoundBoundary 
+        at Router 
+        at AppRouter 
+        at ServerRoot 
         The above error occurred in the <Page> component. It was handled by the <ReactDevOverlay> error boundary."
       `)
     } else {
@@ -97,17 +91,11 @@ describe('app-dir - owner-stack', () => {
         at useThrowError 
         at useErrorHook 
         at Page 
-        at react-stack-bottom-frame 
-        at renderWithHooks 
-        at updateFunctionComponent 
-        at beginWork 
-        at runWithFiberInDEV 
-        at performUnitOfWork 
-        at workLoopSync 
-        at renderRootSync 
-        at performWorkOnRoot 
-        at performWorkOnRootViaSchedulerTask 
-        at MessagePort.performWorkUntilDeadline 
+        at NotFoundBoundary 
+        at DevRootNotFoundBoundary 
+        at Router 
+        at AppRouter 
+        at ServerRoot 
         The above error occurred in the <Page> component. It was handled by the <ReactDevOverlay> error boundary."
       `)
     }
@@ -148,17 +136,9 @@ describe('app-dir - owner-stack', () => {
       at useThrowError 
       at useErrorHook 
       at Thrower 
-      at react-stack-bottom-frame 
-      at renderWithHooks 
-      at updateFunctionComponent 
-      at beginWork 
-      at runWithFiberInDEV 
-      at performUnitOfWork 
-      at workLoopSync 
-      at renderRootSync 
-      at performWorkOnRoot 
-      at performWorkOnRootViaSchedulerTask 
-      at MessagePort.performWorkUntilDeadline 
+      at Inner 
+      at Page 
+      at ClientPageRoot 
       The above error occurred in the <Thrower> component. It was handled by the <MyErrorBoundary> error boundary."
     `)
   })
@@ -191,17 +171,11 @@ describe('app-dir - owner-stack', () => {
       at useThrowError 
       at useErrorHook 
       at Page 
-      at react-stack-bottom-frame 
-      at renderWithHooks 
-      at updateFunctionComponent 
-      at beginWork 
-      at runWithFiberInDEV 
-      at performUnitOfWork 
-      at workLoopSync 
-      at renderRootSync 
-      at performWorkOnRoot 
-      at performWorkOnRootViaSchedulerTask 
-      at MessagePort.performWorkUntilDeadline 
+      at NotFoundBoundary 
+      at DevRootNotFoundBoundary 
+      at Router 
+      at AppRouter 
+      at ServerRoot 
       The above error occurred in the <Page> component. It was handled by the <ReactDevOverlay> error boundary."
     `)
   })

--- a/test/development/app-dir/owner-stack/owner-stack.test.ts
+++ b/test/development/app-dir/owner-stack/owner-stack.test.ts
@@ -74,7 +74,8 @@ describe('app-dir - owner-stack', () => {
 
     if (process.env.TURBOPACK) {
       expect(normalizeStackTrace(errorLog)).toMatchInlineSnapshot(`
-        "Error: browser error
+        "%o
+        %s Error: browser error
         at useThrowError 
         at useErrorHook 
         at Page 
@@ -82,12 +83,12 @@ describe('app-dir - owner-stack', () => {
         at DevRootNotFoundBoundary 
         at Router 
         at AppRouter 
-        at ServerRoot 
-        The above error occurred in the <Page> component. It was handled by the <ReactDevOverlay> error boundary."
+        at ServerRoot  The above error occurred in the <Page> component. It was handled by the <ReactDevOverlay> error boundary."
       `)
     } else {
       expect(normalizeStackTrace(errorLog)).toMatchInlineSnapshot(`
-        "Error: browser error
+        "%o
+        %s Error: browser error
         at useThrowError 
         at useErrorHook 
         at Page 
@@ -95,8 +96,7 @@ describe('app-dir - owner-stack', () => {
         at DevRootNotFoundBoundary 
         at Router 
         at AppRouter 
-        at ServerRoot 
-        The above error occurred in the <Page> component. It was handled by the <ReactDevOverlay> error boundary."
+        at ServerRoot  The above error occurred in the <Page> component. It was handled by the <ReactDevOverlay> error boundary."
       `)
     }
   })
@@ -132,14 +132,14 @@ describe('app-dir - owner-stack', () => {
     }
 
     expect(normalizeStackTrace(errorLog)).toMatchInlineSnapshot(`
-      "Error: browser error
+      "%o
+      %s Error: browser error
       at useThrowError 
       at useErrorHook 
       at Thrower 
       at Inner 
       at Page 
-      at ClientPageRoot 
-      The above error occurred in the <Thrower> component. It was handled by the <MyErrorBoundary> error boundary."
+      at ClientPageRoot  The above error occurred in the <Thrower> component. It was handled by the <MyErrorBoundary> error boundary."
     `)
   })
 
@@ -167,7 +167,8 @@ describe('app-dir - owner-stack', () => {
     }).message
 
     expect(normalizeStackTrace(errorLog)).toMatchInlineSnapshot(`
-      "Error: ssr error
+      "%o
+      %s Error: ssr error
       at useThrowError 
       at useErrorHook 
       at Page 
@@ -175,8 +176,7 @@ describe('app-dir - owner-stack', () => {
       at DevRootNotFoundBoundary 
       at Router 
       at AppRouter 
-      at ServerRoot 
-      The above error occurred in the <Page> component. It was handled by the <ReactDevOverlay> error boundary."
+      at ServerRoot  The above error occurred in the <Page> component. It was handled by the <ReactDevOverlay> error boundary."
     `)
   })
 


### PR DESCRIPTION
### What

Log the origin error instance with the modified stack instead of only logging the modified stack string

### Why

React DevTool can still intercept the origin error or the native browser takes care of it.