### PR TITLE
Clarify that streaming is blocked on generateMetadata for initial load

### DIFF
--- a/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/02-app/02-api-reference/04-functions/generate-metadata.mdx
@@ -46,6 +46,7 @@ export async function generateMetadata({ params }) {
 >
 > - The `metadata` object and `generateMetadata` function exports are **only supported in Server Components**.
 > - You cannot export both the `metadata` object and `generateMetadata` function from the same route segment.
+> - On the initial load, streaming is blocked until `generateMetadata` has fully resolved, including any content from `loading.js`.
 
 ## The `metadata` object
 


### PR DESCRIPTION
The initial load, `generateMetadata` needs to block the streaming for 2 reasons:

1. You want the ability to respond the HTML with special status code based on the `notFound` / `redirect` call inside `generateMetadata`. You cannot do that in out-of-order streaming, hence blocking the streaming.
2. SEO