### PR TITLE
refactor(turbopack-resolve): Port all struct fields in the `turbopack-resolve` crate to `turbo_tasks::ResolvedVc`

### DIFF
--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -96,20 +96,28 @@ pub async fn get_edge_resolve_options_context(
     execution_context: Vc<ExecutionContext>,
 ) -> Result<Vc<ResolveOptionsContext>> {
     let next_edge_import_map =
-        get_next_edge_import_map(project_path, ty, next_config, execution_context);
+        get_next_edge_import_map(project_path, ty, next_config, execution_context)
+            .to_resolved()
+            .await?;
 
     let ty: ServerContextType = ty.into_value();
 
-    let mut before_resolve_plugins = vec![Vc::upcast(ModuleFeatureReportResolvePlugin::new(
-        project_path,
-    ))];
+    let mut before_resolve_plugins = vec![ResolvedVc::upcast(
+        ModuleFeatureReportResolvePlugin::new(project_path)
+            .to_resolved()
+            .await?,
+    )];
     if matches!(
         ty,
         ServerContextType::Pages { .. }
             | ServerContextType::AppSSR { .. }
             | ServerContextType::AppRSC { .. }
     ) {
-        before_resolve_plugins.push(Vc::upcast(NextFontLocalResolvePlugin::new(project_path)));
+        before_resolve_plugins.push(ResolvedVc::upcast(
+            NextFontLocalResolvePlugin::new(project_path)
+                .to_resolved()
+                .await?,
+        ));
     };
 
     if matches!(
@@ -120,17 +128,23 @@ pub async fn get_edge_resolve_options_context(
             | ServerContextType::Middleware { .. }
             | ServerContextType::Instrumentation { .. }
     ) {
-        before_resolve_plugins.push(Vc::upcast(get_invalid_client_only_resolve_plugin(
-            project_path,
-        )));
-        before_resolve_plugins.push(Vc::upcast(get_invalid_styled_jsx_resolve_plugin(
-            project_path,
-        )));
+        before_resolve_plugins.push(ResolvedVc::upcast(
+            get_invalid_client_only_resolve_plugin(project_path)
+                .to_resolved()
+                .await?,
+        ));
+        before_resolve_plugins.push(ResolvedVc::upcast(
+            get_invalid_styled_jsx_resolve_plugin(project_path)
+                .to_resolved()
+                .await?,
+        ));
     }
 
-    let after_resolve_plugins = vec![Vc::upcast(NextSharedRuntimeResolvePlugin::new(
-        project_path,
-    ))];
+    let after_resolve_plugins = vec![ResolvedVc::upcast(
+        NextSharedRuntimeResolvePlugin::new(project_path)
+            .to_resolved()
+            .await?,
+    )];
 
     // https://github.com/vercel/next.js/blob/bf52c254973d99fed9d71507a2e818af80b8ade7/packages/next/src/build/webpack-config.ts#L96-L102
     let mut custom_conditions = vec![mode.await?.condition().into()];
@@ -147,7 +161,7 @@ pub async fn get_edge_resolve_options_context(
     };
 
     let resolve_options_context = ResolveOptionsContext {
-        enable_node_modules: Some(project_path.root().resolve().await?),
+        enable_node_modules: Some(project_path.root().to_resolved().await?),
         enable_edge_node_externals: true,
         custom_conditions,
         import_map: Some(next_edge_import_map),
@@ -166,7 +180,7 @@ pub async fn get_edge_resolve_options_context(
         custom_extensions: next_config.resolve_extension().await?.clone_value(),
         rules: vec![(
             foreign_code_context_condition(next_config, project_path).await?,
-            resolve_options_context.clone().cell(),
+            resolve_options_context.clone().resolved_cell(),
         )],
         ..resolve_options_context
     }

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -128,14 +128,22 @@ pub async fn get_server_resolve_options_context(
     execution_context: Vc<ExecutionContext>,
 ) -> Result<Vc<ResolveOptionsContext>> {
     let next_server_import_map =
-        get_next_server_import_map(project_path, ty, next_config, execution_context);
+        get_next_server_import_map(project_path, ty, next_config, execution_context)
+            .to_resolved()
+            .await?;
     let foreign_code_context_condition =
         foreign_code_context_condition(next_config, project_path).await?;
-    let root_dir = project_path.root().resolve().await?;
-    let module_feature_report_resolve_plugin = ModuleFeatureReportResolvePlugin::new(project_path);
-    let invalid_client_only_resolve_plugin = get_invalid_client_only_resolve_plugin(project_path);
+    let root_dir = project_path.root().to_resolved().await?;
+    let module_feature_report_resolve_plugin = ModuleFeatureReportResolvePlugin::new(project_path)
+        .to_resolved()
+        .await?;
+    let invalid_client_only_resolve_plugin = get_invalid_client_only_resolve_plugin(project_path)
+        .to_resolved()
+        .await?;
     let invalid_styled_jsx_client_only_resolve_plugin =
-        get_invalid_styled_jsx_resolve_plugin(project_path);
+        get_invalid_styled_jsx_resolve_plugin(project_path)
+            .to_resolved()
+            .await?;
 
     // Always load these predefined packages as external.
     let mut external_packages: Vec<RcStr> = load_next_js_templateon(
@@ -181,7 +189,9 @@ pub async fn get_server_resolve_options_context(
         project_path.root(),
         ExternalPredicate::Only(ResolvedVc::cell(external_packages)).cell(),
         *next_config.import_externals().await?,
-    );
+    )
+    .to_resolved()
+    .await?;
 
     let mut custom_conditions = vec![mode.await?.condition().to_string().into()];
     custom_conditions.extend(
@@ -205,19 +215,29 @@ pub async fn get_server_resolve_options_context(
             ExternalPredicate::AllExcept(ResolvedVc::cell(transpiled_packages)).cell(),
             *next_config.import_externals().await?,
         )
+        .to_resolved()
+        .await?
     };
 
-    let next_external_plugin = NextExternalResolvePlugin::new(project_path);
+    let next_external_plugin = NextExternalResolvePlugin::new(project_path)
+        .to_resolved()
+        .await?;
     let next_node_shared_runtime_plugin =
-        NextNodeSharedRuntimeResolvePlugin::new(project_path, Value::new(ty));
+        NextNodeSharedRuntimeResolvePlugin::new(project_path, Value::new(ty))
+            .to_resolved()
+            .await?;
 
     let mut before_resolve_plugins = match ty {
         ServerContextType::Pages { .. }
         | ServerContextType::AppSSR { .. }
         | ServerContextType::AppRSC { .. } => {
             vec![
-                Vc::upcast(NextFontLocalResolvePlugin::new(project_path)),
-                Vc::upcast(module_feature_report_resolve_plugin),
+                ResolvedVc::upcast(
+                    NextFontLocalResolvePlugin::new(project_path)
+                        .to_resolved()
+                        .await?,
+                ),
+                ResolvedVc::upcast(module_feature_report_resolve_plugin),
             ]
         }
         ServerContextType::PagesData { .. }
@@ -225,7 +245,7 @@ pub async fn get_server_resolve_options_context(
         | ServerContextType::AppRoute { .. }
         | ServerContextType::Middleware { .. }
         | ServerContextType::Instrumentation { .. } => {
-            vec![Vc::upcast(module_feature_report_resolve_plugin)]
+            vec![ResolvedVc::upcast(module_feature_report_resolve_plugin)]
         }
     };
 
@@ -234,28 +254,28 @@ pub async fn get_server_resolve_options_context(
         | ServerContextType::PagesApi { .. }
         | ServerContextType::PagesData { .. } => {
             vec![
-                Vc::upcast(next_node_shared_runtime_plugin),
-                Vc::upcast(external_cjs_modules_plugin),
-                Vc::upcast(next_external_plugin),
+                ResolvedVc::upcast(next_node_shared_runtime_plugin),
+                ResolvedVc::upcast(external_cjs_modules_plugin),
+                ResolvedVc::upcast(next_external_plugin),
             ]
         }
         ServerContextType::AppSSR { .. }
         | ServerContextType::AppRSC { .. }
         | ServerContextType::AppRoute { .. } => {
             vec![
-                Vc::upcast(next_node_shared_runtime_plugin),
-                Vc::upcast(server_external_packages_plugin),
-                Vc::upcast(next_external_plugin),
+                ResolvedVc::upcast(next_node_shared_runtime_plugin),
+                ResolvedVc::upcast(server_external_packages_plugin),
+                ResolvedVc::upcast(next_external_plugin),
             ]
         }
         ServerContextType::Middleware { .. } => {
-            vec![Vc::upcast(next_node_shared_runtime_plugin)]
+            vec![ResolvedVc::upcast(next_node_shared_runtime_plugin)]
         }
         ServerContextType::Instrumentation { .. } => {
             vec![
-                Vc::upcast(next_node_shared_runtime_plugin),
-                Vc::upcast(server_external_packages_plugin),
-                Vc::upcast(next_external_plugin),
+                ResolvedVc::upcast(next_node_shared_runtime_plugin),
+                ResolvedVc::upcast(server_external_packages_plugin),
+                ResolvedVc::upcast(next_external_plugin),
             ]
         }
     };
@@ -276,8 +296,10 @@ pub async fn get_server_resolve_options_context(
         | ServerContextType::AppRoute { .. }
         | ServerContextType::Middleware { .. }
         | ServerContextType::Instrumentation { .. } => {
-            before_resolve_plugins.push(Vc::upcast(invalid_client_only_resolve_plugin));
-            before_resolve_plugins.push(Vc::upcast(invalid_styled_jsx_client_only_resolve_plugin));
+            before_resolve_plugins.push(ResolvedVc::upcast(invalid_client_only_resolve_plugin));
+            before_resolve_plugins.push(ResolvedVc::upcast(
+                invalid_styled_jsx_client_only_resolve_plugin,
+            ));
         }
         ServerContextType::AppSSR { .. } => {
             //[TODO] Build error in this context makes rsc-build-error.ts fail which expects runtime error code
@@ -304,7 +326,7 @@ pub async fn get_server_resolve_options_context(
         custom_extensions: next_config.resolve_extension().await?.clone_value(),
         rules: vec![(
             foreign_code_context_condition,
-            resolve_options_context.clone().cell(),
+            resolve_options_context.clone().resolved_cell(),
         )],
         ..resolve_options_context
     }

--- a/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -61,7 +61,7 @@ pub async fn get_swc_ecma_transform_rule_impl(
         let resolve_options = resolve_options(
             project_path,
             ResolveOptionsContext {
-                enable_node_modules: Some(project_path.root().resolve().await?),
+                enable_node_modules: Some(project_path.root().to_resolved().await?),
                 enable_node_native_modules: true,
                 ..Default::default()
             }

--- a/turbopack/crates/node-file-trace/src/lib.rs
+++ b/turbopack/crates/node-file-trace/src/lib.rs
@@ -609,7 +609,7 @@ async fn create_module_asset(
             ResolvedMap {
                 by_glob: glob_mappings,
             }
-            .cell(),
+            .resolved_cell(),
         );
     }
 

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -74,9 +74,9 @@ pub fn get_client_import_map(project_path: Vc<FileSystemPath>) -> Vc<ImportMap> 
 pub async fn get_client_resolve_options_context(
     project_path: Vc<FileSystemPath>,
 ) -> Result<Vc<ResolveOptionsContext>> {
-    let next_client_import_map = get_client_import_map(project_path);
+    let next_client_import_map = get_client_import_map(project_path).to_resolved().await?;
     let module_options_context = ResolveOptionsContext {
-        enable_node_modules: Some(project_path.root().resolve().await?),
+        enable_node_modules: Some(project_path.root().to_resolved().await?),
         custom_conditions: vec!["development".into()],
         import_map: Some(next_client_import_map),
         browser: true,
@@ -88,7 +88,7 @@ pub async fn get_client_resolve_options_context(
         enable_react: true,
         rules: vec![(
             foreign_code_context_condition().await?,
-            module_options_context.clone().cell(),
+            module_options_context.clone().resolved_cell(),
         )],
         ..module_options_context
     }

--- a/turbopack/crates/turbopack-core/src/issue/resolve.rs
+++ b/turbopack/crates/turbopack-core/src/issue/resolve.rs
@@ -72,7 +72,7 @@ impl Issue for ResolvingIssue {
 
         if let Some(import_map) = &self.resolve_options.await?.import_map {
             for request in request_parts {
-                match lookup_import_map(*import_map, self.file_path, *request).await {
+                match lookup_import_map(**import_map, self.file_path, *request).await {
                     Ok(None) => {}
                     Ok(Some(str)) => writeln!(description, "Import map: {}", str)?,
                     Err(err) => {

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -493,12 +493,12 @@ pub struct ResolveOptions {
     /// The default files to resolve in a folder.
     pub default_files: Vec<RcStr>,
     /// An import map to use before resolving a request.
-    pub import_map: Option<Vc<ImportMap>>,
+    pub import_map: Option<ResolvedVc<ImportMap>>,
     /// An import map to use when a request is otherwise unresolvable.
     pub fallback_import_map: Option<Vc<ImportMap>>,
-    pub resolved_map: Option<Vc<ResolvedMap>>,
-    pub before_resolve_plugins: Vec<Vc<Box<dyn BeforeResolvePlugin>>>,
-    pub plugins: Vec<Vc<Box<dyn AfterResolvePlugin>>>,
+    pub resolved_map: Option<ResolvedVc<ResolvedMap>>,
+    pub before_resolve_plugins: Vec<ResolvedVc<Box<dyn BeforeResolvePlugin>>>,
+    pub plugins: Vec<ResolvedVc<Box<dyn AfterResolvePlugin>>>,
     /// Support resolving *.js requests to *.ts files
     pub enable_typescript_with_output_extension: bool,
     /// Warn instead of error for resolve errors
@@ -521,7 +521,9 @@ impl ResolveOptions {
             resolve_options
                 .import_map
                 .map(|current_import_map| current_import_map.extend(import_map))
-                .unwrap_or(import_map),
+                .unwrap_or(import_map)
+                .to_resolved()
+                .await?,
         );
         Ok(resolve_options.into())
     }

--- a/turbopack/crates/turbopack-resolve/src/resolve.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve.rs
@@ -133,7 +133,7 @@ async fn base_resolve_options(
         let additional_import_map = additional_import_map.await?;
         import_map.extend_ref(&additional_import_map);
     }
-    let import_map = import_map.cell();
+    let import_map = import_map.resolved_cell();
 
     let plugins = opt.after_resolve_plugins.clone();
 
@@ -281,7 +281,7 @@ pub async fn resolve_options(
         let context_value = &*resolve_path.await?;
         for (condition, new_options_context) in options_context_value.rules.iter() {
             if condition.matches(context_value).await? {
-                return Ok(resolve_options(resolve_path, *new_options_context));
+                return Ok(resolve_options(resolve_path, **new_options_context));
             }
         }
     }
@@ -304,13 +304,13 @@ pub async fn resolve_options(
     // overwrites any other mappings.
     let resolve_options = options_context_value
         .import_map
-        .map(|import_map| resolve_options.with_extended_import_map(import_map))
+        .map(|import_map| resolve_options.with_extended_import_map(*import_map))
         .unwrap_or(resolve_options);
     // And the same for the fallback_import_map
     let resolve_options = options_context_value
         .fallback_import_map
         .map(|fallback_import_map| {
-            resolve_options.with_extended_fallback_import_map(fallback_import_map)
+            resolve_options.with_extended_fallback_import_map(*fallback_import_map)
         })
         .unwrap_or(resolve_options);
 

--- a/turbopack/crates/turbopack-resolve/src/resolve_options_context.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve_options_context.rs
@@ -29,7 +29,7 @@ pub struct ResolveOptionsContext {
     #[serde(default)]
     /// Enable resolving of the node_modules folder when within the provided
     /// directory
-    pub enable_node_modules: Option<Vc<FileSystemPath>>,
+    pub enable_node_modules: Option<ResolvedVc<FileSystemPath>>,
     #[serde(default)]
     /// Mark well-known Node.js modules as external imports and load them using
     /// native `require`. e.g. url, querystring, os
@@ -53,25 +53,25 @@ pub struct ResolveOptionsContext {
     /// If set, this import map will be applied to `ResolveOption::import_map`.
     /// It is always applied last, so any mapping defined within will take
     /// precedence over any other (e.g. tsconfig.json `compilerOptions.paths`).
-    pub import_map: Option<Vc<ImportMap>>,
+    pub import_map: Option<ResolvedVc<ImportMap>>,
     #[serde(default)]
     /// An import map to fall back to when a request could not be resolved.
     ///
     /// If set, this import map will be applied to
     /// `ResolveOption::fallback_import_map`. It is always applied last, so
     /// any mapping defined within will take precedence over any other.
-    pub fallback_import_map: Option<Vc<ImportMap>>,
+    pub fallback_import_map: Option<ResolvedVc<ImportMap>>,
     #[serde(default)]
     /// An additional resolved map to use after modules have been resolved.
-    pub resolved_map: Option<Vc<ResolvedMap>>,
+    pub resolved_map: Option<ResolvedVc<ResolvedMap>>,
     #[serde(default)]
     /// A list of rules to use a different resolve option context for certain
     /// context paths. The first matching is used.
-    pub rules: Vec<(ContextCondition, Vc<ResolveOptionsContext>)>,
+    pub rules: Vec<(ContextCondition, ResolvedVc<ResolveOptionsContext>)>,
     #[serde(default)]
     /// Plugins which get applied before and after resolving.
-    pub after_resolve_plugins: Vec<Vc<Box<dyn AfterResolvePlugin>>>,
-    pub before_resolve_plugins: Vec<Vc<Box<dyn BeforeResolvePlugin>>>,
+    pub after_resolve_plugins: Vec<ResolvedVc<Box<dyn AfterResolvePlugin>>>,
+    pub before_resolve_plugins: Vec<ResolvedVc<Box<dyn BeforeResolvePlugin>>>,
     /// Warn instead of error for resolve errors
     pub loose_errors: bool,
 
@@ -101,7 +101,9 @@ impl ResolveOptionsContext {
             resolve_options_context
                 .import_map
                 .map(|current_import_map| current_import_map.extend(import_map))
-                .unwrap_or(import_map),
+                .unwrap_or(import_map)
+                .to_resolved()
+                .await?,
         );
         Ok(resolve_options_context.into())
     }
@@ -120,7 +122,9 @@ impl ResolveOptionsContext {
                 .map(|current_fallback_import_map| {
                     current_fallback_import_map.extend(fallback_import_map)
                 })
-                .unwrap_or(fallback_import_map),
+                .unwrap_or(fallback_import_map)
+                .to_resolved()
+                .await?,
         );
         Ok(resolve_options_context.into())
     }

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -196,7 +196,7 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
     };
     let root_fs = DiskFileSystem::new("workspace".into(), REPO_ROOT.clone(), vec![]);
     let project_fs = DiskFileSystem::new("project".into(), REPO_ROOT.clone(), vec![]);
-    let project_root = project_fs.root();
+    let project_root = project_fs.root().to_resolved().await?;
 
     let relative_path = test_path.strip_prefix(&*REPO_ROOT)?;
     let relative_path: RcStr = sys_to_unix(relative_path.to_str().unwrap()).into();
@@ -307,7 +307,7 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                     custom_conditions: vec!["development".into()],
                     ..Default::default()
                 }
-                .cell(),
+                .resolved_cell(),
             )],
             ..Default::default()
         }
@@ -325,7 +325,7 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
     let chunking_context: Vc<Box<dyn ChunkingContext>> = match options.runtime {
         Runtime::Browser => Vc::upcast(
             BrowserChunkingContext::builder(
-                project_root,
+                *project_root,
                 path,
                 path,
                 chunk_root_path,
@@ -337,7 +337,7 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         ),
         Runtime::NodeJs => Vc::upcast(
             NodeJsChunkingContext::builder(
-                project_root,
+                *project_root,
                 path,
                 path,
                 chunk_root_path,

--- a/turbopack/crates/turbopack/examples/turbopack.rs
+++ b/turbopack/crates/turbopack/examples/turbopack.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<()> {
                 ResolveOptionsContext {
                     enable_typescript: true,
                     enable_react: true,
-                    enable_node_modules: Some(fs.root()),
+                    enable_node_modules: Some(fs.root().to_resolved().await?),
                     custom_conditions: vec!["development".into()],
                     ..Default::default()
                 }
@@ -68,7 +68,7 @@ async fn main() -> Result<()> {
             let rebased = RebasedAsset::new(module, input, output);
             emit_with_completion(Vc::upcast(rebased), output).await?;
 
-            Ok::<Vc<()>, _>(Default::default())
+            anyhow::Ok::<Vc<()>>(Default::default())
         })
     });
     spawn({

--- a/turbopack/crates/turbopack/src/evaluate_context.rs
+++ b/turbopack/crates/turbopack/src/evaluate_context.rs
@@ -48,7 +48,7 @@ pub async fn node_evaluate_asset_context(
         )
         .cell(),
     );
-    let import_map = import_map.cell();
+    let import_map = import_map.resolved_cell();
     let node_env: RcStr =
         if let Some(node_env) = &*execution_context.env().read("NODE_ENV".into()).await? {
             node_env.as_str().into()
@@ -59,7 +59,13 @@ pub async fn node_evaluate_asset_context(
     // base context used for node_modules (and context for app code will be derived
     // from this)
     let resolve_options_context = ResolveOptionsContext {
-        enable_node_modules: Some(execution_context.project_path().root().resolve().await?),
+        enable_node_modules: Some(
+            execution_context
+                .project_path()
+                .root()
+                .to_resolved()
+                .await?,
+        ),
         enable_node_externals: true,
         enable_node_native_modules: true,
         custom_conditions: vec![node_env.clone(), "node".into()],
@@ -71,7 +77,7 @@ pub async fn node_evaluate_asset_context(
         import_map: Some(import_map),
         rules: vec![(
             ContextCondition::InDirectory("node_modules".to_string()),
-            resolve_options_context.clone().cell(),
+            resolve_options_context.clone().resolved_cell(),
         )],
         ..resolve_options_context
     }

--- a/turbopack/crates/turbopack/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack/tests/node-file-trace.rs
@@ -410,7 +410,7 @@ fn node_file_trace<B: Backend + 'static>(
                     package_root.clone(),
                     vec![],
                 ));
-                let input_dir = workspace_fs.root();
+                let input_dir = workspace_fs.root().to_resolved().await?;
                 let input = input_dir.join(format!("tests/{input_string}").into());
 
                 #[cfg(not(feature = "bench_against_node_nft"))]
@@ -452,7 +452,7 @@ fn node_file_trace<B: Backend + 'static>(
                 let module = module_asset_context
                     .process(Vc::upcast(source), Value::new(ReferenceType::Undefined))
                     .module();
-                let rebased = RebasedAsset::new(Vc::upcast(module), input_dir, output_dir);
+                let rebased = RebasedAsset::new(Vc::upcast(module), *input_dir, output_dir);
 
                 #[cfg(not(feature = "bench_against_node_nft"))]
                 let output_path = rebased.ident().path();


### PR DESCRIPTION
A hand refactor of all the remaining struct fields in `turbopack-resolve` to `ResolvedVc`.

Note: "resolve" in this context means two different things. `turbopack-resolve` is about resolving module locations on disk. `ResolvedVc` is about resolving "cells" representing incremental computations.

Closes PACK-3344