### PR TITLE
Unflake revalidate-reason deploy test

### DIFF
--- a/test/e2e/revalidate-reason/pages/index.tsx
+++ b/test/e2e/revalidate-reason/pages/index.tsx
@@ -9,6 +9,11 @@ export async function getStaticProps({ params, revalidateReason }) {
     props: {
       reason: revalidateReason,
     },
+    // TODO: Deploy tests occasionally fail since we revalidate due to staleness.
+    // But the default is apparently "no revalidation" (https://nextjs.org/docs/canary/pages/api-reference/functions/get-static-props#revalidate)
+    // This hints at a bug.
+    // The high duration is just a workaround to check if this unflakes the test.
+    revalidate: 60 * 60 * 24 * 365,
   }
 }
 


### PR DESCRIPTION
This [test occasionally flakes because the revalidate reason is "stale"](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Anextjs%20%40test.source.file%3Atest%2Fe2e%2Frevalidate-reason%2Frevalidate-reason.test.ts%20%40test.status%3Afail&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=test.source.file%2Casc&cols=%40test.status%2Ctimestamp%2Clog_test.suite%2Clog_test.name%2Clog_duration%2Clog_test.service%2Clog_git.branch%2C%40test.source.file%2C%40ci.pipeline.name&currentTab=overview&eventStack=&fromUser=false&graphType=flamegraph&index=citest&start=1729513483290&end=1730118283290&paused=false). This [shouldn't happen according to docs](https://nextjs.org/docs/canary/pages/api-reference/functions/get-static-props#revalidate) though.

Revisiting in a week to check if this got fixed and we either have a bug with defaults or Vercel specific bug.