### PR TITLE
refactor(turbopack-core): Change `Modules` type to use ResolvedVc

### DIFF
--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -28,7 +28,7 @@ use turbopack_core::{
 use turbopack_ecmascript::{parse::ParseResult, resolve::esm_resolve, EcmascriptParsable};
 
 async fn collect_chunk_group_inner<F, Fu>(
-    dynamic_import_entries: FxIndexMap<Vc<Box<dyn Module>>, DynamicImportedModules>,
+    dynamic_import_entries: FxIndexMap<ResolvedVc<Box<dyn Module>>, DynamicImportedModules>,
     mut build_chunk: F,
 ) -> Result<Vc<DynamicImportedChunks>>
 where
@@ -46,7 +46,7 @@ where
                 *chunk
             } else {
                 let Some(module) =
-                    Vc::try_resolve_sidecast::<Box<dyn ChunkableModule>>(imported_module).await?
+                    ResolvedVc::try_sidecast::<Box<dyn ChunkableModule>>(imported_module).await?
                 else {
                     bail!("module must be evaluatable");
                 };
@@ -57,7 +57,7 @@ where
                 // naive hash to have additional
                 // chunks in case if there are same modules being imported in different
                 // origins.
-                let chunk_group = build_chunk(module).await?;
+                let chunk_group = build_chunk(*module).await?;
                 chunks_hash.insert(imported_raw_str.clone(), chunk_group);
                 chunk_group
             };
