### PR TITLE
Use `registerClientReference` for ESM client component modules

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "id": "appDirname",
       "type": "promptString",
       "description": "Enter an app dirname from examples or test/e2e",
-      "default": "test/e2e/app-dir/use-cache"
+      "default": "examples/hello-world"
     },
     {
       "id": "nextCommand",
@@ -47,7 +47,6 @@
         "webpack://(?:_N_E)?/(?:../)*src/(.*)": "${workspaceFolder}/packages/next/src/$1",
         "webpack://next/./dist/src/*": "${workspaceFolder}/packages/next/src/*",
         "webpack://next/./dist/compiled/*": "${workspaceFolder}/packages/next/src/compiled/*",
-        "webpack:///(?:../)*packages/next/dist/compiled/(.*)": "${workspaceFolder}/packages/next/src/compiled/$1",
         "webpack://next/./src/*": "${workspaceFolder}/packages/next/src/*",
         "webpack-internal:///\\(rsc\\)/(?:../)*packages/next/dist/(.*)": "${workspaceFolder}/packages/next/src/$1",
         "turbopack://[project]/*": "${workspaceFolder}/*"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "id": "appDirname",
       "type": "promptString",
       "description": "Enter an app dirname from examples or test/e2e",
-      "default": "examples/hello-world"
+      "default": "test/e2e/app-dir/use-cache"
     },
     {
       "id": "nextCommand",
@@ -47,6 +47,7 @@
         "webpack://(?:_N_E)?/(?:../)*src/(.*)": "${workspaceFolder}/packages/next/src/$1",
         "webpack://next/./dist/src/*": "${workspaceFolder}/packages/next/src/*",
         "webpack://next/./dist/compiled/*": "${workspaceFolder}/packages/next/src/compiled/*",
+        "webpack:///(?:../)*packages/next/dist/compiled/(.*)": "${workspaceFolder}/packages/next/src/compiled/$1",
         "webpack://next/./src/*": "${workspaceFolder}/packages/next/src/*",
         "webpack-internal:///\\(rsc\\)/(?:../)*packages/next/dist/(.*)": "${workspaceFolder}/packages/next/src/$1",
         "turbopack://[project]/*": "${workspaceFolder}/*"

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -88,7 +88,6 @@ import {
   getBabelLoader,
   getReactCompilerLoader,
 } from './get-babel-loader-config'
-import type { NextFlightLoaderOptions } from './webpack/loaders/next-flight-loader'
 import {
   NEXT_PROJECT_ROOT,
   NEXT_PROJECT_ROOT_DIST_CLIENT,
@@ -519,13 +518,6 @@ export default async function getBaseWebpackConfig(
     babel: useSWCLoader ? swcDefaultLoader : babelLoader!,
   }
 
-  const nextFlightLoader = {
-    loader: 'next-flight-loader',
-    options: {
-      isEdgeServer,
-    } satisfies NextFlightLoaderOptions,
-  }
-
   const appServerLayerLoaders = hasAppDir
     ? [
         // When using Babel, we will have to add the SWC loader
@@ -539,7 +531,7 @@ export default async function getBaseWebpackConfig(
     : []
 
   const instrumentLayerLoaders = [
-    nextFlightLoader,
+    'next-flight-loader',
     // When using Babel, we will have to add the SWC loader
     // as an additional pass to handle RSC correctly.
     // This will cause some performance overhead but
@@ -549,7 +541,7 @@ export default async function getBaseWebpackConfig(
   ].filter(Boolean)
 
   const middlewareLayerLoaders = [
-    nextFlightLoader,
+    'next-flight-loader',
     // When using Babel, we will have to use SWC to do the optimization
     // for middleware to tree shake the unused default optimized imports like "next/server".
     // This will cause some performance overhead but
@@ -1366,7 +1358,7 @@ export default async function getBaseWebpackConfig(
                     isEdgeServer,
                   }),
                 },
-                use: nextFlightLoader,
+                use: 'next-flight-loader',
               },
             ]
           : []),

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -27,6 +27,7 @@ import {
 import type { ChunkGroup } from 'webpack'
 import { encodeURIPath } from '../../../shared/lib/encode-uri-path'
 import { isMetadataRoute } from '../../../lib/metadata/is-metadata-route'
+import type { ModuleInfo } from './flight-client-entry-plugin'
 
 interface Options {
   dev: boolean
@@ -43,11 +44,11 @@ type ModuleId = string | number /*| null*/
 export type ManifestChunks = Array<string>
 
 const pluginState = getProxiedPluginState({
-  serverModuleIds: {} as Record<string, string | number>,
-  edgeServerModuleIds: {} as Record<string, string | number>,
+  ssrModules: {} as { [ssrModuleId: string]: ModuleInfo },
+  edgeSsrModules: {} as { [ssrModuleId: string]: ModuleInfo },
 
-  rscModuleIds: {} as Record<string, string | number>,
-  edgeRscModuleIds: {} as Record<string, string | number>,
+  rscModules: {} as { [rscModuleId: string]: ModuleInfo },
+  edgeRscModules: {} as { [rscModuleId: string]: ModuleInfo },
 })
 
 export interface ManifestNode {
@@ -356,12 +357,18 @@ export class ClientReferenceManifestPlugin {
         }
 
         function addClientReference() {
+          const isAsync = Boolean(
+            compilation.moduleGraph.isAsync(mod) ||
+              pluginState.ssrModules[ssrNamedModuleId]?.async ||
+              pluginState.edgeSsrModules[ssrNamedModuleId]?.async
+          )
+
           const exportName = resource
           manifest.clientModules[exportName] = {
             id: modId,
             name: '*',
             chunks: requiredChunks,
-            async: false,
+            async: isAsync,
           }
           if (esmResource) {
             const edgeExportName = esmResource
@@ -372,9 +379,9 @@ export class ClientReferenceManifestPlugin {
 
         function addSSRIdMapping() {
           const exportName = resource
-          if (
-            typeof pluginState.serverModuleIds[ssrNamedModuleId] !== 'undefined'
-          ) {
+          const moduleInfo = pluginState.ssrModules[ssrNamedModuleId]
+
+          if (moduleInfo) {
             moduleIdMapping[modId] = moduleIdMapping[modId] || {}
             moduleIdMapping[modId]['*'] = {
               ...manifest.clientModules[exportName],
@@ -382,14 +389,14 @@ export class ClientReferenceManifestPlugin {
               // side with our architecture of Webpack / Turbopack. We can keep
               // this field empty to save some bytes.
               chunks: [],
-              id: pluginState.serverModuleIds[ssrNamedModuleId],
+              id: moduleInfo.moduleId,
+              async: moduleInfo.async,
             }
           }
 
-          if (
-            typeof pluginState.edgeServerModuleIds[ssrNamedModuleId] !==
-            'undefined'
-          ) {
+          const edgeModuleInfo = pluginState.edgeSsrModules[ssrNamedModuleId]
+
+          if (edgeModuleInfo) {
             edgeModuleIdMapping[modId] = edgeModuleIdMapping[modId] || {}
             edgeModuleIdMapping[modId]['*'] = {
               ...manifest.clientModules[exportName],
@@ -397,16 +404,17 @@ export class ClientReferenceManifestPlugin {
               // side with our architecture of Webpack / Turbopack. We can keep
               // this field empty to save some bytes.
               chunks: [],
-              id: pluginState.edgeServerModuleIds[ssrNamedModuleId],
+              id: edgeModuleInfo.moduleId,
+              async: edgeModuleInfo.async,
             }
           }
         }
 
         function addRSCIdMapping() {
           const exportName = resource
-          if (
-            typeof pluginState.rscModuleIds[rscNamedModuleId] !== 'undefined'
-          ) {
+          const moduleInfo = pluginState.rscModules[rscNamedModuleId]
+
+          if (moduleInfo) {
             rscIdMapping[modId] = rscIdMapping[modId] || {}
             rscIdMapping[modId]['*'] = {
               ...manifest.clientModules[exportName],
@@ -414,14 +422,14 @@ export class ClientReferenceManifestPlugin {
               // side with our architecture of Webpack / Turbopack. We can keep
               // this field empty to save some bytes.
               chunks: [],
-              id: pluginState.rscModuleIds[rscNamedModuleId],
+              id: moduleInfo.moduleId,
+              async: moduleInfo.async,
             }
           }
 
-          if (
-            typeof pluginState.edgeRscModuleIds[rscNamedModuleId] !==
-            'undefined'
-          ) {
+          const edgeModuleInfo = pluginState.ssrModules[rscNamedModuleId]
+
+          if (edgeModuleInfo) {
             edgeRscIdMapping[modId] = edgeRscIdMapping[modId] || {}
             edgeRscIdMapping[modId]['*'] = {
               ...manifest.clientModules[exportName],
@@ -429,7 +437,8 @@ export class ClientReferenceManifestPlugin {
               // side with our architecture of Webpack / Turbopack. We can keep
               // this field empty to save some bytes.
               chunks: [],
-              id: pluginState.edgeRscModuleIds[rscNamedModuleId],
+              id: edgeModuleInfo.moduleId,
+              async: edgeModuleInfo.async,
             }
           }
         }

--- a/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -24,6 +24,7 @@ import { getPageFilePath } from '../../entries'
 import { resolveExternal } from '../../handle-externals'
 import swcLoader from '../loaders/next-swc-loader'
 import { isMetadataRoute } from '../../../lib/metadata/is-metadata-route'
+import { isClientComponentEntryModule } from '../loaders/utils'
 
 const PLUGIN_NAME = 'TraceEntryPointsPlugin'
 export const TRACE_IGNORES = [
@@ -533,10 +534,7 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
                 // fallback to reading raw source file, this may fail
                 // due to unsupported syntax but best effort attempt
                 let usingOriginalSource = false
-                if (
-                  !source ||
-                  source.toString().includes('next-flight-loader/module-proxy')
-                ) {
+                if (!source || isClientComponentEntryModule(mod)) {
                   source = await readOriginalSource(path)
                   usingOriginalSource = true
                 }

--- a/test/e2e/app-dir/dynamic-import/app/button.tsx
+++ b/test/e2e/app-dir/dynamic-import/app/button.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export function Button() {
+  return <button>submit</button>
+}

--- a/test/e2e/app-dir/dynamic-import/app/layout.tsx
+++ b/test/e2e/app-dir/dynamic-import/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/dynamic-import/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-import/app/page.tsx
@@ -1,0 +1,16 @@
+// x-ref: https://github.com/vercel/next.js/issues/71840
+
+import { ElementType } from 'react'
+
+async function getImport(
+  slug: string,
+  exportName: string
+): Promise<ElementType> {
+  const moduleExports = await import(`./${slug}`)
+  return moduleExports[exportName]
+}
+
+export default async function Home() {
+  const Button = await getImport('button', 'Button')
+  return <Button />
+}

--- a/test/e2e/app-dir/dynamic-import/dynamic-import.test.ts
+++ b/test/e2e/app-dir/dynamic-import/dynamic-import.test.ts
@@ -1,0 +1,12 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('dynamic-import', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should render the dynamically imported component', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('button').text()).toBe('submit')
+  })
+})

--- a/test/e2e/app-dir/dynamic-import/next.config.js
+++ b/test/e2e/app-dir/dynamic-import/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/dynamic/app/dynamic/named-export/page.js
+++ b/test/e2e/app-dir/dynamic/app/dynamic/named-export/page.js
@@ -2,7 +2,7 @@ import dynamic from 'next/dynamic'
 
 const Button = dynamic(() =>
   import('./client').then((mod) => {
-    return { default: mod.Button }
+    return mod.Button
   })
 )
 

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -231,8 +231,7 @@ describe('app dir - rsc basics', () => {
     expect(html).toContain('dynamic data!')
   })
 
-  // TODO: TLA in client references are currently broken with Webpack on Edge
-  describe.each(process.env.TURBOPACK ? ['node', 'edge'] : ['node'])(
+  describe.each(['node', 'edge'])(
     'client references with TLA (%s)',
     (runtime) => {
       let url = `/async-client${runtime === 'edge' ? '/edge' : ''}`


### PR DESCRIPTION
When registering client references for a client component module, React offers two distinct functions:

- `registerClientReference`: Register a named or default export of an ES module as a client reference.
- `createClientModuleProxy`: Create a client module proxy for a CJS module that registers every module export as a client reference.

Until this PR, we were using the client module proxy for both kinds of modules, which is incorrect. It was especially problematic because in the Node.js runtime we were always awaiting the client module proxy. This was a workaround for handling async modules (see #66990), but led to issues like #71840.

With this PR, we are now using `registerClientReference` if we detect that a module is an ES module. This aligns the Webpack implementation with the one in Turbopack (see #70258).

fixes #71840