### PR TITLE
Prevent prerender errors due to `Math.random()` usage by `@vercel/otel`

### DIFF
--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -12,6 +12,7 @@ import type {
   TextMapGetter,
 } from 'next/dist/compiled/@opentelemetry/api'
 import { isThenable } from '../../../shared/lib/is-thenable'
+import { workUnitAsyncStorage } from '../../app-render/work-unit-async-storage.external'
 
 let api: typeof import('next/dist/compiled/@opentelemetry/api')
 
@@ -300,83 +301,102 @@ class NextTracerImpl implements NextTracer {
       ...options.attributes,
     }
 
-    return context.with(spanContext.setValue(rootSpanIdKey, spanId), () =>
-      this.getTracerInstance().startActiveSpan(
-        spanName,
-        options,
-        (span: Span) => {
-          const startTime =
-            'performance' in globalThis && 'measure' in performance
-              ? globalThis.performance.now()
-              : undefined
+    return context.with(spanContext.setValue(rootSpanIdKey, spanId), () => {
+      const workUnitStore = workUnitAsyncStorage.getStore()
 
-          const onCleanup = () => {
-            rootSpanAttributesStore.delete(spanId)
-            if (
-              startTime &&
-              process.env.NEXT_OTEL_PERFORMANCE_PREFIX &&
-              LogSpanAllowList.includes(type || ('' as any))
-            ) {
-              performance.measure(
-                `${process.env.NEXT_OTEL_PERFORMANCE_PREFIX}:next-${(
-                  type.split('.').pop() || ''
-                ).replace(
-                  /[A-Z]/g,
-                  (match: string) => '-' + match.toLowerCase()
-                )}`,
-                {
-                  start: startTime,
-                  end: performance.now(),
-                }
-              )
-            }
-          }
+      const withSpan = (span: Span) => {
+        const startTime =
+          'performance' in globalThis && 'measure' in performance
+            ? globalThis.performance.now()
+            : undefined
 
-          if (isRootSpan) {
-            rootSpanAttributesStore.set(
-              spanId,
-              new Map(
-                Object.entries(options.attributes ?? {}) as [
-                  AttributeNames,
-                  AttributeValue | undefined,
-                ][]
-              )
+        const onCleanup = () => {
+          rootSpanAttributesStore.delete(spanId)
+          if (
+            startTime &&
+            process.env.NEXT_OTEL_PERFORMANCE_PREFIX &&
+            LogSpanAllowList.includes(type || ('' as any))
+          ) {
+            performance.measure(
+              `${process.env.NEXT_OTEL_PERFORMANCE_PREFIX}:next-${(
+                type.split('.').pop() || ''
+              ).replace(
+                /[A-Z]/g,
+                (match: string) => '-' + match.toLowerCase()
+              )}`,
+              {
+                start: startTime,
+                end: performance.now(),
+              }
             )
           }
-          try {
-            if (fn.length > 1) {
-              return fn(span, (err) => closeSpanWithError(span, err))
-            }
-
-            const result = fn(span)
-            if (isThenable(result)) {
-              // If there's error make sure it throws
-              return result
-                .then((res) => {
-                  span.end()
-                  // Need to pass down the promise result,
-                  // it could be react stream response with error { error, stream }
-                  return res
-                })
-                .catch((err) => {
-                  closeSpanWithError(span, err)
-                  throw err
-                })
-                .finally(onCleanup)
-            } else {
-              span.end()
-              onCleanup()
-            }
-
-            return result
-          } catch (err: any) {
-            closeSpanWithError(span, err)
-            onCleanup()
-            throw err
-          }
         }
+
+        if (isRootSpan) {
+          rootSpanAttributesStore.set(
+            spanId,
+            new Map(
+              Object.entries(options.attributes ?? {}) as [
+                AttributeNames,
+                AttributeValue | undefined,
+              ][]
+            )
+          )
+        }
+        try {
+          if (fn.length > 1) {
+            return fn(span, (err) => closeSpanWithError(span, err))
+          }
+
+          const result = fn(span)
+          if (isThenable(result)) {
+            // If there's error make sure it throws
+            return result
+              .then((res) => {
+                span.end()
+                // Need to pass down the promise result,
+                // it could be react stream response with error { error, stream }
+                return res
+              })
+              .catch((err) => {
+                closeSpanWithError(span, err)
+                throw err
+              })
+              .finally(onCleanup)
+          } else {
+            span.end()
+            onCleanup()
+          }
+
+          return result
+        } catch (err: any) {
+          closeSpanWithError(span, err)
+          onCleanup()
+          throw err
+        }
+      }
+
+      if (workUnitStore) {
+        // Tracing libraries might use `Math.random()` to generate a span ID. To
+        // ensure that this doesn't trigger our dynamic IO access error
+        // handling, we're exiting the work unit storage when the span is
+        // started, and re-entering it before executing the traced function.
+        return workUnitAsyncStorage.exit(() =>
+          this.getTracerInstance().startActiveSpan(
+            spanName,
+            options,
+            (span: Span) =>
+              workUnitAsyncStorage.run(workUnitStore, withSpan, span)
+          )
+        )
+      }
+
+      return this.getTracerInstance().startActiveSpan(
+        spanName,
+        options,
+        withSpan
       )
-    )
+    })
   }
 
   public wrap<T = (...args: Array<any>) => any>(type: SpanTypes, fn: T): T

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -8,6 +8,7 @@ import type { IncomingMessage, ServerResponse } from 'http'
 import type { NextUrlWithParsedQuery } from './request-meta'
 import type { WorkerRequestHandler, WorkerUpgradeHandler } from './lib/types'
 
+import './node-environment'
 import './require-hook'
 import './node-polyfill-crypto'
 

--- a/test/e2e/app-dir/dynamic-io-with-otel/app/layout.tsx
+++ b/test/e2e/app-dir/dynamic-io-with-otel/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/dynamic-io-with-otel/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-io-with-otel/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/dynamic-io-with-otel/dynamic-io-with-otel.test.ts
+++ b/test/e2e/app-dir/dynamic-io-with-otel/dynamic-io-with-otel.test.ts
@@ -1,0 +1,24 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('dynamic-io-with-otel', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    dependencies: require('./package.json').dependencies,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should not log an error for accessing `Math.random()`', async () => {
+    const $ = await next.render$('/')
+    expect($('p').text()).toBe('hello world')
+
+    // @vercel/otel uses `Math.random()` to generate span IDs. This should not
+    // trigger an error during prerendering.
+    expect(next.cliOutput).not.toContain(
+      'Error: Route "/" used `Math.random()` outside of `"use cache"` and without explicitly calling `await connection()` beforehand.'
+    )
+  })
+})