@@ -74,7 +74,7 @@ where
 
 pub(crate) async fn collect_chunk_group(
     chunking_context: Vc<Box<dyn ChunkingContext>>,
-    dynamic_import_entries: FxIndexMap<Vc<Box<dyn Module>>, DynamicImportedModules>,
+    dynamic_import_entries: FxIndexMap<ResolvedVc<Box<dyn Module>>, DynamicImportedModules>,
     availability_info: Value<AvailabilityInfo>,
 ) -> Result<Vc<DynamicImportedChunks>> {
     collect_chunk_group_inner(dynamic_import_entries, |module| async move {
@@ -85,7 +85,7 @@ pub(crate) async fn collect_chunk_group(
 
 pub(crate) async fn collect_evaluated_chunk_group(
     chunking_context: Vc<Box<dyn ChunkingContext>>,
-    dynamic_import_entries: FxIndexMap<Vc<Box<dyn Module>>, DynamicImportedModules>,
+    dynamic_import_entries: FxIndexMap<ResolvedVc<Box<dyn Module>>, DynamicImportedModules>,
 ) -> Result<Vc<DynamicImportedChunks>> {
     collect_chunk_group_inner(dynamic_import_entries, |module| async move {
         if let Some(module) = Vc::try_resolve_downcast::<Box<dyn EvaluatableAsset>>(module).await? {
@@ -103,7 +103,7 @@ pub(crate) async fn collect_evaluated_chunk_group(
 
 #[turbo_tasks::value(shared)]
 pub struct NextDynamicImportsResult {
-    pub client_dynamic_imports: FxIndexMap<Vc<Box<dyn Module>>, DynamicImportedModules>,
+    pub client_dynamic_imports: FxIndexMap<ResolvedVc<Box<dyn Module>>, DynamicImportedModules>,
     pub visited_modules: Vc<VisitedDynamicImportModules>,
 }
 
@@ -186,7 +186,7 @@ pub(crate) async fn collect_next_dynamic_imports(
         });
 
         // Consolidate import mappings into a single indexmap
-        let mut import_mappings: FxIndexMap<Vc<Box<dyn Module>>, DynamicImportedModules> =
+        let mut import_mappings: FxIndexMap<ResolvedVc<Box<dyn Module>>, DynamicImportedModules> =
             FxIndexMap::default();
 
         for module_mapping in imported_modules_mapping {
@@ -282,10 +282,10 @@ impl turbo_tasks::graph::Visit<NextDynamicVisitEntry> for NextDynamicVisit {
 #[turbo_tasks::function]
 async fn build_dynamic_imports_map_for_module(
     client_asset_context: Vc<Box<dyn AssetContext>>,
-    server_module: Vc<Box<dyn Module>>,
+    server_module: ResolvedVc<Box<dyn Module>>,
 ) -> Result<Vc<OptionDynamicImportsMap>> {
     let Some(ecmascript_asset) =
-        Vc::try_resolve_sidecast::<Box<dyn EcmascriptParsable>>(server_module).await?
+        ResolvedVc::try_sidecast::<Box<dyn EcmascriptParsable>>(server_module).await?
     else {
         return Ok(Vc::cell(None));
     };
@@ -409,17 +409,19 @@ impl Visit for CollectImportSourceVisitor {
     }
 }
 
-pub type DynamicImportedModules = Vec<(RcStr, Vc<Box<dyn Module>>)>;
+pub type DynamicImportedModules = Vec<(RcStr, ResolvedVc<Box<dyn Module>>)>;
 pub type DynamicImportedOutputAssets = Vec<(RcStr, Vc<OutputAssets>)>;
 
 /// A struct contains mapping for the dynamic imports to construct chunk per
 /// each individual module (Origin Module, Vec<(ImportSourceString, Module)>)
 #[turbo_tasks::value(transparent)]
-pub struct DynamicImportsMap(pub (Vc<Box<dyn Module>>, DynamicImportedModules));
+pub struct DynamicImportsMap(pub (ResolvedVc<Box<dyn Module>>, DynamicImportedModules));
 
 /// An Option wrapper around [DynamicImportsMap].
 #[turbo_tasks::value(transparent)]
 pub struct OptionDynamicImportsMap(Option<Vc<DynamicImportsMap>>);
 
 #[turbo_tasks::value(transparent)]
-pub struct DynamicImportedChunks(pub FxIndexMap<Vc<Box<dyn Module>>, DynamicImportedOutputAssets>);
+pub struct DynamicImportedChunks(
+    pub FxIndexMap<ResolvedVc<Box<dyn Module>>, DynamicImportedOutputAssets>,
+);

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -6,7 +6,7 @@ use next_core::{
     next_server::{get_server_runtime_entries, ServerContextType},
 };
 use tracing::Instrument;
-use turbo_tasks::{Completion, RcStr, Value, Vc};
+use turbo_tasks::{Completion, RcStr, ResolvedVc, Value, Vc};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent,
@@ -65,27 +65,31 @@ impl InstrumentationEndpoint {
     }
 
     #[turbo_tasks::function]
-    fn core_modules(&self) -> Vc<InstrumentationCoreModules> {
+    async fn core_modules(&self) -> Result<Vc<InstrumentationCoreModules>> {
         let userland_module = self
             .asset_context
             .process(
                 self.source,
                 Value::new(ReferenceType::Entry(EntryReferenceSubType::Instrumentation)),
             )
-            .module();
+            .module()
+            .to_resolved()
+            .await?;
 
         let edge_entry_module = wrap_edge_entry(
             self.asset_context,
             self.project.project_path(),
-            userland_module,
+            *userland_module,
             "instrumentation".into(),
-        );
+        )
+        .to_resolved()
+        .await?;
 
-        InstrumentationCoreModules {
+        Ok(InstrumentationCoreModules {
             userland_module,
             edge_entry_module,
         }
-        .cell()
+        .cell())
     }
 
     #[turbo_tasks::function]
@@ -107,15 +111,15 @@ impl InstrumentationEndpoint {
         .clone_value();
 
         let Some(module) =
-            Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkPlaceable>>(module).await?
+            ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(module).await?
         else {
             bail!("Entry module must be evaluatable");
         };
 
-        let Some(evaluatable) = Vc::try_resolve_sidecast(module).await? else {
+        let Some(evaluatable) = ResolvedVc::try_sidecast(module).await? else {
             bail!("Entry module must be evaluatable");
         };
-        evaluatable_assets.push(evaluatable);
+        evaluatable_assets.push(*evaluatable);
 
         let edge_chunking_context = this.project.edge_chunking_context(false);
 
@@ -136,7 +140,7 @@ impl InstrumentationEndpoint {
 
         let userland_module = self.core_modules().await?.userland_module;
 
-        let Some(module) = Vc::try_resolve_downcast(userland_module).await? else {
+        let Some(module) = ResolvedVc::try_downcast(userland_module).await? else {
             bail!("Entry module must be evaluatable");
         };
 
@@ -145,7 +149,7 @@ impl InstrumentationEndpoint {
                 this.project
                     .node_root()
                     .join("server/instrumentation.js".into()),
-                module,
+                *module,
                 get_server_runtime_entries(
                     Value::new(ServerContextType::Instrumentation {
                         app_dir: this.app_dir,
@@ -211,8 +215,8 @@ impl InstrumentationEndpoint {
 
 #[turbo_tasks::value]
 struct InstrumentationCoreModules {
-    pub userland_module: Vc<Box<dyn Module>>,
-    pub edge_entry_module: Vc<Box<dyn Module>>,
+    pub userland_module: ResolvedVc<Box<dyn Module>>,
+    pub edge_entry_module: ResolvedVc<Box<dyn Module>>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -309,7 +309,7 @@ impl Endpoint for MiddlewareEndpoint {
     }
 
     #[turbo_tasks::function]
-    fn root_modules(self: Vc<Self>) -> Vc<Modules> {
-        Vc::cell(vec![self.userland_module()])
+    async fn root_modules(self: Vc<Self>) -> Result<Vc<Modules>> {
+        Ok(Vc::cell(vec![self.userland_module().to_resolved().await?]))
     }
 }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1278,10 +1278,10 @@ impl Project {
     #[turbo_tasks::function]
     pub async fn client_main_modules(self: Vc<Self>) -> Result<Vc<Modules>> {
         let pages_project = self.pages_project();
-        let mut modules = vec![pages_project.client_main_module()];
+        let mut modules = vec![pages_project.client_main_module().to_resolved().await?];
 
         if let Some(app_project) = *self.app_project().await? {
-            modules.push(app_project.client_main_module());
+            modules.push(app_project.client_main_module().to_resolved().await?);
         }
 
         Ok(Vc::cell(modules))

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -19,7 +19,7 @@ use swc_core::{
 use tracing::Instrument;
 use turbo_tasks::{
     graph::{GraphTraversal, NonDeterministic},
-    FxIndexMap, RcStr, TryFlatJoinIterExt, Value, ValueToString, Vc,
+    FxIndexMap, RcStr, ResolvedVc, TryFlatJoinIterExt, Value, ValueToString, Vc,
 };
 use turbo_tasks_fs::{self, rope::RopeBuilder, File, FileSystemPath};
 use turbopack_core::{
@@ -181,7 +181,7 @@ async fn build_manifest(
 /// returned along with the module which exports that action.
 #[turbo_tasks::function]
 async fn get_actions(
-    rsc_entry: Vc<Box<dyn Module>>,
+    rsc_entry: ResolvedVc<Box<dyn Module>>,
     server_reference_modules: Vc<Modules>,
     asset_context: Vc<Box<dyn AssetContext>>,
 ) -> Result<Vc<AllActions>> {
@@ -213,7 +213,7 @@ async fn get_actions(
             let module = if *layer == ActionLayer::Rsc {
                 *module
             } else {
-                to_rsc_context(*module, asset_context).await?
+                to_rsc_context(**module, asset_context).await?
             };
 
             for (hash_id, name) in &*actions_map.await? {
@@ -242,7 +242,7 @@ async fn get_actions(
 async fn to_rsc_context(
     module: Vc<Box<dyn Module>>,
     asset_context: Vc<Box<dyn AssetContext>>,
-) -> Result<Vc<Box<dyn Module>>> {
+) -> Result<ResolvedVc<Box<dyn Module>>> {
     let source = FileSource::new_with_query(module.ident().path(), module.ident().query());
     let module = asset_context
         .process(
@@ -251,16 +251,18 @@ async fn to_rsc_context(
                 EcmaScriptModulesReferenceSubType::Undefined,
             )),
         )
-        .module();
+        .module()
+        .to_resolved()
+        .await?;
     Ok(module)
 }
 
 /// Our graph traversal visitor, which finds the primary modules directly
 /// referenced by parent.
 async fn get_referenced_modules(
-    (layer, module): (ActionLayer, Vc<Box<dyn Module>>),
-) -> Result<impl Iterator<Item = (ActionLayer, Vc<Box<dyn Module>>)> + Send> {
-    primary_referenced_modules(module)
+    (layer, module): (ActionLayer, ResolvedVc<Box<dyn Module>>),
+) -> Result<impl Iterator<Item = (ActionLayer, ResolvedVc<Box<dyn Module>>)> + Send> {
+    primary_referenced_modules(*module)
         .await
         .map(|modules| modules.into_iter().map(move |&m| (layer, m)))
 }
@@ -409,16 +411,16 @@ fn all_export_names(program: &Program) -> Vec<Atom> {
 /// Converts our cached [parse_actions] call into a data type suitable for
 /// collecting into a flat-mapped [FxIndexMap].
 async fn parse_actions_filter_map(
-    (layer, module): (ActionLayer, Vc<Box<dyn Module>>),
-) -> Result<Option<((ActionLayer, Vc<Box<dyn Module>>), Vc<ActionMap>)>> {
-    parse_actions(module).await.map(|option_action_map| {
+    (layer, module): (ActionLayer, ResolvedVc<Box<dyn Module>>),
+) -> Result<Option<((ActionLayer, ResolvedVc<Box<dyn Module>>), Vc<ActionMap>)>> {
+    parse_actions(*module).await.map(|option_action_map| {
         option_action_map
             .clone_value()
             .map(|action_map| ((layer, module), action_map))
     })
 }
 
-type HashToLayerNameModule = FxIndexMap<String, (ActionLayer, String, Vc<Box<dyn Module>>)>;
+type HashToLayerNameModule = FxIndexMap<String, (ActionLayer, String, ResolvedVc<Box<dyn Module>>)>;
 
 /// A mapping of every module which exports a Server Action, with the hashed id
 /// and exported name of each found action.

--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::Result;
-use turbo_tasks::{FxIndexMap, RcStr, Vc};
+use turbo_tasks::{FxIndexMap, RcStr, ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::{transition::Transition, ModuleAssetContext};
 use turbopack_core::{file_source::FileSource, module::Module};
@@ -187,7 +187,7 @@ impl AppPageLoaderTreeBuilder {
                     app_page.clone(),
                 );
 
-                let module = self.base.process_source(source);
+                let module = self.base.process_source(source).to_resolved().await?;
                 self.base
                     .inner_assets
                     .insert(inner_module_id.into(), module);
@@ -227,7 +227,7 @@ impl AppPageLoaderTreeBuilder {
             BlurPlaceholderMode::None,
             self.base.module_asset_context,
         ));
-        let module = self.base.process_module(module);
+        let module = self.base.process_module(module).to_resolved().await?;
         self.base
             .inner_assets
             .insert(inner_module_id.into(), module);
@@ -274,7 +274,9 @@ impl AppPageLoaderTreeBuilder {
                 .base
                 .process_source(Vc::upcast(TextContentFileSource::new(Vc::upcast(
                     FileSource::new(alt_path),
-                ))));
+                ))))
+                .to_resolved()
+                .await?;
 
             self.base
                 .inner_assets
@@ -373,7 +375,9 @@ impl AppPageLoaderTreeBuilder {
         if let Some(global_error) = modules.global_error {
             let module = self
                 .base
-                .process_source(Vc::upcast(FileSource::new(*global_error)));
+                .process_source(Vc::upcast(FileSource::new(*global_error)))
+                .to_resolved()
+                .await?;
             self.base.inner_assets.insert(GLOBAL_ERROR.into(), module);
         };
 
@@ -390,7 +394,7 @@ impl AppPageLoaderTreeBuilder {
 pub struct AppPageLoaderTreeModule {
     pub imports: Vec<RcStr>,
     pub loader_tree_code: RcStr,
-    pub inner_assets: FxIndexMap<RcStr, Vc<Box<dyn Module>>>,
+    pub inner_assets: FxIndexMap<RcStr, ResolvedVc<Box<dyn Module>>>,
     pub pages: Vec<Vc<FileSystemPath>>,
 }
 

--- a/crates/next-core/src/base_loader_tree.rs
+++ b/crates/next-core/src/base_loader_tree.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use indoc::formatdoc;
-use turbo_tasks::{FxIndexMap, RcStr, Value, ValueToString, Vc};
+use turbo_tasks::{FxIndexMap, RcStr, ResolvedVc, Value, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::{transition::Transition, ModuleAssetContext};
 use turbopack_core::{
@@ -12,7 +12,7 @@ use turbopack_core::{
 use turbopack_ecmascript::{magic_identifier, utils::StringifyJs};
 
 pub struct BaseLoaderTreeBuilder {
-    pub inner_assets: FxIndexMap<RcStr, Vc<Box<dyn Module>>>,
+    pub inner_assets: FxIndexMap<RcStr, ResolvedVc<Box<dyn Module>>>,
     counter: usize,
     pub imports: Vec<RcStr>,
     pub module_asset_context: Vc<ModuleAssetContext>,
@@ -101,7 +101,10 @@ impl BaseLoaderTreeBuilder {
             .into(),
         );
 
-        let module = self.process_source(Vc::upcast(FileSource::new(path)));
+        let module = self
+            .process_source(Vc::upcast(FileSource::new(path)))
+            .to_resolved()
+            .await?;
 
         self.inner_assets
             .insert(format!("MODULE_{i}").into(), module);

--- a/crates/next-core/src/bootstrap.rs
+++ b/crates/next-core/src/bootstrap.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Context, Result};
-use turbo_tasks::{FxIndexMap, Value, ValueToString, Vc};
+use turbo_tasks::{FxIndexMap, ResolvedVc, Value, ValueToString, Vc};
 use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent,
@@ -43,7 +43,7 @@ impl BootstrapConfig {
 
 #[turbo_tasks::function]
 pub async fn bootstrap(
-    asset: Vc<Box<dyn Module>>,
+    asset: ResolvedVc<Box<dyn Module>>,
     asset_context: Vc<Box<dyn AssetContext>>,
     base_path: Vc<FileSystemPath>,
     bootstrap_asset: Vc<Box<dyn Source>>,
@@ -91,7 +91,9 @@ pub async fn bootstrap(
             )),
             Value::new(ReferenceType::Internal(InnerAssets::empty())),
         )
-        .module();
+        .module()
+        .to_resolved()
+        .await?;
 
     let mut inner_assets = inner_assets.await?.clone_value();
     inner_assets.insert("ENTRY".into(), asset);
@@ -102,13 +104,15 @@ pub async fn bootstrap(
             bootstrap_asset,
             Value::new(ReferenceType::Internal(Vc::cell(inner_assets))),
         )
-        .module();
+        .module()
+        .to_resolved()
+        .await?;
 
-    let asset = Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(asset)
+    let asset = ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(asset)
         .await?
         .context("internal module must be evaluatable")?;
 
-    Ok(asset)
+    Ok(*asset)
 }
 
 /// This normalizes an app page to a pathname.

--- a/crates/next-core/src/middleware.rs
+++ b/crates/next-core/src/middleware.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{fxindexmap, FxIndexMap, RcStr, Value, Vc};
+use turbo_tasks::{fxindexmap, FxIndexMap, RcStr, ResolvedVc, Value, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{context::AssetContext, module::Module, reference_type::ReferenceType};
 
@@ -24,7 +24,7 @@ pub async fn middleware_files(page_extensions: Vc<Vec<RcStr>>) -> Result<Vc<Vec<
 pub async fn get_middleware_module(
     asset_context: Vc<Box<dyn AssetContext>>,
     project_root: Vc<FileSystemPath>,
-    userland_module: Vc<Box<dyn Module>>,
+    userland_module: ResolvedVc<Box<dyn Module>>,
 ) -> Result<Vc<Box<dyn Module>>> {
     const INNER: &str = "INNER_MIDDLEWARE_MODULE";
 

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use tracing::Instrument;
 use turbo_tasks::{
-    FxIndexMap, RcStr, TryFlatJoinIterExt, TryJoinIterExt, Value, ValueToString, Vc,
+    FxIndexMap, RcStr, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Value, ValueToString, Vc,
 };
 use turbopack_core::{
     chunk::{availability_info::AvailabilityInfo, ChunkingContext, ChunkingContextExt},
@@ -69,7 +69,7 @@ pub async fn get_app_client_references_chunks(
                                     ecmascript_client_reference.await?;
 
                                 let client_chunk_group = client_chunking_context
-                                    .root_chunk_group(Vc::upcast(
+                                    .root_chunk_group(*ResolvedVc::upcast(
                                         ecmascript_client_reference_ref.client_module,
                                     ))
                                     .await?;
@@ -81,7 +81,7 @@ pub async fn get_app_client_references_chunks(
                                     ),
                                     if let Some(ssr_chunking_context) = ssr_chunking_context {
                                         let ssr_chunk_group = ssr_chunking_context
-                                            .root_chunk_group(Vc::upcast(
+                                            .root_chunk_group(*ResolvedVc::upcast(
                                                 ecmascript_client_reference_ref.ssr_module,
                                             ))
                                             .await?;
@@ -183,7 +183,9 @@ pub async fn get_app_client_references_chunks(
                                 let ecmascript_client_reference_ref =
                                     ecmascript_client_reference.await?;
 
-                                Some(Vc::upcast(ecmascript_client_reference_ref.ssr_module))
+                                Some(*ResolvedVc::upcast(
+                                    ecmascript_client_reference_ref.ssr_module,
+                                ))
                             }
                             _ => None,
                         })
@@ -223,7 +225,7 @@ pub async fn get_app_client_references_chunks(
                             } => {
                                 let ecmascript_client_reference_ref =
                                     ecmascript_client_reference.await?;
-                                Vc::upcast(ecmascript_client_reference_ref.client_module)
+                                *ResolvedVc::upcast(ecmascript_client_reference_ref.client_module)
                             }
                             ClientReferenceType::CssClientReference(css_module) => {
                                 Vc::upcast(*css_module)
@@ -331,7 +333,12 @@ pub async fn get_app_server_reference_modules(
                         ..
                     } => {
                         let ecmascript_client_reference_ref = ecmascript_client_reference.await?;
-                        Some(Vc::upcast(ecmascript_client_reference_ref.client_module))
+                        Some(ResolvedVc::upcast(
+                            ecmascript_client_reference_ref
+                                .client_module
+                                .to_resolved()
+                                .await?,
+                        ))
                     }
                     _ => None,
                 })

--- a/crates/next-core/src/next_app/app_entry.rs
+++ b/crates/next-core/src/next_app/app_entry.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::{RcStr, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, Vc};
 use turbopack_core::module::Module;
 
 use crate::app_segment_config::NextSegmentConfig;
@@ -12,7 +12,7 @@ pub struct AppEntry {
     /// the pathname to refer to this entry.
     pub original_name: RcStr,
     /// The RSC module asset for the route or page.
-    pub rsc_entry: Vc<Box<dyn Module>>,
+    pub rsc_entry: ResolvedVc<Box<dyn Module>>,
     /// The source code config for this entry.
     pub config: Vc<NextSegmentConfig>,
 }

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use anyhow::Result;
-use turbo_tasks::{fxindexmap, RcStr, TryJoinIterExt, Value, ValueToString, Vc};
+use turbo_tasks::{fxindexmap, RcStr, ResolvedVc, TryJoinIterExt, Value, ValueToString, Vc};
 use turbo_tasks_fs::{self, rope::RopeBuilder, File, FileSystemPath};
 use turbopack::ModuleAssetContext;
 use turbopack_core::{
@@ -130,7 +130,7 @@ pub async fn get_app_page_entry(
     Ok(AppEntry {
         pathname,
         original_name,
-        rsc_entry,
+        rsc_entry: rsc_entry.to_resolved().await?,
         config,
     }
     .cell())
@@ -140,7 +140,7 @@ pub async fn get_app_page_entry(
 async fn wrap_edge_page(
     asset_context: Vc<Box<dyn AssetContext>>,
     project_root: Vc<FileSystemPath>,
-    entry: Vc<Box<dyn Module>>,
+    entry: ResolvedVc<Box<dyn Module>>,
     page: AppPage,
     next_config: Vc<NextConfig>,
 ) -> Result<Vc<Box<dyn Module>>> {

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{fxindexmap, RcStr, Value, ValueToString, Vc};
+use turbo_tasks::{fxindexmap, RcStr, ResolvedVc, Value, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::ModuleAssetContext;
 use turbopack_core::{
@@ -94,7 +94,9 @@ pub async fn get_app_route_entry(
             source,
             Value::new(ReferenceType::Entry(EntryReferenceSubType::AppRoute)),
         )
-        .module();
+        .module()
+        .to_resolved()
+        .await?;
 
     let inner_assets = fxindexmap! {
         INNER.into() => userland_module
@@ -120,7 +122,7 @@ pub async fn get_app_route_entry(
     Ok(AppEntry {
         pathname,
         original_name,
-        rsc_entry,
+        rsc_entry: rsc_entry.to_resolved().await?,
         config,
     }
     .cell())
@@ -130,7 +132,7 @@ pub async fn get_app_route_entry(
 async fn wrap_edge_route(
     asset_context: Vc<Box<dyn AssetContext>>,
     project_root: Vc<FileSystemPath>,
-    entry: Vc<Box<dyn Module>>,
+    entry: ResolvedVc<Box<dyn Module>>,
     page: AppPage,
     next_config: Vc<NextConfig>,
 ) -> Result<Vc<Box<dyn Module>>> {

--- a/crates/next-core/src/next_client/runtime_entry.rs
+++ b/crates/next-core/src/next_client/runtime_entry.rs
@@ -46,9 +46,9 @@ impl RuntimeEntry {
         let mut runtime_entries = Vec::with_capacity(modules.len());
         for &module in &modules {
             if let Some(entry) =
-                Vc::try_resolve_downcast::<Box<dyn EvaluatableAsset>>(module).await?
+                ResolvedVc::try_downcast::<Box<dyn EvaluatableAsset>>(module).await?
             {
-                runtime_entries.push(entry);
+                runtime_entries.push(*entry);
             } else {
                 bail!(
                     "runtime reference resolved to an asset ({}) that cannot be evaluated",

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -1,6 +1,6 @@
 #![allow(rustdoc::private_intra_doc_links)]
 use anyhow::{bail, Result};
-use turbo_tasks::{RcStr, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     ident::AssetIdent,
@@ -14,8 +14,8 @@ use turbopack_ecmascript::chunk::EcmascriptChunkPlaceable;
 #[turbo_tasks::value]
 pub struct EcmascriptClientReferenceModule {
     pub server_ident: Vc<AssetIdent>,
-    pub client_module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
-    pub ssr_module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
+    pub client_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
+    pub ssr_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -31,8 +31,8 @@ impl EcmascriptClientReferenceModule {
     #[turbo_tasks::function]
     pub fn new(
         server_ident: Vc<AssetIdent>,
-        client_module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
-        ssr_module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
+        client_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
+        ssr_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
     ) -> Vc<EcmascriptClientReferenceModule> {
         EcmascriptClientReferenceModule {
             server_ident,
@@ -58,8 +58,8 @@ impl Module for EcmascriptClientReferenceModule {
 
     #[turbo_tasks::function]
     fn additional_layers_modules(&self) -> Vc<Modules> {
-        let client_module = Vc::upcast(self.client_module);
-        let ssr_module = Vc::upcast(self.ssr_module);
+        let client_module = ResolvedVc::upcast(self.client_module);
+        let ssr_module = ResolvedVc::upcast(self.ssr_module);
         Vc::cell(vec![client_module, ssr_module])
     }
 }

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -186,7 +186,9 @@ pub async fn client_reference_graph(
                         client_references_by_server_component
                             .entry(client_reference.server_component)
                             .or_insert_with(Vec::new)
-                            .push(Vc::upcast::<Box<dyn Module>>(entry.await?.ssr_module));
+                            .push(*ResolvedVc::upcast::<Box<dyn Module>>(
+                                entry.await?.ssr_module,
+                            ));
                     }
                 }
                 VisitClientReferenceNodeType::ServerUtilEntry(server_util, _) => {

--- a/crates/next-core/src/next_edge/entry.rs
+++ b/crates/next-core/src/next_edge/entry.rs
@@ -1,5 +1,5 @@
 use indoc::formatdoc;
-use turbo_tasks::{fxindexmap, RcStr, Value, Vc};
+use turbo_tasks::{fxindexmap, RcStr, ResolvedVc, Value, Vc};
 use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent, context::AssetContext, module::Module, reference_type::ReferenceType,
@@ -11,7 +11,7 @@ use turbopack_ecmascript::utils::StringifyJs;
 pub async fn wrap_edge_entry(
     asset_context: Vc<Box<dyn AssetContext>>,
     project_root: Vc<FileSystemPath>,
-    entry: Vc<Box<dyn Module>>,
+    entry: ResolvedVc<Box<dyn Module>>,
     pathname: RcStr,
 ) -> Vc<Box<dyn Module>> {
     // The wrapped module could be an async module, we handle that with the proxy

--- a/crates/next-core/src/next_image/module.rs
+++ b/crates/next-core/src/next_image/module.rs
@@ -1,4 +1,5 @@
-use turbo_tasks::{fxindexmap, TaskInput, Value, Vc};
+use anyhow::Result;
+use turbo_tasks::{fxindexmap, ResolvedVc, TaskInput, Value, Vc};
 use turbopack::{module_options::CustomModuleType, ModuleAssetContext};
 use turbopack_core::{
     context::AssetContext, module::Module, reference_type::ReferenceType, resolve::ModulePart,
@@ -38,9 +39,11 @@ impl StructuredImageModuleType {
         source: Vc<Box<dyn Source>>,
         blur_placeholder_mode: BlurPlaceholderMode,
         module_asset_context: Vc<ModuleAssetContext>,
-    ) -> Vc<Box<dyn Module>> {
-        let static_asset = StaticModuleAsset::new(source, Vc::upcast(module_asset_context));
-        module_asset_context
+    ) -> Result<Vc<Box<dyn Module>>> {
+        let static_asset = StaticModuleAsset::new(source, Vc::upcast(module_asset_context))
+            .to_resolved()
+            .await?;
+        Ok(module_asset_context
             .process(
                 Vc::upcast(
                     StructuredImageFileSource {
@@ -50,10 +53,10 @@ impl StructuredImageModuleType {
                     .cell(),
                 ),
                 Value::new(ReferenceType::Internal(Vc::cell(fxindexmap!(
-                    "IMAGE".into() => Vc::upcast(static_asset)
+                    "IMAGE".into() => ResolvedVc::upcast(static_asset)
                 )))),
             )
-            .module()
+            .module())
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use anyhow::{bail, Result};
 use serde::Serialize;
-use turbo_tasks::{fxindexmap, FxIndexMap, RcStr, Value, Vc};
+use turbo_tasks::{fxindexmap, FxIndexMap, RcStr, ResolvedVc, Value, Vc};
 use turbo_tasks_fs::{rope::RopeBuilder, File, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -39,7 +39,9 @@ pub async fn create_page_ssr_entry_module(
 
     let ssr_module = ssr_module_context
         .process(source, reference_type.clone())
-        .module();
+        .module()
+        .to_resolved()
+        .await?;
 
     let reference_type = reference_type.into_value();
 
@@ -120,7 +122,9 @@ pub async fn create_page_ssr_entry_module(
                 pages_structure.document(),
                 Value::new(reference_type.clone()),
                 ssr_module_context,
-            ),
+            )
+            .to_resolved()
+            .await?,
         );
         inner_assets.insert(
             INNER_APP.into(),
@@ -128,7 +132,9 @@ pub async fn create_page_ssr_entry_module(
                 pages_structure.app(),
                 Value::new(reference_type.clone()),
                 ssr_module_context,
-            ),
+            )
+            .to_resolved()
+            .await?,
         );
     }
 
@@ -178,7 +184,7 @@ fn process_global_item(
 async fn wrap_edge_page(
     asset_context: Vc<Box<dyn AssetContext>>,
     project_root: Vc<FileSystemPath>,
-    entry: Vc<Box<dyn Module>>,
+    entry: ResolvedVc<Box<dyn Module>>,
     page: RcStr,
     pathname: RcStr,
     reference_type: Value<ReferenceType>,
@@ -233,9 +239,21 @@ async fn wrap_edge_page(
 
     let inner_assets = fxindexmap! {
         INNER.into() => entry,
-        INNER_DOCUMENT.into() => process_global_item(pages_structure.document(), reference_type.clone(), asset_context),
-        INNER_APP.into() => process_global_item(pages_structure.app(), reference_type.clone(), asset_context),
-        INNER_ERROR.into() => process_global_item(pages_structure.error(), reference_type.clone(), asset_context),
+        INNER_DOCUMENT.into() => process_global_item(
+            pages_structure.document(),
+            reference_type.clone(),
+            asset_context,
+        ).to_resolved().await?,
+        INNER_APP.into() => process_global_item(
+            pages_structure.app(),
+            reference_type.clone(),
+            asset_context,
+        ).to_resolved().await?,
+        INNER_ERROR.into() => process_global_item(
+            pages_structure.error(),
+            reference_type.clone(),
+            asset_context,
+        ).to_resolved().await?,
     };
 
     let wrapped = asset_context

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use anyhow::{bail, Result};
 use indoc::formatdoc;
-use turbo_tasks::{RcStr, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -66,15 +66,19 @@ impl Module for NextServerComponentModule {
     }
 
     #[turbo_tasks::function]
-    fn additional_layers_modules(self: Vc<Self>) -> Vc<Modules> {
+    async fn additional_layers_modules(self: Vc<Self>) -> Result<Vc<Modules>> {
         let base_ident = self.ident();
-        let ssr_entry_module = Vc::upcast(IncludeIdentModule::new(
-            base_ident.with_modifier(client_modules_ssr_modifier()),
-        ));
-        let client_entry_module = Vc::upcast(IncludeIdentModule::new(
-            base_ident.with_modifier(client_modules_modifier()),
-        ));
-        Vc::cell(vec![ssr_entry_module, client_entry_module])
+        let ssr_entry_module = ResolvedVc::upcast(
+            IncludeIdentModule::new(base_ident.with_modifier(client_modules_ssr_modifier()))
+                .to_resolved()
+                .await?,
+        );
+        let client_entry_module = ResolvedVc::upcast(
+            IncludeIdentModule::new(base_ident.with_modifier(client_modules_modifier()))
+                .to_resolved()
+                .await?,
+        );
+        Ok(Vc::cell(vec![ssr_entry_module, client_entry_module]))
     }
 }
 

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -54,7 +54,9 @@ pub async fn create_page_loader_entry_module(
             entry_asset,
             Value::new(ReferenceType::Entry(EntryReferenceSubType::Page)),
         )
-        .module();
+        .module()
+        .to_resolved()
+        .await?;
 
     let module = client_context
         .process(

--- a/turbopack/crates/node-file-trace/src/lib.rs
+++ b/turbopack/crates/node-file-trace/src/lib.rs
@@ -200,7 +200,7 @@ async fn create_fs(name: &str, root: &str, watch: bool) -> Result<Vc<Box<dyn Fil
 async fn add_glob_results(
     asset_context: Vc<Box<dyn AssetContext>>,
     result: Vc<ReadGlobResult>,
-    list: &mut Vec<Vc<Box<dyn Module>>>,
+    list: &mut Vec<ResolvedVc<Box<dyn Module>>>,
 ) -> Result<()> {
     let result = result.await?;
     for entry in result.results.values() {
@@ -211,7 +211,9 @@ async fn add_glob_results(
                     source,
                     Value::new(turbopack_core::reference_type::ReferenceType::Undefined),
                 )
-                .module();
+                .module()
+                .to_resolved()
+                .await?;
             list.push(module);
         }
     }
@@ -219,7 +221,7 @@ async fn add_glob_results(
         fn recurse<'a>(
             asset_context: Vc<Box<dyn AssetContext>>,
             result: Vc<ReadGlobResult>,
-            list: &'a mut Vec<Vc<Box<dyn Module>>>,
+            list: &'a mut Vec<ResolvedVc<Box<dyn Module>>>,
         ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
             Box::pin(add_glob_results(asset_context, result, list))
         }
@@ -260,7 +262,9 @@ async fn input_to_modules(
                     source,
                     Value::new(turbopack_core::reference_type::ReferenceType::Undefined),
                 )
-                .module();
+                .module()
+                .to_resolved()
+                .await?;
             list.push(module);
         } else {
             let glob = Glob::new(input);
@@ -490,7 +494,7 @@ async fn main_operation(
             )
             .await?;
             for module in modules.iter() {
-                let set = all_modules_and_affecting_sources(*module)
+                let set = all_modules_and_affecting_sources(**module)
                     .issue_file_path(module.ident().path(), "gathering list of assets")
                     .await?;
                 for asset in set.await?.iter() {
@@ -517,7 +521,7 @@ async fn main_operation(
             .await?
             .iter()
             {
-                let nft_asset = NftJsonAsset::new(*module);
+                let nft_asset = NftJsonAsset::new(**module);
                 let path = nft_asset.ident().path().await?.path.clone();
                 output_nft_assets.push(path);
                 emits.push(emit_asset(Vc::upcast(nft_asset)));
@@ -550,7 +554,7 @@ async fn main_operation(
             .await?
             .iter()
             {
-                let rebased = Vc::upcast(RebasedAsset::new(*module, input_dir, output_dir));
+                let rebased = Vc::upcast(RebasedAsset::new(**module, input_dir, output_dir));
                 emits.push(emit_with_completion(rebased, output_dir));
             }
             // Wait for all files to be emitted

--- a/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
@@ -46,9 +46,9 @@ impl RuntimeEntry {
         let mut runtime_entries = Vec::with_capacity(modules.len());
         for &module in &modules {
             if let Some(entry) =
-                Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(module).await?
+                ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(module).await?
             {
-                runtime_entries.push(entry);
+                runtime_entries.push(*entry);
             } else {
                 bail!(
                     "runtime reference resolved to an asset ({}) that cannot be evaluated",

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -130,16 +130,16 @@ pub async fn create_web_entry_source(
         .flatten()
         .map(|module| async move {
             if let (Some(chnkable), Some(entry)) = (
-                Vc::try_resolve_sidecast::<Box<dyn ChunkableModule>>(module).await?,
-                Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(module).await?,
+                ResolvedVc::try_sidecast::<Box<dyn ChunkableModule>>(module).await?,
+                ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(module).await?,
             ) {
                 Ok((
                     chnkable,
                     chunking_context,
-                    Some(runtime_entries.with_entry(entry)),
+                    Some(runtime_entries.with_entry(*entry)),
                 ))
             } else if let Some(chunkable) =
-                Vc::try_resolve_sidecast::<Box<dyn ChunkableModule>>(module).await?
+                ResolvedVc::try_sidecast::<Box<dyn ChunkableModule>>(module).await?
             {
                 // TODO this is missing runtime code, so it's probably broken and we should also
                 // add an ecmascript chunk with the runtime code

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -370,7 +370,7 @@ async fn graph_node_to_referenced_nodes(
                 .into_iter()
                 .map(|&module| async move {
                     let Some(chunkable_module) =
-                        Vc::try_resolve_sidecast::<Box<dyn ChunkableModule>>(module).await?
+                        ResolvedVc::try_sidecast::<Box<dyn ChunkableModule>>(module).await?
                     else {
                         return Ok((
                             Some(ChunkGraphEdge {
@@ -458,7 +458,7 @@ async fn graph_node_to_referenced_nodes(
                                     Some(ChunkGraphEdge {
                                         key: None,
                                         node: ChunkContentGraphNode::AsyncModule {
-                                            module: chunkable_module,
+                                            module: *chunkable_module,
                                         },
                                     }),
                                     None,

--- a/turbopack/crates/turbopack-core/src/introspect/utils.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/utils.rs
@@ -87,7 +87,7 @@ pub async fn children_from_module_references(
             .await?
             .iter()
         {
-            children.insert((key, IntrospectableModule::new(module)));
+            children.insert((key, IntrospectableModule::new(*module)));
         }
         for &output_asset in reference
             .resolve_reference()

--- a/turbopack/crates/turbopack-core/src/module.rs
+++ b/turbopack/crates/turbopack-core/src/module.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 
 use crate::{asset::Asset, ident::AssetIdent, reference::ModuleReferences};
 
@@ -22,10 +22,10 @@ pub trait Module: Asset {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct OptionModule(Option<Vc<Box<dyn Module>>>);
+pub struct OptionModule(Option<ResolvedVc<Box<dyn Module>>>);
 
 #[turbo_tasks::value(transparent)]
-pub struct Modules(Vec<Vc<Box<dyn Module>>>);
+pub struct Modules(Vec<ResolvedVc<Box<dyn Module>>>);
 
 #[turbo_tasks::value_impl]
 impl Modules {

--- a/turbopack/crates/turbopack-core/src/reference_type.rs
+++ b/turbopack/crates/turbopack-core/src/reference_type.rs
@@ -10,7 +10,7 @@ use crate::{module::Module, resolve::ModulePart};
 ///
 /// Name is usually in UPPER_CASE to make it clear that this is an inner asset.
 #[turbo_tasks::value(transparent)]
-pub struct InnerAssets(FxIndexMap<RcStr, Vc<Box<dyn Module>>>);
+pub struct InnerAssets(FxIndexMap<RcStr, ResolvedVc<Box<dyn Module>>>);
 
 #[turbo_tasks::value_impl]
 impl InnerAssets {

--- a/turbopack/crates/turbopack-core/src/resolve/origin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/origin.rs
@@ -84,7 +84,7 @@ async fn resolve_asset(
     reference_type: Value<ReferenceType>,
 ) -> Result<Vc<ModuleResolveResult>> {
     if let Some(asset) = *resolve_origin.get_inner_asset(request).await? {
-        return Ok(ModuleResolveResult::module(asset).cell());
+        return Ok(ModuleResolveResult::module(*asset).cell());
     }
     Ok(resolve_origin
         .asset_context()

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{RcStr, TryJoinIterExt, ValueToString, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -232,7 +232,7 @@ impl CssChunkItem for CssModuleChunkItem {
                     .iter()
                 {
                     if let Some(placeable) =
-                        Vc::try_resolve_downcast::<Box<dyn CssChunkPlaceable>>(module).await?
+                        ResolvedVc::try_downcast::<Box<dyn CssChunkPlaceable>>(module).await?
                     {
                         let item = placeable.as_chunk_item(chunking_context);
                         if let Some(css_item) =
@@ -257,7 +257,7 @@ impl CssChunkItem for CssModuleChunkItem {
                     .iter()
                 {
                     if let Some(placeable) =
-                        Vc::try_resolve_downcast::<Box<dyn CssChunkPlaceable>>(module).await?
+                        ResolvedVc::try_downcast::<Box<dyn CssChunkPlaceable>>(module).await?
                     {
                         let item = placeable.as_chunk_item(chunking_context);
                         if let Some(css_item) =

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Context, Result};
 use indoc::formatdoc;
 use lightningcss::css_modules::CssModuleReference;
 use swc_core::common::{BytePos, FileName, LineCol, SourceMap};
-use turbo_tasks::{FxIndexMap, RcStr, Value, ValueToString, Vc};
+use turbo_tasks::{FxIndexMap, RcStr, ResolvedVc, Value, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -339,7 +339,7 @@ impl EcmascriptChunkItem for ModuleChunkItem {
                         };
 
                         let Some(css_module) =
-                            Vc::try_resolve_downcast_type::<ModuleCssAsset>(*resolved_module)
+                            ResolvedVc::try_downcast_type::<ModuleCssAsset>(*resolved_module)
                                 .await?
                         else {
                             CssModuleComposesIssue {
@@ -358,8 +358,8 @@ impl EcmascriptChunkItem for ModuleChunkItem {
                         // TODO(alexkirsz) We should also warn if `original_name` can't be found in
                         // the target module.
 
-                        let placeable: Vc<Box<dyn EcmascriptChunkPlaceable>> =
-                            Vc::upcast(css_module);
+                        let placeable: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>> =
+                            ResolvedVc::upcast(css_module);
 
                         let module_id = placeable
                             .as_chunk_item(Vc::upcast(self.chunking_context))

--- a/turbopack/crates/turbopack-css/src/references/url.rs
+++ b/turbopack/crates/turbopack-css/src/references/url.rs
@@ -62,7 +62,7 @@ impl UrlAssetReference {
     ) -> Result<Vc<ReferencedAsset>> {
         if let Some(module) = *self.resolve_reference().first_module().await? {
             if let Some(chunkable) =
-                Vc::try_resolve_downcast::<Box<dyn ChunkableModule>>(module).await?
+                ResolvedVc::try_downcast::<Box<dyn ChunkableModule>>(module).await?
             {
                 let chunk_item = chunkable.as_chunk_item(chunking_context);
                 if let Some(embeddable) =

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use mime_guess::mime::TEXT_HTML_UTF_8;
-use turbo_tasks::{RcStr, ReadRef, TryJoinIterExt, Value, Vc};
+use turbo_tasks::{RcStr, ReadRef, ResolvedVc, TryJoinIterExt, Value, Vc};
 use turbo_tasks_fs::{File, FileSystemPath};
 use turbo_tasks_hash::{encode_hex, Xxh3Hash64Hasher};
 use turbopack_core::{
@@ -18,7 +18,7 @@ use turbopack_core::{
 // TODO(WEB-945) This should become a struct once we have a
 // `turbo_tasks::input` attribute macro/`Input` derive macro.
 type DevHtmlEntry = (
-    Vc<Box<dyn ChunkableModule>>,
+    ResolvedVc<Box<dyn ChunkableModule>>,
     Vc<Box<dyn ChunkingContext>>,
     Option<Vc<EvaluatableAssets>>,
 );
@@ -135,9 +135,9 @@ impl DevHtmlAsset {
 
                 let assets = if let Some(runtime_entries) = runtime_entries {
                     let runtime_entries = if let Some(evaluatable) =
-                        Vc::try_resolve_downcast(chunkable_module).await?
+                        ResolvedVc::try_downcast(chunkable_module).await?
                     {
-                        runtime_entries.with_entry(evaluatable)
+                        runtime_entries.with_entry(*evaluatable)
                     } else {
                         runtime_entries
                     };
@@ -147,7 +147,7 @@ impl DevHtmlAsset {
                         Value::new(AvailabilityInfo::Root),
                     )
                 } else {
-                    chunking_context.root_chunk_group_assets(Vc::upcast(chunkable_module))
+                    chunking_context.root_chunk_group_assets(*ResolvedVc::upcast(chunkable_module))
                 };
 
                 assets.await

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -188,12 +188,12 @@ impl ModuleReference for EsmAssetReference {
             let part = part.await?;
             if let &ModulePart::Export(export_name) = &*part {
                 for &module in result.primary_modules().await? {
-                    if let Some(module) = Vc::try_resolve_downcast(module).await? {
+                    if let Some(module) = ResolvedVc::try_downcast(module).await? {
                         let export = export_name.await?;
-                        if *is_export_missing(module, export.clone_value()).await? {
+                        if *is_export_missing(*module, export.clone_value()).await? {
                             InvalidExport {
                                 export: *export_name,
-                                module,
+                                module: *module,
                                 source: self.issue_source,
                             }
                             .cell()

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -3,7 +3,7 @@ use swc_core::{
     ecma::ast::{Expr, ExprOrSpread, Lit, NewExpr},
     quote_expr,
 };
-use turbo_tasks::{RcStr, Value, ValueToString, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, Value, ValueToString, Vc};
 use turbopack_core::{
     chunk::{ChunkableModule, ChunkableModuleReference, ChunkingContext},
     issue::{code_gen::CodeGenerationIssue, IssueExt, IssueSeverity, IssueSource, StyledString},
@@ -66,7 +66,7 @@ impl WorkerAssetReference {
         let Some(module) = *module.first_module().await? else {
             bail!("Expected worker to resolve to a module");
         };
-        let Some(chunkable) = Vc::try_resolve_downcast::<Box<dyn ChunkableModule>>(module).await?
+        let Some(chunkable) = ResolvedVc::try_downcast::<Box<dyn ChunkableModule>>(module).await?
         else {
             CodeGenerationIssue {
                 severity: IssueSeverity::Bug.into(),
@@ -79,7 +79,7 @@ impl WorkerAssetReference {
             return Ok(None);
         };
 
-        Ok(Some(WorkerLoaderModule::new(chunkable)))
+        Ok(Some(WorkerLoaderModule::new(*chunkable)))
     }
 }
 

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -13,7 +13,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use turbo_tasks::{
     duration_span, fxindexmap, mark_finished, prevent_gc, util::SharedError, Completion, RawVc,
-    TaskInput, TryJoinIterExt, Value, Vc,
+    ResolvedVc, TaskInput, TryJoinIterExt, Value, Vc,
 };
 use turbo_tasks_bytes::{Bytes, Stream};
 use turbo_tasks_env::ProcessEnv;
@@ -81,7 +81,7 @@ pub struct JavaScriptEvaluation(#[turbo_tasks(trace_ignore)] JavaScriptStream);
 /// Pass the file you cared as `runtime_entries` to invalidate and reload the
 /// evaluated result automatically.
 pub async fn get_evaluate_pool(
-    module_asset: Vc<Box<dyn Module>>,
+    module_asset: ResolvedVc<Box<dyn Module>>,
     cwd: Vc<FileSystemPath>,
     env: Vc<Box<dyn ProcessEnv>>,
     asset_context: Vc<Box<dyn AssetContext>>,
@@ -95,7 +95,9 @@ pub async fn get_evaluate_pool(
             Vc::upcast(FileSource::new(embed_file_path("ipc/evaluate.ts".into()))),
             Value::new(ReferenceType::Internal(InnerAssets::empty())),
         )
-        .module();
+        .module()
+        .to_resolved()
+        .await?;
 
     let module_path = module_asset.ident().path().await?;
     let file_name = module_path.file_name();

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -366,7 +366,9 @@ async fn postcss_executor(
             config_loader_source(project_path, postcss_config_path),
             Value::new(ReferenceType::Entry(EntryReferenceSubType::Undefined)),
         )
-        .module();
+        .module()
+        .to_resolved()
+        .await?;
 
     Ok(asset_context.process(
         Vc::upcast(VirtualSource::new(

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -341,7 +341,9 @@ async fn run_test(prepared_test: Vc<PreparedTest>) -> Result<Vc<RunTestResult>> 
             Vc::upcast(test_source),
             Value::new(ReferenceType::Internal(InnerAssets::empty())),
         )
-        .module();
+        .module()
+        .to_resolved()
+        .await?;
 
     let jest_entry_asset = asset_context
         .process(

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Context, Result};
-use turbo_tasks::{fxindexmap, RcStr, Value, Vc};
+use turbo_tasks::{fxindexmap, RcStr, ResolvedVc, Value, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -73,7 +73,7 @@ impl WebAssemblyModuleAsset {
         let module = this.asset_context.process(
             loader_source,
             Value::new(ReferenceType::Internal(Vc::cell(fxindexmap! {
-                "WASM_PATH".into() => Vc::upcast(RawWebAssemblyModuleAsset::new(this.source, this.asset_context)),
+                "WASM_PATH".into() => ResolvedVc::upcast(RawWebAssemblyModuleAsset::new(this.source, this.asset_context).to_resolved().await?),
             }))),
         ).module();
 

--- a/turbopack/crates/turbopack/src/rebase/mod.rs
+++ b/turbopack/crates/turbopack/src/rebase/mod.rs
@@ -56,7 +56,7 @@ impl OutputAsset for RebasedAsset {
             .iter()
         {
             references.push(Vc::upcast(RebasedAsset::new(
-                module,
+                *module,
                 self.input_dir,
                 self.output_dir,
             )));


### PR DESCRIPTION
A hand refactor of the `Modules` (and `OptionModule`) type in `turbopack-core` to use `ResolvedVc`. This is one of the more common types passed around turbopack, so this touches a lot of code.

Closes PACK-3343