### PR TITLE
test: remove duplicated flaky test

### DIFF
--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/page-export/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/page-export/page.js
@@ -1,3 +1,0 @@
-export default function Page() {
-  return <p>Page</p>
-}

--- a/test/development/acceptance-app/undefined-default-export.test.ts
+++ b/test/development/acceptance-app/undefined-default-export.test.ts
@@ -61,26 +61,6 @@ describe('Undefined default export', () => {
     await cleanup()
   })
 
-  it('should error when root page component export is not valid', async () => {
-    const { session, cleanup } = await sandbox(
-      next,
-      undefined,
-      '/server-with-errors/page-export'
-    )
-
-    await next.patchFile(
-      'app/server-with-errors/page-export/page.js',
-      'export const a = 123'
-    )
-
-    await session.assertHasRedbox()
-    expect(await session.getRedboxDescription()).toInclude(
-      'The default export is not a React Component in "/server-with-errors/page-export/page"'
-    )
-
-    await cleanup()
-  })
-
   it('should error when page component export is not valid on initial load', async () => {
     const { session, cleanup } = await sandbox(
       next,


### PR DESCRIPTION
### What

Removing the flaky test because the wrong setup and it's also duplicated with the next one

### Why

After investigating the playwright trace, I found it's failing due to unable to load the rsc data of that page.

It's because it's using `default-template`, which doesn't contain that target page `/server-with-errors/page-export/page.js`

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2Vkr1hjxbcl3bK6lTFf7/e4aa92f8-fa50-43f4-9b13-76e2833b9b6a.png)

And it's also same as the next test, so we just remove it as we already have case to cover it

Similar tests:

- `should error when page component export is not valid` covers the `/` is missing default export
- `should error when page component export is not valid on initial load` covers other page missing `/` missing default export