### PR TITLE
fix: webpack build error on Windows

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -107,7 +107,7 @@ const buffer = Buffer.from(${JSON.stringify(
 if (${isTwitter || isOpenGraph}) {
   const fileSizeInMB = buffer.byteLength / 1024 / 1024
   if (fileSizeInMB > ${fileSizeLimit}) {
-    throw new Error('File size for ${imgName} image "${resourcePath}" exceeds ${fileSizeLimit}MB. ' +
+    throw new Error('File size for ${imgName} image "${JSON.stringify(resourcePath)}" exceeds ${fileSizeLimit}MB. ' +
     \`(Current: \${fileSizeInMB.toFixed(2)}MB)\n\` +
     'Read more: https://nextjs.org/docs/app/api-reference/file-conventions/metadata/opengraph-image#image-files-jpg-png-gif'
     )

--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -105,7 +105,7 @@ const buffer = Buffer.from(${JSON.stringify(
 if (${isTwitter || isOpenGraph}) {
   const fileSizeInMB = buffer.byteLength / 1024 / 1024
   if (fileSizeInMB > ${fileSizeLimit}) {
-    throw new Error('File size for ${imgName} image "${JSON.stringify(resourcePath)}" exceeds ${fileSizeLimit}MB. ' +
+    throw new Error('File size for ${imgName} image ${JSON.stringify(resourcePath)} exceeds ${fileSizeLimit}MB. ' +
     \`(Current: \${fileSizeInMB.toFixed(2)}MB)\n\` +
     'Read more: https://nextjs.org/docs/app/api-reference/file-conventions/metadata/opengraph-image#image-files-jpg-png-gif'
     )

--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -76,8 +76,6 @@ async function getStaticAssetRouteCode(
   resourcePath: string,
   fileBaseName: string
 ) {
-  resourcePath = path.posix.normalize(resourcePath)
-
   const cache =
     fileBaseName === 'favicon'
       ? 'public, max-age=0, must-revalidate'


### PR DESCRIPTION
### What?
With Next 15.0.1, when using webpack, there is a build error for the `favicon.ico` file.

Had the build error when creating a new project with create-next-app@latest without Turbopack and running `npm run dev`.
The error appeared after refreshing the page a few times or after hitting Ctrl + F5 once.
I've included more details in my comment on the issue : https://github.com/vercel/next.js/issues/71582#issuecomment-2440188399

### Why?
On Windows, backslashes (`\`) + other characters in the path get interpreted as escape characters or octal literals by webpack, leading to a build error.

### How?
Wrapping `resourcePath` with `JSON.stringify()` ensures that the path is correctly treated as a string. This prevents webpack from interpreting backslashes + other characters, fixing the build error on Windows.

Currently, `JSON.stringify()` is already used for the `resourcePath` variable when throwing an error here in the same file :
```ts
function errorOnBadHandler(resourcePath: string) {
  return `
  if (typeof handler !== 'function') {
    throw new Error('Default export is missing in ${JSON.stringify(
      resourcePath
    )}')
  }
  `
}
```

When using the `resourcePath` variable for throwing an error, it has to be wrapped with `JSON.stringify()` as it is already the case on another line in the same file to avoid a webpack build error.

Fixes #71582

### Fixing a bug
- [x] Related issues linked using `fixes #number`