### PR TITLE
refactor(turbopack-core): Change `OutputAssets` type to use ResolvedVc

### DIFF
--- a/crates/next-api/src/font.rs
+++ b/crates/next-api/src/font.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use next_core::{all_assets_from_entries, next_manifests::NextFontManifest};
-use turbo_tasks::{RcStr, ValueToString, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent,
@@ -19,7 +19,7 @@ pub(crate) async fn create_font_manifest(
     pathname: &str,
     client_assets: Vc<OutputAssets>,
     app_dir: bool,
-) -> Result<Vc<Box<dyn OutputAsset>>> {
+) -> Result<ResolvedVc<Box<dyn OutputAsset>>> {
     let all_client_output_assets = all_assets_from_entries(client_assets).await?;
 
     // `_next` gets added again later, so we "strip" it here via
@@ -65,8 +65,14 @@ pub(crate) async fn create_font_manifest(
         }
     };
 
-    Ok(Vc::upcast(VirtualOutputAsset::new(
-        path,
-        AssetContent::file(File::from(serde_json::to_string_pretty(&next_font_manifest)?).into()),
-    )))
+    Ok(ResolvedVc::upcast(
+        VirtualOutputAsset::new(
+            path,
+            AssetContent::file(
+                File::from(serde_json::to_string_pretty(&next_font_manifest)?).into(),
+            ),
+        )
+        .to_resolved()
+        .await?,
+    ))
 }

--- a/crates/next-api/src/loadable_manifest.rs
+++ b/crates/next-api/src/loadable_manifest.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 use next_core::next_manifests::LoadableManifest;
-use turbo_tasks::{RcStr, TryFlatJoinIterExt, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, TryFlatJoinIterExt, Vc};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent,
@@ -56,7 +56,7 @@ pub async fn create_react_loadable_manifest(
         }
     }
 
-    let loadable_manifest = Vc::upcast(VirtualOutputAsset::new(
+    let loadable_manifest = VirtualOutputAsset::new(
         output_path,
         AssetContent::file(
             FileContent::Content(File::from(serde_json::to_string_pretty(
@@ -64,8 +64,10 @@ pub async fn create_react_loadable_manifest(
             )?))
             .cell(),
         ),
-    ));
+    )
+    .to_resolved()
+    .await?;
 
-    output.push(loadable_manifest);
+    output.push(ResolvedVc::upcast(loadable_manifest));
     Ok(Vc::cell(output))
 }

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -239,7 +239,7 @@ impl MiddlewareEndpoint {
                 .collect(),
             ..Default::default()
         };
-        let middleware_manifest_v2 = Vc::upcast(VirtualOutputAsset::new(
+        let middleware_manifest_v2 = VirtualOutputAsset::new(
             node_root.join("server/middleware/middleware-manifest.json".into()),
             AssetContent::file(
                 FileContent::Content(File::from(serde_json::to_string_pretty(
@@ -247,8 +247,10 @@ impl MiddlewareEndpoint {
                 )?))
                 .cell(),
             ),
-        ));
-        output_assets.push(middleware_manifest_v2);
+        )
+        .to_resolved()
+        .await?;
+        output_assets.push(ResolvedVc::upcast(middleware_manifest_v2));
 
         Ok(Vc::cell(output_assets))
     }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -27,8 +27,8 @@ use turbo_tasks::{
     fxindexmap,
     graph::{AdjacencyMap, GraphTraversal},
     trace::TraceRawVcs,
-    Completion, Completions, FxIndexMap, IntoTraitRef, RcStr, ReadRef, State, TaskInput,
-    TransientInstance, TryFlatJoinIterExt, Value, Vc,
+    Completion, Completions, FxIndexMap, IntoTraitRef, RcStr, ReadRef, ResolvedVc, State,
+    TaskInput, TransientInstance, TryFlatJoinIterExt, Value, Vc,
 };
 use turbo_tasks_env::{EnvMap, ProcessEnv};
 use turbo_tasks_fs::{DiskFileSystem, FileSystem, FileSystemPath, VirtualFileSystem};
@@ -1324,7 +1324,7 @@ async fn any_output_changed(
                 && (!server || !asset_path.path.ends_with(".css"))
                 && asset_path.is_inside_ref(path)
             {
-                Ok(Some(content_changed(Vc::upcast(m))))
+                Ok(Some(content_changed(*ResolvedVc::upcast(m))))
             } else {
                 Ok(None)
             }
@@ -1336,8 +1336,8 @@ async fn any_output_changed(
 }
 
 async fn get_referenced_output_assets(
-    parent: Vc<Box<dyn OutputAsset>>,
-) -> Result<impl Iterator<Item = Vc<Box<dyn OutputAsset>>> + Send> {
+    parent: ResolvedVc<Box<dyn OutputAsset>>,
+) -> Result<impl Iterator<Item = ResolvedVc<Box<dyn OutputAsset>>> + Send> {
     Ok(parent.references().await?.clone_value().into_iter())
 }
 

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Result};
 use next_core::emit_assets;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{
-    debug::ValueDebugFormat, trace::TraceRawVcs, Completion, FxIndexSet, RcStr, State,
+    debug::ValueDebugFormat, trace::TraceRawVcs, Completion, FxIndexSet, RcStr, ResolvedVc, State,
     TryFlatJoinIterExt, TryJoinIterExt, ValueDefault, ValueToString, Vc,
 };
 use turbo_tasks_fs::FileSystemPath;
@@ -26,13 +26,13 @@ struct MapEntry {
     assets_operation: Vc<OutputAssets>,
     side_effects: Vc<Completion>,
     /// Precomputed map for quick access to output asset by filepath
-    path_to_asset: HashMap<Vc<FileSystemPath>, Vc<Box<dyn OutputAsset>>>,
+    path_to_asset: HashMap<ResolvedVc<FileSystemPath>, Vc<Box<dyn OutputAsset>>>,
 }
 
 #[turbo_tasks::value(transparent)]
 struct OptionMapEntry(Option<MapEntry>);
 
