### PR TITLE
fix: Add `use client` to client-only components

### DIFF
--- a/packages/next/src/shared/lib/amp-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/amp-context.shared-runtime.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import React from 'react'
 
 export const AmpStateContext: React.Context<any> = React.createContext({})

--- a/packages/next/src/shared/lib/head-manager-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/head-manager-context.shared-runtime.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import React from 'react'
 
 export const HeadManagerContext: React.Context<{

--- a/packages/next/src/shared/lib/html-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/html-context.shared-runtime.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import type { BuildManifest } from '../../server/get-page-files'
 import type { ServerRuntime } from '../../types'
 import type { NEXT_DATA } from './utils'

--- a/packages/next/src/shared/lib/image-config-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/image-config-context.shared-runtime.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import React from 'react'
 import type { ImageConfigComplete } from './image-config'
 import { imageConfigDefault } from './image-config'

--- a/packages/next/src/shared/lib/router-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/router-context.shared-runtime.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import React from 'react'
 import type { NextRouter } from './router/router'
 


### PR DESCRIPTION
### What?

Add `use client` to client-only components in next.js

### Why?

They use `React.createContext`, so they should not be server component, and for some reason with tree shaking enabled turbopack chunk them as a SSR bundle. 

### How?

Closes PACK-3349
