### PR TITLE
example: typo `yarn` → `next`

### DIFF
--- a/examples/analyze-bundles/package.json
+++ b/examples/analyze-bundles/package.json
@@ -4,7 +4,7 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
-    "analyze": "cross-env ANALYZE=true yarn build",
+    "analyze": "cross-env ANALYZE=true next build",
     "serve": "serve .next/analyze"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
The old analyze command use `yarn build`.
This happens an error with node, pnpm and bun.

### Adding or Updating Examples

- [x] The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- [x] Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md