### PR TITLE
codemod(turbopack): Rewrite Vc fields in structs as ResolvedVc (part 6)

### DIFF
--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -8,7 +8,7 @@ use next_core::{
     util::{parse_config_from_source, MiddlewareMatcherKind},
 };
 use tracing::Instrument;
-use turbo_tasks::{Completion, RcStr, Value, Vc};
+use turbo_tasks::{Completion, RcStr, ResolvedVc, Value, Vc};
 use turbo_tasks_fs::{self, File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent,
@@ -36,8 +36,8 @@ pub struct MiddlewareEndpoint {
     project: Vc<Project>,
     asset_context: Vc<Box<dyn AssetContext>>,
     source: Vc<Box<dyn Source>>,
-    app_dir: Option<Vc<FileSystemPath>>,
-    ecmascript_client_reference_transition_name: Option<Vc<RcStr>>,
+    app_dir: Option<ResolvedVc<FileSystemPath>>,
+    ecmascript_client_reference_transition_name: Option<ResolvedVc<RcStr>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -47,8 +47,8 @@ impl MiddlewareEndpoint {
         project: Vc<Project>,
         asset_context: Vc<Box<dyn AssetContext>>,
         source: Vc<Box<dyn Source>>,
-        app_dir: Option<Vc<FileSystemPath>>,
-        ecmascript_client_reference_transition_name: Option<Vc<RcStr>>,
+        app_dir: Option<ResolvedVc<FileSystemPath>>,
+        ecmascript_client_reference_transition_name: Option<ResolvedVc<RcStr>>,
     ) -> Vc<Self> {
         Self {
             project,
@@ -85,9 +85,10 @@ impl MiddlewareEndpoint {
 
         let mut evaluatable_assets = get_server_runtime_entries(
             Value::new(ServerContextType::Middleware {
-                app_dir: self.app_dir,
+                app_dir: self.app_dir.map(|v| *v),
                 ecmascript_client_reference_transition_name: self
-                    .ecmascript_client_reference_transition_name,
+                    .ecmascript_client_reference_transition_name
+                    .map(|v| *v), // Dereference the ResolvedVc to get back a Vc
             }),
             self.project.next_mode(),
         )

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -85,10 +85,11 @@ impl MiddlewareEndpoint {
 
         let mut evaluatable_assets = get_server_runtime_entries(
             Value::new(ServerContextType::Middleware {
-                app_dir: self.app_dir.map(|v| *v),
+                app_dir: self.app_dir.as_deref().copied(),
                 ecmascript_client_reference_transition_name: self
                     .ecmascript_client_reference_transition_name
-                    .map(|v| *v), // Dereference the ResolvedVc to get back a Vc
+                    .as_deref()
+                    .copied(),
             }),
             self.project.next_mode(),
         )

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -139,8 +139,8 @@ impl PagesProject {
             Ok(())
         }
 
-        if let Some(api) = api {
-            add_dir_to_routes(&mut routes, **api, |pathname, original_name, page| {
+        if let Some(api) = *api {
+            add_dir_to_routes(&mut routes, *api, |pathname, original_name, page| {
                 Route::PageApi {
                     endpoint: Vc::upcast(PageEndpoint::new(
                         PageEndpointType::Api,
@@ -174,8 +174,8 @@ impl PagesProject {
             )),
         };
 
-        if let Some(pages) = pages {
-            add_dir_to_routes(&mut routes, **pages, make_page_route).await?;
+        if let Some(pages) = *pages {
+            add_dir_to_routes(&mut routes, *pages, make_page_route).await?;
         }
 
         for route in routes.values_mut() {

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -140,7 +140,7 @@ impl PagesProject {
         }
 
         if let Some(api) = api {
-            add_dir_to_routes(&mut routes, *api, |pathname, original_name, page| {
+            add_dir_to_routes(&mut routes, **api, |pathname, original_name, page| {
                 Route::PageApi {
                     endpoint: Vc::upcast(PageEndpoint::new(
                         PageEndpointType::Api,
@@ -175,7 +175,7 @@ impl PagesProject {
         };
 
         if let Some(pages) = pages {
-            add_dir_to_routes(&mut routes, *pages, make_page_route).await?;
+            add_dir_to_routes(&mut routes, **pages, make_page_route).await?;
         }
 
         for route in routes.values_mut() {

--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -344,7 +344,7 @@ impl AppPageLoaderTreeBuilder {
             .await?;
         self.write_modules_entry(AppDirModuleType::DefaultPage, *default)
             .await?;
-        self.write_modules_entry(AppDirModuleType::GlobalError, *global_error)
+        self.write_modules_entry(AppDirModuleType::GlobalError, global_error.map(|err| *err))
             .await?;
 
         let modules_code = replace(&mut self.loader_tree_code, temp_loader_tree_code);

--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -373,7 +373,7 @@ impl AppPageLoaderTreeBuilder {
         if let Some(global_error) = modules.global_error {
             let module = self
                 .base
-                .process_source(Vc::upcast(FileSource::new(global_error)));
+                .process_source(Vc::upcast(FileSource::new(*global_error)));
             self.base.inner_assets.insert(GLOBAL_ERROR.into(), module);
         };
 

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -296,19 +296,18 @@ async fn get_directory_tree_internal(
                 if basename.ends_with(".d.ts") {
                     continue;
                 }
-                let resolved_file = file.to_resolved().await?;
                 if let Some((stem, ext)) = basename.split_once('.') {
                     if page_extensions_value.iter().any(|e| e == ext) {
                         match stem {
-                            "page" => modules.page = Some(*resolved_file),
-                            "layout" => modules.layout = Some(*resolved_file),
-                            "error" => modules.error = Some(*resolved_file),
-                            "global-error" => modules.global_error = Some(resolved_file),
-                            "loading" => modules.loading = Some(*resolved_file),
-                            "template" => modules.template = Some(*resolved_file),
-                            "not-found" => modules.not_found = Some(*resolved_file),
-                            "default" => modules.default = Some(*resolved_file),
-                            "route" => modules.route = Some(resolved_file),
+                            "page" => modules.page = Some(*file),
+                            "layout" => modules.layout = Some(*file),
+                            "error" => modules.error = Some(*file),
+                            "global-error" => modules.global_error = Some(file),
+                            "loading" => modules.loading = Some(*file),
+                            "template" => modules.template = Some(*file),
+                            "not-found" => modules.not_found = Some(*file),
+                            "default" => modules.default = Some(*file),
+                            "route" => modules.route = Some(file),
                             _ => {}
                         }
                     }
@@ -330,13 +329,9 @@ async fn get_directory_tree_internal(
                     "opengraph-image" => &mut metadata_open_graph,
                     "sitemap" => {
                         if dynamic {
-                            modules.metadata.sitemap = Some(MetadataItem::Dynamic {
-                                path: *resolved_file,
-                            });
+                            modules.metadata.sitemap = Some(MetadataItem::Dynamic { path: *file });
                         } else {
-                            modules.metadata.sitemap = Some(MetadataItem::Static {
-                                path: *resolved_file,
-                            });
+                            modules.metadata.sitemap = Some(MetadataItem::Static { path: *file });
                         }
                         continue;
                     }
@@ -344,12 +339,7 @@ async fn get_directory_tree_internal(
                 };
 
                 if dynamic {
-                    entry.push((
-                        number,
-                        MetadataWithAltItem::Dynamic {
-                            path: *resolved_file,
-                        },
-                    ));
+                    entry.push((number, MetadataWithAltItem::Dynamic { path: *file }));
                     continue;
                 }
 
@@ -365,7 +355,7 @@ async fn get_directory_tree_internal(
                 entry.push((
                     number,
                     MetadataWithAltItem::Static {
-                        path: *resolved_file,
+                        path: *file,
                         alt_path,
                     },
                 ));

--- a/crates/next-core/src/next_dynamic/visit_dynamic.rs
+++ b/crates/next-core/src/next_dynamic/visit_dynamic.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use tracing::Instrument;
 use turbo_tasks::{
     graph::{AdjacencyMap, GraphTraversal, Visit, VisitControlFlow},
-    RcStr, ReadRef, TryJoinIterExt, ValueToString, Vc,
+    RcStr, ReadRef, ResolvedVc, TryJoinIterExt, ValueToString, Vc,
 };
 use turbopack_core::{
     module::{Module, Modules},
@@ -29,7 +29,10 @@ impl NextDynamicEntries {
                         .iter()
                         .copied()
                         .map(|m| async move {
-                            Ok(VisitDynamicNode::Internal(m, m.ident().to_string().await?))
+                            Ok(VisitDynamicNode::Internal(
+                                m.to_resolved().await?,
+                                m.ident().to_string().await?,
+                            ))
                         })
                         .try_join()
                         .await?,
@@ -50,7 +53,7 @@ impl NextDynamicEntries {
                         // traversal.
                     }
                     VisitDynamicNode::Dynamic(dynamic_asset, _) => {
-                        next_dynamics.push(dynamic_asset);
+                        next_dynamics.push(dynamic_asset.resolve().await?);
                     }
                 }
             }
@@ -66,8 +69,8 @@ struct VisitDynamic;
 
 #[derive(Clone, Eq, PartialEq, Hash)]
 enum VisitDynamicNode {
-    Dynamic(Vc<NextDynamicEntryModule>, ReadRef<RcStr>),
-    Internal(Vc<Box<dyn Module>>, ReadRef<RcStr>),
+    Dynamic(ResolvedVc<NextDynamicEntryModule>, ReadRef<RcStr>),
+    Internal(ResolvedVc<Box<dyn Module>>, ReadRef<RcStr>),
 }
 
 impl Visit<VisitDynamicNode> for VisitDynamic {
@@ -85,16 +88,16 @@ impl Visit<VisitDynamicNode> for VisitDynamic {
         let node = node.clone();
         async move {
             let module = match node {
-                VisitDynamicNode::Dynamic(dynamic_module, _) => Vc::upcast(dynamic_module),
-                VisitDynamicNode::Internal(module, _) => module,
+                VisitDynamicNode::Dynamic(dynamic_module, _) => ResolvedVc::upcast(dynamic_module),
+                VisitDynamicNode::Internal(module, _) => module.to_resolved().await?,
             };
 
-            let referenced_modules = primary_referenced_modules(module).await?;
+            let referenced_modules = primary_referenced_modules(*module).await?;
 
             let referenced_modules = referenced_modules.iter().map(|module| async move {
-                let module = module.resolve().await?;
+                let module = module.to_resolved().await?;
                 if let Some(next_dynamic_module) =
-                    Vc::try_resolve_downcast_type::<NextDynamicEntryModule>(module).await?
+                    ResolvedVc::try_downcast_type::<NextDynamicEntryModule>(module).await?
                 {
                     return Ok(VisitDynamicNode::Dynamic(
                         next_dynamic_module,
@@ -103,7 +106,7 @@ impl Visit<VisitDynamicNode> for VisitDynamic {
                 }
 
                 Ok(VisitDynamicNode::Internal(
-                    module,
+                    module, // Removed the dereference since module is already a ResolvedVc
                     module.ident().to_string().await?,
                 ))
             });

--- a/crates/next-core/src/next_dynamic/visit_dynamic.rs
+++ b/crates/next-core/src/next_dynamic/visit_dynamic.rs
@@ -53,7 +53,7 @@ impl NextDynamicEntries {
                         // traversal.
                     }
                     VisitDynamicNode::Dynamic(dynamic_asset, _) => {
-                        next_dynamics.push(dynamic_asset.resolve().await?);
+                        next_dynamics.push(*dynamic_asset);
                     }
                 }
             }
@@ -89,7 +89,7 @@ impl Visit<VisitDynamicNode> for VisitDynamic {
         async move {
             let module = match node {
                 VisitDynamicNode::Dynamic(dynamic_module, _) => ResolvedVc::upcast(dynamic_module),
-                VisitDynamicNode::Internal(module, _) => module.to_resolved().await?,
+                VisitDynamicNode::Internal(module, _) => module,
             };
 
             let referenced_modules = primary_referenced_modules(*module).await?;
@@ -106,7 +106,7 @@ impl Visit<VisitDynamicNode> for VisitDynamic {
                 }
 
                 Ok(VisitDynamicNode::Internal(
-                    module, // Removed the dereference since module is already a ResolvedVc
+                    module,
                     module.ident().to_string().await?,
                 ))
             });

--- a/crates/next-core/src/next_image/source_asset.rs
+++ b/crates/next-core/src/next_image/source_asset.rs
@@ -58,7 +58,7 @@ impl Asset for StructuredImageFileSource {
         let blur_options = blur_options();
         match self.blur_placeholder_mode {
             BlurPlaceholderMode::NextImageUrl => {
-                let info = get_meta_data(self.image.ident(), content, None).await?;
+                let info = get_meta_data(self.image.ident(), *content, None).await?;
                 let width = info.width;
                 let height = info.height;
                 let blur_options = blur_options.await?;
@@ -86,7 +86,7 @@ impl Asset for StructuredImageFileSource {
                 )?;
             }
             BlurPlaceholderMode::DataUrl => {
-                let info = get_meta_data(self.image.ident(), content, Some(blur_options)).await?;
+                let info = get_meta_data(self.image.ident(), *content, Some(blur_options)).await?;
                 writeln!(
                     result,
                     "export default {{ src, width: {width}, height: {height}, blurDataURL: \
@@ -102,7 +102,7 @@ impl Asset for StructuredImageFileSource {
                 )?;
             }
             BlurPlaceholderMode::None => {
-                let info = get_meta_data(self.image.ident(), content, None).await?;
+                let info = get_meta_data(self.image.ident(), *content, None).await?;
                 writeln!(
                     result,
                     "export default {{ src, width: {width}, height: {height} }}",
@@ -111,6 +111,6 @@ impl Asset for StructuredImageFileSource {
                 )?;
             }
         };
-        Ok(AssetContent::File(FileContent::Content(result.build().into()).cell()).cell())
+        Ok(AssetContent::File(FileContent::Content(result.build().into()).resolved_cell()).cell())
     }
 }

--- a/crates/next-core/src/pages_structure.rs
+++ b/crates/next-core/src/pages_structure.rs
@@ -197,13 +197,16 @@ async fn get_pages_structure_for_root_directory(
                     }
                     DirectoryEntry::Directory(dir_project_path) => match name.as_str() {
                         "api" => {
-                            let api_structure = get_pages_structure_for_directory(
-                                *dir_project_path,
-                                next_router_path.join(name.clone()),
-                                1,
-                                page_extensions,
+                            api_directory = Some(
+                                get_pages_structure_for_directory(
+                                    *dir_project_path,
+                                    next_router_path.join(name.clone()),
+                                    1,
+                                    page_extensions,
+                                )
+                                .to_resolved()
+                                .await?,
                             );
-                            api_directory = Some(api_structure.to_resolved().await?);
                         }
                         _ => {
                             children.push((

--- a/crates/next-core/src/pages_structure.rs
+++ b/crates/next-core/src/pages_structure.rs
@@ -67,8 +67,8 @@ pub struct PagesStructure {
     pub app: Vc<PagesStructureItem>,
     pub document: Vc<PagesStructureItem>,
     pub error: Vc<PagesStructureItem>,
-    pub api: Option<Vc<PagesDirectoryStructure>>,
-    pub pages: Option<Vc<PagesDirectoryStructure>>,
+    pub api: Option<ResolvedVc<PagesDirectoryStructure>>,
+    pub pages: Option<ResolvedVc<PagesDirectoryStructure>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -197,12 +197,13 @@ async fn get_pages_structure_for_root_directory(
                     }
                     DirectoryEntry::Directory(dir_project_path) => match name.as_str() {
                         "api" => {
-                            api_directory = Some(get_pages_structure_for_directory(
+                            let api_structure = get_pages_structure_for_directory(
                                 *dir_project_path,
                                 next_router_path.join(name.clone()),
                                 1,
                                 page_extensions,
-                            ));
+                            );
+                            api_directory = Some(api_structure.to_resolved().await?);
                         }
                         _ => {
                             children.push((
@@ -232,7 +233,7 @@ async fn get_pages_structure_for_root_directory(
                 items: items.into_iter().map(|(_, v)| v).collect(),
                 children: children.into_iter().map(|(_, v)| v).collect(),
             }
-            .cell(),
+            .resolved_cell(),
         )
     } else {
         None

--- a/turbopack/crates/turbopack-core/src/asset.rs
+++ b/turbopack/crates/turbopack-core/src/asset.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{Completion, RcStr, Vc};
+use turbo_tasks::{Completion, RcStr, ResolvedVc, Vc};
 use turbo_tasks_fs::{
     FileContent, FileJsonContent, FileLinesContent, FileSystemPath, LinkContent, LinkType,
 };
@@ -21,7 +21,7 @@ pub trait Asset {
 #[turbo_tasks::value(shared)]
 #[derive(Clone)]
 pub enum AssetContent {
-    File(Vc<FileContent>),
+    File(ResolvedVc<FileContent>),
     // for the relative link, the target is raw value read from the link
     // for the absolute link, the target is stripped of the root path while reading
     // See [LinkContent::Link] for more details.
@@ -31,8 +31,8 @@ pub enum AssetContent {
 #[turbo_tasks::value_impl]
 impl AssetContent {
     #[turbo_tasks::function]
-    pub fn file(file: Vc<FileContent>) -> Vc<Self> {
-        AssetContent::File(file).cell()
+    pub async fn file(file: Vc<FileContent>) -> Result<Vc<Self>> {
+        Ok(AssetContent::File(file.to_resolved().await?).cell())
     }
 
     #[turbo_tasks::function]
@@ -50,7 +50,7 @@ impl AssetContent {
     pub async fn file_content(self: Vc<Self>) -> Result<Vc<FileContent>> {
         let this = self.await?;
         match &*this {
-            AssetContent::File(content) => Ok(*content),
+            AssetContent::File(content) => Ok(**content),
             AssetContent::Redirect { .. } => Ok(FileContent::NotFound.cell()),
         }
     }
@@ -88,7 +88,7 @@ impl AssetContent {
     pub async fn write(self: Vc<Self>, path: Vc<FileSystemPath>) -> Result<Vc<Completion>> {
         let this = self.await?;
         Ok(match &*this {
-            AssetContent::File(file) => path.write(*file),
+            AssetContent::File(file) => path.write(**file),
             AssetContent::Redirect { target, link_type } => path.write_link(
                 LinkContent::Link {
                     target: target.clone(),

--- a/turbopack/crates/turbopack-core/src/asset.rs
+++ b/turbopack/crates/turbopack-core/src/asset.rs
@@ -31,8 +31,8 @@ pub enum AssetContent {
 #[turbo_tasks::value_impl]
 impl AssetContent {
     #[turbo_tasks::function]
-    pub async fn file(file: Vc<FileContent>) -> Result<Vc<Self>> {
-        Ok(AssetContent::File(file.to_resolved().await?).cell())
+    pub async fn file(file: ResolvedVc<FileContent>) -> Result<Vc<Self>> {
+        Ok(AssetContent::File(file).cell())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/chunk/chunking.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking.rs
@@ -106,7 +106,14 @@ pub async fn make_chunks(
         }
     }
 
-    Ok(Vc::cell(chunks))
+    // Resolve all chunks before returning
+    let resolved_chunks = chunks
+        .into_iter()
+        .map(|chunk| chunk.to_resolved())
+        .try_join()
+        .await?;
+
+    Ok(Vc::cell(resolved_chunks))
 }
 
 type ChunkItemWithInfo = (

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -96,7 +96,7 @@ pub trait ChunkableModule: Module + Asset {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct Chunks(Vec<Vc<Box<dyn Chunk>>>);
+pub struct Chunks(Vec<ResolvedVc<Box<dyn Chunk>>>);
 
 #[turbo_tasks::value_impl]
 impl Chunks {

--- a/turbopack/crates/turbopack-core/src/file_source.rs
+++ b/turbopack/crates/turbopack-core/src/file_source.rs
@@ -54,9 +54,11 @@ impl Asset for FileSource {
                 .cell()),
                 _ => Err(anyhow::anyhow!("Invalid symlink")),
             },
-            FileSystemEntryType::File => Ok(AssetContent::File(self.path.read()).cell()),
+            FileSystemEntryType::File => {
+                Ok(AssetContent::File(self.path.read().to_resolved().await?).cell())
+            }
             FileSystemEntryType::NotFound => {
-                Ok(AssetContent::File(FileContent::NotFound.cell()).cell())
+                Ok(AssetContent::File(FileContent::NotFound.cell().to_resolved().await?).cell())
             }
             _ => Err(anyhow::anyhow!("Invalid file type {:?}", file_type)),
         }

--- a/turbopack/crates/turbopack-core/src/file_source.rs
+++ b/turbopack/crates/turbopack-core/src/file_source.rs
@@ -58,7 +58,7 @@ impl Asset for FileSource {
                 Ok(AssetContent::File(self.path.read().to_resolved().await?).cell())
             }
             FileSystemEntryType::NotFound => {
-                Ok(AssetContent::File(FileContent::NotFound.cell().to_resolved().await?).cell())
+                Ok(AssetContent::File(FileContent::NotFound.resolved_cell()).cell())
             }
             _ => Err(anyhow::anyhow!("Invalid file type {:?}", file_type)),
         }

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -502,7 +502,7 @@ pub async fn parse_css(
                     Err(_err) => ParseCssResult::Unparseable.cell(),
                     Ok(string) => {
                         process_content(
-                            *file_content,
+                            **file_content,
                             string.into_owned(),
                             fs_path,
                             ident_str,

--- a/turbopack/crates/turbopack-mdx/src/lib.rs
+++ b/turbopack/crates/turbopack-mdx/src/lib.rs
@@ -224,7 +224,7 @@ impl MdxTransformedAsset {
                 .emit();
 
                 Ok(MdxTransformResult {
-                    content: AssetContent::File(FileContent::NotFound.cell()).cell(),
+                    content: AssetContent::File(FileContent::NotFound.resolved_cell()).cell(),
                 }
                 .cell())
             }

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -436,6 +436,17 @@ impl PostCssTransformedAsset {
             env,
         } = *self.execution_context.await?;
 
+        // For this postcss transform, there is no gaurantee that looking up for the
+        // source path will arrives specific project config for the postcss.
+        // i.e, this is possible
+        // - root
+        //  - node_modules
+        //     - somepkg/(some.module.css, postcss.config.js) // this could be symlinked local, or
+        //       actual remote pkg or anything
+        //  - packages // root of workspace pkgs
+        //     - pkg1/(postcss.config.js) // The actual config we're looking for
+        //
+        // We look for the config in the project path first, then the source path
         let Some(config_path) =
             find_config_in_location(project_path, self.config_location, self.source).await?
         else {

--- a/turbopack/crates/turbopack-node/src/transforms/util.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/util.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
-use turbo_tasks::{RcStr, ResolvedVc, TryJoinIterExt};
+use turbo_tasks::{RcStr, ResolvedVc};
 use turbo_tasks_fs::{File, FileContent, FileSystem};
 use turbopack_core::{
     asset::AssetContent, server_fs::ServerFileSystem, virtual_source::VirtualSource,
@@ -20,7 +20,8 @@ pub struct EmittedAsset {
 pub async fn emitted_assets_to_virtual_sources(
     assets: Option<Vec<EmittedAsset>>,
 ) -> Result<Vec<ResolvedVc<VirtualSource>>> {
-    assets
+    let mut result = Vec::new();
+    let file_pairs: BTreeMap<_, _> = assets
         .into_iter()
         .flatten()
         .map(
@@ -30,17 +31,21 @@ pub async fn emitted_assets_to_virtual_sources(
                  source_map,
              }| (file, (content, source_map)),
         )
-        // Sort it to make it determinstic
-        .collect::<BTreeMap<_, _>>()
-        .into_iter()
-        .map(|(file, (content, _source_map))| {
-            // TODO handle SourceMap
-            VirtualSource::new(
-                ServerFileSystem::new().root().join(file),
-                AssetContent::File(FileContent::Content(File::from(content)).cell()).cell(),
-            )
+        .collect();
+
+    for (file, (content, _source_map)) in file_pairs {
+        // TODO handle SourceMap
+        let file_content = FileContent::Content(File::from(content))
+            .cell()
             .to_resolved()
-        })
-        .try_join()
-        .await
+            .await?;
+        let source = VirtualSource::new(
+            ServerFileSystem::new().root().join(file),
+            AssetContent::File(file_content).cell(),
+        )
+        .to_resolved()
+        .await?;
+        result.push(source);
+    }
+    Ok(result)
 }

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -258,11 +258,9 @@ impl WebpackLoadersProcessedAsset {
 
         // handle SourceMap
         let source_map = if let Some(source_map) = processed.map {
-            SourceMap::new_from_file_content(
-                *FileContent::Content(File::from(source_map)).resolved_cell(),
-            )
-            .await?
-            .map(|source_map| source_map.cell())
+            SourceMap::new_from_file_content(FileContent::Content(File::from(source_map)).cell())
+                .await?
+                .map(|source_map| source_map.cell())
         } else {
             None
         };

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -200,7 +200,7 @@ impl WebpackLoadersProcessedAsset {
         };
         let FileContent::Content(content) = &*file.await? else {
             return Ok(ProcessWebpackLoadersResult {
-                content: AssetContent::File(FileContent::NotFound.cell()).cell(),
+                content: AssetContent::File(FileContent::NotFound.resolved_cell()).cell(),
                 assets: Vec::new(),
                 source_map: None,
             }
@@ -245,7 +245,7 @@ impl WebpackLoadersProcessedAsset {
         let SingleValue::Single(val) = config_value.try_into_single().await? else {
             // An error happened, which has already been converted into an issue.
             return Ok(ProcessWebpackLoadersResult {
-                content: AssetContent::File(FileContent::NotFound.cell()).cell(),
+                content: AssetContent::File(FileContent::NotFound.resolved_cell()).cell(),
                 assets: Vec::new(),
                 source_map: None,
             }
@@ -258,9 +258,11 @@ impl WebpackLoadersProcessedAsset {
 
         // handle SourceMap
         let source_map = if let Some(source_map) = processed.map {
-            SourceMap::new_from_file_content(FileContent::Content(File::from(source_map)).cell())
-                .await?
-                .map(|source_map| source_map.cell())
+            SourceMap::new_from_file_content(
+                *FileContent::Content(File::from(source_map)).resolved_cell(),
+            )
+            .await?
+            .map(|source_map| source_map.cell())
         } else {
             None
         };
@@ -273,7 +275,7 @@ impl WebpackLoadersProcessedAsset {
             .into_iter()
             .map(|asset| *asset)
             .collect();
-        let content = AssetContent::File(FileContent::Content(file).cell()).cell();
+        let content = AssetContent::File(FileContent::Content(file).resolved_cell()).cell();
         Ok(ProcessWebpackLoadersResult {
             content,
             assets,

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -905,7 +905,7 @@ async fn top_references(list: Vc<ReferencesList>) -> Result<Vc<ReferencesList>> 
     Ok(ReferencesList {
         referenced_by: top
             .into_iter()
-            .map(|(asset, set)| (asset.clone(), set.clone()))
+            .map(|(asset, set)| (*asset, set.clone()))
             .collect(),
     }
     .into())


### PR DESCRIPTION
Generated using a version of https://github.com/vercel/turbopack-resolved-vc-codemod . This uses Anthropic Claude Sonnet 3.5 for more complicated errors we don't have hardcoded logic for.

- Part 1: #70927
- Part 2: #71172
- Part 3: #71665
- Part 4: #71804
- Part 5: #71861

Closes PACK-3342