--- a/test/e2e/app-dir/dynamic-io-with-otel/instrumentation.ts
+++ b/test/e2e/app-dir/dynamic-io-with-otel/instrumentation.ts
@@ -1,0 +1,5 @@
+import { registerOTel } from '@vercel/otel'
+
+export function register() {
+  registerOTel('next-app')
+}

--- a/test/e2e/app-dir/dynamic-io-with-otel/next.config.js
+++ b/test/e2e/app-dir/dynamic-io-with-otel/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    dynamicIO: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/dynamic-io-with-otel/package.json
+++ b/test/e2e/app-dir/dynamic-io-with-otel/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "@vercel/otel": "^1.10.0",
+    "@opentelemetry/sdk-logs": "^0.54.0",
+    "@opentelemetry/api-logs": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.54.0"
+  }
+}


### PR DESCRIPTION
> [!NOTE]  
> This PR is best reviewed with hidden whitespace changes.

When [`@vercel/otel` is configured as OpenTelemetry implementation](https://nextjs.org/docs/app/building-your-application/optimizing/open-telemetry#using-vercelotel), and `experimental.dynamicIO` is enabled, an error is logged during prerendering with `next dev`, due to the usage of `Math.random()` for generating span IDs. This is triggered by the internal tracing of Next.js.

To fix this, we're exiting the work unit storage before creating a span. This is a solution we're already using in `patchErrorInspect` for the same reason (in this case triggered by the `source-map` library).

Notably, this does not prevent the errors from being logged when app code contains trace calls. For now, users need to use either `await connection()` or `"use cache"` when tracing with `@vercel/otel`.

fixes #72024