### PR TITLE
next-codemod: update gitignore file for parity for yarn recommendations

### DIFF
--- a/packages/next-codemod/lib/cra-to-next/gitignore
+++ b/packages/next-codemod/lib/cra-to-next/gitignore
@@ -3,8 +3,12 @@
 # dependencies
 /node_modules
 /.pnp
-.pnp.js
-.yarn/install-state.gz
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
 
 # testing
 /coverage


### PR DESCRIPTION
## Summary
Update examples `.gitignore` files for parity with [Yarn's official recommendations](https://v3.yarnpkg.com/getting-started/qa#which-files-should-be-gitignored), accounting for Yarn's modern Plug-n-Play functionality.

x-ref: #65823