-type PathToOutputOperation = HashMap<Vc<FileSystemPath>, FxIndexSet<Vc<OutputAssets>>>;
+type PathToOutputOperation = HashMap<ResolvedVc<FileSystemPath>, FxIndexSet<Vc<OutputAssets>>>;
 // A precomputed map for quick access to output asset by filepath
 type OutputOperationToComputeEntry = HashMap<Vc<OutputAssets>, Vc<OptionMapEntry>>;
 
@@ -90,7 +90,7 @@ impl VersionedContentMap {
         Ok(entry.side_effects)
     }
 
-    /// Creates a ComputEntry (a pre-computed map for optimized lookup) for an output assets
+    /// Creates a [`MapEntry`] (a pre-computed map for optimized lookup) for an output assets
     /// operation. When assets change, map_path_to_op is updated.
     #[turbo_tasks::function]
     async fn compute_entry(
@@ -103,13 +103,13 @@ impl VersionedContentMap {
         let assets = *assets_operation.await?;
         async fn get_entries(
             assets: Vc<OutputAssets>,
-        ) -> Result<Vec<(Vc<FileSystemPath>, Vc<Box<dyn OutputAsset>>)>> {
+        ) -> Result<Vec<(ResolvedVc<FileSystemPath>, Vc<Box<dyn OutputAsset>>)>> {
             let assets_ref = assets.await?;
             let entries = assets_ref
                 .iter()
                 .map(|&asset| async move {
-                    let path = asset.ident().path().resolve().await?;
-                    Ok((path, asset))
+                    let path = asset.ident().path().to_resolved().await?;
+                    Ok((path, *asset))
                 })
                 .try_join()
                 .await?;
@@ -189,9 +189,9 @@ impl VersionedContentMap {
     #[turbo_tasks::function]
     pub async fn get_asset(
         self: Vc<Self>,
-        path: Vc<FileSystemPath>,
+        path: ResolvedVc<FileSystemPath>,
     ) -> Result<Vc<OptionOutputAsset>> {
-        let result = self.raw_get(path).await?;
+        let result = self.raw_get(*path).await?;
         if let Some(MapEntry {
             assets_operation: _,
             side_effects,
@@ -230,7 +230,7 @@ impl VersionedContentMap {
     }
 
     #[turbo_tasks::function]
-    fn raw_get(&self, path: Vc<FileSystemPath>) -> Vc<OptionMapEntry> {
+    fn raw_get(&self, path: ResolvedVc<FileSystemPath>) -> Vc<OptionMapEntry> {
         let assets = {
             let map = self.map_path_to_op.get();
             map.get(&path).and_then(|m| m.iter().last().copied())

--- a/crates/next-api/src/webpack_stats.rs
+++ b/crates/next-api/src/webpack_stats.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use serde::Serialize;
-use turbo_tasks::{FxIndexMap, FxIndexSet, RcStr, Vc};
+use turbo_tasks::{FxIndexMap, FxIndexSet, RcStr, ResolvedVc, Vc};
 use turbopack_browser::ecmascript::EcmascriptDevChunk;
 use turbopack_core::{
     chunk::{Chunk, ChunkItem},
@@ -12,7 +12,7 @@ pub async fn generate_webpack_stats<'a, I>(
     entry_assets: I,
 ) -> Result<WebpackStats>
 where
-    I: IntoIterator<Item = &'a Vc<Box<dyn OutputAsset>>>,
+    I: IntoIterator<Item = &'a ResolvedVc<Box<dyn OutputAsset>>>,
 {
     let mut assets = vec![];
     let mut chunks = vec![];
@@ -26,7 +26,7 @@ where
             continue;
         };
 
-        if let Some(chunk) = Vc::try_resolve_downcast_type::<EcmascriptDevChunk>(*asset).await? {
+        if let Some(chunk) = ResolvedVc::try_downcast_type::<EcmascriptDevChunk>(*asset).await? {
             let chunk_ident = normalize_client_path(&chunk.ident().path().await?.path);
             chunks.push(WebpackStatsChunk {
                 size: asset_len,

--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use tracing::Instrument;
 use turbo_tasks::{
     graph::{AdjacencyMap, GraphTraversal},
-    Completion, Completions, TryFlatJoinIterExt, ValueToString, Vc,
+    Completion, Completions, ResolvedVc, TryFlatJoinIterExt, ValueToString, Vc,
 };
 use turbo_tasks_fs::{rebase, FileSystemPath};
 use turbopack_core::{
@@ -108,8 +108,8 @@ pub async fn all_assets_from_entries(entries: Vc<OutputAssets>) -> Result<Vc<Out
 
 /// Computes the list of all chunk children of a given chunk.
 async fn get_referenced_assets(
-    asset: Vc<Box<dyn OutputAsset>>,
-) -> Result<impl Iterator<Item = Vc<Box<dyn OutputAsset>>> + Send> {
+    asset: ResolvedVc<Box<dyn OutputAsset>>,
+) -> Result<impl Iterator<Item = ResolvedVc<Box<dyn OutputAsset>>> + Send> {
     Ok(asset
         .references()
         .await?

--- a/crates/next-core/src/hmr_entry.rs
+++ b/crates/next-core/src/hmr_entry.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use anyhow::Result;
-use turbo_tasks::{RcStr, ValueToString, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{glob::Glob, rope::RopeBuilder};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -99,13 +99,13 @@ impl EvaluatableAsset for HmrEntryModule {}
 
 #[turbo_tasks::value]
 pub struct HmrEntryModuleReference {
-    pub module: Vc<Box<dyn Module>>,
+    pub module: ResolvedVc<Box<dyn Module>>,
 }
 
 #[turbo_tasks::value_impl]
 impl HmrEntryModuleReference {
     #[turbo_tasks::function]
-    pub fn new(module: Vc<Box<dyn Module>>) -> Vc<Self> {
+    pub fn new(module: ResolvedVc<Box<dyn Module>>) -> Vc<Self> {
         HmrEntryModuleReference { module }.cell()
     }
 }

--- a/crates/next-core/src/next_app/include_modules_module.rs
+++ b/crates/next-core/src/next_app/include_modules_module.rs
@@ -143,13 +143,13 @@ impl EcmascriptChunkItem for IncludeModulesChunkItem {
 /// [`IncludeModulesModule`].
 #[turbo_tasks::value]
 pub struct IncludedModuleReference {
-    pub module: Vc<Box<dyn Module>>,
+    pub module: ResolvedVc<Box<dyn Module>>,
 }
 
 #[turbo_tasks::value_impl]
 impl IncludedModuleReference {
     #[turbo_tasks::function]
-    pub fn new(module: Vc<Box<dyn Module>>) -> Vc<Self> {
+    pub fn new(module: ResolvedVc<Box<dyn Module>>) -> Vc<Self> {
         IncludedModuleReference { module }.cell()
     }
 }

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use turbo_tasks::{RcStr, Value, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, Value, Vc};
 use turbopack::{
     transition::{ContextTransition, Transition},
     ModuleAssetContext,
@@ -101,13 +101,13 @@ impl Transition for NextEcmascriptClientReferenceTransition {
         };
 
         let Some(client_module) =
-            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(client_module).await?
+            ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(client_module).await?
         else {
             bail!("client asset is not ecmascript chunk placeable");
         };
 
         let Some(ssr_module) =
-            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(ssr_module).await?
+            ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(ssr_module).await?
         else {
             bail!("SSR asset is not ecmascript chunk placeable");
         };
@@ -123,14 +123,16 @@ impl Transition for NextEcmascriptClientReferenceTransition {
             module_asset_context.layer,
         );
 
-        Ok(
-            ProcessResult::Module(Vc::upcast(EcmascriptClientReferenceProxyModule::new(
+        Ok(ProcessResult::Module(ResolvedVc::upcast(
+            EcmascriptClientReferenceProxyModule::new(
                 ident,
                 Vc::upcast(server_context),
-                client_module,
-                ssr_module,
-            )))
-            .cell(),
-        )
+                *client_module,
+                *ssr_module,
+            )
+            .to_resolved()
+            .await?,
+        ))
+        .cell())
     }
 }

--- a/crates/next-core/src/next_dynamic/dynamic_transition.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_transition.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{RcStr, Value, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, Value, Vc};
 use turbopack::{transition::Transition, ModuleAssetContext};
 use turbopack_core::{context::ProcessResult, reference_type::ReferenceType, source::Source};
 
@@ -50,9 +50,11 @@ impl Transition for NextDynamicTransition {
             )
             .await?
         {
-            ProcessResult::Module(client_module) => {
-                ProcessResult::Module(Vc::upcast(NextDynamicEntryModule::new(client_module)))
-            }
+            ProcessResult::Module(client_module) => ProcessResult::Module(ResolvedVc::upcast(
+                NextDynamicEntryModule::new(*client_module)
+                    .to_resolved()
+                    .await?,
+            )),
             ProcessResult::Ignore => ProcessResult::Ignore,
         }
         .cell())

--- a/crates/next-core/src/next_server_component/server_component_reference.rs
+++ b/crates/next-core/src/next_server_component/server_component_reference.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{RcStr, ValueToString, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
     chunk::ChunkableModuleReference, module::Module, reference::ModuleReference,
     resolve::ModuleResolveResult,
@@ -7,13 +7,13 @@ use turbopack_core::{
 
 #[turbo_tasks::value]
 pub struct NextServerComponentModuleReference {
-    asset: Vc<Box<dyn Module>>,
+    asset: ResolvedVc<Box<dyn Module>>,
 }
 
 #[turbo_tasks::value_impl]
 impl NextServerComponentModuleReference {
     #[turbo_tasks::function]
-    pub fn new(asset: Vc<Box<dyn Module>>) -> Vc<Self> {
+    pub fn new(asset: ResolvedVc<Box<dyn Module>>) -> Vc<Self> {
         NextServerComponentModuleReference { asset }.cell()
     }
 }

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -109,13 +109,15 @@ impl PageLoaderAsset {
             let rebased = chunks
                 .await?
                 .iter()
-                .map(|chunk| {
-                    Vc::upcast(ProxiedAsset::new(
+                .map(|&chunk| {
+                    Vc::upcast::<Box<dyn OutputAsset>>(ProxiedAsset::new(
                         *chunk,
                         FileSystemPath::rebase(chunk.ident().path(), **rebase_path, root_path),
                     ))
+                    .to_resolved()
                 })
-                .collect();
+                .try_join()
+                .await?;
             chunks = Vc::cell(rebased);
         };
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{FxIndexSet, RcStr, ValueToString, Vc};
+use turbo_tasks::{FxIndexSet, RcStr, ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{Chunk, ChunkingContext, OutputChunk, OutputChunkRuntimeInfo},
@@ -106,7 +106,9 @@ impl OutputAsset for EcmascriptDevChunk {
         references.extend(chunk_references.iter().copied());
 
         if include_source_map {
-            references.push(Vc::upcast(SourceMapAsset::new(Vc::upcast(self))));
+            references.push(ResolvedVc::upcast(
+                SourceMapAsset::new(Vc::upcast(self)).to_resolved().await?,
+            ));
         }
 
         Ok(Vc::cell(references))

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use anyhow::{bail, Result};
 use indoc::writedoc;
 use serde::Serialize;
-use turbo_tasks::{RcStr, ReadRef, TryJoinIterExt, Value, ValueToString, Vc};
+use turbo_tasks::{RcStr, ReadRef, ResolvedVc, TryJoinIterExt, Value, ValueToString, Vc};
 use turbo_tasks_fs::File;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -234,7 +234,9 @@ impl OutputAsset for EcmascriptDevEvaluateChunk {
             .await?;
 
         if include_source_map {
-            references.push(Vc::upcast(SourceMapAsset::new(Vc::upcast(self))));
+            references.push(ResolvedVc::upcast(
+                SourceMapAsset::new(Vc::upcast(self)).to_resolved().await?,
+            ));
         }
 
         for chunk_data in &*self.chunks_data().await? {

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -305,7 +305,7 @@ async fn build_internal(
         .try_join()
         .await?;
 
-    let mut chunks: HashSet<Vc<Box<dyn OutputAsset>>> = HashSet::new();
+    let mut chunks: HashSet<ResolvedVc<Box<dyn OutputAsset>>> = HashSet::new();
     for chunk_group in entry_chunk_groups {
         chunks.extend(&*all_assets_from_entries(chunk_group).await?);
     }

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -195,6 +195,7 @@ async fn references_to_output_assets(
         .flatten()
         .copied()
         .filter(|&asset| set.insert(asset))
+        .map(|asset| *asset)
         .collect::<Vec<_>>();
     Ok(OutputAssets::new(output_assets))
 }

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{trace::TraceRawVcs, RcStr, TaskInput, Upcast, Value, Vc};
+use turbo_tasks::{trace::TraceRawVcs, RcStr, ResolvedVc, TaskInput, Upcast, Value, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::DeterministicHash;
 
@@ -43,7 +43,7 @@ pub struct ChunkGroupResult {
 
 #[turbo_tasks::value(shared)]
 pub struct EntryChunkGroupResult {
-    pub asset: Vc<Box<dyn OutputAsset>>,
+    pub asset: ResolvedVc<Box<dyn OutputAsset>>,
     pub availability_info: AvailabilityInfo,
 }
 
@@ -311,7 +311,7 @@ async fn entry_chunk_group_asset(
     extra_chunks: Vc<OutputAssets>,
     availability_info: Value<AvailabilityInfo>,
 ) -> Result<Vc<Box<dyn OutputAsset>>> {
-    Ok(chunking_context
+    Ok(*chunking_context
         .entry_chunk_group(
             path,
             module,

--- a/turbopack/crates/turbopack-core/src/chunk/data.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/data.rs
@@ -126,7 +126,7 @@ impl ChunkData {
             chunks
                 .await?
                 .iter()
-                .map(|&chunk| ChunkData::from_asset(output_root, chunk))
+                .map(|&chunk| ChunkData::from_asset(output_root, *chunk))
                 .try_join()
                 .await?
                 .into_iter()

--- a/turbopack/crates/turbopack-core/src/context.rs
+++ b/turbopack/crates/turbopack-core/src/context.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use turbo_tasks::{RcStr, Value, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, Value, Vc};
 use turbo_tasks_fs::{glob::Glob, FileSystemPath};
 
 use crate::{
@@ -13,7 +13,7 @@ use crate::{
 #[turbo_tasks::value(shared)]
 pub enum ProcessResult {
     /// A module was created.
-    Module(Vc<Box<dyn Module>>),
+    Module(ResolvedVc<Box<dyn Module>>),
 
     /// Reference is ignored. This should lead to no module being included by
     /// the reference.
@@ -25,7 +25,7 @@ impl ProcessResult {
     #[turbo_tasks::function]
     pub async fn module(&self) -> Result<Vc<Box<dyn Module>>> {
         match *self {
-            ProcessResult::Module(m) => Ok(m),
+            ProcessResult::Module(m) => Ok(*m),
             ProcessResult::Ignore => {
                 bail!("Expected process result to be a module, but it was ignored")
             }

--- a/turbopack/crates/turbopack-core/src/introspect/utils.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/utils.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{FxIndexSet, RcStr, Vc};
+use turbo_tasks::{FxIndexSet, RcStr, ResolvedVc, Vc};
 use turbo_tasks_fs::FileContent;
 
 use super::{
@@ -95,7 +95,7 @@ pub async fn children_from_module_references(
             .await?
             .iter()
         {
-            children.insert((key, IntrospectableOutputAsset::new(output_asset)));
+            children.insert((key, IntrospectableOutputAsset::new(*output_asset)));
         }
     }
     Ok(Vc::cell(children))
@@ -109,7 +109,10 @@ pub async fn children_from_output_assets(
     let mut children = FxIndexSet::default();
     let references = references.await?;
     for &reference in &*references {
-        children.insert((key, IntrospectableOutputAsset::new(Vc::upcast(reference))));
+        children.insert((
+            key,
+            IntrospectableOutputAsset::new(*ResolvedVc::upcast(reference)),
+        ));
     }
     Ok(Vc::cell(children))
 }

--- a/turbopack/crates/turbopack-core/src/output.rs
+++ b/turbopack/crates/turbopack-core/src/output.rs
@@ -26,12 +26,12 @@ pub trait OutputAsset: Asset {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct OutputAssets(Vec<Vc<Box<dyn OutputAsset>>>);
+pub struct OutputAssets(Vec<ResolvedVc<Box<dyn OutputAsset>>>);
 
 #[turbo_tasks::value_impl]
 impl OutputAssets {
     #[turbo_tasks::function]
-    pub fn new(assets: Vec<Vc<Box<dyn OutputAsset>>>) -> Vc<Self> {
+    pub fn new(assets: Vec<ResolvedVc<Box<dyn OutputAsset>>>) -> Vc<Self> {
         Vc::cell(assets)
     }
 
@@ -51,7 +51,7 @@ impl OutputAssets {
 
 /// A set of [OutputAsset]s
 #[turbo_tasks::value(transparent)]
-pub struct OutputAssetsSet(FxIndexSet<Vc<Box<dyn OutputAsset>>>);
+pub struct OutputAssetsSet(FxIndexSet<ResolvedVc<Box<dyn OutputAsset>>>);
 
 // TODO All Vc::try_resolve_downcast::<Box<dyn OutputAsset>> calls should be
 // removed

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -63,8 +63,8 @@ use crate::{error::PrettyPrintError, issue::IssueSeverity};
 #[turbo_tasks::value(shared)]
 #[derive(Clone, Debug)]
 pub enum ModuleResolveResultItem {
-    Module(Vc<Box<dyn Module>>),
-    OutputAsset(Vc<Box<dyn OutputAsset>>),
+    Module(ResolvedVc<Box<dyn Module>>),
+    OutputAsset(ResolvedVc<Box<dyn OutputAsset>>),
     External(RcStr, ExternalType),
     Ignore,
     Error(ResolvedVc<RcStr>),
@@ -102,24 +102,13 @@ impl ModuleResolveResult {
         }
     }
 
-    pub fn ignored() -> ModuleResolveResult {
-        Self::ignored_with_key(RequestKey::default())
-    }
-
-    pub fn ignored_with_key(request_key: RequestKey) -> ModuleResolveResult {
-        ModuleResolveResult {
-            primary: fxindexmap! { request_key => ModuleResolveResultItem::Ignore },
-            affecting_sources: Vec::new(),
-        }
-    }
-
-    pub fn module(module: Vc<Box<dyn Module>>) -> ModuleResolveResult {
+    pub fn module(module: ResolvedVc<Box<dyn Module>>) -> ModuleResolveResult {
         Self::module_with_key(RequestKey::default(), module)
     }
 
     pub fn module_with_key(
         request_key: RequestKey,
-        module: Vc<Box<dyn Module>>,
+        module: ResolvedVc<Box<dyn Module>>,
     ) -> ModuleResolveResult {
         ModuleResolveResult {
             primary: fxindexmap! { request_key => ModuleResolveResultItem::Module(module) },
@@ -129,7 +118,7 @@ impl ModuleResolveResult {
 
     pub fn output_asset(
         request_key: RequestKey,
-        output_asset: Vc<Box<dyn OutputAsset>>,
+        output_asset: ResolvedVc<Box<dyn OutputAsset>>,
     ) -> ModuleResolveResult {
         ModuleResolveResult {
             primary: fxindexmap! { request_key => ModuleResolveResultItem::OutputAsset(output_asset) },
@@ -138,7 +127,7 @@ impl ModuleResolveResult {
     }
 
     pub fn modules(
-        modules: impl IntoIterator<Item = (RequestKey, Vc<Box<dyn Module>>)>,
+        modules: impl IntoIterator<Item = (RequestKey, ResolvedVc<Box<dyn Module>>)>,
     ) -> ModuleResolveResult {
         ModuleResolveResult {
             primary: modules
@@ -149,20 +138,8 @@ impl ModuleResolveResult {
         }
     }
 
-    pub fn output_assets(
-        output_assets: impl IntoIterator<Item = (RequestKey, Vc<Box<dyn OutputAsset>>)>,
-    ) -> ModuleResolveResult {
-        ModuleResolveResult {
-            primary: output_assets
-                .into_iter()
-                .map(|(k, v)| (k, ModuleResolveResultItem::OutputAsset(v)))
-                .collect(),
-            affecting_sources: Vec::new(),
-        }
-    }
-
     pub fn modules_with_affecting_sources(
-        modules: impl IntoIterator<Item = (RequestKey, Vc<Box<dyn Module>>)>,
+        modules: impl IntoIterator<Item = (RequestKey, ResolvedVc<Box<dyn Module>>)>,
         affecting_sources: Vec<Vc<Box<dyn Source>>>,
     ) -> ModuleResolveResult {
         ModuleResolveResult {
@@ -174,7 +151,7 @@ impl ModuleResolveResult {
         }
     }
 
-    pub fn primary_modules_iter(&self) -> impl Iterator<Item = Vc<Box<dyn Module>>> + '_ {
+    pub fn primary_modules_iter(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Module>>> + '_ {
         self.primary.iter().filter_map(|(_, item)| match item {
             &ModuleResolveResultItem::Module(a) => Some(a),
             _ => None,
@@ -346,17 +323,15 @@ impl ModuleResolveResult {
         let Some(first) = iter.next() else {
             return Ok(Vc::cell(vec![]));
         };
-        let first = first.to_resolved().await?;
 
         let Some(second) = iter.next() else {
             return Ok(Vc::cell(vec![first]));
         };
-        let second = second.to_resolved().await?;
 
         // We have at least two items, so we need to deduplicate them
         let mut set = fxindexset![first, second];
         for module in self.primary_modules_iter() {
-            set.insert(module.to_resolved().await?);
+            set.insert(module);
         }
         Ok(Vc::cell(set.into_iter().collect()))
     }
@@ -740,9 +715,9 @@ impl ResolveResult {
     pub async fn as_raw_module_result(&self) -> Result<Vc<ModuleResolveResult>> {
         Ok(self
             .map_module(|asset| async move {
-                Ok(ModuleResolveResultItem::Module(Vc::upcast(RawModule::new(
-                    asset,
-                ))))
+                Ok(ModuleResolveResultItem::Module(ResolvedVc::upcast(
+                    RawModule::new(asset).to_resolved().await?,
+                )))
             })
             .await?
             .cell())

--- a/turbopack/crates/turbopack-core/src/resolve/origin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/origin.rs
@@ -84,7 +84,7 @@ async fn resolve_asset(
     reference_type: Value<ReferenceType>,
 ) -> Result<Vc<ModuleResolveResult>> {
     if let Some(asset) = *resolve_origin.get_inner_asset(request).await? {
-        return Ok(ModuleResolveResult::module(*asset).cell());
+        return Ok(ModuleResolveResult::module(asset).cell());
     }
     Ok(resolve_origin
         .asset_context()

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
 use anyhow::Result;
-use turbo_tasks::{RcStr, ValueToString, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::File;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -120,7 +120,11 @@ impl OutputAsset for SingleItemCssChunk {
             .reference_chunk_source_maps(Vc::upcast(self))
             .await?
         {
-            references.push(Vc::upcast(SingleItemCssChunkSourceMapAsset::new(self)));
+            references.push(ResolvedVc::upcast(
+                SingleItemCssChunkSourceMapAsset::new(self)
+                    .to_resolved()
+                    .await?,
+            ));
         }
         Ok(Vc::cell(references))
     }

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -83,7 +83,7 @@ impl Module for ModuleCssAsset {
             .copied()
             .chain(match *self.inner().await? {
                 ProcessResult::Module(inner) => {
-                    Some(Vc::upcast(InternalCssAssetReference::new(inner)))
+                    Some(Vc::upcast(InternalCssAssetReference::new(*inner)))
                 }
                 ProcessResult::Ignore => None,
             })

--- a/turbopack/crates/turbopack-css/src/references/internal.rs
+++ b/turbopack/crates/turbopack-css/src/references/internal.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{RcStr, ValueToString, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
     chunk::ChunkableModuleReference, module::Module, reference::ModuleReference,
     resolve::ModuleResolveResult,
@@ -9,14 +9,14 @@ use turbopack_core::{
 #[turbo_tasks::value]
 #[derive(Hash, Debug)]
 pub struct InternalCssAssetReference {
-    module: Vc<Box<dyn Module>>,
+    module: ResolvedVc<Box<dyn Module>>,
 }
 
 #[turbo_tasks::value_impl]
 impl InternalCssAssetReference {
     /// Creates a new [`Vc<InternalCssAssetReference>`].
     #[turbo_tasks::function]
-    pub fn new(module: Vc<Box<dyn Module>>) -> Vc<Self> {
+    pub fn new(module: ResolvedVc<Box<dyn Module>>) -> Vc<Self> {
         Self::cell(InternalCssAssetReference { module })
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
@@ -187,7 +187,7 @@ impl ChunkItem for AsyncLoaderChunkItem {
                 .copied()
                 .map(|chunk| {
                     Vc::upcast(SingleOutputAssetReference::new(
-                        chunk,
+                        *chunk,
                         chunk_reference_description(),
                     ))
                 })

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/content.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/content.rs
@@ -1,4 +1,4 @@
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::{chunk::AsyncModuleInfo, output::OutputAsset};
 
 use super::item::EcmascriptChunkItem;
@@ -11,5 +11,5 @@ type EcmascriptChunkItemWithAsyncInfo = (
 #[turbo_tasks::value(shared)]
 pub struct EcmascriptChunkContent {
     pub chunk_items: Vec<EcmascriptChunkItemWithAsyncInfo>,
-    pub referenced_output_assets: Vec<Vc<Box<dyn OutputAsset>>>,
+    pub referenced_output_assets: Vec<ResolvedVc<Box<dyn OutputAsset>>>,
 }

--- a/turbopack/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
@@ -205,7 +205,7 @@ impl ChunkItem for ChunkGroupFilesChunkItem {
                 .copied()
                 .map(|chunk| {
                     SingleOutputAssetReference::new(
-                        chunk,
+                        *chunk,
                         chunk_group_chunk_reference_description(),
                     )
                 })

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -119,7 +119,7 @@ impl Module for ManifestAsyncModule {
                 .copied()
                 .map(|chunk| {
                     Vc::upcast(SingleOutputAssetReference::new(
-                        chunk,
+                        *chunk,
                         manifest_chunk_reference_description(),
                     ))
                 })

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
@@ -86,7 +86,7 @@ impl ChunkItem for ManifestChunkItem {
 
         for chunk_data in &*self.chunks_data().await? {
             references.extend(chunk_data.references().await?.iter().map(|&output_asset| {
-                Vc::upcast(SingleOutputAssetReference::new(output_asset, key))
+                Vc::upcast(SingleOutputAssetReference::new(*output_asset, key))
             }));
         }
 

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
@@ -104,7 +104,7 @@ impl ChunkItem for ManifestLoaderChunkItem {
             .iter()
             .map(|&chunk| {
                 Vc::upcast(SingleOutputAssetReference::new(
-                    chunk,
+                    *chunk,
                     manifest_loader_chunk_reference_description(),
                 ))
             })
@@ -113,7 +113,7 @@ impl ChunkItem for ManifestLoaderChunkItem {
         for chunk_data in &*self.chunks_data().await? {
             references.extend(chunk_data.references().await?.iter().map(|&output_asset| {
                 Vc::upcast(SingleOutputAssetReference::new(
-                    output_asset,
+                    *output_asset,
                     chunk_data_reference_description(),
                 ))
             }));

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -84,10 +84,10 @@ impl ReferencedAsset {
                 }
                 &ModuleResolveResultItem::Module(module) => {
                     if let Some(placeable) =
-                        Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkPlaceable>>(module)
+                        ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(module)
                             .await?
                     {
-                        return Ok(ReferencedAsset::Some(placeable.to_resolved().await?).cell());
+                        return Ok(ReferencedAsset::Some(placeable).cell());
                     }
                 }
                 // TODO ignore should probably be handled differently
@@ -167,7 +167,9 @@ impl ModuleReference for EsmAssetReference {
                             .expect("EsmAssetReference origin should be a EcmascriptModuleAsset");
 
                     return Ok(ModuleResolveResult::module(
-                        EcmascriptModulePartAsset::select_part(module, *part),
+                        EcmascriptModulePartAsset::select_part(module, *part)
+                            .to_resolved()
+                            .await?,
                     )
                     .cell());
                 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -11,7 +11,8 @@ use swc_core::{
     quote, quote_expr,
 };
 use turbo_tasks::{
-    debug::ValueDebugFormat, trace::TraceRawVcs, FxIndexMap, RcStr, TryJoinIterExt, Value, Vc,
+    debug::ValueDebugFormat, trace::TraceRawVcs, FxIndexMap, RcStr, ResolvedVc, TryJoinIterExt,
+    Value, Vc,
 };
 use turbopack_core::{
     chunk::{ChunkItemExt, ChunkableModule, ChunkingContext, ModuleId},
@@ -340,10 +341,10 @@ async fn to_single_pattern_mapping(
             return Ok(SinglePatternMapping::Invalid);
         }
     };
-    if let Some(chunkable) = Vc::try_resolve_downcast::<Box<dyn ChunkableModule>>(module).await? {
+    if let Some(chunkable) = ResolvedVc::try_downcast::<Box<dyn ChunkableModule>>(module).await? {
         match resolve_type {
             ResolveType::AsyncChunkLoader => {
-                let loader_id = chunking_context.async_loader_chunk_item_id(chunkable);
+                let loader_id = chunking_context.async_loader_chunk_item_id(*chunkable);
                 return Ok(SinglePatternMapping::ModuleLoader(
                     loader_id.await?.clone_value(),
                 ));

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -201,7 +201,7 @@ impl RequireContextMap {
 #[turbo_tasks::value]
 #[derive(Hash, Debug)]
 pub struct RequireContextAssetReference {
-    pub inner: Vc<RequireContextAsset>,
+    pub inner: ResolvedVc<RequireContextAsset>,
     pub dir: RcStr,
     pub include_subdirs: bool,
 
@@ -239,7 +239,7 @@ impl RequireContextAssetReference {
             dir: dir.clone(),
             include_subdirs,
         }
-        .cell();
+        .resolved_cell();
 
         Self::cell(RequireContextAssetReference {
             inner,
@@ -256,7 +256,7 @@ impl RequireContextAssetReference {
 impl ModuleReference for RequireContextAssetReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        ModuleResolveResult::module(Vc::upcast(self.inner)).cell()
+        ModuleResolveResult::module(ResolvedVc::upcast(self.inner)).cell()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -88,7 +88,10 @@ impl ModuleReference for WorkerAssetReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
         if let Some(worker_loader_module) = self.worker_loader_module().await? {
-            Ok(ModuleResolveResult::module(Vc::upcast(worker_loader_module)).cell())
+            Ok(ModuleResolveResult::module(ResolvedVc::upcast(
+                worker_loader_module.to_resolved().await?,
+            ))
+            .cell())
         } else {
             Ok(ModuleResolveResult::unresolvable().cell())
         }

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use serde_json::Value as JsonValue;
-use turbo_tasks::{RcStr, Value, ValueToString, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, Value, ValueToString, Vc};
 use turbo_tasks_fs::DirectoryContent;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -212,8 +212,13 @@ impl TsExtendsReference {
 #[turbo_tasks::value_impl]
 impl ModuleReference for TsExtendsReference {
     #[turbo_tasks::function]
-    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        ModuleResolveResult::module(Vc::upcast(RawModule::new(Vc::upcast(self.config)))).cell()
+    async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
+        Ok(ModuleResolveResult::module(ResolvedVc::upcast(
+            RawModule::new(Vc::upcast(self.config))
+                .to_resolved()
+                .await?,
+        ))
+        .cell())
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -127,7 +127,7 @@ impl ChunkItem for WorkerLoaderChunkItem {
                 .copied()
                 .map(|chunk| {
                     Vc::upcast(SingleOutputAssetReference::new(
-                        chunk,
+                        *chunk,
                         chunk_reference_description(),
                     ))
                 })

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -78,7 +78,7 @@ async fn internal_assets(
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct AssetsForSourceMapping(HashMap<String, Vc<Box<dyn GenerateSourceMap>>>);
+pub struct AssetsForSourceMapping(HashMap<String, ResolvedVc<Box<dyn GenerateSourceMap>>>);
 
 /// Extracts a map of "internal" assets ([`internal_assets`]) which implement
 /// the [GenerateSourceMap] trait.
@@ -92,7 +92,7 @@ async fn internal_assets_for_source_mapping(
     let mut internal_assets_for_source_mapping = HashMap::new();
     for asset in internal_assets.iter() {
         if let Some(generate_source_map) =
-            Vc::try_resolve_sidecast::<Box<dyn GenerateSourceMap>>(*asset).await?
+            ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(*asset).await?
         {
             if let Some(path) = intermediate_output_path.get_path_to(&*asset.ident().path().await?)
             {
@@ -177,10 +177,10 @@ async fn separate_assets(
     for item in graph.into_reverse_topological() {
         match item {
             Type::Internal(asset) => {
-                internal_assets.insert(*asset);
+                internal_assets.insert(asset);
             }
             Type::External(asset) => {
-                external_asset_entrypoints.insert(*asset);
+                external_asset_entrypoints.insert(asset);
             }
         }
     }

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -211,7 +211,7 @@ async fn extra_configs_changed(
                         .await?
                     {
                         ProcessResult::Module(module) => {
-                            Some(any_content_changed_of_module(module))
+                            Some(any_content_changed_of_module(*module))
                         }
                         ProcessResult::Ignore => None,
                     }

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks::{FxIndexSet, RcStr, ValueToString, Vc};
+use turbo_tasks::{FxIndexSet, RcStr, ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{Chunk, ChunkingContext},
@@ -87,7 +87,9 @@ impl OutputAsset for EcmascriptBuildNodeChunk {
         }
 
         if include_source_map {
-            references.push(Vc::upcast(SourceMapAsset::new(Vc::upcast(self))));
+            references.push(ResolvedVc::upcast(
+                SourceMapAsset::new(Vc::upcast(self)).to_resolved().await?,
+            ));
         }
 
         Ok(Vc::cell(references))

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use anyhow::{bail, Result};
 use indoc::writedoc;
-use turbo_tasks::{RcStr, ValueToString, Vc};
+use turbo_tasks::{RcStr, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{File, FileSystem};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -119,7 +119,9 @@ impl OutputAsset for EcmascriptBuildNodeRuntimeChunk {
             .reference_chunk_source_maps(Vc::upcast(self))
             .await?
         {
-            references.push(Vc::upcast(SourceMapAsset::new(Vc::upcast(self))))
+            references.push(ResolvedVc::upcast(
+                SourceMapAsset::new(Vc::upcast(self)).to_resolved().await?,
+            ))
         }
 
         Ok(Vc::cell(references))

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -14,7 +14,8 @@ use dunce::canonicalize;
 use serde::Deserialize;
 use serde_json::json;
 use turbo_tasks::{
-    RcStr, ReadConsistency, ReadRef, TryJoinIterExt, TurboTasks, Value, ValueToString, Vc,
+    RcStr, ReadConsistency, ReadRef, ResolvedVc, TryJoinIterExt, TurboTasks, Value, ValueToString,
+    Vc,
 };
 use turbo_tasks_env::DotenvProcessEnv;
 use turbo_tasks_fs::{
@@ -440,10 +441,10 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
 }
 
 async fn walk_asset(
-    asset: Vc<Box<dyn OutputAsset>>,
+    asset: ResolvedVc<Box<dyn OutputAsset>>,
     output_path: &ReadRef<FileSystemPath>,
     seen: &mut HashSet<Vc<FileSystemPath>>,
-    queue: &mut VecDeque<Vc<Box<dyn OutputAsset>>>,
+    queue: &mut VecDeque<ResolvedVc<Box<dyn OutputAsset>>>,
 ) -> Result<()> {
     let path = asset.ident().path().resolve().await?;
 
@@ -463,7 +464,7 @@ async fn walk_asset(
             .iter()
             .copied()
             .map(|asset| async move {
-                Ok(Vc::try_resolve_downcast::<Box<dyn OutputAsset>>(asset).await?)
+                Ok(ResolvedVc::try_downcast::<Box<dyn OutputAsset>>(asset).await?)
             })
             .try_join()
             .await?

--- a/turbopack/crates/turbopack/src/rebase/mod.rs
+++ b/turbopack/crates/turbopack/src/rebase/mod.rs
@@ -1,7 +1,7 @@
 use std::hash::Hash;
 
 use anyhow::Result;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -55,11 +55,11 @@ impl OutputAsset for RebasedAsset {
             .await?
             .iter()
         {
-            references.push(Vc::upcast(RebasedAsset::new(
-                *module,
-                self.input_dir,
-                self.output_dir,
-            )));
+            references.push(ResolvedVc::upcast(
+                RebasedAsset::new(*module, self.input_dir, self.output_dir)
+                    .to_resolved()
+                    .await?,
+            ));
         }
         Ok(Vc::cell(references))
     }

--- a/turbopack/crates/turbopack/src/transition/mod.rs
+++ b/turbopack/crates/turbopack/src/transition/mod.rs
@@ -93,9 +93,11 @@ pub trait Transition {
         let module_asset_context = self.process_context(module_asset_context);
         let m = module_asset_context.process_default(asset, reference_type);
         Ok(match *m.await? {
-            ProcessResult::Module(m) => {
-                ProcessResult::Module(self.process_module(m, module_asset_context))
-            }
+            ProcessResult::Module(m) => ProcessResult::Module(
+                self.process_module(*m, module_asset_context)
+                    .to_resolved()
+                    .await?,
+            ),
             ProcessResult::Ignore => ProcessResult::Ignore,
         }
         .cell())

--- a/turbopack/crates/turbopack/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack/tests/node-file-trace.rs
@@ -29,7 +29,9 @@ use rstest_reuse::{
 };
 use serde::{Deserialize, Serialize};
 use tokio::{process::Command, time::timeout};
-use turbo_tasks::{backend::Backend, RcStr, ReadRef, TurboTasks, Value, ValueToString, Vc};
+use turbo_tasks::{
+    backend::Backend, RcStr, ReadRef, ResolvedVc, TurboTasks, Value, ValueToString, Vc,
+};
 use turbo_tasks_fs::{DiskFileSystem, FileSystem, FileSystemPath};
 use turbo_tasks_memory::MemoryBackend;
 use turbopack::{
@@ -452,14 +454,16 @@ fn node_file_trace<B: Backend + 'static>(
                 let module = module_asset_context
                     .process(Vc::upcast(source), Value::new(ReferenceType::Undefined))
                     .module();
-                let rebased = RebasedAsset::new(Vc::upcast(module), *input_dir, output_dir);
+                let rebased = RebasedAsset::new(Vc::upcast(module), *input_dir, output_dir)
+                    .to_resolved()
+                    .await?;
 
                 #[cfg(not(feature = "bench_against_node_nft"))]
                 let output_path = rebased.ident().path();
 
-                print_graph(Vc::upcast(rebased)).await?;
+                print_graph(ResolvedVc::upcast(rebased)).await?;
 
-                emit_with_completion(Vc::upcast(rebased), output_dir).await?;
+                emit_with_completion(*ResolvedVc::upcast(rebased), output_dir).await?;
 
                 #[cfg(not(feature = "bench_against_node_nft"))]
                 {
@@ -748,7 +752,7 @@ impl std::str::FromStr for CaseInput {
     }
 }
 
-async fn print_graph(asset: Vc<Box<dyn OutputAsset>>) -> Result<()> {
+async fn print_graph(asset: ResolvedVc<Box<dyn OutputAsset>>) -> Result<()> {
     let mut visited = HashSet::new();
     let mut queue = Vec::new();
     queue.push((0, asset));


### PR DESCRIPTION
A hand refactor of the `OutputAssets` type in `turbopack-core` to use `ResolvedVc`. This is one of the more common types passed around turbopack, so this touches a lot of code.

Closes PACK-3358