### PR TITLE
Fix swc version mismatch when checking out an older version

### DIFF
--- a/scripts/install-native.mjs
+++ b/scripts/install-native.mjs
@@ -43,21 +43,21 @@ import fsp from 'fs/promises'
       name: 'dummy-package',
       version: '1.0.0',
       optionalDependencies: {
-        '@next/swc-darwin-arm64': 'canary',
-        '@next/swc-darwin-x64': 'canary',
-        '@next/swc-linux-arm64-gnu': 'canary',
-        '@next/swc-linux-arm64-musl': 'canary',
-        '@next/swc-linux-x64-gnu': 'canary',
-        '@next/swc-linux-x64-musl': 'canary',
-        '@next/swc-win32-arm64-msvc': 'canary',
-        '@next/swc-win32-x64-msvc': 'canary',
+        '@next/swc-darwin-arm64': nextVersion,
+        '@next/swc-darwin-x64': nextVersion,
+        '@next/swc-linux-arm64-gnu': nextVersion,
+        '@next/swc-linux-arm64-musl': nextVersion,
+        '@next/swc-linux-x64-gnu': nextVersion,
+        '@next/swc-linux-x64-musl': nextVersion,
+        '@next/swc-win32-arm64-msvc': nextVersion,
+        '@next/swc-win32-x64-msvc': nextVersion,
       },
       packageManager,
     }
     fs.writeFileSync(path.join(tmpdir, 'package.json'), JSON.stringify(pkgJson))
     fs.writeFileSync(path.join(tmpdir, '.npmrc'), 'node-linker=hoisted')
 
-    let { stdout } = await execa('pnpm', ['add', 'next@canary'], {
+    let { stdout } = await execa('pnpm', ['add', `next@${nextVersion}`], {
       cwd: tmpdir,
     })
     console.log(stdout)


### PR DESCRIPTION
Repro steps:
1. check out an older branch (e.g.: `git checkout v14.2.7`)
2. install NPM packages by `pnpm i`
3. build a local dist by `pnpm build` 
4. create a production build of a Next.js app (e.g., `pnpm next build <app-dir>`

**You would see an error like**
```
 ⚠ Mismatching @next/swc version, detected: 15.0.2-canary.9 while Next.js is on 14.2.7. Please ensure these match
```

The `post-install` script always installs the `canary`: see https://github.com/vercel/next.js/commit/5a5b683a9786d81d87741702eadf92e2a9210593#diff-907b7be0cfc75bd37773e5ebc38d1deffa40861b8ac1cde92e4992e284a1ee59R46

Now it installs native `swc` build that corresponds to the Next.js version in the branch. This PR resolves the issue starting from the current commit onward, as changes to previous code are not 
retroactive.